### PR TITLE
Add fixed PyPTO ir_parser PTO snapshots

### DIFF
--- a/test/samples/PyPTOIRParser/README.md
+++ b/test/samples/PyPTOIRParser/README.md
@@ -1,0 +1,29 @@
+# PyPTO IR Parser Fixed PTO Cases
+
+These cases are vendored snapshots of `.pto` files generated from `pypto/examples/ir_parser`
+on `main` so PTOAS does not depend on PyPTO's future behavior at test time.
+
+Source provenance:
+- PyPTO repo: `https://github.com/hw-native-sys/pypto`
+- PyPTO commit: `9f6985f7b92acb1754cf479e179427afcdd1934a`
+- Source directory: `examples/ir_parser`
+
+Generation settings used to materialize these files:
+- `backend_type=BackendType.PTO`
+- `strategy=OptimizationStrategy.PTOAS`
+- `skip_ptoas=True`
+
+Included positive cases:
+- `orchestration_example`: `kernel_add`, `kernel_add_scalar`, `kernel_mul`
+- `vector_example_dag`: `kernel_add`, `kernel_add_scalar`, `kernel_mul`
+- `paged_attention_example`: `kernel_init_inplace`, `kernel_qk_matmul`, `kernel_softmax_prepare`, `kernel_pv_matmul`, `kernel_online_update`
+
+Intentionally not included:
+- `program_example`: parser/program roundtrip example, does not emit PTO kernels
+- `batch_paged_attention_example`: currently fails on PyPTO `main`
+- `paged_attention_with_incore`: currently fails on PyPTO `main`
+- `paged_attention_tensor`: currently fails on PyPTO `main`
+- `flash_attention_parsing`: currently fails on PyPTO `main`
+
+If upstream PyPTO changes these examples, update these snapshots manually after re-validating
+that the new `.pto` still compiles with PTOAS.

