### PR TITLE
Fix #170: SSA treshape + bitcast views

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -305,6 +305,39 @@ def SubsetOp : PTO_Op<"subset", [
   }];
 }
 
+// ============================================================================
+// SSA TileBuf Config Ops (aliasing views)
+// ============================================================================
+
+def BitcastOp : PTO_Op<"bitcast", [
+    Pure,
+    ViewLikeOpInterface
+  ]> {
+  let summary = "SSA dtype reinterpretation of a tile buffer view (aliases src storage)";
+  let description = [{
+    Returns a tile buffer view with a different element type (dtype) while
+    reusing the same underlying storage as the source.
+
+    This op is a metadata/config rewrite only (no data movement).
+  }];
+
+  let arguments = (ins
+    TileBufType:$src
+  );
+
+  let results = (outs
+    TileBufType:$result
+  );
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
+
+  let extraClassDeclaration = [{
+    ::mlir::Value getViewSource() { return getSrc(); }
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // DMA Ops
 //===----------------------------------------------------------------------===//
@@ -2834,34 +2867,31 @@ def TRemSOp: PTO_TOp<"trems", [
   }];
 }
 //===----------------------------------------------------------------------===//
-// PTOOps.td  (add TRESHAPE TBDPS/tile buffer op)
+// PTOOps.td  (TRESHAPE: SSA view op; aliases src storage)
 //===----------------------------------------------------------------------===//
 
 def TReshapeOp: PTO_TOp<"treshape", [
-  PTO_DpsInitOpInterface,
   OpPipeInterface,
-  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  Pure,
+  ViewLikeOpInterface
 ]> {
-  let summary = "TRESHAPE: Elementwise remainder with a scalar";
+  let summary = "TRESHAPE: Reinterpret a tile buffer view (SSA; aliases src storage)";
 
   let arguments = (ins
-    PTODpsType:$src,
-    PTODpsType:$dst
+    PTODpsType:$src
   );
 
-  let results = (outs);
+  let results = (outs
+    PTODpsType:$result
+  );
 
   let hasVerifier = 1;
 
-  let assemblyFormat = [{
-    `ins` `(` $src `:` qualified(type($src)) `)`
-    `outs` `(` $dst `:` qualified(type($dst) ) `)`
-    attr-dict
-  }];
+  let assemblyFormat = "$src attr-dict `:` qualified(type($src)) `->` qualified(type($result))";
 
   let extraClassDeclaration = [{
     ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
-    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+    ::mlir::Value getViewSource() { return getSrc(); }
   }];
 }
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2750,15 +2750,120 @@ mlir::LogicalResult mlir::pto::TRemSOp::verify() {
   return mlir::success();
 }
 //===----------------------------------------------------------------------===//
-// PTO.cpp  (add verifier for TRESHAPE DPS/tilebuf op)
+// PTO.cpp  (verifiers for SSA treshape / bitcast)
 //===----------------------------------------------------------------------===//
+
+static std::optional<int64_t> getStaticNumElements(ArrayRef<int64_t> shape) {
+  int64_t numel = 1;
+  for (int64_t d : shape) {
+    if (d == ShapedType::kDynamic)
+      return std::nullopt;
+    if (d < 0)
+      return std::nullopt;
+    numel *= d;
+  }
+  return numel;
+}
+
+static std::optional<int64_t> getElemBytes(Type elemTy) {
+  if (!elemTy)
+    return std::nullopt;
+  if (auto ft = dyn_cast<FloatType>(elemTy)) {
+    if (ft.isF16() || ft.isBF16())
+      return 2;
+    if (ft.isF32())
+      return 4;
+    if (ft.isF64())
+      return 8;
+    return std::nullopt;
+  }
+  if (auto it = dyn_cast<IntegerType>(elemTy)) {
+    int64_t bits = it.getWidth();
+    if (bits <= 0)
+      return std::nullopt;
+    return std::max<int64_t>(1, bits / 8);
+  }
+  return std::nullopt;
+}
+
+static bool isTileBufOrMemref(Type ty) {
+  return ty.isa<MemRefType, pto::TileBufType>();
+}
 
 mlir::LogicalResult mlir::pto::TReshapeOp::verify() {
   Type ts = getSrc().getType();
-  Type td = getDst().getType();
-  if (!isPTOShapedLike(ts) || !isPTOShapedLike(td))
-    return emitOpError("expects src/dst to be memref/tensor/tile_buf/tile_view types");
-  return mlir::success();
+  Type tr = getResult().getType();
+  if (!isTileBufOrMemref(ts) || !isTileBufOrMemref(tr))
+    return emitOpError("expects src/result to be tile_buf or memref types");
+
+  // Memory space must match (treshape is an aliasing view).
+  Attribute srcSpace;
+  Attribute dstSpace;
+  if (auto tb = dyn_cast<pto::TileBufType>(ts))
+    srcSpace = tb.getMemorySpace();
+  else
+    srcSpace = cast<MemRefType>(ts).getMemorySpace();
+  if (auto tb = dyn_cast<pto::TileBufType>(tr))
+    dstSpace = tb.getMemorySpace();
+  else
+    dstSpace = cast<MemRefType>(tr).getMemorySpace();
+  if (srcSpace != dstSpace)
+    return emitOpError("expects src/result to have the same memorySpace");
+
+  // Reshape only changes shape/layout/config; dtype changes are modeled by
+  // pto.bitcast.
+  Type es = getElemTy(ts);
+  Type er = getElemTy(tr);
+  if (!es || !er)
+    return emitOpError("failed to get element type for operands");
+  if (es != er)
+    return emitOpError("expects src/result to have the same element type; use pto.bitcast for dtype changes");
+
+  auto srcNumel = getStaticNumElements(getShapeVec(ts));
+  auto dstNumel = getStaticNumElements(getShapeVec(tr));
+  if (!srcNumel.has_value() || !dstNumel.has_value())
+    return emitOpError("expects static shapes for treshape");
+  if (srcNumel.value() != dstNumel.value())
+    return emitOpError("expects src/result to have the same total element count");
+
+  return success();
+}
+
+mlir::LogicalResult mlir::pto::BitcastOp::verify() {
+  auto srcTy = llvm::dyn_cast<TileBufType>(getSrc().getType());
+  auto dstTy = llvm::dyn_cast<TileBufType>(getResult().getType());
+  if (!srcTy || !dstTy)
+    return emitOpError("expects tile_buf src and tile_buf result");
+
+  if (srcTy.getMemorySpace() != dstTy.getMemorySpace())
+    return emitOpError("expects src/result to have the same memorySpace");
+
+  if (srcTy.getShape() != dstTy.getShape())
+    return emitOpError("expects src/result to have the same shape; use pto.treshape for shape changes");
+
+  if (srcTy.getValidShape() != dstTy.getValidShape())
+    return emitOpError("expects src/result to have the same validShape");
+
+  auto srcCfg = srcTy.getConfigAttr();
+  auto dstCfg = dstTy.getConfigAttr();
+  if (srcCfg != dstCfg)
+    return emitOpError("expects src/result to have the same tile config");
+
+  auto numel = getStaticNumElements(srcTy.getShape());
+  if (!numel.has_value())
+    return emitOpError("expects static shapes for bitcast");
+
+  auto srcBytes = getElemBytes(srcTy.getElementType());
+  auto dstBytes = getElemBytes(dstTy.getElementType());
+  if (!srcBytes.has_value() || !dstBytes.has_value())
+    return emitOpError("unsupported element type for bitcast");
+
+  int64_t srcTotalBytes = numel.value() * srcBytes.value();
+  int64_t dstTotalBytes = numel.value() * dstBytes.value();
+  if (dstTotalBytes > srcTotalBytes)
+    return emitOpError("bitcast result requires more bytes than source storage");
+
+  return success();
 }
 //===----------------------------------------------------------------------===//
 // PTO.cpp  (add verifier for TROWEXPAND DPS/tilebuf op)
@@ -4313,7 +4418,6 @@ PTO_DEFINE_UNARY_EFFECTS(TRecipOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TReluOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_BINARY_EFFECTS(TRemOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TRemSOp, getSrcMutable(), getDstMutable())
-PTO_DEFINE_UNARY_EFFECTS(TReshapeOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TRowExpandOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_BINARY_EFFECTS(TRowExpandDivOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())
 PTO_DEFINE_BINARY_EFFECTS(TRowExpandMulOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5456,31 +5456,6 @@ struct PTORemSToEmitC : public OpConversionPattern<pto::TRemSOp> {
 };
 
 //===----------------------------------------------------------------------===//
-// PTOConvert.cpp  (add lowering + patterns.add for TRESHAPE DPS/memref op)
-//===----------------------------------------------------------------------===//
-
-struct PTOReshapeToEmitC : public OpConversionPattern<pto::TReshapeOp> {
-  using OpConversionPattern<pto::TReshapeOp>::OpConversionPattern;
-
-  LogicalResult matchAndRewrite(pto::TReshapeOp op, OpAdaptor adaptor,
-                                ConversionPatternRewriter &rewriter) const override {
-    auto loc = op.getLoc();
-
-    Value src = peelUnrealized(adaptor.getSrc());
-    Value dst = peelUnrealized(adaptor.getDst());
-
-    SmallVector<Value, 2> operands{dst, src};
-    rewriter.create<emitc::CallOpaqueOp>(
-        loc, TypeRange{}, "TRESHAPE",
-        /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
-        /*operands=*/operands);
-
-    rewriter.eraseOp(op);
-    return success();
-  }
-};
-
-//===----------------------------------------------------------------------===//
 // PTOConvert.cpp  (add lowering + patterns.add for TROWEXPAND DPS/memref op)
 //===----------------------------------------------------------------------===//
 
@@ -6970,7 +6945,6 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTODivSToEmitC>(typeConverter, ctx);
   patterns.add<PTOTDivSToEmitC>(typeConverter, ctx);
   patterns.add<PTORemToEmitC>(typeConverter, ctx);
-  patterns.add<PTOReshapeToEmitC>(typeConverter, ctx);
   patterns.add<PTORecipToEmitC>(typeConverter, ctx);
   patterns.add<PTOMulsToEmitC>(typeConverter, ctx);
   patterns.add<PTOExpToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -1029,6 +1029,106 @@ struct PTOViewToMemrefPass
       }
 
       // ------------------------------------------------------------------
+      // Stage 2.75: Lower SSA tile_buf view ops (pto.treshape / pto.bitcast)
+      // ------------------------------------------------------------------
+      auto lowerTileBufViewLike = [&](Operation *anchorOp, Value src,
+                                      mlir::pto::TileBufType tbTy) -> Value {
+        Location loc = anchorOp->getLoc();
+        IRRewriter rewriter(ctx);
+        rewriter.setInsertionPoint(anchorOp);
+
+        auto srcMrTy = dyn_cast<MemRefType>(src.getType());
+        if (!srcMrTy) {
+          anchorOp->emitError("tile_buf view op src must be lowered to memref first");
+          signalPassFailure();
+          return Value();
+        }
+
+        auto targetType = dyn_cast<MemRefType>(convertPTOTypeToMemRef(tbTy));
+        if (!targetType) {
+          anchorOp->emitError("failed to convert tile_buf type to memref type");
+          signalPassFailure();
+          return Value();
+        }
+
+        // Require static shape for now (alloc_tile lowering also requires this).
+        for (int64_t d : targetType.getShape()) {
+          if (d == ShapedType::kDynamic) {
+            anchorOp->emitError("dynamic shapes are not supported for tile_buf view ops");
+            signalPassFailure();
+            return Value();
+          }
+        }
+
+        // Re-bind (possibly-updated) tile metadata.
+        Value parentVRow;
+        Value parentVCol;
+        lookupValidDims(src, parentVRow, parentVCol);
+
+        Value vRow = parentVRow;
+        Value vCol = parentVCol;
+        ArrayRef<int64_t> validShape = tbTy.getValidShape();
+        if (!tbTy.hasDynamicValid()) {
+          if (validShape.size() >= 1 && validShape[0] >= 0) {
+            vRow = rewriter
+                       .create<arith::ConstantOp>(loc, rewriter.getIndexType(),
+                                                  rewriter.getIndexAttr(validShape[0]))
+                       .getResult();
+          }
+          if (validShape.size() >= 2 && validShape[1] >= 0) {
+            vCol = rewriter
+                       .create<arith::ConstantOp>(loc, rewriter.getIndexType(),
+                                                  rewriter.getIndexAttr(validShape[1]))
+                       .getResult();
+          }
+        }
+
+        auto configAttr = tbTy.getConfigAttr();
+        if (!configAttr) configAttr = pto::TileBufConfigAttr::getDefault(ctx);
+
+        auto bindOp = rewriter.create<pto::BindTileOp>(
+            loc, targetType, src,
+            vRow ? vRow : Value(), vCol ? vCol : Value(), configAttr);
+        return bindOp.getResult();
+      };
+
+      SmallVector<mlir::pto::TReshapeOp, 8> reshapes;
+      func.walk([&](mlir::pto::TReshapeOp op) { reshapes.push_back(op); });
+
+      for (auto op : reshapes) {
+        Value src = op.getSrc();
+        auto tbTy = dyn_cast<mlir::pto::TileBufType>(op.getResult().getType());
+        if (!tbTy) {
+          op.emitError("treshape result must be tile_buf type");
+          signalPassFailure();
+          return;
+        }
+        Value lowered = lowerTileBufViewLike(op, src, tbTy);
+        if (!lowered)
+          return;
+        IRRewriter rewriter(ctx);
+        rewriter.replaceOp(op, lowered);
+      }
+
+      SmallVector<mlir::pto::BitcastOp, 8> bitcasts;
+      func.walk([&](mlir::pto::BitcastOp op) { bitcasts.push_back(op); });
+
+      for (auto op : bitcasts) {
+        Value src = op.getSrc();
+        auto tbTy = dyn_cast<mlir::pto::TileBufType>(op.getResult().getType());
+        if (!tbTy) {
+          op.emitError("bitcast result must be tile_buf type");
+          signalPassFailure();
+          return;
+        }
+        Value lowered = lowerTileBufViewLike(op, src, tbTy);
+        if (!lowered)
+          return;
+        IRRewriter rewriter(ctx);
+        rewriter.replaceOp(op, lowered);
+      }
+
+      // ------------------------------------------------------------------
       // Stage 3: Rewrite Compute Ops 
       // [关键] 全面使用 op->getOperand(i) 避免 Typed Accessor Crash
       // ------------------------------------------------------------------

--- a/test/samples/Reshape/bitcast_inplace_cvt.py
+++ b/test/samples/Reshape/bitcast_inplace_cvt.py
@@ -1,0 +1,72 @@
+from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.dialects import func, arith, pto
+from mlir.ir import F16Type, F32Type, IndexType
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+
+        with Location.unknown(ctx):
+            m = Module.create()
+
+            f16 = F16Type.get(ctx)
+            f32 = F32Type.get(ctx)
+
+            ptr_f16 = pto.PtrType.get(f16, ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+
+            tv2_f16 = pto.TensorViewType.get(2, f16, ctx)
+            tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
+            tile_view_32_f16 = pto.PartitionTensorViewType.get([32, 32], f16, ctx)
+            tile_view_32_f32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+
+            vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+            pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+
+            fractal_ab_size = pto.TileConfig.fractalABSize
+            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+
+            tile_buf_32_f16 = pto.TileBufType.get([32, 32], f16, vec, [32, 32], cfg, ctx)
+            tile_buf_32_f32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+
+            rmode_attr = pto.RoundModeAttr.get(pto.RoundMode.ROUND, ctx)
+
+            fn_ty = func.FunctionType.get([ptr_f16, ptr_f32], [])
+            with InsertionPoint(m.body):
+                fn = func.FuncOp("bitcast_inplace_cvt", fn_ty)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
+                c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
+                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+
+                arg_in, arg_out = entry.arguments
+
+                tv_in = pto.MakeTensorViewOp(tv2_f16, arg_in, [c32, c32], [c32, c1]).result
+                tv_out = pto.MakeTensorViewOp(tv2_f32, arg_out, [c32, c32], [c32, c1]).result
+
+                sv_in = pto.PartitionViewOp(tile_view_32_f16, tv_in, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv_out = pto.PartitionViewOp(tile_view_32_f32, tv_out, offsets=[c0, c0], sizes=[c32, c32]).result
+
+                # Allocate a f32 tile, then bitcast it as a f16 view to load input.
+                # Use tcvt ins/outs to express an in-place conversion back to f32.
+                tb_f32 = pto.AllocTileOp(tile_buf_32_f32).result
+                tb_f16 = pto.BitcastOp(tile_buf_32_f16, tb_f32).result
+
+                pto.TLoadOp(None, sv_in, tb_f16)  # load f16 into the aliased view
+                pto.TCvtOp(tb_f16, tb_f32, rmode=rmode_attr)
+                pto.TStoreOp(None, tb_f32, sv_out)
+
+                func.ReturnOp([])
+
+            m.operation.verify()
+            return m
+
+
+if __name__ == "__main__":
+    print(build())
+

--- a/test/samples/Reshape/reshape.py
+++ b/test/samples/Reshape/reshape.py
@@ -16,13 +16,16 @@ def build():
             tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
             tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
-            bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_row = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
-            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
-            tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            cfg_row = pto.TileBufConfigAttr.get(bl_row, sl, fractal_ab_size, pd, ctx)
+            cfg_col = pto.TileBufConfigAttr.get(bl_col, sl, fractal_ab_size, pd, ctx)
+            tile_buf_32_row = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg_row, ctx)
+            tile_buf_32_col = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg_col, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
@@ -47,12 +50,12 @@ def build():
                 sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
 
                 # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
-                tb0 = pto.AllocTileOp(tile_buf_32).result
-                tb1 = pto.AllocTileOp(tile_buf_32).result
+                tb0 = pto.AllocTileOp(tile_buf_32_row).result
 
                 pto.TLoadOp(None, sv0, tb0)  # result=None
 
-                pto.TReshapeOp(tb0, tb1)
+                # SSA view op: reinterpret the same underlying storage with a new config.
+                tb1 = pto.TReshapeOp(tile_buf_32_col, tb0).result
 
                 # %8 = subview on output tensor_view
                 sv2 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result


### PR DESCRIPTION
Fixes #170.

Implements the issue #170 solution in PTOAS (no ptobc changes):

- Make `pto.treshape` an SSA + `ViewLikeOpInterface` op (aliasing view) so tile buffer config/shape can be rewritten without DPS.
- Keep `pto.tcvt` as DPS (ins/outs) since it has real memory effects.
- Add SSA `pto.bitcast` for dtype-only reinterpretation (aliasing view).
- Lower SSA `treshape/bitcast` in `PTOViewToMemref` via `pto.bind_tile` to update type/config/valid dims while preserving the same address.
- Update/add samples under `test/samples/Reshape/`.

Local CI-equivalent run (no ptobc roundtrip): `ninja -C build ptoas`, `ninja -C build install`, `bash test/samples/runop.sh all`.
