### PR TITLE
Save MacOS CI resources by skipping PR events and skip x86 + py3.10 combo

### DIFF
--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -23,6 +23,10 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12"]
         arch: ["x86_64", "aarch64"]
+        # Keep macOS matrix jobs at 5 to stay within GitHub Actions macOS job limits.
+        exclude:
+          - python: "3.10"
+            arch: "x86_64"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
CI job example: https://github.com/learning-chip/PTOAS/actions/runs/22614740756
Release example: https://github.com/learning-chip/PTOAS/releases/tag/20260303

@zhangstevenunity please manually delete the previous PR-triggerd Mac CI jobs at https://github.com/zhangstevenunity/PTOAS/actions/workflows/build_wheel_mac.yml, to free the CI resources