### PR TITLE
[WIP] Fix redundant reruns in npu validation scripts

### DIFF
--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 STAGE="${STAGE:-run}"         # build|run
 RUN_MODE="${RUN_MODE:-npu}"   # npu|sim
 SOC_VERSION="${SOC_VERSION:-Ascend910}"
-GOLDEN_MODE="${GOLDEN_MODE:-npu}"  # sim|npu|skip
+GOLDEN_MODE="${GOLDEN_MODE:-npu}"  # sim|npu|npu_precision|skip
 PTO_ISA_REPO="${PTO_ISA_REPO:-https://gitcode.com/cann/pto-isa.git}"
 PTO_ISA_COMMIT="${PTO_ISA_COMMIT:-}"
 DEVICE_ID="${DEVICE_ID:-0}"
@@ -307,6 +307,19 @@ while IFS= read -r -d '' cpp; do
       done
     }
 
+    has_reference_golden_outputs() {
+      local found=0
+      if [[ -f "./outputs.txt" ]]; then
+        while IFS= read -r name; do
+          [[ -n "${name}" ]] || continue
+          found=1
+          [[ -f "./golden_${name}.bin" ]] || return 1
+        done < "./outputs.txt"
+        [[ "${found}" -eq 1 ]] && return 0
+      fi
+      compgen -G "./golden_*.bin" > /dev/null
+    }
+
     case "${GOLDEN_MODE}" in
       sim)
         python3 ./golden.py
@@ -333,6 +346,19 @@ while IFS= read -r -d '' cpp; do
         fi
         COMPARE_STRICT=1 python3 ./compare.py
         ;;
+      npu_precision)
+        if [[ "${RUN_MODE}" != "npu" ]]; then
+          log "ERROR: GOLDEN_MODE=npu_precision requires RUN_MODE=npu"
+          exit 2
+        fi
+        python3 ./golden.py
+        if ! has_reference_golden_outputs; then
+          log "ERROR: GOLDEN_MODE=npu_precision requires golden.py to generate golden_*.bin"
+          exit 2
+        fi
+        LD_LIBRARY_PATH="${LD_LIBRARY_PATH_NPU}" ./build/${testcase}
+        COMPARE_STRICT=1 python3 ./compare.py
+        ;;
       skip)
         python3 ./golden.py
         if [[ "${RUN_MODE}" == "npu" ]]; then
@@ -341,7 +367,7 @@ while IFS= read -r -d '' cpp; do
         log "WARN: compare skipped (GOLDEN_MODE=skip)"
         ;;
       *)
-        log "ERROR: unknown GOLDEN_MODE=${GOLDEN_MODE} (expected: sim|npu|skip)"
+        log "ERROR: unknown GOLDEN_MODE=${GOLDEN_MODE} (expected: sim|npu|npu_precision|skip)"
         exit 2
         ;;
     esac

--- a/test/npu_validation/templates/run_sh_template.sh
+++ b/test/npu_validation/templates/run_sh_template.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 RUN_MODE="@RUN_MODE@"
 SOC_VERSION="@SOC_VERSION@"
-GOLDEN_MODE="${GOLDEN_MODE:-npu}"  # sim|npu|skip
+GOLDEN_MODE="${GOLDEN_MODE:-npu}"  # sim|npu|npu_precision|skip
 BUILD_DIR="${BUILD_DIR:-build}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -110,6 +110,19 @@ copy_outputs_as_golden() {
   done
 }
 
+has_reference_golden_outputs() {
+  local found=0
+  if [[ -f "${ROOT_DIR}/outputs.txt" ]]; then
+    while IFS= read -r name; do
+      [[ -n "${name}" ]] || continue
+      found=1
+      [[ -f "${ROOT_DIR}/golden_${name}.bin" ]] || return 1
+    done < "${ROOT_DIR}/outputs.txt"
+    [[ "${found}" -eq 1 ]] && return 0
+  fi
+  compgen -G "${ROOT_DIR}/golden_*.bin" > /dev/null
+}
+
 case "${GOLDEN_MODE}" in
   sim)
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH_SIM}" "${ROOT_DIR}/${BUILD_DIR}/@EXECUTABLE@_sim"
@@ -131,6 +144,19 @@ case "${GOLDEN_MODE}" in
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH_NPU}" "${ROOT_DIR}/${BUILD_DIR}/@EXECUTABLE@"
     COMPARE_STRICT=1 python3 "${ROOT_DIR}/compare.py"
     ;;
+  npu_precision)
+    if [[ "${RUN_MODE}" != "npu" ]]; then
+      echo "[ERROR] GOLDEN_MODE=npu_precision requires RUN_MODE=npu" >&2
+      exit 2
+    fi
+    python3 "${ROOT_DIR}/golden.py"
+    if ! has_reference_golden_outputs; then
+      echo "[ERROR] GOLDEN_MODE=npu_precision requires golden.py to generate golden_*.bin" >&2
+      exit 2
+    fi
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH_NPU}" "${ROOT_DIR}/${BUILD_DIR}/@EXECUTABLE@"
+    COMPARE_STRICT=1 python3 "${ROOT_DIR}/compare.py"
+    ;;
   skip)
     if [[ "${RUN_MODE}" == "npu" ]]; then
       python3 "${ROOT_DIR}/golden.py"
