### PR TITLE
Fix bind_tile view lowering for reshape and bitcast

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6569,7 +6569,26 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       return rewriter.create<emitc::CastOp>(loc, u64Ty, rawPtr).getResult();
     };
 
-    Value tileCandidate = peelAllCasts(adaptor.getSource());
+    // For view-like bind_tile chains (for example, treshape/bitcast lowered by
+    // PTOViewToMemref), the upstream bind_tile/alloc_tile may already have
+    // been converted to a Tile. Reuse that remapped Tile so semantic views can
+    // lower via TRESHAPE/TASSIGN instead of falling back to a raw pointer path.
+    Value remappedSource;
+    if (Value v = rewriter.getRemappedValue(op.getSource()))
+      remappedSource = peelAllCasts(v);
+    Value tileCandidate =
+        remappedSource ? remappedSource : peelAllCasts(adaptor.getSource());
+
+    int64_t ignored = 0;
+    bool hasDynamicValidShape =
+        (op.getValidRow() && !getIndexConst(op.getValidRow(), ignored)) ||
+        (op.getValidCol() && !getIndexConst(op.getValidCol(), ignored));
+
+    if (!viewSemantics && remappedSource && isTileLike(remappedSource) &&
+        !hasDynamicValidShape) {
+      rewriter.replaceOp(op, remappedSource);
+      return success();
+    }
     if (viewSemantics && viewSemantics.getValue() == "bitcast" &&
         isTileLike(tileCandidate)) {
       FailureOr<Value> dstTile = buildTileValue();

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -385,7 +385,7 @@ process_one_dir() {
         overall=1
         continue
       fi
-      if [[ $(grep -c "TRESHAPE(" "$cpp") -ne 1 ]]; then
+      if grep -Fq "TRESHAPE(" "$cpp"; then
         echo -e "${A}(${base}.py)	FAIL	pto.bitcast should not lower via TRESHAPE()"
         overall=1
         continue
@@ -406,21 +406,29 @@ import re
 import sys
 
 text = open(sys.argv[1], "r", encoding="utf-8").read()
+
+# Accept either:
+# 1. Two-step lowering:
+#      ptr = tile.data();
+#      addr = reinterpret_cast<uint64_t>(ptr);
+#      TASSIGN(dst, addr);
+# 2. Inline lowering:
+#      addr = reinterpret_cast<uint64_t>(tile.data());
+#      TASSIGN(dst, addr);
 ptr_vars = {
     match.group(1)
     for match in re.finditer(r"\b(\w+)\s*=\s*\w+\.data\(\);", text)
 }
-addr_vars = {
-    match.group(1)
-    for match in re.finditer(
-        r"\b(\w+)\s*=\s*reinterpret_cast<uint64_t>\((\w+)\);", text
-    )
-    if match.group(2) in ptr_vars
-}
-ok = any(
-    re.search(rf"TASSIGN\([^,]+,\s*{re.escape(addr_var)}\);", text)
-    for addr_var in addr_vars
-)
+addr_vars = set()
+for match in re.finditer(
+    r"\b(\w+)\s*=\s*reinterpret_cast<uint64_t>\((.+)\);", text
+):
+    addr_var = match.group(1)
+    src_expr = match.group(2).strip()
+    if src_expr in ptr_vars or src_expr.endswith(".data()"):
+        addr_vars.add(addr_var)
+
+ok = any(re.search(rf"TASSIGN\([^,]+,\s*{re.escape(addr_var)}\);", text) for addr_var in addr_vars)
 sys.exit(0 if ok else 1)
 PY
       then


### PR DESCRIPTION
## Summary
- reuse remapped tile values in `PTOBindTileToEmitC` so view-like `bind_tile` chains keep semantic lowering instead of falling back to raw pointers
- directly replace non-view `bind_tile` with the remapped tile when the valid shape is static, which fixes the `reshape.py` regression and preserves the dynamic valid-shape path
- relax the sample assertions in `runop.sh` so correct bitcast alias lowering is not reported as a failure

## Validation
- `PYTHONPATH=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/tools/mlir/python_packages/mlir_core:/Users/laoda/pto/PTOAS/build/python DYLD_LIBRARY_PATH=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/lib:/Users/laoda/pto/PTOAS/build/lib PYTHON_BIN=/usr/bin/python3 bash test/samples/runop.sh --enablebc -t Reshape`
- `PYTHONPATH=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/tools/mlir/python_packages/mlir_core:/Users/laoda/pto/PTOAS/build/python DYLD_LIBRARY_PATH=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/lib:/Users/laoda/pto/PTOAS/build/lib PYTHON_BIN=/usr/bin/python3 bash test/samples/runop.sh --enablebc -t Sync`
- A3 end-to-end validation of the generated `kernel_qk_matmul.pto` path using `pypto -> PTOAS -> pto-isa -> simpler`