### PR TITLE
ci: skip print in remote validation defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ on:
       skip_cases:
         description: "Comma/space separated testcase names to skip (e.g. scatter,mrgsort)"
         type: string
-        default: "mix_kernel,vadd_validshape,vadd_validshape_dynamic"
+        default: "mix_kernel,vadd_validshape,vadd_validshape_dynamic,print"
       run_only_cases:
         description: "Comma/space separated testcase names to run (empty = run all)"
         type: string
@@ -236,7 +236,7 @@ jobs:
       # Temporary CI gate: skip cases that still error/flap on the remote NPU.
       # Update this list as we fix the underlying issues.
       DEFAULT_SKIP_CASES: >-
-        mix_kernel,vadd_validshape,vadd_validshape_dynamic
+        mix_kernel,vadd_validshape,vadd_validshape_dynamic,print
     steps:
       - name: Resolve validation parameters
         shell: bash


### PR DESCRIPTION
## Summary
- add `print` to the default `skip_cases` input for manual remote validation runs
- add `print` to `DEFAULT_SKIP_CASES` so scheduled remote-board validation skips it by default
- keep local sample test coverage unchanged; this only gates the remote NPU workflow

## Testing
- not run (GitHub Actions workflow change only)
