### PR TITLE
fix:  avoid over-optimization for tprint

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3240,9 +3240,10 @@ mlir::LogicalResult mlir::pto::TSyncOp::verify() {
 
 mlir::LogicalResult mlir::pto::TPrintOp::verify() {
   auto srcType = getSrc().getType();
-  
+
   // Support TileBufType and PartitionTensorViewType (replaces legacy TileView).
   if (mlir::dyn_cast<mlir::pto::TileBufType>(srcType) ||
+      mlir::dyn_cast<MemRefType>(srcType) ||
       mlir::dyn_cast<mlir::pto::PartitionTensorViewType>(srcType)) {
     return mlir::success();
   }
@@ -4347,6 +4348,7 @@ void TTransOp::getEffects(
 void TPrintOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
+  PTO_ADD_WRITE(getSrcMutable());
 }
 
 #undef PTO_DEFINE_TERNARY_EFFECTS


### PR DESCRIPTION
避免 tprint 被过度优化 (fixes #209)

- 问题：tprint 仅声明 Read 效果，被优化器重排或删除。
- 修复：为 TPrintOp 的 src 增加 Write 效果声明。
- 测试：./build/tools/ptoas/ptoas prtint.pto
输入： print.pto
```
module {
  func.func @vec_add_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %c1024 = arith.constant 1024 : index
    %c20480 = arith.constant 20480 : index
    %0 = pto.get_block_idx
    %1 = pto.get_subblock_idx
    %2 = pto.get_subblock_num
    %3 = arith.muli %0, %2 : i64
    %4 = arith.addi %3, %1 : i64
    %5 = pto.make_tensor_view %arg0, shape = [%c1, %c1024], strides = [%c1024, %c1] : !pto.tensor_view<?x?xf32>
    %6 = pto.make_tensor_view %arg1, shape = [%c1, %c1024], strides = [%c1024, %c1] : !pto.tensor_view<?x?xf32>
    %7 = pto.make_tensor_view %arg2, shape = [%c1, %c1024], strides = [%c1024, %c1] : !pto.tensor_view<?x?xf32>
    %8 = arith.index_cast %4 : i64 to index
    %9 = arith.muli %8, %c1024 : index
    %10 = pto.partition_view %5, offsets = [%c0, %9], sizes = [%c1, %c1024] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x1024xf32>
    %11 = pto.partition_view %6, offsets = [%c0, %9], sizes = [%c1, %c1024] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x1024xf32>
    %12 = pto.partition_view %7, offsets = [%c0, %9], sizes = [%c1, %c1024] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x1024xf32>
    pto.section.vector {
      %13 = pto.alloc_tile valid_row = %c1 valid_col = %c1024 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
      %14 = pto.alloc_tile valid_row = %c1 valid_col = %c1024 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
      %15 = pto.alloc_tile valid_row = %c1 valid_col = %c1024 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
      // TPRINT a TileBufType
      pto.tprint ins(%13 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
      //
      pto.tload ins(%10 : !pto.partition_tensor_view<1x1024xf32>) outs(%13 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
      pto.tload ins(%11 : !pto.partition_tensor_view<1x1024xf32>) outs(%14 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
      pto.tadd ins(%13, %14 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%15 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
      pto.tstore ins(%15 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=1024, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%12 : !pto.partition_tensor_view<1x1024xf32>)
    }
    return
  }
}
```
输出：
```
#include "pto/pto-inst.hpp"
using namespace pto;
__global__ AICORE void vec_add_kernel(__gm__ float* v1, __gm__ float* v2, __gm__ float* v3) {
  unsigned v4 = 1024;
  unsigned v5 = 1;
  unsigned v6 = 0;
  int32_t v7 = 1024;
  int32_t v8 = 1;
  int64_t v9 = 0;
  int64_t v10 = 4096;
  int64_t v11 = 8192;
  using T = float;
  int64_t v12 = get_block_idx();
  int64_t v13 = get_subblockid();
  int64_t v14 = get_subblockdim();
  int32_t v15 = (int32_t) ((uint32_t) ((int32_t) (int64_t) ((uint64_t) ((int64_t) (uint64_t) ((int64_t) v12) * (uint64_t) ((int64_t) v14)) + (uint64_t) ((int64_t) v13))) * (uint32_t) v7);
  pto::Shape<1, 1, 1, 1, 1024> v16 = pto::Shape<1, 1, 1, 1, 1024>();
  pto::Stride<1024, 1024, 1024, 1024, 1> v17 = pto::Stride<1024, 1024, 1024, 1024, 1>();
  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1024>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v18 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1024>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v1 + (v6 + v6 * (unsigned) v7 + (unsigned) v15 * (unsigned) v8), v16, v17);
  pto::Shape<1, 1, 1, 1, 1024> v19 = pto::Shape<1, 1, 1, 1, 1024>();
  pto::Stride<1024, 1024, 1024, 1024, 1> v20 = pto::Stride<1024, 1024, 1024, 1024, 1>();
  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1024>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v21 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1024>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v2 + (v6 + v6 * (unsigned) v7 + (unsigned) v15 * (unsigned) v8), v19, v20);
  pto::Shape<1, 1, 1, 1, 1024> v22 = pto::Shape<1, 1, 1, 1, 1024>();
  pto::Stride<1024, 1024, 1024, 1024, 1> v23 = pto::Stride<1024, 1024, 1024, 1024, 1>();
  GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1024>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND> v24 = GlobalTensor<float, pto::Shape<1, 1, 1, 1, 1024>, pto::Stride<1024, 1024, 1024, 1024, 1>, pto::Layout::ND>(v3 + (v6 + v6 * (unsigned) v7 + (unsigned) v15 * (unsigned) v8), v22, v23);

  #if defined(__DAV_VEC__)
  set_mask_norm();
  set_vector_mask(-1, -1);
  Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, 1, 1024> v25;
  TASSIGN(v25, v9);
  Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, 1, 1024, SLayout::NoneBox, 512, PadValue::Null> v26;
  TRESHAPE(v26, v25);
  Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, 1, 1024> v27;
  TASSIGN(v27, v10);
  Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, 1, 1024, SLayout::NoneBox, 512, PadValue::Null> v28;
  TRESHAPE(v28, v27);
  Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, 1, 1024> v29;
  TASSIGN(v29, v11);
  Tile<TileType::Vec, float, 1, 1024, BLayout::RowMajor, 1, 1024, SLayout::NoneBox, 512, PadValue::Null> v30;
  TRESHAPE(v30, v29);
  TPRINT(v26);
  TLOAD(v26, v18);
  TLOAD(v28, v21);
  TADD(v30, v26, v28);
  TSTORE(v24, v30);
  #endif // __DAV_VEC__

  return;
}
```