### PR TITLE
fix(ci): skip storefp in scheduled validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
       # Temporary CI gate: skip cases that still error/flap on the remote NPU.
       # Update this list as we fix the underlying issues.
       DEFAULT_SKIP_CASES: >-
-        mix_kernel,vadd_validshape,vadd_validshape_dynamic,print
+        mix_kernel,vadd_validshape,vadd_validshape_dynamic,print,storefp
     steps:
       - name: Resolve validation parameters
         shell: bash


### PR DESCRIPTION
## Summary
- add `storefp` to `DEFAULT_SKIP_CASES` used by the scheduled remote-NPU workflow
- keep schedule behavior consistent with the existing `workflow_dispatch` default skip list

## Validation
- confirmed `.github/workflows/ci.yml` now contains `storefp` in both the manual `skip_cases` default and `DEFAULT_SKIP_CASES` used by schedule
- verified the diff is limited to the scheduled skip list entry