### PR TITLE
fix(cse): preserve treshape across intervening tile writes

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -244,7 +244,7 @@ def AllocTileOp : PTO_Op<"alloc_tile", [AttrSizedOperandSegments]> {
 // BindTileOp: 将 Config 和 Valid Dims 绑定到 MemRef 上
 // ============================================================================
 def BindTileOp : PTO_Op<"bind_tile", [
-    Pure,
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     AttrSizedOperandSegments
     // 允许输入 offset:0 -> 输出 offset:?
   ]> {
@@ -3443,7 +3443,7 @@ def TRemSOp: PTO_TOp<"trems", [
 
 def TReshapeOp: PTO_TOp<"treshape", [
   OpPipeInterface,
-  Pure,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
   ViewLikeOpInterface
 ]> {
   let summary = "TRESHAPE: Reinterpret a tile buffer view (SSA; aliases src storage)";

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -7357,6 +7357,16 @@ void TSort32Op::getEffects(
     PTO_ADD_WRITE(tmp[0]);
 }
 
+void BindTileOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_READ(getSourceMutable());
+}
+
+void TReshapeOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_READ(getSrcMutable());
+}
+
 PTO_DEFINE_UNARY_EFFECTS(TSqrtOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_BINARY_EFFECTS(TSubOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())
 PTO_DEFINE_TERNARY_EFFECTS(TSubCOp, getSrc0Mutable(), getSrc1Mutable(), getSrc2Mutable(), getDstMutable())

--- a/test/basic/treshape_cse_after_write.pto
+++ b/test/basic/treshape_cse_after_write.pto
@@ -1,0 +1,30 @@
+// RUN: ptoas %s -o %t.cpp > /dev/null 2>&1
+// RUN: FileCheck %s --input-file=%t.cpp
+
+module {
+  func.func @treshape_cse_after_write() {
+    %cst = arith.constant 5.000000e-01 : f32
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %sum = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %mean = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %var = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.trowsum ins(%src, %tmp0 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%sum : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+    %reshape0 = pto.treshape %sum : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmuls ins(%reshape0, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32) outs(%mean : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.trowsum ins(%src, %tmp1 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%sum : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+    %reshape1 = pto.treshape %sum : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0> -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmuls ins(%reshape1, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32) outs(%var : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: TROWSUM(
+// CHECK: TRESHAPE(
+// CHECK: TMULS(
+// CHECK: TROWSUM(
+// CHECK: TRESHAPE(
+// CHECK: TMULS(


### PR DESCRIPTION
## Summary
- add read effects to `pto.treshape` and lowered `pto.bind_tile` treshape views so CSE does not fold them across intervening writes
- cover the regression with a `.pto` FileCheck test that requires both reshapes to remain after two writes into the same tile

## Validation
- `/private/tmp/ptoas-issue321.VOdASF/build/tools/ptoas/ptoas /tmp/issue321_repro.pto -o /tmp/issue321_repro_fixed.cpp`
- `FileCheck test/basic/treshape_cse_after_write.pto --input-file=/tmp/treshape_cse_after_write.cpp`
- `python3.9 test/samples/Reshape/reshape.py > /tmp/reshape_sample.pto && ptoas /tmp/reshape_sample.pto -o /tmp/reshape_sample.cpp`

Fixes #321