### PR TITLE
fix(sync): map A5 textract mat->scaling to PIPE_MTE1

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2640,7 +2640,7 @@ def TExtractOp : PTO_TOp<"textract", [
   let extraClassDeclaration = [{
     ::mlir::pto::PIPE getPipe() {
       // Align with pto-isa TEXTRACT op classes:
-      //   - TEXTRACT_M2LR : MAT -> LEFT/RIGHT (MTE1)
+      //   - TEXTRACT_M2LR : MAT -> LEFT/RIGHT (and scaling-like targets) (MTE1)
       //   - TEXTRACT_V2M  : VEC -> MAT       (FIX)
       //   - TEXTRACT_A2M  : ACC -> MAT       (FIX)
       // For pure UB slices (VEC -> VEC), treat as vector pipe.
@@ -2674,7 +2674,8 @@ def TExtractOp : PTO_TOp<"textract", [
       if (s == ::mlir::pto::AddressSpace::MAT &&
           (d == ::mlir::pto::AddressSpace::LEFT ||
            d == ::mlir::pto::AddressSpace::RIGHT ||
-           d == ::mlir::pto::AddressSpace::BIAS)) {
+           d == ::mlir::pto::AddressSpace::BIAS ||
+           d == ::mlir::pto::AddressSpace::SCALING)) {
         return ::mlir::pto::PIPE::PIPE_MTE1;
       }
 

--- a/test/basic/textract_a5_scaling_pipe_selection.pto
+++ b/test/basic/textract_a5_scaling_pipe_selection.pto
@@ -1,0 +1,23 @@
+// RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  // A5: textract mat->scaling follows TEXTRACT_M2LR data-movement path and
+  // must be treated as PIPE_MTE1 in sync insertion.
+  func.func @textract_mat_scaling_sync(%in: memref<32x32xf16, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+
+    pto.tload ins(%in : memref<32x32xf16, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+    pto.textract ins(%src, %c0, %c0 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>, index, index)
+                outs(%dst : !pto.tile_buf<loc=scaling, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void textract_mat_scaling_sync(
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+// CHECK-NOT: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK: TEXTRACT(


### PR DESCRIPTION
Summary
- Fix `pto.textract` pipe classification on A5 for `MAT -> SCALING` destination.
- Add a regression test to lock sync insertion behavior for this path.

Motivation
- Codex review reported a P1 mismatch: verifier accepts A5 `MAT -> SCALING`, but `TExtractOp::getPipe()` did not include `SCALING`, so insert-sync treated this path as `PIPE_V`.
- This could insert wrong sync edges (e.g. `PIPE_MTE2 -> PIPE_V`) for a data-movement path that should be MTE1-class.

Design
- Update `TExtractOp::getPipe()` (`include/PTO/IR/PTOOps.td`) to classify:
  - `MAT -> LEFT/RIGHT/BIAS/SCALING` as `PIPE_MTE1`.
- Add `test/basic/textract_a5_scaling_pipe_selection.pto`:
  - checks `set/wait(PIPE_MTE2, PIPE_MTE1, EVENT_ID0)`
  - checks NOT `PIPE_MTE2 -> PIPE_V` for this case.

Testing
- Targeted local checks with rebuilt `ptoas`:
  - `ptoas --pto-arch a5 --enable-insert-sync test/basic/textract_a5_scaling_pipe_selection.pto`
    - output contains `set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0)`
    - output does not contain `set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0)`
  - Regeneration sanity for `decode_attention_incore_1.pto` still keeps expected A5 sync style (no `PIPE_MTE1` regressions there).

Risk / Rollback
- Risk is limited to A5 `pto.textract` with `dst=SCALING`; other paths unchanged.
- Rollback: revert this PR commit.
