### PR TITLE
fix: stabilize A5 scatter and gatherb validation

### DIFF
--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -1022,11 +1022,11 @@ def generate_testcase(
     init_ptrs = list(data_ptrs)
     output_ptrs = [p for p in data_ptrs if p["role"] == "output"]
 
-    ptr_elem_counts = {p["name"]: logical_elem_count for p in data_ptrs}
     inferred_counts = _infer_gm_pointer_elem_counts(raw_kernel_for_analysis, pointer_param_names)
-    for name, cnt in inferred_counts.items():
-        if name in ptr_elem_counts:
-            ptr_elem_counts[name] = max(ptr_elem_counts.get(name, logical_elem_count), cnt)
+    ptr_elem_counts = {}
+    for p in data_ptrs:
+        inferred = inferred_counts.get(p["name"])
+        ptr_elem_counts[p["name"]] = int(inferred) if inferred and int(inferred) > 0 else logical_elem_count
 
     templates_root = Path(__file__).resolve().parents[1] / "templates"
     template = (templates_root / "main_template.cpp").read_text(encoding="utf-8")
@@ -1182,14 +1182,19 @@ def generate_testcase(
     golden_template = (templates_root / "golden_template.py").read_text(encoding="utf-8")
     input_generate = []
     elem_count = logical_elem_count
+    kernel_has_tscatter = "TSCATTER" in raw_kernel
+    kernel_has_tgather = "TGATHER" in raw_kernel
+    kernel_has_tgatherb = "TGATHERB" in raw_kernel
     # Some kernels use an integer tensor as "indices". The safe in-range domain
-    # depends on the op semantics (see pto-isa docs):
-    # - TSCATTER: indices are linear indices in [0, rows*cols)
-    # - TGATHER/TGATHERB: indices are linear indices in [0, rows*cols)
+    # depends on the op semantics:
+    # - TSCATTER: use a deterministic, collision-free permutation so NPU-vs-NPU
+    #   golden mode stays stable across runs.
+    # - TGATHER: indices are linear indices in [0, rows*cols).
+    # - TGATHERB: offsets are block addresses (bytes), not per-element indices.
     index_mod = None
-    if "TSCATTER" in raw_kernel:
+    if kernel_has_tscatter:
         index_mod = max(elem_count, 1)
-    elif any(m in raw_kernel for m in ("TGATHER", "TGATHERB")):
+    elif kernel_has_tgather and not kernel_has_tgatherb:
         index_mod = max(elem_count, 1)
     mrgsort_packed = "TMRGSORT" in raw_kernel
     for p in init_ptrs:
@@ -1197,6 +1202,10 @@ def generate_testcase(
         name = p["name"]
         size = ptr_elem_counts.get(name, elem_count)
         is_output = p.get("role") == "output"
+        is_integer = np_dtype.startswith("np.int") or np_dtype.startswith("np.uint")
+        is_tscatter_indices = kernel_has_tscatter and p.get("role") == "input" and is_integer and size == elem_count
+        is_tgatherb_offset = kernel_has_tgatherb and p.get("role") == "input" and is_integer and size < elem_count
+        is_tgatherb_src = kernel_has_tgatherb and p.get("role") == "input" and not is_tgatherb_offset
         # If the kernel has both inputs and outputs, default to zero-init for
         # output buffers to match pto-isa ST conventions (and improve determinism).
         zero_init = is_output and len(init_ptrs) > 1
@@ -1262,7 +1271,23 @@ def generate_testcase(
                 input_generate.append(f"    {name}__packed['pad'] = np.uint16(0)")
             input_generate.append(f"    {name}__packed['i'] = {name}__idx")
             input_generate.append(f"    {name}__packed.tofile(\"{name}.bin\")")
-        elif np_dtype.startswith("np.int") or np_dtype.startswith("np.uint"):
+        elif is_tscatter_indices:
+            input_generate.append(f"    {name}__cols = np.arange({cols}, dtype=np.int64).reshape(1, {cols})")
+            input_generate.append(f"    {name}__row_perm = np.random.permutation({rows}).astype(np.int64).reshape({rows}, 1)")
+            input_generate.append(
+                f"    {name} = ({name}__row_perm * {cols} + {name}__cols).astype({np_dtype}).reshape(-1)"
+            )
+            input_generate.append(f"    {name}.tofile(\"{name}.bin\")")
+        elif is_tgatherb_offset:
+            input_generate.append(f"    {name} = (np.arange({size}, dtype=np.uint32) * 32).astype({np_dtype})")
+            input_generate.append(f"    {name}.tofile(\"{name}.bin\")")
+        elif is_tgatherb_src:
+            if is_integer:
+                input_generate.append(f"    {name} = np.arange({size}, dtype=np.int64).astype({np_dtype})")
+            else:
+                input_generate.append(f"    {name} = np.arange({size}, dtype=np.float32).astype({np_dtype})")
+            input_generate.append(f"    {name}.tofile(\"{name}.bin\")")
+        elif is_integer:
             if index_mod is not None:
                 input_generate.append(
                     f"    {name} = (np.arange({size}, dtype=np.int64) % {index_mod}).astype({np_dtype})"
@@ -1487,6 +1512,13 @@ endif()
     compare_template = (templates_root / "compare_template.py").read_text(encoding="utf-8")
     compare_lines = ["    ok = True"]
     compare_prefix_counts = {}
+    tscatter_indices_input = None
+    if kernel_has_tscatter:
+        for p in init_ptrs:
+            p_dtype = _np_dtype_for_cpp(p["cpp_type"])
+            if p.get("role") == "input" and (p_dtype.startswith("np.int") or p_dtype.startswith("np.uint")):
+                tscatter_indices_input = p
+                break
     for p in output_ptrs:
         name = p["name"]
         req = inferred_counts.get(name)
@@ -1505,7 +1537,12 @@ endif()
         np_dtype = _np_dtype_for_cpp(p["cpp_type"])
         name = p["name"]
         eps = _default_eps_for_cpp_type(p["cpp_type"])
-        if has_packed_pred_mask and p["cpp_type"] in {"uint8_t", "int8_t"}:
+        if kernel_has_tscatter and tscatter_indices_input is not None:
+            compare_lines.append(
+                f"    ok = compare_bin_at_indices(\"golden_{name}.bin\", \"{name}.bin\", {np_dtype}, {eps}, "
+                f"\"{tscatter_indices_input['name']}.bin\", {_np_dtype_for_cpp(tscatter_indices_input['cpp_type'])}) and ok"
+            )
+        elif has_packed_pred_mask and p["cpp_type"] in {"uint8_t", "int8_t"}:
             compare_lines.append(
                 f"    ok = compare_packed_pred_mask(\"golden_{name}.bin\", \"{name}.bin\", {rows}, {cols}) and ok"
             )

--- a/test/npu_validation/templates/compare_template.py
+++ b/test/npu_validation/templates/compare_template.py
@@ -94,6 +94,66 @@ def compare_bin_prefix(golden_path, output_path, dtype, eps, count):
     return True
 
 
+def compare_bin_at_indices(golden_path, output_path, dtype, eps, indices_path, indices_dtype):
+    if not os.path.exists(output_path):
+        print(f"[ERROR] Output missing: {output_path}")
+        return False
+    if not os.path.exists(golden_path):
+        print(f"[ERROR] Golden missing: {golden_path}")
+        return False
+    if not os.path.exists(indices_path):
+        print(f"[ERROR] Indices missing: {indices_path}")
+        return False
+
+    dtype_np = np.dtype(dtype)
+    indices_dtype_np = np.dtype(indices_dtype)
+    golden = np.fromfile(golden_path, dtype=dtype_np)
+    output = np.fromfile(output_path, dtype=dtype_np)
+    indices = np.fromfile(indices_path, dtype=indices_dtype_np)
+
+    if golden.shape != output.shape:
+        print(f"[ERROR] Shape mismatch: {golden_path} {golden.shape} vs {output_path} {output.shape}")
+        return False
+
+    if indices.size == 0:
+        return True
+
+    indices_i64 = indices.astype(np.int64, copy=False)
+    if np.any(indices_i64 < 0) or np.any(indices_i64 >= golden.size):
+        bad = int(np.nonzero((indices_i64 < 0) | (indices_i64 >= golden.size))[0][0])
+        print(
+            f"[ERROR] Indexed compare out of range at idx={bad} "
+            f"(value={indices_i64[bad]}, limit={golden.size})"
+        )
+        return False
+
+    golden_sel = golden[indices_i64]
+    output_sel = output[indices_i64]
+    if not np.allclose(golden_sel, output_sel, atol=eps, rtol=eps, equal_nan=True):
+        if golden_sel.size:
+            if np.issubdtype(dtype_np, np.floating):
+                g = golden_sel.astype(np.float64, copy=False)
+                o = output_sel.astype(np.float64, copy=False)
+            elif np.issubdtype(dtype_np, np.integer) or np.issubdtype(dtype_np, np.unsignedinteger):
+                g = golden_sel.astype(np.int64, copy=False)
+                o = output_sel.astype(np.int64, copy=False)
+            else:
+                g = golden_sel.astype(np.float64, copy=False)
+                o = output_sel.astype(np.float64, copy=False)
+            abs_diff = np.abs(g - o)
+            pos = int(np.argmax(abs_diff))
+            diff = float(abs_diff[pos])
+            src_idx = int(indices_i64[pos])
+            print(
+                f"[ERROR] Mismatch (indexed): {golden_path} vs {output_path}, max diff={diff} at output_idx={src_idx} "
+                f"(golden={g[pos]}, out={o[pos]}, dtype={dtype_np})"
+            )
+        else:
+            print(f"[ERROR] Mismatch (indexed): {golden_path} vs {output_path}, empty indexed selection, dtype={dtype_np}")
+        return False
+    return True
+
+
 def compare_packed_pred_mask(golden_path, output_path, rows, cols):
     """
     Compare outputs of pto.tcmp / pto.tcmps.

--- a/test/samples/Gatherb/gatherb.py
+++ b/test/samples/Gatherb/gatherb.py
@@ -1,6 +1,5 @@
-from mlir.ir import Context, Location, Module, InsertionPoint
-from mlir.dialects import func, arith, pto
-from mlir.ir import F32Type, IndexType, IntegerType
+from mlir.dialects import arith, func, pto
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
 
 
 def build():
@@ -8,76 +7,67 @@ def build():
         pto.register_dialect(ctx, load=True)
 
         with Location.unknown(ctx):
-            m = Module.create()
+            module = Module.create()
 
             f32 = F32Type.get(ctx)
-            ptr_f32 = pto.PtrType.get(f32, ctx)
-            tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
-
             u32 = IntegerType.get_unsigned(32, ctx)
+
+            ptr_f32 = pto.PtrType.get(f32, ctx)
             ptr_u32 = pto.PtrType.get(u32, ctx)
+            tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
             tv2_u32 = pto.TensorViewType.get(2, u32, ctx)
 
-            tile_view_f32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
-            tile_view_u32 = pto.PartitionTensorViewType.get([32, 32], u32, ctx)
+            src_rows = 2
+            src_cols = 128
+            offset_rows = 2
+            offset_cols = 16
+
+            tile_view_f32 = pto.PartitionTensorViewType.get([src_rows, src_cols], f32, ctx)
+            tile_view_u32 = pto.PartitionTensorViewType.get([offset_rows, offset_cols], u32, ctx)
 
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+            cfg = pto.TileBufConfigAttr.get(bl, sl, pto.TileConfig.fractalABSize, pd, ctx)
 
-            fractal_ab_size = pto.TileConfig.fractalABSize
-            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
-            tile_buf_f32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
-            tile_buf_u32 = pto.TileBufType.get([32, 32], u32, vec, [32, 32], cfg, ctx)
+            tile_buf_f32 = pto.TileBufType.get([src_rows, src_cols], f32, vec, [src_rows, src_cols], cfg, ctx)
+            tile_buf_u32 = pto.TileBufType.get([offset_rows, offset_cols], u32, vec, [offset_rows, offset_cols], cfg, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_u32, ptr_f32], [])
-            with InsertionPoint(m.body):
+            with InsertionPoint(module.body):
                 fn = func.FuncOp("vec_add_kernel_2d", fn_ty)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):
-                # constants
                 c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
                 c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
-                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+                c2 = arith.ConstantOp(IndexType.get(ctx), src_rows).result
+                c128 = arith.ConstantOp(IndexType.get(ctx), src_cols).result
+                c16 = arith.ConstantOp(IndexType.get(ctx), offset_cols).result
 
-                arg0, arg1, arg2 = entry.arguments
+                src_ptr, offset_ptr, dst_ptr = entry.arguments
 
-                # %0/%1/%2 = pto.make_tensor_view %arg?, shape=[%c32,%c32] strides=[%c32,%c1]
-                # 这里用原生 builder：通常签名会是 (result_type, ptr, shape, strides)
-                tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_u32, arg1, [c32, c32], [c32, c1]).result
-                tv2 = pto.MakeTensorViewOp(tv2_f32, arg2, [c32, c32], [c32, c1]).result
+                src_tv = pto.MakeTensorViewOp(tv2_f32, src_ptr, [c2, c128], [c128, c1]).result
+                offset_tv = pto.MakeTensorViewOp(tv2_u32, offset_ptr, [c2, c16], [c16, c1]).result
+                dst_tv = pto.MakeTensorViewOp(tv2_f32, dst_ptr, [c2, c128], [c128, c1]).result
 
-                # %3/%4/%8 = pto.subview %tv, offsets=[%c0,%c0], sizes=[32,32]
-                sv0 = pto.PartitionViewOp(tile_view_f32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
-                sv1 = pto.PartitionViewOp(tile_view_u32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
+                src_view = pto.PartitionViewOp(tile_view_f32, src_tv, offsets=[c0, c0], sizes=[c2, c128]).result
+                offset_view = pto.PartitionViewOp(tile_view_u32, offset_tv, offsets=[c0, c0], sizes=[c2, c16]).result
+                dst_view = pto.PartitionViewOp(tile_view_f32, dst_tv, offsets=[c0, c0], sizes=[c2, c128]).result
 
-                # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
-                tb0 = pto.AllocTileOp(tile_buf_f32).result
-                tb1 = pto.AllocTileOp(tile_buf_u32).result
-                tb2 = pto.AllocTileOp(tile_buf_f32).result
+                src_tile = pto.AllocTileOp(tile_buf_f32).result
+                offset_tile = pto.AllocTileOp(tile_buf_u32).result
+                dst_tile = pto.AllocTileOp(tile_buf_f32).result
 
-                # pto.load_dps_tb ins(%sv) outs(%tb)
-                # 原生 builder 一般会把 optional operands/attrs 做成可选参数
-                # valid_dims 这里不给
-                pto.TLoadOp(None, sv0, tb0)  # result=None
-                pto.TLoadOp(None, sv1, tb1)  # result=None
-
-                # pto.addf_dps_tb ins(%tb0,%tb1) outs(%tb2)
-                # 你在 ODS 里提供了 builders (lhs,rhs,dst) 版本，所以这里直接这么构造
-                pto.TGatherBOp(tb0, tb1, tb2)
-
-                # %8 = subview on output tensor_view
-                sv2 = pto.PartitionViewOp(tile_view_f32, tv2, offsets=[c0, c0], sizes=[c32, c32]).result
-
-                # pto.store_dps_tb ins(%tb2) outs(%sv2)
-                pto.TStoreOp(None, tb2, sv2)
-
+                pto.TLoadOp(None, src_view, src_tile)
+                pto.TLoadOp(None, offset_view, offset_tile)
+                pto.TGatherBOp(src_tile, offset_tile, dst_tile)
+                pto.TStoreOp(None, dst_tile, dst_view)
                 func.ReturnOp([])
-            m.operation.verify()
-            return m
+
+            module.operation.verify()
+            return module
 
 
 if __name__ == "__main__":

--- a/test/samples/Scatter/scatter.py
+++ b/test/samples/Scatter/scatter.py
@@ -1,6 +1,5 @@
-from mlir.ir import Context, Location, Module, InsertionPoint
-from mlir.dialects import func, arith, pto
-from mlir.ir import F32Type, IndexType, IntegerType
+from mlir.dialects import arith, func, pto
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
 
 
 def build():
@@ -8,73 +7,64 @@ def build():
         pto.register_dialect(ctx, load=True)
 
         with Location.unknown(ctx):
-            m = Module.create()
+            module = Module.create()
 
             f32 = F32Type.get(ctx)
+            u32 = IntegerType.get_unsigned(32, ctx)
+
+            rows = 32
+            cols = 64
+
             ptr_f32 = pto.PtrType.get(f32, ctx)
+            ptr_u32 = pto.PtrType.get(u32, ctx)
             tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
+            tv2_u32 = pto.TensorViewType.get(2, u32, ctx)
 
-            i32 = IntegerType.get_signless(32, ctx)
-            ptr_i32 = pto.PtrType.get(i32, ctx)
-            tv2_i32 = pto.TensorViewType.get(2, i32, ctx)
-
-            tile_view_f32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
-            tile_view_i32 = pto.PartitionTensorViewType.get([32, 32], i32, ctx)
+            tile_view_f32 = pto.PartitionTensorViewType.get([rows, cols], f32, ctx)
+            tile_view_u32 = pto.PartitionTensorViewType.get([rows, cols], u32, ctx)
 
             vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
             bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
             sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
             pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+            cfg = pto.TileBufConfigAttr.get(bl, sl, pto.TileConfig.fractalABSize, pd, ctx)
 
-            fractal_ab_size = pto.TileConfig.fractalABSize
-            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
-            tile_buf_f32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
-            tile_buf_i32 = pto.TileBufType.get([32, 32], i32, vec, [32, 32], cfg, ctx)
+            tile_buf_f32 = pto.TileBufType.get([rows, cols], f32, vec, [rows, cols], cfg, ctx)
+            tile_buf_u32 = pto.TileBufType.get([rows, cols], u32, vec, [rows, cols], cfg, ctx)
 
-            fn_ty = func.FunctionType.get([ptr_f32, ptr_i32, ptr_f32], [])
-            with InsertionPoint(m.body):
+            fn_ty = func.FunctionType.get([ptr_f32, ptr_u32, ptr_f32], [])
+            with InsertionPoint(module.body):
                 fn = func.FuncOp("Scatter_kernel_2d", fn_ty)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):
-                # constants
                 c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
                 c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
-                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+                c32 = arith.ConstantOp(IndexType.get(ctx), rows).result
+                c64 = arith.ConstantOp(IndexType.get(ctx), cols).result
 
-                arg0, arg1, arg2 = entry.arguments
+                src_ptr, indices_ptr, dst_ptr = entry.arguments
 
-                # %0/%1/%2 = pto.make_tensor_view %arg?, shape=[%c32,%c32] strides=[%c32,%c1]
-                tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_i32, arg1, [c32, c32], [c32, c1]).result
-                tv2 = pto.MakeTensorViewOp(tv2_f32, arg2, [c32, c32], [c32, c1]).result
+                src_tv = pto.MakeTensorViewOp(tv2_f32, src_ptr, [c32, c64], [c64, c1]).result
+                indices_tv = pto.MakeTensorViewOp(tv2_u32, indices_ptr, [c32, c64], [c64, c1]).result
+                dst_tv = pto.MakeTensorViewOp(tv2_f32, dst_ptr, [c32, c64], [c64, c1]).result
 
-                # %3/%4/%8 = pto.subview %tv, offsets=[%c0,%c0], sizes=[32,32]
-                sv0 = pto.PartitionViewOp(tile_view_f32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
-                sv1 = pto.PartitionViewOp(tile_view_i32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
+                src_view = pto.PartitionViewOp(tile_view_f32, src_tv, offsets=[c0, c0], sizes=[c32, c64]).result
+                indices_view = pto.PartitionViewOp(tile_view_u32, indices_tv, offsets=[c0, c0], sizes=[c32, c64]).result
+                dst_view = pto.PartitionViewOp(tile_view_f32, dst_tv, offsets=[c0, c0], sizes=[c32, c64]).result
 
-                # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
-                tb0 = pto.AllocTileOp(tile_buf_f32).result
-                tb1 = pto.AllocTileOp(tile_buf_i32).result
-                tb2 = pto.AllocTileOp(tile_buf_f32).result
+                src_tile = pto.AllocTileOp(tile_buf_f32).result
+                indices_tile = pto.AllocTileOp(tile_buf_u32).result
+                dst_tile = pto.AllocTileOp(tile_buf_f32).result
 
-                # pto.load_dps_tb ins(%sv) outs(%tb)
-                pto.TLoadOp(None, sv0, tb0)  # result=None
-                pto.TLoadOp(None, sv1, tb1)  # result=None
-
-                # pto.addf_dps_tb ins(%tb0,%tb1) outs(%tb2)
-                pto.TScatterOp(tb0, tb1, tb2)
-
-                # %8 = subview on output tensor_view
-                sv2 = pto.PartitionViewOp(tile_view_f32, tv2, offsets=[c0, c0], sizes=[c32, c32]).result
-
-                # pto.store_dps_tb ins(%tb2) outs(%sv2)
-                pto.TStoreOp(None, tb2, sv2)
-
+                pto.TLoadOp(None, src_view, src_tile)
+                pto.TLoadOp(None, indices_view, indices_tile)
+                pto.TScatterOp(src_tile, indices_tile, dst_tile)
+                pto.TStoreOp(None, dst_tile, dst_view)
                 func.ReturnOp([])
 
-            m.operation.verify()
-            return m
+            module.operation.verify()
+            return module
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stabilize `scatter`/`gatherb` board validation inputs so indexed compares stay deterministic
- honor `pto.target_arch=a5` when selecting the `TSCATTER` sync pipe
- add A3/A5 pipe-selection regression tests for `pto.tscatter`

## Validation
- local: `ptoas --pto-arch a3 --enable-insert-sync test/basic/tscatter_a3_pipe_selection.pto`
- local: `ptoas --pto-arch a5 --enable-insert-sync test/basic/tscatter_a5_pipe_selection.pto`
- local: `bash test/samples/runop.sh --enablebc -t Scatter`
- local: `bash test/samples/runop.sh --enablebc -t Gatherb`
- local: `python3 test/npu_validation/scripts/generate_testcase.py ...` smoke for `scatter` / `gatherb`
- A5 board: `192.168.1.28` device `1`, `RUN_ONLY_CASES=scatter,gatherb`, result `OK=2 FAIL=0 SKIP=0`
  - remote log: `/tmp/ptoas_a5_scatter_gatherb_20260324_153930/run.log`
  - remote results: `/tmp/ptoas_a5_scatter_gatherb_20260324_153930/results.tsv`
