### PR TITLE
test(samples): fix a5 npu validation build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,28 @@ jobs:
               PTO_ISA_COMMIT="${DEFAULT_PTO_ISA_COMMIT}"
             fi
           fi
+
+          # Some validation samples have A3 vs A5 variants due to stricter
+          # pto-isa static checks on Ascend950 (A5). When running the full test
+          # suite (RUN_ONLY_CASES is empty), skip the non-matching variant based
+          # on SOC_VERSION to keep the remote validation portable.
+          A3_ONLY_CASES="partition5d,partition5d_dynamic,mrgsort,tmatmulk_autosync"
+          A5_ONLY_CASES="partition5d_a5,partition5d_dynamic_a5,mrgsort_a5,tmatmulk_autosync_a5"
+
+          sv_lc="$(printf '%s' "${SOC_VERSION}" | tr '[:upper:]' '[:lower:]')"
+          is_a5=0
+          if [[ "${sv_lc}" == *"950"* || "${sv_lc}" == *"a5"* ]]; then
+            is_a5=1
+          fi
+
+          if [[ -z "${RUN_ONLY_CASES}" ]]; then
+            if [[ ${is_a5} -eq 1 ]]; then
+              SKIP_CASES="${SKIP_CASES:+${SKIP_CASES},}${A3_ONLY_CASES}"
+            else
+              SKIP_CASES="${SKIP_CASES:+${SKIP_CASES},}${A5_ONLY_CASES}"
+            fi
+          fi
+
           echo "STAGE=${STAGE}" >> "${GITHUB_ENV}"
           echo "RUN_MODE=${RUN_MODE}" >> "${GITHUB_ENV}"
           echo "SOC_VERSION=${SOC_VERSION}" >> "${GITHUB_ENV}"

--- a/test/samples/Mrgsort/mrgsort_a5.py
+++ b/test/samples/Mrgsort/mrgsort_a5.py
@@ -1,0 +1,78 @@
+from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.dialects import func, arith, pto
+from mlir.ir import F32Type, IndexType, IntegerType
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+
+        with Location.unknown(ctx):
+            m = Module.create()
+
+            f32 = F32Type.get(ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+
+            # Mergesort on a 1x1024 list for TMrgSort.
+            #
+            # NOTE: A5 pto-isa requires that Vec TLOAD's tile ValidCol matches
+            # GlobalTensor's staticShape[4]. Build a 1x1024 tensor_view so the
+            # generated GlobalTensor column dimension is 1024.
+            tv2_f32 = pto.TensorViewType.get([1, 1024], f32, ctx)
+            part_view_1x1024 = pto.PartitionTensorViewType.get([1, 1024], f32, ctx)
+            vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+            pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+
+            fractal_ab_size = pto.TileConfig.fractalABSize
+            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            # NOTE: pto.tmrgsort (format1) expects a rank-2 tile with rows == 1.
+            tile_buf_1x1024 = pto.TileBufType.get([1, 1024], f32, vec, [1, 1024], cfg, ctx)
+
+            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
+            with InsertionPoint(m.body):
+                fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                # constants
+                c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
+                c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
+                c1024 = arith.ConstantOp(IndexType.get(ctx), 1024).result
+                # blockLen for tmrgsort format1: ins(src, blockLen) outs(dst), must be integer (e.g. i32)
+                i32 = IntegerType.get_signless(32, ctx)
+                c64_i32 = arith.ConstantOp(i32, 64).result
+
+                arg0, arg1 = entry.arguments
+
+                # Flatten as a 1x1024 tensor.
+                tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c1, c1024], [c1024, c1]).result
+                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c1, c1024], [c1024, c1]).result
+
+                sv0 = pto.PartitionViewOp(
+                    part_view_1x1024, tv0, offsets=[c0, c0], sizes=[c1, c1024]
+                ).result
+
+                # Format1: ins(%src, %blockLen : tile_buf, i32) outs(%dst : tile_buf)
+                tb0 = pto.AllocTileOp(tile_buf_1x1024).result
+                tb1 = pto.AllocTileOp(tile_buf_1x1024).result
+
+                pto.TLoadOp(None, sv0, tb0)  # result=None
+                pto.TMrgSortOp(srcs=[tb0], dsts=[tb1], blockLen=c64_i32)
+
+                sv1 = pto.PartitionViewOp(
+                    part_view_1x1024, tv1, offsets=[c0, c0], sizes=[c1, c1024]
+                ).result
+
+                pto.TStoreOp(None, tb1, sv1)
+
+                func.ReturnOp([])
+
+            m.operation.verify()
+
+            return m
+
+
+if __name__ == "__main__":
+    print(build())

