### PR TITLE
Fix A5 PIPE_V barrier emission in autosync and barrier_sync

### DIFF
--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -2,6 +2,7 @@
 #include "PTO/IR/PTO.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/STLExtras.h"
  
 #define DEBUG_TYPE "pto-inject-sync"
@@ -21,6 +22,14 @@ static pto::PipeAttr getPipeAttr(Builder &builder, PipelineType pipe) {
 static pto::EventAttr getEventAttr(Builder &builder, int id) {
   auto odsEventVal = static_cast<pto::EVENT>(id);
   return pto::EventAttr::get(builder.getContext(), odsEventVal);
+}
+
+static bool isTargetArchA5(func::FuncOp func) {
+  auto module = func.getOperation()->getParentOfType<ModuleOp>();
+  if (!module)
+    return false;
+  auto arch = module->getAttrOfType<StringAttr>("pto.target_arch");
+  return arch && arch.getValue().equals_insensitive("a5");
 }
  
 static bool IsSyncExist(const SyncOps &list, SyncOperation *newSync) {
@@ -216,6 +225,13 @@ void SyncCodegen::SyncInsert(IRRewriter &rewriter, Operation *op,
 // [核心修改] 加强版 CreateBarrierOp
 void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
                                   SyncOperation *sync, bool beforeInsert) {
+  // A5: PIPE_V intra-pipe ordering is guaranteed by hardware; do not emit
+  // explicit vector barrier (it is also rejected by backend checks).
+  if (isTargetArchA5(func_) &&
+      sync->GetActualSrcPipe() == PipelineType::PIPE_V) {
+    return;
+  }
+
   // [Fix] 判定是否需要前置插入：如果是显式 Before，或者 Op 是 Terminator (如 Yield)
   bool insertAtPos = beforeInsert || op->hasTrait<OpTrait::IsTerminator>();
  

--- a/lib/PTO/Transforms/LoweringSyncToPipe.cpp
+++ b/lib/PTO/Transforms/LoweringSyncToPipe.cpp
@@ -1,6 +1,7 @@
 #include "PTO/Transforms/Passes.h"
 #include "PTO/IR/PTO.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -47,6 +48,14 @@ static PIPE getPipeFromOpType(SyncOpType opType) {
   default:
     return PIPE::PIPE_UNASSIGNED;
   }
+}
+
+static bool isTargetArchA5(Operation *op) {
+  auto module = op->getParentOfType<ModuleOp>();
+  if (!module)
+    return false;
+  auto arch = module->getAttrOfType<StringAttr>("pto.target_arch");
+  return arch && arch.getValue().equals_insensitive("a5");
 }
 
 static FailureOr<SyncOpType> getSyncOpTypeFromAttr(Attribute attr, Operation *op,
@@ -128,9 +137,30 @@ struct BarrierSyncLowering : public OpRewritePattern<BarrierSyncOp> {
       return failure();
     }
 
+    // A5: TVEC single-pipe barrier is unnecessary/unsupported.
+    if (pipe == PIPE::PIPE_V && isTargetArchA5(op.getOperation())) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     rewriter.replaceOpWithNewOp<BarrierOp>(
         op, PipeAttr::get(op.getContext(), pipe));
     return success();
+  }
+};
+
+// Legalize explicit low-level barriers for arch constraints.
+struct BarrierLegalizeForArch : public OpRewritePattern<BarrierOp> {
+  using OpRewritePattern<BarrierOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(BarrierOp op,
+                                PatternRewriter &rewriter) const override {
+    if (isTargetArchA5(op.getOperation()) &&
+        op.getPipe().getPipe() == PIPE::PIPE_V) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+    return failure();
   }
 };
 
