### PR TITLE
samples: rename bf16 regression case

### DIFF
--- a/test/samples/Bf16/bf16_tile.py
+++ b/test/samples/Bf16/bf16_tile.py
@@ -37,7 +37,7 @@ def build():
 
         fn_ty = func.FunctionType.get([ptr_bf16], [])
         with InsertionPoint(module.body):
-            fn = func.FuncOp("issue152_bf16", fn_ty)
+            fn = func.FuncOp("bf16_tile", fn_ty)
             entry = fn.add_entry_block()
 
         with InsertionPoint(entry):
@@ -62,4 +62,3 @@ def build():
 
 if __name__ == "__main__":
     print(build())
-

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -267,16 +267,15 @@ process_one_dir() {
       fi
     fi
 
-    # Regression guard for Issue #152:
-    # bf16 tiles must lower to `__bf16` in Tile<> / GlobalTensor<> templates.
-    if [[ "$base" == "issue152_bf16" ]]; then
+    # Regression guard: bf16 tiles must lower to `__bf16` in Tile<> / GlobalTensor<> templates.
+    if [[ "$base" == "bf16_tile" ]]; then
       if ! grep -Fq "GlobalTensor<__bf16" "$cpp"; then
-        echo -e "${A}(${base}.py)\tFAIL\tbf16 GlobalTensor element type is not __bf16 (issue #152)"
+        echo -e "${A}(${base}.py)\tFAIL\tbf16 GlobalTensor element type is not __bf16"
         overall=1
         continue
       fi
       if ! grep -Eq "Tile<[^>]*, __bf16," "$cpp"; then
-        echo -e "${A}(${base}.py)\tFAIL\tbf16 Tile element type is not __bf16 (issue #152)"
+        echo -e "${A}(${base}.py)\tFAIL\tbf16 Tile element type is not __bf16"
         overall=1
         continue
       fi


### PR DESCRIPTION
Rename the bf16 lowering regression sample to avoid issue-number naming.

- Move sample to `test/samples/Bf16/bf16_tile.py`.
- Update `test/samples/runop.sh` guard to match the new name.