--- a/test/samples/Partition5D/partition5d_a5.py
+++ b/test/samples/Partition5D/partition5d_a5.py
@@ -1,0 +1,77 @@
+"""
+5D partition_view -> tile load/store sample (static shape).
+
+Scenario from design doc:
+1) make_tensor_view defines 5D global tensor
+2) partition_view slices a 5D window
+3) tload collapses to 2D tile_buf
+4) tstore writes back to the destination tensor_view
+"""
+
+from mlir.ir import (
+    Context,
+    Location,
+    InsertionPoint,
+    Module,
+    IndexType,
+)
+from mlir.dialects import arith, func, pto, builtin
+
+
+def idx(val: int):
+    return arith.ConstantOp(IndexType.get(), val).result
+
+
+def build_module():
+    with Context() as ctx, Location.unknown():
+        pto.register_dialect(ctx, load=True)
+
+        f32 = builtin.F32Type.get()
+        vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+
+        tensor_view_ty = pto.TensorViewType.get([1, 1, 16, 1024, 1024], f32)
+        part_view_ty = pto.PartitionTensorViewType.get([1, 1, 16, 16, 16], f32)
+        tile_buf_ty = pto.TileBufType.get(
+            [256, 16], f32, vec, [256, 16], pto.TileBufConfigAttr.get_default(ctx)
+        )
+
+        ptr_f32 = pto.PtrType.get(f32)
+
+        m = Module.create()
+        with InsertionPoint(m.body):
+            @func.FuncOp.from_py_func(ptr_f32, ptr_f32)
+            def run_partition(src, dst):
+                c0 = idx(0)
+                # Shapes/strides for make_tensor_view
+                shape = [idx(1), idx(1), idx(16), idx(1024), idx(1024)]
+                strides = [idx(1048576), idx(1048576), idx(1048576), idx(1024), idx(1)]
+
+                base_view = pto.MakeTensorViewOp(tensor_view_ty, src, shape, strides).result
+
+                part = pto.PartitionViewOp(
+                    part_view_ty,
+                    base_view,
+                    offsets=[c0, c0, c0, c0, c0],
+                    sizes=[idx(1), idx(1), idx(16), idx(16), idx(16)],
+                ).result
+
+                tile = pto.AllocTileOp(tile_buf_ty).result
+                pto.TLoadOp(None, part, tile)
+
+                dst_view = pto.MakeTensorViewOp(tensor_view_ty, dst, shape, strides).result
+                dst_part = pto.PartitionViewOp(
+                    part_view_ty,
+                    dst_view,
+                    offsets=[c0, c0, c0, c0, c0],
+                    sizes=[idx(1), idx(1), idx(16), idx(16), idx(16)],
+                ).result
+                pto.TStoreOp(None, tile, dst_part)
+
+                return
+
+        return m
+
+
+if __name__ == "__main__":
+    module = build_module()
+    print(module)

