### PR TITLE
Fix make_tensor_view layout roundtrip and GlobalTensor emission

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -577,7 +577,7 @@ void mlir::pto::MakeTensorViewOp::print(OpAsmPrinter &p) {
   p << "]";
 
   p.printOptionalAttrDict((*this)->getAttrs(),
-                        /*elidedAttrs=*/{"operandSegmentSizes", "layout"});
+                        /*elidedAttrs=*/{"operandSegmentSizes"});
 
   p << " : " << getResult().getType();
 }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -2482,8 +2482,13 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         if (!strToInt(finalShape[i], shapeInt[i]) || !strToInt(finalStride[i], strideInt[i]))
             allStatic = false;
     }
-    // 推导规则与 InferPTOLayout 保持一致
+    // 推导规则与 InferPTOLayout 保持一致。
+    //
+    // Note: Some shapes/strides may be ambiguous (e.g. dimensions of size 1),
+    // so we track whether the inference is reliable before validating against
+    // a user-specified `layout` attribute.
     int layoutTag = 0; // ND
+    bool inferredReliable = false;
     auto elemBytes = 4; // default float
     if (elemTypeStr.find("half") != std::string::npos || elemTypeStr.find("f16") != std::string::npos ||
         elemTypeStr.find("bf16") != std::string::npos)
@@ -2495,6 +2500,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         if (shapeInt[2] == 16 && shapeInt[2] * shapeInt[3] * elemBytes == 512 &&
             strideInt[4] == 1 && strideInt[3] == shapeInt[4]) {
             layoutTag = 2; // NZ
+            inferredReliable = true;
         } else {
             bool isRow = strideInt[4] == 1;
             for (int i = 3; i >= 0; --i)
@@ -2502,11 +2508,18 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
             bool isCol = strideInt[0] == 1;
             for (int i = 0; i < 4; ++i)
                 isCol &= (strideInt[i + 1] == strideInt[i] * shapeInt[i]);
-            if (isCol) layoutTag = 1; // DN
-            else layoutTag = isRow ? 0 : 0; // fallback ND
+            if (isCol) {
+              layoutTag = 1; // DN
+              inferredReliable = true;
+            } else if (isRow) {
+              layoutTag = 0; // ND
+              inferredReliable = true;
+            } else {
+              layoutTag = 0; // fallback ND
+            }
         }
     }
