### PR TITLE
fix: remove duplicate InsertSeqSync call causing NPU deadlock (#112)

### DIFF
--- a/lib/PTO/Transforms/BlockSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/BlockSyncAnalysis.cpp
@@ -499,10 +499,6 @@ unsigned BlockSyncAnalysis::InsertBranchSync(
                  << ", ElseAnchor=" << (elseAnchor ? elseAnchor->GetIndex() : -1) << "\n";
  
     InsertSeqSync(nowCompound, syncElement, ifStart + 1, ifEnd, 
-                  syncRecordIfList, forEndIndex, nullptr);
-
-    // [Fix] 传递 waitAnchor 给 If 分支
-    InsertSeqSync(nowCompound, syncElement, ifStart + 1, ifEnd, 
                   syncRecordIfList, forEndIndex, waitAnchor);
 
     if (branchElement->branchId != branchElement->endId) {


### PR DESCRIPTION
## Problem
Issue #112: `--enable-insert-sync` causes NPU aicore timeout deadlock.

## Root Cause
In `BlockSyncAnalysis::InsertBranchSync`, the if-branch was analyzed twice:
1. First call with `waitAnchor=nullptr`
2. Second call with the actual `waitAnchor`

This generated duplicate `SET_EVENT`/`WAIT_EVENT` pairs where `WAIT_EVENT` count exceeded `SET_EVENT` count. The NPU waited for an event that was never set again → deadlock.

## Fix
Remove the redundant first call, keep only the single call with `waitAnchor` passed correctly.

## Test
Verified with `test/samples/InjectSync/test_inject_sync_if_else.pto` — SET/WAIT counts now match correctly.