### PR TITLE
ci(remote): skip inter-core sync structural samples in NPU runtime validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ on:
       skip_cases:
         description: "Comma/space separated testcase names to skip (e.g. scatter,mrgsort)"
         type: string
-        default: "mix_kernel,vadd_validshape,vadd_validshape_dynamic,print"
+        default: "mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,test_intercore_sync_a3,test_intercore_sync_a5"
       run_only_cases:
         description: "Comma/space separated testcase names to run (empty = run all)"
         type: string
@@ -237,8 +237,11 @@ jobs:
       PAYLOAD_TGZ: ${{ github.workspace }}/_payload/ptoas_payload.tgz
       # Temporary CI gate: skip cases that still error/flap on the remote NPU.
       # Update this list as we fix the underlying issues.
+      # NOTE:
+      # - test_intercore_sync_a3/a5 are structural lowering gates (compile-shape checks),
+      #   not functional dataflow kernels; running them as standalone NPU cases is unstable.
       DEFAULT_SKIP_CASES: >-
-        mix_kernel,vadd_validshape,vadd_validshape_dynamic,print
+        mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,test_intercore_sync_a3,test_intercore_sync_a5
     steps:
       - name: Resolve validation parameters
         shell: bash


### PR DESCRIPTION
## Background
Remote NPU validation run [23126851603](https://github.com/zhangstevenunity/PTOAS/actions/runs/23126851603/job/67172009766) failed with:

- `test_intercore_sync_a3` runtime device exception (illegal instruction)

`test_intercore_sync_a3/a5` are structural lowering checks for inter-core sync call shape, not functional dataflow kernels suitable for standalone runtime compare.

## Change
Update remote-validation default skip lists to exclude these two structural samples:

- `test_intercore_sync_a3`
- `test_intercore_sync_a5`

Updated in two places in `.github/workflows/ci.yml`:

1. `workflow_dispatch.inputs.skip_cases.default`
2. `jobs.remote-npu-validation.env.DEFAULT_SKIP_CASES`

Also added an inline note to clarify why these two are skipped in runtime NPU validation.

## Scope
Only CI workflow skip policy is changed. No compiler/lowering/runtime code changes.

## Notes
This does **not** address unrelated `tinsert` runtime mismatch seen in the same run.
