### PR TITLE
test(samples): fix A5 build for Partition5D/mrgsort/tmatmulk_autosync

### DIFF
--- a/test/samples/MatMul/tmatmulk_autosync.py
+++ b/test/samples/MatMul/tmatmulk_autosync.py
@@ -83,7 +83,8 @@ def build(
         )
 
         cfg_left = pto.TileBufConfigAttr.get(
-            pto.BLayoutAttr.get(pto.BLayout.RowMajor),
+            # NOTE: A5 pto-isa requires Left tiles to be ColMajor.
+            pto.BLayoutAttr.get(pto.BLayout.ColMajor),
             pto.SLayoutAttr.get(pto.SLayout.RowMajor),
             s_fractal_ab,
             pto.PadValueAttr.get(pto.PadValue.Null),

--- a/test/samples/Mrgsort/mrgsort.py
+++ b/test/samples/Mrgsort/mrgsort.py
@@ -23,6 +23,8 @@ def build():
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            tile_buf_32x32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            # NOTE: pto.tmrgsort (format1) expects a rank-2 tile with rows == 1.
             tile_buf_1x1024 = pto.TileBufType.get([1, 1024], f32, vec, [1, 1024], cfg, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
@@ -49,20 +51,25 @@ def build():
                 # %3/%4/%8 = pto.partition_view %tv, offsets=[%c0,%c0], sizes=[%c32,%c32]
                 sv0 = pto.PartitionViewOp(part_view_32x32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
 
-                # %5/%6/%7 = pto.alloc_tile : <1x1024xf32>
-                tb0 = pto.AllocTileOp(tile_buf_1x1024).result
-                tb1 = pto.AllocTileOp(tile_buf_1x1024).result
+                # A5 pto-isa does not allow collapsing a static 32x32 GlobalTensor
+                # directly into a 1x1024 Vec tile via TLOAD. Load as 32x32 first,
+                # then alias as 1x1024 for TMRGSORT.
+                tb_load_32x32 = pto.AllocTileOp(tile_buf_32x32).result
+                tb_sort_in_1x1024 = pto.AllocTileOp(tile_buf_1x1024).result
+                tb_sort_out_1x1024 = pto.AllocTileOp(tile_buf_1x1024).result
 
-                pto.TLoadOp(None, sv0, tb0)  # result=None
+                pto.TLoadOp(None, sv0, tb_load_32x32)  # result=None
+                pto.TReshapeOp(tb_load_32x32, tb_sort_in_1x1024)
 
                 # Format1: ins(%src, %blockLen : tile_buf, i32) outs(%dst : tile_buf)
-                pto.TMrgSortOp(srcs=[tb0], dsts=[tb1], blockLen=c64_i32)
+                pto.TMrgSortOp(srcs=[tb_sort_in_1x1024], dsts=[tb_sort_out_1x1024], blockLen=c64_i32)
+                pto.TReshapeOp(tb_sort_out_1x1024, tb_load_32x32)
 
                 # %8 = partition_view on output tensor_view
                 sv1 = pto.PartitionViewOp(part_view_32x32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
 
                 # pto.store_dps_tb ins(%tb1) outs(%sv1)
-                pto.TStoreOp(None, tb1, sv1)
+                pto.TStoreOp(None, tb_load_32x32, sv1)
 
                 func.ReturnOp([])
 

--- a/test/samples/Partition5D/partition5d.py
+++ b/test/samples/Partition5D/partition5d.py
@@ -27,12 +27,12 @@ def build_module():
         pto.register_dialect(ctx, load=True)
 
         f32 = builtin.F32Type.get()
-        mat = pto.AddressSpaceAttr.get(pto.AddressSpace.MAT, ctx)
+        vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
 
         tensor_view_ty = pto.TensorViewType.get([1, 1, 16, 1024, 1024], f32)
         part_view_ty = pto.PartitionTensorViewType.get([1, 1, 16, 16, 16], f32)
         tile_buf_ty = pto.TileBufType.get(
-            [256, 16], f32, mat, [256, 16], pto.TileBufConfigAttr.get_default(ctx)
+            [256, 16], f32, vec, [256, 16], pto.TileBufConfigAttr.get_default(ctx)
         )
 
         ptr_f32 = pto.PtrType.get(f32)
@@ -75,4 +75,3 @@ def build_module():
 if __name__ == "__main__":
     module = build_module()
     print(module)
-

--- a/test/samples/Partition5D/partition5d_dynamic.py
+++ b/test/samples/Partition5D/partition5d_dynamic.py
@@ -36,10 +36,10 @@ MLIR_TEXT = r'''module {
     %tmp2 = arith.muli %tmp1, %arg10 : index
 
     %tile = pto.alloc_tile valid_row = %tmp2 valid_col = %arg11
-           : !pto.tile_buf<loc=mat, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+           : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tload ins(%part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
-            outs(%tile : !pto.tile_buf<loc=mat, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     %dst_view = pto.make_tensor_view %arg1, shape = [%c1, %c1_0, %c16, %c1024, %c1024_1] strides = [%c1048576, %c1048576_2, %c1048576_3, %c1024_4, %c1_5]
                : !pto.tensor_view<1x1x16x1024x1024xf32>
@@ -49,7 +49,7 @@ MLIR_TEXT = r'''module {
                 sizes   = [%arg7, %arg8, %arg9, %arg10, %arg11]
                : !pto.tensor_view<1x1x16x1024x1024xf32> -> !pto.partition_tensor_view<?x?x?x?x?xf32>
 
-    pto.tstore ins(%tile : !pto.tile_buf<loc=mat, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              outs(%dst_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
     return
   }


### PR DESCRIPTION
Fix A5 NPU build failures caused by stricter pto-isa compile-time checks.

Changes:
- Partition5D: switch tile_buf loc from MAT to VEC for tload/tstore (A5 TSTORE only supports Vec/Acc source tiles).
- Mrgsort (format1): tload into 32x32 Vec tile, then treshape to 1x1024 for tmrgsort, and treshape back before tstore.
- tmatmulk_autosync: set Left tile blayout to ColMajor to satisfy A5 tmov/tmatmul fractal constraints.

Validation:
- CI: run `bash test/samples/runop.sh all`
- Remote NPU validation: re-run build/run on Ascend910 (A3) and Ascend910B* (A5).
