### PR TITLE
Align TInsert/TExtract with pto-isa PR576

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3041,6 +3041,10 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
       return ft.getWidth() == 8 || ft.isF16() || ft.isBF16() || ft.isF32();
     return false;
   };
+  auto isRowMajorNoneBoxND = [&](pto::TileBufType ty) -> bool {
+    return ty.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor) &&
+           ty.getSLayoutValueI32() == static_cast<int32_t>(pto::SLayout::NoneBox);
+  };
   auto verifyA2A3 = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
@@ -3107,7 +3111,8 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
           *dstSpace == pto::AddressSpace::RIGHT ||
           *dstSpace == pto::AddressSpace::SCALING)) ||
         (*srcSpace == pto::AddressSpace::VEC &&
-         *dstSpace == pto::AddressSpace::MAT);
+         (*dstSpace == pto::AddressSpace::MAT ||
+          *dstSpace == pto::AddressSpace::VEC));
     if (!okPair)
       return emitOpError("expects A5 textract to use a supported src/dst loc pair");
     if (*srcSpace == pto::AddressSpace::MAT) {
@@ -3119,9 +3124,15 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
           return emitOpError("expects A5 left dst to use col_major blayout and row_major slayout");
       } else if (*dstSpace == pto::AddressSpace::RIGHT) {
         if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
-            dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor))
+          dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::ColMajor))
           return emitOpError("expects A5 right dst to use row_major blayout and col_major slayout");
       }
+    } else if (*srcSpace == pto::AddressSpace::VEC &&
+               *dstSpace == pto::AddressSpace::VEC) {
+      if (!isRowMajorNoneBoxND(srcTb) || !isRowMajorNoneBoxND(dstTb))
+        return emitOpError(
+            "expects A5 vec->vec textract src/dst to use ND layout "
+            "(blayout=row_major, slayout=none_box)");
     }
     return success();
   };

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5691,78 +5691,8 @@ struct PTOExtractToEmitC : public OpConversionPattern<pto::TExtractOp> {
 };
 //===----------------------------------------------------------------------===//
 // pto.tinsert lowering -> TINSERT(dst, src, indexRow, indexCol)
-// A5 specializations:
-//   vec->vec : TINSERT<TInsertMode::ND_VEC>(...)
-//   vec->mat : TINSERT<TInsertMode::ND/NZ>(...)
+// Keep lowering arch-agnostic and let PTO-ISA infer proper A5 path.
 //===----------------------------------------------------------------------===//
