### PR TITLE
Fix debug assert in set_validshape lowering

### DIFF
--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -846,7 +846,10 @@ struct PTOViewToMemrefPass
 
       auto lowerSetValidShapeOp = [&](mlir::pto::SetValidShapeOp op,
                                       bool requireMemRefSource) -> LogicalResult {
-        Value src = op.getSource();
+        // Use raw operand access here: by the time this helper runs, source
+        // may already be rewritten to memref type, while typed accessors on
+        // SetValidShapeOp still expect tile_buf and can assert in debug builds.
+        Value src = op->getOperand(0);
         auto srcMrTy = dyn_cast<MemRefType>(src.getType());
         if (!srcMrTy) {
           if (!requireMemRefSource)


### PR DESCRIPTION
## Summary
- fix debug-build assert when lowering pto.set_validshape
- use raw operand access in PTOViewToMemref lowering helper to avoid typed accessor cast after source is rewritten to memref

## Root cause
SetValidShapeOp typed accessor expects tile_buf, but in lowering stage the operand may already be memref. Calling op.getSource() could assert in debug builds.

## Fix
- change source retrieval from op.getSource() to op->getOperand(0) in lowerSetValidShapeOp

## Validation
- debug build: set_validshape.py -> .pto -> .cpp passes
- debug build: test/samples/runop.sh -t SetValidShape passes
- release build: same case still passes
