### PR TITLE
(docker) fix platform on manylinux wheel

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN ninja -C $LLVM_BUILD_DIR
 
 # build ptoas
 WORKDIR $WORKSPACE_DIR
-RUN git clone https://github.com/learning-chip/PTOAS.git
+RUN git clone https://github.com/zhangstevenunity/PTOAS.git
 # TODO: tag git commit of PTOAS repo
 
 WORKDIR $PTO_SOURCE_DIR


### PR DESCRIPTION
Explicitly passes the `--plat manylinux_2_34_x86_64` parameter in `auditwheel repair` to make sure the output wheel has the correct tag `ptoas-0.1.0-py3-none-manylinux_2_34_x86_64.whl`.

Generated wheel is already released on pypi: https://pypi.org/project/ptoas/#files