### PR TITLE
fix(sync): select A5 tinsert pipe by src/dst workspace

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2081,20 +2081,57 @@ def TInsertOp : PTO_TOp<"tinsert", [
   }];
 
   let extraClassDeclaration = [{
-    // TINSERT runs on different DMA pipes across targets.
-    // - A5 (Ascend950/910_95): UB->L1 path is MTE3 in pto-isa custom kernels.
-    // - Others: keep MTE1 for compatibility with existing data-movement sync.
+    // TINSERT runs on different pipes depending on target/path:
+    // - A5 Vec(UB)->Mat(L1): PIPE_MTE3 (custom UB->L1 copy path).
+    // - Acc->Mat (A2/A3/A5 regular path): PIPE_FIX.
     ::mlir::pto::PIPE getPipe() {
-      auto moduleOp = getOperation()->getParentOfType<::mlir::ModuleOp>();
-      if (moduleOp) {
-        if (auto spec = moduleOp->getAttrOfType<::mlir::StringAttr>("pto.device-spec")) {
-          auto s = spec.getValue();
-          if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95")) {
-            return ::mlir::pto::PIPE::PIPE_MTE3;
-          }
+      auto isA5Target = [&]() -> bool {
+        auto moduleOp = getOperation()->getParentOfType<::mlir::ModuleOp>();
+        if (!moduleOp)
+          return false;
+
+        if (auto arch =
+                moduleOp->getAttrOfType<::mlir::StringAttr>("pto.target_arch")) {
+          if (arch.getValue().equals_insensitive("a5"))
+            return true;
         }
-      }
-      return ::mlir::pto::PIPE::PIPE_MTE1;
+
+        if (auto spec =
+                moduleOp->getAttrOfType<::mlir::StringAttr>("pto.device-spec")) {
+          auto s = spec.getValue();
+          if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95"))
+            return true;
+        }
+        return false;
+      };
+
+      auto getASFromType = [](Type ty)
+          -> std::optional<::mlir::pto::AddressSpace> {
+        if (auto tb = ::mlir::dyn_cast<::mlir::pto::TileBufType>(ty)) {
+          if (auto as = ::mlir::dyn_cast_or_null<::mlir::pto::AddressSpaceAttr>(
+                  tb.getMemorySpace()))
+            return as.getAddressSpace();
+          return std::nullopt;
+        }
+        if (auto mr = ::mlir::dyn_cast<::mlir::MemRefType>(ty)) {
+          if (auto ms = mr.getMemorySpace()) {
+            if (auto as = ::mlir::dyn_cast<::mlir::pto::AddressSpaceAttr>(ms))
+              return as.getAddressSpace();
+          }
+          return std::nullopt;
+        }
+        return std::nullopt;
+      };
+
+      auto sOpt = getASFromType(getSrc().getType());
+      auto dOpt = getASFromType(getDst().getType());
+      if (isA5Target() && sOpt.has_value() && dOpt.has_value() &&
+          sOpt.value() == ::mlir::pto::AddressSpace::VEC &&
+          dOpt.value() == ::mlir::pto::AddressSpace::MAT)
+        return ::mlir::pto::PIPE::PIPE_MTE3;
+
+      // Default and Acc->Mat path.
+      return ::mlir::pto::PIPE::PIPE_FIX;
     }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
   }];

