### PR TITLE
fix(sync): place auto tail clean helper before return

### DIFF
--- a/include/PTO/Transforms/InsertSync/SyncCodegen.h
+++ b/include/PTO/Transforms/InsertSync/SyncCodegen.h
@@ -41,6 +41,9 @@ private:
   // --- 指令生成 ---
   void CreateBarrierOp(IRRewriter &rewriter, Operation *op, SyncOperation *sync,
                        bool beforeInsert);
+
+  // Insert the compiler tail-clean barrier right before function return.
+  void AppendAutoSyncTailBarrierIfNeeded(IRRewriter &rewriter);
  
   void CreateSetWaitOpForSingleBuffer(IRRewriter &rewriter, Operation *op,
                                       SyncOperation *sync, bool beforeInsert);
@@ -73,6 +76,9 @@ private:
  
   // 记录 SyncIndex -> EventID Value 的映射 (缓存)
   DenseMap<unsigned, Value> SyncIndex2SelectBuffer;
+
+  // Deferred tail-clean barrier requested by sync analysis.
+  bool pendingAutoSyncTailBarrier_ = false;
 };
  
 } // namespace pto

--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -71,6 +71,10 @@ void SyncCodegen::Run() {
       }
     }
   });
+
+  // Ensure the tail clean barrier is emitted at function tail, right before
+  // return, instead of being interleaved with other trailing sync ops.
+  AppendAutoSyncTailBarrierIfNeeded(rewriter);
 }
  
 void SyncCodegen::UpdateOpInsertSync(IRRewriter &rewriter) {
@@ -224,6 +228,13 @@ void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
     return;
   }
 
+  // Compiler-inserted tail clean barrier must be anchored at function tail.
+  if (sync->GetActualSrcPipe() == PipelineType::PIPE_ALL &&
+      sync->GetActualDstPipe() == PipelineType::PIPE_ALL) {
+    pendingAutoSyncTailBarrier_ = true;
+    return;
+  }
+
   // [Fix] 判定是否需要前置插入：如果是显式 Before，或者 Op 是 Terminator (如 Yield)
   bool insertAtPos = beforeInsert || op->hasTrait<OpTrait::IsTerminator>();
  
@@ -261,17 +272,30 @@ void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
   auto barrier =
       rewriter.create<pto::BarrierOp>(op->getLoc(), currentPipeAttr);
 
