### PR TITLE
fix(pto): preserve tsels copy semantics and xor scratch

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3598,6 +3598,36 @@ def TXorSOp: PTO_TOp<"txors", [
   }];
 
 }
+
+def TXorSWithTmpOp: PTO_TOp<"txors_tmp", [
+  PTO_DpsInitOpInterface,
+  OpPipeInterface,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Internal TXORS form with an explicit scratch tile.";
+
+  let arguments = (ins
+    PTODpsType:$src,
+    AnyInteger:$scalar,
+    PTODpsType:$tmp,
+    PTODpsType:$dst
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `ins` `(` $src `,` $scalar `,` $tmp `:` qualified(type($src)) `,` type($scalar) `,` qualified(type($tmp)) `)`
+    `outs` `(` $dst `:` qualified(type($dst) ) `)`
+    attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+  }];
+}
 //===----------------------------------------------------------------------===//
 // PTOOps.td  (add TSYNC TBDPS/tile buffer op)
 //===----------------------------------------------------------------------===//
@@ -3658,6 +3688,36 @@ def TXorOp: PTO_TOp<"txor", [
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
   }];
 
+}
+
+def TXorWithTmpOp: PTO_TOp<"txor_tmp", [
+  PTO_DpsInitOpInterface,
+  OpPipeInterface,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Internal TXOR form with an explicit scratch tile.";
+
+  let arguments = (ins
+    PTODpsType:$src0,
+    PTODpsType:$src1,
+    PTODpsType:$tmp,
+    PTODpsType:$dst
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `ins` `(` $src0 `,` $src1 `,` $tmp `:` qualified(type($src0)) `,` qualified(type($src1)) `,` qualified(type($tmp)) `)`
+    `outs` `(` $dst `:` qualified(type($dst) ) `)`
+    attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+  }];
 }
 
 def TPrintOp: PTO_TOp<"tprint", [

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -60,6 +60,7 @@ createPlanMemoryPass(const PlanMemoryOptions &planMemoryOption = {});
 
 std::unique_ptr<Pass> createPTOInsertCVMovPass();
 std::unique_ptr<Pass> createPTOConvertToDPSPass();
+std::unique_ptr<Pass> createPTOExpandImplicitScratchPass();
 std::unique_ptr<Pass> createPTORemoveRedundantBarrierPass();
 std::unique_ptr<Pass> createPTOViewToMemrefPass();
 std::unique_ptr<mlir::Pass> createPTOInsertLoadStoreForMixCVPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -32,6 +32,18 @@ def PTOConvertToDPS : Pass<"pto-convert-to-dps", "func::FuncOp"> {
   ];
 }
 
