### PR TITLE
fix: align TInsert A5 vec paths with latest PTO-ISA (PR561)

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2671,6 +2671,7 @@ def TInsertOp : PTO_TOp<"tinsert", [
 
   let extraClassDeclaration = [{
     // TINSERT runs on different pipes depending on target/path:
+    // - A5 Vec(UB)->Vec(UB): PIPE_V  (ND_VEC path).
     // - A5 Vec(UB)->Mat(L1): PIPE_MTE3 (custom UB->L1 copy path).
     // - Acc->Mat (A2/A3/A5 regular path): PIPE_FIX.
     ::mlir::pto::PIPE getPipe() {
@@ -2714,6 +2715,10 @@ def TInsertOp : PTO_TOp<"tinsert", [
 
       auto sOpt = getASFromType(getSrc().getType());
       auto dOpt = getASFromType(getDst().getType());
+      if (isA5Target() && sOpt.has_value() && dOpt.has_value() &&
+          sOpt.value() == ::mlir::pto::AddressSpace::VEC &&
+          dOpt.value() == ::mlir::pto::AddressSpace::VEC)
+        return ::mlir::pto::PIPE::PIPE_V;
       if (isA5Target() && sOpt.has_value() && dOpt.has_value() &&
           sOpt.value() == ::mlir::pto::AddressSpace::VEC &&
           dOpt.value() == ::mlir::pto::AddressSpace::MAT)

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3101,69 +3101,162 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 mlir::LogicalResult mlir::pto::TInsertOp::verify() {
-  Type srcTy = getSrc().getType();
-  Type dstTy = getDst().getType();
-  if (!isPTOShapedLike(srcTy) || !isPTOShapedLike(dstTy))
-    return emitOpError("expects src/dst to be PTO shaped-like types");
-
-  auto srcShape = getShapeVec(srcTy);
-  auto dstShape = getShapeVec(dstTy);
-  if (srcShape.size() != 2 || dstShape.size() != 2)
-    return emitOpError("expects rank-2 shaped types for src/dst");
-
-  Type srcElemTy = getElemTy(srcTy);
-  Type dstElemTy = getElemTy(dstTy);
-  bool sameElemTy = srcElemTy == dstElemTy;
-  bool castElemTy =
-      srcElemTy.isF32() && (dstElemTy.isF16() || dstElemTy.isBF16());
-  if (!sameElemTy && !castElemTy)
-    return emitOpError(
-        "expects src/dst element types to match, or src=f32 with dst=f16/bf16");
-
-  if (!getIndexRow().getType().isIndex() || !getIndexCol().getType().isIndex())
-    return emitOpError("expects indexRow/indexCol to be index type");
-
-  auto readConstIndex = [&](Value v, int64_t &out) -> bool {
-    if (auto cOp = v.getDefiningOp<mlir::arith::ConstantIndexOp>()) {
-      out = cOp.value();
-      return true;
+  auto getConstIndex = [&](Value v) -> std::optional<int64_t> {
+    if (auto cst = v.getDefiningOp<mlir::arith::ConstantIndexOp>())
+      return cst.value();
+    if (auto cst = v.getDefiningOp<mlir::arith::ConstantIntOp>())
+      return cst.value();
+    if (auto cst = v.getDefiningOp<mlir::arith::ConstantOp>()) {
+      if (auto attr = mlir::dyn_cast<mlir::IntegerAttr>(cst.getValue()))
+        return attr.getInt();
     }
-    if (auto cInt = v.getDefiningOp<mlir::arith::ConstantIntOp>()) {
-      out = cInt.value();
-      return true;
-    }
-    if (auto cOp = v.getDefiningOp<mlir::arith::ConstantOp>()) {
-      if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(cOp.getValue())) {
-        out = ia.getInt();
-        return true;
-      }
-    }
+    return std::nullopt;
+  };
+  auto verifyIndexOperands = [&]() -> LogicalResult {
+    if (!getIndexRow().getType().isIndex() || !getIndexCol().getType().isIndex())
+      return emitOpError("expects indexRow and indexCol to be index type");
+    auto row = getConstIndex(getIndexRow());
+    auto col = getConstIndex(getIndexCol());
+    if (row && *row < 0)
+      return emitOpError("expects indexRow to be non-negative");
+    if (col && *col < 0)
+      return emitOpError("expects indexCol to be non-negative");
+    return success();
+  };
+  auto verifyStaticBounds = [&](Type srcTy, Type dstTy) -> LogicalResult {
+    auto row = getConstIndex(getIndexRow());
+    auto col = getConstIndex(getIndexCol());
+    auto srcShape = getValidShapeVec(srcTy);
+    auto dstShape = getShapeVec(dstTy);
+    if (srcShape.size() != 2 || dstShape.size() != 2)
+      return emitOpError("expects src and dst to be rank-2 tile_buf");
+    if (row && srcShape[0] != ShapedType::kDynamic &&
+        dstShape[0] != ShapedType::kDynamic &&
+        *row + srcShape[0] > dstShape[0])
+      return emitOpError("expects indexRow + src.rows <= dst.rows");
+    if (col && srcShape[1] != ShapedType::kDynamic &&
+        dstShape[1] != ShapedType::kDynamic &&
+        *col + srcShape[1] > dstShape[1])
+      return emitOpError("expects indexCol + src.cols <= dst.cols");
+    return success();
+  };
+  auto isColMajorRowMajorNZ = [&](pto::TileBufType ty) -> bool {
+    return ty.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) &&
+           ty.getSLayoutValueI32() == static_cast<int32_t>(pto::SLayout::RowMajor);
+  };
+  auto isRowMajorNoneBoxND = [&](pto::TileBufType ty) -> bool {
+    return ty.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor) &&
+           ty.getSLayoutValueI32() == static_cast<int32_t>(pto::SLayout::NoneBox);
+  };
+  auto isA5SupportedVecElemType = [&](Type ty) -> bool {
+    if (auto it = dyn_cast<IntegerType>(ty))
+      return it.getWidth() == 8 || it.getWidth() == 32;
+    if (auto ft = dyn_cast<FloatType>(ty))
+      return ft.getWidth() == 8 || ft.isF16() || ft.isBF16() || ft.isF32();
     return false;
   };
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    Type srcTy = getSrc().getType();
+    Type dstTy = getDst().getType();
+    auto srcTb = dyn_cast<pto::TileBufType>(srcTy);
+    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
+    if (!srcTb || !dstTb)
+      return emitOpError("expects src and dst to be !pto.tile_buf");
+    if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
+        failed(verifyTileBufCommon(*this, dstTy, "dst")) ||
+        failed(verifyIndexOperands()) ||
+        failed(verifyStaticBounds(srcTy, dstTy)))
+      return failure();
 
-  int64_t r0 = 0;
-  int64_t c0 = 0;
-  bool rowConst = readConstIndex(getIndexRow(), r0);
-  bool colConst = readConstIndex(getIndexCol(), c0);
-  if (rowConst && r0 < 0)
-    return emitOpError("indexRow must be non-negative");
-  if (colConst && c0 < 0)
-    return emitOpError("indexCol must be non-negative");
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    if (!srcSpace || !dstSpace || *srcSpace != pto::AddressSpace::ACC ||
+        *dstSpace != pto::AddressSpace::MAT)
+      return emitOpError("expects A2/A3 tinsert src to use loc=acc and dst to use loc=mat");
 
-  int64_t srcRows = srcShape[0];
-  int64_t srcCols = srcShape[1];
-  int64_t dstRows = dstShape[0];
-  int64_t dstCols = dstShape[1];
-  if (rowConst && srcRows != mlir::ShapedType::kDynamic &&
-      dstRows != mlir::ShapedType::kDynamic &&
-      r0 + srcRows > dstRows)
-    return emitOpError("indexRow + src rows exceeds dst rows");
-  if (colConst && srcCols != mlir::ShapedType::kDynamic &&
-      dstCols != mlir::ShapedType::kDynamic &&
-      c0 + srcCols > dstCols)
-    return emitOpError("indexCol + src cols exceeds dst cols");
+    if (!isColMajorRowMajorNZ(srcTb))
+      return emitOpError("expects A2/A3 tinsert src to use blayout=col_major and slayout=row_major");
+    if (!isColMajorRowMajorNZ(dstTb))
+      return emitOpError("expects A2/A3 tinsert dst to use blayout=col_major and slayout=row_major");
+    if (dstTb.getSFractalSizeI32() != 512)
+      return emitOpError("expects A2/A3 tinsert dst fractal size to be 512");
 
-  return mlir::success();
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    if (!(srcElem.isF32() && (dstElem.isF16() || dstElem.isBF16())))
+      return emitOpError("expects A2/A3 tinsert element types to be src=f32, dst=f16/bf16");
+    return success();
+  };
+  auto verifyA5 = [&]() -> LogicalResult {
+    Type srcTy = getSrc().getType();
+    Type dstTy = getDst().getType();
+    auto srcTb = dyn_cast<pto::TileBufType>(srcTy);
+    auto dstTb = dyn_cast<pto::TileBufType>(dstTy);
+    if (!srcTb || !dstTb)
+      return emitOpError("expects src and dst to be !pto.tile_buf");
+    if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
+        failed(verifyTileBufCommon(*this, dstTy, "dst")) ||
+        failed(verifyIndexOperands()) ||
+        failed(verifyStaticBounds(srcTy, dstTy)))
+      return failure();
+
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    Type srcElem = getElemTy(srcTy);
+    Type dstElem = getElemTy(dstTy);
+    if (!srcSpace || !dstSpace)
+      return emitOpError("expects A5 tinsert src/dst to have explicit loc");
+
+    // A5 regular acc->mat path.
+    if (*srcSpace == pto::AddressSpace::ACC && *dstSpace == pto::AddressSpace::MAT) {
+      if (!isColMajorRowMajorNZ(srcTb))
+        return emitOpError("expects A5 acc->mat tinsert src to use blayout=col_major and slayout=row_major");
+      if (!isColMajorRowMajorNZ(dstTb))
+        return emitOpError("expects A5 acc->mat tinsert dst to use blayout=col_major and slayout=row_major");
+      bool okTypes = (srcElem.isF32() &&
+                      (dstElem.isF16() || dstElem.isBF16() || dstElem.isF32())) ||
+                     (srcElem.isInteger(32) && dstElem.isInteger(32));
+      if (!okTypes)
+        return emitOpError(
+            "expects A5 acc->mat tinsert element types to be "
+            "(src=f32,dst=f16/bf16/f32) or (src=i32,dst=i32)");
+      return success();
+    }
+
+    // A5 vec->mat path (ND/NZ modes in pto-isa).
+    if (*srcSpace == pto::AddressSpace::VEC && *dstSpace == pto::AddressSpace::MAT) {
+      if (!isColMajorRowMajorNZ(dstTb))
+        return emitOpError("expects A5 vec->mat tinsert dst to use blayout=col_major and slayout=row_major");
+      bool srcIsND = isRowMajorNoneBoxND(srcTb);
+      bool srcIsNZ = isColMajorRowMajorNZ(srcTb);
+      if (!srcIsND && !srcIsNZ)
+        return emitOpError(
+            "expects A5 vec->mat tinsert src to use ND(row_major/none_box) or NZ(col_major/row_major) layout");
+      if (srcElem != dstElem || !isA5SupportedVecElemType(srcElem))
+        return emitOpError(
+            "expects A5 vec->mat tinsert src/dst to have same supported dtype "
+            "(fp8/f16/bf16/f32/i8/i32)");
+      return success();
+    }
+
+    // A5 vec->vec path (PR561 ND_VEC).
+    if (*srcSpace == pto::AddressSpace::VEC && *dstSpace == pto::AddressSpace::VEC) {
+      if (!isRowMajorNoneBoxND(srcTb) || !isRowMajorNoneBoxND(dstTb))
+        return emitOpError(
+            "expects A5 vec->vec tinsert src/dst to use ND layout "
+            "(blayout=row_major, slayout=none_box)");
+      if (srcElem != dstElem || !isA5SupportedVecElemType(srcElem))
+        return emitOpError(
+            "expects A5 vec->vec tinsert src/dst to have same supported dtype "
+            "(fp8/f16/bf16/f32/i8/i32)");
+      return success();
+    }
+
+    return emitOpError(
+        "expects A5 tinsert to use a supported src/dst loc pair: "
+        "acc->mat, vec->mat, or vec->vec");
+  };
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
 static mlir::LogicalResult verifyTFillPadLike(Operation *op, Type srcTy, Type dstTy,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5690,7 +5690,78 @@ struct PTOExtractToEmitC : public OpConversionPattern<pto::TExtractOp> {
 };
 //===----------------------------------------------------------------------===//
 // pto.tinsert lowering -> TINSERT(dst, src, indexRow, indexCol)
+// A5 specializations:
+//   vec->vec : TINSERT<TInsertMode::ND_VEC>(...)
+//   vec->mat : TINSERT<TInsertMode::ND/NZ>(...)
 //===----------------------------------------------------------------------===//
+
+static std::optional<pto::AddressSpace> getAddressSpaceFromType(Type ty) {
+  if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
+    if (auto as = dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace()))
+      return as.getAddressSpace();
+    return std::nullopt;
+  }
+  if (auto mr = dyn_cast<MemRefType>(ty)) {
+    if (auto ms = mr.getMemorySpace()) {
+      if (auto as = dyn_cast<pto::AddressSpaceAttr>(ms))
+        return as.getAddressSpace();
+      return std::nullopt;
+    }
+    return pto::AddressSpace::GM;
+  }
+  return std::nullopt;
+}
+
+static bool isA5TargetForTInsert(pto::TInsertOp op) {
+  auto moduleOp = op->getParentOfType<ModuleOp>();
+  if (!moduleOp)
+    return false;
+  if (auto arch = moduleOp->getAttrOfType<StringAttr>("pto.target_arch")) {
+    if (arch.getValue().equals_insensitive("a5"))
+      return true;
+  }
+  if (auto spec = moduleOp->getAttrOfType<StringAttr>("pto.device-spec")) {
+    auto s = spec.getValue();
+    if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95"))
+      return true;
+  }
+  return false;
+}
+
+static std::optional<StringRef> getA5TInsertModeToken(pto::TInsertOp op) {
+  if (!isA5TargetForTInsert(op))
+    return std::nullopt;
+  auto srcAs = getAddressSpaceFromType(op.getSrc().getType());
+  auto dstAs = getAddressSpaceFromType(op.getDst().getType());
+  if (!srcAs || !dstAs)
+    return std::nullopt;
+  if (*srcAs == pto::AddressSpace::VEC && *dstAs == pto::AddressSpace::VEC)
+    return StringRef("TInsertMode::ND_VEC");
+  if (*srcAs == pto::AddressSpace::VEC && *dstAs == pto::AddressSpace::MAT) {
+    if (auto srcTb = dyn_cast<pto::TileBufType>(op.getSrc().getType())) {
+      int32_t bl = srcTb.getBLayoutValueI32();
+      int32_t sl = srcTb.getSLayoutValueI32();
+      bool srcIsND = bl == static_cast<int32_t>(pto::BLayout::RowMajor) &&
+                     sl == static_cast<int32_t>(pto::SLayout::NoneBox);
+      return srcIsND ? StringRef("TInsertMode::ND") : StringRef("TInsertMode::NZ");
+    }
+    // Best effort for memref path: recover from paired tload's layout attr.
+    for (Operation *user : op.getSrc().getUsers()) {
+      auto tload = dyn_cast<pto::TLoadOp>(user);
+      if (!tload || tload.getDst() != op.getSrc())
+        continue;
+      auto layoutAttr = tload->getAttrOfType<pto::LayoutAttr>("layout");
+      if (!layoutAttr)
+        continue;
+      return layoutAttr.getLayout() == pto::Layout::ND
+                 ? StringRef("TInsertMode::ND")
+                 : StringRef("TInsertMode::NZ");
+    }
+    // MemRef source loses explicit tile layout metadata; keep legacy default.
+    return StringRef("TInsertMode::NZ");
+  }
+  return std::nullopt;
+}
 
 struct PTOInsertToEmitC : public OpConversionPattern<pto::TInsertOp> {
   using OpConversionPattern<pto::TInsertOp>::OpConversionPattern;
@@ -5698,15 +5769,22 @@ struct PTOInsertToEmitC : public OpConversionPattern<pto::TInsertOp> {
   LogicalResult matchAndRewrite(pto::TInsertOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
 
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
     Value r0  = peelUnrealized(adaptor.getIndexRow());
     Value c0  = peelUnrealized(adaptor.getIndexCol());
 
+    ArrayAttr templateArgs = ArrayAttr{};
+    if (auto modeTok = getA5TInsertModeToken(op)) {
+      templateArgs = rewriter.getArrayAttr(
+          {emitc::OpaqueAttr::get(ctx, modeTok->str())});
+    }
+
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TINSERT",
-        /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
+        /*args=*/ArrayAttr{}, /*templateArgs=*/templateArgs,
         /*operands=*/ValueRange{dst, src, r0, c0});
 
     rewriter.eraseOp(op);

--- a/test/basic/tinsert_a3_pipe_selection.pto
+++ b/test/basic/tinsert_a3_pipe_selection.pto
@@ -1,0 +1,57 @@
+// RUN: ptoas --pto-arch a3 --enable-insert-sync %s | FileCheck %s
+
+module attributes {"pto.target_arch" = "a3"} {
+  // A3: acc->mat TINSERT uses PIPE_FIX.
+  func.func @tinsert_acc_mat_pipeline_a3(%a: memref<32x32xf32, #pto.address_space<gm>>,
+                                         %b: memref<32x32xf32, #pto.address_space<gm>>,
+                                         %i: memref<32x32xf16, #pto.address_space<gm>>,
+                                         %out: memref<32x32xf32, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+
+    %a_mat = memref.alloc() : memref<32x32xf32, #pto.address_space<mat>>
+    %b_mat = memref.alloc() : memref<32x32xf32, #pto.address_space<mat>>
+    %a_left = memref.alloc() : memref<32x32xf32, #pto.address_space<left>>
+    %b_right = memref.alloc() : memref<32x32xf32, #pto.address_space<right>>
+    %src_acc = memref.alloc() : memref<32x32xf32, #pto.address_space<acc>>
+
+    %dst_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %i_mat = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    %out_left = memref.alloc() : memref<32x32xf16, #pto.address_space<left>>
+    %i_right = memref.alloc() : memref<32x32xf16, #pto.address_space<right>>
+    %out_acc = memref.alloc() : memref<32x32xf32, #pto.address_space<acc>>
+
+    pto.tload ins(%a : memref<32x32xf32, #pto.address_space<gm>>)
+              outs(%a_mat : memref<32x32xf32, #pto.address_space<mat>>)
+    pto.tload ins(%b : memref<32x32xf32, #pto.address_space<gm>>)
+              outs(%b_mat : memref<32x32xf32, #pto.address_space<mat>>)
+    pto.tmov ins(%a_mat : memref<32x32xf32, #pto.address_space<mat>>)
+             outs(%a_left : memref<32x32xf32, #pto.address_space<left>>)
+    pto.tmov ins(%b_mat : memref<32x32xf32, #pto.address_space<mat>>)
+             outs(%b_right : memref<32x32xf32, #pto.address_space<right>>)
+    pto.tmatmul ins(%a_left, %b_right : memref<32x32xf32, #pto.address_space<left>>,
+                                      memref<32x32xf32, #pto.address_space<right>>)
+                outs(%src_acc : memref<32x32xf32, #pto.address_space<acc>>)
+
+    pto.tinsert ins(%src_acc, %c0, %c0 : memref<32x32xf32, #pto.address_space<acc>>, index, index)
+               outs(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+
+    pto.tload ins(%i : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%i_mat : memref<32x32xf16, #pto.address_space<mat>>)
+    pto.tmov ins(%dst_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%out_left : memref<32x32xf16, #pto.address_space<left>>)
+    pto.tmov ins(%i_mat : memref<32x32xf16, #pto.address_space<mat>>)
+             outs(%i_right : memref<32x32xf16, #pto.address_space<right>>)
+    pto.tmatmul ins(%out_left, %i_right : memref<32x32xf16, #pto.address_space<left>>,
+                                        memref<32x32xf16, #pto.address_space<right>>)
+                outs(%out_acc : memref<32x32xf32, #pto.address_space<acc>>)
+    pto.tstore ins(%out_acc : memref<32x32xf32, #pto.address_space<acc>>)
+               outs(%out : memref<32x32xf32, #pto.address_space<gm>>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void tinsert_acc_mat_pipeline_a3(
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TINSERT(
+// CHECK-NOT: PIPE_MTE3

--- a/test/basic/tinsert_a5_vec_mat_mode_lowering.pto
+++ b/test/basic/tinsert_a5_vec_mat_mode_lowering.pto
@@ -1,0 +1,31 @@
+// RUN: ptoas --pto-arch=a5 %s | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @tinsert_vec_mat_nd(%src_gm: memref<32x32xf16, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tload ins(%src_gm : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {layout = #pto.layout<nd>}
+    pto.tinsert ins(%src, %c0, %c0 : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, index, index)
+               outs(%dst : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @tinsert_vec_mat_nz(%src_gm: memref<32x32xf16, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tload ins(%src_gm : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {layout = #pto.layout<nz>}
+    pto.tinsert ins(%src, %c0, %c0 : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, index, index)
+               outs(%dst : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_nd(
+// CHECK: TINSERT<TInsertMode::ND>(
+
+// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_nz(
+// CHECK: TINSERT<TInsertMode::NZ>(

--- a/test/basic/tinsert_a5_vec_pipe_selection.pto
+++ b/test/basic/tinsert_a5_vec_pipe_selection.pto
@@ -1,7 +1,7 @@
 // RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
 
 module attributes {"pto.device-spec" = "Ascend950"} {
-  // A5: vec->vec TINSERT should use non-custom path (PIPE_FIX).
+  // A5: vec->vec TINSERT should use ND_VEC mode on PIPE_V.
   func.func @tinsert_vec_vec_pipeline(%a: memref<32x32xf16, #pto.address_space<gm>>) {
     %c0 = arith.constant 0 : index
     %src_vec = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
@@ -19,8 +19,7 @@ module attributes {"pto.device-spec" = "Ascend950"} {
 }
 
 // CHECK-LABEL: __global__ AICORE void tinsert_vec_vec_pipeline(
-// CHECK: set_flag(PIPE_MTE2, PIPE_FIX, EVENT_ID0);
-// CHECK: wait_flag(PIPE_MTE2, PIPE_FIX, EVENT_ID0);
-// CHECK: TINSERT(
-// CHECK: set_flag(PIPE_FIX, PIPE_V, EVENT_ID0);
-// CHECK: wait_flag(PIPE_FIX, PIPE_V, EVENT_ID0);
+// CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK: TINSERT<TInsertMode::ND_VEC>(
+// CHECK-NOT: PIPE_FIX

--- a/test/basic/tinsert_verify_a2a3_invalid_dtype.pto
+++ b/test/basic/tinsert_verify_a2a3_invalid_dtype.pto
@@ -1,0 +1,16 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a3"} {
+  func.func @tinsert_a2a3_invalid_dtype() {
+    %c0 = arith.constant 0 : index
+
+    %src = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+
+    pto.tinsert ins(%src, %c0, %c0 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, index, index)
+               outs(%dst : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tinsert' op expects A2/A3 tinsert element types to be src=f32, dst=f16/bf16

--- a/test/basic/tinsert_verify_a5_f32_ok.pto
+++ b/test/basic/tinsert_verify_a5_f32_ok.pto
@@ -1,0 +1,17 @@
+// RUN: ptoas --pto-arch=a5 %s | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @tinsert_a5_f32_to_f32_ok() {
+    %c0 = arith.constant 0 : index
+
+    %src = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+
+    pto.tinsert ins(%src, %c0, %c0 : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, index, index)
+               outs(%dst : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void tinsert_a5_f32_to_f32_ok(
+// CHECK: TINSERT(

--- a/test/basic/tinsert_verify_a5_invalid_loc.pto
+++ b/test/basic/tinsert_verify_a5_invalid_loc.pto
@@ -1,0 +1,16 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @tinsert_a5_invalid_loc() {
+    %c0 = arith.constant 0 : index
+
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+
+    pto.tinsert ins(%src, %c0, %c0 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, index, index)
+               outs(%dst : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tinsert' op expects A5 tinsert to use a supported src/dst loc pair: acc->mat, vec->mat, or vec->vec


### PR DESCRIPTION
## 背景与原因
PTO-ISA 的更新（PR561）为 A5 `TINSERT` 新增了 UB->UB（vec->vec）路径，并引入 `TInsertMode::ND_VEC`。
PTOAS 现有实现仍按旧语义处理，导致：
- A5 vec->vec 管线/pipe 归属不准确（应走 `PIPE_V`）
- EmitC 下发未按 `TInsertMode` 显式分发（无法命中新路径）
- verifier 对 A5 路径约束过窄（仅 acc->mat）

本 PR 将 PTOAS 行为与最新 PTO-ISA 语义对齐。

## 主要改动
1. `pto.tinsert` verifier 对齐
- 文件：`lib/PTO/IR/PTO.cpp`
- A3 保持：仅允许 `acc->mat`，并保留原有 dtype/layout 约束
- A5 扩展为三类合法组合：
  - `acc->mat`
  - `vec->mat`
  - `vec->vec`（ND layout）
- 同步完善 A5 dtype/layout 约束与越界检查（基于 valid shape）

2. `getPipe()` 对齐 A5 vec->vec
- 文件：`include/PTO/IR/PTOOps.td`
- A5 下：
  - `vec->vec` -> `PIPE_V`
  - `vec->mat` -> `PIPE_MTE3`
  - 其他路径（含 `acc->mat`）-> `PIPE_FIX`

3. EmitC 下发支持 `TInsertMode`
- 文件：`lib/PTO/Transforms/PTOToEmitC.cpp`
- A5 下发改为按路径选择模板参数：
  - `vec->vec` -> `TINSERT<TInsertMode::ND_VEC>(...)`
  - `vec->mat` -> `TINSERT<TInsertMode::ND/NZ>(...)`
- 对 memref 源场景，补充从配对 `tload` 的 `layout` 属性恢复 ND/NZ 的 best-effort 逻辑

## 测试覆盖
新增/更新 `test/basic`：
- 新增 `tinsert_a3_pipe_selection.pto`（A3 正向）
- 更新 `tinsert_a5_vec_pipe_selection.pto`（A5 vec->vec 走 `PIPE_V` + `ND_VEC`）
- 新增 `tinsert_a5_vec_mat_mode_lowering.pto`（A5 vec->mat 下发 `ND/NZ`）
- 新增 `tinsert_verify_a5_f32_ok.pto`（A5 正向）
- 新增 `tinsert_verify_a5_invalid_loc.pto`（A5 反向）
- 新增 `tinsert_verify_a2a3_invalid_dtype.pto`（A3 反向）

## 本地验证
- `ninja -C build ptoas` 通过
- 逐项执行上述 `tinsert` 相关 case（A3/A5 正向+反向）通过

## 影响范围
- 仅涉及 `tinsert` 的 verifier / pipe 选择 / EmitC 下发与对应测试
- 不改变其它算子语义
