### PR TITLE
fix(emitc): mark auto-sync tail helper as AICORE

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -7973,7 +7973,7 @@ enum class PTOAutoSyncTailMode : int {
   kSetWaitMte3ToSEvent0 = 1,
 };
 
-static inline void ptoas_auto_sync_tail(
+static AICORE inline void ptoas_auto_sync_tail(
     PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
   switch (mode) {
   case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:


### PR DESCRIPTION
Summary
- Make the auto-sync tail helper emitted by `PTOToEmitC` device-callable.
- Change generated helper signature from `static inline void ptoas_auto_sync_tail(...)` to `static AICORE inline void ...`.

Motivation
- Fix remote-board compile failures like:
  - `use of undeclared identifier 'set_flag'`
  - `candidate function not viable: call to [host] function from __global__ [aicore] function`
- Root cause: tail helper calls device intrinsics (`set_flag/wait_flag/pipe_barrier`) but was emitted as host inline function.

Design
- Minimal one-line codegen fix in `lib/PTO/Transforms/PTOToEmitC.cpp`.
- No behavior or policy changes for tail synchronization modes.

Testing
- Local sample generation: `bash test/samples/runop.sh --enablebc all` (OK=176, FAIL=0, SKIP=2 expected skips).
- Remote NPU validation on `101.245.68.6` (`run_remote_npu_validation.sh`, full run):
  - `relu`, `trap`, `test_auto_sync_tail_hint` all pass.
  - Previous helper host/device mismatch diagnostics no longer appear.
  - Remaining failures are unrelated/pre-existing sample issues (matmul/bias typing, print TPRINT_IMPL availability, prelu dtype checks, etc.).

Risk / Rollback
- Risk is low: only function qualifier changes.
- Rollback is straightforward by reverting this commit.