@@ -139,7 +165,7 @@ case "${GOLDEN_MODE}" in
     echo "[WARN] compare skipped (GOLDEN_MODE=skip)"
     ;;
   *)
-    echo "[ERROR] Unknown GOLDEN_MODE=${GOLDEN_MODE} (expected: sim|npu|skip)" >&2
+    echo "[ERROR] Unknown GOLDEN_MODE=${GOLDEN_MODE} (expected: sim|npu|npu_precision|skip)" >&2
     exit 2
     ;;
 esac

--- a/test/samples/TInsert/board_validation/run.sh
+++ b/test/samples/TInsert/board_validation/run.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 RUN_MODE="npu"
 SOC_VERSION="Ascend910"
-GOLDEN_MODE="${GOLDEN_MODE:-sim}"  # sim|npu|skip
+GOLDEN_MODE="${GOLDEN_MODE:-sim}"  # sim|npu|npu_precision|skip
 BUILD_DIR="${BUILD_DIR:-build}"
 ACL_DEVICE_ID_NPU="${ACL_DEVICE_ID:-}"
 ACL_DEVICE_ID_SIM="${ACL_DEVICE_ID_SIM:-0}"
@@ -112,6 +112,19 @@ copy_outputs_as_golden() {
   done
 }
 
+has_reference_golden_outputs() {
+  local found=0
+  if [[ -f "${ROOT_DIR}/outputs.txt" ]]; then
+    while IFS= read -r name; do
+      [[ -n "${name}" ]] || continue
+      found=1
+      [[ -f "${ROOT_DIR}/golden_${name}.bin" ]] || return 1
+    done < "${ROOT_DIR}/outputs.txt"
+    [[ "${found}" -eq 1 ]] && return 0
+  fi
+  compgen -G "${ROOT_DIR}/golden_*.bin" > /dev/null
+}
+
 case "${GOLDEN_MODE}" in
   sim)
     ACL_DEVICE_ID="${ACL_DEVICE_ID_SIM}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH_SIM}" "${ROOT_DIR}/${BUILD_DIR}/tinsert_sim"
@@ -137,6 +150,23 @@ case "${GOLDEN_MODE}" in
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH_NPU}" "${ROOT_DIR}/${BUILD_DIR}/tinsert"
     COMPARE_STRICT=1 python3 "${ROOT_DIR}/compare.py"
     ;;
+  npu_precision)
+    if [[ "${RUN_MODE}" != "npu" ]]; then
+      echo "[ERROR] GOLDEN_MODE=npu_precision requires RUN_MODE=npu" >&2
+      exit 2
+    fi
+    python3 "${ROOT_DIR}/golden.py"
+    if ! has_reference_golden_outputs; then
+      echo "[ERROR] GOLDEN_MODE=npu_precision requires golden.py to generate golden_*.bin" >&2
+      exit 2
+    fi
+    if [[ -n "${ACL_DEVICE_ID_NPU}" ]]; then
+      ACL_DEVICE_ID="${ACL_DEVICE_ID_NPU}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH_NPU}" "${ROOT_DIR}/${BUILD_DIR}/tinsert"
+    else
+      LD_LIBRARY_PATH="${LD_LIBRARY_PATH_NPU}" "${ROOT_DIR}/${BUILD_DIR}/tinsert"
+    fi
+    COMPARE_STRICT=1 python3 "${ROOT_DIR}/compare.py"
+    ;;
   skip)
     if [[ "${RUN_MODE}" == "npu" ]]; then
       python3 "${ROOT_DIR}/golden.py"
@@ -145,7 +175,7 @@ case "${GOLDEN_MODE}" in
     echo "[WARN] compare skipped (GOLDEN_MODE=skip)"
     ;;
   *)
-    echo "[ERROR] Unknown GOLDEN_MODE=${GOLDEN_MODE} (expected: sim|npu|skip)" >&2
+    echo "[ERROR] Unknown GOLDEN_MODE=${GOLDEN_MODE} (expected: sim|npu|npu_precision|skip)" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary

- split the old `GOLDEN_MODE=npu` behavior into two explicit modes:
  - `npu`: run the NPU executable once and compare against pre-generated `golden_*.bin`
  - `npu_consistency`: run the NPU executable twice and compare the two runs for consistency
- change the default `GOLDEN_MODE` to `npu`
- add explicit golden-file checks for `GOLDEN_MODE=npu` and surface clear guidance when callers should use `npu_consistency` instead
- align the generated `run.sh` template and the remote batch runner with the same mode semantics
- load `validation_meta.env` in generated `run.sh` so custom golden handling matches the remote runner
- avoid overwriting sample-provided golden outputs in `sim` mode when `CUSTOM_GOLDEN=1`

## Testing

- `bash -n test/npu_validation/templates/run_sh_template.sh`
- `bash -n test/npu_validation/scripts/run_remote_npu_validation.sh`

Fixes #305.

依赖前置 PR #251
