### PR TITLE
Update LLVM baseline to 19.1.7 in CI and README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-22.04
     env:
-      LLVM_COMMIT: e21dc4bd5474d04b8e62d7331362edcc5648d7e5
+      LLVM_COMMIT: cd708029e0b2869e80abe31ddb175f7c35361f90
       LLVM_DIR: ${{ github.workspace }}/llvm-project/llvm/build-shared
       PTO_INSTALL_DIR: ${{ github.workspace }}/install
       MLIR_PYTHONPATH: ${{ github.workspace }}/llvm-project/llvm/build-shared/tools/mlir/python_packages/mlir_core
@@ -133,7 +133,7 @@ jobs:
             git remote add origin https://github.com/llvm/llvm-project.git
           fi
 
-          git fetch --depth 1 origin tag llvmorg-19.1.6
+          git fetch --depth 1 origin tag llvmorg-19.1.7
           git checkout "${LLVM_COMMIT}"
 
       - name: Build LLVM/MLIR (only if cache miss)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 1. 项目简介 (Introduction)
 
-**PTOAS** (`ptoas`) 是一个基于 **LLVM/MLIR (release/19.x)***(Commit e21dc4bd5474d04b8e62d7331362edcc5648d7e5)* 框架构建的专用编译器工具链，专为 **PTO Bytecode** (Programming Tiling Operator Bytecode) 设计。
+**PTOAS** (`ptoas`) 是一个基于 **LLVM/MLIR (llvmorg-19.1.7)***(Commit cd708029e0b2869e80abe31ddb175f7c35361f90)* 框架构建的专用编译器工具链，专为 **PTO Bytecode** (Programming Tiling Operator Bytecode) 设计。
 
 项目仓库：[https://github.com/zhangstevenunity/PTOAS](https://github.com/zhangstevenunity/PTOAS)
 
@@ -38,7 +38,7 @@ pto-project/
 
 ## 3. 构建指南 (Build Instructions)
 
-⚠️ **重要提示**：本项目严格依赖 **LLVM release/19.x** 分支。
+⚠️ **重要提示**：本项目严格依赖 **LLVM llvmorg-19.1.7** 版本。
 
 ### 3.0 环境变量配置 (Configuration)
 
@@ -79,7 +79,7 @@ pip3 install pybind11 numpy
 
 ### 3.2 第一步：构建 LLVM/MLIR (Dependency)
 
-我们需要下载 LLVM 源码，切换到 `release/19.x` 分支，并以**动态库 (Shared Libs)** 模式编译，以确保 Python Binding 的正确链接。
+我们需要下载 LLVM 源码，切换到 `llvmorg-19.1.7` 标签，并以**动态库 (Shared Libs)** 模式编译，以确保 Python Binding 的正确链接。
 
 ```bash
 # 1. 下载 LLVM 源码
@@ -87,8 +87,8 @@ cd $WORKSPACE_DIR
 git clone https://github.com/llvm/llvm-project.git
 cd $LLVM_SOURCE_DIR
 
-# 2. [关键] 切换到 release/19.x 分支
-git checkout release/19.x
+# 2. [关键] 切换到 llvmorg-19.1.7
+git checkout llvmorg-19.1.7
 
 # 3. 配置 CMake (构建动态库并启用 Python 绑定)
 cmake -G Ninja -S llvm -B $LLVM_BUILD_DIR \


### PR DESCRIPTION
## Summary
This PR updates the LLVM baseline from 19.1.6 to 19.1.7 and keeps the documentation aligned with CI.

## Changes
- Update LLVM_COMMIT in .github/workflows/ci.yml to the llvmorg-19.1.7 commit: cd708029e0b2869e80abe31ddb175f7c35361f90.
- Update the LLVM source fetch tag in CI from llvmorg-19.1.6 to llvmorg-19.1.7.
- Update README build instructions and dependency notes to llvmorg-19.1.7.

## Scope
- Branch is created from the latest upstream main.
- Only LLVM version alignment changes are included.
- No functional PTOAS logic changes are included.
