### PR TITLE
Fix insert-sync control-flow for double-buffer dynamic IR (#128)

### DIFF
--- a/include/PTO/Transforms/BlockSyncAnalysis.h
+++ b/include/PTO/Transforms/BlockSyncAnalysis.h
@@ -4,24 +4,24 @@
 #include "PTO/Transforms/SyncCommon.h"
 #include "PTO/Transforms/MemoryDependentAnalyzer.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include <array>
  
 namespace mlir {
 namespace pto {
  
 struct SyncRecord {
-  SmallVector<const SyncOperation *> alreadySync;
- 
-  // [Fix] 显式 resize，防止越界访问
-  SyncRecord() {
-      alreadySync.resize(32, nullptr); 
-  }
- 
-  SyncRecord(int pipeNum) {
-      alreadySync.resize(pipeNum, nullptr);
-  }
+  // Record pipes that have already been waited for (per multi-buffer slot).
+  //
+  // Use PIPE_LAST + 1 to keep indices stable even if PIPE_UNASSIGNED (99)
+  // appears transiently in intermediate states.
+  std::array<bool, static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U>
+      alreadySync{false};
+
+  // Record the pairing status of set/wait within a syncIndex.
+  llvm::DenseMap<int, bool> syncFinder;
 };
  
-using SyncRecordList = std::vector<SyncRecord>;
+using SyncRecordList = std::array<SyncRecord, MAX_MULTI_BUFFER_NUM>;
  
 class BlockSyncAnalysis {
 public:
@@ -68,45 +68,45 @@ private:
                      SyncIRs &syncElement,
                      int begin, int end, 
                      SyncRecordList &syncRecordList,
-                     const std::optional<unsigned> &forEndIndex,
-                     InstanceElement *waitAnchor);
+                     const std::optional<unsigned> &forEndIndex);
                      
   /// 处理 Loop 内部的递归调用
   unsigned InsertLoopSync(
     unsigned index, CompoundInstanceElement *nowCompound, unsigned begin,
     LoopInstanceElement *loopElement, SyncIRs &syncElement,
-    SyncRecordList &syncRecordList, const std::optional<unsigned> &forEndIndex,
-    InstanceElement *waitAnchor); // [New Arg]
+    SyncRecordList &syncRecordList,
+    const std::optional<unsigned> &forEndIndex);
 
   unsigned InsertBranchSync(
     unsigned index, CompoundInstanceElement *nowCompound, unsigned begin,
     BranchInstanceElement *branchElement, SyncIRs &syncElement,
-    SyncRecordList &syncRecordList, const std::optional<unsigned> &forEndIndex,
-    InstanceElement *waitAnchor); // [New Arg]
+    SyncRecordList &syncRecordList,
+    const std::optional<unsigned> &forEndIndex);
 
   /// 合并两个分支的同步状态 (Intersection)
   void MergeAlreadySync(SyncRecordList &syncRecordList,
-                      const SyncRecordList &syncRecordIfList,
-                      const SyncRecordList &syncRecordElseList,
-                      InstanceElement* ifAnchor,
-                      InstanceElement* elseAnchor,
-                      const std::optional<unsigned> &forEndIndex);
+                        const SyncRecordList &syncRecordIfList,
+                        const SyncRecordList &syncRecordElseList);
  
   // --- Dependency & Sync Insertion ---
+
+  /// Inset backward sync with LoopInstanceElement's end by copying a loop body
+  /// slice and running the sequential inserter on the copied structure.
+  void InsertBackForSync(CompoundInstanceElement *nowCompound,
+                         SyncIRs &backSyncIr,
+                         const LoopInstanceElement *loopElement);
  
   /// 检查 nowCompound 和 frontCompound 是否需要同步
   void InsertSync(CompoundInstanceElement *nowCompound,
                   CompoundInstanceElement *frontCompound,
                   SyncRecordList &syncRecordList,
-                  const std::optional<unsigned> &forEndIndex,
-                  InstanceElement *waitAnchor);
+                  const std::optional<unsigned> &forEndIndex);
  
   /// 调用 memAnalyzer 判断内存依赖
   void MemAnalyze(CompoundInstanceElement *nowCompound,
                   CompoundInstanceElement *frontCompound,
                   SyncRecordList &syncRecordList,
-                  const std::optional<unsigned> &forEndIndex,
-                  InstanceElement *waitAnchor);
+                  const std::optional<unsigned> &forEndIndex);
  
   /// 判断两个节点是否存在 RAW/WAR/WAW 依赖
   bool IsMemInfoHasDependency(CompoundInstanceElement *nowCompound,
@@ -117,8 +117,7 @@ private:
   void InsertSyncOperation(CompoundInstanceElement *nowCompound,
                            CompoundInstanceElement *frontCompound,
                            DepBaseMemInfoPairVec &depBaseMemInfosVec,
-                           const std::optional<unsigned> &forEndIndex,
-                           InstanceElement *waitAnchor);
+                           const std::optional<unsigned> &forEndIndex);
  
   // --- Utility Methods ---
  
@@ -131,8 +130,7 @@ private:
   /// 更新 SyncRecord (当插入新同步后)
   void UpdateAlreadySync(const SyncOps &syncVector,
                          SyncRecordList &syncRecordList,
-                         const PipelineType nowPipeValue,
-                         unsigned index); // [Fix] 增加参数声明
+                         const PipelineType nowPipeValue);
                             
   void UpdateSyncRecordInfo(CompoundInstanceElement *frontCompound,
                             SyncRecordList &syncRecordList);

--- a/lib/PTO/Transforms/BlockSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/BlockSyncAnalysis.cpp
@@ -1,684 +1,564 @@
 #include "PTO/Transforms/BlockSyncAnalysis.h"
 #include "PTO/Transforms/SyncCommon.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/Operation.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
-#include <utility>
 #include <memory>
 #include <optional>
- 
+#include <utility>
+
 #define DEBUG_TYPE "pto-block-sync-analysis"
- 
+
 using namespace mlir;
 using namespace mlir::pto;
