### PR TITLE
fix: avoid unexpected TRESHAPE from bind_tile

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6603,8 +6603,9 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
     };
 
     Value tileCandidate = peelAllCasts(adaptor.getSource());
-    if (viewSemantics && viewSemantics.getValue() == "bitcast" &&
-        isTileLike(tileCandidate)) {
+    const bool tileLike = isTileLike(tileCandidate);
+
+    if (viewSemantics && viewSemantics.getValue() == "bitcast" && tileLike) {
       FailureOr<Value> dstTile = buildTileValue();
       if (failed(dstTile))
         return failure();
@@ -6619,10 +6620,54 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       return success();
     }
 
-    if (isTileLike(tileCandidate)) {
+    if (viewSemantics && viewSemantics.getValue() == "treshape" && tileLike) {
       FailureOr<Value> dstTile = buildTileValue();
       if (failed(dstTile))
         return failure();
+      if ((*dstTile).getType() == tileCandidate.getType()) {
+        rewriter.replaceOp(op, tileCandidate);
+        return success();
+      }
+
+      rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "TRESHAPE",
+                                           ArrayAttr{}, ArrayAttr{},
+                                           ValueRange{*dstTile, tileCandidate});
+      rewriter.replaceOp(op, *dstTile);
+      return success();
+    }
+
+    Value source = op.getSource();
+
+    while (auto castOp = source.getDefiningOp<UnrealizedConversionCastOp>())
+      source = castOp.getOperand(0);
+
+    if (auto upstreamCast = source.getDefiningOp<pto::PointerCastOp>()) {
+      // Prefer reconstructing the tile view from the original physical address
+      // when possible. This avoids generating redundant TRESHAPE() calls for
+      // alloc_tile/bind_tile lowering and keeps view semantics localized to
+      // explicit SSA view ops (pto.treshape / pto.bitcast).
+      SmallVector<Value> physAddrs;
+      auto upstreamOperands = upstreamCast.getAddrs();
+      physAddrs.append(upstreamOperands.begin(), upstreamOperands.end());
+
+      Value vRow = op.getValidRow();
+      Value vCol = op.getValidCol();
+
+      rewriter.replaceOpWithNewOp<pto::PointerCastOp>(
+          op, op.getType(), physAddrs, vRow ? vRow : Value(),
+          vCol ? vCol : Value(), configAttr);
+
+      return success();
+    }
+
+    if (tileLike) {
+      FailureOr<Value> dstTile = buildTileValue();
+      if (failed(dstTile))
+        return failure();
+      if ((*dstTile).getType() == tileCandidate.getType()) {
+        rewriter.replaceOp(op, tileCandidate);
+        return success();
+      }
 
       rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "TRESHAPE",
                                            ArrayAttr{}, ArrayAttr{},
@@ -6632,17 +6677,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
     }
 
     SmallVector<Value> physAddrs;
-    Value source = op.getSource();
-
-    while (auto castOp = source.getDefiningOp<UnrealizedConversionCastOp>())
-      source = castOp.getOperand(0);
-
-    if (auto upstreamCast = source.getDefiningOp<pto::PointerCastOp>()) {
-      auto upstreamOperands = upstreamCast.getAddrs();
-      physAddrs.append(upstreamOperands.begin(), upstreamOperands.end());
-    } else {
-      physAddrs.push_back(adaptor.getSource());
-    }
+    physAddrs.push_back(adaptor.getSource());
 
     Value vRow = op.getValidRow();
     Value vCol = op.getValidCol();

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -362,8 +362,8 @@ process_one_dir() {
     # SSA `pto.treshape` (lowered into `pto.bind_tile`) must lower to a single
     # `TRESHAPE(dst, src)` instead of an invalid Tile-to-pointer cast sequence.
     if [[ "$base" == "reshape" ]]; then
-      if ! grep -Fq "TRESHAPE(" "$cpp"; then
-        echo -e "${A}(${base}.py)	FAIL	missing TRESHAPE() lowering for SSA treshape"
+      if [[ $(grep -c "TRESHAPE(" "$cpp") -ne 1 ]]; then
+        echo -e "${A}(${base}.py)	FAIL	expected exactly one TRESHAPE() for SSA treshape"
         overall=1
         continue
       fi
@@ -385,7 +385,7 @@ process_one_dir() {
         overall=1
         continue
       fi
-      if [[ $(grep -c "TRESHAPE(" "$cpp") -ne 1 ]]; then
+      if [[ $(grep -c "TRESHAPE(" "$cpp") -ne 0 ]]; then
         echo -e "${A}(${base}.py)	FAIL	pto.bitcast should not lower via TRESHAPE()"
         overall=1
         continue


### PR DESCRIPTION
## Problem
In v0.5, `pto.bind_tile` -> EmitC lowering can emit `TRESHAPE(dst, src)` whenever the converted source is tile-like.
After `memref.alloc` is rewritten to `pto.pointer_cast`, this makes tile creation paths (e.g. `alloc_tile` + `bind_tile`) generate redundant `TRESHAPE()` calls, which can trigger CCEC errors like **"unexpected TRESHAPE"** in PA matmul/softmax cases.

## Fix
- In `PTOBindTileToEmitC`, prefer reconstructing the tile view from the original upstream `pto.pointer_cast` physical address when available (v0.4-style behavior).
- Keep `TRESHAPE` / `TASSIGN` generation localized to explicit SSA view ops (`pto.treshape` / `pto.bitcast`) or when we truly only have a tile value and cannot trace a physical address.
- Fold no-op reshapes when dst/src tile types are identical.

## Tests
- Strengthen `test/samples/runop.sh` regression guards:
  - `reshape`: expect exactly one `TRESHAPE()`
  - `bitcast_dtype_alias`: expect zero `TRESHAPE()`
