### PR TITLE
fix: cleanup dead emitc casts/constants after lowering

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -7424,6 +7424,11 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
         v = castOp.getOperand();
       return v;
     };
+    auto sourceCastOp = adaptor.getSource().getDefiningOp<emitc::CastOp>();
+    auto eraseDeadSourceCast = [&]() {
+      if (sourceCastOp && sourceCastOp->use_empty())
+        rewriter.eraseOp(sourceCastOp);
+    };
     auto isTileLike = [](Value v) -> bool {
       auto ot = dyn_cast<emitc::OpaqueType>(v.getType());
       if (!ot)
@@ -7690,6 +7695,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
                                            ArrayAttr{}, ArrayAttr{},
                                            ValueRange{dstTile, *addr});
       rewriter.replaceOp(op, dstTile);
+      eraseDeadSourceCast();
       return success();
     }
 
@@ -7704,6 +7710,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
                                            ArrayAttr{}, ArrayAttr{},
                                            ValueRange{dstTile, tileCandidate});
       rewriter.replaceOp(op, dstTile);
+      eraseDeadSourceCast();
       return success();
     }
 
@@ -7718,6 +7725,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
         if (auto srcTy = dyn_cast<emitc::OpaqueType>(tileCandidate.getType())) {
           if (srcTy.getValue() == tileSpec->tileTypeStr) {
             rewriter.replaceOp(op, tileCandidate);
+            eraseDeadSourceCast();
             return success();
           }
         }
@@ -7732,6 +7740,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
                                            ArrayAttr{}, ArrayAttr{},
                                            ValueRange{dstTile, *addr});
       rewriter.replaceOp(op, dstTile);
+      eraseDeadSourceCast();
       return success();
     }
 
@@ -7758,6 +7767,7 @@ struct PTOBindTileToEmitC : public OpConversionPattern<pto::BindTileOp> {
       newCast->setAttr(kForceDynamicValidShapeAttrName,
                        op->getAttr(kForceDynamicValidShapeAttrName));
     rewriter.replaceOp(op, newCast.getResult());
+    eraseDeadSourceCast();
 
     return success();
   }

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -441,6 +441,27 @@ static void materializeControlFlowOperands(Operation *rootOp) {
   }
 }
 
+// Remove trivially dead scalar helpers that commonly remain after conversion.
+// These are pure value producers and safe to erase when they have no uses.
+static void dropTriviallyDeadEmitCOps(Operation *rootOp) {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    llvm::SmallVector<Operation *, 32> toErase;
+    rootOp->walk([&](Operation *op) {
+      if (!op->use_empty())
+        return;
+      if (isa<emitc::CastOp, emitc::ConstantOp, UnrealizedConversionCastOp>(op))
+        toErase.push_back(op);
+    });
+    if (toErase.empty())
+      continue;
+    changed = true;
+    for (Operation *op : llvm::reverse(toErase))
+      op->erase();
+  }
+}
+
 static bool rewriteMarkerCallToSubscript(std::string &cpp, llvm::StringRef marker,
                                          unsigned expectedNumArgs,
                                          bool isStore) {
@@ -871,6 +892,7 @@ int main(int argc, char **argv) {
 
   dropEmptyEmitCExpressions(module.get());
   materializeControlFlowOperands(module.get());
+  dropTriviallyDeadEmitCOps(module.get());
   if (failed(reorderEmitCFunctions(module.get()))) {
     llvm::errs() << "Error: Failed to order emitted functions for C++ emission.\n";
     return 1;


### PR DESCRIPTION
## Summary
- Add a post-conversion cleanup in `ptoas` to erase trivially dead pure helper ops:
  - `emitc.cast`
  - `emitc.constant`
  - `builtin.unrealized_conversion_cast`
- In `PTOBindTileToEmitC`, erase dead source `emitc.cast` once `pto.bind_tile` has been rewritten.

## Motivation
Some lowering paths can leave unused scalar helper ops in the final EmitC module (unused constants/casts and dead source cast wrappers). These generate noisy C++ and can confuse inspection/debugging.

This PR keeps the cleanup conservative: only erase when `use_empty()` is true.

## Design
- `tools/ptoas/ptoas.cpp`
  - Add `dropTriviallyDeadEmitCOps(Operation *rootOp)`
  - Run it after existing expression/control-flow materialization cleanup
- `lib/PTO/Transforms/PTOToEmitC.cpp`
  - In `PTOBindTileToEmitC::matchAndRewrite`, opportunistically remove dead `emitc::CastOp` from source value after replacement paths

## Testing
- `ninja -C build ptoas` (pass)
- `ninja -C build install` (pass)
- `bash test/samples/runop.sh -t Subset` with Python runtime env configured (pass; expected XFAIL preserved)

## Risk / Safety
- Low risk: cleanup only applies to ops with zero uses.
- No semantic rewrite of live values; only dead helper ops are removed.
