### PR TITLE
fix: align reserve_buffer handling across planning modes

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -6625,7 +6625,8 @@ generated IR. The detailed design document is:
 ##### `pto.reserve_buffer` - Reserve Local Consumer FIFO Buffer
 
 **Summary:** Declares a local reserved FIFO buffer region for the consumer side
-of one frontend logical pipe.
+of one frontend logical pipe. The valid way to write this op depends on
+whether the active PTOAS compilation flow enables local address planning.
 
 **Syntax:**
 
@@ -6635,6 +6636,18 @@ of one frontend logical pipe.
   size = 8192,
   location = #pto.address_space<vec>,
   auto = true
+} -> i32
+```
+
+When the address is already fixed in the input IR:
+
+```mlir
+%buf = pto.reserve_buffer {
+  name = "c2v_fifo",
+  size = 8192,
+  location = #pto.address_space<vec>,
+  auto = false,
+  base = 4096
 } -> i32
 ```
 
@@ -6651,8 +6664,17 @@ of one frontend logical pipe.
 **Constraints & Verification:**
 
 - At most one `pto.reserve_buffer` is expected in one function
-- `auto = false` requires explicit `base`
 - `location` must be a supported local address space
+- Op-level verification requires:
+  - `auto = false` must provide `base`
+  - `auto = true` must not provide `base`
+- Pipeline compatibility requires:
+  - if the active compilation flow enables local address planning: write
+    `auto = true` and omit `base`; `PlanMemory` assigns the address and
+    `pto-resolve-reserved-buffers` materializes it
+  - if the active compilation flow skips local address planning: write
+    `auto = false` with explicit `base`; `pto-resolve-reserved-buffers` only
+    propagates the pre-resolved address
 
 ##### `pto.import_reserved_buffer` - Import Peer Reserved FIFO Buffer
 
@@ -6679,6 +6701,11 @@ function's reserved buffer declaration.
 
 - At most one `pto.import_reserved_buffer` is expected in one function
 - `peer_func` must contain a matching `pto.reserve_buffer`
+- The imported address is resolved by `pto-resolve-reserved-buffers`
+  - from the peer `reserve_buffer.base` filled by `PlanMemory` when the active
+    compilation flow enables local address planning
+  - from the peer's explicit `base` when the active compilation flow skips
+    local address planning
 
 ##### `pto.aic_initialize_pipe` - Frontend Cube Pipe Initialization
 

--- a/docs/designs/ptoas-tpush-tpop-design.md
+++ b/docs/designs/ptoas-tpush-tpop-design.md
@@ -149,7 +149,8 @@ pto.tfree_from_aiv { split = 0 }
 
 #### `pto.reserve_buffer`
 
-用于在当前函数内声明一块 consumer slot buffer 预留空间。
+用于在当前函数内声明一块 consumer slot buffer 预留空间。其合法写法由
+当前编译流程是否启用 local address planning 决定。
 
 ```mlir
 %buf = pto.reserve_buffer {
@@ -179,15 +180,18 @@ pto.tfree_from_aiv { split = 0 }
 | `name` | 字符串属性 | 本函数内唯一的预留段名字 |
 | `size` | 整数属性 | 预留字节数 |
 | `location` | 地址空间属性 | 预留空间所在 local 地址空间 |
-| `auto` | `bool` 属性 | 函数级地址分配模式；`true` 表示本函数 local 地址由 plan memory 统一分配；`false` 表示本函数使用显式 local 地址，plan memory 不再为本函数分配 local 地址 |
-| `base` | 可选整数属性 | 起始地址；与 `auto` 分别表达地址值和分配策略 |
+| `auto` | `bool` 属性 | 地址解析路径标志；`true` 表示地址由 PTOAS 地址规划路径分配，`false` 表示地址已在输入 IR 中显式给定 |
+| `base` | 可选整数属性 | 显式起始地址；仅 manual 路径使用 |
 
 #### 结果
 
 - 结果类型为 `i32`
 - 结果值表示该 buffer 当前可用的基址
 - 当前可用基址可来自显式 `base`，也可来自 plan memory 回填后的解析地址
-- 在当前约束下，每个函数最多一条 `reserve_buffer`；该 `reserve_buffer.auto` 用于决定该函数采用 `auto` 模式还是 `manual` 模式
+- 在当前约束下，每个函数最多一条 `reserve_buffer`
+- 编译路径与 `auto` 的合法组合只有两种：
+  - 启用 local address planning：`auto = true`，且不带 `base`
+  - 跳过 local address planning：`auto = false`，且显式提供 `base`
 
 #### `pto.import_reserved_buffer`
 
@@ -227,8 +231,10 @@ pto.tfree_from_aiv { split = 0 }
 - C2V consumer 的 `reserve_buffer.location` 必须是 `VEC`
 - V2C consumer 的 `reserve_buffer.location` 必须是 `MAT`
 - `reserve_buffer.name` 在本函数内必须唯一
-- `reserve_buffer.auto = false` 时必须提供 `base`，且该函数进入 manual 地址模式
-- `reserve_buffer.auto = true` 时必须不提供 `base`，且该函数进入 auto 地址模式，由 plan memory 统一分配本函数 local 地址
+- op 级约束：`reserve_buffer.auto = false` 时必须提供 `base`
+- op 级约束：`reserve_buffer.auto = true` 时必须不提供 `base`
+- 启用 local address planning 的编译流程：`reserve_buffer` 只允许 `auto = true`
+- 跳过 local address planning 的编译流程：`reserve_buffer` 只允许 `auto = false` 且显式提供 `base`
 - `import_reserved_buffer` 必须能在 `peer_func` 中找到同名 `reserve_buffer`
 
 ## 4. 核心约定
@@ -478,12 +484,12 @@ pto.tfree(%pipe) { split = 0 }
 - `reserve_buffer` 只表示本函数 consumer slot buffer 的本地预留
 - `import_reserved_buffer` 只表示对 peer 预留段地址的引用
 - `reserve_buffer` 用属性描述“如何得到地址”，用结果值统一承载“当前可用地址”
-- `reserve_buffer.auto` 决定函数级 local 地址分配模式
-- `auto = true` 时，plan memory 负责本函数全部 local 地址分配
-- `auto = false` 时，本函数 local 地址视为已整体定版，plan memory 不再为本函数分配 local 地址
+- 当前编译流程是否启用 local address planning 与 `reserve_buffer.auto` 共同决定地址处理路径
+- 启用 local address planning：`reserve_buffer` 必须使用 `auto = true`，由 `PlanMemory` 分配地址
+- 跳过 local address planning：`reserve_buffer` 必须使用 `auto = false` 且显式提供 `base`，不再进入 `PlanMemory` 分配路径
 - PTOAS 复用现有 `PlanMemory` pass 实现 `reserve_buffer` 地址确定，不额外增加独立的预分配 pass
 - PTOAS 新增独立地址传播 pass，专门处理 `import_reserved_buffer` 常量替换与 peer pipe 的 `flag_base` 对齐
-- 地址传播 pass 在 plan memory 之后运行，将 `import_reserved_buffer` 替换为 peer 的已解析地址
+- 地址传播 pass 在 EmitC 之前运行；启用规划时位于 plan memory 之后，跳过规划时直接消费前端已给定地址
 
 ### 7.2 使用规则
 
@@ -499,18 +505,29 @@ pto.tfree(%pipe) { split = 0 }
 - Cube function 需要 `reserve_buffer(location = MAT)`
 - Vector function 需要 `import_reserved_buffer(peer_func = @cube_kernel)`
 
-### 7.3 函数级地址分配模式
+### 7.3 编译路径与地址处理路径
 
-对包含 `reserve_buffer` 的函数，PTOAS 读取该唯一 `reserve_buffer` 的 `auto` 选择函数级模式：
+对包含 `reserve_buffer` 的函数，PTOAS 按当前编译流程是否启用 local address planning 以及 `auto` 的组合选择地址处理路径：
 
-- `auto = true`：该函数进入 auto 模式
-- `auto = false`：该函数进入 manual 模式
+- 启用 local address planning + `auto = true`
+  - 进入 auto 路径
+  - 由 `PlanMemory` 为 `reserve_buffer` 分配 `base`
+  - 随后由 `pto-resolve-reserved-buffers` 传播地址并完成 peer `flag_base` 对齐
+- 跳过 local address planning + `auto = false` + 显式 `base`
+  - 进入 manual 路径
+  - 跳过 `PlanMemory`
+  - 由 `pto-resolve-reserved-buffers` 直接传播已给定地址并完成 peer `flag_base` 对齐
 
-若函数内不存在 `reserve_buffer`，则保持现有 `PlanMemory` 行为，不引入额外模式切换。
+以下组合均非法：
 
-### 7.4 auto 模式下的 plan memory 规则
+- 启用 local address planning + `auto = false`
+- 跳过 local address planning + `auto = true`
 
-在 auto 模式下，plan memory 负责该函数全部 local 地址分配。
+若函数内不存在 `reserve_buffer`，则保持现有编译流程对 `PlanMemory` 的原始控制行为，不引入额外语义。
+
+### 7.4 启用 local address planning 的 auto 路径
+
+在启用 local address planning 的编译流程中，`reserve_buffer` 必须使用 `auto = true`，并由 plan memory 负责地址分配。
 
 若函数中存在 `reserve_buffer`，则对其 `location` 对应的地址空间执行：
 
@@ -527,18 +544,17 @@ pto.tfree(%pipe) { split = 0 }
 - `reserve_buffer` 不保证位于地址空间起始地址，也不保证形成预留前缀；其语义仅为“在该地址空间中为 consumer slot buffer 找到一段对齐且连续的可用地址”
 - 若整体容量足够但 `MemPlan` 结果将空间打散，导致不存在满足大小和对齐要求的连续空洞，则 `reserve_buffer` 分配失败并报错
 
-### 7.5 manual 模式下的 plan memory 规则
+### 7.5 跳过 local address planning 的 manual 路径
 
-在 manual 模式下：
+在跳过 local address planning 的编译流程中：
 
 - 每个 `reserve_buffer` 必须显式提供 `base`
 - PTOAS 只校验 `base` 的基本合法性
-- plan memory 不再为该函数分配任何 local 地址
+- `PlanMemory` 不参与该函数的 local 地址分配
 - 因此该函数中其他 local buffer 地址也必须已由前端或更前阶段整体确定
-- 若函数中仍存在需要 PTOAS 分配地址的普通 local buffer，PTOAS 需要在进入 `PlanMemory` 前直接报错
-- 实现上，manual 模式函数跳过既有 local `MemPlan` 分配路径，只保留必要的合法性检查
+- 地址传播 pass 不做地址分配，只将显式 `base` 传播到 `import_reserved_buffer`
 
-manual 模式的目标是：
+该 manual 路径的目标是：
 
 - 保持前端或外部地址规划结果不被 PTOAS 改写
 - 避免 `reserve_buffer` 显式地址与 PTOAS 自动规划结果相互覆盖
@@ -564,13 +580,15 @@ manual 模式的目标是：
 #### 7.7.1 pass 落点
 
 - PTOAS 增加独立 `ModulePass`：`pto-resolve-reserved-buffers`
-- 该 pass 固定运行在 `pto-plan-memory` 之后、EmitC lowering 之前
+- 该 pass 固定运行在 EmitC lowering 之前
+- 启用规划时：运行在 `pto-plan-memory` 之后
+- 跳过规划时：不经过 `pto-plan-memory`，但该 pass 仍会运行
 - 该 pass 不负责地址分配，只消费前一阶段已经确定的 `reserve_buffer.base`
 
 #### 7.7.2 输入假设
 
-- `reserve_buffer.auto = true` 时，其 `base` 已由 `PlanMemory` 回填
-- `reserve_buffer.auto = false` 时，其 `base` 已由前端显式给定
+- 启用规划时，`reserve_buffer.auto = true`，其 `base` 已由 `PlanMemory` 回填
+- 跳过规划时，`reserve_buffer.auto = false`，其 `base` 已由前端显式给定
 - `import_reserved_buffer.peer_func` 已能解析到合法 peer function
 - `import_reserved_buffer.name` 已能在 peer function 中找到唯一匹配的 `reserve_buffer`
 
@@ -620,6 +638,8 @@ pass 在模块级按两步执行：
 若出现以下情况，pass 直接报错：
 
 - `reserve_buffer.base` 在 pass 运行时仍未解析
+- 启用规划的编译流程却出现 `reserve_buffer.auto = false`
+- 跳过规划的编译流程却出现 `reserve_buffer.auto = true`
 - `peer_func` 无法解析到函数
 - 在 peer function 中找不到同名 `reserve_buffer`
 - 某条未显式提供 `flag_base` 的内部 init，其 `local_addr` 不来自 `reserve_buffer` / `import_reserved_buffer`
@@ -676,6 +696,8 @@ pass 在模块级按两步执行：
 - `reserve_buffer.name` 在函数内唯一
 - `reserve_buffer.auto = false` 时必须带 `base`
 - `reserve_buffer.auto = true` 时必须不带 `base`
+- driver / pipeline 级约束：启用规划的编译流程只接受 `auto = true`
+- driver / pipeline 级约束：跳过规划的编译流程只接受 `auto = false` 且显式 `base`
 - `import_reserved_buffer` 能在 `peer_func` 中找到同名 `reserve_buffer`
 - 方向相关 op 只能出现在合法 kernel 中
 - 前端数据传输 op 的 `split` 必须是合法的编译期常量属性
@@ -794,7 +816,7 @@ InsertSync 只依赖：
 其中：
 
 - lowering pass 负责拆分 `DIR_MASK=3`、绑定方向与 pipe
-- plan memory 先根据函数级 `auto/manual` 模式决定是否接管该函数 local 地址分配
-- auto 模式下，plan memory 先按既有逻辑规划普通 local buffer，再为 `reserve_buffer` 在目标地址空间中分配 hole
+- 启用规划的编译流程中，plan memory 先按既有逻辑规划普通 local buffer，再为 `reserve_buffer` 在目标地址空间中分配 hole
+- 跳过规划的编译流程中，不运行 plan memory；`reserve_buffer.base` 必须已由前端给定
 - 地址传播 pass 负责 `import_reserved_buffer` 常量替换与 peer pipe 的 `flag_base` 对齐
 - EmitC 只负责将内部 `initialize_l2l_pipe` / `initialize_l2g2l_pipe` / `tpush` / `tpop` / `tfree` 及其属性透传到底层

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -211,19 +211,6 @@ static LogicalResult assignAutoReserveBufferBase(
   return success();
 }
 
-static LogicalResult verifyManualReserveBufferMode(func::FuncOp funcOp) {
-  LogicalResult result = success();
-  funcOp.walk([&](memref::AllocOp allocOp) {
-    auto memorySpaceAttr = GetBufferSpaceAttr(allocOp.getResult());
-    if (!isLocalBuffer(memorySpaceAttr))
-      return WalkResult::advance();
-    result = allocOp.emitOpError("cannot use pto.reserve_buffer with auto = "
-                                 "false when local memref.alloc "
-                                 "still requires PlanMemory allocation");
-    return WalkResult::interrupt();
-  });
-  return result;
-}
 
 // bool isReusableCastOp(pto::VCastOp &castOp, Value output, Value input) {
 //   auto rank = dyn_cast<MemRefType>(output.getType()).getRank();
@@ -2169,12 +2156,10 @@ void PlanMemoryPass::runOnOperation() {
     }
     if (this->memMode == MemPlanMode::LOCAL_MEM_PLAN &&
         reservePlan.mode == ReserveBufferMode::Manual) {
-      // Manual mode means the function's local addresses are already fixed.
-      // Reject any remaining local allocs that would still need PlanMemory.
-      if (failed(verifyManualReserveBufferMode(funcOp))) {
-        return signalPassFailure();
-      }
-      continue;
+      reservePlan.reserveOp.emitOpError(
+          "pto.reserve_buffer with explicit 'base' (auto = false) is not "
+          "supported in PlanMemory; use --pto-level=level3 or set auto = true");
+      return signalPassFailure();
     }
 
     MemLivenessAnalysis memLiveness(funcOp, this->memMode);

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -848,8 +848,8 @@ int main(int argc, char **argv) {
     planMemoryOption.enableGlobalReuse = false;
     planMemoryOption.enablePrintMemoryAllocatedSize = false;
     pm.addPass(pto::createPlanMemoryPass(planMemoryOption));
-    pm.addPass(pto::createPTOResolveReservedBuffersPass());
   }
+  pm.addPass(pto::createPTOResolveReservedBuffersPass());
 
   // Conditionally add Sync pass based on flag.
   if (enableInsertSync)


### PR DESCRIPTION
Always run PTOResolveReservedBuffersPass before EmitC so explicit-base reserve_buffer and import_reserved_buffer addresses are materialized even when local address planning is skipped.

Reject reserve_buffer { auto = false } inside PlanMemory, which only supports auto-allocation, and update the docs to describe the planning vs non-planning paths via auto/base semantics.