### PR TITLE
test(sync): add A5 inter-core functional board validation

### DIFF
--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -453,6 +453,14 @@ def _infer_aicore_arch(kernel_text: str, soc_version: str) -> str:
     return "dav-c220-cube" if needs_cube else "dav-c220-vec"
 
 
+def _infer_launch_block_count(kernel_text: str, testcase: str) -> int:
+    # Inter-core sync functional cases need at least two cores:
+    # one producer core does sync.set, one consumer core does sync.wait.
+    if testcase.startswith("test_intercore_sync_") and "get_block_idx()" in kernel_text:
+        return 2
+    return 1
+
+
 def _parse_int_list(blob: str):
     items = []
     for part in blob.split(","):
@@ -1305,6 +1313,7 @@ def generate_testcase(
     kernel_call_args_device = ", ".join(kernel_call_args_device)
     kernel_call_args_host = ", ".join(kernel_call_args_host)
     raw_params_host = [_rewrite_host_unsupported_types(p) for p in raw_params]
+    launch_block_count = _infer_launch_block_count(raw_kernel_for_analysis, testcase)
     launch_cpp = (
         INCLUDE_REPLACEMENT
         + "\n"
@@ -1315,9 +1324,9 @@ def generate_testcase(
         "#endif\n\n"
         f"void {launch_name}({launch_fn_params}) {{\n"
         "#if defined(__CCE_AICORE__)\n"
-        f"    {kernel_name}<<<1, nullptr, stream>>>({kernel_call_args_device});\n"
+        f"    {kernel_name}<<<{launch_block_count}, nullptr, stream>>>({kernel_call_args_device});\n"
         "#else\n"
-        f"    {kernel_name}<<<1, nullptr, stream>>>({kernel_call_args_host});\n"
+        f"    {kernel_name}<<<{launch_block_count}, nullptr, stream>>>({kernel_call_args_host});\n"
         "#endif\n"
         f"}}\n"
     )
@@ -1510,6 +1519,25 @@ endif()
                 compare_lines.append(
                     f"    ok = compare_bin(\"golden_{name}.bin\", \"{name}.bin\", {np_dtype}, {eps}) and ok"
                 )
+    if testcase == "test_intercore_sync_a5_functional":
+        # Extra functional check (not just run-to-run determinism):
+        # core0 writes 2.0 to output[0], core1 waits then mirrors to output[1].
+        out_name = output_ptrs[0]["name"] if output_ptrs else "v1"
+        compare_lines.append(f"    __inter_out = np.fromfile(\"{out_name}.bin\", dtype=np.float32)")
+        compare_lines.append("    if __inter_out.size < 2:")
+        compare_lines.append("        print(f\"[ERROR] intercore check requires >=2 elements, got {__inter_out.size}\")")
+        compare_lines.append("        ok = False")
+        compare_lines.append("    else:")
+        compare_lines.append("        if abs(float(__inter_out[0]) - 2.0) > 1e-6:")
+        compare_lines.append(
+            "            print(f\"[ERROR] intercore check failed: out[0]={float(__inter_out[0])}, expect 2.0\")"
+        )
+        compare_lines.append("            ok = False")
+        compare_lines.append("        if abs(float(__inter_out[1]) - 2.0) > 1e-6:")
+        compare_lines.append(
+            "            print(f\"[ERROR] intercore check failed: out[1]={float(__inter_out[1])}, expect 2.0\")"
+        )
+        compare_lines.append("            ok = False")
     compare_py = compare_template.replace("@COMPARES@", "\n".join(compare_lines))
     (output_dir / "compare.py").write_text(compare_py, encoding="utf-8")
 

--- a/test/samples/Sync/test_intercore_sync_a5.py
+++ b/test/samples/Sync/test_intercore_sync_a5.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python3
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
-from mlir.dialects import arith, func, pto
+from mlir.ir import (
+    Context,
+    F32Type,
+    IndexType,
+    InsertionPoint,
+    IntegerType,
+    Location,
+    Module,
+)
+from mlir.dialects import arith, func, pto, scf
 
 
 def build():
@@ -10,8 +18,9 @@ def build():
             module = Module.create()
             f32 = F32Type.get(ctx)
             idx = IndexType.get(ctx)
+            i32 = IntegerType.get_signless(32, ctx)
             ptr_f32 = pto.PtrType.get(f32, ctx)
-            fn_ty = func.FunctionType.get([ptr_f32], [])
+            fn_ty = func.FunctionType.get([ptr_f32, i32], [])
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a5", fn_ty)
@@ -19,11 +28,20 @@ def build():
 
             with InsertionPoint(entry):
                 c0 = arith.ConstantOp(idx, 0).result
+                c0_i32 = arith.ConstantOp(i32, 0).result
                 two = arith.ConstantOp(f32, 2.0).result
                 pipe_mte3 = pto.PipeAttr.get(pto.PIPE.PIPE_MTE3, ctx)
                 pipe_v = pto.PipeAttr.get(pto.PIPE.PIPE_V, ctx)
                 pto.sync_set(pipe_mte3, 5)
-                pto.sync_wait(pipe_v, 5)
+                # Keep sync.wait in generated code shape checks, but avoid
+                # unconditional wait deadlock in single-core functional runs.
+                should_wait = arith.CmpIOp(
+                    arith.CmpIPredicate.eq, entry.arguments[1], c0_i32
+                ).result
+                if_op = scf.IfOp(should_wait, [], hasElse=False)
+                with InsertionPoint(if_op.then_block):
+                    pto.sync_wait(pipe_v, 5)
+                    scf.YieldOp([])
                 pto.store_scalar(entry.arguments[0], c0, two)
                 func.ReturnOp([])
 

--- a/test/samples/Sync/test_intercore_sync_a5_functional.py
+++ b/test/samples/Sync/test_intercore_sync_a5_functional.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.dialects import arith, func, pto, scf
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+        with Location.unknown(ctx):
+            module = Module.create()
+
+            f32 = F32Type.get(ctx)
+            i64 = IntegerType.get_signless(64, ctx)
+            idx = IndexType.get(ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+            fn_ty = func.FunctionType.get([ptr_f32], [])
+
+            with InsertionPoint(module.body):
+                fn = func.FuncOp("test_intercore_sync_a5_functional", fn_ty)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                out = entry.arguments[0]
+
+                c0_idx = arith.ConstantOp(idx, 0).result
+                c1_idx = arith.ConstantOp(idx, 1).result
+                c0_i64 = arith.ConstantOp(i64, 0).result
+                c1_i64 = arith.ConstantOp(i64, 1).result
+                c2 = arith.ConstantOp(f32, 2.0).result
+
+                bid = pto.GetBlockIdxOp().result
+                pipe_mte3 = pto.PipeAttr.get(pto.PIPE.PIPE_MTE3, ctx)
+                pipe_v = pto.PipeAttr.get(pto.PIPE.PIPE_V, ctx)
+
+                is_producer = arith.CmpIOp(arith.CmpIPredicate.eq, bid, c0_i64).result
+                producer_if = scf.IfOp(is_producer, [], hasElse=False)
+                with InsertionPoint(producer_if.then_block):
+                    # producer core: publish data then signal event 5.
+                    pto.store_scalar(out, c0_idx, c2)
+                    pto.sync_set(pipe_mte3, 5)
+                    scf.YieldOp([])
+
+                is_consumer = arith.CmpIOp(arith.CmpIPredicate.eq, bid, c1_i64).result
+                consumer_if = scf.IfOp(is_consumer, [], hasElse=False)
+                with InsertionPoint(consumer_if.then_block):
+                    # consumer core: wait event 5 then observe producer write.
+                    pto.sync_wait(pipe_v, 5)
+                    loaded = pto.load_scalar(f32, out, c0_idx)
+                    pto.store_scalar(out, c1_idx, loaded)
+                    scf.YieldOp([])
+
+                func.ReturnOp([])
+
+            module.operation.verify()
+            return module
+
+
+if __name__ == "__main__":
+    print(build())

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -203,6 +203,10 @@ process_one_dir() {
       echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a5"
       continue
     fi
+    if [[ "$base" == "test_intercore_sync_a5_functional" && "$(printf '%s' "$target_arch" | tr '[:upper:]' '[:lower:]')" != "a5" ]]; then
+      echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a5"
+      continue
+    fi
     if [[ "$base" == "test_intercore_sync_a3" && "$(printf '%s' "$target_arch" | tr '[:upper:]' '[:lower:]')" != "a3" ]]; then
       echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a3"
       continue
@@ -423,6 +427,28 @@ process_one_dir() {
       fi
     fi
     if [[ "$base" == "test_intercore_sync_a5" ]]; then
+      if ! grep -Fq "set_intra_block(PIPE_MTE3, 5)" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing A5 sync.set lowering to set_intra_block"
+        overall=1
+        continue
+      fi
+      if ! grep -Fq "wait_intra_block(PIPE_V, 5)" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing A5 sync.wait lowering to wait_intra_block"
+        overall=1
+        continue
+      fi
+      if grep -Fq "ffts_cross_core_sync(" "$cpp" || grep -Fq "wait_flag_dev(" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tunexpected A3-style inter-core sync call in A5 output"
+        overall=1
+        continue
+      fi
+    fi
+    if [[ "$base" == "test_intercore_sync_a5_functional" ]]; then
+      if ! grep -Fq "get_block_idx()" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing block-role dispatch (get_block_idx)"
+        overall=1
+        continue
+      fi
       if ! grep -Fq "set_intra_block(PIPE_MTE3, 5)" "$cpp"; then
         echo -e "${A}(${base}.py)\tFAIL\tmissing A5 sync.set lowering to set_intra_block"
         overall=1


### PR DESCRIPTION
Summary
- Add a real A5 inter-core functional test case, instead of relying only on structure assertions.
- Keep existing `test_intercore_sync_a5.py` as a stable lowering-shape regression case (avoid unconditional wait deadlock in single-core run).
- Extend npu_validation testcase generation to launch inter-core functional kernels with 2 blocks and validate semantic outputs.

Motivation
- Previous inter-core tests mainly checked emitted call shapes (`set_intra_block`/`wait_intra_block`) but could still miss runtime handshake correctness issues.
- We need a board-facing test that exercises producer/consumer cross-core sync semantics directly.

Changes
1. New functional sample
- `test/samples/Sync/test_intercore_sync_a5_functional.py`
  - Core 0 (`get_block_idx()==0`): `store_scalar(out[0], 2.0)` then `sync.set(MTE3, 5)`.
  - Core 1 (`get_block_idx()==1`): `sync.wait(V, 5)`, then `out[1] = load(out[0])`.

2. Keep existing A5 sample board-stable
- `test/samples/Sync/test_intercore_sync_a5.py`
  - Gate wait in a conditional branch to keep lowering coverage while avoiding unconditional wait hangs in single-core functional runs.

3. runop regression checks
- `test/samples/runop.sh`
  - Add A5-only gating and structure checks for `test_intercore_sync_a5_functional`.

4. npu_validation functional enablement
- `test/npu_validation/scripts/generate_testcase.py`
  - Launch inter-core functional cases with `<<<2, ...>>>` when test name is `test_intercore_sync_*` and kernel uses `get_block_idx()`.
  - Add explicit semantic assertions for `test_intercore_sync_a5_functional`:
    - `out[0] == 2.0`
    - `out[1] == 2.0`

Testing
- Local sample regression:
  - `PTOAS_FLAGS='--pto-arch=a5' bash test/samples/runop.sh -t Sync` (pass)
  - `PTOAS_FLAGS='--pto-arch=a3' bash test/samples/runop.sh -t Sync` (pass; A5-specific cases skipped)
- Verified generated artifacts for functional case:
  - `launch.cpp` uses `<<<2, nullptr, stream>>>`
  - `compare.py` includes explicit output semantic checks (`out[0]/out[1]`)

Risk / Rollback
- Change scope is limited to test/sample and validation harness logic.
- Rollback is a single-commit revert.
