### PR TITLE
feat: gate vector mask reset emission under --cpu-sim

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -42,6 +42,9 @@ std::unique_ptr<Pass> createPTOInsertSyncPass();
 std::unique_ptr<Pass> createEmitPTOManualPass();
 // Explicitly select target arch for codegen.
 std::unique_ptr<Pass> createEmitPTOManualPass(PTOArch arch);
+// CPU simulation mode suppresses vector mask reset boilerplate that breaks
+// pto-isa simulation.
+std::unique_ptr<Pass> createEmitPTOManualPass(PTOArch arch, bool cpuSim);
 
 
 /// Create a pass to convert ops from other dialects to PTO Ops.

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -2393,7 +2393,11 @@ static std::optional<StringRef> getKernelKindMacro(func::FuncOp funcOp) {
 }
 
 struct FuncToEmitC : public OpConversionPattern<func::FuncOp> {
-  using OpConversionPattern<func::FuncOp>::OpConversionPattern;
+  FuncToEmitC(TypeConverter &typeConverter, MLIRContext *context, bool cpuSim)
+      : OpConversionPattern<func::FuncOp>(typeConverter, context),
+        cpuSim(cpuSim) {}
+
+  bool cpuSim;
 
   LogicalResult matchAndRewrite(func::FuncOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
@@ -2463,7 +2467,7 @@ struct FuncToEmitC : public OpConversionPattern<func::FuncOp> {
       if (kernelKindMacro) {
         std::string startMacro = "\n#if defined(" + kernelKindMacro->str() + ")";
         rewriter.create<emitc::VerbatimOp>(op.getLoc(), startMacro);
-        if (*kernelKindMacro == "__DAV_VEC__") {
+        if (!cpuSim && *kernelKindMacro == "__DAV_VEC__") {
           rewriter.create<emitc::VerbatimOp>(op.getLoc(), "set_mask_norm();");
           rewriter.create<emitc::VerbatimOp>(op.getLoc(),
                                              "set_vector_mask(-1, -1);");
@@ -7834,7 +7838,12 @@ public:
 //===----------------------------------------------------------------------===//
 template <typename SectionOpTy>
 struct SectionToEmitC : public OpConversionPattern<SectionOpTy> {
-  using OpConversionPattern<SectionOpTy>::OpConversionPattern;
+  SectionToEmitC(TypeConverter &typeConverter, MLIRContext *context,
+                 bool cpuSim)
+      : OpConversionPattern<SectionOpTy>(typeConverter, context),
+        cpuSim(cpuSim) {}
+
+  bool cpuSim;
 
   std::string getMacroName() const {
     if (std::is_same<SectionOpTy, pto::SectionCubeOp>::value)
@@ -7856,8 +7865,10 @@ struct SectionToEmitC : public OpConversionPattern<SectionOpTy> {
       // Vector mask is a global HW state and may be modified by previous kernels
       // (or earlier sections). Reset it to a well-defined state for deterministic
       // execution of VEC ops.
-      rewriter.create<emitc::VerbatimOp>(loc, "set_mask_norm();");
-      rewriter.create<emitc::VerbatimOp>(loc, "set_vector_mask(-1, -1);");
+      if (!cpuSim) {
+        rewriter.create<emitc::VerbatimOp>(loc, "set_mask_norm();");
+        rewriter.create<emitc::VerbatimOp>(loc, "set_vector_mask(-1, -1);");
+      }
     }
 
     Block &innerBlock = op.getBody().front();
@@ -8317,7 +8328,8 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
                                        TypeConverter &typeConverter,
                                        MLIRContext *ctx,
                                        DataFlowSolver &solver,
-                                       PTOArch targetArch) {
+                                       PTOArch targetArch,
+                                       bool cpuSim) {
   (void)solver;
   patterns.add<ArithCmpIToEmitC>(typeConverter, ctx);
   patterns.add<PTOBindTileToEmitC>(typeConverter, ctx);
@@ -8390,7 +8402,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOMovFPToEmitC>(typeConverter, ctx);
   patterns.add<PTOOrsToEmitC>(typeConverter, ctx);
   patterns.add<PTOLogToEmitC>(typeConverter, ctx);
-  patterns.add<FuncToEmitC>(typeConverter, ctx);
+  patterns.add<FuncToEmitC>(typeConverter, ctx, cpuSim);
   patterns.add<PTOMovToEmitC>(typeConverter, ctx);
   patterns.add<ArithConstantToEmitC>(typeConverter, ctx);
   patterns.add<ArithAddUIExtendedToEmitC>(typeConverter, ctx);
@@ -8490,8 +8502,9 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOTFreeToEmitC>(typeConverter, ctx, targetArch);
   patterns.add<PTOSyncSetToEmitC>(typeConverter, ctx, targetArch);
   patterns.add<PTOSyncWaitToEmitC>(typeConverter, ctx, targetArch);
-  patterns.add<SectionToEmitC<pto::SectionCubeOp>>(typeConverter, ctx);
-  patterns.add<SectionToEmitC<pto::SectionVectorOp>>(typeConverter, ctx);
+  patterns.add<SectionToEmitC<pto::SectionCubeOp>>(typeConverter, ctx, cpuSim);
+  patterns.add<SectionToEmitC<pto::SectionVectorOp>>(typeConverter, ctx,
+                                                     cpuSim);
   patterns.add<PTOGetBlockIdxToEmitC>(typeConverter, ctx);
   patterns.add<PTOGetBlockNumToEmitC>(typeConverter, ctx);
   patterns.add<PTOGetSubBlockIdxToEmitC>(typeConverter, ctx);
@@ -8530,10 +8543,14 @@ struct EmitPTOManualPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(EmitPTOManualPass)
 
   PTOArch targetArch;
+  bool cpuSim;
 
-  EmitPTOManualPass() : targetArch(PTOArch::A3) {}
+  EmitPTOManualPass() : targetArch(PTOArch::A3), cpuSim(false) {}
 
-  explicit EmitPTOManualPass(PTOArch arch) : targetArch(arch) {}
+  explicit EmitPTOManualPass(PTOArch arch) : targetArch(arch), cpuSim(false) {}
+
+  EmitPTOManualPass(PTOArch arch, bool cpuSim)
+      : targetArch(arch), cpuSim(cpuSim) {}
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<emitc::EmitCDialect, func::FuncDialect, arith::ArithDialect,
@@ -8736,7 +8753,8 @@ static AICORE inline void ptoas_auto_sync_tail(
       return signalPassFailure();
 
     RewritePatternSet patterns(ctx);
-    populatePTOToEmitCPatterns(patterns, typeConverter, ctx, *solver, targetArch);
+    populatePTOToEmitCPatterns(patterns, typeConverter, ctx, *solver,
+                               targetArch, cpuSim);
 
     // 4. 执行转换
     if (failed(applyPartialConversion(mop, target, std::move(patterns)))) {
@@ -8923,4 +8941,9 @@ std::unique_ptr<Pass> mlir::pto::createEmitPTOManualPass() {
 
 std::unique_ptr<Pass> mlir::pto::createEmitPTOManualPass(PTOArch arch) {
   return std::make_unique<EmitPTOManualPass>(arch);
+}
+
+std::unique_ptr<Pass> mlir::pto::createEmitPTOManualPass(PTOArch arch,
+                                                         bool cpuSim) {
+  return std::make_unique<EmitPTOManualPass>(arch, cpuSim);
 }

--- a/test/basic/kernel_kind_vector_scf_while_emitc.pto
+++ b/test/basic/kernel_kind_vector_scf_while_emitc.pto
@@ -1,4 +1,5 @@
 // RUN: ptoas %s | FileCheck %s
+// RUN: ptoas --cpu-sim %s | FileCheck %s --check-prefix=CPU-SIM
 
 module {
   func.func @vector_while_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
@@ -74,3 +75,18 @@ module {
 // CHECK: goto [[HEADER]];
 // CHECK: [[EXIT]]:
 // CHECK: #endif // __DAV_VEC__
+
+// CPU-SIM: AICORE void vector_while_kernel()
+// CPU-SIM: using T = float;
+// CPU-SIM: #if defined(__DAV_VEC__)
+// CPU-SIM-NOT: set_mask_norm();
+// CPU-SIM-NOT: set_vector_mask(-1, -1);
+// CPU-SIM: goto [[CPU_HEADER:label[0-9]+]];
+// CPU-SIM: [[CPU_HEADER]]:
+// CPU-SIM: if ({{.*}}) {
+// CPU-SIM: goto [[CPU_BODY:label[0-9]+]];
+// CPU-SIM: goto [[CPU_EXIT:label[0-9]+]];
+// CPU-SIM: [[CPU_BODY]]:
+// CPU-SIM: goto [[CPU_HEADER]];
+// CPU-SIM: [[CPU_EXIT]]:
+// CPU-SIM: #endif // __DAV_VEC__

--- a/test/basic/section_vector_cpu_sim.pto
+++ b/test/basic/section_vector_cpu_sim.pto
@@ -1,0 +1,23 @@
+// RUN: ptoas %s | FileCheck %s --check-prefix=DEFAULT
+// RUN: ptoas --cpu-sim %s | FileCheck %s --check-prefix=CPU-SIM
+
+module {
+  func.func @section_vec() {
+    pto.section.vector {
+      %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    }
+    return
+  }
+}
+
+// DEFAULT-LABEL: AICORE void section_vec()
+// DEFAULT: #if defined(__DAV_VEC__)
+// DEFAULT: set_mask_norm();
+// DEFAULT: set_vector_mask(-1, -1);
+// DEFAULT: #endif // __DAV_VEC__
+
+// CPU-SIM-LABEL: AICORE void section_vec()
+// CPU-SIM: #if defined(__DAV_VEC__)
+// CPU-SIM-NOT: set_mask_norm();
+// CPU-SIM-NOT: set_vector_mask(-1, -1);
+// CPU-SIM: #endif // __DAV_VEC__

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -190,6 +190,13 @@ static llvm::cl::opt<bool> emitAddPtrTrace(
     llvm::cl::desc("Emit addptr trace comments in generated C++ output"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> cpuSim(
+    "cpu-sim",
+    llvm::cl::desc(
+        "Emit C++ suitable for pto-isa CPU simulation by suppressing vector "
+        "mask reset boilerplate"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<std::string> ptoTargetArch(
     "pto-arch",
     llvm::cl::desc("Target Ascend architecture for codegen: a3 or a5 (default: a3)"),
@@ -857,9 +864,9 @@ int main(int argc, char **argv) {
 
   pm.addPass(createCSEPass());
   if (arch == "a3") {
-    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A3));
+    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A3, cpuSim));
   } else {
-    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A5));
+    pm.addPass(pto::createEmitPTOManualPass(pto::PTOArch::A5, cpuSim));
   }
   pm.addPass(emitc::createFormExpressionsPass());
   pm.addPass(mlir::createCSEPass());


### PR DESCRIPTION
## Summary
- add a `--cpu-sim` CLI flag and thread it into the EmitC lowering pass
- suppress `set_mask_norm();` and `set_vector_mask(-1, -1);` when emitting vector prologue and `pto.section.vector` code for CPU simulation
- add coverage for both `pto.kernel_kind = vector` and `pto.section.vector`

## Validation
- `cmake --build build --target ptoas -j8`
- `/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/basic/kernel_kind_vector_scf_while_emitc.pto --input-file=<(build/tools/ptoas/ptoas test/basic/kernel_kind_vector_scf_while_emitc.pto)`
- `/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/basic/kernel_kind_vector_scf_while_emitc.pto --check-prefix=CPU-SIM --input-file=<(build/tools/ptoas/ptoas --cpu-sim test/basic/kernel_kind_vector_scf_while_emitc.pto)`
- `/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/basic/section_vector_cpu_sim.pto --check-prefix=DEFAULT --input-file=<(build/tools/ptoas/ptoas test/basic/section_vector_cpu_sim.pto)`
- `/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/basic/section_vector_cpu_sim.pto --check-prefix=CPU-SIM --input-file=<(build/tools/ptoas/ptoas --cpu-sim test/basic/section_vector_cpu_sim.pto)`
