### PR TITLE
Fix barrier_sync lowering for non-compute op types

### DIFF
--- a/lib/PTO/Transforms/LoweringSyncToPipe.cpp
+++ b/lib/PTO/Transforms/LoweringSyncToPipe.cpp
@@ -120,13 +120,13 @@ struct BarrierSyncLowering : public OpRewritePattern<BarrierSyncOp> {
   LogicalResult matchAndRewrite(BarrierSyncOp op,
                                 PatternRewriter &rewriter) const override {
     SyncOpType ty = op.getOpType().getOpType();
-    // Only support TMATMUL / TVEC for now
-    if (ty != SyncOpType::TMATMUL && ty != SyncOpType::TVEC)
-      return op.emitError("barrier_sync supports only TMATMUL or TVEC");
-
     PIPE pipe = getPipeFromOpType(ty);
-    if (pipe == PIPE::PIPE_UNASSIGNED)
-      return op.emitError("Failed to map SyncOpType to hardware pipe during barrier lowering.");
+    if (pipe == PIPE::PIPE_UNASSIGNED) {
+      auto diag = op.emitError(
+          "barrier_sync failed to map SyncOpType to hardware pipe during lowering: ");
+      diag << op.getOpType();
+      return failure();
+    }
 
     rewriter.replaceOpWithNewOp<BarrierOp>(
         op, PipeAttr::get(op.getContext(), pipe));

--- a/test/samples/Sync/test_barrier_sync.py
+++ b/test/samples/Sync/test_barrier_sync.py
@@ -1,0 +1,15 @@
+if __name__ == "__main__":
+    # Regression for zhangstevenunity/PTOAS#185:
+    # barrier_sync should support any SyncOpType that can be mapped to a PIPE
+    # (not just TMATMUL/TVEC).
+    print(
+        r"""module {
+  func.func @test_barrier_sync_py() {
+    pto.barrier_sync[<TLOAD>]
+    pto.barrier_sync[<TSTORE_VEC>]
+    pto.barrier_sync[<TVEC>]
+    return
+  }
+}
+"""
+    )

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -291,6 +291,26 @@ process_one_dir() {
       fi
     fi
 
+    # Regression guard for issue #185: barrier_sync must support op types
+    # beyond TMATMUL/TVEC and lower to the expected per-pipe barrier.
+    if [[ "$base" == "test_barrier_sync" ]]; then
+      if ! grep -Fq "pipe_barrier(PIPE_MTE2)" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing pipe_barrier(PIPE_MTE2) lowering for barrier_sync[TLOAD]"
+        overall=1
+        continue
+      fi
+      if ! grep -Fq "pipe_barrier(PIPE_MTE3)" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing pipe_barrier(PIPE_MTE3) lowering for barrier_sync[TSTORE_VEC]"
+        overall=1
+        continue
+      fi
+      if ! grep -Fq "pipe_barrier(PIPE_V)" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing pipe_barrier(PIPE_V) lowering for barrier_sync[TVEC]"
+        overall=1
+        continue
+      fi
+    fi
+
     # Regression guard for issue #117: vector mask must be reset for each
     # `pto.section.vector` region to avoid cross-kernel state leakage.
     # Use an existing sample (Complex/cv_region.py) that contains a vector section.


### PR DESCRIPTION
Fixes #185.

**Problem**
`pto.barrier_sync` is a high-level convenience op that takes a `SyncOpType` and should lower to `pto.barrier <PIPE_...>`.

However, `LoweringSyncToPipe` previously hard-coded `barrier_sync` to only accept `TMATMUL/TVEC`. If users wrote `pto.barrier_sync[<TLOAD>]` / `pto.barrier("TLOAD")`, lowering failed, the op remained, and `PTOToEmitC` then failed legalization because the `pto` dialect is marked illegal.

**Fix**
- Lower `pto.barrier_sync[<...>]` for any `SyncOpType` that maps to a concrete hardware `PIPE` via the existing `getPipeFromOpType()` table.
- Emit a clear error only when the op type cannot be mapped.

**Tests**
- Add `test/samples/Sync/test_barrier_sync.py` and a `runop.sh` guard that checks the generated C++ contains:
  - `pipe_barrier(PIPE_MTE2)` for `barrier_sync[<TLOAD>]`
  - `pipe_barrier(PIPE_MTE3)` for `barrier_sync[<TSTORE_VEC>]`
  - `pipe_barrier(PIPE_V)` for `barrier_sync[<TVEC>]`
