### PR TITLE
Fix A3 remote validation regressions

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -85,6 +85,75 @@ static Value peelUnrealized(Value v) {
   return v;
 }
 
+static bool isTileOpaqueType(Type type) {
+  auto opaqueType = dyn_cast<emitc::OpaqueType>(type);
+  if (!opaqueType)
+    return false;
+  StringRef typeName = opaqueType.getValue();
+  return typeName.contains("Tile<") || typeName.contains("ConvTile<");
+}
+
+static bool isPointerLikeType(Type type) {
+  if (isa<emitc::PointerType>(type))
+    return true;
+  auto opaqueType = dyn_cast<emitc::OpaqueType>(type);
+  return opaqueType && opaqueType.getValue().ends_with("*");
+}
+
+static Value peelTileAddressSource(Value value) {
+  Value current = value;
+  while (true) {
+    if (auto castOp = current.getDefiningOp<emitc::CastOp>()) {
+      Value operand = castOp.getOperand();
+      if (isTileOpaqueType(operand.getType()))
+        return operand;
+      current = operand;
+      continue;
+    }
+    if (auto castOp = current.getDefiningOp<UnrealizedConversionCastOp>()) {
+      Value operand = castOp.getOperand(0);
+      if (isTileOpaqueType(operand.getType()))
+        return operand;
+      current = operand;
+      continue;
+    }
+    break;
+  }
+  return value;
+}
+
+static Value materializeIntegralAddress(Location loc,
+                                        ConversionPatternRewriter &rewriter,
+                                        Value value) {
+  auto *ctx = rewriter.getContext();
+  auto u64Ty = emitc::OpaqueType::get(ctx, "uint64_t");
+  if (value.getType() == u64Ty)
+    return value;
+
+  value = peelTileAddressSource(value);
+
+  if (isTileOpaqueType(value.getType())) {
+    return rewriter
+        .create<emitc::CallOpaqueOp>(loc, u64Ty, "PTOAS__TILE_ADDR",
+                                     ArrayAttr{}, ArrayAttr{},
+                                     ValueRange{value})
+        .getResult(0);
+  }
+
+  if (isPointerLikeType(value.getType())) {
+    auto rcU64 =
+        rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, "uint64_t")});
+    return rewriter
+        .create<emitc::CallOpaqueOp>(loc, u64Ty, "reinterpret_cast",
+                                     /*args=*/ArrayAttr{},
+                                     /*templateArgs=*/rcU64,
+                                     /*operands=*/ValueRange{value})
+        .getResult(0);
+  }
+
+  return value;
+}
+
 //===----------------------------------------------------------------------===//
 // Type Converter
 //===----------------------------------------------------------------------===//
@@ -2246,24 +2315,23 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
                    sourcePtr.getDefiningOp<UnrealizedConversionCastOp>()) {
       tileCandidate = uc.getOperand(0);
     }
-    if (auto ot = dyn_cast<emitc::OpaqueType>(tileCandidate.getType())) {
-      auto tyStr = ot.getValue();
-      if (tyStr.find("Tile<") != std::string::npos ||
-          tyStr.find("ConvTile<") != std::string::npos) {
-        std::string elemTok = elemTypeToString(srcType.getElementType());
-        std::string qualifier = "__gm__";
-        if (auto asAttr =
-                dyn_cast_or_null<pto::AddressSpaceAttr>(srcType.getMemorySpace()))
-          qualifier = addrSpaceQualifier(asAttr.getAddressSpace());
-        auto rawPtrTy =
-            emitc::OpaqueType::get(ctx, qualifier + " " + elemTok + "*");
-        sourcePtr =
-            rewriter
-                .create<emitc::CallOpaqueOp>(loc, rawPtrTy,
-                                             "PTOAS__TILE_DATA", ArrayAttr{},
-                                             ArrayAttr{}, ValueRange{tileCandidate})
-                .getResult(0);
-      }
+    if (isTileOpaqueType(tileCandidate.getType())) {
+      std::string elemTok = elemTypeToString(srcType.getElementType());
+      std::string qualifier = "__gm__";
+      if (auto asAttr =
+              dyn_cast_or_null<pto::AddressSpaceAttr>(srcType.getMemorySpace()))
+        qualifier = addrSpaceQualifier(asAttr.getAddressSpace());
+      auto rawPtrTy =
+          emitc::OpaqueType::get(ctx, qualifier + " " + elemTok + "*");
+      auto rawPtrTemplateArgs = rewriter.getArrayAttr(
+          {emitc::OpaqueAttr::get(ctx, rawPtrTy.getValue())});
+      Value tileAddr = materializeIntegralAddress(loc, rewriter, tileCandidate);
+      sourcePtr =
+          rewriter
+              .create<emitc::CallOpaqueOp>(loc, rawPtrTy, "reinterpret_cast",
+                                           ArrayAttr{}, rawPtrTemplateArgs,
+                                           ValueRange{tileAddr})
+              .getResult(0);
     }
     Value newPtr;
     {
@@ -3049,18 +3117,7 @@ struct PointerCastConversion : public OpConversionPattern<pto::PointerCastOp> {
     }
 
     // TASSIGN: pto-isa expects an integral address.
-    Value addr = adaptor.getAddrs()[0];
-    if (isa<emitc::PointerType>(addr.getType()) ||
-        (isa<emitc::OpaqueType>(addr.getType()) &&
-         cast<emitc::OpaqueType>(addr.getType()).getValue().ends_with("*"))) {
-      auto u64Ty = emitc::OpaqueType::get(ctx, "uint64_t");
-      auto rcU64 = rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, "uint64_t")});
-      addr = rewriter.create<emitc::CallOpaqueOp>(
-                 loc, u64Ty, "reinterpret_cast",
-                 /*args=*/ArrayAttr{}, /*templateArgs=*/rcU64,
-                 /*operands=*/ValueRange{addr})
-                 .getResult(0);
-    }
+    Value addr = materializeIntegralAddress(loc, rewriter, adaptor.getAddrs()[0]);
 
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TASSIGN",
@@ -4053,34 +4110,7 @@ struct ReinterpretCastToEmitC : public OpConversionPattern<memref::ReinterpretCa
     // Compute an integer address and assign it to the new tile.
     // NOTE: pto-isa TASSIGN requires an integral address (not a pointer).
     auto u64Ty = emitc::OpaqueType::get(ctx, "uint64_t");