@@ -140,7 +170,8 @@ struct LoweringSyncToPipe
     func::FuncOp func = getOperation();
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
-    patterns.add<RecordEventLowering, WaitEventLowering, BarrierSyncLowering>(
+    patterns.add<RecordEventLowering, WaitEventLowering, BarrierSyncLowering,
+                 BarrierLegalizeForArch>(
         context);
     if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns))))
       signalPassFailure();

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -137,6 +137,23 @@ process_one_dir() {
     fi
     [[ $has_insync -eq 1 ]] || ptoas_flags+=(--enable-insert-sync)
   fi
+
+  local target_arch="a3"
+  if ((${#ptoas_flags[@]})); then
+    for ((idx=0; idx<${#ptoas_flags[@]}; ++idx)); do
+      if [[ "${ptoas_flags[idx]}" == "--pto-arch" && $((idx + 1)) -lt ${#ptoas_flags[@]} ]]; then
+        target_arch="${ptoas_flags[idx + 1]}"
+      elif [[ "${ptoas_flags[idx]}" == --pto-arch=* ]]; then
+        target_arch="${ptoas_flags[idx]#--pto-arch=}"
+      fi
+    done
+  fi
+  local expected_vec_barrier="pipe_barrier(PIPE_V)"
+  local skip_vec_barrier=0
+  if [[ "${target_arch,,}" == "a5" ]]; then
+    skip_vec_barrier=1
+  fi
+
   local -a ptoas_cmd_base=("$ptoas")
   if (( ${#ptoas_flags[@]} )); then
     ptoas_cmd_base+=("${ptoas_flags[@]}")
@@ -285,10 +302,18 @@ process_one_dir() {
     # Regression guard: intra-pipe dependencies must be serialized by a
     # per-pipe barrier (PyPTO expects `bar_v` / `bar_m` behavior).
     if [[ "$base" == "test_inject_sync_intra_pipe_barrier" ]]; then
-      if ! grep -Fq "pipe_barrier(PIPE_V)" "$cpp"; then
-        echo -e "${A}(${base}.py)\tFAIL\tmissing pipe_barrier(PIPE_V) for intra-pipe dependency"
-        overall=1
-        continue
+      if [[ "${skip_vec_barrier}" == "1" ]]; then
+        if grep -Fq "pipe_barrier(PIPE_V)" "$cpp"; then
+          echo -e "${A}(${base}.py)\tFAIL\tunexpected pipe_barrier(PIPE_V) on A5"
+          overall=1
+          continue
+        fi
+      else
+        if ! grep -Fq "${expected_vec_barrier}" "$cpp"; then
+          echo -e "${A}(${base}.py)\tFAIL\tmissing ${expected_vec_barrier} for intra-pipe dependency"
+          overall=1
+          continue
+        fi
       fi
     fi
 
@@ -305,10 +330,18 @@ process_one_dir() {
         overall=1
         continue
       fi
-      if ! grep -Fq "pipe_barrier(PIPE_V)" "$cpp"; then
-        echo -e "${A}(${base}.py)\tFAIL\tmissing pipe_barrier(PIPE_V) lowering for barrier_sync[TVEC]"
-        overall=1
-        continue
+      if [[ "${skip_vec_barrier}" == "1" ]]; then
+        if grep -Fq "pipe_barrier(PIPE_V)" "$cpp"; then
+          echo -e "${A}(${base}.py)\tFAIL\tunexpected pipe_barrier(PIPE_V) lowering for barrier_sync[TVEC] on A5"
+          overall=1
+          continue
+        fi
+      else
+        if ! grep -Fq "${expected_vec_barrier}" "$cpp"; then
+          echo -e "${A}(${base}.py)\tFAIL\tmissing ${expected_vec_barrier} lowering for barrier_sync[TVEC]"
+          overall=1
+          continue
+        fi
       fi
     fi
 
@@ -531,10 +564,18 @@ PY
       # Regression guard: intra-pipe dependencies must be serialized by a
       # per-pipe barrier (PyPTO expects `bar_v` / `bar_m` behavior).
       if [[ "$base" == "test_inject_sync_intra_pipe_barrier" ]]; then
-        if ! grep -Fq "pipe_barrier(PIPE_V)" "$cpp"; then
-          echo -e "${A}(${base}.pto)\tFAIL\tmissing pipe_barrier(PIPE_V) for intra-pipe dependency"
-          overall=1
-          continue
+        if [[ "${skip_vec_barrier}" == "1" ]]; then
+          if grep -Fq "pipe_barrier(PIPE_V)" "$cpp"; then
+            echo -e "${A}(${base}.pto)\tFAIL\tunexpected pipe_barrier(PIPE_V) on A5"
+            overall=1
+            continue
+          fi
+        else
+          if ! grep -Fq "${expected_vec_barrier}" "$cpp"; then
+            echo -e "${A}(${base}.pto)\tFAIL\tmissing ${expected_vec_barrier} for intra-pipe dependency"
+            overall=1
+            continue
+          fi
         fi
       fi
 

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -672,14 +672,17 @@ int main(int argc, char **argv) {
   std::string arch = ptoTargetArch;
   for (char &c : arch)
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-  if (arch == "a3") {
-    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A3));
-  } else if (arch == "a5") {
-    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A5));
-  } else {
+  if (arch != "a3" && arch != "a5") {
     llvm::errs() << "Error: invalid --pto-arch='" << ptoTargetArch
                  << "'. Expected 'a3' or 'a5'.\n";
     return 1;
+  }
+  module->getOperation()->setAttr("pto.target_arch",
+                                  mlir::StringAttr::get(&context, arch));
+  if (arch == "a3") {
+    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A3));
+  } else {
+    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A5));
   }
   pm.addPass(emitc::createFormExpressionsPass());
   pm.addPass(mlir::createCSEPass());


### PR DESCRIPTION
## Summary
- Fix A5 `PIPE_V` barrier handling for both auto-inserted sync and `barrier_sync` lowering.
- Keep A3 behavior unchanged.

## Motivation
- A5 toolchain rejects `pipe_barrier(PIPE_V)` (compile-time range check failure).
- On A5, `PIPE_V` intra-pipe ordering is guaranteed, so explicit vector barrier should not be emitted.

## Design
- Add module attribute `pto.target_arch` in `ptoas` so earlier sync passes can make arch-aware decisions.
- In `SyncCodegen`, skip generating `PIPE_BARRIER` when `target_arch == a5` and pipe is `PIPE_V`.
- In `LoweringSyncToPipe`:
  - erase `barrier_sync[TVEC]` on A5;
  - erase explicit low-level `pto.barrier #pto.pipe<PIPE_V>` on A5.
- Update `test/samples/runop.sh` arch-aware expectations:
  - A5: must **not** contain `pipe_barrier(PIPE_V)` in relevant sync samples.
  - non-A5: keep existing `pipe_barrier(PIPE_V)` expectation.

## Testing
- Local build: `ninja -C build ptoas` (pass).
- Targeted checks:
  - `--pto-arch a5` + `test_inject_sync_intra_pipe_barrier.pto`: no `pipe_barrier(PIPE_V)`.
  - `--pto-arch a5` + `barrier_sync[TVEC]`: no `pipe_barrier(PIPE_V)`; `TLOAD/TSTORE_VEC` barriers remain.
  - `--pto-arch a3`: `pipe_barrier(PIPE_V)` behavior unchanged.

## Risk / Rollback
- Risk is limited to A5 vector intra-pipe barrier emission path.
- Rollback: revert this PR.
