### PR TITLE
[InsertSync] add per-function hint for auto tail sync inline sequence

### DIFF
--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -266,7 +266,20 @@ void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
   }
  
   // 4. 创建指令
-  rewriter.create<pto::BarrierOp>(op->getLoc(), currentPipeAttr);
+  auto barrier =
+      rewriter.create<pto::BarrierOp>(op->getLoc(), currentPipeAttr);
+
+  // Mark the compiler-inserted function-tail PIPE_ALL barrier. EmitC lowering
+  // routes this to a dedicated inline epilogue helper to enable future,
+  // policy-driven lightweight tails without changing sync analysis.
+  if (sync->GetActualSrcPipe() == PipelineType::PIPE_ALL &&
+      sync->GetActualDstPipe() == PipelineType::PIPE_ALL) {
+    barrier->setAttr("pto.auto_sync_tail_barrier", rewriter.getUnitAttr());
+    if (auto hintAttr =
+            func_->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint")) {
+      barrier->setAttr("pto.auto_sync_tail_hint", hintAttr);
+    }
+  }
 }
  
 void SyncCodegen::CreateSetWaitOpForSingleBuffer(IRRewriter &rewriter,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -3481,6 +3481,46 @@ struct CallToEmitC : public OpConversionPattern<func::CallOp> {
 // Sync lowering
 //===----------------------------------------------------------------------===
 
+static constexpr llvm::StringLiteral kAutoSyncTailBarrierAttr =
+    "pto.auto_sync_tail_barrier";
+static constexpr llvm::StringLiteral kAutoSyncTailHintAttr =
+    "pto.auto_sync_tail_hint";
+static constexpr llvm::StringLiteral kAutoSyncTailPolicyBarrierAll =
+    "barrier_all";
+static constexpr llvm::StringLiteral kAutoSyncTailPolicyMte3ToSEvent0 =
+    "setwait_mte3_to_s_event0";
+static constexpr llvm::StringLiteral kAutoSyncTailModeBarrierAllToken =
+    "PTOAutoSyncTailMode::kBarrierAll";
+static constexpr llvm::StringLiteral kAutoSyncTailModeMte3ToSEvent0Token =
+    "PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0";
+
+static std::string getAutoSyncTailModeToken(Operation *op) {
+  if (op) {
+    if (auto hintAttr = op->getAttrOfType<StringAttr>(kAutoSyncTailHintAttr)) {
+      if (hintAttr.getValue() == kAutoSyncTailPolicyBarrierAll)
+        return kAutoSyncTailModeBarrierAllToken.str();
+      if (hintAttr.getValue() == kAutoSyncTailPolicyMte3ToSEvent0)
+        return kAutoSyncTailModeMte3ToSEvent0Token.str();
+    }
+  }
+
+  auto func = op ? op->getParentOfType<func::FuncOp>() : func::FuncOp();
+  if (!func)
+    return kAutoSyncTailModeBarrierAllToken.str();
+
+  auto hintAttr = func->getAttrOfType<StringAttr>(kAutoSyncTailHintAttr);
+  if (!hintAttr)
+    return kAutoSyncTailModeBarrierAllToken.str();
+
+  if (hintAttr.getValue() == kAutoSyncTailPolicyBarrierAll)
+    return kAutoSyncTailModeBarrierAllToken.str();
+  if (hintAttr.getValue() == kAutoSyncTailPolicyMte3ToSEvent0)
+    return kAutoSyncTailModeMte3ToSEvent0Token.str();
+
+  // Fallback to the conservative behavior when seeing unknown policies.
+  return kAutoSyncTailModeBarrierAllToken.str();
+}
+
 static std::string getPipeName(pto::PIPE pipe) {
   switch (pipe) {
     case pto::PIPE::PIPE_S: return "PIPE_S";
@@ -3510,6 +3550,15 @@ struct PTOBarrierToEmitC : public OpConversionPattern<pto::BarrierOp> {
   LogicalResult matchAndRewrite(pto::BarrierOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto *ctx = rewriter.getContext();
+
+    if (op->hasAttr(kAutoSyncTailBarrierAttr)) {
+      auto args = rewriter.getArrayAttr(
+          {emitc::OpaqueAttr::get(ctx, getAutoSyncTailModeToken(op))});
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          op, TypeRange{}, "ptoas_auto_sync_tail",
+          args, ArrayAttr{}, ValueRange{});
+      return success();
+    }
 
     // [FIX] op.getPipe() returns PipeAttr. 
     // We must call .getPipe() on the attribute to get the actual Enum value.
@@ -7718,6 +7767,27 @@ struct EmitPTOManualPass
 	        loc, builder.getStringAttr("pto/pto-inst.hpp"), /*isAngled=*/nullptr);
 	    builder.create<emitc::VerbatimOp>(
 	        loc, builder.getStringAttr("using namespace pto;"));
+	    builder.create<emitc::VerbatimOp>(
+	        loc, builder.getStringAttr(R"cpp(
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+)cpp"));
 	
 	    // Only inject the bitcast helper when we actually lower ops that need it
 	    // (e.g. arith.bitcast or arith.maximumf/minimumf tie-breaking on zeros).

--- a/test/samples/Sync/test_auto_sync_tail_hint.pto
+++ b/test/samples/Sync/test_auto_sync_tail_hint.pto
@@ -1,0 +1,20 @@
+module attributes {"pto.device-spec" = "Ascend910B1"} {
+  func.func @test_auto_sync_tail_hint(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>)
+      attributes {pto.auto_sync_tail_hint = "mte3-to-s-event0"} {
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    %c1 = arith.constant 1 : index
+
+    %view0 = pto.make_tensor_view %arg0, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %view1 = pto.make_tensor_view %arg1, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %pt0 = pto.partition_view %view0, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %pt1 = pto.partition_view %view1, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %buf0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %buf1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%pt0 : !pto.partition_tensor_view<32x32xf32>) outs(%buf0 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%pt1 : !pto.partition_tensor_view<32x32xf32>) outs(%buf1 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/samples/Sync/test_auto_sync_tail_hint.py
+++ b/test/samples/Sync/test_auto_sync_tail_hint.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+if __name__ == "__main__":
+    print(Path(__file__).with_suffix(".pto").read_text(encoding="utf-8"))

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -324,6 +324,27 @@ process_one_dir() {
       fi
     fi
 
+    # Regression guard for per-function auto tail hint:
+    # function attr `pto.auto_sync_tail_hint = "mte3-to-s-event0"` should
+    # select the lightweight tail sequence instead of PIPE_ALL barrier.
+    if [[ "$base" == "test_auto_sync_tail_hint" ]]; then
+      if ! grep -Fq "set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing MTE3->S set_flag in tail helper"
+        overall=1
+        continue
+      fi
+      if ! grep -Fq "wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing MTE3->S wait_flag in tail helper"
+        overall=1
+        continue
+      fi
+      if ! grep -Fq "ptoas_auto_sync_tail(PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0);" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\ttail call did not select kSetWaitMte3ToSEvent0"
+        overall=1
+        continue
+      fi
+    fi
+
     # Regression guard: intra-pipe dependencies must be serialized by a
     # per-pipe barrier (PyPTO expects `bar_v` / `bar_m` behavior).
     if [[ "$base" == "test_inject_sync_intra_pipe_barrier" ]]; then

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -272,6 +272,28 @@ static bool parseBuildLevel(llvm::StringRef levelStr, PTOBuildLevel &out) {
   return false;
 }
 
+static constexpr llvm::StringLiteral kAutoSyncTailPolicyBarrierAll =
+    "barrier_all";
+static constexpr llvm::StringLiteral kAutoSyncTailPolicyMte3ToSEvent0 =
+    "setwait_mte3_to_s_event0";
+
+static bool parseAutoSyncTailHint(llvm::StringRef hintStr, std::string &normalized) {
+  std::string s = hintStr.str();
+  for (char &c : s)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  if (s == "barrier-all" || s == "barrier_all" || s == "default") {
+    normalized = kAutoSyncTailPolicyBarrierAll.str();
+    return true;
+  }
+  if (s == "mte3-to-s-event0" || s == "mte3_to_s_event0" ||
+      s == "setwait-mte3-to-s-event0" ||
+      s == "setwait_mte3_to_s_event0") {
+    normalized = kAutoSyncTailPolicyMte3ToSEvent0.str();
+    return true;
+  }
+  return false;
+}
+
 // --------------------------------------------------------------------------
 // Post-process C++ output: rewrite marker calls into Tile member calls.
 //
@@ -773,6 +795,28 @@ int main(int argc, char **argv) {
                  << "'. Expected 'level1', 'level2', or 'level3'.\n";
     return 1;
   }
+
+  bool invalidAutoSyncTailHint = false;
+  module->walk([&](mlir::func::FuncOp func) {
+    auto hintAttr =
+        func->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint");
+    if (!hintAttr)
+      return;
+
+    std::string normalizedHint;
+    if (!parseAutoSyncTailHint(hintAttr.getValue(), normalizedHint)) {
+      func.emitError("invalid pto.auto_sync_tail_hint '")
+          << hintAttr.getValue()
+          << "'. Expected 'barrier-all' (or 'default') or "
+             "'mte3-to-s-event0'.";
+      invalidAutoSyncTailHint = true;
+      return;
+    }
+    func->setAttr("pto.auto_sync_tail_hint",
+                  mlir::StringAttr::get(&context, normalizedHint));
+  });
+  if (invalidAutoSyncTailHint)
+    return 1;
 
   if (effectiveLevel == PTOBuildLevel::Level3) {
     bool missing = false;


### PR DESCRIPTION
## Summary
- keep compiler-inserted function-tail `PIPE_ALL` barrier marked via `pto.auto_sync_tail_barrier`
- switch policy selection from global CLI option to **per-function hint**
- introduce function attribute `pto.auto_sync_tail_hint` and validate/normalize it in `ptoas`
- propagate function hint onto the marked auto tail barrier op during InsertSync
- in EmitC lowering, select inline tail sync mode by hint (op attr first, then parent function attr)
- keep manual `pto.barrier <PIPE_ALL>` lowering unchanged (still direct `pipe_barrier(PIPE_ALL)`)

## Function Hint
Set on `func.func` as string attr:
- default/barrier-all: `default`, `barrier-all`, `barrier_all` -> normalized to `barrier_all`
- lightweight example: `mte3-to-s-event0` (plus underscore aliases) -> normalized to `setwait_mte3_to_s_event0`

If hint is invalid, `ptoas` emits function-level error and exits non-zero.

## EmitC Tail Inline Modes
- `kBarrierAll`: `pipe_barrier(PIPE_ALL)`
- `kSetWaitMte3ToSEvent0`:
  - `set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);`
  - `wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);`

## Tests
- `ninja -C build ptoas`
- `python3 test/samples/Sync/test_auto_sync_tail_hint.py > build/test_auto_sync_tail_hint-pto-ir.pto`
- `build/tools/ptoas/ptoas --enable-insert-sync build/test_auto_sync_tail_hint-pto-ir.pto -o build/test_auto_sync_tail_hint-pto.cpp`
- verify generated C++ contains:
  - `set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);`
  - `wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);`
  - `ptoas_auto_sync_tail(PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0);`
- run sample guard in `test/samples/runop.sh` for `Sync/test_auto_sync_tail_hint.py`