-    // 若源 IR 上存在 layout 属性，则校验是否一致，不一致时报错
+    // 若源 IR 上存在 layout 属性：仅在推导结果可靠时校验一致性；否则直接采用用户指定值。
     if (auto attr = op->getAttrOfType<mlir::pto::LayoutAttr>("layout")) {
         int userTag = 0;
         switch (attr.getLayout()) {
@@ -2514,7 +2527,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         case mlir::pto::Layout::DN: userTag = 1; break;
         case mlir::pto::Layout::NZ: userTag = 2; break;
         }
-        if (userTag != layoutTag) {
+        if (inferredReliable && userTag != layoutTag) {
             return rewriter.notifyMatchFailure(
                 op, "layout mismatch: user-specified layout=" +
                         std::string(attr.getLayout() == mlir::pto::Layout::ND ? "ND" :

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -622,6 +622,9 @@ struct PTOViewToMemrefPass
         if (foldedAddPtr) {
           rc->setAttr("pto.addptr_trace", rewriter.getUnitAttr());
         }
+        if (auto layoutAttr = op.getLayoutAttr()) {
+          rc->setAttr("layout", layoutAttr);
+        }
 
         rewriter.replaceOp(op, rc.getResult());
       }
@@ -832,6 +835,11 @@ struct PTOViewToMemrefPass
             mixedSizes, 
             mixedStrides
         );
+        if (Operation *srcDef = src.getDefiningOp()) {
+          if (auto layoutAttr = srcDef->getAttrOfType<pto::LayoutAttr>("layout")) {
+            sv->setAttr("layout", layoutAttr);
+          }
+        }
         
         rewriter.replaceOp(op, sv.getResult());
       }

--- a/test/samples/Layout/tensor_view_layout_dn.py
+++ b/test/samples/Layout/tensor_view_layout_dn.py
@@ -1,0 +1,76 @@
+"""
+Explicit tensor_view layout sample (DN).
+
+This checks that:
+  - User-specified `layout` on pto.make_tensor_view is preserved through
+    view lowering (make_tensor_view -> reinterpret_cast -> subview)
+  - The generated C++ GlobalTensor uses pto::Layout::DN.
+"""
+
+from mlir.ir import Context, Location, InsertionPoint, Module, IndexType
+from mlir.dialects import arith, func, pto, builtin
+
+
+def idx(val: int):
+    return arith.ConstantOp(IndexType.get(), val).result
+
+
+def build_module():
+    with Context() as ctx, Location.unknown():
+        pto.register_dialect(ctx, load=True)
+
+        f32 = builtin.F32Type.get()
+        mat = pto.AddressSpaceAttr.get(pto.AddressSpace.MAT, ctx)
+
+        tensor_view_ty = pto.TensorViewType.get([1, 1, 16, 1024, 1024], f32)
+        part_view_ty = pto.PartitionTensorViewType.get([1, 1, 16, 16, 16], f32)
+        tile_buf_ty = pto.TileBufType.get(
+            [256, 16], f32, mat, [256, 16], pto.TileBufConfigAttr.get_default(ctx)
+        )
+
+        ptr_f32 = pto.PtrType.get(f32)
+        layout_dn = pto.LayoutAttr.get(pto.Layout.DN, ctx)
+
+        m = Module.create()
+        with InsertionPoint(m.body):
+
+            @func.FuncOp.from_py_func(ptr_f32, ptr_f32)
+            def run(src, dst):
+                c0 = idx(0)
+
+                shape = [idx(1), idx(1), idx(16), idx(1024), idx(1024)]
+                # Keep the same stride pattern as the existing 5D partition sample.
+                strides = [idx(1048576), idx(1048576), idx(1048576), idx(1024), idx(1)]
+
+                src_view = pto.MakeTensorViewOp(
+                    tensor_view_ty, src, shape, strides, layout=layout_dn
+                ).result
+                src_part = pto.PartitionViewOp(
+                    part_view_ty,
+                    src_view,
+                    offsets=[c0, c0, c0, c0, c0],
+                    sizes=[idx(1), idx(1), idx(16), idx(16), idx(16)],
+                ).result
+
+                tile = pto.AllocTileOp(tile_buf_ty).result
+                pto.TLoadOp(None, src_part, tile)
+
+                dst_view = pto.MakeTensorViewOp(
+                    tensor_view_ty, dst, shape, strides, layout=layout_dn
+                ).result
+                dst_part = pto.PartitionViewOp(
+                    part_view_ty,
+                    dst_view,
+                    offsets=[c0, c0, c0, c0, c0],
+                    sizes=[idx(1), idx(1), idx(16), idx(16), idx(16)],
+                ).result
+
+                pto.TStoreOp(None, tile, dst_part)
+                return
+
+        return m
+
+
+if __name__ == "__main__":
+    print(build_module())
+

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -313,6 +313,17 @@ process_one_dir() {
       fi
     fi
 
+    # Regression guard for Issue #174:
+    # Explicit layout on make_tensor_view must be preserved and reflected in the
+    # emitted GlobalTensor layout parameter.
+    if [[ "$base" == "tensor_view_layout_dn" ]]; then
+      if ! grep -Fq "pto::Layout::DN" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing pto::Layout::DN in emitted GlobalTensor"
+        overall=1
+        continue
+      fi
+    fi
+
     echo -e "${A}(${base}.py)\tOK\tgenerated: $(basename "$cpp")"
   done
 

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -640,9 +640,9 @@ int main(int argc, char **argv) {
   // pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertLoadStoreForMixCVPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());
   
-  pm.addPass(pto::createPTOViewToMemrefPass());
   if (!disableInferLayout)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
+  pm.addPass(pto::createPTOViewToMemrefPass());
   // bufferizationPipeline(pm);
   //pm.addPass(createInferPTOMemScopePass());
 


### PR DESCRIPTION
Fixes #174.

### What was wrong
- `pto.make_tensor_view` supports an optional `layout` attribute, but it was not round-trippable/usable end-to-end:
  - The custom printer elided `layout`, so textual IR (and Python-generated IR) dropped it.
  - The `InferPTOLayout` pass was scheduled after `PTOViewToMemref`, so it couldn't see `MakeTensorViewOp` (already lowered).
  - During view lowering, the `layout` attribute was not propagated to the memref ops that drive GlobalTensor emission.

### What this PR changes
- Print `layout` in `MakeTensorViewOp` so it survives textual IR and bytecode roundtrips.
- Run `InferPTOLayout` before `PTOViewToMemref` in the `ptoas` pipeline.
- Propagate `layout` through `make_tensor_view -> memref.reinterpret_cast -> memref.subview`.
- Make GlobalTensor emission honor user-specified `layout` even when layout inference is not reliable.

### Tests
- Add `test/samples/Layout/tensor_view_layout_dn.py` and a `runop.sh` guard to assert the emitted C++ contains `pto::Layout::DN`.