--- a/test/samples/Partition5D/partition5d_dynamic_a5.py
+++ b/test/samples/Partition5D/partition5d_dynamic_a5.py
@@ -1,0 +1,60 @@
+"""
+Dynamic-size partition_view -> tload -> tstore.
+Text is emitted as hand-crafted MLIR assembly to keep output clean (non-generic).
+Offsets:  fixed at 0
+Sizes:    %arg2..%arg6
+
+NOTE: Ascend950 (A5) pto-isa requires Vec/Acc tiles for TSTORE. This sample uses
+Vec tiles to stay portable across A2/A3 and A5.
+"""
+
+MLIR_TEXT = r'''module {
+  func.func @run_partition(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>,
+                           %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1_0 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c1024 = arith.constant 1024 : index
+    %c1024_1 = arith.constant 1024 : index
+    %c1048576 = arith.constant 1048576 : index
+    %c1048576_2 = arith.constant 1048576 : index
+    %c1048576_3 = arith.constant 1048576 : index
+    %c1024_4 = arith.constant 1024 : index
+    %c1_5 = arith.constant 1 : index
+
+    %base = pto.make_tensor_view %arg0, shape = [%c1, %c1_0, %c16, %c1024, %c1024_1] strides = [%c1048576, %c1048576_2, %c1048576_3, %c1024_4, %c1_5]
+           : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %part = pto.partition_view %base,
+             offsets = [%c0, %c0, %c0, %c0, %c0],
+             sizes   = [%arg2, %arg3, %arg4, %arg5, %arg6]
+           : !pto.tensor_view<1x1x16x1024x1024xf32> -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    %tmp0 = arith.muli %arg2, %arg3 : index
+    %tmp1 = arith.muli %tmp0, %arg4 : index
+    %tmp2 = arith.muli %tmp1, %arg5 : index
+
+    %tile = pto.alloc_tile valid_row = %tmp2 valid_col = %arg6
+           : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %dst_view = pto.make_tensor_view %arg1, shape = [%c1, %c1_0, %c16, %c1024, %c1024_1] strides = [%c1048576, %c1048576_2, %c1048576_3, %c1024_4, %c1_5]
+               : !pto.tensor_view<1x1x16x1024x1024xf32>
+
+    %dst_part = pto.partition_view %dst_view,
+                offsets = [%c0, %c0, %c0, %c0, %c0],
+                sizes   = [%arg2, %arg3, %arg4, %arg5, %arg6]
+               : !pto.tensor_view<1x1x16x1024x1024xf32> -> !pto.partition_tensor_view<?x?x?x?x?xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst_part : !pto.partition_tensor_view<?x?x?x?x?xf32>)
+    return
+  }
+}
+'''
+
+if __name__ == "__main__":
+    print(MLIR_TEXT)