- 
-namespace mlir {
-namespace pto {
- 
-static void printMemInfoVec(const char* tag, const SmallVector<const BaseMemInfo *> &vec) {
-  llvm::errs() << tag << " (Size " << vec.size() << "):\n";
-  for (const auto *info : vec) {
-    llvm::errs() << " - Root: ";
-    if (info->rootBuffer) {
-      if (auto *op = info->rootBuffer.getDefiningOp())
-        llvm::errs() << op->getName();
-      else
-        llvm::errs() << "BlockArg";
-      llvm::errs() << " | Scope: " << (int)info->scope << "\n";
-    } else {
-      llvm::errs() << "NULL\n";
-    }
-  }
+
+namespace mlir::pto {
+
+static constexpr unsigned kPipeStateSize =
+    static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U;
+
+static bool isValidPipeIndex(PipelineType pipe) {
+  return static_cast<unsigned>(pipe) < kPipeStateSize;
 }
- 
+
 // ==============================================================================
-// 1. Plan / Entry Point
+// 1. Entry Point
 // ==============================================================================
+
 void BlockSyncAnalysis::Run(bool insertBarAllAtLast) {
   syncIndex_ = syncOperations_.size();
-  
+
   for (auto &nowElement : syncIR_) {
-    if (auto *nowCompound = dyn_cast<CompoundInstanceElement>(nowElement.get())) {
+    if (auto *nowCompound =
+            dyn_cast<CompoundInstanceElement>(nowElement.get())) {
       DealWithCompoundSync(nowCompound);
-    } else if (auto *loopElement = dyn_cast<LoopInstanceElement>(nowElement.get())) {
+    } else if (auto *loopElement =
+                   dyn_cast<LoopInstanceElement>(nowElement.get())) {
       DealWithLoopSync(loopElement);
     } else if (isa<BranchInstanceElement>(nowElement.get())) {
       continue;
+    } else if (isa<PlaceHolderInstanceElement>(nowElement.get())) {
+      continue;
     }
   }
- 
+
   if (insertBarAllAtLast) {
     InsertLastPipeAll();
   }
 }
- 
+
 // ==============================================================================
-// 2. High-Level Recursion & Traversal
+// 2. High-Level Traversal
 // ==============================================================================
- 
+
 void BlockSyncAnalysis::DealWithCompoundSync(CompoundInstanceElement *nowCompound) {
-  // [Fix] Initialize vector size
-  SyncRecordList syncRecordList(syncIR_.size());
-  
+  SyncRecordList syncRecordList;
   InsertSeqSync(nowCompound, syncIR_, 0, nowCompound->GetIndex(), syncRecordList,
-                std::nullopt, nullptr);
+                std::nullopt);
 }
- 
+
 void BlockSyncAnalysis::DealWithLoopSync(LoopInstanceElement *nowElement) {
-  if (nowElement->getLoopKind() == KindOfLoop::LOOP_END) {
-    SyncIRs backSyncIr;
-    assert(syncIR_.size() >= nowElement->endId);
-    
-    for (unsigned i = nowElement->beginId; i < nowElement->endId; i++) {
-      if (auto *compound = dyn_cast<CompoundInstanceElement>(syncIR_[i].get())) {
-         auto backCompound = std::make_unique<CompoundInstanceElement>(
-             compound->GetIndex(), compound->defVec, compound->useVec,
-             compound->kPipeValue, compound->opName);
-         backCompound->elementOp = compound->elementOp;
-         backSyncIr.emplace_back(std::move(backCompound));
-      } 
-    }
- 
-    SyncRecordList syncRecordList(syncIR_.size());
-    unsigned loopEndIndex = nowElement->endId;
-    
-    for (auto &backElem : backSyncIr) {
-      if (auto *backCompound = dyn_cast<CompoundInstanceElement>(backElem.get())) {
-        // [Fix] 将最后一个参数 waitAnchor 设为 nullptr
-        // 这样 Wait 指令就会自然地附着在循环内部的消费者 (nowCompound) 上
-        InsertSeqSync(backCompound, syncIR_, nowElement->beginId, 
-                    loopEndIndex, syncRecordList, loopEndIndex, nullptr);
-      }
+  // Insert backward sync by copying the loop body slice and running the same
+  // sequential insertion on the copied structure (AscendNPU-IR style).
+  if (nowElement->getLoopKind() != KindOfLoop::LOOP_END) {
+    return;
+  }
+
+  SyncIRs backSyncIr;
+  assert(syncIR_.size() >= nowElement->endId);
+  for (unsigned i = nowElement->beginId; i < nowElement->endId; i++) {
+    if (auto *compound = dyn_cast<CompoundInstanceElement>(syncIR_[i].get())) {
+      InsertBackForSync(compound, backSyncIr, nowElement);
+    } else if (auto *loopElement =
+                   dyn_cast<LoopInstanceElement>(syncIR_[i].get())) {
+      auto loopKind = loopElement->getLoopKind();
+      backSyncIr.emplace_back(loopElement->CloneFor(loopKind));
+    } else if (auto *branchElement =
+                   dyn_cast<BranchInstanceElement>(syncIR_[i].get())) {
+      backSyncIr.emplace_back(
+          branchElement->CloneBranch(branchElement->getBranchKind()));
+    } else if (auto *placeHolderElement =
+                   dyn_cast<PlaceHolderInstanceElement>(syncIR_[i].get())) {
+      backSyncIr.emplace_back(placeHolderElement->Clone());
     }
   }
 }
- 
+
+void BlockSyncAnalysis::InsertBackForSync(CompoundInstanceElement *nowCompound,
+                                         SyncIRs &backSyncIr,
+                                         const LoopInstanceElement *loopElement) {
+  SyncRecordList syncRecordList;
+
+  auto backCompound = std::make_unique<CompoundInstanceElement>(
+      nowCompound->GetIndex(), nowCompound->defVec, nowCompound->useVec,
+      nowCompound->kPipeValue, nowCompound->opName);
+  backCompound->compoundCoreType = nowCompound->compoundCoreType;
+  backCompound->elementOp = nowCompound->elementOp;
+
+  auto *backCompoundPtr = backCompound.get();
+  backSyncIr.emplace_back(std::move(backCompound));
+
+  // Insert sync between the copied commands (j+1 slice).
+  InsertSeqSync(backCompoundPtr, backSyncIr, 0,
+                static_cast<int>(backSyncIr.size()) - 1, syncRecordList,
+                loopElement->endId);
+
+  // Insert sync between original and copied commands to model loop-carried deps.
+  InsertSeqSync(nowCompound, syncIR_, nowCompound->GetIndex(), loopElement->endId,
+                syncRecordList, loopElement->endId);
+}
+
 // ==============================================================================
 // 3. Sequential Sync Insertion (Core Logic)
 // ==============================================================================
- 
+
 bool BlockSyncAnalysis::IsNoNeedToInsertSync(
     const CompoundInstanceElement *nowCompound,
-    const CompoundInstanceElement *frontCompound, 
-    bool isBackwardDep) const {
- 
+    const CompoundInstanceElement *frontCompound, bool isBackwardDep) const {
   const PipelineType frontPipe = frontCompound->kPipeValue;
   const PipelineType nowPipe = nowCompound->kPipeValue;
- 
+
   if (frontPipe == nowPipe && frontPipe == PipelineType::PIPE_S) {
     return true;
   }
- 
+
   if (nowCompound->elementOp == frontCompound->elementOp && !isBackwardDep) {
     return true;
   }
- 
-  if (frontPipe == nowPipe) {
-      if (!isBackwardDep) {
-          if (IsGMHazard(nowCompound, frontCompound)) {
-              return false;
-          }
-          return true;
-      }
+
+  if (frontPipe == nowPipe && !isBackwardDep) {
+    // Only insert an intra-pipe barrier for real GM hazards.
+    return !IsGMHazard(nowCompound, frontCompound);
   }
- 
+
   return false;
 }
- 
+
 void BlockSyncAnalysis::InsertSeqSync(CompoundInstanceElement *nowCompound,
                                       SyncIRs &syncElement, int begin, int end,
                                       SyncRecordList &syncRecordList,
-                                      const std::optional<unsigned> &forEndIndex,
-                                      InstanceElement *waitAnchor) {
+                                      const std::optional<unsigned> &forEndIndex) {
   const PipelineType nowPipeValue = nowCompound->kPipeValue;
-  
-  if (end >= 0 && static_cast<size_t>(end) < syncElement.size()) {
-      unsigned syncIRIndex = syncElement[end]->GetIndex();
-      if (syncIRIndex < syncIR_.size()) {
-          UpdateAlreadySync(syncIR_[syncIRIndex]->pipeBefore, syncRecordList, nowPipeValue, syncIRIndex);
-      }
-  }
- 
+
+  checkSyncIRIndex(syncElement, begin);
+  checkSyncIRIndex(syncElement, end);
+
+  unsigned syncIRIndex = syncElement[end]->GetIndex();
+  UpdateAlreadySync(syncIR_[syncIRIndex]->pipeBefore, syncRecordList, nowPipeValue);
+
   for (int i = end - 1; i >= begin; i--) {
     auto &frontPtr = syncElement[i];
     unsigned frontIndex = frontPtr->GetIndex();
-    
-    if (auto *frontCompound = dyn_cast<CompoundInstanceElement>(frontPtr.get())) {
-        UpdateAlreadySync(syncIR_[frontIndex]->pipeAfter, syncRecordList, nowPipeValue, frontIndex);
-        
-        InsertSync(nowCompound, frontCompound, syncRecordList, forEndIndex, waitAnchor);
-        
-        UpdateAlreadySync(syncIR_[frontIndex]->pipeBefore, syncRecordList, nowPipeValue, frontIndex);
-        
-    } else if (auto *loopInstance = dyn_cast<LoopInstanceElement>(frontPtr.get())) {
-        int skipLoop = static_cast<int>(InsertLoopSync(i, nowCompound, begin, loopInstance,
-                                        syncElement, syncRecordList, forEndIndex, waitAnchor));
-        i -= skipLoop;
-    } else if (auto *branchElement = dyn_cast<BranchInstanceElement>(frontPtr.get())) {
-        int skipBranch = static_cast<int>(InsertBranchSync(i, nowCompound, begin, 
-                                          branchElement, syncElement,
-                                          syncRecordList, forEndIndex, waitAnchor));
-        i -= skipBranch;
+    assert(frontIndex < syncIR_.size());
+    assert(syncIR_[frontIndex] != nullptr);
+
+    if (auto *frontCompound =
+            dyn_cast<CompoundInstanceElement>(frontPtr.get())) {
+      UpdateAlreadySync(syncIR_[frontIndex]->pipeAfter, syncRecordList,
+                        nowPipeValue);
+      InsertSync(nowCompound, frontCompound, syncRecordList, forEndIndex);
+      UpdateAlreadySync(syncIR_[frontIndex]->pipeBefore, syncRecordList,
+                        nowPipeValue);
+    } else if (auto *loopInstance =
+                   dyn_cast<LoopInstanceElement>(frontPtr.get())) {
+      int skipLoop = static_cast<int>(InsertLoopSync(
+          i, nowCompound, begin, loopInstance, syncElement, syncRecordList,
+          forEndIndex));
+      i -= skipLoop;
+    } else if (auto *branchElement =
+                   dyn_cast<BranchInstanceElement>(frontPtr.get())) {
+      int skipBranch = static_cast<int>(InsertBranchSync(
+          i, nowCompound, begin, branchElement, syncElement, syncRecordList,
+          forEndIndex));
+      i -= skipBranch;
     }
   }
 }
- 
+
 unsigned BlockSyncAnalysis::InsertLoopSync(
     unsigned index, CompoundInstanceElement *nowCompound, unsigned begin,
     LoopInstanceElement *loopElement, SyncIRs &syncElement,
-    SyncRecordList &syncRecordList, const std::optional<unsigned> &forEndIndex,
-    InstanceElement *waitAnchor) { 
+    SyncRecordList &syncRecordList,
+    const std::optional<unsigned> &forEndIndex) {
   if (loopElement->getLoopKind() == KindOfLoop::LOOP_END) {
     SyncRecordList syncRecordForList = syncRecordList;
-    
-    unsigned loopLen = loopElement->endId - loopElement->beginId;
-    unsigned newBegin = std::max((int)begin, (int)(index - loopLen));
-    unsigned newEnd = index; 
-    
-    InsertSeqSync(nowCompound, syncElement, newBegin, newEnd, syncRecordForList, forEndIndex, waitAnchor);
-    
+    unsigned newBegin =
+        std::max(begin, index - (loopElement->endId - loopElement->beginId));
+    unsigned newEnd = index;
+    InsertSeqSync(nowCompound, syncElement, static_cast<int>(newBegin),
+                  static_cast<int>(newEnd), syncRecordForList, forEndIndex);
+    // Conservatively assume loop bodies are executed and keep the updated state.
     syncRecordList = std::move(syncRecordForList);
-    
-    return loopLen; 
+    return (loopElement->endId - loopElement->beginId);
   }
   return 0;
 }
- 
-// ==============================================================================
-// 4. Dependency Analysis & Operation Insertion
-// ==============================================================================
- 
-void BlockSyncAnalysis::InsertSync(CompoundInstanceElement *nowCompound,
-                                   CompoundInstanceElement *frontCompound,
-                                   SyncRecordList &syncRecordList,
-                                   const std::optional<unsigned> &forEndIndex,
-                                   InstanceElement *waitAnchor) {
-    if (IsNoNeedToInsertSync(nowCompound, frontCompound, forEndIndex.has_value())) {
-        return;
-    }
-    MemAnalyze(nowCompound, frontCompound, syncRecordList, forEndIndex, waitAnchor);
-}
- 
-void BlockSyncAnalysis::MemAnalyze(CompoundInstanceElement *nowCompound,
-                                   CompoundInstanceElement *frontCompound,
-                                   SyncRecordList &syncRecordList,
-                                   const std::optional<unsigned> &forEndIndex,
-                                   InstanceElement *waitAnchor) {
-    // ... [Debug Prints Keep Same] ...
-    llvm::errs() << "\n[MemAnalyze] Analyzing Dependency:\n";
-    llvm::errs() << "  Now Node: " << nowCompound->elementOp->getName() << "\n";
-    printMemInfoVec("    DefVec", nowCompound->defVec);
-    printMemInfoVec("    UseVec", nowCompound->useVec);
-    llvm::errs() << "  Front Node: " << frontCompound->elementOp->getName() << "\n";
-    printMemInfoVec("    DefVec", frontCompound->defVec);
-    printMemInfoVec("    UseVec", frontCompound->useVec);
- 
-    if (isAlreadySync(nowCompound, frontCompound, syncRecordList, frontCompound->GetIndex())) {
-        llvm::errs() << "  -> Already Synced at Pipe Level. Skipping.\n";
-        return;
-    }
- 
-    DepBaseMemInfoPairVec depVec;
-    bool hasDep = IsMemInfoHasDependency(nowCompound, frontCompound, depVec);
-    
-    if (hasDep) {
-        llvm::errs() << "  -> Dependency FOUND!\n";
-    } else {
-        llvm::errs() << "  -> No Dependency.\n";
-        return; // No dep -> return
-    }
-    
-    // [Fix] Intra-Pipe Barrier 过滤逻辑
-    if (nowCompound->kPipeValue == frontCompound->kPipeValue) {
-        bool isRealGMHazard = false;
-        for (auto &pair : depVec) {
-            // 只要有一对依赖涉及 GM，就认为是真正的 Hazard
-            if ((pair.first && pair.first->scope == pto::AddressSpace::GM) ||
-                (pair.second && pair.second->scope == pto::AddressSpace::GM)) {
-                isRealGMHazard = true;
-                break;
-            }
-        }
-        if (!isRealGMHazard) {
-             llvm::errs() << "  -> Intra-Pipe dep on Local Mem (No GM). Skipping Barrier.\n";
-             return; 
-        }
-    }
-    
-    if (forEndIndex.has_value()) {
-        int eventIdNum = GetEventIdNum(depVec);
-        for (int i = 1; i < eventIdNum; i++) {
-             if (isAlreadySync(nowCompound, frontCompound, syncRecordList, frontCompound->GetIndex())) {
-                 return;
-             }
-        }
-    }
-    
-    InsertSyncOperation(nowCompound, frontCompound, depVec, forEndIndex, waitAnchor);
-    UpdateSyncRecordInfo(frontCompound, syncRecordList);
-}
- 
-bool BlockSyncAnalysis::IsMemInfoHasDependency(
-    CompoundInstanceElement *nowCompound,
-    CompoundInstanceElement *frontCompound,
-    DepBaseMemInfoPairVec &depBaseMemInfosVec) {
-    
-    bool hasDependency = false;
-    hasDependency |= memAnalyzer_.DepBetween(nowCompound->useVec, frontCompound->defVec, depBaseMemInfosVec);
-    hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->useVec, depBaseMemInfosVec);
-    hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->defVec, depBaseMemInfosVec);
 
-    // ---------------------------------------------------------------------
-    // Special hazard: ACC (L0C) read/read cross-pipe ordering.
-    //
-    // Some PTO-ISA sequences (e.g. TMOV_FP reading ACC on PIPE_MTE1 and TSTORE
-    // reading ACC on PIPE_MTE3) are semantically "read/read", but executing
-    // them concurrently can trigger nondeterminism or device exceptions on NPU.
-    //
-    // Model this as a dependency to force an explicit event ordering between
-    // different pipelines when they alias on ACC.
-    // ---------------------------------------------------------------------
-    if (nowCompound->kPipeValue != frontCompound->kPipeValue) {
-      DepBaseMemInfoPairVec rrDepVec;
-      if (memAnalyzer_.DepBetween(nowCompound->useVec, frontCompound->useVec,
-                                 rrDepVec)) {
-        for (auto &pair : rrDepVec) {
-          if (!pair.first) continue;
-          if (pair.first->scope != pto::AddressSpace::ACC) continue;
-          depBaseMemInfosVec.push_back(pair);
-          hasDependency = true;
-        }
-      }
-    }
-    
-    return hasDependency;
-}
- 
-void BlockSyncAnalysis::InsertSyncOperation(
-    CompoundInstanceElement *nowCompound,
-    CompoundInstanceElement *frontCompound,
-    DepBaseMemInfoPairVec &depBaseMemInfosVec,
-    const std::optional<unsigned> &forEndIndex,
-    InstanceElement *waitAnchor) {
-    
-    PipelineType nowPipe = nowCompound->kPipeValue;
-    PipelineType frontPipe = frontCompound->kPipeValue;
-    
-    if (nowPipe == frontPipe) {
-        unsigned insertId = nowCompound->GetIndex();
-        
-        auto barrier = std::make_unique<SyncOperation>(
-            SyncOperation::TYPE::PIPE_BARRIER, frontPipe, nowPipe,
-            syncIndex_++, nowCompound->GetIndex(), forEndIndex);
-        
-        llvm::errs() << " [Trace Insert] Intra-Pipe Barrier at Node " << insertId << " (PRE)\n";
-        syncIR_[insertId]->pipeBefore.push_back(barrier.get());
-        
-        SmallVector<std::unique_ptr<SyncOperation>> newSync;
-        newSync.emplace_back(std::move(barrier));
-        syncOperations_.emplace_back(std::move(newSync));
-        
-    } else {
-        unsigned insertSetId = frontCompound->GetIndex();
-        unsigned insertWaitId = nowCompound->GetIndex();
-        
-        bool useAnchor = (waitAnchor != nullptr);
- 
-        auto setOp = std::make_unique<SyncOperation>(
-            SyncOperation::TYPE::SET_EVENT, frontPipe, nowPipe,
-            syncIndex_, insertSetId, forEndIndex);
-            
-        auto waitOp = setOp->GetMatchSync(insertWaitId); 
-        
-        llvm::errs() << " [Trace Insert] SET_EVENT at Node " << insertSetId << " (POST)\n";
-        syncIR_[insertSetId]->pipeAfter.push_back(setOp.get());
-        
-        if (useAnchor) {
-            llvm::errs() << " [Trace Insert] WAIT_EVENT at Anchor Node " << waitAnchor->GetIndex() << " (PRE)\n";
-            waitAnchor->pipeBefore.push_back(waitOp.get());
-        } else {
-            llvm::errs() << " [Trace Insert] WAIT_EVENT at Node " << insertWaitId << " (PRE)\n";
-            syncIR_[insertWaitId]->pipeBefore.push_back(waitOp.get());
-        }
-        
-        SmallVector<std::unique_ptr<SyncOperation>> newSync;
-        newSync.emplace_back(std::move(setOp));
-        newSync.emplace_back(std::move(waitOp));
-        syncOperations_.emplace_back(std::move(newSync));
-        
-        syncIndex_++;
-    }
-}
- 
-// ==============================================================================
-// 5. Utility & Record Management
-// ==============================================================================
- 
-bool BlockSyncAnalysis::isAlreadySync(CompoundInstanceElement *nowCompound,
-                                      CompoundInstanceElement *frontCompound,
-                                      SyncRecordList &syncRecordList,
-                                      unsigned recordListIndex) {
-    PipelineType frontPipe = frontCompound->kPipeValue;
-    if (recordListIndex >= syncRecordList.size()) return false; 
-    return syncRecordList[recordListIndex].alreadySync[static_cast<unsigned>(frontPipe)] != nullptr;
-}
- 
-void BlockSyncAnalysis::UpdateAlreadySync(const SyncOps &syncVector,
-                                          SyncRecordList &syncRecordList,
-                                          const PipelineType nowPipeValue,
-                                          unsigned index) {
-    if (index >= syncRecordList.size()) return;
- 
-    for (auto &sync : syncVector) {
-        UpdateSyncRecord(sync, syncRecordList[index], nowPipeValue);
-    }
-}
- 
-void BlockSyncAnalysis::UpdateSyncRecord(const SyncOperation *sync,
-                                         SyncRecord &syncRecord,
-                                         PipelineType nowPipeValue) {
-    PipelineType setPipe = sync->GetSrcPipe();
-    PipelineType waitPipe = sync->GetDstPipe();
-    
-    bool isBarrier = (sync->GetType() == SyncOperation::TYPE::PIPE_BARRIER);
-    
-    if (isBarrier) {
-        syncRecord.alreadySync[static_cast<unsigned>(nowPipeValue)] = sync;
-    } else if (syncRecord.alreadySync[static_cast<unsigned>(waitPipe)] || 
-               nowPipeValue == waitPipe) {
-        if (sync->GetType() == SyncOperation::TYPE::SET_EVENT) {
-             syncRecord.alreadySync[static_cast<unsigned>(setPipe)] = sync;
-        }
-    }
-}
- 
-void BlockSyncAnalysis::UpdateSyncRecordInfo(CompoundInstanceElement *frontCompound,
-                                             SyncRecordList &syncRecordList) {
-    assert(!syncOperations_.empty());
-    auto &lastSyncPair = syncOperations_.back(); 
-    auto *setOp = lastSyncPair[0].get();
-    
-    unsigned idx = frontCompound->GetIndex();
-    // [Trace]
-    llvm::errs() << " [Trace Record] Updating Record for Node " << idx 
-                 << ", SetPipe=" << (int)setOp->GetSrcPipe() << "\n";
- 
-    if (idx < syncRecordList.size()) {
-        syncRecordList[idx].alreadySync[static_cast<unsigned>(setOp->GetSrcPipe())] = setOp;
-    }
-}
- 
-void BlockSyncAnalysis::InsertLastPipeAll() {
-  llvm::errs() << "\n[InsertLastPipeAll] Scan backwards for injection point...\n";
-  for (auto it = syncIR_.rbegin(); it != syncIR_.rend(); ++it) {
-    auto *element = it->get();
-    
-    // [Debug] Print Element Type
-    llvm::errs() << "  Scanning Node " << element->GetIndex() << " Kind: ";
-    switch(element->GetKind()) {
-        case InstanceElement::KindTy::COMPOUND: llvm::errs() << "COMPOUND\n"; break;
-        case InstanceElement::KindTy::LOOP: llvm::errs() << "LOOP\n"; break;
-        case InstanceElement::KindTy::BRANCH: llvm::errs() << "BRANCH\n"; break;
-        case InstanceElement::KindTy::PLACE_HOLDER: llvm::errs() << "PLACE_HOLDER\n"; break;
-        default: llvm::errs() << "UNKNOWN\n"; break;
-    }
- 
-    if (isa<PlaceHolderInstanceElement>(element)) continue;
- 
-    auto barrierOp = std::make_unique<SyncOperation>(
-        SyncOperation::TYPE::PIPE_BARRIER, 
-        PipelineType::PIPE_ALL, 
-        PipelineType::PIPE_ALL, 
-        syncOperations_.size(), 0, std::nullopt);
- 
-    SyncOperation* barrierRawPtr = barrierOp.get();
-    SmallVector<std::unique_ptr<SyncOperation>> syncGroup;
-    syncGroup.push_back(std::move(barrierOp));
-    syncOperations_.push_back(std::move(syncGroup));
- 
-    if (auto *compound = dyn_cast<CompoundInstanceElement>(element)) {
-      llvm::errs() << "  [Trace Insert] Final Barrier at Node " << compound->GetIndex() << " (POST)\n";
-      compound->pipeAfter.push_back(barrierRawPtr);
-      return; 
-    } 
-    else if (auto *loop = dyn_cast<LoopInstanceElement>(element)) {
-      llvm::errs() << "  [Trace Insert] Final Barrier at Node " << loop->GetIndex() << " (POST)\n";
-      loop->pipeAfter.push_back(barrierRawPtr);
-      return; 
-    }
-    else if (auto *branch = dyn_cast<BranchInstanceElement>(element)) {
-      // 只有 IF_END 才适合挂载 Barrier
-      if (branch->getBranchKind() == KindOfBranch::IF_END) {
-        llvm::errs() << "  [Trace Insert] Final Barrier at Node " << branch->GetIndex() << " (POST)\n";
-        branch->pipeAfter.push_back(barrierRawPtr);
-        return; 
-      }
-    }
-  }
-  llvm::errs() << "  [Warning] No valid insertion point found for Final Barrier.\n";
-}
- 
-// ==============================================================================
-// 6. Branch Handling Logic
-// ==============================================================================
- 
 unsigned BlockSyncAnalysis::InsertBranchSync(
     unsigned index, CompoundInstanceElement *nowCompound, unsigned begin,
     BranchInstanceElement *branchElement, SyncIRs &syncElement,
-    SyncRecordList &syncRecordList, const std::optional<unsigned> &forEndIndex,
-    InstanceElement *waitAnchor) { 
+    SyncRecordList &syncRecordList,
+    const std::optional<unsigned> &forEndIndex) {
   if (branchElement->getBranchKind() == KindOfBranch::IF_END) {
-    SyncRecordList syncRecordIfList = syncRecordList;   
-    SyncRecordList syncRecordElseList = syncRecordList; 
- 
-    unsigned ifStart = branchElement->beginId;
-    unsigned ifEnd   = branchElement->branchId; 
-    unsigned elseStart = branchElement->branchId;
-    unsigned elseEnd   = branchElement->endId;   
- 
-    InstanceElement* ifAnchor = nullptr;
-    if (branchElement->branchId > 0) {
-        ifAnchor = syncElement[branchElement->branchId - 1].get();
-    }
- 
-    InstanceElement* elseAnchor = nullptr;
-    if (branchElement->branchId < syncElement.size()) {
-        if (auto *elseBeginElem = dyn_cast<BranchInstanceElement>(syncElement[branchElement->branchId].get())) {
-            if (elseBeginElem->endId > 0) {
-                elseAnchor = syncElement[elseBeginElem->endId - 1].get();
-            }
-        }
-    }
-    
-    // [Trace]
-    llvm::errs() << "\n [Trace Branch] IF Analysis. IfStart=" << ifStart << ", IfEnd=" << ifEnd 
-                 << ", ElseStart=" << elseStart << ", ElseEnd=" << elseEnd << "\n";
-    llvm::errs() << "   IfAnchor=" << (ifAnchor ? ifAnchor->GetIndex() : -1) 
-                 << ", ElseAnchor=" << (elseAnchor ? elseAnchor->GetIndex() : -1) << "\n";
- 
-    InsertSeqSync(nowCompound, syncElement, ifStart + 1, ifEnd, 
-                  syncRecordIfList, forEndIndex, nullptr);
+    SyncRecordList syncRecordIfList = syncRecordList;
 
-    // [Fix] 传递 waitAnchor 给 If 分支
-    InsertSeqSync(nowCompound, syncElement, ifStart + 1, ifEnd, 
-                  syncRecordIfList, forEndIndex, waitAnchor);
+    // The indices here are positions in `syncElement` (which may be a slice
+    // like backSyncIr), so compute ranges relative to `index`.
+    unsigned branchIf =
+        index - (branchElement->endId - branchElement->beginId);
+    unsigned branchElse =
+        index - (branchElement->endId - branchElement->branchId);
+    unsigned branchEnd = index;
+
+    InsertSeqSync(nowCompound, syncElement, static_cast<int>(branchIf),
+                  static_cast<int>(branchElse), syncRecordIfList, forEndIndex);
 
     if (branchElement->branchId != branchElement->endId) {
-      InsertSeqSync(nowCompound, syncElement, elseStart + 1, elseEnd, 
-                    syncRecordElseList, forEndIndex, waitAnchor);
-      
-      MergeAlreadySync(syncRecordList, syncRecordIfList, syncRecordElseList, 
-                       ifAnchor, elseAnchor, forEndIndex);
-      
+      SyncRecordList syncRecordElseList = syncRecordList;
+      InsertSeqSync(nowCompound, syncElement, static_cast<int>(branchElse),
+                    static_cast<int>(branchEnd), syncRecordElseList, forEndIndex);
+      MergeAlreadySync(syncRecordList, syncRecordIfList, syncRecordElseList);
     } else {
-        MergeAlreadySync(syncRecordList, syncRecordIfList, syncRecordList, 
-                         ifAnchor, elseAnchor, forEndIndex);
+      // No else-branch: do not promote `alreadySync`, but keep syncFinder
+      // updates from the then-branch.
+      for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
+        syncRecordList[bufferIdx].syncFinder = syncRecordIfList[bufferIdx].syncFinder;
     }
- 
     return (branchElement->endId - branchElement->beginId);
- 
   } else if (branchElement->getBranchKind() == KindOfBranch::ELSE_BEGIN &&
              index != begin) {
     assert(nowCompound->GetIndex() > branchElement->branchId);
     return (branchElement->branchId - branchElement->beginId);
   }
-  
   return 0;
 }
- 
+
 void BlockSyncAnalysis::MergeAlreadySync(SyncRecordList &syncRecordList,
                                          const SyncRecordList &syncRecordIfList,
-                                         const SyncRecordList &syncRecordElseList,
-                                         InstanceElement* ifAnchor,
-                                         InstanceElement* elseAnchor,
-                                         const std::optional<unsigned> &forEndIndex) {
-  
-  size_t maxPipe = getPipeNum();
-  
-  // [Trace]
-  llvm::errs() << " [Trace Merge] Merging branch results...\n";
-  
-  for (size_t i = 0; i < syncRecordList.size(); i++) {
-    if (syncRecordList[i].alreadySync.size() <= maxPipe) {
-        syncRecordList[i].alreadySync.resize(maxPipe + 1, nullptr);
-    }
-    
-    for (size_t j = 0; j < maxPipe; j++) {
-      if (j >= syncRecordIfList[i].alreadySync.size() || 
-          j >= syncRecordElseList[i].alreadySync.size()) {
-          continue; 
-      }
- 
-      const SyncOperation* syncIf = syncRecordIfList[i].alreadySync[j];
-      const SyncOperation* syncElse = syncRecordElseList[i].alreadySync[j];
-      
-      if (syncIf && syncElse) {
-        // Both synced
-        syncRecordList[i].alreadySync[j] = syncIf;
-      } 
-      else if (syncIf && !syncElse) {
-        llvm::errs() << "   Compensating Else: Node " << i << " Pipe " << j << " -> Set at ElseAnchor\n";
-        if (elseAnchor) {
-            unsigned targetSyncIndex = syncIf->GetSyncIndex();
-            auto phantomSet = std::make_unique<SyncOperation>(
-                SyncOperation::TYPE::SET_EVENT, 
-                syncIf->GetSrcPipe(), syncIf->GetDstPipe(),
-                targetSyncIndex, 
-                elseAnchor->GetIndex(), forEndIndex, true);
-            
-            SyncOperation* rawPtr = phantomSet.get();
-            if (targetSyncIndex < syncOperations_.size()) {
-                syncOperations_[targetSyncIndex].push_back(std::move(phantomSet));
-            } else {
-                SmallVector<std::unique_ptr<SyncOperation>> newSync;
-                newSync.emplace_back(std::move(phantomSet));
-                syncOperations_.emplace_back(std::move(newSync));
-            }
-            // [Trace]
-            llvm::errs() << "   [Trace Insert] Phantom SET at Node " << elseAnchor->GetIndex() << " (PRE)\n";
-            elseAnchor->pipeBefore.push_back(rawPtr);
-            syncRecordList[i].alreadySync[j] = rawPtr;
-        } else {
-            syncRecordList[i].alreadySync[j] = nullptr;
-        }
-      } 
-      else if (!syncIf && syncElse) {
-        llvm::errs() << "   Compensating Then: Node " << i << " Pipe " << j << " -> Set at IfAnchor\n";
-        if (ifAnchor) {
-            unsigned targetSyncIndex = syncElse->GetSyncIndex();
-            auto phantomSet = std::make_unique<SyncOperation>(
-                SyncOperation::TYPE::SET_EVENT, 
-                syncElse->GetSrcPipe(), syncElse->GetDstPipe(),
-                targetSyncIndex, 
-                ifAnchor->GetIndex(), forEndIndex, true);
-            
-            SyncOperation* rawPtr = phantomSet.get();
-            if (targetSyncIndex < syncOperations_.size()) {
-                syncOperations_[targetSyncIndex].push_back(std::move(phantomSet));
-            } else {
-                SmallVector<std::unique_ptr<SyncOperation>> newSync;
-                newSync.emplace_back(std::move(phantomSet));
-                syncOperations_.emplace_back(std::move(newSync));
-            }
-            // [Trace]
-            llvm::errs() << "   [Trace Insert] Phantom SET at Node " << ifAnchor->GetIndex() << " (PRE)\n";
-            ifAnchor->pipeBefore.push_back(rawPtr);
-            syncRecordList[i].alreadySync[j] = rawPtr;
-        } else {
-            syncRecordList[i].alreadySync[j] = nullptr;
-        }
-      } 
-      else {
-        syncRecordList[i].alreadySync[j] = nullptr;
+                                         const SyncRecordList &syncRecordElseList) {
+  for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
+    for (size_t pipeIdx = 0; pipeIdx < kPipeStateSize; pipeIdx++) {
+      if (syncRecordIfList[bufferIdx].alreadySync[pipeIdx] &&
+          syncRecordElseList[bufferIdx].alreadySync[pipeIdx]) {
+        syncRecordList[bufferIdx].alreadySync[pipeIdx] = true;
       }
     }
   }
 }
- 
-// ... Helpers (IsMemAllocOp, GetMemInfoBuffers, GetEventIdNum, IsGMHazard) 保持不变 ...
+
+// ==============================================================================
+// 4. Dependency Analysis & Operation Insertion
+// ==============================================================================
+
+void BlockSyncAnalysis::InsertSync(CompoundInstanceElement *nowCompound,
+                                   CompoundInstanceElement *frontCompound,
+                                   SyncRecordList &syncRecordList,
+                                   const std::optional<unsigned> &forEndIndex) {
+  if (IsNoNeedToInsertSync(nowCompound, frontCompound, forEndIndex.has_value())) {
+    return;
+  }
+  MemAnalyze(nowCompound, frontCompound, syncRecordList, forEndIndex);
+}
+
+void BlockSyncAnalysis::MemAnalyze(CompoundInstanceElement *nowCompound,
+                                   CompoundInstanceElement *frontCompound,
+                                   SyncRecordList &syncRecordList,
+                                   const std::optional<unsigned> &forEndIndex) {
+  if (isAlreadySync(nowCompound, frontCompound, syncRecordList, 0)) {
+    return;
+  }
+
+  DepBaseMemInfoPairVec depVec;
+  if (!IsMemInfoHasDependency(nowCompound, frontCompound, depVec)) {
+    return;
+  }
+
+  // Intra-pipe dependencies that do not touch GM can be ignored to avoid
+  // over-synchronization on local memories.
+  if (nowCompound->kPipeValue == frontCompound->kPipeValue) {
+    bool touchesGM = false;
+    for (auto &pair : depVec) {
+      if ((pair.first && pair.first->scope == pto::AddressSpace::GM) ||
+          (pair.second && pair.second->scope == pto::AddressSpace::GM)) {
+        touchesGM = true;
+        break;
+      }
+    }
+    if (!touchesGM) {
+      return;
+    }
+  }
+
+  if (forEndIndex.has_value()) {
+    int eventIdNum = GetEventIdNum(depVec);
+    for (int i = 1; i < eventIdNum; i++) {
+      if (isAlreadySync(nowCompound, frontCompound, syncRecordList,
+                        static_cast<unsigned>(i))) {
+        return;
+      }
+    }
+  }
+
+  InsertSyncOperation(nowCompound, frontCompound, depVec, forEndIndex);
+  UpdateSyncRecordInfo(frontCompound, syncRecordList);
+}
+
+bool BlockSyncAnalysis::IsMemInfoHasDependency(
+    CompoundInstanceElement *nowCompound,
+    CompoundInstanceElement *frontCompound,
+    DepBaseMemInfoPairVec &depBaseMemInfosVec) {
+  bool hasDependency = false;
+  hasDependency |= memAnalyzer_.DepBetween(nowCompound->useVec, frontCompound->defVec,
+                                          depBaseMemInfosVec);
+  hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->useVec,
+                                          depBaseMemInfosVec);
+  hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->defVec,
+                                          depBaseMemInfosVec);
+
+  // Special hazard: ACC (L0C) read/read cross-pipe ordering.
+  //
+  // Some PTO-ISA sequences have semantically "read/read" patterns on ACC, but
+  // executing them concurrently across pipelines can trigger device-side issues.
+  if (nowCompound->kPipeValue != frontCompound->kPipeValue) {
+    DepBaseMemInfoPairVec rrDepVec;
+    if (memAnalyzer_.DepBetween(nowCompound->useVec, frontCompound->useVec,
+                               rrDepVec)) {
+      for (auto &pair : rrDepVec) {
+        if (!pair.first) continue;
+        if (pair.first->scope != pto::AddressSpace::ACC) continue;
+        depBaseMemInfosVec.push_back(pair);
+        hasDependency = true;
+      }
+    }
+  }
+
+  return hasDependency;
+}
+
+void BlockSyncAnalysis::InsertSyncOperation(
+    CompoundInstanceElement *nowCompound, CompoundInstanceElement *frontCompound,
+    DepBaseMemInfoPairVec &depBaseMemInfosVec,
+    const std::optional<unsigned> &forEndIndex) {
+  PipelineType nowPipe = nowCompound->kPipeValue;
+  PipelineType frontPipe = frontCompound->kPipeValue;
+
+  if (nowPipe == frontPipe) {
+    unsigned insertBarrierId = nowCompound->GetIndex();
+    auto barrierOp = std::make_unique<SyncOperation>(
+        SyncOperation::TYPE::PIPE_BARRIER, frontPipe, nowPipe, syncIndex_,
+        insertBarrierId, forEndIndex);
+    barrierOp->SetDepSyncIRIndex(frontCompound->GetIndex());
+    syncIR_[insertBarrierId]->pipeBefore.push_back(barrierOp.get());
+    barrierOp->SetSyncIRIndex(insertBarrierId);
+
+    SmallVector<std::unique_ptr<SyncOperation>> newSync;
+    newSync.emplace_back(std::move(barrierOp));
+    syncOperations_.emplace_back(std::move(newSync));
+  } else {
+    unsigned insertWaitId = nowCompound->GetIndex();
+    unsigned insertSetId = frontCompound->GetIndex();
+    auto setOp = std::make_unique<SyncOperation>(
+        SyncOperation::TYPE::SET_EVENT, frontPipe, nowPipe, syncIndex_,
+        insertSetId, forEndIndex);
+    auto waitOp = setOp->GetMatchSync(insertWaitId);
+
+    // Back-edge dependencies may require multi-buffer event IDs.
+    if (forEndIndex.has_value()) {
+      int eventIdNum = GetEventIdNum(depBaseMemInfosVec);
+      setOp->eventIdNum = eventIdNum;
+      waitOp->eventIdNum = eventIdNum;
+    }
+
+    syncIR_[insertSetId]->pipeAfter.push_back(setOp.get());
+    syncIR_[insertWaitId]->pipeBefore.push_back(waitOp.get());
+
+    SmallVector<std::unique_ptr<SyncOperation>> newSync;
+    newSync.emplace_back(std::move(setOp));
+    newSync.emplace_back(std::move(waitOp));
+    syncOperations_.emplace_back(std::move(newSync));
+  }
+
+  syncIndex_++;
+  assert(syncOperations_.size() == syncIndex_);
+}
+
+// ==============================================================================
+// 5. Sync Record Maintenance
+// ==============================================================================
+
+bool BlockSyncAnalysis::isAlreadySync(CompoundInstanceElement *nowCompound,
+                                      CompoundInstanceElement *frontCompound,
+                                      SyncRecordList &syncRecordList,
+                                      unsigned recordListIndex) {
+  (void)nowCompound;
+  const PipelineType frontPipe = frontCompound->kPipeValue;
+  if (recordListIndex >= syncRecordList.size()) return false;
+  if (!isValidPipeIndex(frontPipe)) return false;
+  return syncRecordList[recordListIndex]
+      .alreadySync[static_cast<unsigned>(frontPipe)];
+}
+
+void BlockSyncAnalysis::UpdateAlreadySync(const SyncOps &syncVector,
+                                         SyncRecordList &syncRecordList,
+                                         const PipelineType nowPipeValue) {
+  for (auto *sync : syncVector) {
+    for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
+      if (bufferIdx == 0 && sync->eventIdNum > 1 &&
+          sync->GetForEndIndex().has_value()) {
+        continue;
+      }
+      UpdateSyncRecord(sync, syncRecordList[bufferIdx], nowPipeValue);
+    }
+  }
+}
+
+void BlockSyncAnalysis::UpdateSyncRecord(const SyncOperation *sync,
+                                        SyncRecord &syncRecord,
+                                        PipelineType nowPipeValue) {
+  PipelineType setPipeValue = sync->GetSrcPipe();
+  PipelineType waitPipeValue = sync->GetDstPipe();
+
+  // Block-sync mode behaves like a global blocking pipe-s wait.
+  if (syncAnalysisMode_ == SyncAnalysisMode::BLOCKSYNC) {
+    nowPipeValue = PipelineType::PIPE_S;
+    waitPipeValue = PipelineType::PIPE_S;
+  }
+
+  if (!isValidPipeIndex(nowPipeValue) || !isValidPipeIndex(waitPipeValue) ||
+      !isValidPipeIndex(setPipeValue)) {
+    return;
+  }
+
+  auto &recordAlready = syncRecord.alreadySync;
+  auto &recordFinder = syncRecord.syncFinder;
+
+  bool barrierFinder =
+      (nowPipeValue == waitPipeValue) &&
+      (sync->GetType() == SyncOperation::TYPE::PIPE_BARRIER);
+  if (barrierFinder) {
+    recordAlready[static_cast<unsigned>(nowPipeValue)] = true;
+    return;
+  }
+
+  bool canTransitivelyEliminate =
+      recordAlready[static_cast<unsigned>(waitPipeValue)] ||
+      (nowPipeValue == waitPipeValue);
+  if (!canTransitivelyEliminate) return;
+
+  if (recordFinder[sync->GetSyncIndex()] &&
+      (sync->GetType() == SyncOperation::TYPE::SET_EVENT ||
+       sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_SET)) {
+    recordAlready[static_cast<unsigned>(setPipeValue)] = true;
+  }
+
+  if (sync->GetType() == SyncOperation::TYPE::WAIT_EVENT ||
+      sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_WAIT) {
+    recordFinder[sync->GetSyncIndex()] = true;
+  }
+}
+
+void BlockSyncAnalysis::UpdateSyncRecordInfo(CompoundInstanceElement *frontCompound,
+                                             SyncRecordList &syncRecordList) {
+  (void)frontCompound;
+  assert(!syncOperations_.empty());
+  auto &syncPair = syncOperations_.back();
+  assert(!syncPair.empty());
+
+  auto *newSync = syncPair[0].get();
+  for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
+    if (bufferIdx == 0 && newSync->eventIdNum > 1) {
+      continue;
+    }
+    if (!isValidPipeIndex(newSync->GetSrcPipe())) continue;
+    syncRecordList[bufferIdx]
+        .alreadySync[static_cast<unsigned>(newSync->GetSrcPipe())] = true;
+  }
+}
+
+// ==============================================================================
+// 6. Final Barrier
+// ==============================================================================
+
+void BlockSyncAnalysis::InsertLastPipeAll() {
+  for (auto it = syncIR_.rbegin(); it != syncIR_.rend(); ++it) {
+    auto *element = it->get();
+    if (isa<PlaceHolderInstanceElement>(element)) continue;
+
+    auto barrierOp = std::make_unique<SyncOperation>(
+        SyncOperation::TYPE::PIPE_BARRIER, PipelineType::PIPE_ALL,
+        PipelineType::PIPE_ALL, syncIndex_, element->GetIndex(), std::nullopt);
+
+    SyncOperation *barrierRawPtr = barrierOp.get();
+    SmallVector<std::unique_ptr<SyncOperation>> syncGroup;
+    syncGroup.emplace_back(std::move(barrierOp));
+    syncOperations_.emplace_back(std::move(syncGroup));
+    syncIndex_++;
+
+    element->pipeAfter.push_back(barrierRawPtr);
+    return;
+  }
+}
+
+// ==============================================================================
+// 7. Helpers
+// ==============================================================================
+
 bool BlockSyncAnalysis::IsMemAllocOp(Operation *op) const {
-    return isa<memref::AllocOp>(op) || isa<pto::PointerCastOp>(op); 
+  return isa<memref::AllocOp>(op) || isa<pto::PointerCastOp>(op);
 }
- 
-SmallVector<Value> BlockSyncAnalysis::GetMemInfoBuffers(
+
+SmallVector<Value>
+BlockSyncAnalysis::GetMemInfoBuffers(const DepBaseMemInfoPairVec &depBaseMemInfosVec) {
+  llvm::DenseSet<Value> touchedBuffer;
+  SmallVector<Value> result;
+  for (auto &pair : depBaseMemInfosVec) {
+    if (pair.first && pair.first->rootBuffer)
+      touchedBuffer.insert(pair.first->rootBuffer);
+    if (pair.second && pair.second->rootBuffer)
+      touchedBuffer.insert(pair.second->rootBuffer);
+  }
+  for (auto v : touchedBuffer)
+    result.push_back(v);
+  return result;
+}
+
+int BlockSyncAnalysis::GetEventIdNum(
     const DepBaseMemInfoPairVec &depBaseMemInfosVec) {
-    llvm::DenseSet<Value> touchedBuffer;
-    SmallVector<Value> result;
-    for (auto &pair : depBaseMemInfosVec) {
-        if (pair.first && pair.first->rootBuffer) touchedBuffer.insert(pair.first->rootBuffer);
-        if (pair.second && pair.second->rootBuffer) touchedBuffer.insert(pair.second->rootBuffer);
-    }
-    for (auto v : touchedBuffer) result.push_back(v);
-    return result;
+  for (const auto &pair : depBaseMemInfosVec) {
+    bool isLocalA =
+        pair.first && (pair.first->scope == pto::AddressSpace::MAT ||
+                       pair.first->scope == pto::AddressSpace::VEC);
+    bool isLocalB =
+        pair.second && (pair.second->scope == pto::AddressSpace::MAT ||
+                        pair.second->scope == pto::AddressSpace::VEC);
+    if (isLocalA || isLocalB) return 2;
+  }
+  return 1;
 }
- 
-int BlockSyncAnalysis::GetEventIdNum(const DepBaseMemInfoPairVec &depBaseMemInfosVec) {
-    for (const auto &pair : depBaseMemInfosVec) {
-        // 逻辑含义：只要涉及 Matrix Buffer (MAT) 或者 Vector Buffer (UB)，都视为片上依赖，可能需要 Double Buffer。
-        bool isLocalA = pair.first && (pair.first->scope == pto::AddressSpace::MAT || pair.first->scope == pto::AddressSpace::VEC);
-        bool isLocalB = pair.second && (pair.second->scope == pto::AddressSpace::MAT || pair.second->scope == pto::AddressSpace::VEC);
-        if (isLocalA || isLocalB) return 2;
-    }
-    return 1; 
-}
- 
+
 bool BlockSyncAnalysis::IsGMHazard(const CompoundInstanceElement *nowCompound,
-                                   const CompoundInstanceElement *frontCompound) const {
-  // Helper: 检查集合中是否包含 GM 资源
+                                  const CompoundInstanceElement *frontCompound) const {
   auto hasGM = [](const SmallVector<const BaseMemInfo *> &vec) {
     for (const auto *info : vec) {
-        if (info->scope == pto::AddressSpace::GM) return true;
+      if (info->scope == pto::AddressSpace::GM) return true;
     }
     return false;
   };
 
-  // 1. 获取前驱节点 (Front) 的 GM 读写状态
-  bool frontWritesGM = hasGM(frontCompound->defVec); // Def = Write
-  bool frontReadsGM  = hasGM(frontCompound->useVec); // Use = Read
+  bool frontWritesGM = hasGM(frontCompound->defVec);
+  bool frontReadsGM = hasGM(frontCompound->useVec);
 
-  // 2. 获取当前节点 (Now) 的 GM 读写状态
   bool nowWritesGM = hasGM(nowCompound->defVec);
-  bool nowReadsGM  = hasGM(nowCompound->useVec);
+  bool nowReadsGM = hasGM(nowCompound->useVec);
 
-  // 3. 判定 Hazard (只要命中以下任意一种，就需要 Barrier)
-  
-  // Case A: RAW (Read After Write) - 前面写，后面读
-  if (frontWritesGM && nowReadsGM) return true;
+  if (frontWritesGM && nowReadsGM) return true;  // RAW
+  if (frontReadsGM && nowWritesGM) return true;  // WAR
+  if (frontWritesGM && nowWritesGM) return true; // WAW
 
-  // Case B: WAR (Write After Read) - 前面读，后面写
-  if (frontReadsGM && nowWritesGM) return true;
-
-  // Case C: WAW (Write After Write) - 前面写，后面也写
-  if (frontWritesGM && nowWritesGM) return true;
-
-  // Case D: RAR (Read After Read) - 前面读，后面也读
-  // 这是唯一的安全情况！也是本次优化的目标。
-  // explicitly: if (frontReadsGM && nowReadsGM) return false;
-
+  // RAR is considered safe for GM in this simplified model.
   return false;
 }
- 
-} // namespace pto
-} // namespace mlir
+
+} // namespace mlir::pto

--- a/test/samples/InsertSync/add_double_dynamic.py
+++ b/test/samples/InsertSync/add_double_dynamic.py
@@ -1,0 +1,77 @@
+def main():
+    # Reproducer for zhangstevenunity/PTOAS#128:
+    # `ptoas --enable-insert-sync` must handle double-buffer + dynamic-shape IR
+    # without crashing in SyncEventIdAllocation.
+    print(
+        r"""module {
+  func.func @vec_add_1d_dynamic(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>, %arg3: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8192 = arith.constant 8192 : index
+    %0 = pto.get_block_idx
+    %1 = pto.get_subblock_idx
+    %2 = pto.get_subblock_num
+    %3 = arith.muli %0, %2 : i64
+    %4 = arith.addi %3, %1 : i64
+    %5 = pto.get_block_num
+    %6 = arith.index_cast %4 : i64 to index
+    %7 = arith.index_cast %5 : i64 to index
+    %8 = arith.index_cast %arg3 : i32 to index
+    %9 = arith.ceildivsi %8, %c8192 : index
+    %10 = arith.ceildivsi %9, %7 : index
+    %11 = arith.muli %6, %10 : index
+    pto.section.vector {
+      %12 = pto.make_tensor_view %arg0, shape = [%8] strides = [%c1] : !pto.tensor_view<?xf32>
+      %13 = pto.make_tensor_view %arg1, shape = [%8] strides = [%c1] : !pto.tensor_view<?xf32>
+      %14 = pto.make_tensor_view %arg2, shape = [%8] strides = [%c1] : !pto.tensor_view<?xf32>
+      %15 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %16 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %17 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %18 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %19 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %20 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %21 = arith.cmpi slt, %11, %9 : index
+      scf.if %21 {
+        %22 = arith.addi %11, %10 : index
+        %23 = arith.cmpi sgt, %22, %9 : index
+        %24 = arith.subi %9, %11 : index
+        %25 = arith.select %23, %24, %10 : index
+        %26 = arith.muli %25, %c8192 : index
+        %27 = arith.cmpi sgt, %26, %c0 : index
+        scf.if %27 {
+          scf.for %arg4 = %c0 to %25 step %c1 {
+            %28 = arith.addi %arg4, %11 : index
+            %29 = arith.muli %28, %c8192 : index
+            %30 = pto.partition_view %12, offsets = [%29], sizes = [%c8192] : !pto.tensor_view<?xf32> -> !pto.partition_tensor_view<1x8192xf32>
+            %31 = pto.partition_view %13, offsets = [%29], sizes = [%c8192] : !pto.tensor_view<?xf32> -> !pto.partition_tensor_view<1x8192xf32>
+            %32 = pto.partition_view %14, offsets = [%29], sizes = [%c8192] : !pto.tensor_view<?xf32> -> !pto.partition_tensor_view<1x8192xf32>
+            %33 = arith.remui %arg4, %c2 : index
+            %34 = arith.cmpi eq, %33, %c0 : index
+            scf.if %34 {
+              pto.tload ins(%30 : !pto.partition_tensor_view<1x8192xf32>) outs(%15 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              pto.tload ins(%31 : !pto.partition_tensor_view<1x8192xf32>) outs(%16 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              pto.tadd ins(%15, %16 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%17 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              pto.tstore ins(%17 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%32 : !pto.partition_tensor_view<1x8192xf32>)
+            }
+            %35 = arith.cmpi eq, %33, %c1 : index
+            scf.if %35 {
+              pto.tload ins(%30 : !pto.partition_tensor_view<1x8192xf32>) outs(%18 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              pto.tload ins(%31 : !pto.partition_tensor_view<1x8192xf32>) outs(%19 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              pto.tadd ins(%18, %19 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%20 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              pto.tstore ins(%20 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8192, v_row=1, v_col=8192, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%32 : !pto.partition_tensor_view<1x8192xf32>)
+            }
+          }
+        }
+      }
+    }
+    return
+  }
+}
+"""
+    )
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
Fixes #128.

## Root cause
`--enable-insert-sync` builds a linearized SyncIR and then `SyncEventIdAllocation` assumes every sync pair has a well-ordered lifetime interval (`begin < end`).

For double-buffer + dynamic-shape + control-flow (nested `scf.if` + `scf.for`), the previous loop/branch handling could form “reverse” / degenerate intervals (e.g. a branch-merged phantom SET sharing a syncIndex with a barrier, or loop-carried/back-edge sets where the computed begin/end order is inverted). That violates the allocator invariant and triggers `assert(begin < end)` (or produces a bad set/wait ordering across if/else paths, which can hang on device).

## What this PR changes
- Rework loop + branch control-flow sync analysis to follow the AscendNPU-IR style interval construction, keeping set/wait lifetimes ordered.
- Adjust branch sync-state movement so SETs are placed on the correct side of branches (so the paired WAIT is guaranteed to observe a SET on all control paths).

## Tests
- Add `test/samples/InsertSync/add_double_dynamic.py` reproducer from the issue.
- Verified locally: `ptoas --enable-insert-sync` no longer aborts on the reproducer and generates C++ successfully.

## Notes
This PR intentionally keeps the diff focused on insert-sync (no unrelated sample-op naming cleanups).
