### PR TITLE
fix(tinsert): follow-up for PR338 correctness gaps

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -211,6 +211,10 @@ static bool isGmAddressSpaceAttr(Attribute memorySpace) {
   return false;
 }
 
+static bool isA5DeviceSpec(StringRef spec) {
+  return spec.starts_with("Ascend950") || spec.starts_with("Ascend910_95");
+}
+
 static VerifierTargetArch getVerifierTargetArch(Operation *op) {
   auto module = op ? op->getParentOfType<ModuleOp>() : ModuleOp();
   if (!module)
@@ -218,6 +222,10 @@ static VerifierTargetArch getVerifierTargetArch(Operation *op) {
   auto arch = module->getAttrOfType<StringAttr>("pto.target_arch");
   if (arch && arch.getValue().equals_insensitive("a5"))
     return VerifierTargetArch::A5;
+  if (auto spec = module->getAttrOfType<StringAttr>("pto.device-spec")) {
+    if (isA5DeviceSpec(spec.getValue()))
+      return VerifierTargetArch::A5;
+  }
   return VerifierTargetArch::A2A3;
 }
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5728,39 +5728,116 @@ static bool isA5TargetForTInsert(pto::TInsertOp op) {
   return false;
 }
 
-static std::optional<StringRef> getA5TInsertModeToken(pto::TInsertOp op) {
-  if (!isA5TargetForTInsert(op))
+static std::optional<pto::Layout>
+getNearestTLoadLayoutForBuffer(pto::TInsertOp op, Value buffer) {
+  Block *block = op->getBlock();
+  if (!block)
     return std::nullopt;
+  pto::TLoadOp nearestWriter = nullptr;
+  for (Operation &candidate : *block) {
+    if (&candidate == op.getOperation())
+      break;
+    auto tload = dyn_cast<pto::TLoadOp>(&candidate);
+    if (!tload || tload.getDst() != buffer)
+      continue;
+    nearestWriter = tload;
+  }
+  if (!nearestWriter)
+    return std::nullopt;
+  auto layoutAttr = nearestWriter->getAttrOfType<pto::LayoutAttr>("layout");
+  if (!layoutAttr)
+    return std::nullopt;
+  auto layout = layoutAttr.getLayout();
+  if (layout != pto::Layout::ND && layout != pto::Layout::NZ)
+    return std::nullopt;
+  return layout;
+}
+
+static std::optional<pto::Layout> getLayoutFromTileConfigAttr(pto::TileBufConfigAttr cfg) {
+  if (!cfg)
+    return std::nullopt;
+  auto bl = cfg.getBLayout().getValue();
+  auto sl = cfg.getSLayout().getValue();
+  if (sl != pto::SLayout::NoneBox)
+    return pto::Layout::NZ;
+  if (bl == pto::BLayout::RowMajor)
+    return pto::Layout::ND;
+  if (bl == pto::BLayout::ColMajor)
+    return pto::Layout::DN;
+  return std::nullopt;
+}
+
+static std::optional<pto::Layout> getLayoutFromDefConfig(Value value) {
+  Operation *def = value.getDefiningOp();
+  if (!def)
+    return std::nullopt;
+  auto cfg = def->getAttrOfType<pto::TileBufConfigAttr>("config");
+  return getLayoutFromTileConfigAttr(cfg);
+}
+
+static FailureOr<std::optional<StringRef>> getA5TInsertModeToken(pto::TInsertOp op) {
+  if (!isA5TargetForTInsert(op))
+    return std::optional<StringRef>{};
   auto srcAs = getAddressSpaceFromType(op.getSrc().getType());
   auto dstAs = getAddressSpaceFromType(op.getDst().getType());
   if (!srcAs || !dstAs)
+    return failure();
+
+  auto asNDMode = [](std::optional<pto::Layout> l) -> std::optional<StringRef> {
+    if (!l)
+      return std::nullopt;
+    if (*l == pto::Layout::ND)
+      return StringRef("TInsertMode::ND");
+    if (*l == pto::Layout::NZ)
+      return StringRef("TInsertMode::NZ");
     return std::nullopt;
-  if (*srcAs == pto::AddressSpace::VEC && *dstAs == pto::AddressSpace::VEC)
-    return StringRef("TInsertMode::ND_VEC");
+  };
+
+  if (*srcAs == pto::AddressSpace::VEC && *dstAs == pto::AddressSpace::VEC) {
+    // vec->vec must be ND_VEC; only enable when ND is provable.
+    if (auto srcTb = dyn_cast<pto::TileBufType>(op.getSrc().getType())) {
+      int32_t bl = srcTb.getBLayoutValueI32();
+      int32_t sl = srcTb.getSLayoutValueI32();
+      bool srcIsND = bl == static_cast<int32_t>(pto::BLayout::RowMajor) &&
+                     sl == static_cast<int32_t>(pto::SLayout::NoneBox);
+      if (!srcIsND)
+        return failure();
+      return std::optional<StringRef>{StringRef("TInsertMode::ND_VEC")};
+    }
+    auto srcCfgLayout = getLayoutFromDefConfig(op.getSrc());
+    if (srcCfgLayout && *srcCfgLayout == pto::Layout::ND)
+      return std::optional<StringRef>{StringRef("TInsertMode::ND_VEC")};
+    auto srcLayout = getNearestTLoadLayoutForBuffer(op, op.getSrc());
+    if (srcLayout && *srcLayout == pto::Layout::ND)
+      return std::optional<StringRef>{StringRef("TInsertMode::ND_VEC")};
+    // Avoid mis-lowering unknown/non-ND memref vec->vec to ND_VEC.
+    return failure();
+  }
+
   if (*srcAs == pto::AddressSpace::VEC && *dstAs == pto::AddressSpace::MAT) {
     if (auto srcTb = dyn_cast<pto::TileBufType>(op.getSrc().getType())) {
       int32_t bl = srcTb.getBLayoutValueI32();
       int32_t sl = srcTb.getSLayoutValueI32();
       bool srcIsND = bl == static_cast<int32_t>(pto::BLayout::RowMajor) &&
                      sl == static_cast<int32_t>(pto::SLayout::NoneBox);
-      return srcIsND ? StringRef("TInsertMode::ND") : StringRef("TInsertMode::NZ");
+      bool srcIsNZ = bl != static_cast<int32_t>(pto::BLayout::RowMajor) &&
+                     sl == static_cast<int32_t>(pto::SLayout::RowMajor);
+      if (srcIsND)
+        return std::optional<StringRef>{StringRef("TInsertMode::ND")};
+      if (srcIsNZ)
+        return std::optional<StringRef>{StringRef("TInsertMode::NZ")};
+      return failure();
     }
-    // Best effort for memref path: recover from paired tload's layout attr.
-    for (Operation *user : op.getSrc().getUsers()) {
-      auto tload = dyn_cast<pto::TLoadOp>(user);
-      if (!tload || tload.getDst() != op.getSrc())
-        continue;
-      auto layoutAttr = tload->getAttrOfType<pto::LayoutAttr>("layout");
-      if (!layoutAttr)
-        continue;
-      return layoutAttr.getLayout() == pto::Layout::ND
-                 ? StringRef("TInsertMode::ND")
-                 : StringRef("TInsertMode::NZ");
-    }
-    // MemRef source loses explicit tile layout metadata; keep legacy default.
-    return StringRef("TInsertMode::NZ");
+    auto modeFromCfg = asNDMode(getLayoutFromDefConfig(op.getSrc()));
+    if (modeFromCfg)
+      return modeFromCfg;
+    auto mode = asNDMode(getNearestTLoadLayoutForBuffer(op, op.getSrc()));
+    if (mode)
+      return mode;
+    // Avoid forcing wrong default mode for unknown memref source layout.
+    return failure();
   }
-  return std::nullopt;
+  return std::optional<StringRef>{};
 }
 
 struct PTOInsertToEmitC : public OpConversionPattern<pto::TInsertOp> {
@@ -5777,9 +5854,14 @@ struct PTOInsertToEmitC : public OpConversionPattern<pto::TInsertOp> {
     Value c0  = peelUnrealized(adaptor.getIndexCol());
 
     ArrayAttr templateArgs = ArrayAttr{};
-    if (auto modeTok = getA5TInsertModeToken(op)) {
+    auto modeTokOr = getA5TInsertModeToken(op);
+    if (failed(modeTokOr))
+      return op.emitOpError(
+          "cannot safely infer A5 tinsert mode for current src/dst; "
+          "use tile_buf ND/NZ layout or make nearest preceding tload set explicit layout");
+    if (modeTokOr->has_value()) {
       templateArgs = rewriter.getArrayAttr(
-          {emitc::OpaqueAttr::get(ctx, modeTok->str())});
+          {emitc::OpaqueAttr::get(ctx, modeTokOr->value().str())});
     }
 
     rewriter.create<emitc::CallOpaqueOp>(

--- a/test/basic/tinsert_a5_vec_mat_mode_lowering.pto
+++ b/test/basic/tinsert_a5_vec_mat_mode_lowering.pto
@@ -22,10 +22,46 @@ module attributes {"pto.target_arch" = "a5"} {
                outs(%dst : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
     return
   }
+
+  // memref source: choose mode from nearest preceding writer to %src.
+  func.func @tinsert_vec_mat_memref_last_writer_nz(%src0: memref<32x32xf16, #pto.address_space<gm>>,
+                                                    %src1: memref<32x32xf16, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %src = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
+    %dst = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    pto.tload ins(%src0 : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : memref<32x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nd>}
+    pto.tload ins(%src1 : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : memref<32x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nz>}
+    pto.tinsert ins(%src, %c0, %c0 : memref<32x32xf16, #pto.address_space<vec>>, index, index)
+               outs(%dst : memref<32x32xf16, #pto.address_space<mat>>)
+    return
+  }
+
+  // memref source: choose mode from nearest preceding writer to %src.
+  func.func @tinsert_vec_mat_memref_last_writer_nd(%src0: memref<32x32xf16, #pto.address_space<gm>>,
+                                                    %src1: memref<32x32xf16, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %src = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
+    %dst = memref.alloc() : memref<32x32xf16, #pto.address_space<mat>>
+    pto.tload ins(%src0 : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : memref<32x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nz>}
+    pto.tload ins(%src1 : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : memref<32x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nd>}
+    pto.tinsert ins(%src, %c0, %c0 : memref<32x32xf16, #pto.address_space<vec>>, index, index)
+               outs(%dst : memref<32x32xf16, #pto.address_space<mat>>)
+    return
+  }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_nd(
+// CHECK-LABEL: AICORE void tinsert_vec_mat_nd(
 // CHECK: TINSERT<TInsertMode::ND>(
 
-// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_nz(
+// CHECK-LABEL: AICORE void tinsert_vec_mat_nz(
 // CHECK: TINSERT<TInsertMode::NZ>(
+
+// CHECK-LABEL: AICORE void tinsert_vec_mat_memref_last_writer_nz(
+// CHECK: TINSERT<TInsertMode::NZ>(
+
+// CHECK-LABEL: AICORE void tinsert_vec_mat_memref_last_writer_nd(
+// CHECK: TINSERT<TInsertMode::ND>(

--- a/test/basic/tinsert_a5_vec_vec_mode_infer_fail.pto
+++ b/test/basic/tinsert_a5_vec_vec_mode_infer_fail.pto
@@ -1,0 +1,17 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  // vec->vec with memref source written as NZ is not legal ND_VEC input.
+  func.func @tinsert_a5_vec_vec_mode_infer_fail(%src_gm: memref<32x32xf16, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %src = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
+    %dst = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
+    pto.tload ins(%src_gm : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : memref<32x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nz>}
+    pto.tinsert ins(%src, %c0, %c0 : memref<32x32xf16, #pto.address_space<vec>>, index, index)
+               outs(%dst : memref<32x32xf16, #pto.address_space<vec>>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tinsert' op cannot safely infer A5 tinsert mode for current src/dst

--- a/test/basic/tinsert_verify_a5_device_spec_ok.pto
+++ b/test/basic/tinsert_verify_a5_device_spec_ok.pto
@@ -1,0 +1,15 @@
+// RUN: ptoas %s | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend950"} {
+  func.func @tinsert_a5_device_spec_tilebuf_ok() {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tinsert ins(%src, %c0, %c0 : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, index, index)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tinsert_a5_device_spec_tilebuf_ok(
+// CHECK: TINSERT<TInsertMode::ND_VEC>(


### PR DESCRIPTION
## 背景
PR #338 合入后，自动 review 暴露了 3 个 A5 `tinsert` 相关 correctness/regression 风险：
- vec->vec memref 路径 mode 推断过于激进（直接 ND_VEC）
- vec->mat memref 模式选择会从错误 writer 取 layout，且未知时错误回退 NZ
- verifier 架构识别与 lowering 侧对 `pto.device-spec` 的处理不一致

本 PR 作为 follow-up，仅修复上述问题。

## 修复内容
1. A5 mode 推断改为“保守可证明”
- 文件：`lib/PTO/Transforms/PTOToEmitC.cpp`
- `vec->vec`：仅在可证明 ND 时下发 `ND_VEC`，否则报错
- `vec->mat`：不再默认回退 `NZ`，未知时报错避免错代码

2. memref writer 选择改为最近前驱写入者
- 文件：`lib/PTO/Transforms/PTOToEmitC.cpp`
- 不再遍历所有 users 取任意 `tload`
- 改为当前 block 内、`tinsert` 之前、写入同一 buffer 的最近 `tload`

3. verifier 架构识别补齐 `pto.device-spec`
- 文件：`lib/PTO/IR/PTO.cpp`
- `Ascend950` / `Ascend910_95*` 按 A5 识别，和 pipe/lowering 一致

## 测试
- 更新：`test/basic/tinsert_a5_vec_mat_mode_lowering.pto`
  - 覆盖“同一 buffer 多次写入，按最近 writer 取 mode”
- 新增：`test/basic/tinsert_a5_vec_vec_mode_infer_fail.pto`
  - 覆盖 vec->vec 非 ND 推断失败（应报错）
- 新增：`test/basic/tinsert_verify_a5_device_spec_ok.pto`
  - 覆盖仅 `pto.device-spec` 情况下按 A5 语义通过

## 本地验证
- `ninja -C build ptoas` 通过
- 相关 A3/A5 tinsert 正向/反向 case 全部通过
