### PR TITLE
Fix NPU validation golden indices for TSCATTER

### DIFF
--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -1024,12 +1024,12 @@ def generate_testcase(
     input_generate = []
     elem_count = logical_elem_count
     # Some kernels use an integer tensor as "indices". The safe in-range domain
-    # depends on the op semantics. For the pto-isa a2a3 implementations:
-    # - TSCATTER: indices are linear indices in [0, rows*cols)
+    # depends on the op semantics (see pto-isa docs):
+    # - TSCATTER: indices are row indices in [0, rows)
     # - TGATHER/TGATHERB: indices are linear indices in [0, rows*cols)
     index_mod = None
     if "TSCATTER" in raw_kernel:
-        index_mod = max(elem_count, 1)
+        index_mod = max(rows, 1)
     elif any(m in raw_kernel for m in ("TGATHER", "TGATHERB")):
         index_mod = max(elem_count, 1)
     mrgsort_packed = "TMRGSORT" in raw_kernel


### PR DESCRIPTION
Fixes a bug in `test/npu_validation/scripts/generate_testcase.py` where we generate integer "indices" inputs for kernels containing `TSCATTER`.

**Root cause**
- The generator assumed `TSCATTER` indices are *linear indices* in `[0, rows*cols)`.
- Per PTO-ISA semantics, `TSCATTER` uses **row indices**: for each `(i, j)`, it writes `dst[idx[i,j], j] = src[i,j]`.
- Generating indices up to `rows*cols` (e.g. 0..1023 for 32x32) can go out-of-bounds on the row dimension and may crash on NPU (vector core exception).

**Fix**
- For kernels containing `TSCATTER`, generate indices in-range: `index_mod = rows`.
- Keep `TGATHER/TGATHERB` generation unchanged.

**How to validate**
- Run remote NPU validation for `scatter` (or any case using `TSCATTER`). It should no longer hit `aclrtSynchronizeStream=507035` / vector core exception.
