### PR TITLE
fix(emitc): elide redundant bind_tile rewrap

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6802,6 +6802,12 @@ struct PTOTrapOpToEmitC : public OpConversionPattern<pto::TrapOp> {
 struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
   using OpConversionPattern::OpConversionPattern;
 
+  struct TileBuildSpec {
+    std::string tileTypeStr;
+    bool useConstructor = false;
+    SmallVector<Value> constructorArgs;
+  };
+
   static bool getIndexConst(Value v, int64_t &out) {
     if (!v)
       return false;
@@ -6835,8 +6841,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       StringRef s = ot.getValue();
       return s.contains("Tile<") || s.contains("ConvTile<");
     };
-
-    auto buildTileValue = [&]() -> FailureOr<Value> {
+    auto buildTileSpec = [&]() -> FailureOr<TileBuildSpec> {
       auto resMrTy = dyn_cast<MemRefType>(op.getType());
       if (!resMrTy)
         return failure();
@@ -6990,12 +6995,16 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
                                 ", " + vrowTok + ", " + vcolTok + ", " + slTok +
                                 ", " + std::to_string(fractal) + ", " + padTok +
                                 ">";
+      return TileBuildSpec{tileTypeStr, useConstructor, constructorArgs};
+    };
 
-      auto tileType = emitc::OpaqueType::get(ctx, tileTypeStr);
-      if (useConstructor) {
+    auto buildTileValue = [&](const TileBuildSpec &spec) -> Value {
+      auto tileType = emitc::OpaqueType::get(ctx, spec.tileTypeStr);
+      if (spec.useConstructor) {
         return rewriter
-            .create<emitc::CallOpaqueOp>(loc, tileType, tileTypeStr, ArrayAttr{},
-                                         ArrayAttr{}, ValueRange(constructorArgs))
+            .create<emitc::CallOpaqueOp>(loc, tileType, spec.tileTypeStr,
+                                         ArrayAttr{}, ArrayAttr{},
+                                         ValueRange(spec.constructorArgs))
             .getResult(0);
       }
 
@@ -7071,47 +7080,60 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
     Value tileCandidate = peelAllCasts(adaptor.getSource());
     if (viewSemantics && viewSemantics.getValue() == "bitcast" &&
         isTileLike(tileCandidate)) {
-      FailureOr<Value> dstTile = buildTileValue();
-      if (failed(dstTile))
+      FailureOr<TileBuildSpec> tileSpec = buildTileSpec();
+      if (failed(tileSpec))
         return failure();
+      Value dstTile = buildTileValue(*tileSpec);
       FailureOr<Value> addr = buildIntegralAddress(tileCandidate);
       if (failed(addr))
         return failure();
 
       rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "TASSIGN",
                                            ArrayAttr{}, ArrayAttr{},
-                                           ValueRange{*dstTile, *addr});
-      rewriter.replaceOp(op, *dstTile);
+                                           ValueRange{dstTile, *addr});
+      rewriter.replaceOp(op, dstTile);
       return success();
     }
 
     if (viewSemantics && viewSemantics.getValue() == "treshape" &&
         isTileLike(tileCandidate)) {
-      FailureOr<Value> dstTile = buildTileValue();
-      if (failed(dstTile))
+      FailureOr<TileBuildSpec> tileSpec = buildTileSpec();
+      if (failed(tileSpec))
         return failure();
+      Value dstTile = buildTileValue(*tileSpec);
 
       rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "TRESHAPE",
                                            ArrayAttr{}, ArrayAttr{},
-                                           ValueRange{*dstTile, tileCandidate});
-      rewriter.replaceOp(op, *dstTile);
+                                           ValueRange{dstTile, tileCandidate});
+      rewriter.replaceOp(op, dstTile);
       return success();
     }
 
     // Generic tile-to-tile rebind path: preserve the same backing storage and
     // rebuild a sibling tile with updated metadata/valid dims.
     if (isTileLike(tileCandidate)) {
-      FailureOr<Value> dstTile = buildTileValue();
-      if (failed(dstTile))
+      FailureOr<TileBuildSpec> tileSpec = buildTileSpec();
+      if (failed(tileSpec))
         return failure();
+
+      if (!tileSpec->useConstructor) {
+        if (auto srcTy = dyn_cast<emitc::OpaqueType>(tileCandidate.getType())) {
+          if (srcTy.getValue() == tileSpec->tileTypeStr) {
+            rewriter.replaceOp(op, tileCandidate);
+            return success();
+          }
+        }
+      }
+
+      Value dstTile = buildTileValue(*tileSpec);
       FailureOr<Value> addr = buildIntegralAddress(tileCandidate);
       if (failed(addr))
         return failure();
 
       rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "TASSIGN",
                                            ArrayAttr{}, ArrayAttr{},
-                                           ValueRange{*dstTile, *addr});
-      rewriter.replaceOp(op, *dstTile);
+                                           ValueRange{dstTile, *addr});
+      rewriter.replaceOp(op, dstTile);
       return success();
     }
 

--- a/test/basic/tprint_alloc_tile_no_rebind.pto
+++ b/test/basic/tprint_alloc_tile_no_rebind.pto
@@ -1,0 +1,21 @@
+// RUN: ptoas %s | FileCheck %s
+
+module {
+  func.func @print_kernel() attributes {pto.entry} {
+    %0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tprint ins(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32,
+                                      v_row=32, v_col=32, blayout=row_major,
+                                      slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void print_kernel() {
+// CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null> [[TILE:v[0-9]+]];
+// CHECK: TASSIGN([[TILE]], [[ADDR:v[0-9]+]]);
+// CHECK-NOT: TASSIGN(
+// CHECK-NOT: .data()
+// CHECK-NOT: reinterpret_cast<uint64_t>
+// CHECK: TPRINT([[TILE]]);


### PR DESCRIPTION
## Summary
- elide redundant `bind_tile` EmitC rewrites when the source tile already has the exact same static tile type
- keep the existing rebind path for cases that still need new runtime-valid metadata or different configs/layouts
- add a regression test covering `alloc_tile -> tprint` so the generated C++ stays compact

## Why
For simple cases like `alloc_tile` followed by `pto.tprint`, the current lowering creates a second sibling tile and rebinds through `tile.data()` + `reinterpret_cast<uint64_t>`, even though the original tile is already the exact value `TPRINT` needs. The code works, but the generated C++ is unnecessarily noisy.

## Validation
- `cmake --build build -j8`
- `build/tools/ptoas/ptoas test/basic/tprint_alloc_tile_no_rebind.pto | FileCheck test/basic/tprint_alloc_tile_no_rebind.pto`
- `build/tools/ptoas/ptoas test/basic/set_validshape_local_lowering.pto | FileCheck test/basic/set_validshape_local_lowering.pto`
- `build/tools/ptoas/ptoas test/basic/set_validshape_if.pto | FileCheck test/basic/set_validshape_if.pto`