### PR TITLE
fix(layout): preserve bind_tile config in alloc pointer_cast

### DIFF
--- a/lib/PTO/Transforms/AllocToPointerCast.cpp
+++ b/lib/PTO/Transforms/AllocToPointerCast.cpp
@@ -25,6 +25,25 @@ namespace {} // namespace
 LogicalResult MemrefAllocaOpToPointerCastOpPattern::matchAndRewrite(
     memref::AllocOp op, PatternRewriter &rewriter) const {
   const auto &currentMemRefType = cast<BaseMemRefType>(op.getType());
+
+  // Preserve tile config carried by the downstream bind_tile user. Losing this
+  // metadata here makes PointerCast lowering fall back to RowMajor defaults,
+  // which can generate illegal intermediate TRESHAPE sequences.
+  TileBufConfigAttr configAttr;
+  for (Operation *user : op.getResult().getUsers()) {
+    auto bind = dyn_cast<pto::BindTileOp>(user);
+    if (!bind || bind.getSource() != op.getResult())
+      continue;
+    if (!configAttr) {
+      configAttr = bind.getConfigAttr();
+      continue;
+    }
+    if (configAttr != bind.getConfigAttr()) {
+      op.emitWarning("alloc has multiple bind_tile users with different configs; "
+                     "using the first one");
+      break;
+    }
+  }
   
   constexpr uint64_t kAlign = 4096;
   auto iter = buffer2Offsets.find(op.getResult());
@@ -101,7 +120,7 @@ LogicalResult MemrefAllocaOpToPointerCastOpPattern::matchAndRewrite(
       ValueRange(addrs),      // addrs
       vRow ? vRow : Value(),  // valid_row
       vCol ? vCol : Value(),  // valid_col
-      TileBufConfigAttr()     // config (空对象)
+      configAttr              // preserve bind_tile config when available
   );
 
   rewriter.replaceOp(op, ptoPointerCastOp->getResults());

--- a/test/samples/Layout/tensor_view_layout_dn.py
+++ b/test/samples/Layout/tensor_view_layout_dn.py
@@ -20,13 +20,15 @@ def build_module():
         pto.register_dialect(ctx, load=True)
 
         f32 = builtin.F32Type.get()
-        mat = pto.AddressSpaceAttr.get(pto.AddressSpace.MAT, ctx)
+        vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+        bl = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
+        sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+        pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+        cfg = pto.TileBufConfigAttr.get(bl, sl, pto.TileConfig.fractalABSize, pd, ctx)
 
-        tensor_view_ty = pto.TensorViewType.get([1, 1, 16, 1024, 1024], f32)
-        part_view_ty = pto.PartitionTensorViewType.get([1, 1, 16, 16, 16], f32)
-        tile_buf_ty = pto.TileBufType.get(
-            [256, 16], f32, mat, [256, 16], pto.TileBufConfigAttr.get_default(ctx)
-        )
+        tensor_view_ty = pto.TensorViewType.get(2, f32, ctx)
+        part_view_ty = pto.PartitionTensorViewType.get([16, 1], f32, ctx)
+        tile_buf_ty = pto.TileBufType.get([16, 1], f32, vec, [16, 1], cfg, ctx)
 
         ptr_f32 = pto.PtrType.get(f32)
         layout_dn = pto.LayoutAttr.get(pto.Layout.DN, ctx)
@@ -38,11 +40,11 @@ def build_module():
             def run(src, dst):
                 c0 = idx(0)
 
-                shape = [idx(1), idx(1), idx(16), idx(1024), idx(1024)]
-                # DN (col-major) for the minor 2D dims (rows x cols):
-                #   addr(r, c) = base + r * 1 + c * rows
-                # so we want strides [..., 1, rows] for the last two dims.
-                strides = [idx(1048576), idx(1048576), idx(1048576), idx(1), idx(1024)]
+                c1 = idx(1)
+                c16 = idx(16)
+                shape = [c16, c1]
+                # DN for (16 x 1): addr(r, c) = base + r*1 + c*rows.
+                strides = [c1, c1]
 
                 src_view = pto.MakeTensorViewOp(
                     tensor_view_ty, src, shape, strides, layout=layout_dn
@@ -50,8 +52,8 @@ def build_module():
                 src_part = pto.PartitionViewOp(
                     part_view_ty,
                     src_view,
-                    offsets=[c0, c0, c0, c0, c0],
-                    sizes=[idx(1), idx(1), idx(16), idx(16), idx(16)],
+                    offsets=[c0, c0],
+                    sizes=[c16, c1],
                 ).result
 
                 tile = pto.AllocTileOp(tile_buf_ty).result
@@ -63,8 +65,8 @@ def build_module():
                 dst_part = pto.PartitionViewOp(
                     part_view_ty,
                     dst_view,
-                    offsets=[c0, c0, c0, c0, c0],
-                    sizes=[idx(1), idx(1), idx(16), idx(16), idx(16)],
+                    offsets=[c0, c0],
+                    sizes=[c16, c1],
                 ).result
 
                 pto.TStoreOp(None, tile, dst_part)


### PR DESCRIPTION
## Summary
- preserve `bind_tile` layout/config when lowering `memref.alloc` to `pto.pointer_cast` in `AllocToPointerCast`
- avoid accidental fallback to default row-major tile form that can violate downstream layout constraints
- update `tensor_view_layout_dn.py` to a minimal valid explicit DN-layout scenario for stable regression coverage

## Root Cause
During alloc-to-pointer-cast lowering, the original tile binding metadata was not fully propagated. This changed generated intermediate tile forms and could break layout consistency checks in downstream `TSTORE` static assertions.

## Changes
- `lib/PTO/Transforms/AllocToPointerCast.cpp`
  - keep bind-tile configuration when creating pointer-cast replacement
- `test/samples/Layout/tensor_view_layout_dn.py`
  - revise sample to a minimal explicit DN case (`[16,1]`, VEC, ColMajor + NoneBox)

## Validation
### Local
- `bash test/samples/runop.sh --enablebc all`
- Result: `OK=141 FAIL=0 SKIP=1`

### Remote board (A3, CI-like flow)
- Full suite on this branch (with CI skip list): `OK=123 FAIL=4 SKIP=7`
- Failed cases: `print,rowmin,rowmax,rowsum`

### Baseline check (origin/main)
- Re-ran remote on `origin/main` for `print,rowmin,rowmax,rowsum`
- Result: `OK=0 FAIL=4 SKIP=0`
- Fail signatures are identical (same compile-time failure families), so these are pre-existing baseline issues in current remote environment, not introduced by this PR.

## Risk
- Scope is limited to alloc-pointer-cast metadata preservation + one DN sample update.
- No pass pipeline ordering or sync/event allocation logic changes.