-
-static std::optional<pto::AddressSpace> getAddressSpaceFromType(Type ty) {
-  if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
-    if (auto as = dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace()))
-      return as.getAddressSpace();
-    return std::nullopt;
-  }
-  if (auto mr = dyn_cast<MemRefType>(ty)) {
-    if (auto ms = mr.getMemorySpace()) {
-      if (auto as = dyn_cast<pto::AddressSpaceAttr>(ms))
-        return as.getAddressSpace();
-      return std::nullopt;
-    }
-    return pto::AddressSpace::GM;
-  }
-  return std::nullopt;
-}
-
-static bool isA5TargetForTInsert(pto::TInsertOp op) {
-  auto moduleOp = op->getParentOfType<ModuleOp>();
-  if (!moduleOp)
-    return false;
-  if (auto arch = moduleOp->getAttrOfType<StringAttr>("pto.target_arch")) {
-    if (arch.getValue().equals_insensitive("a5"))
-      return true;
-  }
-  if (auto spec = moduleOp->getAttrOfType<StringAttr>("pto.device-spec")) {
-    auto s = spec.getValue();
-    if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95"))
-      return true;
-  }
-  return false;
-}
-
-static std::optional<StringRef> getA5TInsertModeToken(pto::TInsertOp op) {
-  if (!isA5TargetForTInsert(op))
-    return std::nullopt;
-  auto srcAs = getAddressSpaceFromType(op.getSrc().getType());
-  auto dstAs = getAddressSpaceFromType(op.getDst().getType());
-  if (!srcAs || !dstAs)
-    return std::nullopt;
-  if (*srcAs == pto::AddressSpace::VEC && *dstAs == pto::AddressSpace::VEC)
-    return StringRef("TInsertMode::ND_VEC");
-  if (*srcAs == pto::AddressSpace::VEC && *dstAs == pto::AddressSpace::MAT) {
-    if (auto srcTb = dyn_cast<pto::TileBufType>(op.getSrc().getType())) {
-      int32_t bl = srcTb.getBLayoutValueI32();
-      int32_t sl = srcTb.getSLayoutValueI32();
-      bool srcIsND = bl == static_cast<int32_t>(pto::BLayout::RowMajor) &&
-                     sl == static_cast<int32_t>(pto::SLayout::NoneBox);
-      return srcIsND ? StringRef("TInsertMode::ND") : StringRef("TInsertMode::NZ");
-    }
-    // Best effort for memref path: recover from paired tload's layout attr.
-    for (Operation *user : op.getSrc().getUsers()) {
-      auto tload = dyn_cast<pto::TLoadOp>(user);
-      if (!tload || tload.getDst() != op.getSrc())
-        continue;
-      auto layoutAttr = tload->getAttrOfType<pto::LayoutAttr>("layout");
-      if (!layoutAttr)
-        continue;
-      return layoutAttr.getLayout() == pto::Layout::ND
-                 ? StringRef("TInsertMode::ND")
-                 : StringRef("TInsertMode::NZ");
-    }
-    // MemRef source loses explicit tile layout metadata; keep legacy default.
-    return StringRef("TInsertMode::NZ");
-  }
-  return std::nullopt;
-}
 
 struct PTOInsertToEmitC : public OpConversionPattern<pto::TInsertOp> {
   using OpConversionPattern<pto::TInsertOp>::OpConversionPattern;
@@ -5770,22 +5700,15 @@ struct PTOInsertToEmitC : public OpConversionPattern<pto::TInsertOp> {
   LogicalResult matchAndRewrite(pto::TInsertOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = rewriter.getContext();
 
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
     Value r0  = peelUnrealized(adaptor.getIndexRow());
     Value c0  = peelUnrealized(adaptor.getIndexCol());
 
-    ArrayAttr templateArgs = ArrayAttr{};
-    if (auto modeTok = getA5TInsertModeToken(op)) {
-      templateArgs = rewriter.getArrayAttr(
-          {emitc::OpaqueAttr::get(ctx, modeTok->str())});
-    }
-
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TINSERT",
-        /*args=*/ArrayAttr{}, /*templateArgs=*/templateArgs,
+        /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
         /*operands=*/ValueRange{dst, src, r0, c0});
 
     rewriter.eraseOp(op);

--- a/test/basic/textract_a5_vec_vec_nd_lowering.pto
+++ b/test/basic/textract_a5_vec_vec_nd_lowering.pto
@@ -1,0 +1,15 @@
+// RUN: ptoas --pto-arch=a5 %s | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @textract_vec_vec_nd() {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.textract ins(%src, %c0, %c0 : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, index, index)
+                outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void textract_vec_vec_nd(
+// CHECK: TEXTRACT(

--- a/test/basic/textract_verify_a5_vec_vec_invalid_layout.pto
+++ b/test/basic/textract_verify_a5_vec_vec_invalid_layout.pto
@@ -1,0 +1,14 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @textract_a5_vec_vec_invalid_layout() {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.textract ins(%src, %c0, %c0 : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, index, index)
+                outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.textract' op expects A5 vec->vec textract src/dst to use ND layout (blayout=row_major, slayout=none_box)

--- a/test/basic/tinsert_a5_vec_mat_mode_lowering.pto
+++ b/test/basic/tinsert_a5_vec_mat_mode_lowering.pto
@@ -24,8 +24,8 @@ module attributes {"pto.target_arch" = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_nd(
-// CHECK: TINSERT<TInsertMode::ND>(
+// CHECK-LABEL: AICORE void tinsert_vec_mat_nd(
+// CHECK: TINSERT(
 
-// CHECK-LABEL: __global__ AICORE void tinsert_vec_mat_nz(
-// CHECK: TINSERT<TInsertMode::NZ>(
+// CHECK-LABEL: AICORE void tinsert_vec_mat_nz(
+// CHECK: TINSERT(

--- a/test/basic/tinsert_a5_vec_pipe_selection.pto
+++ b/test/basic/tinsert_a5_vec_pipe_selection.pto
@@ -1,7 +1,7 @@
 // RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
 
 module attributes {"pto.device-spec" = "Ascend950"} {
-  // A5: vec->vec TINSERT should use ND_VEC mode on PIPE_V.
+  // A5: vec->vec TINSERT keeps PIPE_V path and no explicit mode template.
   func.func @tinsert_vec_vec_pipeline(%a: memref<32x32xf16, #pto.address_space<gm>>) {
     %c0 = arith.constant 0 : index
     %src_vec = memref.alloc() : memref<32x32xf16, #pto.address_space<vec>>
@@ -18,8 +18,8 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_vec_vec_pipeline(
+// CHECK-LABEL: AICORE void tinsert_vec_vec_pipeline(
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-// CHECK: TINSERT<TInsertMode::ND_VEC>(
+// CHECK: TINSERT(
 // CHECK-NOT: PIPE_FIX


### PR DESCRIPTION
Summary
- Align `pto.tinsert`/`pto.textract` lowering+verify behavior with latest pto-isa PR576 updates.
- Remove A5-specific `TInsertMode` template emission in EmitC and use plain `TINSERT(dst, src, row, col)`.
- Extend A5 `pto.textract` verifier to accept `vec->vec` and enforce ND layout constraints.
- Update/add `test/basic` coverage for new semantics.

Motivation
- pto-isa PR576 refactors A5 `TINSERT` to infer vec/mat paths without exposing `ND/ND_VEC` mode in the public enum path.
- PR576 also adds A5 `TEXTRACT` vec->vec ND path.
- PTOAS needed to stop hard-coding removed mode tokens and unlock the new verifier-legal `vec->vec` textract path.

Design
- `lib/PTO/Transforms/PTOToEmitC.cpp`
  - Remove `getA5TInsertModeToken` and all A5 mode-token inference helpers.
  - Lower `pto.tinsert` to `TINSERT(dst, src, indexRow, indexCol)` with no template args.
- `lib/PTO/IR/PTO.cpp`
  - In `TExtractOp::verify` (A5 branch), allow src/dst loc pair `vec->vec`.
  - Add ND layout check for A5 vec->vec:
    - `blayout=row_major`
    - `slayout=none_box`
- Tests
  - Update existing A5 tinsert checks to assert plain `TINSERT(`.
  - Add:
    - `test/basic/textract_a5_vec_vec_nd_lowering.pto`
    - `test/basic/textract_verify_a5_vec_vec_invalid_layout.pto`

Testing
- Local build
  - `cmake -G Ninja ...`
  - `ninja -C build ptoas`
  - `ninja -C build install`
- Local targeted checks
  - `tinsert_a5_vec_mat_mode_lowering.pto` (FileCheck)
  - `tinsert_a5_vec_pipe_selection.pto` (FileCheck)
  - `textract_a5_vec_vec_nd_lowering.pto` (FileCheck)
  - `textract_verify_a5_vec_vec_invalid_layout.pto` (negative FileCheck)
- Remote board validation (101.245.68.6, DEVICE_ID=2, pto-isa@893e4b00a826)
  - A5 payload cases:
    - `textract_a5_vec_vec_nd` -> OK
    - `tinsert` -> OK
    - Summary: `OK=2 FAIL=0 SKIP=0`
  - A3 regression payload case:
    - `tinsert` -> OK
    - Summary: `OK=1 FAIL=0 SKIP=0`

Risk / Rollback
- Risk is low and scoped to `tinsert/textract` codegen+verify paths.
- Rollback is a single-commit revert.
