### PR TITLE
fix(validation): gate FFTS runtime header wiring

### DIFF
--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -1058,9 +1058,15 @@ def generate_testcase(
             f"    WriteFile(\"./{p['name']}.bin\", {p['name']}Host, {size_var});"
         )
 
+    runtime_rt_include = '#include "runtime/rt.h"' if ffts_ptrs else ""
+    runtime_host_include_dirs = ""
+    if ffts_ptrs:
+        runtime_host_include_dirs = "    ${ASCEND_HOME_PATH}/pkg_inc/runtime\n"
+
     param_decls = "\n".join(param_decls_lines)
     main_cpp = (
         template
+        .replace("@RUNTIME_RT_INCLUDE@", runtime_rt_include)
         .replace("@TEST_SUITE@", testcase.upper())
         .replace("@CASE_NAME@", case_name)
         .replace(
@@ -1353,7 +1359,7 @@ target_compile_options({testcase} PRIVATE ${{CMAKE_CPP_COMPILE_OPTIONS}})
 target_include_directories({testcase} PRIVATE
     ${{PTO_ISA_ROOT}}/include
     ${{PTO_ISA_ROOT}}/tests/common
-)
+{runtime_host_include_dirs})
 
 target_link_directories({testcase} PUBLIC
     ${{ASCEND_HOME_PATH}}/lib64
@@ -1372,7 +1378,7 @@ if(ENABLE_SIM_GOLDEN)
     target_include_directories({testcase}_sim PRIVATE
         ${{PTO_ISA_ROOT}}/include
         ${{PTO_ISA_ROOT}}/tests/common
-    )
+{runtime_host_include_dirs})
     target_link_directories({testcase}_sim PUBLIC
         ${{ASCEND_HOME_PATH}}/lib64
         ${{ASCEND_HOME_PATH}}/aarch64-linux/simulator/${{SOC_VERSION}}/lib

--- a/test/npu_validation/templates/main_template.cpp
+++ b/test/npu_validation/templates/main_template.cpp
@@ -10,7 +10,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 #include "test_common.h"
 #include "acl/acl.h"
-#include "runtime/rt.h"
+@RUNTIME_RT_INCLUDE@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>


### PR DESCRIPTION
## Summary
- only include `runtime/rt.h` in generated validation mains when FFTS runtime pointers are actually used
- add the runtime include path to generated host/sim targets for FFTS cases
- keep non-FFTS board-validation cases from depending on CANN runtime headers they do not use

## Validation
- `python3 -m py_compile test/npu_validation/scripts/generate_testcase.py`
- generated a non-FFTS testcase from `test/samples/Matmul_transpose/Matmul_transpose-pto.cpp` and verified `main.cpp` no longer includes `runtime/rt.h`
- generated a synthetic FFTS testcase and verified `main.cpp` still includes `runtime/rt.h` and generated CMake adds `${ASCEND_HOME_PATH}/pkg_inc/runtime` for host/sim targets