### PR TITLE
pto: arch-aware sync lowering + alloc_tile addr

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -187,7 +187,8 @@ def AllocTileOp : PTO_Op<"alloc_tile", [AttrSizedOperandSegments]> {
 
   let arguments = (ins
     Optional<Index>:$valid_row,
-    Optional<Index>:$valid_col
+    Optional<Index>:$valid_col,
+    Optional<I64>:$addr
   );
 
   let results = (outs TileBufType:$result);
@@ -195,6 +196,7 @@ def AllocTileOp : PTO_Op<"alloc_tile", [AttrSizedOperandSegments]> {
   let assemblyFormat = [{
     (`valid_row` `=` $valid_row^)? 
     (`valid_col` `=` $valid_col^)?
+    (`addr` `=` $addr^)?
      attr-dict `:` qualified(type($result))
   }];
 

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -34,9 +34,15 @@ std::unique_ptr<Pass> createPTOHighDimLoweringPass();
 std::unique_ptr<Pass> createPTOVFloopGatherPass();
 std::unique_ptr<Pass> createLoweringSyncToPipePass();
 
+enum class PTOArch {
+  A3,
+  A5,
+};
+
 // Creates a pass for ...
 std::unique_ptr<Pass> createPTOInsertSyncPass();
 std::unique_ptr<Pass> createEmitPTOManualPass();
+std::unique_ptr<Pass> createEmitPTOManualPass(PTOArch arch);
 
 
 /// Create a pass to convert ops from other dialects to PTO Ops.
@@ -54,7 +60,6 @@ std::unique_ptr<Pass> createPTOInsertCVMovPass();
 std::unique_ptr<Pass> createPTOConvertToDPSPass();
 std::unique_ptr<Pass> createPTORemoveRedundantBarrierPass();
 std::unique_ptr<Pass> createPTOViewToMemrefPass();
-std::unique_ptr<Pass> createEmitPTOManualPass();
 std::unique_ptr<mlir::Pass> createPTOInsertLoadStoreForMixCVPass();
 std::unique_ptr<Pass> createInferPTOLayoutPass();
 // Declare register function

--- a/python/pto/dialects/PTOOps.td
+++ b/python/pto/dialects/PTOOps.td
@@ -1,0 +1,13 @@
+//===- PTOOps.td - PTO dialect ops for python bindings --------*- tablegen -*-===//
+//
+// This file exists to drive -gen-python-op-bindings. Keep it as a thin wrapper
+// around the canonical ODS definitions in include/PTO/IR.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_PTO_PYTHON_PTOOPS
+#define MLIR_DIALECT_PTO_PYTHON_PTOOPS
+
+include "PTO/IR/PTOOps.td"
+
+#endif // MLIR_DIALECT_PTO_PYTHON_PTOOPS


### PR DESCRIPTION
Sync changes from local ptoas repo (commit ee3f121f53734a1ae2329175c39e0d97cafca1ce):
- Add optional addr to alloc_tile
- Add PTOArch and overload createEmitPTOManualPass
- Switch sync set/wait emitc callee for A3
- Add python ODS wrapper for -gen-python-op-bindings