### PR TITLE
test(npu): functionalize inter-core sync validation and fix FFTS runtime wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ on:
       skip_cases:
         description: "Comma/space separated testcase names to skip (e.g. scatter,mrgsort)"
         type: string
-        default: "mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,test_intercore_sync_a3,test_intercore_sync_a5"
+        default: "mix_kernel,vadd_validshape,vadd_validshape_dynamic,print"
       run_only_cases:
         description: "Comma/space separated testcase names to run (empty = run all)"
         type: string
@@ -237,11 +237,8 @@ jobs:
       PAYLOAD_TGZ: ${{ github.workspace }}/_payload/ptoas_payload.tgz
       # Temporary CI gate: skip cases that still error/flap on the remote NPU.
       # Update this list as we fix the underlying issues.
-      # NOTE:
-      # - test_intercore_sync_a3/a5 are structural lowering gates (compile-shape checks),
-      #   not functional dataflow kernels; running them as standalone NPU cases is unstable.
       DEFAULT_SKIP_CASES: >-
-        mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,test_intercore_sync_a3,test_intercore_sync_a5
+        mix_kernel,vadd_validshape,vadd_validshape_dynamic,print
     steps:
       - name: Resolve validation parameters
         shell: bash

--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -186,6 +186,18 @@ def _detect_output_pointer_param(text: str, pointer_param_names):
     return None
 
 
+def _detect_set_ffts_pointer_params(text: str, pointer_param_names):
+    if not pointer_param_names:
+        return set()
+
+    hits = set()
+    for name in pointer_param_names:
+        pat = rf"\bset_ffts_base_addr\b[^\n;]*\b{re.escape(name)}\b"
+        if re.search(pat, text):
+            hits.add(name)
+    return hits
+
+
 def _parse_kernel_params(text: str):
     match = re.search(r"__global__\s+(?:\w+\s+)*void\s+\w+\s*\(([^)]*)\)", text, re.S)
     if not match:
@@ -874,9 +886,16 @@ def generate_testcase(
             if inferred:
                 inferred_void_ptr_types[name] = inferred
 
-    output_ptr = _detect_output_pointer_param(raw_kernel_for_analysis, pointer_param_names)
-    if output_ptr is None and pointer_param_names:
-        output_ptr = pointer_param_names[0] if len(pointer_param_names) == 1 else pointer_param_names[-1]
+    ffts_param_names = _detect_set_ffts_pointer_params(raw_kernel_for_analysis, pointer_param_names)
+    non_ffts_pointer_param_names = [n for n in pointer_param_names if n not in ffts_param_names]
+
+    output_ptr = _detect_output_pointer_param(raw_kernel_for_analysis, non_ffts_pointer_param_names)
+    if output_ptr is None and non_ffts_pointer_param_names:
+        output_ptr = (
+            non_ffts_pointer_param_names[0]
+            if len(non_ffts_pointer_param_names) == 1
+            else non_ffts_pointer_param_names[-1]
+        )
 
     params = []
     for raw in raw_params:
@@ -892,7 +911,11 @@ def generate_testcase(
                     "name": name,
                     "cpp_type": cpp_type,
                     "host_type": _cpp_host_type(cpp_type),
-                    "role": "output" if name == output_ptr else "input",
+                    "role": (
+                        "ffts"
+                        if name in ffts_param_names
+                        else ("output" if name == output_ptr else "input")
+                    ),
                 }
             )
         else:
