### PR TITLE
[InsertSync] Fix TMOV ACC->MAT pipe classification

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -949,12 +949,18 @@ def TMovOp  : PTO_TOp<"tmov", [
         return ::mlir::pto::PIPE::PIPE_V;
       }
 
-      // MAT -> L0 (Left/Right/Bias/Scaling) and ACC -> MAT are MTE1 moves.
+      // MAT -> L0 (Left/Right/Bias/Scaling) are MTE1 moves.
       if ((s == ::mlir::pto::AddressSpace::MAT &&
            (d == ::mlir::pto::AddressSpace::LEFT || d == ::mlir::pto::AddressSpace::RIGHT ||
-            d == ::mlir::pto::AddressSpace::BIAS || d == ::mlir::pto::AddressSpace::SCALING)) ||
-          (s == ::mlir::pto::AddressSpace::ACC && d == ::mlir::pto::AddressSpace::MAT)) {
+            d == ::mlir::pto::AddressSpace::BIAS || d == ::mlir::pto::AddressSpace::SCALING))) {
         return ::mlir::pto::PIPE::PIPE_MTE1;
+      }
+
+      // ACC -> MAT uses FIX in PTO-ISA sync mapping (TMOV_A2M/TMOV_V2M class),
+      // and InsertSync relies on this pipe classification to generate the
+      // required M->FIX and FIX->MTE1 dependency edges.
+      if (s == ::mlir::pto::AddressSpace::ACC && d == ::mlir::pto::AddressSpace::MAT) {
+        return ::mlir::pto::PIPE::PIPE_FIX;
       }
 
       // Fallback: treat as vector pipe (safe default for most intra-domain moves).

--- a/test/basic/tmov_acc_mat_pipe_selection.mlir
+++ b/test/basic/tmov_acc_mat_pipe_selection.mlir
@@ -1,0 +1,39 @@
+// RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend950"} {
+  // A5: tmov acc->mat should be treated as PIPE_FIX for sync insertion.
+  func.func @tmov_acc_mat_pipeline(%a: memref<32x32xf16, #pto.address_space<gm>>,
+                                   %b: memref<32x32xf16, #pto.address_space<gm>>) {
+    %a_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %b_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %a_left = memref.alloc() : memref<32x32xf16, #pto.address_space<left>>
+    %b_right = memref.alloc() : memref<32x32xf16, #pto.address_space<right>>
+    %acc = memref.alloc() : memref<32x32xf32, #pto.address_space<acc>>
+    %dst_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %dst_left = memref.alloc() : memref<32x32xf16, #pto.address_space<left>>
+
+    pto.tload ins(%a : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%a_mat : memref<32x32xf16, #pto.address_space<mat>>)
+    pto.tload ins(%b : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%b_mat : memref<32x32xf16, #pto.address_space<mat>>)
+    pto.tmov ins(%a_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%a_left : memref<32x32xf16, #pto.address_space<left>>)
+    pto.tmov ins(%b_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%b_right : memref<32x32xf16, #pto.address_space<right>>)
+    pto.tmatmul ins(%a_left, %b_right : memref<32x32xf16, #pto.address_space<left>>,
+                                        memref<32x32xf16, #pto.address_space<right>>)
+                outs(%acc : memref<32x32xf32, #pto.address_space<acc>>)
+    pto.tmov ins(%acc : memref<32x32xf32, #pto.address_space<acc>>)
+             outs(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+    pto.tmov ins(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%dst_left : memref<32x32xf16, #pto.address_space<left>>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void tmov_acc_mat_pipeline(
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TMOV(
+// CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
+// CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);


### PR DESCRIPTION
Summary
- Fix `pto.tmov` pipeline classification for `ACC -> MAT` to return `PIPE_FIX` instead of `PIPE_MTE1`.
- Add regression test `test/basic/tmov_acc_mat_pipe_selection.mlir` to lock expected sync chain `PIPE_M -> PIPE_FIX -> PIPE_MTE1`.

Motivation
- Fixes #283.
- `--enable-insert-sync` missed required sync edges around `TMOV(L0C->L1)` when this op was treated as `PIPE_MTE1`.

Design
- Keep existing source/destination based classification in `TMovOp::getPipe()`.
- Adjust only the `ACC -> MAT` branch to `PIPE_FIX` (aligned with PTO-ISA sync mapping for `TMOV_A2M`).
- Add a focused FileCheck test that validates generated C++ contains:
  - `set/wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0)`
  - `set/wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0)`

Testing
- Build: `ninja -C build ptoas` (on this branch).
- Targeted checks:
  - `ptoas --pto-arch a5 --enable-insert-sync test/basic/tmov_acc_mat_pipe_selection.mlir | FileCheck ...`
  - `ptoas --pto-arch a5 --enable-insert-sync test/basic/tinsert_a5_pipe_selection.mlir | FileCheck ...`
- Reproducer sanity check:
  - Running patched `ptoas --enable-insert-sync` on issue #283 reproducer now emits missing `PIPE_M->PIPE_FIX` and `PIPE_FIX->PIPE_MTE1` edges.

A3/A5 PTO-ISA consistency check
- Compared `pto-isa/include/pto/npu/a2a3/TSync.hpp` and `pto-isa/include/pto/npu/a5/TSync.hpp` for relevant sync op mappings.
- For this fix scope, mapping is consistent on both arches:
  - `TMOV_V2M -> PIPE_FIX`
  - `TMOV_M2L/TMOV_M2B -> PIPE_MTE1`
  - `TMOV_M2S -> PIPE_FIX`
  - `TMOV_A2M -> PIPE_FIX`
  - `TSTORE_ACC -> PIPE_FIX`
  - `TMATMUL -> PIPE_M`
- Note: cross-core event qualification logic differs slightly between A3 and A5, but it does not change the above op->pipe mapping used by this fix.

Risk / Rollback
- Risk: low and localized to `TMOV ACC->MAT` sync classification; expected effect is additional required ordering, not broader behavior change.
- Rollback: revert this PR commit.
