### PR TITLE
fix syntax error in mix_kernel.py

### DIFF
--- a/test/samples/Complex/mix_kernel.py
+++ b/test/samples/Complex/mix_kernel.py
@@ -37,19 +37,19 @@ def build(M=32, N=32, K=32, TM=32, TN=32, TK=32):
                 pto.BLayout.ColMajor, ctx), pto.SLayoutAttr.get(pto.SLayout.RowMajor, ctx), 1024, pd, ctx)
 
             # ub type and layout
-            ub_tile = pto.TileBufType.get([TM, TN], f32, ub, ub_nd_cfg, ctx)
+            ub_tile = pto.TileBufType.get([TM, TN], f32, ub, [TM, TN], ub_nd_cfg, ctx)
             ub_reduce_tile = pto.TileBufType.get(
-                [TM, 1], f32, ub, ub_dn_cfg, ctx)
+                [TM, 1], f32, ub, [TM, 1], ub_dn_cfg, ctx)
 
             # cbuf type and layout
-            mat_tile_a = pto.TileBufType.get([TM, TK], f32, mat, cfg_mat, ctx)
-            mat_tile_b = pto.TileBufType.get([TK, TN], f32, mat, cfg_mat, ctx)
+            mat_tile_a = pto.TileBufType.get([TM, TK], f32, mat, [TM, TK], cfg_mat, ctx)
+            mat_tile_b = pto.TileBufType.get([TK, TN], f32, mat, [TK, TN], cfg_mat, ctx)
 
             # l0 type and layout
-            left_tile = pto.TileBufType.get([TM, TK], f32, left, cfg_mat, ctx)
+            left_tile = pto.TileBufType.get([TM, TK], f32, left, [TM, TK], cfg_mat, ctx)
             right_tile = pto.TileBufType.get(
-                [TK, TN], f32, right, cfg_right, ctx)
-            acc_tile = pto.TileBufType.get([TM, TN], f32, acc, cfg_acc, ctx)
+                [TK, TN], f32, right, [TK, TN], cfg_right, ctx)
+            acc_tile = pto.TileBufType.get([TM, TN], f32, acc, [TM, TN], cfg_acc, ctx)
 
             PIPE_FIX = Attribute.parse("#pto.pipe<PIPE_FIX>", ctx)
             PIPE_V = Attribute.parse("#pto.pipe<PIPE_V>", ctx)
@@ -104,17 +104,17 @@ def build(M=32, N=32, K=32, TM=32, TN=32, TK=32):
                 ubReduceTile = pto.AllocTileOp(ub_reduce_tile)
 
                 # load from gm to cbuf
-                pto.TLoadOp(None, sv0, aMatTile, [],)
-                pto.TLoadOp(None, sv1, bMatTile, [],)
+                pto.TLoadOp(None, sv0, aMatTile)
+                pto.TLoadOp(None, sv1, bMatTile)
 
                 # move to l0A/l0B from cbuf
-                pto.TMovOp(None, aMatTile, aTile, [],)
-                pto.TMovOp(None, bMatTile, bTile, [],)
+                pto.TMovOp(None, aMatTile, aTile)
+                pto.TMovOp(None, bMatTile, bTile)
 
-                pto.TMatmulOp(None, aTile, bTile, cTile, [ctm, ctk, ctn])
+                pto.TMatmulOp(None, aTile, bTile, cTile)
 
                 # move result from l0c to
-                pto.TMovOp(None, cTile, ubTile, [],)
+                pto.TMovOp(None, cTile, ubTile)
 
                 pto.SyncSetOp(PIPE_FIX, 0)
                 pto.SyncSetOp(PIPE_FIX, 16)


### PR DESCRIPTION
Fix https://github.com/zhangstevenunity/PTOAS/issues/11#issuecomment-3834348304

Now `python mix_kernel.py` runs correctly.

It generates

```
module {
  func.func @vector_cube_mixed_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %c32 = arith.constant 32 : index
    %c32_0 = arith.constant 32 : index
    %c32_1 = arith.constant 32 : index
    %c32_2 = arith.constant 32 : index
    %c32_3 = arith.constant 32 : index
    %c32_4 = arith.constant 32 : index
    %0 = pto.get_block_idx
    %1 = pto.get_subblock_idx
    %2 = pto.get_subblock_num
    %3 = arith.muli %0, %2 : i64
    %4 = arith.addi %3, %1 : i64
    %5 = arith.index_cast %4 : i64 to index
    %6 = arith.muli %c32, %c32_1 : index
    %7 = arith.muli %5, %6 : index
    %8 = arith.index_cast %4 : i64 to index
    %9 = arith.muli %c32_1, %c32_0 : index
    %10 = arith.muli %8, %9 : index
    %11 = pto.make_tensor_view %arg0, shape = [%c32, %c32_1] strides = [%c32_4, %c1] : !pto.tensor_view<2xf32>
    %12 = pto.make_tensor_view %arg1, shape = [%c32_1, %c32_0] strides = [%c32_3, %c1] : !pto.tensor_view<2xf32>
    %13 = pto.make_tensor_view %arg2, shape = [%c32, %c32_0] strides = [%c32_3, %c1] : !pto.tensor_view<2xf32>
    %14 = pto.subview %11, offsets = [%c0, %7], sizes = [%c32, %c32_1] : !pto.tensor_view<2xf32> -> !pto.tile_view<32x32xf32>
    %15 = pto.subview %12, offsets = [%c0, %10], sizes = [%c32_1, %c32_0] : !pto.tensor_view<2xf32> -> !pto.tile_view<32x32xf32>
    %16 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>
    %17 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>
    %18 = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>
    %19 = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=1>
    %20 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=1>
    %21 = pto.alloc_tile : !pto.tile_buf<loc=ub, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>
    %22 = pto.alloc_tile : !pto.tile_buf<loc=ub, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=1>
    pto.tload ins(%14 : !pto.tile_view<32x32xf32>) outs(%16 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>)
    pto.tload ins(%15 : !pto.tile_view<32x32xf32>) outs(%17 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>)
    pto.tmov ins(%16 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>) outs(%18 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>)
    pto.tmov ins(%17 : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>) outs(%19 : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=1>)
    pto.tmatmul ins(%18, %19 : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=1>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=1>) outs(%20 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=1>)
    pto.tmov ins(%20 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=1>) outs(%21 : !pto.tile_buf<loc=ub, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
    pto.sync.set <PIPE_FIX>, 0
    pto.sync.set <PIPE_FIX>, 16
    pto.sync.wait <PIPE_V>, 0
    pto.trowmax ins(%21 : !pto.tile_buf<loc=ub, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>) outs(%22 : !pto.tile_buf<loc=ub, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=1>)
    return
  }
}
```

However `ptoas` on the above IR gives error:

```
...
Hello PTO Infer Mem Scope!
...
loc("./mix_kernel.pto":39:5): error: 'pto.mov_dps' op Failed to infer/propagate memory scope for mA
end PTO Infer Mem Scope!
...
Error: Pass execution failed.
```