-  // Mark the compiler-inserted function-tail PIPE_ALL barrier. EmitC lowering
-  // routes this to a dedicated inline epilogue helper to enable future,
-  // policy-driven lightweight tails without changing sync analysis.
-  if (sync->GetActualSrcPipe() == PipelineType::PIPE_ALL &&
-      sync->GetActualDstPipe() == PipelineType::PIPE_ALL) {
+  (void)barrier;
+}
+
+void SyncCodegen::AppendAutoSyncTailBarrierIfNeeded(IRRewriter &rewriter) {
+  if (!pendingAutoSyncTailBarrier_)
+    return;
+
+  SmallVector<func::ReturnOp, 4> returns;
+  func_.walk([&](func::ReturnOp ret) { returns.push_back(ret); });
+  if (returns.empty())
+    return;
+
+  auto pipeAllAttr = getPipeAttr(rewriter, PipelineType::PIPE_ALL);
+  for (auto ret : returns) {
+    rewriter.setInsertionPoint(ret);
+    auto barrier = rewriter.create<pto::BarrierOp>(ret.getLoc(), pipeAllAttr);
     barrier->setAttr("pto.auto_sync_tail_barrier", rewriter.getUnitAttr());
     if (auto hintAttr =
             func_->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint")) {
       barrier->setAttr("pto.auto_sync_tail_hint", hintAttr);
     }
   }
+
+  pendingAutoSyncTailBarrier_ = false;
 }
  
 void SyncCodegen::CreateSetWaitOpForSingleBuffer(IRRewriter &rewriter,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -3764,11 +3764,27 @@ struct PTOTMatmulAccToTMATMULACC : public OpConversionPattern<pto::TMatmulAccOp>
 // Return lowering
 //===----------------------------------------------------------------------===
 
+static constexpr llvm::StringLiteral kAutoSyncTailPendingModeAttr =
+    "__pto.auto_sync_tail_mode";
+
 struct ReturnToEmitC : public OpConversionPattern<func::ReturnOp> {
   using OpConversionPattern<func::ReturnOp>::OpConversionPattern;
 
   LogicalResult matchAndRewrite(func::ReturnOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
+    if (auto emitcFunc = op->getParentOfType<emitc::FuncOp>()) {
+      if (auto modeAttr =
+              emitcFunc->getAttrOfType<StringAttr>(kAutoSyncTailPendingModeAttr)) {
+        auto *ctx = rewriter.getContext();
+        rewriter.setInsertionPoint(op);
+        auto args = rewriter.getArrayAttr(
+            {emitc::OpaqueAttr::get(ctx, modeAttr.getValue())});
+        rewriter.create<emitc::CallOpaqueOp>(
+            op.getLoc(), TypeRange{}, "ptoas_auto_sync_tail",
+            args, ArrayAttr{}, ValueRange{});
+      }
+    }
+
     auto vals = adaptor.getOperands();
     if (vals.empty()) {
       rewriter.replaceOpWithNewOp<emitc::ReturnOp>(op, Value{});
@@ -3876,14 +3892,14 @@ struct PTOBarrierToEmitC : public OpConversionPattern<pto::BarrierOp> {
 
   LogicalResult matchAndRewrite(pto::BarrierOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
-    auto *ctx = rewriter.getContext();
-
     if (op->hasAttr(kAutoSyncTailBarrierAttr)) {
-      auto args = rewriter.getArrayAttr(
-          {emitc::OpaqueAttr::get(ctx, getAutoSyncTailModeToken(op))});
-      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-          op, TypeRange{}, "ptoas_auto_sync_tail",
-          args, ArrayAttr{}, ValueRange{});
+      auto modeAttr = rewriter.getStringAttr(getAutoSyncTailModeToken(op));
+      if (auto emitcFunc = op->getParentOfType<emitc::FuncOp>()) {
+        emitcFunc->setAttr(kAutoSyncTailPendingModeAttr, modeAttr);
+      } else if (auto funcOp = op->getParentOfType<func::FuncOp>()) {
+        funcOp->setAttr(kAutoSyncTailPendingModeAttr, modeAttr);
+      }
+      rewriter.eraseOp(op);
       return success();
     }
 
@@ -3893,6 +3909,7 @@ struct PTOBarrierToEmitC : public OpConversionPattern<pto::BarrierOp> {
 
     // Convert Enum to String (e.g., PIPE_ALL -> "PIPE_ALL")
     std::string pipeStr = pto::stringifyPIPE(pipeEnum).str();
+    auto *ctx = rewriter.getContext();
 
     auto args = rewriter.getArrayAttr({
         emitc::OpaqueAttr::get(ctx, pipeStr)

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -343,6 +343,14 @@ process_one_dir() {
         overall=1
         continue
       fi
+
+      tail_line=$(grep -n "ptoas_auto_sync_tail(PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0);" "$cpp" | tail -n1 | cut -d: -f1)
+      next_return_line=$(awk -v l="$tail_line" 'NR>l && /^[[:space:]]*return;[[:space:]]*$/ {print NR; exit}' "$cpp")
+      if [[ -z "${tail_line}" || -z "${next_return_line}" || $((next_return_line - tail_line)) -gt 6 ]]; then
+        echo -e "${A}(${base}.py)\tFAIL\ttail call is not placed at function tail (before return)"
+        overall=1
+        continue
+      fi
     fi
 
     # Regression guard: Python unified low-level sync API should dispatch to


### PR DESCRIPTION
Summary
- Ensure compiler auto tail-clean is emitted immediately before function `return`.
- Defer `PIPE_ALL -> PIPE_ALL` auto tail barrier insertion to function tail in InsertSync codegen.
- In EmitC lowering, treat `pto.auto_sync_tail_barrier` as a deferred epilogue marker and emit `ptoas_auto_sync_tail(...)` right before each `return`.
- Add regression check in `test/samples/runop.sh` to require tail helper near `return` for `test_auto_sync_tail_hint`.

Motivation
- `decode_attention_incore_1.pto` (A5) still emitted trailing `wait_flag(...)` after `ptoas_auto_sync_tail(...)`, so tail clean was not at true epilogue.

Design
- `SyncCodegen`
  - Add `pendingAutoSyncTailBarrier_`.
  - Record auto tail barrier requests in `CreateBarrierOp` instead of immediate insertion.
  - Append marked barrier at `func.return` in `AppendAutoSyncTailBarrierIfNeeded`.
- `PTOToEmitC`
  - For `pto.auto_sync_tail_barrier`, store a pending tail mode attr on function and erase barrier op.
  - Inject `ptoas_auto_sync_tail(mode)` in `ReturnToEmitC` before lowering `return`.

Testing
- Build
  - `ninja -C build ptoas` (pass)
- Target regression (user case)
  - Input: `/Users/lishengtao/Downloads/decode_attention_incore_1.pto`
  - Command:
    - `build/tools/ptoas/ptoas --enable-insert-sync --pto-level=level3 --pto-arch=a5 decode_attention_incore_1.pto -o decode_attention_incore_1.fixed_tail_branch.cpp`
  - Verified output order near function end:
    - trailing `wait_flag(...)`
    - then `ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);`
    - then `return;`
- Tail hint sample
  - `test/samples/Sync/test_auto_sync_tail_hint.py` output keeps:
    - `ptoas_auto_sync_tail(PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0);`
    - immediately followed by `return;`

Risk / Rollback
- Risk: low; behavior change is scoped to auto tail-clean path (`pto.auto_sync_tail_barrier`).
- Rollback: revert this PR.