@@ -912,13 +935,16 @@ def generate_testcase(
     # - Some kernels are in-place (single pointer param) or may read from an
     #   "output" pointer as scratch. Leaving buffers uninitialized leads to
     #   non-determinism between CPU golden and real NPU.
-    init_ptrs = [p for p in params if p["kind"] == "ptr"]
-    output_ptrs = [p for p in params if p["kind"] == "ptr" and p["role"] == "output"]
+    data_ptrs = [p for p in params if p["kind"] == "ptr" and p["role"] != "ffts"]
+    ffts_ptrs = [p for p in params if p["kind"] == "ptr" and p["role"] == "ffts"]
+    init_ptrs = list(data_ptrs)
+    output_ptrs = [p for p in data_ptrs if p["role"] == "output"]
 
-    ptr_elem_counts = {p["name"]: logical_elem_count for p in params if p["kind"] == "ptr"}
+    ptr_elem_counts = {p["name"]: logical_elem_count for p in data_ptrs}
     inferred_counts = _infer_gm_pointer_elem_counts(raw_kernel_for_analysis, pointer_param_names)
     for name, cnt in inferred_counts.items():
-        ptr_elem_counts[name] = max(ptr_elem_counts.get(name, logical_elem_count), cnt)
+        if name in ptr_elem_counts:
+            ptr_elem_counts[name] = max(ptr_elem_counts.get(name, logical_elem_count), cnt)
 
     templates_root = Path(__file__).resolve().parents[1] / "templates"
     template = (templates_root / "main_template.cpp").read_text(encoding="utf-8")
@@ -937,10 +963,8 @@ def generate_testcase(
             launch_call_args.append(p["name"])
 
     param_decls_lines = []
-    if any(p["kind"] == "ptr" for p in params):
-        for p in params:
-            if p["kind"] != "ptr":
-                continue
+    if data_ptrs:
+        for p in data_ptrs:
             elem_cnt = ptr_elem_counts.get(p["name"], logical_elem_count)
             param_decls_lines.append(f"    size_t elemCount_{p['name']} = {elem_cnt};")
             param_decls_lines.append(
@@ -975,16 +999,20 @@ def generate_testcase(
     for p in params:
         if p["kind"] != "ptr":
             continue
-        param_decls_lines.append(f"    {p['host_type']} *{p['name']}Host = nullptr;")
-        param_decls_lines.append(f"    {p['host_type']} *{p['name']}Device = nullptr;")
+        if p["role"] == "ffts":
+            param_decls_lines.append(f"    {p['host_type']} *{p['name']}Device = nullptr;")
+            param_decls_lines.append(f"    uint64_t {p['name']}FftsAddr = 0;")
+            param_decls_lines.append(f"    uint32_t {p['name']}FftsLen = 0;")
+        else:
+            param_decls_lines.append(f"    {p['host_type']} *{p['name']}Host = nullptr;")
+            param_decls_lines.append(f"    {p['host_type']} *{p['name']}Device = nullptr;")
 
     alloc_host = []
     alloc_device = []
+    init_runtime_ptrs = []
     free_host = []
     free_device = []
-    for p in params:
-        if p["kind"] != "ptr":
-            continue
+    for p in data_ptrs:
         size_var = f"fileSize_{p['name']}"
         alloc_host.append(
             f"    ACL_CHECK(aclrtMallocHost((void **)(&{p['name']}Host), {size_var}));"
@@ -994,6 +1022,19 @@ def generate_testcase(
         )
         free_device.append(f"    aclrtFree({p['name']}Device);")
         free_host.append(f"    aclrtFreeHost({p['name']}Host);")
+    for p in ffts_ptrs:
+        init_runtime_ptrs.append(
+            f"    if (const rtError_t _rt = rtGetC2cCtrlAddr(&{p['name']}FftsAddr, &{p['name']}FftsLen); _rt != RT_ERROR_NONE) {{"
+        )
+        init_runtime_ptrs.append(
+            f"        std::fprintf(stderr, \"[ERROR] rtGetC2cCtrlAddr failed for {p['name']}: %d (%s:%d)\\n\", (int)_rt, __FILE__, __LINE__);"
+        )
+        init_runtime_ptrs.append("        rc = 1;")
+        init_runtime_ptrs.append("        goto cleanup;")
+        init_runtime_ptrs.append("    }")
+        init_runtime_ptrs.append(
+            f"    {p['name']}Device = reinterpret_cast<{p['host_type']} *>({p['name']}FftsAddr);"
+        )
 
     read_inputs = []
     copy_inputs = []
@@ -1029,6 +1070,7 @@ def generate_testcase(
         .replace("@PARAM_DECLS@", param_decls)
         .replace("@ALLOC_HOST@", "\n".join(alloc_host))
         .replace("@ALLOC_DEVICE@", "\n".join(alloc_device))
+        .replace("@INIT_RUNTIME_PTRS@", "\n".join(init_runtime_ptrs))
         .replace("@READ_INPUTS@", "\n".join(read_inputs))
         .replace("@COPY_TO_DEVICE@", "\n".join(copy_inputs))
         .replace(

--- a/test/npu_validation/templates/main_template.cpp
+++ b/test/npu_validation/templates/main_template.cpp
@@ -10,6 +10,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 #include "test_common.h"
 #include "acl/acl.h"
+#include "runtime/rt.h"
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -63,6 +64,7 @@ int main() {
 
     @ALLOC_HOST@
     @ALLOC_DEVICE@
+    @INIT_RUNTIME_PTRS@
 
     @READ_INPUTS@
     @COPY_TO_DEVICE@

--- a/test/samples/Sync/test_intercore_sync_a3.py
+++ b/test/samples/Sync/test_intercore_sync_a3.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
-from mlir.ir import Context, InsertionPoint, IntegerType, Location, MemRefType, Module
-from mlir.dialects import func, pto
+from mlir.ir import (
+    Context,
+    F32Type,
+    IndexType,
+    InsertionPoint,
+    IntegerType,
+    Location,
+    MemRefType,
+    Module,
+)
+from mlir.dialects import arith, func, pto
 
 
 def build():
@@ -9,21 +18,27 @@ def build():
         with Location.unknown(ctx):
             module = Module.create()
 
+            f32 = F32Type.get(ctx)
+            idx = IndexType.get(ctx)
             i64 = IntegerType.get_signless(64, ctx)
-            # Minimal valid memref operand for pto.set_ffts verifier (i64 element).
-            ffts_ty = MemRefType.get([1], i64)
-            fn_ty = func.FunctionType.get([ffts_ty], [])
+            # Reserve a practical FFTS workspace size instead of a 1-element stub.
+            ffts_ty = MemRefType.get([256], i64)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+            fn_ty = func.FunctionType.get([ffts_ty, ptr_f32], [])
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a3", fn_ty)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):
+                c0 = arith.ConstantOp(idx, 0).result
+                one = arith.ConstantOp(f32, 1.0).result
                 pipe_fix = pto.PipeAttr.get(pto.PIPE.PIPE_FIX, ctx)
                 pipe_v = pto.PipeAttr.get(pto.PIPE.PIPE_V, ctx)
                 pto.set_ffts(entry.arguments[0])
                 pto.sync_set(pipe_fix, 3)
                 pto.sync_wait(pipe_v, 3)
+                pto.store_scalar(entry.arguments[1], c0, one)
                 func.ReturnOp([])
 
             module.operation.verify()

--- a/test/samples/Sync/test_intercore_sync_a5.py
+++ b/test/samples/Sync/test_intercore_sync_a5.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-from mlir.ir import Context, InsertionPoint, Location, Module
-from mlir.dialects import func, pto
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.dialects import arith, func, pto
 
 
 def build():
@@ -8,17 +8,23 @@ def build():
         pto.register_dialect(ctx, load=True)
         with Location.unknown(ctx):
             module = Module.create()
-            fn_ty = func.FunctionType.get([], [])
+            f32 = F32Type.get(ctx)
+            idx = IndexType.get(ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+            fn_ty = func.FunctionType.get([ptr_f32], [])
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a5", fn_ty)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):
+                c0 = arith.ConstantOp(idx, 0).result
+                two = arith.ConstantOp(f32, 2.0).result
                 pipe_fix = pto.PipeAttr.get(pto.PIPE.PIPE_FIX, ctx)
                 pipe_v = pto.PipeAttr.get(pto.PIPE.PIPE_V, ctx)
                 pto.sync_set(pipe_fix, 5)
                 pto.sync_wait(pipe_v, 5)
+                pto.store_scalar(entry.arguments[0], c0, two)
                 func.ReturnOp([])
 
             module.operation.verify()


### PR DESCRIPTION
Summary
- Convert inter-core sync samples from structure-only checks into function-observable NPU validation cases.
- Fix remote npu_validation testcase generation for `set_ffts_base_addr(...)` kernels by wiring FFTS pointer from runtime (`rtGetC2cCtrlAddr`) instead of treating it as ordinary GM tensor input.
- Re-enable inter-core samples in remote validation default case set.

Background / Why
- We previously validated inter-core lowering shape via `runop.sh` grep assertions, but this cannot prove runtime functional correctness.
- In remote NPU validation, `test_intercore_sync_a3` failed with illegal instruction / stream sync error. Root cause: generated harness treated the FFTS control pointer as a normal host/device buffer, while inter-core sync expects a runtime-provided control address.
- As a result, CI had temporarily skipped inter-core cases. This PR removes the skip by making the validation path function-correct.

What changed
1. npu_validation generator: special handling for FFTS pointer params
- File: `test/npu_validation/scripts/generate_testcase.py`
- Detect parameters consumed by `set_ffts_base_addr(...)`.
- Mark them as `role=ffts` and exclude them from normal host/device bin IO paths.
- Generate runtime init code:
  - `rtGetC2cCtrlAddr(&<name>FftsAddr, &<name>FftsLen)`
  - cast to device pointer passed to kernel launch.
- Keep normal pointer IO behavior unchanged for non-FFTS params.

2. npu_validation main template support for runtime FFTS init
- File: `test/npu_validation/templates/main_template.cpp`
- Add `#include "runtime/rt.h"`.
- Add `@INIT_RUNTIME_PTRS@` insertion point between allocation and file IO.

3. Inter-core samples become function-observable
- Files:
  - `test/samples/Sync/test_intercore_sync_a3.py`
  - `test/samples/Sync/test_intercore_sync_a5.py`
- Add explicit output pointer argument and one scalar store after sync op sequence, so generated testcase has deterministic output and can be compared by golden flow.
- A3 sample keeps `set_ffts + sync.set + sync.wait`; A5 sample keeps `sync.set + sync.wait`.

4. Re-enable inter-core cases in remote CI default coverage
- File: `.github/workflows/ci.yml`
- Remove `test_intercore_sync_a3,test_intercore_sync_a5` from default `skip_cases` and `DEFAULT_SKIP_CASES`.

Validation
- `python3 -m py_compile`:
  - `test/npu_validation/scripts/generate_testcase.py`
  - `test/samples/Sync/test_intercore_sync_a3.py`
  - `test/samples/Sync/test_intercore_sync_a5.py`
- generator dry-run with synthetic inter-core kernel containing `set_ffts_base_addr`:
  - confirms generated `main.cpp` uses `rtGetC2cCtrlAddr` and does not read/write fake `ffts.bin`.

Scope / Non-goals
- Does not change inter-core IR syntax or lowering semantics introduced earlier.
- Keeps existing structure assertions in `runop.sh`; this PR adds functional validation path in remote NPU lane.
