### PR TITLE
fix: Fix TCI i16 scalar emitc type

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5117,9 +5117,10 @@ struct PTOTCIToEmitC : public OpConversionPattern<pto::TCIOp> {
     Value dst = peelUnrealized(adaptor.getDst());
     Value S   = peelUnrealized(adaptor.getS());
 
-    // scalar cpp type token
+    // The TCI scalar template parameter should follow the original PTO IR
+    // scalar type, not the converted EmitC value type.
     std::string scalarTok = "int32_t";
-    if (auto it = S.getType().dyn_cast<IntegerType>()) {
+    if (auto it = dyn_cast<IntegerType>(op.getS().getType())) {
       scalarTok = (it.getWidth() == 16) ? "int16_t" : "int32_t";
     }
 

--- a/test/basic/tci_i16_emitc.pto
+++ b/test/basic/tci_i16_emitc.pto
@@ -1,0 +1,18 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @tci_i16_kernel(%dst: memref<16xi16, #pto.address_space<gm>>) {
+    %c0_i16 = arith.constant 0 : i16
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %src = memref.reinterpret_cast %dst to offset: [%c0], sizes: [%c1, %c16], strides: [%c16, %c1] {layout = #pto.layout<nd>} : memref<16xi16, #pto.address_space<gm>> to memref<1x16xi16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=1>
+    pto.tci ins(%c0_i16 : i16) outs(%tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=1>) outs(%src : memref<1x16xi16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
+    return
+  }
+}
+
+// A3: TCI<Tile<TileType::Vec, int16_t, 1, 16, BLayout::RowMajor, 1, 16, SLayout::NoneBox, 512, PadValue::Zero>, int16_t, 0>(
+// A3-NOT: TCI<Tile<TileType::Vec, int16_t, 1, 16, BLayout::RowMajor, 1, 16, SLayout::NoneBox, 512, PadValue::Zero>, int32_t, 0>(


### PR DESCRIPTION
**问题**
pto.tci 的 EmitC lowering 在 S 为 i16 时，会错误生成：

TCI<..., int32_t, 0>(...)
而不是：

TCI<..., int16_t, 0>(...)
根因是 PTOToEmitC.cpp (line 5353) 原来用的是 adaptor.getS() 对应的“转换后类型”来判断模板参数类型；这个阶段的值已经不是原始 MLIR IntegerType，判断失败后就回落到了默认的 int32_t。

**修复方式**
在 PTOTCIToEmitC 中，把模板参数类型判断从“转换后的 EmitC 值类型”改成“原始 PTO IR 的类型”：

从看 S.getType()
改为看 op.getS().getType()
这样 pto.tci ins(%c0_i16 : i16) 会按原始 IR 正确生成 TCI<..., int16_t, 0>。

同时新增了回归用例 tci_i16_emitc.pto (line 1)，显式检查：

必须出现 TCI<..., int16_t, 0>
不能出现 TCI<..., int32_t, 0>
