### PR TITLE
test(tinsert): update A5 vec pipe case to vec->vec

### DIFF
--- a/test/basic/tinsert_a5_vec_pipe_selection.mlir
+++ b/test/basic/tinsert_a5_vec_pipe_selection.mlir
@@ -1,30 +1,26 @@
 // RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
 
 module attributes {"pto.device-spec" = "Ascend950"} {
-  // A5: vec->mat TINSERT must use PIPE_MTE3 (custom UB->L1 path).
-  func.func @tinsert_vec_mat_pipeline(%a: memref<32x32xf16, #pto.address_space<gm>>,
-                                      %b: memref<32x32xf16, #pto.address_space<gm>>) {
+  // A5: vec->vec TINSERT should use non-custom path (PIPE_FIX).
+  func.func @tinsert_vec_vec_pipeline(%a: memref<32x32xf16, #pto.address_space<gm>>) {
     %c0 = arith.constant 0 : index
     %src_vec = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
-    %dst_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
-    %tmp_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
-    %out_left = memref.alloc() : memref<32x32xf16, #pto.address_space<left>>
+    %dst_vec = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
+    %out_vec = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
 
     pto.tload ins(%a : memref<32x32xf16, #pto.address_space<gm>>)
               outs(%src_vec : memref<32x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nd>}
     pto.tinsert ins(%src_vec, %c0, %c0 : memref<32x32xf16, #pto.address_space<vec>>, index, index)
-               outs(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
-    pto.tload ins(%b : memref<32x32xf16, #pto.address_space<gm>>)
-              outs(%tmp_mat : memref<32x32xf16, #pto.address_space<mat>>) {layout = #pto.layout<nd>}
-    pto.tmov ins(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
-             outs(%out_left : memref<32x32xf16, #pto.address_space<left>>)
+               outs(%dst_vec : memref<32x32xf16, #pto.address_space<vec>>)
+    pto.tmov ins(%dst_vec : memref<32x32xf16, #pto.address_space<vec>>)
+             outs(%out_vec : memref<32x32xf16, #pto.address_space<vec>>)
     return
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_pipeline(
-// CHECK: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+// CHECK-LABEL: __global__ AICORE void tinsert_vec_vec_pipeline(
+// CHECK: set_flag(PIPE_MTE2, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_FIX, EVENT_ID0);
 // CHECK: TINSERT(
-// CHECK: set_flag(PIPE_MTE3, PIPE_MTE1, EVENT_ID0);
-// CHECK: wait_flag(PIPE_MTE3, PIPE_MTE1, EVENT_ID0);
+// CHECK: set_flag(PIPE_FIX, PIPE_V, EVENT_ID0);
+// CHECK: wait_flag(PIPE_FIX, PIPE_V, EVENT_ID0);


### PR DESCRIPTION
## Summary
- update `test/basic/tinsert_a5_vec_pipe_selection.mlir` from `vec->mat` to `vec->vec`
- keep the test focused on A5 `vec->vec` sync behavior for `tinsert`

## Assertion Changes
- check `tload(gm->vec)` to `tinsert(vec->vec)` dependency uses `PIPE_MTE2 -> PIPE_FIX`
- check `tinsert(vec->vec)` to `tmov(vec->vec)` dependency uses `PIPE_FIX -> PIPE_V`

## Validation
- `ptoas --pto-arch a5 --enable-insert-sync test/basic/tinsert_a5_vec_pipe_selection.mlir | FileCheck ...`
- re-ran `test/basic/tinsert_a5_pipe_selection.mlir` to ensure existing `acc->mat` coverage stays green