+def PTOExpandImplicitScratch : Pass<"pto-expand-implicit-scratch", "func::FuncOp"> {
+  let summary = "Materialize scratch tiles for PTO ops that need real temp storage";
+  let description = [{
+    Rewrites PTO ops with implicit scratch requirements into internal forms
+    that carry explicit tmp tiles before memory planning.
+  }];
+  let constructor = "mlir::pto::createPTOExpandImplicitScratchPass()";
+  let dependentDialects = [
+    "mlir::pto::PTODialect"
+  ];
+}
+
 // Define PTOInsertSync Pass
 def PTOInsertSync : Pass<"pto-insert-sync", "func::FuncOp"> {
   let summary = "Insert synchronization flags for PTO dialect";

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3013,19 +3013,35 @@ mlir::LogicalResult mlir::pto::TSelSOp::verify() {
   Type td = getDst().getType();
   if (!isPTOShapedLike(t0) || !isPTOShapedLike(t1) || !isPTOShapedLike(td))
     return emitOpError("expects src0/src1/dst to be memref/tensor/tile_buf/tile_view types");
-  Type es = getElemTy(t0), ed = getElemTy(td);
-  if (!es || !ed)
+  Type e0 = getElemTy(t0), e1 = getElemTy(t1), ed = getElemTy(td);
+  if (!e0 || !e1 || !ed)
     return emitOpError("failed to get element type for operands");
-  if (es != ed)
-    return emitOpError("expects src0 and dst to have the same element type");
+  if (e0 != e1 || e0 != ed)
+    return emitOpError("expects src0/src1/dst to have the same element type");
   auto isAllowedElem = [&](mlir::Type t) -> bool {
     if (t.isF16() || t.isF32() || t.isBF16()) return true;
     if (auto it = mlir::dyn_cast<mlir::IntegerType>(t))
       return (it.getWidth() == 8 || it.getWidth() == 16 || it.getWidth() == 32);
     return false;
   };
-  if (!isAllowedElem(es))
-    return emitOpError("expects src0 and dst element type to be i8/i16/i32/f16/bf16/f32");
+  if (!isAllowedElem(e0))
+    return emitOpError("expects src0/src1/dst element type to be i8/i16/i32/f16/bf16/f32");
+
+  auto s0 = getShapeVec(t0);
+  auto s1 = getShapeVec(t1);
+  auto sd = getShapeVec(td);
+  if (s0.size() != s1.size() || s0.size() != sd.size())
+    return emitOpError("expects src0/src1/dst to have the same rank");
+  for (size_t i = 0; i < s0.size(); ++i) {
+    if (s0[i] != mlir::ShapedType::kDynamic &&
+        s1[i] != mlir::ShapedType::kDynamic &&
+        s0[i] != s1[i])
+      return emitOpError("expects src0 and src1 static shapes to match");
+    if (s0[i] != mlir::ShapedType::kDynamic &&
+        sd[i] != mlir::ShapedType::kDynamic &&
+        s0[i] != sd[i])
+      return emitOpError("expects src0 and dst static shapes to match");
+  }
   return mlir::success();
 }
 //===----------------------------------------------------------------------===//
@@ -3266,6 +3282,62 @@ mlir::LogicalResult mlir::pto::TXorOp::verify() {
   if (elem != getElemTy(src1Ty) || elem != getElemTy(dstTy))
     return emitOpError() << "expects src0, src1, and dst to have the same element type";
 
+  auto src0Shape = getShapeVec(src0Ty);
+  auto src1Shape = getShapeVec(src1Ty);
+  auto dstShape = getShapeVec(dstTy);
+  if (src0Shape.size() != src1Shape.size() || src0Shape.size() != dstShape.size())
+    return emitOpError() << "expects src0, src1, and dst to have the same rank";
+  for (size_t i = 0; i < src0Shape.size(); ++i) {
+    if (src0Shape[i] != mlir::ShapedType::kDynamic &&
+        src1Shape[i] != mlir::ShapedType::kDynamic &&
+        src0Shape[i] != src1Shape[i])
+      return emitOpError() << "expects src0 and src1 static shapes to match";
+    if (src0Shape[i] != mlir::ShapedType::kDynamic &&
+        dstShape[i] != mlir::ShapedType::kDynamic &&
+        src0Shape[i] != dstShape[i])
+      return emitOpError() << "expects src0 and dst static shapes to match";
+  }
+
+  return mlir::success();
+}
+
+mlir::LogicalResult mlir::pto::TXorWithTmpOp::verify() {
+  Type src0Ty = getSrc0().getType();
+  Type src1Ty = getSrc1().getType();
+  Type tmpTy = getTmp().getType();
+  Type dstTy = getDst().getType();
+  if (!isPTOShapedLike(src0Ty) || !isPTOShapedLike(src1Ty) ||
+      !isPTOShapedLike(tmpTy) || !isPTOShapedLike(dstTy))
+    return emitOpError() << "expects PTO shaped-like src0, src1, tmp, and dst";
+
+  auto elem = getElemTy(src0Ty);
+  if (elem != getElemTy(src1Ty) || elem != getElemTy(tmpTy) ||
+      elem != getElemTy(dstTy))
+    return emitOpError()
+           << "expects src0, src1, tmp, and dst to have the same element type";
+
+  auto src0Shape = getShapeVec(src0Ty);
+  auto src1Shape = getShapeVec(src1Ty);
+  auto tmpShape = getShapeVec(tmpTy);
+  auto dstShape = getShapeVec(dstTy);
+  if (src0Shape.size() != src1Shape.size() || src0Shape.size() != tmpShape.size() ||
+      src0Shape.size() != dstShape.size())
+    return emitOpError() << "expects src0, src1, tmp, and dst to have the same rank";
+  for (size_t i = 0; i < src0Shape.size(); ++i) {
+    if (src0Shape[i] != mlir::ShapedType::kDynamic &&
+        src1Shape[i] != mlir::ShapedType::kDynamic &&
+        src0Shape[i] != src1Shape[i])
+      return emitOpError() << "expects src0 and src1 static shapes to match";
+    if (src0Shape[i] != mlir::ShapedType::kDynamic &&
+        tmpShape[i] != mlir::ShapedType::kDynamic &&
+        src0Shape[i] != tmpShape[i])
+      return emitOpError() << "expects src0 and tmp static shapes to match";
+    if (src0Shape[i] != mlir::ShapedType::kDynamic &&
+        dstShape[i] != mlir::ShapedType::kDynamic &&
+        src0Shape[i] != dstShape[i])
+      return emitOpError() << "expects src0 and dst static shapes to match";
+  }
+
   return mlir::success();
 }
 //===----------------------------------------------------------------------===//
@@ -3280,6 +3352,46 @@ mlir::LogicalResult mlir::pto::TXorSOp::verify() {
 
   if (getElemTy(srcTy) != getElemTy(dstTy))
     return emitOpError() << "expects src and dst to have the same element type";
+
+  auto srcShape = getShapeVec(srcTy);
+  auto dstShape = getShapeVec(dstTy);
+  if (srcShape.size() != dstShape.size())
+    return emitOpError() << "expects src and dst to have the same rank";
+  for (size_t i = 0; i < srcShape.size(); ++i) {
+    if (srcShape[i] != mlir::ShapedType::kDynamic &&
+        dstShape[i] != mlir::ShapedType::kDynamic &&
+        srcShape[i] != dstShape[i])
+      return emitOpError() << "expects src and dst static shapes to match";
+  }
+
+  return mlir::success();
+}
+
+mlir::LogicalResult mlir::pto::TXorSWithTmpOp::verify() {
+  Type srcTy = getSrc().getType();
+  Type tmpTy = getTmp().getType();
+  Type dstTy = getDst().getType();
+  if (!isPTOShapedLike(srcTy) || !isPTOShapedLike(tmpTy) || !isPTOShapedLike(dstTy))
+    return emitOpError() << "expects PTO shaped-like src, tmp, and dst";
+
+  if (getElemTy(srcTy) != getElemTy(tmpTy) || getElemTy(srcTy) != getElemTy(dstTy))
+    return emitOpError() << "expects src, tmp, and dst to have the same element type";
+
+  auto srcShape = getShapeVec(srcTy);
+  auto tmpShape = getShapeVec(tmpTy);
+  auto dstShape = getShapeVec(dstTy);
+  if (srcShape.size() != tmpShape.size() || srcShape.size() != dstShape.size())
+    return emitOpError() << "expects src, tmp, and dst to have the same rank";
+  for (size_t i = 0; i < srcShape.size(); ++i) {
+    if (srcShape[i] != mlir::ShapedType::kDynamic &&
+        tmpShape[i] != mlir::ShapedType::kDynamic &&
+        srcShape[i] != tmpShape[i])
+      return emitOpError() << "expects src and tmp static shapes to match";
+    if (srcShape[i] != mlir::ShapedType::kDynamic &&
+        dstShape[i] != mlir::ShapedType::kDynamic &&
+        srcShape[i] != dstShape[i])
+      return emitOpError() << "expects src and dst static shapes to match";
+  }
 
   return mlir::success();
 }
@@ -4405,6 +4517,19 @@ PTO_DEFINE_BINARY_EFFECTS(TSubSCOp, getSrc0Mutable(), getSrc1Mutable(), getDstMu
 
 PTO_DEFINE_UNARY_EFFECTS(TXorSOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_BINARY_EFFECTS(TXorOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())
+void TXorSWithTmpOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_READ(getSrcMutable());
+  PTO_ADD_WRITE(getTmpMutable());
+  PTO_ADD_WRITE(getDstMutable());
+}
+void TXorWithTmpOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_READ(getSrc0Mutable());
+  PTO_ADD_READ(getSrc1Mutable());
+  PTO_ADD_WRITE(getTmpMutable());
+  PTO_ADD_WRITE(getDstMutable());
+}
 
 // TTRANS: Read(src) -> Write(tmp, dst)
 void TTransOp::getEffects(

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_mlir_dialect_library(PTOTransforms
   InsertLoadStoreForMixCV.cpp
   PTOInsertCVMov.cpp
   PTOConvertToDPS.cpp
+  PTOExpandImplicitScratch.cpp
   InsertSync/PTOInsertSync.cpp
   InsertSync/InsertSyncDebug.cpp
   PTOViewToMemref.cpp

--- a/lib/PTO/Transforms/PTOExpandImplicitScratch.cpp
+++ b/lib/PTO/Transforms/PTOExpandImplicitScratch.cpp
@@ -1,0 +1,94 @@
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOEXPANDIMPLICITSCRATCH
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+namespace {
+
+static std::pair<Value, Value> inferDynamicValidDims(Value value) {
+  while (value) {
+    if (auto alloc = value.getDefiningOp<pto::AllocTileOp>())
+      return {alloc.getValidRow(), alloc.getValidCol()};
+    if (auto bitcast = value.getDefiningOp<pto::BitcastOp>()) {
+      value = bitcast.getSrc();
+      continue;
+    }
+    if (auto treshape = value.getDefiningOp<pto::TReshapeOp>()) {
+      value = treshape.getSrc();
+      continue;
+    }
+    break;
+  }
+  return {};
+}
+
+struct ExpandTXorPattern : public OpRewritePattern<pto::TXorOp> {
+  using OpRewritePattern<pto::TXorOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(pto::TXorOp op,
+                                PatternRewriter &rewriter) const override {
+    auto dstTy = dyn_cast<pto::TileBufType>(op.getDst().getType());
+    if (!dstTy)
+      return rewriter.notifyMatchFailure(
+          op, "expected tile_buf dst before memref lowering");
+
+    auto [validRow, validCol] = inferDynamicValidDims(op.getDst());
+    Value tmp = rewriter.create<pto::AllocTileOp>(op.getLoc(), dstTy,
+                                                  /*addr=*/Value(), validRow,
+                                                  validCol);
+    rewriter.replaceOpWithNewOp<pto::TXorWithTmpOp>(
+        op, TypeRange{}, op.getSrc0(), op.getSrc1(), tmp, op.getDst());
+    return success();
+  }
+};
+
+struct ExpandTXorSPattern : public OpRewritePattern<pto::TXorSOp> {
+  using OpRewritePattern<pto::TXorSOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(pto::TXorSOp op,
+                                PatternRewriter &rewriter) const override {
+    auto dstTy = dyn_cast<pto::TileBufType>(op.getDst().getType());
+    if (!dstTy)
+      return rewriter.notifyMatchFailure(
+          op, "expected tile_buf dst before memref lowering");
+
+    auto [validRow, validCol] = inferDynamicValidDims(op.getDst());
+    Value tmp = rewriter.create<pto::AllocTileOp>(op.getLoc(), dstTy,
+                                                  /*addr=*/Value(), validRow,
+                                                  validCol);
+    rewriter.replaceOpWithNewOp<pto::TXorSWithTmpOp>(
+        op, TypeRange{}, op.getSrc(), op.getScalar(), tmp, op.getDst());
+    return success();
+  }
+};
+
+struct PTOExpandImplicitScratchPass
+    : public mlir::pto::impl::PTOExpandImplicitScratchBase<
+          PTOExpandImplicitScratchPass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<ExpandTXorPattern, ExpandTXorSPattern>(&getContext());
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOExpandImplicitScratchPass() {
+  return std::make_unique<PTOExpandImplicitScratchPass>();
+}

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6027,17 +6027,35 @@ struct PTOSelSToEmitC : public OpConversionPattern<pto::TSelSOp> {
   LogicalResult matchAndRewrite(pto::TSelSOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
 
     Value src0 = peelUnrealized(adaptor.getSrc0());
     Value src1 = peelUnrealized(adaptor.getSrc1());
     Value selectMode = peelUnrealized(adaptor.getSelectMode());
     Value dst  = peelUnrealized(adaptor.getDst());
 
-    SmallVector<Value, 4> operands{dst, src0, src1, selectMode};
-    rewriter.create<emitc::CallOpaqueOp>(
-        loc, TypeRange{}, "TSELS",
-        /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
-        /*operands=*/operands);
+    Type u8Ty = getUnsignedIntOpaqueType(ctx, 8);
+    Value selectModeU8 = emitCCast(rewriter, loc, u8Ty, selectMode);
+    Value one = makeEmitCIntConstant(rewriter, loc, u8Ty, 1);
+    Value selectSrc0 = rewriter.create<emitc::CmpOp>(
+        loc, rewriter.getI1Type(), emitc::CmpPredicate::eq, selectModeU8, one);
+
+    auto ifOp = rewriter.create<emitc::IfOp>(loc, selectSrc0,
+                                             /*withElseRegion=*/true);
+    {
+      OpBuilder thenBuilder = ifOp.getThenBodyBuilder();
+      thenBuilder.create<emitc::CallOpaqueOp>(
+          loc, TypeRange{}, "TMOV", /*args=*/ArrayAttr{},
+          /*templateArgs=*/ArrayAttr{}, /*operands=*/ValueRange{dst, src0});
+      thenBuilder.create<emitc::YieldOp>(loc);
+    }
+    {
+      OpBuilder elseBuilder = ifOp.getElseBodyBuilder();
+      elseBuilder.create<emitc::CallOpaqueOp>(
+          loc, TypeRange{}, "TMOV", /*args=*/ArrayAttr{},
+          /*templateArgs=*/ArrayAttr{}, /*operands=*/ValueRange{dst, src1});
+      elseBuilder.create<emitc::YieldOp>(loc);
+    }
 
     rewriter.eraseOp(op);
     return success();
@@ -6330,20 +6348,19 @@ struct PTOSubSCToEmitC : public OpConversionPattern<pto::TSubSCOp> {
 // PTOConvert.cpp  (add lowering + patterns.add for TXOR DPS/memref op)
 //===----------------------------------------------------------------------===//
 
-struct PTOXORToEmitC : public OpConversionPattern<pto::TXorOp> {
-  using OpConversionPattern<pto::TXorOp>::OpConversionPattern;
+struct PTOXORToEmitC : public OpConversionPattern<pto::TXorWithTmpOp> {
+  using OpConversionPattern<pto::TXorWithTmpOp>::OpConversionPattern;
 
-  LogicalResult matchAndRewrite(pto::TXorOp op, OpAdaptor adaptor,
+  LogicalResult matchAndRewrite(pto::TXorWithTmpOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
 
     Value src0 = peelUnrealized(adaptor.getSrc0());
     Value src1 = peelUnrealized(adaptor.getSrc1());
+    Value tmp = peelUnrealized(adaptor.getTmp());
     Value dst = peelUnrealized(adaptor.getDst());
 
-    // pto-isa TXOR requires a tmp tile argument. Current NPU implementation
-    // does not use tmp, so we safely pass dst as tmp for compatibility.
-    SmallVector<Value, 4> operands{dst, src0, src1, dst};
+    SmallVector<Value, 4> operands{dst, src0, src1, tmp};
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TXOR",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -6378,20 +6395,19 @@ struct PTOTTransToEmitC : public OpConversionPattern<pto::TTransOp> {
 // PTOConvert.cpp  (add lowering + patterns.add for TXORS DPS/memref op)
 //===----------------------------------------------------------------------===//
 
-struct PTOXORSToEmitC : public OpConversionPattern<pto::TXorSOp> {
-  using OpConversionPattern<pto::TXorSOp>::OpConversionPattern;
+struct PTOXORSToEmitC : public OpConversionPattern<pto::TXorSWithTmpOp> {
+  using OpConversionPattern<pto::TXorSWithTmpOp>::OpConversionPattern;
 
-  LogicalResult matchAndRewrite(pto::TXorSOp op, OpAdaptor adaptor,
+  LogicalResult matchAndRewrite(pto::TXorSWithTmpOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
 
     Value src = peelUnrealized(adaptor.getSrc());
     Value scalar = peelUnrealized(adaptor.getScalar());
+    Value tmp = peelUnrealized(adaptor.getTmp());
     Value dst = peelUnrealized(adaptor.getDst());
 
-    // pto-isa TXORS requires a tmp tile argument. Current NPU implementation
-    // does not use tmp, so we safely pass dst as tmp for compatibility.
-    SmallVector<Value, 4> operands{dst, src, scalar, dst};
+    SmallVector<Value, 4> operands{dst, src, scalar, tmp};
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TXORS",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -7572,7 +7588,8 @@ struct EmitPTOManualPass
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<emitc::EmitCDialect, func::FuncDialect, arith::ArithDialect,
                     memref::MemRefDialect, affine::AffineDialect,
-                    mlir::cf::ControlFlowDialect, mlir::pto::PTODialect>();
+                    mlir::cf::ControlFlowDialect, mlir::scf::SCFDialect,
+                    mlir::pto::PTODialect>();
   }
 
 	  void runOnOperation() override {

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -479,6 +479,41 @@ process_one_dir() {
       fi
     fi
 
+    if [[ "$base" == "sels" ]]; then
+      if grep -Fq "TSELS(" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tpto.tsels should lower via TMOV branches, not TSELS()"
+        overall=1
+        continue
+      fi
+      if [[ $(grep -c "TMOV(" "$cpp") -lt 2 ]]; then
+        echo -e "${A}(${base}.py)\tFAIL\tpto.tsels should emit copy-style TMOV() branches"
+        overall=1
+        continue
+      fi
+    fi
+
+    if [[ "$base" == "xor" || "$base" == "xors" ]]; then
+      if ! "$python" - "$cpp" "$base" <<'PY'
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+callee = "TXOR" if sys.argv[2] == "xor" else "TXORS"
+match = re.search(rf"{callee}\(([^)]*)\);", text)
+if not match:
+    sys.exit(1)
+operands = [item.strip() for item in match.group(1).split(",")]
+if len(operands) != 4:
+    sys.exit(1)
+sys.exit(0 if operands[0] != operands[3] else 1)
+PY
+      then
+        echo -e "${A}(${base}.py)\tFAIL\t${base} lowering must pass a distinct planned tmp tile"
+        overall=1
+        continue
+      fi
+    fi
+
     if [[ "$base" == "bitcast_dtype_alias" ]]; then
       if ! grep -Eq "Tile<[^>]*, int32_t," "$cpp"; then
         echo -e "${A}(${base}.py)	FAIL	missing int32_t Tile declaration for pto.bitcast"

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -701,6 +701,7 @@ int main(int argc, char **argv) {
   
   if (!disableInferLayout)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
+  pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOExpandImplicitScratchPass());
   pm.addPass(pto::createPTOViewToMemrefPass());
   // bufferizationPipeline(pm);
   //pm.addPass(createInferPTOMemScopePass());


### PR DESCRIPTION
## Summary
- lower `pto.tsels` with copy semantics by truncating `selectMode` to `uint8_t` and branching to `TMOV(dst, src0/src1)`
- materialize explicit scratch tiles for `pto.txor` / `pto.txors` before memref lowering and pass the planned tmp tile through EmitC lowering
- tighten verifier/effect coverage and add regression guards for `sels`, `xor`, and `xors` sample lowering

## Testing
- `cmake --build build --target pto-opt -j8`
- `PTOAS_BIN=... bash test/samples/runop.sh -t Sels`
- `PTOAS_BIN=... bash test/samples/runop.sh -t Xor`
- `PTOAS_BIN=... bash test/samples/runop.sh -t Xors`