### PR TITLE
Fix #249: subset valid-shape inference with dynamic offsets

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3838,51 +3838,24 @@ LogicalResult SubsetOp::inferReturnTypes(
     resultShape.push_back(dim);
   }
 
-  // Derive valid shape from parent valid dims when possible.
+  // Derive result valid shape from static sizes and parent valid shape.
+  // NOTE: Do not make this depend on subset offsets. Offsets may be dynamic,
+  // but they should not force a static valid dim to become dynamic.
   SmallVector<int64_t> validShape;
   constexpr int64_t kDynamicValidDim = -1;
   ArrayRef<int64_t> parentValid = sourceType.getValidShape();
+  bool sameRank = parentValid.size() == resultShape.size();
+  validShape.reserve(resultShape.size());
   for (size_t i = 0, e = resultShape.size(); i < e; ++i) {
     int64_t sizeDim = resultShape[i];
     int64_t vdim = sizeDim;
 
-    if (parentValid.size() == resultShape.size()) {
+    if (sameRank) {
       int64_t pv = parentValid[i];
       if (pv < 0) {
         vdim = kDynamicValidDim;
       } else {
-        int64_t off = 0;
-        // operands: [source, offsets...]
-        if (operands.size() > 1 + i) {
-          auto offOpt = getConstIndexValue(operands[1 + i]);
-          if (!offOpt) {
-            vdim = kDynamicValidDim;
-            validShape.push_back(vdim);
-            continue;
-          }
-          off = *offOpt;
-          // Interpret parent valid dims as a per-tile "period" when the parent
-          // buffer is wider than the valid region (e.g. ping/pong workspace).
-          // This avoids inferring a zero valid dim when taking a view at an
-          // offset equal to the parent valid dim.
-          //
-          // Example:
-          //   parent: shape 32x64, valid 32x32
-          //   subset: offset [0,32], sizes [32,32]
-          // should infer v_col=32 (not 0).
-          int64_t diff = 0;
-          if (pv > 0) {
-            int64_t offMod = off % pv;
-            if (offMod < 0)
-              offMod += pv;
-            diff = pv - offMod; // in [1, pv] when pv>0
-          }
-          if (diff < 0)
-            diff = 0;
-          vdim = std::min<int64_t>(sizeDim, diff);
-        } else {
-          vdim = kDynamicValidDim;
-        }
+        vdim = std::min<int64_t>(sizeDim, pv);
       }
     }
 

--- a/test/basic/subset_infer_dynamic_offset.mlir
+++ b/test/basic/subset_infer_dynamic_offset.mlir
@@ -1,0 +1,14 @@
+// RUN: ptoas %s | FileCheck %s
+
+module {
+  func.func @subset_infer_dynamic_offset(%off : index) {
+    %c0 = arith.constant 0 : index
+    %ws = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %sub = "pto.subset"(%ws, %c0, %off) {sizes = [32, 64]} :
+      (!pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, index, index)
+      -> !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}
+
+// CHECK: Success


### PR DESCRIPTION
Summary
- Fix `pto.subset` return type inference so valid-shape inference does not depend on subset offsets.
- Add regression test `test/basic/subset_infer_dynamic_offset.mlir` to cover dynamic offset + static result type.

Motivation
- Fixes #249.
- With dynamic offsets, previous inference could degrade a static valid dim to dynamic or invalid values, causing type inference conflicts for valid code.

Design
- In `SubsetOp::inferReturnTypes`, derive result `validShape` only from:
  - static `sizes`
  - parent tile `validShape`
- Explicitly remove offset-dependent valid-shape derivation.
- Invariant: dynamic offsets must not force static valid dims to become dynamic.

Testing
- Local targeted check:
  - `/tmp/PTOAS_upstream_compare_20260312_165206/build/tools/ptoas/ptoas test/basic/subset_infer_dynamic_offset.mlir` (pass)
- Remote full-board validation on `101.245.68.6` (2026-03-12):
  - Upstream `main` baseline: `OK=150 FAIL=3 SKIP=7`
  - `main + this fix`: `OK=150 FAIL=3 SKIP=7`
  - FAIL set unchanged (`plan_memory_scopes_independent`, `prelu`, `print`), no new regressions.

Risk / Rollback
- Risk: low, change is localized to subset return type inference.
- Rollback: revert this commit.

Review Focus
- Verify `SubsetOp::inferReturnTypes` no longer uses offsets to derive valid dims.
- Verify dynamic-offset subset with static result type now passes.
- Verify no regressions in full-board run relative to upstream baseline.