--- a/test/samples/Sync/tmatmulk_autosync_a5.py
+++ b/test/samples/Sync/tmatmulk_autosync_a5.py
@@ -1,0 +1,238 @@
+from mlir.ir import (
+    Context, Location, InsertionPoint,
+    IndexType, IntegerType, F16Type, F32Type, StringAttr
+)
+from mlir.dialects import func, arith, scf, pto, builtin
+from mlir.dialects.arith import CmpIPredicate
+
+
+def _idx_const(v: int):
+    return arith.ConstantOp(IndexType.get(), v).result
+
+
+def build(
+    M=32, K=256, N=32,
+    validM=32, validK=256, validN=32,
+    BASEK=32,
+    # 下面两个 fractal size 你按工程真实 TileConfig 改一下：
+    s_fractal_ab=512,
+    s_fractal_c=1024,
+):
+    # This sample intentionally contains NO explicit sync ops
+    # (record_event/wait_event or set_flag/wait_flag).
+    #
+    # It is meant to be used with:
+    #   ptoas --enable-insert-sync
+    #
+    # to exercise the auto-sync insertion + event-id allocation pipeline.
+    assert K % BASEK == 0
+    iters = K // BASEK
+
+    with Context() as ctx, Location.unknown():
+        pto.register_dialect(ctx, load=True)
+
+        module = builtin.ModuleOp()
+        module.attributes["pto.device-spec"] = StringAttr.get("Ascend910B1")
+
+        # ---- element types ----
+        t_out = F32Type.get()
+        t_a = F32Type.get()
+        t_b = F32Type.get()
+        t_bias = F32Type.get()
+
+        # ---- ptr types ----
+        ptr_out = pto.PtrType.get(t_out)
+        ptr_a = pto.PtrType.get(t_a)
+        ptr_b = pto.PtrType.get(t_b)
+        ptr_bias = pto.PtrType.get(t_bias)
+
+        i1 = IntegerType.get_signless(1)
+
+        # ---- tensor view types ----
+        tv2_a = pto.TensorViewType.get(2, t_a)        # [validM, validK]
+        tv2_b = pto.TensorViewType.get(2, t_b)        # [validK, validN]
+        tv2_out = pto.TensorViewType.get(2, t_out)    # [validM, validN]
+        tv2_bias = pto.TensorViewType.get(2, t_bias)  # [1, validN]
+
+        # ---- tile view types ----
+        tile_view_a = pto.PartitionTensorViewType.get([M, BASEK], t_a)
+        tile_view_b = pto.PartitionTensorViewType.get([BASEK, N], t_b)
+        tile_view_out = pto.PartitionTensorViewType.get([M, N], t_out)
+        tile_view_bias = pto.PartitionTensorViewType.get([1, N], t_bias)
+
+        # ---- address spaces ----
+        mat = pto.AddressSpaceAttr.get(pto.AddressSpace.MAT)
+        left = pto.AddressSpaceAttr.get(pto.AddressSpace.LEFT)
+        right = pto.AddressSpaceAttr.get(pto.AddressSpace.RIGHT)
+        acc = pto.AddressSpaceAttr.get(pto.AddressSpace.ACC)
+        bias = pto.AddressSpaceAttr.get(pto.AddressSpace.BIAS)
+
+        # ---- configs (3rd arg = s_fractal_size) ----
+        cfg_mat = pto.TileBufConfigAttr.get(
+            pto.BLayoutAttr.get(pto.BLayout.ColMajor),
+            pto.SLayoutAttr.get(pto.SLayout.RowMajor),
+            s_fractal_ab,
+            pto.PadValueAttr.get(pto.PadValue.Null),
+        )
+
+        cfg_mat_bias = pto.TileBufConfigAttr.get(
+            pto.BLayoutAttr.get(pto.BLayout.RowMajor),
+            pto.SLayoutAttr.get(pto.SLayout.NoneBox),
+            s_fractal_ab,
+            pto.PadValueAttr.get(pto.PadValue.Null),
+        )
+
+        cfg_left = pto.TileBufConfigAttr.get(
+            # NOTE: A5 pto-isa requires Left tiles to be ColMajor.
+            pto.BLayoutAttr.get(pto.BLayout.ColMajor),
+            pto.SLayoutAttr.get(pto.SLayout.RowMajor),
+            s_fractal_ab,
+            pto.PadValueAttr.get(pto.PadValue.Null),
+        )
+
+        cfg_right = pto.TileBufConfigAttr.get(
+            pto.BLayoutAttr.get(pto.BLayout.RowMajor),
+            pto.SLayoutAttr.get(pto.SLayout.ColMajor),
+            s_fractal_ab,
+            pto.PadValueAttr.get(pto.PadValue.Null),
+        )
+
+        cfg_acc = pto.TileBufConfigAttr.get(
+            pto.BLayoutAttr.get(pto.BLayout.ColMajor),
+            pto.SLayoutAttr.get(pto.SLayout.RowMajor),
+            s_fractal_c,
+            pto.PadValueAttr.get(pto.PadValue.Null),
+        )
+
+        cfg_bias = pto.TileBufConfigAttr.get(
+            pto.BLayoutAttr.get(pto.BLayout.RowMajor),
+            pto.SLayoutAttr.get(pto.SLayout.NoneBox),
+            pto.TileConfig.fractalABSize,
+            pto.PadValueAttr.get(pto.PadValue.Null),
+        )
+
+        # ---- tile buf types (each has its own cfg) ----
+        tile_buf_aMat = pto.TileBufType.get([M, BASEK], t_a, mat, [M, BASEK], cfg_mat)
+        tile_buf_bMat = pto.TileBufType.get([BASEK, N], t_b, mat, [BASEK, N], cfg_mat)
+        tile_buf_biasData = pto.TileBufType.get([1, N], t_bias, mat, [1, N], cfg_mat_bias)
+
+        tile_buf_aTile = pto.TileBufType.get([M, BASEK], t_a, left, [M, BASEK], cfg_left)
+        tile_buf_bTile = pto.TileBufType.get([BASEK, N], t_b, right, [BASEK, N], cfg_right)
+        tile_buf_cTile = pto.TileBufType.get([M, N], t_out, acc, [M, N], cfg_acc)
+        tile_buf_biasTile = pto.TileBufType.get([1, N], t_bias, bias, [1, N], cfg_bias)
+
+        # ---- function ----
+        # (out, A, B, bias, isBias)
+        fn_ty = func.FunctionType.get([ptr_out, ptr_a, ptr_b, ptr_bias, i1], [])
+        with InsertionPoint(module.body):
+            fn = func.FuncOp("RunTMATMULSplitK", fn_ty)
+            entry = fn.add_entry_block()
+
+        with InsertionPoint(entry):
+            out_ptr, a_ptr, b_ptr, bias_ptr, isBias = entry.arguments
+
+            # ---- constants ----
+            c0 = _idx_const(0)
+            c1 = _idx_const(1)
+            cOne = _idx_const(1)
+
+            cM = _idx_const(validM)
+            cK = _idx_const(validK)
+            cN = _idx_const(validN)
+
+            cBASEK = _idx_const(BASEK)
+            cIter = _idx_const(iters)
+
+            cTileM = _idx_const(M)
+            cTileN = _idx_const(N)
+
+            # ---- make_tensor_view ----
+            tvA = pto.MakeTensorViewOp(tv2_a, a_ptr, [cM, cK], [cK, c1]).result
+            tvB = pto.MakeTensorViewOp(tv2_b, b_ptr, [cK, cN], [cN, c1]).result
+            tvOut = pto.MakeTensorViewOp(tv2_out, out_ptr, [cM, cN], [cN, c1]).result
+            tvBias = pto.MakeTensorViewOp(tv2_bias, bias_ptr, [cOne, cN], [cN, c1]).result
+
+            # ---- alloc tiles ----
+            aMatTile = pto.AllocTileOp(tile_buf_aMat).result
+            bMatTile = pto.AllocTileOp(tile_buf_bMat).result
+            biasDataTile = pto.AllocTileOp(tile_buf_biasData).result
+
+            aTile = pto.AllocTileOp(tile_buf_aTile).result
+            bTile = pto.AllocTileOp(tile_buf_bTile).result
+            cTile = pto.AllocTileOp(tile_buf_cTile).result
+            biasTile = pto.AllocTileOp(tile_buf_biasTile).result
+
+            # ---- loop for split-K ----
+            loop = scf.ForOp(c0, cIter, c1, [])
+            with InsertionPoint(loop.body):
+                i = loop.induction_variable
+
+                kOff = arith.MulIOp(i, cBASEK).result
+
+                svA = pto.PartitionViewOp(
+                    tile_view_a, tvA, offsets=[c0, kOff], sizes=[cTileM, cBASEK]
+                ).result
+                svB = pto.PartitionViewOp(
+                    tile_view_b, tvB, offsets=[kOff, c0], sizes=[cBASEK, cTileN]
+                ).result
+                svBias = pto.PartitionViewOp(
+                    tile_view_bias, tvBias, offsets=[c0, c0], sizes=[cOne, cTileN]
+                ).result
+
+                # ---- TLOAD ----
+                pto.TLoadOp(None, svA, aMatTile)
+                pto.TLoadOp(None, svB, bMatTile)
+
+                if_load_bias = scf.IfOp(isBias, [], hasElse=True)
+                with InsertionPoint(if_load_bias.then_block):
+                    pto.TLoadOp(None, svBias, biasDataTile)
+                    scf.YieldOp([])
+                with InsertionPoint(if_load_bias.else_block):
+                    scf.YieldOp([])
+
+                # ---- TMOV ----
+                pto.TMovOp(None, aMatTile, aTile)
+                pto.TMovOp(None, bMatTile, bTile)
+
+                if_mov_bias = scf.IfOp(isBias, [], hasElse=True)
+                with InsertionPoint(if_mov_bias.then_block):
+                    pto.TMovOp(None, biasDataTile, biasTile)
+                    scf.YieldOp([])
+                with InsertionPoint(if_mov_bias.else_block):
+                    scf.YieldOp([])
+
+                # ---- i == 0 ? (bias? TMATMUL_BIAS : TMATMUL) : TMATMUL_ACC ----
+                is_i0 = arith.CmpIOp(CmpIPredicate.eq, i, c0).result
+                if_i0 = scf.IfOp(is_i0, [], hasElse=True)
+
+                with InsertionPoint(if_i0.then_block):
+                    if_bias0 = scf.IfOp(isBias, [], hasElse=True)
+                    with InsertionPoint(if_bias0.then_block):
+                        pto.TMatmulBiasOp(None, aTile, bTile, biasTile, cTile)
+                        scf.YieldOp([])
+                    with InsertionPoint(if_bias0.else_block):
+                        pto.TMatmulOp(None, aTile, bTile, cTile)
+                        scf.YieldOp([])
+                    scf.YieldOp([])
+
+                with InsertionPoint(if_i0.else_block):
+                    pto.TMatmulAccOp(None, cTile, aTile, bTile, cTile)
+                    scf.YieldOp([])
+
+                scf.YieldOp([])
+
+            # ---- after loop ----
+            svOut = pto.PartitionViewOp(
+                tile_view_out, tvOut, offsets=[c0, c0], sizes=[cTileM, cTileN]
+            ).result
+            pto.TStoreOp(None, cTile, svOut)
+
+            func.ReturnOp([])
+
+        module.operation.verify()
+        return module
+
+
+if __name__ == "__main__":
+    m = build()
+    print(m)


