### PR TITLE
Fix SyncHigh build on A5 (set_flag pipe constraints)

### DIFF
--- a/test/samples/SyncHigh/syncHigh.py
+++ b/test/samples/SyncHigh/syncHigh.py
@@ -1,51 +1,81 @@
 #!/usr/bin/env python3
-from mlir.ir import Context, Location, Module, InsertionPoint, IndexType
-from mlir.dialects import func, pto, arith
-from mlir.dialects.pto import (
-    TLOAD, TSTORE_VEC,
-    TMOV_M2V,
-    TMATMUL, TVEC, TVECWAIT_EVENT,
-    EVENT_ID0, EVENT_ID1, EVENT_ID2, EVENT_ID3, EVENT_ID4,
-)
+from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.dialects import func, arith, pto
+from mlir.ir import F32Type, IndexType
 
-def cidx(v):
-    return arith.ConstantOp(IndexType.get(), v).result
 
-def main():
-    with Context() as ctx, Location.unknown():
-        pto.register_dialect(ctx)
-        module = Module.create()
-        with InsertionPoint(module.body):
-            f = func.FuncOp("run_sync_high", func.FunctionType.get([], []))
-        entry = f.add_entry_block()
-        with InsertionPoint(entry):
-            # NOTE(A5):
-            # `pto.record_event/pto.wait_event` lower to `set_flag/wait_flag`.
-            # On Ascend A5 toolchains, `set_flag/wait_flag` only accept a
-            # subset of PIPE enums (commonly S/V/MTE2/MTE3). Keep this sample
-            # restricted to those pipes so it can be compiled in vector mode.
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+
+        with Location.unknown(ctx):
+            m = Module.create()
+
+            f32 = F32Type.get(ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+
+            tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
+            tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+            vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+            pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+
+            fractal_ab_size = pto.TileConfig.fractalABSize
+            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+
+            # A real kernel that manually inserts set_flag/wait_flag.
             #
-            # Use string names to exercise helper auto-conversion.
-            pto.record_event(TLOAD,          TLOAD,          EVENT_ID0)
-            pto.wait_event  (TLOAD,          TLOAD,          EVENT_ID0)
+            # NOTE(A5): `set_flag/wait_flag` only accept a subset of PIPE enums on A5.
+            # Keep this sample in the supported set by using MTE2/V/MTE3 only.
+            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
+            with InsertionPoint(m.body):
+                fn = func.FuncOp("run_sync_high", fn_ty)
+                entry = fn.add_entry_block()
 
-            pto.record_event(TSTORE_VEC,     TSTORE_VEC,     EVENT_ID1)
-            pto.wait_event  (TSTORE_VEC,     TSTORE_VEC,     EVENT_ID1)
+            with InsertionPoint(entry):
+                c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
+                c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
+                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+                scale = arith.ConstantOp(f32, 3.14).result
+                pipe_mte2 = pto.PipeAttr.get(pto.PIPE.PIPE_MTE2, ctx)
+                pipe_v = pto.PipeAttr.get(pto.PIPE.PIPE_V, ctx)
+                pipe_mte3 = pto.PipeAttr.get(pto.PIPE.PIPE_MTE3, ctx)
+                evt0 = pto.EventAttr.get(pto.EVENT.EVENT_ID0, ctx)
+                evt1 = pto.EventAttr.get(pto.EVENT.EVENT_ID1, ctx)
 
-            pto.record_event(TMOV_M2V,       TMOV_M2V,       EVENT_ID2)
-            pto.wait_event  (TMOV_M2V,       TMOV_M2V,       EVENT_ID2)
+                arg0, arg1 = entry.arguments
 
-            pto.record_event(TVEC,           TVEC,           EVENT_ID3)
-            pto.wait_event  (TVEC,           TVEC,           EVENT_ID3)
+                tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
+                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
 
-            pto.record_event(TVECWAIT_EVENT, TVECWAIT_EVENT, EVENT_ID4)
-            pto.wait_event  (TVECWAIT_EVENT, TVECWAIT_EVENT, EVENT_ID4)
+                sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
 
-            # Barrier coverage for TMATMUL and TVEC
-            pto.barrier(TMATMUL)
-            pto.barrier(TVEC)
-            func.ReturnOp([])
-        print(module)
+                tb0 = pto.AllocTileOp(tile_buf_32).result
+                tb1 = pto.AllocTileOp(tile_buf_32).result
+
+                # Load (PIPE_MTE2)
+                pto.TLoadOp(None, sv0, tb0)
+                # MTE2 -> V sync before vector compute.
+                pto.set_flag(pipe_mte2, pipe_v, evt0)
+                pto.wait_flag(pipe_mte2, pipe_v, evt0)
+
+                # Compute (PIPE_V)
+                pto.TAddSOp(tb0, scale, tb1)
+                # V -> MTE3 sync before store.
+                pto.set_flag(pipe_v, pipe_mte3, evt1)
+                pto.wait_flag(pipe_v, pipe_mte3, evt1)
+
+                # Store (PIPE_MTE3)
+                pto.TStoreOp(None, tb1, sv1)
+
+                func.ReturnOp([])
+
+            m.operation.verify()
+            return m
+
 
 if __name__ == "__main__":
-    main()
+    print(build())


### PR DESCRIPTION
A5 toolchains reject some PIPE values for `set_flag/wait_flag` (e.g. `PIPE_FIX`, `PIPE_MTE1`), which caused the SyncHigh sample to fail compiling when it attempted to cover every pipe via `pto.record_event/pto.wait_event`.

This PR rewrites `test/samples/SyncHigh/syncHigh.py` into a real, runnable kernel that *manually* inserts `pto.set_flag/pto.wait_flag` around a simple MTE2 -> V -> MTE3 pipeline:
- `TLOAD` (MTE2)
- `set_flag/wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0)`
- `TADDS` (V)
- `set_flag/wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID1)`
- `TSTORE` (MTE3)

This keeps the sample meaningful while staying within the A5-supported PIPE set for `set_flag/wait_flag`.
