### PR TITLE
ci: use latest pto-isa by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,8 @@ on:
       pto_isa_commit:
         description: "pto-isa ref (commit/tag/branch; empty = default branch)"
         type: string
-        # NOTE: Remote NPU validation depends on upstream pto-isa. Pin a known-good
-        # commit by default to keep scheduled runs deterministic.
-        default: 082b94a3d2eaa17d63d1e5b0d74714a00594ace0
+        # NOTE: Leave empty to use the latest default-branch pto-isa.
+        default: ""
       remote_host:
         description: "SSH host/IP for the NPU machine"
         type: string
@@ -237,8 +236,6 @@ jobs:
       # Update this list as we fix the underlying issues.
       DEFAULT_SKIP_CASES: >-
         mix_kernel,vadd_validshape,vadd_validshape_dynamic
-      # Keep nightly runs deterministic by pinning pto-isa unless overridden.
-      DEFAULT_PTO_ISA_COMMIT: 082b94a3d2eaa17d63d1e5b0d74714a00594ace0
     steps:
       - name: Resolve validation parameters
         shell: bash
@@ -262,9 +259,6 @@ jobs:
           if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]]; then
             if [[ -z "${SKIP_CASES}" ]]; then
               SKIP_CASES="${DEFAULT_SKIP_CASES}"
-            fi
-            if [[ -z "${PTO_ISA_COMMIT}" ]]; then
-              PTO_ISA_COMMIT="${DEFAULT_PTO_ISA_COMMIT}"
             fi
           fi
 

--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -153,10 +153,14 @@ if [[ ! -d "${PTO_ISA_ROOT}/.git" ]]; then
   log "Cloning pto-isa into ${PTO_ISA_ROOT} ..."
   git clone "${PTO_ISA_REPO}" "${PTO_ISA_ROOT}"
 fi
+log "Fetching pto-isa updates ..."
+git -C "${PTO_ISA_ROOT}" fetch --all --prune
 if [[ -n "${PTO_ISA_COMMIT}" ]]; then
   log "Checking out pto-isa ${PTO_ISA_COMMIT} ..."
-  git -C "${PTO_ISA_ROOT}" fetch --all --prune
-  git -C "${PTO_ISA_ROOT}" checkout "${PTO_ISA_COMMIT}"
+  git -C "${PTO_ISA_ROOT}" checkout -f "${PTO_ISA_COMMIT}"
+else
+  log "Checking out pto-isa origin/HEAD (remote default branch) ..."
+  git -C "${PTO_ISA_ROOT}" checkout -f origin/HEAD
 fi
 
 status=0


### PR DESCRIPTION
## Summary

Use the latest `pto-isa` by default in remote NPU validation.

## Changes

- `.github/workflows/ci.yml`
  - Default `pto_isa_commit` is now empty, so remote validation uses the latest default-branch `pto-isa` unless overridden.
  - Remove the scheduled-run auto pin of `pto-isa`.
- `test/npu_validation/scripts/run_remote_npu_validation.sh`
  - Always `fetch` pto-isa updates.
  - If `PTO_ISA_COMMIT` is empty, checkout `origin/HEAD` (remote default branch).

## Testing

- `bash -n test/npu_validation/scripts/run_remote_npu_validation.sh`
