### PR TITLE
[CI] only do strict version check for formal release, but relax check for pre-release

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -10,7 +10,7 @@ on:
     - cron: "10 17 * * *"
   workflow_dispatch:
   release:
-    types: [created, published]
+    types: [prereleased, released]
 
 permissions:
   contents: write
@@ -49,8 +49,12 @@ jobs:
 
       - name: Compute PTOAS CLI version
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "release" ] && [ "${{ github.event.action }}" = "published" ]; then
-            PTOAS_VERSION="$(${PY_PATH}/bin/python .github/scripts/compute_ptoas_version.py --mode release --check-tag "${GITHUB_REF_NAME}")"
+          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            if [ "${{ github.event.action }}" = "released" ]; then
+              PTOAS_VERSION="$(${PY_PATH}/bin/python .github/scripts/compute_ptoas_version.py --mode release --check-tag "${GITHUB_REF_NAME}")"
+            else
+              PTOAS_VERSION="$(${PY_PATH}/bin/python .github/scripts/compute_ptoas_version.py --mode release)"
+            fi
           else
             PTOAS_VERSION="$(${PY_PATH}/bin/python .github/scripts/compute_ptoas_version.py --mode dev)"
           fi

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -9,7 +9,7 @@ on:
     - cron: "40 17 * * *"
   workflow_dispatch:
   release:
-    types: [created, published]
+    types: [prereleased, released]
 
 permissions:
   contents: write
@@ -46,8 +46,12 @@ jobs:
 
       - name: Compute PTOAS CLI version
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "release" ] && [ "${{ github.event.action }}" = "published" ]; then
-            PTOAS_VERSION="$(python .github/scripts/compute_ptoas_version.py --mode release --check-tag "${GITHUB_REF_NAME}")"
+          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            if [ "${{ github.event.action }}" = "released" ]; then
+              PTOAS_VERSION="$(python .github/scripts/compute_ptoas_version.py --mode release --check-tag "${GITHUB_REF_NAME}")"
+            else
+              PTOAS_VERSION="$(python .github/scripts/compute_ptoas_version.py --mode release)"
+            fi
           else
             PTOAS_VERSION="$(python .github/scripts/compute_ptoas_version.py --mode dev)"
           fi


### PR DESCRIPTION
Since https://github.com/zhangstevenunity/PTOAS/pull/242, the manually-created release tag **must** use a name that matches version name in `CMakeLists.txt` (must use `0.8` if `project(ptoas VERSION 0.7)`) If any other release name is used, will get error [like this job](https://github.com/huawei-csl/PTOAS/actions/runs/23137002718): 
`release tag '20260316' does not match computed version '0.8'`

But our internal development needs more incremental small releases between the formal versions, to bring bug fixes timely.

This PR **keeps the current checking behavior for formal releases**, but additionally allow "Pre-release" to use any tag names, so we can keep smaller internal releases.

- Example "Pre-release" https://github.com/learning-chip/PTOAS/releases/tag/20260316
- Example CI job: https://github.com/learning-chip/PTOAS/actions/runs/23150065280