### PR TITLE
fix(release): persist base version after successful release

### DIFF
--- a/.github/scripts/update_ptoas_base_version.py
+++ b/.github/scripts/update_ptoas_base_version.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+PROJECT_VERSION_RE = re.compile(
+    r"(project\s*\(\s*ptoas\s+VERSION\s+)([0-9]+\.[0-9]+)(\s*\))"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Update the base PTOAS version in the top-level CMakeLists.txt."
+    )
+    parser.add_argument(
+        "--cmake-file",
+        default="CMakeLists.txt",
+        help="Path to the top-level CMakeLists.txt file.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Released version to write back, e.g. v0.8 or 0.8.",
+    )
+    return parser.parse_args()
+
+
+def normalize_version(version: str) -> str:
+    normalized = version.strip()
+    if normalized.startswith("v"):
+        normalized = normalized[1:]
+    if not re.fullmatch(r"[0-9]+\.[0-9]+", normalized):
+        raise ValueError(f"invalid PTOAS version '{version}'")
+    return normalized
+
+
+def update_base_version(cmake_file: pathlib.Path, version: str) -> bool:
+    content = cmake_file.read_text(encoding="utf-8")
+
+    def repl(match: re.Match[str]) -> str:
+        return f"{match.group(1)}{version}{match.group(3)}"
+
+    updated, count = PROJECT_VERSION_RE.subn(repl, content, count=1)
+    if count != 1:
+        raise ValueError(
+            f"could not find 'project(ptoas VERSION x.y)' in {cmake_file}"
+        )
+    if updated == content:
+        return False
+    cmake_file.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    args = parse_args()
+    version = normalize_version(args.version)
+    cmake_file = pathlib.Path(args.cmake_file)
+    update_base_version(cmake_file, version)
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -274,3 +274,33 @@ jobs:
           files: |
             release-artifacts/*.whl
             release-artifacts/*.tar.gz
+
+  bump_base_version:
+    name: Bump base version after release
+    if: github.event_name == 'release' && github.event.action == 'released'
+    needs: upload_release_assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Update CMake base version
+        run: |
+          python3 .github/scripts/update_ptoas_base_version.py \
+            --version "${GITHUB_REF_NAME}"
+
+      - name: Commit version bump
+        run: |
+          if git diff --quiet -- CMakeLists.txt; then
+            echo "CMakeLists.txt already matches released version."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CMakeLists.txt
+          git commit -m "chore(release): bump base version to ${GITHUB_REF_NAME}"
+          git push origin HEAD:${{ github.event.repository.default_branch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20.0)
-project(ptoas VERSION 0.7)
+project(ptoas VERSION 0.8)
 
 set(PTOAS_RELEASE_VERSION_OVERRIDE ""
     CACHE STRING "Override the version printed by ptoas --version")


### PR DESCRIPTION
## Summary
- bump the current CMake base version from 0.7 to 0.8 so the next release tag v0.9 matches the computed release version
- add a release follow-up job that writes the released version back to `CMakeLists.txt` on the default branch
- add a small helper script to update the base version from a release tag

## Why
The current release workflow only overrides the version string for build artifacts. It never updates the repository base version, so after publishing v0.8 the source tree still stayed at 0.7. The next release run for v0.9 therefore computed 0.8 again and failed in `Compute PTOAS CLI version`.

## Validation
- `python3 .github/scripts/compute_ptoas_version.py --cmake-file CMakeLists.txt --mode dev` -> `0.8`
- `python3 .github/scripts/compute_ptoas_version.py --cmake-file CMakeLists.txt --mode release --check-tag v0.9` -> `0.9`
- `python3 .github/scripts/update_ptoas_base_version.py --cmake-file CMakeLists.txt --version v0.11` updates the base version to `0.11` as expected