### PR TITLE
[A5] Add buffer-id sync ops (get_buf/rls_buf)

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1164,6 +1164,58 @@ def WaitFlagOp : PTO_Op<"wait_flag"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// Buffer-ID Synchronization (A5)
+//===----------------------------------------------------------------------===//
+
+def GetBufOp : PTO_Op<"get_buf"> {
+  let summary = "Acquire a buffer-id token on a given pipe (A5)";
+  let description = [{
+    `pto.get_buf` participates in a buffer-id based ordering model. Operations
+    in the same pipe that are guarded by the same buffer-id are enforced to
+    execute in program order relative to other pipes using the same buffer-id.
+
+    This op is intended to be lowered to the CCEC builtin intrinsic `get_buf`.
+  }];
+
+  let arguments = (ins
+    PTO_PipeAttr:$pipe,
+    I32Attr:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `[` $pipe `,` $buf_id `]` attr-dict
+  }];
+}
+
+def RlsBufOp : PTO_Op<"rls_buf"> {
+  let summary = "Release a buffer-id token on a given pipe (A5)";
+  let description = [{
+    Releases the previously acquired buffer-id token for the given pipe.
+
+    This op is intended to be lowered to the CCEC builtin intrinsic `rls_buf`.
+  }];
+
+  let arguments = (ins
+    PTO_PipeAttr:$pipe,
+    I32Attr:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `[` $pipe `,` $buf_id `]` attr-dict
+  }];
+}
+
 def SyncSetOp : PTO_Op<"sync.set"> {
   let summary = "Set a synchronization signal (trigger) between cube and vector.";
   let description = [{

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2123,6 +2123,41 @@ LogicalResult StoreScalarOp::verify() {
 
   return success();
 }
+
+// ---- GetBufOp / RlsBufOp ----
+static LogicalResult verifyBufSyncOp(Operation *op, PipeAttr pipeAttr,
+                                     IntegerAttr bufIdAttr, IntegerAttr modeAttr) {
+  if (!pipeAttr)
+    return op->emitOpError("expects 'pipe' attribute");
+
+  pto::PIPE pipe = pipeAttr.getPipe();
+  if (pipe == pto::PIPE::PIPE_ALL || pipe == pto::PIPE::PIPE_UNASSIGNED)
+    return op->emitOpError("expects 'pipe' to be a concrete pipe, not PIPE_ALL/PIPE_UNASSIGNED");
+
+  if (!bufIdAttr)
+    return op->emitOpError("expects 'buf_id' attribute");
+  int64_t bufId = bufIdAttr.getInt();
+  if (bufId < 0 || bufId > 31)
+    return op->emitOpError("expects 'buf_id' in range [0, 31]");
+
+  if (modeAttr) {
+    int64_t mode = modeAttr.getInt();
+    if (mode < 0)
+      return op->emitOpError("expects 'mode' to be non-negative");
+  }
+
+  return success();
+}
+
+LogicalResult GetBufOp::verify() {
+  return verifyBufSyncOp(getOperation(), getPipe(), getBufIdAttr(),
+                         getModeAttr());
+}
+
+LogicalResult RlsBufOp::verify() {
+  return verifyBufSyncOp(getOperation(), getPipe(), getBufIdAttr(),
+                         getModeAttr());
+}
 // ---- TOp ----
 LogicalResult TGemvBiasOp::verify() {
   if (getPTOTypeRank(getA().getType()) == -1 ||

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -3568,6 +3568,54 @@ struct PTOWaitFlagToEmitC : public OpConversionPattern<mlir::pto::WaitFlagOp> {
   }
 };
 
+struct PTOGetBufToEmitC : public OpConversionPattern<mlir::pto::GetBufOp> {
+  using OpConversionPattern<mlir::pto::GetBufOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::GetBufOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    auto *ctx = rewriter.getContext();
+
+    std::string pipeTok = pipeTokFromPipeAttr(op.getPipe());
+    auto argsAttr = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        op.getBufIdAttr(),
+        op.getModeAttr(),
+    });
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "get_buf",
+        /*args=*/argsAttr,
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange{});
+    return success();
+  }
+};
+
+struct PTORlsBufToEmitC : public OpConversionPattern<mlir::pto::RlsBufOp> {
+  using OpConversionPattern<mlir::pto::RlsBufOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::RlsBufOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    auto *ctx = rewriter.getContext();
+
+    std::string pipeTok = pipeTokFromPipeAttr(op.getPipe());
+    auto argsAttr = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        op.getBufIdAttr(),
+        op.getModeAttr(),
+    });
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "rls_buf",
+        /*args=*/argsAttr,
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange{});
+    return success();
+  }
+};
+
 struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
   using OpConversionPattern<mlir::pto::SyncSetOp>::OpConversionPattern;
 
@@ -6862,6 +6910,8 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOSubSCToEmitC>(typeConverter, ctx);
   patterns.add<PTOSubCSToEmitC>(typeConverter, ctx);
   patterns.add<PTOWaitFlagToEmitC>(typeConverter, ctx);
+  patterns.add<PTOGetBufToEmitC>(typeConverter, ctx);
+  patterns.add<PTORlsBufToEmitC>(typeConverter, ctx);
   patterns.add<PTOXORSToEmitC>(typeConverter, ctx);
   patterns.add<PTOSYNCToEmitC>(typeConverter, ctx);
   patterns.add<PTOSubSToEmitC>(typeConverter, ctx);

--- a/test/samples/InjectSync/test_a5_buf_sync.pto
+++ b/test/samples/InjectSync/test_a5_buf_sync.pto
@@ -1,0 +1,14 @@
+module {
+  func.func @test_a5_buf_sync() {
+    // Minimal smoke for A5 buffer-id synchronization ops.
+    // These ops are lowered to the CCEC builtin intrinsics `get_buf/rls_buf`.
+    pto.section.cube {
+      pto.get_buf[<PIPE_MTE2>, 0]
+      pto.rls_buf[<PIPE_MTE2>, 0]
+      pto.get_buf[<PIPE_V>, 0]
+      pto.rls_buf[<PIPE_V>, 0]
+    }
+    return
+  }
+}
+

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -337,6 +337,15 @@ process_one_dir() {
         fi
       fi
 
+      # Smoke guard: A5 buffer-id sync ops must lower to get_buf/rls_buf calls.
+      if [[ "$base" == "test_a5_buf_sync" ]]; then
+        if ! grep -Fq "get_buf(" "$cpp" || ! grep -Fq "rls_buf(" "$cpp"; then
+          echo -e "${A}(${base}.pto)\tFAIL\tmissing get_buf/rls_buf lowering"
+          overall=1
+          continue
+        fi
+      fi
+
       echo -e "${A}(${base}.pto)\tOK\tgenerated: $(basename "$cpp")"
     done
   fi


### PR DESCRIPTION
### What
- Add A5 buffer-id synchronization ops: `pto.get_buf` / `pto.rls_buf`.
- Lower them in `PTOToEmitC` to the CCEC builtin intrinsics `get_buf(...)` / `rls_buf(...)`.

### Notes
- These ops are intended for A5-only usage; existing code paths are unchanged unless the new ops are emitted.
- Add an InjectSync `.pto` smoke sample + runner guard to ensure the lowering keeps producing `get_buf/rls_buf` calls.

### Tests
- `ninja -C build ptoas _pto`
- `PYTHONPATH=<mlir_core>:<PTOAS build/python> bash test/samples/runop.sh all`
