### PR TITLE
Fix Scatter NPU validation on Ascend910 (TSCATTER PIPE_S sync)

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3073,7 +3073,7 @@ def TScatterOp: PTO_TOp<"tscatter", [
   OpPipeInterface,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]> {
-  let summary = "TSCATTER: Scatter rows of a source tile into a destination tile using per-element row indices.";
+  let summary = "TSCATTER: Scatter elements of a source tile into a destination tile using per-element indices.";
 
   let arguments = (ins
     PTODpsType:$src,
@@ -3092,7 +3092,25 @@ def TScatterOp: PTO_TOp<"tscatter", [
   }];
 
   let extraClassDeclaration = [{
-    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::pto::PIPE getPipe() {
+      // NOTE: On dav-c220 (Ascend910 A2/A3), pto-isa implements TSCATTER as a
+      // scalar loop over UB pointers, which executes on the scalar pipeline
+      // (PIPE_S). Waiting on PIPE_V does not block scalar UB accesses and can
+      // lead to using uninitialized indices/data (crash / aivec exception).
+      //
+      // On A5 instruction set devices, TSCATTER is implemented with vector
+      // scatter instructions and should be treated as PIPE_V.
+      auto moduleOp = getOperation()->getParentOfType<::mlir::ModuleOp>();
+      if (moduleOp) {
+        if (auto spec = moduleOp->getAttrOfType<::mlir::StringAttr>("pto.device-spec")) {
+          auto s = spec.getValue();
+          if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95")) {
+            return ::mlir::pto::PIPE::PIPE_V;
+          }
+        }
+      }
+      return ::mlir::pto::PIPE::PIPE_S;
+    }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
   }];
 }

--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -1040,11 +1040,11 @@ def generate_testcase(
     elem_count = logical_elem_count
     # Some kernels use an integer tensor as "indices". The safe in-range domain
     # depends on the op semantics (see pto-isa docs):
-    # - TSCATTER: indices are row indices in [0, rows)
+    # - TSCATTER: indices are linear indices in [0, rows*cols)
     # - TGATHER/TGATHERB: indices are linear indices in [0, rows*cols)
     index_mod = None
     if "TSCATTER" in raw_kernel:
-        index_mod = max(rows, 1)
+        index_mod = max(elem_count, 1)
     elif any(m in raw_kernel for m in ("TGATHER", "TGATHERB")):
         index_mod = max(elem_count, 1)
     mrgsort_packed = "TMRGSORT" in raw_kernel


### PR DESCRIPTION
### Problem
On Ascend910 (dav-c220) board validation, the `Scatter` sample can fail at runtime with `aclrtSynchronizeStream(stream) failed: 507035` (AIVEC exception). In addition, the NPU-golden compare can be flaky because most of the output tile is left uninitialized when indices are restricted to `[0, rows)`.

### Root cause
1. **Wrong pipe used for auto-inserted sync around `TSCATTER`**
   - `pto.tscatter` was modeled as `PIPE_V`, so InsertSync inserted `set_flag/wait_flag(PIPE_MTE2, PIPE_V, ...)` before `TSCATTER` and `set_flag/wait_flag(PIPE_V, PIPE_MTE3, ...)` before `TSTORE`.
   - On Ascend910 A2/A3, `pto-isa` implements `TSCATTER` as a scalar loop over UB pointers, which executes on the scalar pipeline (`PIPE_S`). Waiting on `PIPE_V` does **not** block those scalar UB accesses, so `TSCATTER` can observe unready/garbage indices and trigger invalid UB addressing (AIVEC exception).
2. **`TSCATTER` indices generation for NPU validation**
   - The generated indices were constrained to `[0, rows)`, which means only a small prefix of the destination tile is written. The rest remains uninitialized UB data, so the second run may not match the first run in `GOLDEN_MODE=npu`.

### Fix
- Model `pto.tscatter` as `PIPE_S` for dav-c220 targets so InsertSync inserts:
  - `PIPE_MTE2 -> PIPE_S` before `TSCATTER`
  - `PIPE_S -> PIPE_MTE3` before `TSTORE`
- Keep `PIPE_V` for A5 device-specs (`Ascend950*` / `Ascend910_95*`).
- In NPU validation testcase generation, treat `TSCATTER` indices as linear offsets in `[0, rows*cols)`.

### Tests
- Codegen: `bash test/samples/runop.sh -t Scatter` produces `scatter-pto.cpp` with `PIPE_MTE2 -> PIPE_S` and `PIPE_S -> PIPE_MTE3` sync.
- Board validation (Ascend910): `RUN_ONLY_CASES=scatter ... run_remote_npu_validation.sh` passed 3 consecutive runs.