--- a/test/samples/PyPTOIRParser/orchestration_example_kernel_add.pto
+++ b/test/samples/PyPTOIRParser/orchestration_example_kernel_add.pto
@@ -1,0 +1,21 @@
+module {
+  func.func @kernel_add(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
+  %c16 = arith.constant 16 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %3 = pto.make_tensor_view %arg0, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %4 = pto.make_tensor_view %arg1, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %5 = pto.make_tensor_view %arg2, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %6 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tload ins(%6 : !pto.partition_tensor_view<16x16xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %7 = pto.partition_view %4, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tload ins(%7 : !pto.partition_tensor_view<16x16xf32>) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tadd ins(%0, %1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%8 : !pto.partition_tensor_view<16x16xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/orchestration_example_kernel_add.py
+++ b/test/samples/PyPTOIRParser/orchestration_example_kernel_add.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/orchestration_example_kernel_add_scalar.pto
+++ b/test/samples/PyPTOIRParser/orchestration_example_kernel_add_scalar.pto
@@ -1,0 +1,17 @@
+module {
+  func.func @kernel_add_scalar(%arg0: !pto.ptr<f32>, %arg1: f32, %arg2: !pto.ptr<f32>) {
+  %c16 = arith.constant 16 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %2 = pto.make_tensor_view %arg0, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %3 = pto.make_tensor_view %arg2, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %4 = pto.partition_view %2, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tload ins(%4 : !pto.partition_tensor_view<16x16xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tadds ins(%0, %arg1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %5 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tstore ins(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%5 : !pto.partition_tensor_view<16x16xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/orchestration_example_kernel_add_scalar.py
+++ b/test/samples/PyPTOIRParser/orchestration_example_kernel_add_scalar.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/orchestration_example_kernel_mul.pto
+++ b/test/samples/PyPTOIRParser/orchestration_example_kernel_mul.pto
@@ -1,0 +1,21 @@
+module {
+  func.func @kernel_mul(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
+  %c16 = arith.constant 16 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %3 = pto.make_tensor_view %arg0, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %4 = pto.make_tensor_view %arg1, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %5 = pto.make_tensor_view %arg2, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %6 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tload ins(%6 : !pto.partition_tensor_view<16x16xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %7 = pto.partition_view %4, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tload ins(%7 : !pto.partition_tensor_view<16x16xf32>) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tmul ins(%0, %1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
+  pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%8 : !pto.partition_tensor_view<16x16xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/orchestration_example_kernel_mul.py
+++ b/test/samples/PyPTOIRParser/orchestration_example_kernel_mul.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_init_inplace.pto
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_init_inplace.pto
@@ -1,0 +1,11 @@
+module {
+  func.func @kernel_init_inplace(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %0 = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %1 = pto.make_tensor_view %arg1, shape = [%c16, %c1], strides = [%c1, %c1] : !pto.tensor_view<?x?xf32>
+  %2 = pto.make_tensor_view %arg2, shape = [%c16, %c1], strides = [%c1, %c1] : !pto.tensor_view<?x?xf32>
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_init_inplace.py
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_init_inplace.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_online_update.pto
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_online_update.pto
@@ -1,0 +1,96 @@
+module {
+  func.func @kernel_online_update(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>, %arg3: !pto.ptr<f32>, %arg4: !pto.ptr<f32>, %arg5: !pto.ptr<f32>, %arg6: !pto.ptr<f32>, %arg7: i1, %arg8: i1) {
+  %c16 = arith.constant 16 : index
+  %c1 = arith.constant 1 : index
+  %c128 = arith.constant 128 : index
+  %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f32
+  %13 = pto.make_tensor_view %arg0, shape = [%c16, %c1], strides = [%c1, %c16] : !pto.tensor_view<?x?xf32>
+  %14 = pto.make_tensor_view %arg1, shape = [%c16, %c1], strides = [%c1, %c16] : !pto.tensor_view<?x?xf32>
+  %15 = pto.make_tensor_view %arg2, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %16 = pto.make_tensor_view %arg3, shape = [%c16, %c1], strides = [%c1, %c16] : !pto.tensor_view<?x?xf32>
+  %17 = pto.make_tensor_view %arg4, shape = [%c16, %c1], strides = [%c1, %c16] : !pto.tensor_view<?x?xf32>
+  %18 = pto.make_tensor_view %arg5, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %19 = pto.make_tensor_view %arg6, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %3 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %4 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %5 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %6 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %7 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %8 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %9 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %10 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %11 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %12 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %20 = pto.partition_view %13, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+  pto.tload ins(%20 : !pto.partition_tensor_view<16x1xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+  %21 = pto.partition_view %14, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+  pto.tload ins(%21 : !pto.partition_tensor_view<16x1xf32>) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+  %22 = pto.partition_view %15, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+  pto.tload ins(%22 : !pto.partition_tensor_view<16x128xf32>) outs(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %23 = pto.partition_view %16, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+  pto.tload ins(%23 : !pto.partition_tensor_view<16x1xf32>) outs(%3 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+  %24 = pto.partition_view %17, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+  pto.tload ins(%24 : !pto.partition_tensor_view<16x1xf32>) outs(%4 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+  %25 = pto.partition_view %18, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+  pto.tload ins(%25 : !pto.partition_tensor_view<16x128xf32>) outs(%5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  scf.if %arg7 {
+    %26 = pto.partition_view %16, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+    pto.tstore ins(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%26 : !pto.partition_tensor_view<16x1xf32>)
+    %27 = pto.partition_view %17, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+    pto.tstore ins(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%27 : !pto.partition_tensor_view<16x1xf32>)
+    %28 = pto.partition_view %18, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+    pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%28 : !pto.partition_tensor_view<16x128xf32>)
+    scf.if %arg8 {
+      pto.trowexpanddiv ins(%2, %1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%6 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      %29 = pto.partition_view %19, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+      pto.tstore ins(%6 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%29 : !pto.partition_tensor_view<16x128xf32>)
+    } else {
+      pto.texpands ins(%cst : f32) outs(%6 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      %30 = pto.partition_view %19, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+      pto.tstore ins(%6 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%30 : !pto.partition_tensor_view<16x128xf32>)
+    }
+  } else {
+    %31 = pto.treshape %3 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %32 = pto.treshape %0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %33 = pto.treshape %4 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %34 = pto.treshape %1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmax ins(%31, %32 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%7 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tsub ins(%31, %7 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%8 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.texp ins(%8 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%9 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tsub ins(%32, %7 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%8 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.texp ins(%8 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%10 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmul ins(%9, %33 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%8 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmul ins(%10, %34 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%11 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tadd ins(%8, %11 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%12 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %35 = pto.treshape %9 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpandmul ins(%5, %35 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%6 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %36 = pto.treshape %10 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpandmul ins(%2, %36 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tadd ins(%6, %5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %37 = pto.treshape %7 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %38 = pto.treshape %12 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %39 = pto.partition_view %16, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+    pto.tstore ins(%37 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%39 : !pto.partition_tensor_view<16x1xf32>)
+    %40 = pto.partition_view %17, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+    pto.tstore ins(%38 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%40 : !pto.partition_tensor_view<16x1xf32>)
+    scf.if %arg8 {
+      pto.trowexpanddiv ins(%2, %38 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      %41 = pto.partition_view %19, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+      pto.tstore ins(%5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%41 : !pto.partition_tensor_view<16x128xf32>)
+      %42 = pto.partition_view %18, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+      pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%42 : !pto.partition_tensor_view<16x128xf32>)
+    } else {
+      pto.texpands ins(%cst : f32) outs(%5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      %43 = pto.partition_view %19, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+      pto.tstore ins(%5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%43 : !pto.partition_tensor_view<16x128xf32>)
+      %44 = pto.partition_view %18, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+      pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%44 : !pto.partition_tensor_view<16x128xf32>)
+    }
+  }
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_online_update.py
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_online_update.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_pv_matmul.pto
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_pv_matmul.pto
@@ -1,0 +1,26 @@
+module {
+  func.func @kernel_pv_matmul(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<f32>) {
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %5 = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xbf16>
+  %6 = pto.make_tensor_view %arg1, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xbf16>
+  %7 = pto.make_tensor_view %arg2, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+  %3 = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+  %4 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+  %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<16x128xbf16>
+  pto.tload ins(%8 : !pto.partition_tensor_view<16x128xbf16>) outs(%0 : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+  %9 = pto.partition_view %6, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<128x128xbf16>
+  pto.tload ins(%9 : !pto.partition_tensor_view<128x128xbf16>) outs(%1 : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+  pto.tmov ins(%0 : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+  pto.tmov ins(%1 : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%3 : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+  pto.tmatmul ins(%2, %3 : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%4 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+  %10 = pto.partition_view %7, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+  pto.tstore ins(%4 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) outs(%10 : !pto.partition_tensor_view<16x128xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_pv_matmul.py
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_pv_matmul.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_qk_matmul.pto
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_qk_matmul.pto
@@ -1,0 +1,26 @@
+module {
+  func.func @kernel_qk_matmul(%arg0: !pto.ptr<bf16>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<f32>) {
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %5 = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xbf16>
+  %6 = pto.make_tensor_view %arg1, shape = [%c128, %c128], strides = [%c1, %c128] : !pto.tensor_view<?x?xbf16>
+  %7 = pto.make_tensor_view %arg2, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+  %3 = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+  %4 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+  %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<16x128xbf16>
+  pto.tload ins(%8 : !pto.partition_tensor_view<16x128xbf16>) outs(%0 : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+  %9 = pto.partition_view %6, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<128x128xbf16>
+  pto.tload ins(%9 : !pto.partition_tensor_view<128x128xbf16>) outs(%1 : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+  pto.tmov ins(%0 : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+  pto.tmov ins(%1 : !pto.tile_buf<loc=mat, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%3 : !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+  pto.tmatmul ins(%2, %3 : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=bf16, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%4 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+  %10 = pto.partition_view %7, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+  pto.tstore ins(%4 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) outs(%10 : !pto.partition_tensor_view<16x128xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_qk_matmul.py
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_qk_matmul.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_softmax_prepare.pto
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_softmax_prepare.pto
@@ -1,0 +1,35 @@
+module {
+  func.func @kernel_softmax_prepare(%arg0: !pto.ptr<f32>, %arg1: f32, %arg2: !pto.ptr<bf16>, %arg3: !pto.ptr<f32>, %arg4: !pto.ptr<f32>) {
+  %c16 = arith.constant 16 : index
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %7 = pto.make_tensor_view %arg0, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %8 = pto.make_tensor_view %arg2, shape = [%c16, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xbf16>
+  %9 = pto.make_tensor_view %arg3, shape = [%c16, %c1], strides = [%c1, %c1] : !pto.tensor_view<?x?xf32>
+  %10 = pto.make_tensor_view %arg4, shape = [%c16, %c1], strides = [%c1, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %3 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %4 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %5 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %6 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %11 = pto.partition_view %7, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x128xf32>
+  pto.tload ins(%11 : !pto.partition_tensor_view<16x128xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tmuls ins(%0, %arg1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.trowmax ins(%1, %0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+  pto.trowexpandsub ins(%1, %2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%3 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.texp ins(%3 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tcvt ins(%1{rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%4 : !pto.tile_buf<loc=vec, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tcvt ins(%4{rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%5 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.trowsum ins(%5, %0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%6 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+  %12 = pto.partition_view %8, offsets = [%c0, %c0], sizes = [%c16, %c128] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<16x128xbf16>
+  pto.tstore ins(%4 : !pto.tile_buf<loc=vec, dtype=bf16, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%12 : !pto.partition_tensor_view<16x128xbf16>)
+  %13 = pto.partition_view %9, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+  pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%13 : !pto.partition_tensor_view<16x1xf32>)
+  %14 = pto.partition_view %10, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x1xf32>
+  pto.tstore ins(%6 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%14 : !pto.partition_tensor_view<16x1xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/paged_attention_example_kernel_softmax_prepare.py
+++ b/test/samples/PyPTOIRParser/paged_attention_example_kernel_softmax_prepare.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/vector_example_dag_kernel_add.pto
+++ b/test/samples/PyPTOIRParser/vector_example_dag_kernel_add.pto
@@ -1,0 +1,21 @@
+module {
+  func.func @kernel_add(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %3 = pto.make_tensor_view %arg0, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %4 = pto.make_tensor_view %arg1, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %5 = pto.make_tensor_view %arg2, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %6 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tload ins(%6 : !pto.partition_tensor_view<128x128xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %7 = pto.partition_view %4, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tload ins(%7 : !pto.partition_tensor_view<128x128xf32>) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tadd ins(%0, %1 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%8 : !pto.partition_tensor_view<128x128xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/vector_example_dag_kernel_add.py
+++ b/test/samples/PyPTOIRParser/vector_example_dag_kernel_add.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/vector_example_dag_kernel_add_scalar.pto
+++ b/test/samples/PyPTOIRParser/vector_example_dag_kernel_add_scalar.pto
@@ -1,0 +1,17 @@
+module {
+  func.func @kernel_add_scalar(%arg0: !pto.ptr<f32>, %arg1: f32, %arg2: !pto.ptr<f32>) {
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %2 = pto.make_tensor_view %arg0, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %3 = pto.make_tensor_view %arg2, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %4 = pto.partition_view %2, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tload ins(%4 : !pto.partition_tensor_view<128x128xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tadds ins(%0, %arg1 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %5 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tstore ins(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%5 : !pto.partition_tensor_view<128x128xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/vector_example_dag_kernel_add_scalar.py
+++ b/test/samples/PyPTOIRParser/vector_example_dag_kernel_add_scalar.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/PyPTOIRParser/vector_example_dag_kernel_mul.pto
+++ b/test/samples/PyPTOIRParser/vector_example_dag_kernel_mul.pto
@@ -1,0 +1,21 @@
+module {
+  func.func @kernel_mul(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
+  %c128 = arith.constant 128 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %3 = pto.make_tensor_view %arg0, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %4 = pto.make_tensor_view %arg1, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %5 = pto.make_tensor_view %arg2, shape = [%c128, %c128], strides = [%c128, %c1] : !pto.tensor_view<?x?xf32>
+  %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %6 = pto.partition_view %3, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tload ins(%6 : !pto.partition_tensor_view<128x128xf32>) outs(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %7 = pto.partition_view %4, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tload ins(%7 : !pto.partition_tensor_view<128x128xf32>) outs(%1 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  pto.tmul ins(%0, %1 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+  %8 = pto.partition_view %5, offsets = [%c0, %c0], sizes = [%c128, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<128x128xf32>
+  pto.tstore ins(%2 : !pto.tile_buf<loc=vec, dtype=f32, rows=128, cols=128, v_row=128, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%8 : !pto.partition_tensor_view<128x128xf32>)
+  return
+  }
+}

--- a/test/samples/PyPTOIRParser/vector_example_dag_kernel_mul.py
+++ b/test/samples/PyPTOIRParser/vector_example_dag_kernel_mul.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- add fixed `.pto` snapshots generated from `pypto/examples/ir_parser`
- add thin `.py` wrappers so the cases are discoverable by existing sample tooling without depending on live PyPTO behavior
- document the upstream PyPTO commit and generation settings in a local README

## Included cases
Source: `https://github.com/hw-native-sys/pypto/tree/main/examples/ir_parser`
PyPTO commit used for the snapshots: `9f6985f7b92acb1754cf479e179427afcdd1934a`

Included positive snapshot groups:
- `orchestration_example`
  - `kernel_add`
  - `kernel_add_scalar`
  - `kernel_mul`
- `vector_example_dag`
  - `kernel_add`
  - `kernel_add_scalar`
  - `kernel_mul`
- `paged_attention_example`
  - `kernel_init_inplace`
  - `kernel_qk_matmul`
  - `kernel_softmax_prepare`
  - `kernel_pv_matmul`
  - `kernel_online_update`

Not included:
- `program_example` (does not emit PTO kernels)
- `batch_paged_attention_example`
- `paged_attention_with_incore`
- `paged_attention_tensor`
- `flash_attention_parsing`

The excluded cases currently do not compile to stable PTO outputs on upstream PyPTO `main` and should be handled separately.

## Testing
Local:
- `ptoas` successfully generated `.cpp` for all 11 vendored `.pto` snapshots

Remote board (`ci.yml`-like flow, `STAGE=run`, `RUN_MODE=npu`, `SOC_VERSION=Ascend910`, `DEVICE_ID=2`, `PTO_ISA_COMMIT=68b7cd178622763f658be42f013e84ddeaa4beee`):
- passed:
  - `orchestration_example_kernel_add`
  - `orchestration_example_kernel_add_scalar`
  - `orchestration_example_kernel_mul`
  - `paged_attention_example_kernel_init_inplace`
  - `paged_attention_example_kernel_softmax_prepare`
  - `paged_attention_example_kernel_online_update`
- failed and will need follow-up:
  - `vector_example_dag_kernel_add`
  - `vector_example_dag_kernel_add_scalar`
  - `vector_example_dag_kernel_mul`
  - `paged_attention_example_kernel_qk_matmul`
  - `paged_attention_example_kernel_pv_matmul`

This PR still adds the full snapshot set so we can iterate on the failing cases in follow-up fixes without needing to regenerate the source snapshots.