### PR DESCRIPTION
## Summary

Add Ascend950 (A5) variants for a few NPU validation samples that fail to compile with stricter pto-isa static checks, and select the matching variant in remote validation based on `SOC_VERSION`.

## Changes

- Add A5 variants:
  - `Partition5D/partition5d_a5`: use `loc=vec` tile so `tstore` satisfies A5's Vec/Acc source-tile requirement.
  - `Partition5D/partition5d_dynamic_a5`: fixed offsets at 0, dynamic sizes only, `loc=vec` tile.
  - `Mrgsort/mrgsort_a5`: use a `1x1024` tensor_view/tile to satisfy A5 `tload` ValidRow/ValidCol constraints.
  - `Sync/tmatmulk_autosync_a5`: make Left tiles `ColMajor` to satisfy A5 `tmov`/`tmatmul` layout/fractal constraints.
- CI remote validation (`.github/workflows/ci.yml`): when `RUN_ONLY_CASES` is empty, skip the non-matching variant based on `SOC_VERSION`:
  - A3: skip `*_a5` variants
  - A5: skip the original cases and run `*_a5` variants

## Testing

- Local sample generation:
  - `bash test/samples/runop.sh -t Partition5D`
  - `bash test/samples/runop.sh -t Mrgsort`
- `ptoas --enable-insert-sync` generates C++ for `Sync/tmatmulk_autosync_a5`