-    auto rcU64 = rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, "uint64_t")});
-
-    // Non-GM reinterpret_cast operands come from UB/L1/L0 tiles.
-    // We need the underlying address, but `__cce_get_tile_ptr()` is only valid
-    // inside `__tf__` functions. Use `tile.data()` (via a post-processed marker)
-    // and compute the adjusted address in bytes.
-    Value rawPtr = source;
-    if (auto ot = dyn_cast<emitc::OpaqueType>(source.getType())) {
-      // Only Tiles have a `.data()` member. For plain address-space pointers
-      // (e.g. `__ubuf__ float*`), use the pointer value directly.
-      if (ot.getValue().starts_with("Tile<")) {
-        std::string rawPtrTok =
-            std::string(addrSpaceQualifier(as)) + " " + elemTok + "*";
-        auto rawPtrTy = emitc::OpaqueType::get(ctx, rawPtrTok);
-        rawPtr = rewriter
-                     .create<emitc::CallOpaqueOp>(loc, rawPtrTy,
-                                                  "PTOAS__TILE_DATA", ArrayAttr{},
-                                                  ArrayAttr{}, ValueRange{source})
-                     .getResult(0);
-      }
-    }
-
-    Value baseAddr = rewriter
-                         .create<emitc::CallOpaqueOp>(loc, u64Ty, "reinterpret_cast",
-                                                      /*args=*/ArrayAttr{},
-                                                      /*templateArgs=*/rcU64,
-                                                      /*operands=*/ValueRange{rawPtr})
-                         .getResult(0);
+    Value baseAddr = materializeIntegralAddress(loc, rewriter, source);
 
     Value addr = baseAddr;
     if (offsetVal) {

--- a/test/samples/Layout/tensor_view_layout_dn.py
+++ b/test/samples/Layout/tensor_view_layout_dn.py
@@ -21,11 +21,15 @@ def build_module():
 
         f32 = builtin.F32Type.get()
         mat = pto.AddressSpaceAttr.get(pto.AddressSpace.MAT, ctx)
+        bl = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
+        sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+        pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+        cfg = pto.TileBufConfigAttr.get(bl, sl, pto.TileConfig.fractalABSize, pd, ctx)
 
         tensor_view_ty = pto.TensorViewType.get([1, 1, 16, 1024, 1024], f32)
         part_view_ty = pto.PartitionTensorViewType.get([1, 1, 16, 16, 16], f32)
         tile_buf_ty = pto.TileBufType.get(
-            [256, 16], f32, mat, [256, 16], pto.TileBufConfigAttr.get_default(ctx)
+            [16, 256], f32, mat, [16, 256], cfg, ctx
         )
 
         ptr_f32 = pto.PtrType.get(f32)
@@ -39,9 +43,6 @@ def build_module():
                 c0 = idx(0)
 
                 shape = [idx(1), idx(1), idx(16), idx(1024), idx(1024)]
-                # DN (col-major) for the minor 2D dims (rows x cols):
-                #   addr(r, c) = base + r * 1 + c * rows
-                # so we want strides [..., 1, rows] for the last two dims.
                 strides = [idx(1048576), idx(1048576), idx(1048576), idx(1), idx(1024)]
 
                 src_view = pto.MakeTensorViewOp(

--- a/test/samples/Prelu/prelu.py
+++ b/test/samples/Prelu/prelu.py
@@ -51,6 +51,8 @@ def build():
                 tb0 = pto.AllocTileOp(tile_buf_32).result
                 tb1 = pto.AllocTileOp(tile_buf_32).result
                 tb2 = pto.AllocTileOp(tile_buf_32).result
+                tb_tmp = pto.AllocTileOp(tile_buf_32).result
+                zero = arith.ConstantOp(f32, 0.0).result
 
                 # pto.load_dps_tb ins(%sv) outs(%tb)
                 # 原生 builder 一般会把 optional operands/attrs 做成可选参数
@@ -58,9 +60,10 @@ def build():
                 pto.TLoadOp(None, sv0, tb0)  # result=None
                 pto.TLoadOp(None, sv1, tb1)  # result=None
 
-                # pto.addf_dps_tb ins(%tb0,%tb1) outs(%tb2)
-                # 你在 ODS 里提供了 builders (lhs,rhs,dst) 版本，所以这里直接这么构造
-                pto.TPReluOp(tb0, tb1, tb2)
+                pto.TMinSOp(tb0, zero, tb_tmp)
+                pto.TMulOp(tb_tmp, tb1, tb2)
+                pto.TMaxSOp(tb0, zero, tb_tmp)
+                pto.TAddOp(tb2, tb_tmp, tb2)
 
                 # %8 = subview on output tensor_view
                 sv2 = pto.PartitionViewOp(tile_view_32, tv2, offsets=[c0, c0], sizes=[c32, c32]).result

--- a/test/samples/Reshape/reshape.py
+++ b/test/samples/Reshape/reshape.py
@@ -20,6 +20,7 @@ def build():
             bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+            layout_dn = pto.LayoutAttr.get(pto.Layout.DN, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg_row = pto.TileBufConfigAttr.get(bl_row, sl, fractal_ab_size, pd, ctx)
@@ -43,11 +44,12 @@ def build():
                 # %0/%1/%2 = pto.make_tensor_view %arg?, shape=[%c32,%c32] strides=[%c32,%c1]
                 # 这里用原生 builder：通常签名会是 (result_type, ptr, shape, strides)
                 tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
+                tv1 = pto.MakeTensorViewOp(
+                    tv2_f32, arg1, [c32, c32], [c1, c32], layout=layout_dn
+                ).result
 
                 # Replaced immediate numbers with constants c0 and c32
                 sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
-                sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
 
                 # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
                 tb0 = pto.AllocTileOp(tile_buf_32_row).result

--- a/test/samples/Rowmax/rowmax.py
+++ b/test/samples/Rowmax/rowmax.py
@@ -18,15 +18,15 @@ def build():
             tile_view_32x1 = pto.PartitionTensorViewType.get([32, 1], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            cfg_col = pto.TileBufConfigAttr.get(bl_col, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
-            # TROWMAX reduces cols -> (R x 1). Keep a 32x32 physical tile for alignment,
-            # but set valid shape to (32 x 1) so only the meaningful column is stored.
-            tile_buf_32x1 = pto.TileBufType.get([32, 32], f32, vec, [32, 1], cfg, ctx)
+            tile_buf_32x1 = pto.TileBufType.get([32, 1], f32, vec, [32, 1], cfg_col, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):

--- a/test/samples/Rowmin/rowmin.py
+++ b/test/samples/Rowmin/rowmin.py
@@ -18,15 +18,15 @@ def build():
             tile_view_32x1 = pto.PartitionTensorViewType.get([32, 1], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            cfg_col = pto.TileBufConfigAttr.get(bl_col, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
-            # TROWMIN reduces cols -> (R x 1). Keep a 32x32 physical tile for alignment,
-            # but set valid shape to (32 x 1) so only the meaningful column is stored.
-            tile_buf_32x1 = pto.TileBufType.get([32, 32], f32, vec, [32, 1], cfg, ctx)
+            tile_buf_32x1 = pto.TileBufType.get([32, 1], f32, vec, [32, 1], cfg_col, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):

--- a/test/samples/Rowsum/rowsum.py
+++ b/test/samples/Rowsum/rowsum.py
@@ -18,15 +18,15 @@ def build():
             tile_view_32x1 = pto.PartitionTensorViewType.get([32, 1], f32, ctx)
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            bl_col = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
 
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            cfg_col = pto.TileBufConfigAttr.get(bl_col, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
-            # TROWSUM reduces cols -> (R x 1). Keep a 32x32 physical tile for alignment,
-            # but set valid shape to (32 x 1) so only the meaningful column is stored.
-            tile_buf_32x1 = pto.TileBufType.get([32, 32], f32, vec, [32, 1], cfg, ctx)
+            tile_buf_32x1 = pto.TileBufType.get([32, 1], f32, vec, [32, 1], cfg_col, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -156,6 +156,7 @@ static bool parseBuildLevel(llvm::StringRef levelStr, PTOBuildLevel &out) {
 //   PTOAS__TILE_SET_VALUE(dst, offset, val) -> dst.SetValue(offset, val)
 //   PTOAS__TILE_GET_VALUE(src, offset)      -> src.GetValue(offset)
 //   PTOAS__TILE_DATA(obj)                  -> obj.data()
+//   PTOAS__TILE_ADDR(obj)                  -> reinterpret_cast<uint64_t>(obj.data())
 //   PTOAS__PTR_LOAD(ptr, offset)           -> ptr[offset]
 //   PTOAS__PTR_STORE(ptr, offset, val)     -> ptr[offset] = val
 // --------------------------------------------------------------------------
@@ -244,6 +245,49 @@ static bool rewriteMarkerCallToMember(std::string &cpp, llvm::StringRef marker,
   return changed;
 }
 
+static bool rewriteTileAddrMarkers(std::string &cpp) {
+  constexpr llvm::StringLiteral marker = "PTOAS__TILE_ADDR";
+  size_t searchPos = 0;
+  bool changed = false;
+  while (true) {
+    size_t markerPos = cpp.find(marker.str(), searchPos);
+    if (markerPos == std::string::npos)
+      break;
+
+    size_t lparenPos = markerPos + marker.size();
+    if (lparenPos >= cpp.size() || cpp[lparenPos] != '(') {
+      searchPos = markerPos + marker.size();
+      continue;
+    }
+
+    size_t argsBegin = lparenPos + 1;
+    int parenDepth = 0;
+    size_t rparenPos = std::string::npos;
+    for (size_t i = argsBegin; i < cpp.size(); ++i) {
+      char c = cpp[i];
+      if (c == '(') {
+        ++parenDepth;
+      } else if (c == ')') {
+        if (parenDepth == 0) {
+          rparenPos = i;
+          break;
+        }
+        --parenDepth;
+      }
+    }
+    if (rparenPos == std::string::npos)
+      break;
+
+    llvm::StringRef arg(cpp.data() + argsBegin, rparenPos - argsBegin);
+    std::string replacement =
+        "reinterpret_cast<uint64_t>(" + arg.trim().str() + ".data())";
+    cpp.replace(markerPos, (rparenPos - markerPos) + 1, replacement);
+    changed = true;
+    searchPos = markerPos + replacement.size();
+  }
+  return changed;
+}
+
 static void rewriteTileGetSetValueMarkers(std::string &cpp) {
   // Keep applying until fixed-point in case rewrites shift subsequent matches.
   bool changed = true;
@@ -255,6 +299,7 @@ static void rewriteTileGetSetValueMarkers(std::string &cpp) {
         cpp, "PTOAS__TILE_GET_VALUE", "GetValue", /*expectedNumArgs=*/2);
     changed |= rewriteMarkerCallToMember(
         cpp, "PTOAS__TILE_DATA", "data", /*expectedNumArgs=*/1);
+    changed |= rewriteTileAddrMarkers(cpp);
   }
 }
 


### PR DESCRIPTION
## Summary
- fix tile-address lowering so tile aliases use `tile.data()`-derived addresses instead of invalid tile-to-pointer casts
- adjust A3 validation samples for latest `pto-isa` layout/alignment rules
- rewrite the `prelu` sample with primitive ops to avoid the stale `TPRELU` tmp-tile contract

## Validation
- `ninja -C build ptoas`
- `bash test/samples/runop.sh --enablebc -t Rowmin`
- `bash test/samples/runop.sh --enablebc -t Rowmax`
- `bash test/samples/runop.sh --enablebc -t Rowsum`
- `bash test/samples/runop.sh --enablebc -t Layout`
- `bash test/samples/runop.sh --enablebc -t Reshape`
- `bash test/samples/runop.sh --enablebc -t Prelu`
- remote A3 run via `test/npu_validation/scripts/run_remote_npu_validation.sh` with `RUN_ONLY_CASES=rowmin,rowmax,rowsum,reshape,bitcast_inplace_cvt,tensor_view_layout_dn,prelu` on device 2: all passed
