### PR TITLE
fix(sync): detect A5 scatter pipe via target arch

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3866,23 +3866,33 @@ def TScatterOp: PTO_TOp<"tscatter", [
 
   let extraClassDeclaration = [{
     ::mlir::pto::PIPE getPipe() {
-      // NOTE: On dav-c220 (Ascend910 A2/A3), pto-isa implements TSCATTER as a
-      // scalar loop over UB pointers, which executes on the scalar pipeline
-      // (PIPE_S). Waiting on PIPE_V does not block scalar UB accesses and can
-      // lead to using uninitialized indices/data (crash / aivec exception).
-      //
-      // On A5 instruction set devices, TSCATTER is implemented with vector
-      // scatter instructions and should be treated as PIPE_V.
-      auto moduleOp = getOperation()->getParentOfType<::mlir::ModuleOp>();
-      if (moduleOp) {
-        if (auto spec = moduleOp->getAttrOfType<::mlir::StringAttr>("pto.device-spec")) {
-          auto s = spec.getValue();
-          if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95")) {
-            return ::mlir::pto::PIPE::PIPE_V;
-          }
+      // NOTE:
+      // - On A2/A3, pto-isa TSCATTER is a scalar UB loop (PIPE_S).
+      // - On A5, pto-isa TSCATTER is vector scatter (PIPE_V).
+      // We accept either `pto.target_arch=a5` or A5 `pto.device-spec`.
+      auto isA5Target = [&]() -> bool {
+        auto moduleOp = getOperation()->getParentOfType<::mlir::ModuleOp>();
+        if (!moduleOp)
+          return false;
+
+        if (auto arch =
+                moduleOp->getAttrOfType<::mlir::StringAttr>("pto.target_arch")) {
+          if (arch.getValue().equals_insensitive("a5"))
+            return true;
         }
-      }
-      return ::mlir::pto::PIPE::PIPE_S;
+
+        if (auto spec =
+                moduleOp->getAttrOfType<::mlir::StringAttr>("pto.device-spec")) {
+          auto s = spec.getValue();
+          if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95"))
+            return true;
+        }
+
+        return false;
+      };
+
+      return isA5Target() ? ::mlir::pto::PIPE::PIPE_V
+                          : ::mlir::pto::PIPE::PIPE_S;
     }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
   }];


### PR DESCRIPTION
Summary
- Fix `pto.tscatter` pipe detection so A5 targets use `PIPE_V` and A2/A3 stay on `PIPE_S`.
- The detection now accepts either `pto.target_arch=a5` or A5 `pto.device-spec` (`Ascend950*` / `Ascend910_95*`).

Motivation
- Root cause of A5 scatter regression: when only `--pto-arch=a5` is provided (without `pto.device-spec`), `TScatterOp::getPipe()` previously fell back to `PIPE_S`.
- This caused wrong sync edges around `TSCATTER` in InsertSync-generated code.

Design
- File changed: `include/PTO/IR/PTOOps.td`
- `TScatterOp::getPipe()` now:
  - first checks module attr `pto.target_arch` (case-insensitive `a5`),
  - then checks `pto.device-spec` A5 prefixes,
  - returns `PIPE_V` iff A5 target is detected, else `PIPE_S`.
- No IR syntax change, no pass pipeline change.

Testing
- Local codegen checks
  - `PTOAS_FLAGS='--pto-arch=a3' bash test/samples/runop.sh -t Scatter` (OK)
  - `PTOAS_FLAGS='--pto-arch=a3' bash test/samples/runop.sh -t Gatherb` (OK)
  - `PTOAS_FLAGS='--pto-arch=a3' bash test/samples/runop.sh -t Sync` (OK)
  - `PTOAS_FLAGS='--pto-arch=a5' bash test/samples/runop.sh -t Scatter` (OK)
  - Verified generated A5 `scatter-pto.cpp` uses:
    - `set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0)`
    - `TSCATTER(...)`
    - `set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0)`
- A3 board run (functional)
  - Env: `STAGE=run RUN_MODE=npu SOC_VERSION=Ascend910 DEVICE_ID=2 RUN_ONLY_CASES=scatter,gatherb`
  - Result: `OK=2 FAIL=0 SKIP=0`
  - Cases: `gatherb=OK`, `scatter=OK`

Risk / Rollback
- Risk is low and localized to `TScatterOp` pipe classification.
- Rollback is a single-commit revert.

Review Focus
- A5 detection precedence (`pto.target_arch` + `pto.device-spec`) in `TScatterOp::getPipe()`.
- A3 behavior unchanged (`PIPE_S`) for scatter.
- No unrelated behavior changes outside scatter pipe selection.
