### PR TITLE
feat(pto): add inplace set_validshape op

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -496,6 +496,49 @@ result = source[offsets] with static sizes
 %sub = pto.subset %src[%i, %j] sizes [32, 32] : !pto.tile_buf<loc=vec, dtype=f16, rows=64, cols=64, v_row=64, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 ```
 
+##### `pto.set_validshape` - Update Dynamic Tile Valid Row/Col In Place
+
+**Summary:** Updates runtime valid row/col metadata directly on an existing dynamic `pto.tile_buf`.
+
+**Semantics:**
+
+```
+set_validshape(source, valid_row, valid_col)
+```
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `source` | `pto.tile_buf` | Dynamic tile buffer whose runtime valid shape will be updated |
+| `valid_row` | `Index` | Runtime valid row count |
+| `valid_col` | `Index` | Runtime valid column count |
+
+**Results:** None
+
+**Constraints & Verification:**
+
+- `source` must be a rank-2 `pto.tile_buf`
+- `source` must have dynamic valid shape:
+  - `v_row = ?`
+  - `v_col = ?`
+- User-authored PTO IR must use the `pto.tile_buf` form; any memref form seen
+  later in the pipeline is compiler-internal lowering state only
+- If `valid_row` / `valid_col` are compile-time constants, they must be non-negative and not exceed the tile's static shape bounds
+
+**Hardware Mapping:**
+
+- No hardware pipeline (metadata update op only)
+- Lowers in `PTOToEmitC` to updates of the tile's runtime valid-shape fields
+
+**Basic Example:**
+
+```mlir
+%src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+pto.set_validshape %src, %vr, %vc
+  : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+```
+
 ---
 
 ### 4.2 Buffer-ID Token Operations (A5)

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -40,6 +40,9 @@ def PTODpsType :
 def PtrOrMemRef :
   AnyTypeOf<[PtrType, AnyMemRef], "Ptr or MemRef">;
 
+def TileBufOrMemRef :
+  AnyTypeOf<[TileBufType, AnyMemRef], "TileBuf or MemRef">;
+
 def ScalarPtrOrMemRef :
   TypeConstraint<
     CPred<"::mlir::pto::isScalarPtrOrMemRef($_self)">,
@@ -304,6 +307,34 @@ def SubsetOp : PTO_Op<"subset", [
     // ViewLikeOpInterface 可能还需要 getOffsets (如果 Variadic 不自动匹配)
     // 但通常 Variadic<Index>:$offsets 会生成 getOffsets()，这应该没问题。
     // 如果后续报 getOffsets 错，也可以在这里加。
+  }];
+}
+
+def SetValidShapeOp : PTO_Op<"set_validshape", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Update valid row/col metadata in-place on a dynamic tile";
+  let description = [{
+    Updates the runtime valid_row/valid_col metadata on an existing dynamic
+    tile_buf handle in place.
+
+    This op does not allocate or alias a new tile handle. It is only valid for
+    tile_buf types whose valid_row and valid_col are both dynamic (`?`), and
+    the source must be a locally bound tile handle (for example `alloc_tile`
+    or a view derived from it). Function arguments/results are not supported.
+  }];
+
+  let arguments = (ins
+    TileBufOrMemRef:$source,
+    Index:$valid_row,
+    Index:$valid_col
+  );
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $source `,` $valid_row `,` $valid_col attr-dict `:`
+    qualified(type($source))
   }];
 }
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4743,6 +4743,98 @@ static bool isTileBufOrMemref(Type ty) {
   return ty.isa<MemRefType, pto::TileBufType>();
 }
 
+static constexpr llvm::StringLiteral kLoweredSetValidShapeAttrName =
+    "__pto.lowered_set_validshape";
+
+static bool isLocallyBoundTileSource(Value value) {
+  if (!value || isa<BlockArgument>(value))
+    return false;
+
+  if (isa<AllocTileOp, BindTileOp, PointerCastOp>(value.getDefiningOp()))
+    return true;
+
+  if (auto bitcast = value.getDefiningOp<BitcastOp>())
+    return isLocallyBoundTileSource(bitcast.getSrc());
+  if (auto reshape = value.getDefiningOp<TReshapeOp>())
+    return isLocallyBoundTileSource(reshape.getSrc());
+
+  return false;
+}
+
+static std::optional<int64_t> getConstIndexLike(Value v) {
+  if (auto cOp = v.getDefiningOp<arith::ConstantIndexOp>())
+    return cOp.value();
+  if (auto cInt = v.getDefiningOp<arith::ConstantIntOp>())
+    return cInt.value();
+  if (auto cOp = v.getDefiningOp<arith::ConstantOp>()) {
+    if (auto ia = dyn_cast<IntegerAttr>(cOp.getValue()))
+      return ia.getInt();
+  }
+  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>())
+    return getConstIndexLike(castOp.getIn());
+  if (auto extOp = v.getDefiningOp<arith::ExtSIOp>())
+    return getConstIndexLike(extOp.getIn());
+  if (auto extOp = v.getDefiningOp<arith::ExtUIOp>())
+    return getConstIndexLike(extOp.getIn());
+  if (auto truncOp = v.getDefiningOp<arith::TruncIOp>())
+    return getConstIndexLike(truncOp.getIn());
+  return std::nullopt;
+}
+
+mlir::LogicalResult mlir::pto::SetValidShapeOp::verify() {
+  SmallVector<int64_t> shape;
+  if (auto srcTy = llvm::dyn_cast<TileBufType>(getSource().getType())) {
+    if (srcTy.getRank() != 2)
+      return emitOpError("expects rank-2 tile_buf source");
+
+    ArrayRef<int64_t> validShape = srcTy.getValidShape();
+    if (validShape.size() != 2)
+      return emitOpError("expects source validShape to be rank-2");
+    if (!srcTy.hasDynamicValid())
+      return emitOpError("expects source tile_buf to have dynamic validShape (?, ?)");
+
+    shape.assign(srcTy.getShape().begin(), srcTy.getShape().end());
+
+    if (!isLocallyBoundTileSource(getSource()))
+      return emitOpError(
+          "requires a locally bound tile source; function arguments/results "
+          "are unsupported");
+  } else if (auto srcTy = llvm::dyn_cast<MemRefType>(getSource().getType())) {
+    if (!(*this)->hasAttr(kLoweredSetValidShapeAttrName))
+      return emitOpError(
+          "expects tile_buf source; memref source is only valid for the internal lowered form");
+    if (srcTy.getRank() != 2)
+      return emitOpError("expects rank-2 memref source after tile lowering");
+    shape.assign(srcTy.getShape().begin(), srcTy.getShape().end());
+  } else {
+    return emitOpError("expects tile_buf source (or lowered memref source)");
+  }
+
+  auto checkDim = [&](Value operand, unsigned dimIdx,
+                      StringRef dimName) -> LogicalResult {
+    int64_t maxStatic = shape[dimIdx];
+
+    auto constVal = getConstIndexLike(operand);
+    if (!constVal)
+      return success();
+
+    if (*constVal < 0)
+      return emitOpError() << "expects " << dimName << " operand to be non-negative";
+    if (maxStatic != ShapedType::kDynamic && *constVal > maxStatic)
+      return emitOpError() << "expects " << dimName << " operand <= shape dim ("
+                           << maxStatic << ")";
+    return success();
+  };
+
+  if (failed(checkDim(getValidRow(), /*dimIdx=*/0, "row")))
+    return failure();
+  if (failed(checkDim(getValidCol(), /*dimIdx=*/1, "col")))
+    return failure();
+
+  return success();
+}
+
+
 mlir::LogicalResult mlir::pto::TReshapeOp::verify() {
   if (shouldBypassDecodedMemrefVerifier(getOperation()))
     return success();
@@ -6970,6 +7062,12 @@ void TGetValOp::getEffects(
 void TSetValOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_WRITE(getDstMutable());
+}
+
+// SET_VALIDSHAPE: update runtime valid row/col metadata on source tile in-place.
+void SetValidShapeOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_WRITE(getSourceMutable());
 }
 
 // Elementwise + reductions: mostly PIPE_V tilebuf ops

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -130,6 +130,13 @@ void MemLivenessAnalysis::RecursionIR(Region *region, Liveness live) {
       (void)tgetvalOp;
       UpdateOpGenInfo(curOpInfo, llvm::to_vector(op->getOperands()));
       OpKillHandle(curOpInfo, live, op->getBlock());
+    } else if (auto setValidShapeOp = dyn_cast<pto::SetValidShapeOp>(op)) {
+      (void)setValidShapeOp;
+      // Metadata-only update on an existing tile handle. Keep the source buffer
+      // alive through this operation, but do not model it as producing a new
+      // alias/result buffer.
+      UpdateOpGenInfo(curOpInfo, ValueRange{op->getOperand(0)});
+      OpKillHandle(curOpInfo, live, op->getBlock());
     } else if (auto storeOp = dyn_cast<memref::StoreOp>(op)) {
       UpdateStoreOpInfo(curOpInfo, storeOp.getMemRef(), live);
     } else if (auto ptoDpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -81,6 +81,9 @@ static const char *addrSpaceQualifier(pto::AddressSpace as) {
   return "__gm__";
 }
 
+static constexpr llvm::StringLiteral kForceDynamicValidShapeAttrName =
+    "__pto.force_dynamic_valid_shape";
+
 static Value peelUnrealized(Value v) {
   if (auto castOp = v.getDefiningOp<UnrealizedConversionCastOp>())
     return castOp.getOperand(0);
@@ -329,6 +332,53 @@ static bool isSetFFTsPointerLikeType(Type ty) {
   if (auto opaqueTy = dyn_cast<emitc::OpaqueType>(ty))
     return opaqueTy.getValue().ends_with("*");
   return false;
+}
+
+static bool tileDataReturnsIntegralAddress(pto::AddressSpace as) {
+  return as == pto::AddressSpace::BIAS;
+}
+
+static emitc::OpaqueType getTileDataResultType(MLIRContext *ctx,
+                                               pto::AddressSpace as,
+                                               StringRef elemTok) {
+  if (tileDataReturnsIntegralAddress(as))
+    return emitc::OpaqueType::get(ctx, "uint64_t");
+  return emitc::OpaqueType::get(
+      ctx, std::string(addrSpaceQualifier(as)) + " " + elemTok.str() + "*");
+}
+
+static Value materializeTileDataValue(ConversionPatternRewriter &rewriter,
+                                      Location loc, Value tile,
+                                      pto::AddressSpace as,
+                                      StringRef elemTok) {
+  auto rawTy = getTileDataResultType(rewriter.getContext(), as, elemTok);
+  return rewriter
+      .create<emitc::CallOpaqueOp>(loc, rawTy, "PTOAS__TILE_DATA",
+                                   ArrayAttr{}, ArrayAttr{},
+                                   ValueRange{tile})
+      .getResult(0);
+}
+
+static Value materializeAddressAsPointer(ConversionPatternRewriter &rewriter,
+                                         Location loc, Value addr,
+                                         pto::AddressSpace as,
+                                         StringRef elemTok) {
+  auto *ctx = rewriter.getContext();
+  std::string ptrTyStr =
+      std::string(addrSpaceQualifier(as)) + " " + elemTok.str() + "*";
+  auto ptrTy = emitc::OpaqueType::get(ctx, ptrTyStr);
+  if (isSetFFTsPointerLikeType(addr.getType())) {
+    if (addr.getType() == ptrTy)
+      return addr;
+    return rewriter.create<emitc::CastOp>(loc, ptrTy, addr).getResult();
+  }
+  auto castTyAttr =
+      rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, ptrTyStr)});
+  return rewriter
+      .create<emitc::CallOpaqueOp>(loc, ptrTy, "reinterpret_cast",
+                                   ArrayAttr{}, castTyAttr,
+                                   ValueRange{addr})
+      .getResult(0);
 }
 
 struct InterCoreSyncCallDesc {
@@ -2432,18 +2482,15 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
       if (tyStr.find("Tile<") != std::string::npos ||
           tyStr.find("ConvTile<") != std::string::npos) {
         std::string elemTok = elemTypeToString(srcType.getElementType());
-        std::string qualifier = "__gm__";
+        pto::AddressSpace as = pto::AddressSpace::GM;
         if (auto asAttr =
                 dyn_cast_or_null<pto::AddressSpaceAttr>(srcType.getMemorySpace()))
-          qualifier = addrSpaceQualifier(asAttr.getAddressSpace());
-        auto rawPtrTy =
-            emitc::OpaqueType::get(ctx, qualifier + " " + elemTok + "*");
+          as = asAttr.getAddressSpace();
         sourcePtr =
-            rewriter
-                .create<emitc::CallOpaqueOp>(loc, rawPtrTy,
-                                             "PTOAS__TILE_DATA", ArrayAttr{},
-                                             ArrayAttr{}, ValueRange{tileCandidate})
-                .getResult(0);
+            materializeTileDataValue(rewriter, loc, tileCandidate, as, elemTok);
+        if (tileDataReturnsIntegralAddress(as))
+          sourcePtr =
+              materializeAddressAsPointer(rewriter, loc, sourcePtr, as, elemTok);
       }
     }
     Value newPtr;
@@ -2796,11 +2843,6 @@ static std::string getElemTypeStringForGT(Type elemTy) {
   return "float";
 }
 
-static uint64_t nextGlobalTensorNameId() {
-  static uint64_t counter = 0;
-  return counter++;
-}
-
 static Value buildGlobalTensorFromMemref(ConversionPatternRewriter &rewriter,
                                          Location loc, Value basePtr,
                                          MemRefType mrTy,
@@ -2843,8 +2885,7 @@ static Value buildGlobalTensorFromMemref(ConversionPatternRewriter &rewriter,
                                         offVal);
   }
 
-  (void)anchor;
-  std::string suffix = "_" + std::to_string(nextGlobalTensorNameId());
+  std::string suffix = "_" + std::to_string(reinterpret_cast<uintptr_t>(anchor));
   std::string shapeTypeName  = "GTShape"  + suffix;
   std::string strideTypeName = "GTStride" + suffix;
   std::string gtTypeName     = "GT"       + suffix;
@@ -3135,8 +3176,7 @@ struct PointerCastConversion : public OpConversionPattern<pto::PointerCastOp> {
     // [核心修改] Valid Dims 处理逻辑 (支持混合静态/动态)
     std::string vrowTok, vcolTok;
     bool useConstructor = false;
-    
-    // 引入标志位，明确记录哪个维度是动态的
+
     bool rowIsDynamic = false;
     bool colIsDynamic = false;
 
@@ -3144,44 +3184,56 @@ struct PointerCastConversion : public OpConversionPattern<pto::PointerCastOp> {
 
     Value vRow = op.getValidRow();
     Value vCol = op.getValidCol();
-    Value vRowEmitC = adaptor.getValidRow(); 
+    Value vRowEmitC = adaptor.getValidRow();
     Value vColEmitC = adaptor.getValidCol();
+    bool forceDynamicValid = op->hasAttr(kForceDynamicValidShapeAttrName);
 
-    int64_t cRow, cCol;
+    int64_t cRow = 0, cCol = 0;
+    bool rowIsConst = vRow && isConstant(vRow, cRow);
+    bool colIsConst = vCol && isConstant(vCol, cCol);
 
-    // --- Row 逻辑 ---
-    if (vRow && isConstant(vRow, cRow)) {
-        // Case A: 静态常量 (e.g., 32)
+    auto makeCtorDimValue = [&](Value emitted, int64_t fallback) -> Value {
+      if (emitted)
+        return emitted;
+      return makeEmitCIntConstant(
+          rewriter, loc, emitc::OpaqueType::get(ctx, "int32_t"), fallback);
+    };
+
+    if (forceDynamicValid) {
+      vrowTok = "-1";
+      vcolTok = "-1";
+      useConstructor = true;
+      constructorArgs.push_back(
+          makeCtorDimValue(vRowEmitC, rowIsConst ? cRow : shape[0]));
+      constructorArgs.push_back(
+          makeCtorDimValue(vColEmitC, colIsConst ? cCol : shape[1]));
+    } else {
+      if (rowIsConst) {
         vrowTok = std::to_string(cRow);
-    } else if (vRow) {
-        // Case B: 动态变量 (e.g., %arg0)
+      } else if (vRow) {
         vrowTok = "-1";
-        rowIsDynamic = true; // 标记为动态
+        rowIsDynamic = true;
         useConstructor = true;
-    } else {
-        // Case C: 默认静态 (Shape)
+      } else {
         vrowTok = std::to_string(shape[0]);
-    }
+      }
 
-    // --- Col 逻辑 ---
-    if (vCol && isConstant(vCol, cCol)) {
-        // Case A: 静态常量
+      if (colIsConst) {
         vcolTok = std::to_string(cCol);
-    } else if (vCol) {
-        // Case B: 动态变量
+      } else if (vCol) {
         vcolTok = "-1";
-        colIsDynamic = true; // 标记为动态
+        colIsDynamic = true;
         useConstructor = true;
-    } else {
-        // Case C: 默认静态
+      } else {
         vcolTok = std::to_string(shape[1]);
-    }
+      }
 
-    // --- 收集构造参数 ---
-    // [修复] 只收集被标记为 Dynamic 的维度的值
-    if (useConstructor) {
-        if (rowIsDynamic && vRowEmitC) constructorArgs.push_back(vRowEmitC);
-        if (colIsDynamic && vColEmitC) constructorArgs.push_back(vColEmitC);
+      if (useConstructor) {
+        if (rowIsDynamic && vRowEmitC)
+          constructorArgs.push_back(vRowEmitC);
+        if (colIsDynamic && vColEmitC)
+          constructorArgs.push_back(vColEmitC);
+      }
     }
 
     // 5. 生成 Tile 类型字符串
@@ -4112,6 +4164,43 @@ struct PTOGetValToGETVAL : public OpConversionPattern<pto::TGetValOp> {
   }
 };
 
+struct PTOSetValidShapeToEmitC : public OpConversionPattern<pto::SetValidShapeOp> {
+  using OpConversionPattern<pto::SetValidShapeOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::SetValidShapeOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto peelAllCasts = [](Value v) {
+      while (auto castOp = v.getDefiningOp<UnrealizedConversionCastOp>())
+        v = castOp.getOperand(0);
+      if (auto castOp = v.getDefiningOp<emitc::CastOp>())
+        v = castOp.getOperand();
+      return v;
+    };
+    auto isTileLike = [](Value v) -> bool {
+      auto ot = dyn_cast<emitc::OpaqueType>(v.getType());
+      if (!ot)
+        return false;
+      StringRef s = ot.getValue();
+      return s.contains("Tile<") || s.contains("ConvTile<");
+    };
+
+    Value src = peelAllCasts(peelUnrealized(adaptor.getSource()));
+    Value row = peelUnrealized(adaptor.getValidRow());
+    Value col = peelUnrealized(adaptor.getValidCol());
+
+    if (!isTileLike(src))
+      return rewriter.notifyMatchFailure(
+          op, "set_validshape source must lower to a tile-like value");
+
+    rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), TypeRange{}, "PTOAS__TILE_SET_VALIDSHAPE", ArrayAttr{},
+        ArrayAttr{}, ValueRange{src, row, col});
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // pto.load_scalar / pto.store_scalar lowering -> ptr[offset]
 //===----------------------------------------------------------------------===//
@@ -4336,23 +4425,21 @@ struct ReinterpretCastToEmitC : public OpConversionPattern<memref::ReinterpretCa
       // Only Tiles have a `.data()` member. For plain address-space pointers
       // (e.g. `__ubuf__ float*`), use the pointer value directly.
       if (ot.getValue().starts_with("Tile<")) {
-        std::string rawPtrTok =
-            std::string(addrSpaceQualifier(as)) + " " + elemTok + "*";
-        auto rawPtrTy = emitc::OpaqueType::get(ctx, rawPtrTok);
-        rawPtr = rewriter
-                     .create<emitc::CallOpaqueOp>(loc, rawPtrTy,
-                                                  "PTOAS__TILE_DATA", ArrayAttr{},
-                                                  ArrayAttr{}, ValueRange{source})
-                     .getResult(0);
+        rawPtr = materializeTileDataValue(rewriter, loc, source, as, elemTok);
       }
     }
 
-    Value baseAddr = rewriter
-                         .create<emitc::CallOpaqueOp>(loc, u64Ty, "reinterpret_cast",
-                                                      /*args=*/ArrayAttr{},
-                                                      /*templateArgs=*/rcU64,
-                                                      /*operands=*/ValueRange{rawPtr})
-                         .getResult(0);
+    Value baseAddr = rawPtr;
+    if (isSetFFTsPointerLikeType(rawPtr.getType())) {
+      baseAddr = rewriter
+                     .create<emitc::CallOpaqueOp>(loc, u64Ty, "reinterpret_cast",
+                                                  /*args=*/ArrayAttr{},
+                                                  /*templateArgs=*/rcU64,
+                                                  /*operands=*/ValueRange{rawPtr})
+                     .getResult(0);
+    } else if (rawPtr.getType() != u64Ty) {
+      baseAddr = rewriter.create<emitc::CastOp>(loc, u64Ty, rawPtr).getResult();
+    }
 
     Value addr = baseAddr;
     if (offsetVal) {
@@ -6434,22 +6521,8 @@ struct PTOStoreFPSToEmitC : public OpConversionPattern<pto::TStoreFPOp> {
     Value src = peelUnrealized(adaptor.getSrc());
     Value fp = peelUnrealized(adaptor.getFp());
     Value dst = peelUnrealized(adaptor.getDst());
-    Value dstArg = dst;
-    if (auto dstMrTy = dyn_cast<MemRefType>(op.getDst().getType())) {
-      bool isGlobal = true;
-      if (auto asAttr =
-              dyn_cast_or_null<pto::AddressSpaceAttr>(dstMrTy.getMemorySpace())) {
-        auto as = asAttr.getAddressSpace();
-        isGlobal = (as == pto::AddressSpace::GM || as == pto::AddressSpace::Zero);
-      }
-      if (isGlobal) {
-        if (Value gt = buildGlobalTensorFromMemref(rewriter, loc, dst, dstMrTy,
-                                                  op.getOperation()))
-          dstArg = gt;
-      }
-    }
 
-    SmallVector<Value, 3> operands{dstArg, src, fp};
+    SmallVector<Value, 4> operands{dst, src, fp};
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TSTORE_FP",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -6862,33 +6935,53 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       Value vCol = op.getValidCol();
       Value vRowEmitC = adaptor.getValidRow();
       Value vColEmitC = adaptor.getValidCol();
+      bool forceDynamicValid = op->hasAttr(kForceDynamicValidShapeAttrName);
       int64_t cRow = 0, cCol = 0;
+      bool rowIsConst = vRow && getIndexConst(vRow, cRow);
+      bool colIsConst = vCol && getIndexConst(vCol, cCol);
 
-      if (vRow && getIndexConst(vRow, cRow)) {
-        vrowTok = std::to_string(cRow);
-      } else if (vRow) {
+      auto makeCtorDimValue = [&](Value emitted, int64_t fallback) -> Value {
+        if (emitted)
+          return emitted;
+        return makeEmitCIntConstant(
+            rewriter, loc, emitc::OpaqueType::get(ctx, "int32_t"), fallback);
+      };
+
+      if (forceDynamicValid) {
         vrowTok = "-1";
-        rowIsDynamic = true;
-        useConstructor = true;
-      } else {
-        vrowTok = std::to_string(rows);
-      }
-
-      if (vCol && getIndexConst(vCol, cCol)) {
-        vcolTok = std::to_string(cCol);
-      } else if (vCol) {
         vcolTok = "-1";
-        colIsDynamic = true;
         useConstructor = true;
+        constructorArgs.push_back(
+            makeCtorDimValue(vRowEmitC, rowIsConst ? cRow : rows));
+        constructorArgs.push_back(
+            makeCtorDimValue(vColEmitC, colIsConst ? cCol : cols));
       } else {
-        vcolTok = std::to_string(cols);
-      }
+        if (rowIsConst) {
+          vrowTok = std::to_string(cRow);
+        } else if (vRow) {
+          vrowTok = "-1";
+          rowIsDynamic = true;
+          useConstructor = true;
+        } else {
+          vrowTok = std::to_string(rows);
+        }
 
-      if (useConstructor) {
-        if (rowIsDynamic && vRowEmitC)
-          constructorArgs.push_back(vRowEmitC);
-        if (colIsDynamic && vColEmitC)
-          constructorArgs.push_back(vColEmitC);
+        if (colIsConst) {
+          vcolTok = std::to_string(cCol);
+        } else if (vCol) {
+          vcolTok = "-1";
+          colIsDynamic = true;
+          useConstructor = true;
+        } else {
+          vcolTok = std::to_string(cols);
+        }
+
+        if (useConstructor) {
+          if (rowIsDynamic && vRowEmitC)
+            constructorArgs.push_back(vRowEmitC);
+          if (colIsDynamic && vColEmitC)
+            constructorArgs.push_back(vColEmitC);
+        }
       }
 
       std::string tileTypeStr = std::string("Tile<") + roleTok + ", " +
@@ -6958,20 +7051,12 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
           if (auto asAttr =
                   dyn_cast_or_null<pto::AddressSpaceAttr>(srcMrTy.getMemorySpace()))
             as = asAttr.getAddressSpace();
-          std::string rawPtrTok =
-              std::string(addrSpaceQualifier(as)) + " " + elemTok + "*";
-          auto rawPtrTy = emitc::OpaqueType::get(ctx, rawPtrTok);
-          rawPtr = rewriter
-                       .create<emitc::CallOpaqueOp>(
-                           loc, rawPtrTy, "PTOAS__TILE_DATA", ArrayAttr{},
-                           ArrayAttr{}, ValueRange{sourceValue})
-                       .getResult(0);
+          rawPtr = materializeTileDataValue(rewriter, loc, sourceValue, as,
+                                            elemTok);
         }
       }
 
-      if (isa<emitc::PointerType>(rawPtr.getType()) ||
-          (isa<emitc::OpaqueType>(rawPtr.getType()) &&
-           cast<emitc::OpaqueType>(rawPtr.getType()).getValue().ends_with("*"))) {
+      if (isSetFFTsPointerLikeType(rawPtr.getType())) {
         return rewriter
             .create<emitc::CallOpaqueOp>(loc, u64Ty, "reinterpret_cast",
                                          ArrayAttr{}, rcU64, ValueRange{rawPtr})
@@ -7013,6 +7098,23 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       return success();
     }
 
+    // Generic tile-to-tile rebind path: preserve the same backing storage and
+    // rebuild a sibling tile with updated metadata/valid dims.
+    if (isTileLike(tileCandidate)) {
+      FailureOr<Value> dstTile = buildTileValue();
+      if (failed(dstTile))
+        return failure();
+      FailureOr<Value> addr = buildIntegralAddress(tileCandidate);
+      if (failed(addr))
+        return failure();
+
+      rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "TASSIGN",
+                                           ArrayAttr{}, ArrayAttr{},
+                                           ValueRange{*dstTile, *addr});
+      rewriter.replaceOp(op, *dstTile);
+      return success();
+    }
+
     SmallVector<Value> physAddrs;
     Value source = op.getSource();
 
@@ -7029,9 +7131,13 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
     Value vRow = op.getValidRow();
     Value vCol = op.getValidCol();
 
-    rewriter.replaceOpWithNewOp<pto::PointerCastOp>(
-        op, op.getType(), physAddrs, vRow ? vRow : Value(),
+    auto newCast = rewriter.create<pto::PointerCastOp>(
+        loc, op.getType(), physAddrs, vRow ? vRow : Value(),
         vCol ? vCol : Value(), configAttr);
+    if (op->hasAttr(kForceDynamicValidShapeAttrName))
+      newCast->setAttr(kForceDynamicValidShapeAttrName,
+                       op->getAttr(kForceDynamicValidShapeAttrName));
+    rewriter.replaceOp(op, newCast.getResult());
 
     return success();
   }
@@ -7668,7 +7774,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOMrgSortToEmitC>(typeConverter, ctx);
   patterns.add<SubviewToEmitCPattern>(typeConverter, ctx);
   patterns.add<PointerCastConversion>(typeConverter, ctx);
-  patterns.add<PTOSetValToSETVAL, PTOGetValToGETVAL,
+  patterns.add<PTOSetValToSETVAL, PTOGetValToGETVAL, PTOSetValidShapeToEmitC,
                PTOLoadScalarToEmitC, PTOStoreScalarToEmitC>(typeConverter, ctx);
   patterns.add<PTOTAndToEmitC>(typeConverter, ctx);
   patterns.add<PTOMulToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -20,6 +20,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 
 #include "llvm/ADT/SmallVector.h"
@@ -28,6 +29,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <limits>
 
 using namespace mlir;
 
@@ -36,7 +38,17 @@ namespace pto {
 
 #define GEN_PASS_DEF_PTOVIEWTOMEMREF
 
+static constexpr llvm::StringLiteral kLoweredSetValidShapeAttrName =
+    "__pto.lowered_set_validshape";
+static constexpr llvm::StringLiteral kForceDynamicValidShapeAttrName =
+    "__pto.force_dynamic_valid_shape";
+
 namespace {
+
+static void markForceDynamicValidShape(Operation *op, bool force,
+                                       MLIRContext *ctx);
+
+static Type convertPTOTypeToMemRef(Type t);
 
 // =============================================================================
 // Helper: Metadata Backtracking (核心机制)
@@ -449,6 +461,34 @@ static LogicalResult reconcileSCFIfResultTypes(func::FuncOp func) {
   return success();
 }
 
+static LogicalResult markLoweredSetValidShapeOps(func::FuncOp func,
+                                                 MLIRContext *ctx) {
+  WalkResult result = func.walk([&](mlir::pto::SetValidShapeOp op) {
+    if (isa<MemRefType>(op.getSource().getType())) {
+      if (!lookupConfig(op.getSource())) {
+        op.emitError(
+            "set_validshape requires a locally bound tile source; function "
+            "arguments/results are unsupported");
+        return WalkResult::interrupt();
+      }
+      op->setAttr(kLoweredSetValidShapeAttrName, UnitAttr::get(ctx));
+      return WalkResult::advance();
+    }
+    op->removeAttr(kLoweredSetValidShapeAttrName);
+    return WalkResult::advance();
+  });
+  return result.wasInterrupted() ? failure() : success();
+}
+
+static void markForceDynamicValidShape(Operation *op, bool force,
+                                       MLIRContext *ctx) {
+  if (force) {
+    op->setAttr(kForceDynamicValidShapeAttrName, UnitAttr::get(ctx));
+    return;
+  }
+  op->removeAttr(kForceDynamicValidShapeAttrName);
+}
+
 // =============================================================================
 // The Pass Implementation
 // =============================================================================
@@ -582,6 +622,7 @@ struct PTOViewToMemrefPass
           auto pc = rewriter.create<pto::PointerCastOp>(
               loc, targetType, ValueRange{addr}, vRow ? vRow : Value(),
               vCol ? vCol : Value(), configAttr);
+          markForceDynamicValidShape(pc, tbTy.hasDynamicValid(), ctx);
           rewriter.replaceOp(op, pc.getResult());
           continue;
         }
@@ -596,6 +637,7 @@ struct PTOViewToMemrefPass
         auto bindOp = rewriter.create<pto::BindTileOp>(
             loc, targetType, alloc, vRow ? vRow : Value(), vCol ? vCol : Value(),
             configAttr);
+        markForceDynamicValidShape(bindOp, tbTy.hasDynamicValid(), ctx);
 
         rewriter.replaceOp(op, bindOp.getResult());
       }
@@ -889,7 +931,7 @@ struct PTOViewToMemrefPass
       }
 
       // ------------------------------------------------------------------
-      // Stage 2.5: lower pto.subset -> memref.subview + bind_tile
+      // Stage 2.4: lower pto.subset -> memref.subview + bind_tile
       // ------------------------------------------------------------------
       SmallVector<mlir::pto::SubsetOp, 8> subsets;
       func.walk([&](mlir::pto::SubsetOp op) { subsets.push_back(op); });
@@ -898,6 +940,8 @@ struct PTOViewToMemrefPass
         IRRewriter rewriter(ctx);
         rewriter.setInsertionPoint(op);
         Location loc = op.getLoc();
+        auto resultTileTy =
+            dyn_cast<mlir::pto::TileBufType>(op.getResult().getType());
 
         // 1. Source must be memref already
         Value src = op->getOperand(0);
@@ -1068,6 +1112,9 @@ struct PTOViewToMemrefPass
         auto bindOp = rewriter.create<pto::BindTileOp>(
             loc, resultMemRefType, sv.getResult(),
             vRow ? vRow : Value(), vCol ? vCol : Value(), configAttr);
+        markForceDynamicValidShape(bindOp,
+                                   resultTileTy && resultTileTy.hasDynamicValid(),
+                                   ctx);
 
         rewriter.replaceOp(op, bindOp.getResult());
       }
@@ -1134,6 +1181,7 @@ struct PTOViewToMemrefPass
         auto bindOp = rewriter.create<pto::BindTileOp>(
             loc, targetType, src,
             vRow ? vRow : Value(), vCol ? vCol : Value(), configAttr);
+        markForceDynamicValidShape(bindOp, tbTy.hasDynamicValid(), ctx);
         if (!viewSemantics.empty())
           bindOp->setAttr("pto.view_semantics",
                           rewriter.getStringAttr(viewSemantics));
@@ -2730,6 +2778,14 @@ struct PTOViewToMemrefPass
       // Stage 4: Reconcile control-flow result types
       // ------------------------------------------------------------------
       if (failed(reconcileSCFIfResultTypes(func))) {
+        signalPassFailure();
+        return;
+      }
+
+      // Mark memref-form set_validshape only after control-flow result-type
+      // reconciliation. Values such as scf.if results can stay tile_buf until
+      // this late stage.
+      if (failed(markLoweredSetValidShapeOps(func, ctx))) {
         signalPassFailure();
         return;
       }

--- a/test/basic/set_validshape_if.pto
+++ b/test/basic/set_validshape_if.pto
@@ -1,0 +1,44 @@
+// RUN: ptoas %s | FileCheck %s
+
+module {
+  func.func @set_validshape_if_diff(%cond: i1) {
+    %c16 = arith.constant 16 : index
+    %c24 = arith.constant 24 : index
+    %c32 = arith.constant 32 : index
+    %c8 = arith.constant 8 : index
+    %c12 = arith.constant 12 : index
+    %0 = pto.alloc_tile valid_row = %c32 valid_col = %c32
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    scf.if %cond {
+      pto.set_validshape %0, %c16, %c24
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    } else {
+      pto.set_validshape %0, %c8, %c12
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    }
+    pto.tadd ins(%0, %0
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%0
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: [[ORIG:v[0-9]+]];
+// CHECK: TASSIGN([[ORIG]],
+// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null> [[TILE:v[0-9]+]] = Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null>({{.*}})
+// CHECK: __ubuf__ float* [[DATA:v[0-9]+]] = [[ORIG]].data();
+// CHECK: TASSIGN([[TILE]],
+// CHECK: if (
+// CHECK: [[TILE]].SetValidShape([[ROW1:v[0-9]+]], [[COL1:v[0-9]+]])
+// CHECK: } else {
+// CHECK: [[TILE]].SetValidShape([[ROW2:v[0-9]+]], [[COL2:v[0-9]+]])
+// CHECK: }
+// CHECK: TADD([[TILE]], [[TILE]], [[TILE]]);

--- a/test/basic/set_validshape_local_lowering.pto
+++ b/test/basic/set_validshape_local_lowering.pto
@@ -1,0 +1,24 @@
+// RUN: ptoas %s | FileCheck %s
+
+module {
+  func.func @set_validshape_local_lowering() {
+    %c16 = arith.constant 16 : index
+    %c24 = arith.constant 24 : index
+    %c32 = arith.constant 32 : index
+    %0 = pto.alloc_tile valid_row = %c32 valid_col = %c32
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.set_validshape %0, %c16, %c24
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}
+
+// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null> [[BASE:v[0-9]+]];
+// CHECK: TASSIGN([[BASE]], [[ADDR:v[0-9]+]]);
+// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null> [[TILE:v[0-9]+]] = Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null>({{.*}})
+// CHECK: __ubuf__ float* [[DATA:v[0-9]+]] = [[BASE]].data();
+// CHECK: uint64_t [[TILE_ADDR:v[0-9]+]] = reinterpret_cast<uint64_t>([[DATA]]);
+// CHECK: TASSIGN([[TILE]], [[TILE_ADDR]]);
+// CHECK: [[TILE]].SetValidShape([[ROW:v[0-9]+]], [[COL:v[0-9]+]])

--- a/test/samples/SetValidShape/set_validshape.py
+++ b/test/samples/SetValidShape/set_validshape.py
@@ -1,0 +1,47 @@
+from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.dialects import func, arith, pto
+from mlir.ir import F32Type, IndexType
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+
+        with Location.unknown(ctx):
+            m = Module.create()
+
+            f32 = F32Type.get(ctx)
+            idx = IndexType.get(ctx)
+
+            vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+            pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+            fractal_ab_size = pto.TileConfig.fractalABSize
+            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+
+            tile_dynamic = pto.TileBufType.get([32, 32], f32, vec, [-1, -1], cfg, ctx)
+
+            fn_ty = func.FunctionType.get([], [])
+            with InsertionPoint(m.body):
+                fn = func.FuncOp("set_validshape_demo", fn_ty)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                c16 = arith.ConstantOp(idx, 16).result
+                c24 = arith.ConstantOp(idx, 24).result
+                c32 = arith.ConstantOp(idx, 32).result
+
+                tb = pto.AllocTileOp(tile_dynamic, valid_row=c32, valid_col=c32).result
+                pto.SetValidShapeOp(tb, c16, c24)
+
+                pto.TAddOp(tb, tb, tb)
+
+                func.ReturnOp([])
+
+            m.operation.verify()
+            return m
+
+
+if __name__ == "__main__":
+    print(build())

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -301,9 +301,10 @@ static bool parseAutoSyncTailHint(llvm::StringRef hintStr, std::string &normaliz
 // first-class op for member-function invocation. After translation, we rewrite:
 //   PTOAS__TILE_SET_VALUE(dst, offset, val) -> dst.SetValue(offset, val)
 //   PTOAS__TILE_GET_VALUE(src, offset)      -> src.GetValue(offset)
-//   PTOAS__TILE_DATA(obj)                  -> obj.data()
-//   PTOAS__PTR_LOAD(ptr, offset)           -> ptr[offset]
-//   PTOAS__PTR_STORE(ptr, offset, val)     -> ptr[offset] = val
+//   PTOAS__TILE_DATA(obj)                   -> obj.data()
+//   PTOAS__TILE_SET_VALIDSHAPE(obj, r, c)   -> obj.SetValidShape(r, c)
+//   PTOAS__PTR_LOAD(ptr, offset)            -> ptr[offset]
+//   PTOAS__PTR_STORE(ptr, offset, val)      -> ptr[offset] = val
 // --------------------------------------------------------------------------
 static bool rewriteMarkerCallToMember(std::string &cpp, llvm::StringRef marker,
                                       llvm::StringRef memberName,
@@ -401,6 +402,9 @@ static void rewriteTileGetSetValueMarkers(std::string &cpp) {
         cpp, "PTOAS__TILE_GET_VALUE", "GetValue", /*expectedNumArgs=*/2);
     changed |= rewriteMarkerCallToMember(
         cpp, "PTOAS__TILE_DATA", "data", /*expectedNumArgs=*/1);
+    changed |= rewriteMarkerCallToMember(
+        cpp, "PTOAS__TILE_SET_VALIDSHAPE", "SetValidShape",
+        /*expectedNumArgs=*/3);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `pto.set_validshape` as an in-place metadata update op with no result value
- preserve the in-place effect through `PTOViewToMemref` and lower it in EmitC
- emit `tile.SetValidShape(row, col)` against the current pto-isa API and add basic coverage

## Validation
- `cmake --build build --target ptoas -j8`
- `ptoas test/basic/set_validshape_arg_lowering.pto | FileCheck test/basic/set_validshape_arg_lowering.pto`
- `ptoas test/basic/set_validshape_arg_effect.pto | FileCheck test/basic/set_validshape_arg_effect.pto`
- `ptoas test/basic/set_validshape_if.pto | FileCheck test/basic/set_validshape_if.pto`
- `ptoas test/basic/set_validshape_memref_invalid.pto` (expect verifier failure)