### PR TITLE
InferPTOLayout: accept user ND/DN in ambiguous minor-2D cases

### DIFF
--- a/lib/PTO/Transforms/InferPTOLayout.cpp
+++ b/lib/PTO/Transforms/InferPTOLayout.cpp
@@ -73,6 +73,10 @@ struct ShapeStride5D {
   SmallVector<int64_t, 5> stride;
 };
 
+static bool isMinor2DLayout(Layout layout) {
+  return layout == Layout::ND || layout == Layout::DN;
+}
+
 static std::optional<ShapeStride5D> rightAlignTo5D(ArrayRef<int64_t> shape,
                                                    ArrayRef<int64_t> stride) {
   if (shape.size() != stride.size())
@@ -331,11 +335,16 @@ struct InferPTOLayoutPass
       }
     };
 
-    auto verifyOrSetLayout = [&](Operation *op,
-                                 std::optional<Layout> inferred) -> void {
+    auto verifyOrSetLayout = [&](Operation *op, std::optional<Layout> inferred,
+                                 bool isMinor2DAmbiguous = false) -> void {
       auto existing = op->getAttrOfType<LayoutAttr>(kLayoutAttrName);
       if (existing) {
         if (inferred && existing.getLayout() != *inferred) {
+          // For minor-2D ambiguous cases, ND/DN are both legal and should be
+          // treated as equivalent ABI hints. Keep user-specified layout.
+          if (isMinor2DAmbiguous && isMinor2DLayout(existing.getLayout()) &&
+              isMinor2DLayout(*inferred))
+            return;
           op->emitError() << "layout mismatch: user-specified layout="
                           << stringifyLayout(existing.getLayout())
                           << " but inferred=" << stringifyLayout(*inferred);
@@ -370,7 +379,7 @@ struct InferPTOLayoutPass
           elemByteSize(cast<TensorViewType>(op.getResult().getType())
                            .getElementType()),
           preferredForAmbiguous, &isAmbiguous);
-      verifyOrSetLayout(op.getOperation(), inferred);
+      verifyOrSetLayout(op.getOperation(), inferred, isAmbiguous);
 
       // If this make_tensor_view layout was inferred in an ambiguous ND/DN
       // shape and a downstream tile has a clear BLayout preference, force-align
@@ -419,9 +428,11 @@ struct InferPTOLayoutPass
         strides.push_back(*v);
       }
 
-      verifyOrSetLayout(
-          op.getOperation(),
-          inferLayout5D(shape, strides, elemByteSize(mrTy.getElementType())));
+      bool isMinor2DAmbiguous = false;
+      auto inferred =
+          inferLayout5D(shape, strides, elemByteSize(mrTy.getElementType()),
+                        std::nullopt, &isMinor2DAmbiguous);
+      verifyOrSetLayout(op.getOperation(), inferred, isMinor2DAmbiguous);
     });
 
     // ------------------------------------------------------------------

--- a/test/basic/infer_layout_ambiguous_minor2d_user_dn.pto
+++ b/test/basic/infer_layout_ambiguous_minor2d_user_dn.pto
@@ -1,0 +1,21 @@
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+module {
+  func.func @infer_layout_ambiguous_minor2d_user_dn(%src: !pto.ptr<f16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+
+    // shape=[1,16], strides=[1,1] is minor-2D ambiguous (ND/DN both legal).
+    // User-specified DN should be accepted and preserved.
+    %tv = pto.make_tensor_view %src, shape = [%c1, %c16], strides = [%c1, %c1] {layout = #pto.layout<dn>} : !pto.tensor_view<?x?xf16>
+    %sv = pto.partition_view %tv, offsets = [%c0, %c0], sizes = [%c1, %c16] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<1x16xf16>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=none_box, fractal=512, pad=1>
+    pto.tload ins(%sv : !pto.partition_tensor_view<1x16xf16>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=none_box, fractal=512, pad=1>)
+    return
+  }
+}
+
+// CHECK-NOT: layout mismatch:
+// CHECK: pto::Layout::DN


### PR DESCRIPTION
Summary
- Fix InferPTOLayout conflict handling for ambiguous minor-2D layout cases (ND/DN both legal).
- When user explicitly sets ND or DN and inference picks the other one in an ambiguous case, keep the user layout instead of raising layout mismatch.
- Add lit regression: test/basic/infer_layout_ambiguous_minor2d_user_dn.pto.
 
Motivation
- Users reported infer-layout failures where both ND and DN are valid, but pass rejected user-specified layout because inferred default differed.

Design
- Extend verifyOrSetLayout with ambiguity context and allow ND<->DN mismatch only when inferLayout5D reports minor-2D ambiguity.
- Apply the same logic to both make_tensor_view and memref.reinterpret_cast paths.

Testing
- ninja -C build ptoas
- build/tools/ptoas/ptoas /tmp/wrong_618.mlir -o /tmp/wrong_618_out.cpp
- build/tools/ptoas/ptoas test/basic/infer_layout_ambiguous_minor2d_user_dn.pto 2>&1 | FileCheck test/basic/infer_layout_ambiguous_minor2d_user_dn.pto

Risk / Rollback
- Risk: low, behavior change is scoped to explicit ND/DN ambiguity only.
- Rollback: revert this PR.