### PR TITLE
Fix vector-kernel scf.while lowering

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -8457,6 +8457,53 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
 }
 
+static void lowerSectionOpsBeforeSCFPreLowering(ModuleOp module) {
+  IRRewriter rewriter(module.getContext());
+  SmallVector<Operation *> sectionOps;
+
+  module.walk([&](Operation *op) {
+    if (isa<pto::SectionCubeOp, pto::SectionVectorOp>(op))
+      sectionOps.push_back(op);
+  });
+
+  for (Operation *op : sectionOps) {
+    std::string macroName;
+    Block *innerBlock = nullptr;
+    bool isVectorSection = false;
+    if (auto section = dyn_cast<pto::SectionCubeOp>(op)) {
+      macroName = "__DAV_CUBE__";
+      innerBlock = &section.getBody().front();
+    } else if (auto section = dyn_cast<pto::SectionVectorOp>(op)) {
+      macroName = "__DAV_VEC__";
+      innerBlock = &section.getBody().front();
+      isVectorSection = true;
+    } else {
+      continue;
+    }
+
+    rewriter.setInsertionPoint(op);
+    rewriter.create<emitc::VerbatimOp>(
+        op->getLoc(),
+        rewriter.getStringAttr("\n#if defined(" + macroName + ")"));
+
+    if (isVectorSection) {
+      // Vector mask is global HW state; reset it before emitting the section.
+      rewriter.create<emitc::VerbatimOp>(op->getLoc(),
+                                         rewriter.getStringAttr("set_mask_norm();"));
+      rewriter.create<emitc::VerbatimOp>(
+          op->getLoc(), rewriter.getStringAttr("set_vector_mask(-1, -1);"));
+    }
+
+    if (innerBlock && !innerBlock->empty())
+      rewriter.inlineBlockBefore(innerBlock, op, ValueRange{});
+
+    rewriter.create<emitc::VerbatimOp>(
+        op->getLoc(),
+        rewriter.getStringAttr("#endif // " + macroName + "\n"));
+    rewriter.eraseOp(op);
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
@@ -8544,21 +8591,26 @@ static AICORE inline void ptoas_auto_sync_tail(
 	      }
 	      return WalkResult::advance();
 	    });
-	    if (needsBitcastHelper) {
-	      builder.create<emitc::VerbatimOp>(
-	          loc, builder.getStringAttr(R"cpp(
-		template <typename To, typename From>
+		    if (needsBitcastHelper) {
+		      builder.create<emitc::VerbatimOp>(
+		          loc, builder.getStringAttr(R"cpp(
+	template <typename To, typename From>
 		static inline To ptoas_bitcast(From from) {
 		  static_assert(sizeof(To) == sizeof(From), "ptoas_bitcast: size mismatch");
 		  To to;
 		  __builtin_memcpy(&to, &from, sizeof(To));
 		  return to;
 		}
-		)cpp"));
-	    }
+	)cpp"));
+		    }
 
-	    // 1.5 Pre-lower SCF constructs not handled by SCFToEmitC.
-	    {
+        // Lower section wrappers into EmitC verbatim guards before SCF
+        // pre-lowering so CFG-based rewrites do not have to operate inside
+        // single-block `pto.section.*` regions.
+        lowerSectionOpsBeforeSCFPreLowering(mop);
+
+		    // 1.5 Pre-lower SCF constructs not handled by SCFToEmitC.
+		    {
 	      // scf.while / scf.index_switch are lowered via CFG blocks. This is not
       // possible inside ops that require single-block regions (e.g. scf.for /
       // scf.if). If we see such nesting, lower the entire function to the
@@ -8576,10 +8628,15 @@ static AICORE inline void ptoas_auto_sync_tail(
         FrozenRewritePatternSet frozenSCFToCF(std::move(scfToCfPatterns));
 
         ConversionTarget scfToCfTarget(*ctx);
-        // Only eliminate the single-block SCF constructs; we'll pre-lower
-        // scf.while/index_switch/execute_region ourselves afterwards.
+        // `scf.while` nested under remaining single-block parents such as
+        // `scf.for` / `scf.if` cannot be handled by the later local CFG
+        // pre-lowering, so force SCFToCF to eliminate it here together with
+        // the other single-block SCF ops. `pto.section.*` wrappers have
+        // already been lowered out of the way above.
+        // `scf.index_switch` / `scf.execute_region` remain on the custom
+        // pre-lowering path below.
         scfToCfTarget.addIllegalOp<scf::ForallOp, scf::ForOp, scf::IfOp,
-                                   scf::ParallelOp>();
+                                   scf::ParallelOp, scf::WhileOp>();
         scfToCfTarget.markUnknownOpDynamicallyLegal(
             [](Operation *) { return true; });
 

--- a/test/basic/vector_kernel_scf_while.pto
+++ b/test/basic/vector_kernel_scf_while.pto
@@ -1,0 +1,70 @@
+// RUN: ptoas %s | FileCheck %s
+
+module {
+  func.func @vector_while_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c4 = arith.constant 4 : index
+    %true = arith.constant true
+    %false = arith.constant false
+    %one = arith.constant 1.0 : f32
+    %ten = arith.constant 10.0 : f32
+
+    %tile = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %final:2 = scf.while (%i = %c0, %alive = %true)
+        : (index, i1) -> (index, i1) {
+      %lt = arith.cmpi slt, %i, %c4 : index
+      %go = arith.andi %lt, %alive : i1
+      scf.condition(%go) %i, %alive : index, i1
+    } do {
+    ^bb0(%iter: index, %alive_iter: i1):
+      pto.tadds ins(%tile, %one
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+          f32)
+        outs(%tile
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      %break_now = arith.cmpi eq, %iter, %c2 : index
+      %next = arith.addi %iter, %c1 : index
+      %yield:2 = scf.if %break_now -> (index, i1) {
+        scf.yield %next, %false : index, i1
+      } else {
+        pto.tadds ins(%tile, %ten
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+            f32)
+          outs(%tile
+          : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+        scf.yield %next, %true : index, i1
+      }
+      scf.yield %yield#0, %yield#1 : index, i1
+    }
+
+    %stopped = arith.xori %final#1, %true : i1
+    scf.if %stopped {
+      pto.tadds ins(%tile, %one
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+          f32)
+        outs(%tile
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+    return
+  }
+}
+
+// CHECK: #if defined(__DAV_VEC__)
+// CHECK: goto [[HEADER:label[0-9]+]];
+// CHECK: [[HEADER]]:
+// CHECK: if (
+// CHECK: goto [[BODY:label[0-9]+]];
+// CHECK: [[BODY]]:
+// CHECK: goto [[HEADER]];
+// CHECK: #endif // __DAV_VEC__


### PR DESCRIPTION
## Summary
- lower `pto.section.*` wrappers into EmitC verbatim guards before SCF pre-lowering
- let `scf.while` in vector kernels lower in the surrounding function CFG instead of getting trapped in a single-block section region
- keep whole-function SCFToCF handling for `scf.while` under other single-block parents and add a regression test

## Verification
- build `ptoas` on latest `origin/main`
- compile `/Users/laoda/Downloads/kernel_while_add(1).pto` successfully with `pto.kernel_kind = vector` present
- compile the same repro without the attribute successfully
- compile `test/basic/vector_kernel_scf_while.pto` successfully and confirm the generated C++ contains both `#if defined(__DAV_VEC__)` and CFG labels