### PR TITLE
fix: emit AICORE on non-entry PTO functions

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -2200,7 +2200,10 @@ struct FuncToEmitC : public OpConversionPattern<func::FuncOp> {
       emitcFunc.setSpecifiersAttr(
           rewriter.getStrArrayAttr({"__global__ AICORE"}));
     } else if (op.isPrivate()) {
-      emitcFunc.setSpecifiersAttr(rewriter.getStrArrayAttr({"static"}));
+      emitcFunc.setSpecifiersAttr(
+          rewriter.getStrArrayAttr({"static", "AICORE"}));
+    } else {
+      emitcFunc.setSpecifiersAttr(rewriter.getStrArrayAttr({"AICORE"}));
     }
 
     // Inline the original body, then convert region/block argument types to

--- a/test/basic/pto_entry_multifunc.pto
+++ b/test/basic/pto_entry_multifunc.pto
@@ -13,6 +13,6 @@ module {
   }
 }
 
-// CHECK-LABEL: static int32_t helper(
+// CHECK-LABEL: static AICORE int32_t helper(
 // CHECK-LABEL: __global__ AICORE void kernel(
 // CHECK: helper(

--- a/test/basic/pto_entry_multifunc_no_entry.pto
+++ b/test/basic/pto_entry_multifunc_no_entry.pto
@@ -13,7 +13,7 @@ module {
   }
 }
 
-// CHECK-LABEL: static int32_t helper(
+// CHECK-LABEL: static AICORE int32_t helper(
 // CHECK-NOT: __global__ AICORE
-// CHECK-LABEL: void kernel(
+// CHECK-LABEL: AICORE void kernel(
 // CHECK: helper(


### PR DESCRIPTION
## Summary
- emit `AICORE` on non-entry PTO function definitions so helper/device functions are compiled as AICORE code
- keep launchable entry functions as `__global__ AICORE`
- update `pto_entry` regression checks for private helpers and multi-function no-entry modules

## Validation
- `ninja -C build ptoas`
- `build/tools/ptoas/ptoas test/basic/pto_entry_single_func_default.pto | FileCheck test/basic/pto_entry_single_func_default.pto`
- `build/tools/ptoas/ptoas test/basic/pto_entry_multifunc.pto | FileCheck test/basic/pto_entry_multifunc.pto`
- `build/tools/ptoas/ptoas test/basic/pto_entry_multifunc_no_entry.pto | FileCheck test/basic/pto_entry_multifunc_no_entry.pto`
- `build/tools/ptoas/ptoas test/basic/pto_entry_recursive_rejected.pto` (expected failure)
- `build/tools/ptoas/ptoas test/basic/pto_entry_nonvoid_rejected.pto` (expected failure)
- `build/tools/ptoas/ptoas test/basic/pto_entry_single_nonvoid_rejected.pto` (expected failure)
