### PR TITLE
test(layout): add explicit pto.entry for multi-func layout inference module

### DIFF
--- a/test/samples/LayoutInference/layout_inference.py
+++ b/test/samples/LayoutInference/layout_inference.py
@@ -19,6 +19,7 @@ from mlir.ir import (
     Module,
     F32Type,
     IndexType,
+    UnitAttr,
 )
 from mlir.dialects import func, arith, pto
 from typing import Optional
@@ -70,6 +71,9 @@ def build_case(
             name,
             func.FunctionType.get([pto.PtrType.get(elem_ty)], []),
         )
+    # Multi-function modules require explicit entry markers after pto.entry
+    # enforcement; mark each generated function as an entry kernel.
+    f.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
     entry = f.add_entry_block()
     with InsertionPoint(entry):
         shape_vals = [cidx(ctx, s) for s in shape]


### PR DESCRIPTION
Summary
- Mark each function generated by `test/samples/LayoutInference/layout_inference.py` with explicit `pto.entry`.

Motivation
- After `pto.entry` enforcement (PR #277), multi-function modules no longer auto-select an entry.
- `layout_inference.py` emits one module with four functions, so no `__global__` entry can be inferred implicitly, which leads to downstream link failures in testcase generation/build.

Design
- Add `UnitAttr` import.
- Set `f.operation.attributes["pto.entry"] = UnitAttr.get(ctx)` for each generated function in `build_case`.
- Keep test semantics unchanged (still validates layout inference across four cases in one module).

Testing
- `python3 -m py_compile test/samples/LayoutInference/layout_inference.py`
- `python test/samples/LayoutInference/layout_inference.py` (with PTO env) and verified all four funcs carry `attributes {pto.entry}`.

Risk / Rollback
- Risk: low, test-only change.
- Rollback: revert this commit.
