### PR TITLE
InsertSync: avoid over-pruning sync for gather/scatter kernels

### DIFF
--- a/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
@@ -42,6 +42,19 @@ namespace {
 // ==============================================================================
 // Main Pass Implementation
 // ==============================================================================
+
+static bool hasGatherScatterLikeOps(func::FuncOp func) {
+  bool found = false;
+  func.walk([&](Operation *op) {
+    if (isa<pto::TGatherOp, pto::TGatherBOp, pto::TScatterOp, pto::MGatherOp,
+            pto::MScatterOp>(op)) {
+      found = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return found;
+}
  
 struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSyncPass> {
   
@@ -101,9 +114,19 @@ struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSy
                         func.getOperation());
  
     // 4. [NEW] Optimization 2: Remove Redundant Sync
-    // 消除由于 Motion 或 Analysis 产生的冗余同步对
-    RemoveRedundantSync removeRedundant(syncIR, syncOpsStorage, SyncAnalysisMode::NORMALSYNC);
-    removeRedundant.Run();
+    // 消除由于 Motion 或 Analysis 产生的冗余同步对。
+    //
+    // NOTE:
+    // Current redundancy matching is pipe-pair based and may over-remove
+    // set/wait around gather/scatter-like ops on A5, causing runtime mismatch
+    // or vector exceptions. Keep correctness-first behavior here by skipping
+    // this optimization for those kernels until dependency-aware matching is
+    // added.
+    if (!hasGatherScatterLikeOps(func)) {
+      RemoveRedundantSync removeRedundant(syncIR, syncOpsStorage,
+                                          SyncAnalysisMode::NORMALSYNC);
+      removeRedundant.Run();
+    }
  
     dumpInsertSyncPhase("After Remove Redundant Sync", syncIR, syncOpsStorage,
                         func.getOperation());


### PR DESCRIPTION
## Background
`PTORemoveRedundantBarrier` is already disabled in the default `ptoas` pipeline, so it is not the runtime root cause for A5 `scatter/gatherb` failures.

However, `PTOInsertSync` still runs `RemoveRedundantSync`, which removes `set/wait` pairs using a pipe-pair-only matching heuristic. For gather/scatter-like kernels this can over-prune required sync and lead to runtime mismatch or vector exceptions on A5.

## What changed
- In `lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp`, add a guard:
  - If a function contains any of `{TGatherOp, TGatherBOp, TScatterOp, MGatherOp, MScatterOp}`,
    skip `RemoveRedundantSync` optimization.
  - Keep the rest of InsertSync flow unchanged (analysis/motion/event allocation/codegen).

## Why
- Correctness-first hotfix for A5 gather/scatter board failures.
- Avoids deleting potentially required set/wait while we implement dependency-aware redundant-sync elimination.

## Notes
- This change is intentionally conservative and localized to gather/scatter-like kernels.
- Follow-up work should replace pipe-only matching with memory-dependency-aware matching in `RemoveRedundantSync`.
