### PR TITLE
feat: Expand ptobc v0 coverage for recent PTO ops

### DIFF
--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -136,11 +136,16 @@ inline constexpr OpInfo kOpTable[] = {
   {0x1068, "pto.tsubc", 0, 0x00, 0x00, 4, 0, 0, 0x00},
   {0x1069, "pto.tsubs", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x106A, "pto.tsubsc", 0, 0x00, 0x00, 4, 0, 0, 0x00},
+  {0x106B, "pto.trowexpandsub", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x106C, "pto.ttrans", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x106D, "pto.ttri", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x106E, "pto.txor", 0, 0x00, 0x00, 4, 0, 0, 0x00},
   {0x106F, "pto.txors", 0, 0x00, 0x00, 4, 0, 0, 0x00},
   {0x1070, "pto.wait_event", 0, 0x00, 0x00, 0, 0, 0, 0x02},
+  {0x1071, "pto.tprint", 0, 0x00, 0x00, 1, 0, 0, 0x00},
+  {0x1072, "pto.subset", 0, 0x01, 0x02, 0, 1, 0, 0x00},
+  {0x1073, "pto.trowexpanddiv", 0, 0x00, 0x02, 0, 0, 0, 0x00},
+  {0x1074, "pto.trowexpandmul", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -296,11 +301,16 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.tsubc", 0x1068)
     .Case("pto.tsubs", 0x1069)
     .Case("pto.tsubsc", 0x106A)
+    .Case("pto.trowexpandsub", 0x106B)
     .Case("pto.ttrans", 0x106C)
     .Case("pto.ttri", 0x106D)
     .Case("pto.txor", 0x106E)
     .Case("pto.txors", 0x106F)
     .Case("pto.wait_event", 0x1070)
+    .Case("pto.tprint", 0x1071)
+    .Case("pto.subset", 0x1072)
+    .Case("pto.trowexpanddiv", 0x1073)
+    .Case("pto.trowexpandmul", 0x1074)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -442,11 +452,16 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.tsubc", OpcodeAndVariant{0x1068, 0, 0})
     .Case("pto.tsubs", OpcodeAndVariant{0x1069, 0, 0})
     .Case("pto.tsubsc", OpcodeAndVariant{0x106A, 0, 0})
+    .Case("pto.trowexpandsub", OpcodeAndVariant{0x106B, 0, 0})
     .Case("pto.ttrans", OpcodeAndVariant{0x106C, 0, 0})
     .Case("pto.ttri", OpcodeAndVariant{0x106D, 0, 0})
     .Case("pto.txor", OpcodeAndVariant{0x106E, 0, 0})
     .Case("pto.txors", OpcodeAndVariant{0x106F, 0, 0})
     .Case("pto.wait_event", OpcodeAndVariant{0x1070, 0, 0})
+    .Case("pto.tprint", OpcodeAndVariant{0x1071, 0, 0})
+    .Case("pto.subset", OpcodeAndVariant{0x1072, 0, 0})
+    .Case("pto.trowexpanddiv", OpcodeAndVariant{0x1073, 0, 0})
+    .Case("pto.trowexpandmul", OpcodeAndVariant{0x1074, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})

--- a/tools/ptobc/testdata/recent_ops_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/recent_ops_v0_roundtrip.pto
@@ -1,0 +1,17 @@
+module {
+  func.func @recent_ops_v0() {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %sub = pto.subset %src[%c0, %c0] sizes [16, 16] : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tprint ins(%sub : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpandmul ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/tools/ptobc/testdata/tprint_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tprint_v0_roundtrip.pto
@@ -1,0 +1,7 @@
+module {
+  func.func @tprint_v0() {
+    %0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tprint ins(%0 : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/tools/ptobc/testdata/trowexpandsub_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/trowexpandsub_v0_roundtrip.pto
@@ -1,0 +1,27 @@
+module {
+  func.func @trowexpandsub_v0(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %src0_tv = pto.make_tensor_view %arg0, shape = [%c16, %c32], strides = [%c32, %c1] : !pto.tensor_view<16x32xf32>
+    %src1_tv = pto.make_tensor_view %arg1, shape = [%c16, %c1], strides = [%c1, %c1] : !pto.tensor_view<16x1xf32>
+    %dst_tv = pto.make_tensor_view %arg2, shape = [%c16, %c32], strides = [%c32, %c1] : !pto.tensor_view<16x32xf32>
+    %src0 = pto.partition_view %src0_tv, offsets = [%c0, %c0], sizes = [%c16, %c32] : !pto.tensor_view<16x32xf32> -> !pto.partition_tensor_view<16x32xf32>
+    %src1 = pto.partition_view %src1_tv, offsets = [%c0, %c0], sizes = [%c16, %c1] : !pto.tensor_view<16x1xf32> -> !pto.partition_tensor_view<16x1xf32>
+    %dst0 = pto.partition_view %dst_tv, offsets = [%c0, %c0], sizes = [%c16, %c32] : !pto.tensor_view<16x32xf32> -> !pto.partition_tensor_view<16x32xf32>
+    %dst1 = pto.partition_view %dst_tv, offsets = [%c0, %c0], sizes = [%c16, %c32] : !pto.tensor_view<16x32xf32> -> !pto.partition_tensor_view<16x32xf32>
+    %a = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %out0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %out1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tload ins(%src0 : !pto.partition_tensor_view<16x32xf32>) outs(%a : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : !pto.partition_tensor_view<16x1xf32>) outs(%b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpandsub ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%out0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpandsub ins(%a, %b, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%out1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%out0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst0 : !pto.partition_tensor_view<16x32xf32>)
+    pto.tstore ins(%out1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst1 : !pto.partition_tensor_view<16x32xf32>)
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -27,3 +27,24 @@ add_test(NAME ptobc_opcode_coverage_check
     ${CMAKE_SOURCE_DIR}/include/PTO/IR/PTOOps.td
     ${CMAKE_SOURCE_DIR}/tools/ptobc/generated/ptobc_opcodes_v0.h
 )
+
+add_test(NAME ptobc_trowexpandsub_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/trowexpandsub_v0_encode.sh
+)
+
+add_test(NAME ptobc_tprint_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/tprint_v0_encode.sh
+)
+
+add_test(NAME ptobc_recent_ops_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/recent_ops_v0_encode.sh
+)

--- a/tools/ptobc/tests/recent_ops_v0_encode.sh
+++ b/tools/ptobc/tests/recent_ops_v0_encode.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/recent_ops_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_recent_ops_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/recent_ops_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/recent_ops_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.subset " "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tprint ins(" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.trowexpanddiv ins(" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.trowexpandmul ins(" "${ROUNDTRIP}" >/dev/null

--- a/tools/ptobc/tests/tprint_v0_encode.sh
+++ b/tools/ptobc/tests/tprint_v0_encode.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/tprint_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_tprint_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/tprint_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/tprint_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.tprint ins(" "${ROUNDTRIP}" >/dev/null

--- a/tools/ptobc/tests/trowexpandsub_v0_encode.sh
+++ b/tools/ptobc/tests/trowexpandsub_v0_encode.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/trowexpandsub_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_trowexpandsub_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/trowexpandsub_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/trowexpandsub_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.trowexpandsub ins(" "${ROUNDTRIP}" >/dev/null


### PR DESCRIPTION
**问题**
来源：https://gitcode.com/cann/pto-as/issues/4

ptobc 的 v0 紧凑 opcode 表没有及时覆盖最近新增的一批 PTO op，导致不打开 PTOBC_ALLOW_GENERIC 时，像下面这些 IR 会直接编码失败：
```
pto.trowexpandsub
pto.trowexpanddiv
pto.trowexpandmul
pto.tprint
pto.subset
```
典型报错是：
```
ERROR: op is not in v0 opcode table (and PTOBC_ALLOW_GENERIC is not set): pto.xxx
```
这会让正常的 ptobc encode <file>.pto -o <file>.ptobc 工作流被迫退回 generic escape，不符合 v0 紧凑编码的预期。

**解决方法**

主要做了两类修复。
第一类是补全 v0 opcode/schema 表，位置在 ptobc_opcodes_v0.h：
新增 pto.subset
新增 pto.tprint
新增 pto.trowexpanddiv
新增 pto.trowexpandmul
新增 pto.trowexpandsub
其中 schema 按各自 IR 形态建模：
tprint：固定 1 个 operand、0 result
subset：变长 operands、1 result type
trowexpanddiv / trowexpandmul / trowexpandsub：变长 operands，兼容有无 tmp

第二类是补充回归测试，确保这些 op 能稳定走 v0 编码而不是 generic：
recent_ops_v0_roundtrip.pto
tprint_v0_roundtrip.pto
trowexpandsub_v0_roundtrip.pto
recent_ops_v0_encode.sh
tprint_v0_encode.sh
trowexpandsub_v0_encode.sh
并更新了 CMakeLists.txt

验证上，这笔改动通过了：
cmake --build /Users/fangrui/workspace/huawei/PTOAS/build --target ptobc
ctest --test-dir /Users/fangrui/workspace/huawei/PTOAS/build -R 'ptobc_(recent_ops_v0_encode|trowexpandsub_v0_encode|tprint_v0_encode|opcode_coverage_check)' --output-on-failure