--- a/test/basic/tinsert_a5_pipe_selection.mlir
+++ b/test/basic/tinsert_a5_pipe_selection.mlir
@@ -1,0 +1,60 @@
+// RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend950"} {
+  // A5: acc->mat TINSERT must use PIPE_FIX (regular A2M path).
+  func.func @tinsert_acc_mat_pipeline(%a: memref<32x32xf32, #pto.address_space<gm>>,
+                                      %b: memref<32x32xf32, #pto.address_space<gm>>,
+                                      %i: memref<32x32xf16, #pto.address_space<gm>>,
+                                      %out: memref<32x32xf32, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+
+    %a_mat = memref.alloc() : memref<32x32xf32, #pto.address_space<mat>>
+    %b_mat = memref.alloc() : memref<32x32xf32, #pto.address_space<mat>>
+    %a_left = memref.alloc() : memref<32x32xf32, #pto.address_space<left>>
+    %b_right = memref.alloc() : memref<32x32xf32, #pto.address_space<right>>
+    %src_acc = memref.alloc() : memref<32x32xf32, #pto.address_space<acc>>
+
+    %dst_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %i_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %out_left = memref.alloc() : memref<32x32xf16, #pto.address_space<left>>
+    %i_right = memref.alloc() : memref<32x32xf16, #pto.address_space<right>>
+    %out_acc = memref.alloc() : memref<32x32xf32, #pto.address_space<acc>>
+
+    pto.tload ins(%a : memref<32x32xf32, #pto.address_space<gm>>)
+              outs(%a_mat : memref<32x32xf32, #pto.address_space<mat>>)
+    pto.tload ins(%b : memref<32x32xf32, #pto.address_space<gm>>)
+              outs(%b_mat : memref<32x32xf32, #pto.address_space<mat>>)
+    pto.tmov ins(%a_mat : memref<32x32xf32, #pto.address_space<mat>>)
+             outs(%a_left : memref<32x32xf32, #pto.address_space<left>>)
+    pto.tmov ins(%b_mat : memref<32x32xf32, #pto.address_space<mat>>)
+             outs(%b_right : memref<32x32xf32, #pto.address_space<right>>)
+    pto.tmatmul ins(%a_left, %b_right : memref<32x32xf32, #pto.address_space<left>>,
+                                      memref<32x32xf32, #pto.address_space<right>>)
+                outs(%src_acc : memref<32x32xf32, #pto.address_space<acc>>)
+
+    pto.tinsert ins(%src_acc, %c0, %c0 : memref<32x32xf32, #pto.address_space<acc>>, index, index)
+               outs(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+
+    pto.tload ins(%i : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%i_mat : memref<32x32xf16, #pto.address_space<mat>>)
+    pto.tmov ins(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%out_left : memref<32x32xf16, #pto.address_space<left>>)
+    pto.tmov ins(%i_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%i_right : memref<32x32xf16, #pto.address_space<right>>)
+    pto.tmatmul ins(%out_left, %i_right : memref<32x32xf16, #pto.address_space<left>>,
+                                        memref<32x32xf16, #pto.address_space<right>>)
+                outs(%out_acc : memref<32x32xf32, #pto.address_space<acc>>)
+    pto.tstore ins(%out_acc : memref<32x32xf32, #pto.address_space<acc>>)
+               outs(%out : memref<32x32xf32, #pto.address_space<gm>>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void tinsert_acc_mat_pipeline(
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK-NOT: set_flag(PIPE_M, PIPE_MTE3, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TINSERT(
+// CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
+// CHECK-NOT: set_flag(PIPE_MTE3, PIPE_MTE1, EVENT_ID0);
+// CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);

--- a/test/basic/tinsert_a5_vec_pipe_selection.mlir
+++ b/test/basic/tinsert_a5_vec_pipe_selection.mlir
@@ -1,0 +1,30 @@
+// RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend950"} {
+  // A5: vec->mat TINSERT must use PIPE_MTE3 (custom UB->L1 path).
+  func.func @tinsert_vec_mat_pipeline(%a: memref<32x32xf16, #pto.address_space<gm>>,
+                                      %b: memref<32x32xf16, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %src_vec = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
+    %dst_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %tmp_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %out_left = memref.alloc() : memref<32x32xf16, #pto.address_space<left>>
+
+    pto.tload ins(%a : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src_vec : memref<32x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nd>}
+    pto.tinsert ins(%src_vec, %c0, %c0 : memref<32x32xf16, #pto.address_space<vec>>, index, index)
+               outs(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+    pto.tload ins(%b : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%tmp_mat : memref<32x32xf16, #pto.address_space<mat>>) {layout = #pto.layout<nd>}
+    pto.tmov ins(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%out_left : memref<32x32xf16, #pto.address_space<left>>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_pipeline(
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+// CHECK: TINSERT(
+// CHECK: set_flag(PIPE_MTE3, PIPE_MTE1, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE3, PIPE_MTE1, EVENT_ID0);


### PR DESCRIPTION
## Summary
- fix `pto.tinsert` pipe selection on A5 to be path-aware instead of always MTE3
- keep `PIPE_MTE3` only for A5 `Vec -> Mat` (UB->L1 custom path)
- use `PIPE_FIX` for `Acc -> Mat` and default/fallback paths
- detect A5 via `pto.target_arch` (preferred) and keep `pto.device-spec` compatibility

## Tests
- add `test/basic/tinsert_a5_pipe_selection.mlir`
  - checks A5 `acc->mat` path uses `PIPE_FIX` around TINSERT sync
- add `test/basic/tinsert_a5_vec_pipe_selection.mlir`
  - checks A5 `vec->mat` path uses `PIPE_MTE3` around TINSERT sync

## Motivation
A5 has at least two TINSERT data paths in PTO-ISA:
- regular A2M path (`PIPE_FIX`)
- custom UB->L1 path (`PIPE_MTE3`)
Using a single fixed pipe for all A5 TINSERT forms can generate wrong sync ordering.
