### PR TITLE
fix: avoid unexpected TRESHAPE from bind_tile

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6619,7 +6619,8 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       return success();
     }
 
-    if (isTileLike(tileCandidate)) {
+    if (viewSemantics && viewSemantics.getValue() == "treshape" &&
+        isTileLike(tileCandidate)) {
       FailureOr<Value> dstTile = buildTileValue();
       if (failed(dstTile))
         return failure();

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -385,7 +385,7 @@ process_one_dir() {
         overall=1
         continue
       fi
-      if [[ $(grep -c "TRESHAPE(" "$cpp") -ne 1 ]]; then
+      if [[ $(grep -c "TRESHAPE(" "$cpp") -ne 0 ]]; then
         echo -e "${A}(${base}.py)	FAIL	pto.bitcast should not lower via TRESHAPE()"
         overall=1
         continue


### PR DESCRIPTION
**问题**
普通 bind_tile 只要输入是 tile-like，就会误走 TRESHAPE lowering，
导致生成代码里出现很多非预期的 TRESHAPE()（RESHAPE()）调用。

**修复方式**
给 TRESHAPE lowering 增加语义门控：只有明确标记为 treshape 语义的 bind_tile 才允许转成 TRESHAPE。
其它 bind_tile 继续走原有 pointer/address lowering 路径，不再误生成 TRESHAPE。