### PR TITLE
[Feature] Support explicit getFFTSMsg modes in sync.set

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1723,11 +1723,14 @@ def SyncSetOp : PTO_Op<"sync.set"> {
   let description = [{
     Sets a synchronization signal on the specified pipeline stage.
     Corresponds to `ffts_cross_core_sync` (A3) or `set_intra_block` (A5).
+    On A3, the optional `ffts_mode` attribute selects the first argument passed
+    to `getFFTSMsg`; if omitted, the legacy `FFTS_MODE_VAL` path is preserved.
   }];
 
   let arguments = (ins
     PTO_PipeAttr:$pipe,
     OptionalAttr<I32Attr>:$event_id,
+    OptionalAttr<I32Attr>:$ffts_mode,
     Optional<Index>:$event_id_dyn
   );
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -1532,6 +1532,12 @@ LogicalResult mlir::pto::SyncSetOp::verify() {
   if (hasStatic == hasDynamic)
     return emitOpError()
            << "expects exactly one event-id form: static attr or dynamic index operand";
+  if (IntegerAttr fftsModeAttr = getFftsModeAttr()) {
+    int64_t fftsMode = fftsModeAttr.getInt();
+    if (fftsMode < 0 || fftsMode > 2)
+      return emitOpError() << "requires ffts_mode in range [0, 2], but got "
+                           << fftsMode;
+  }
   return success();
 }
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -487,9 +487,17 @@ static Value castInterCoreEventIdToI32(ConversionPatternRewriter &rewriter,
   return emitCCast(rewriter, loc, i32Ty, eventId);
 }
 
+static Attribute getFFTSModeCodegenArg(ConversionPatternRewriter &rewriter,
+                                       int64_t fftsMode) {
+  auto *ctx = rewriter.getContext();
+  if (fftsMode == 2)
+    return emitc::OpaqueAttr::get(ctx, "FFTS_MODE_VAL");
+  return emitc::OpaqueAttr::get(ctx, std::to_string(fftsMode));
+}
+
 static InterCoreSyncCallDesc buildInterCoreSyncSetCall(
     ConversionPatternRewriter &rewriter, Location loc, PTOArch targetArch,
-    pto::PipeAttr pipeAttr, IntegerAttr eventIdAttr) {
+    pto::PipeAttr pipeAttr, IntegerAttr eventIdAttr, int64_t fftsMode) {
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
@@ -500,7 +508,7 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCall(
 
     auto msgTy = emitc::OpaqueType::get(ctx, "uint16_t");
     auto msgArgs = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, "FFTS_MODE_VAL"),
+        getFFTSModeCodegenArg(rewriter, fftsMode),
         IntegerAttr::get(IndexType::get(ctx), 0),
     });
     Value msgVal =
@@ -530,7 +538,7 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCall(
 
 static InterCoreSyncCallDesc buildInterCoreSyncSetCallDyn(
     ConversionPatternRewriter &rewriter, Location loc, PTOArch targetArch,
-    pto::PipeAttr pipeAttr, Value eventIdVal) {
+    pto::PipeAttr pipeAttr, Value eventIdVal, int64_t fftsMode) {
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
   Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdVal);
@@ -538,7 +546,7 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCallDyn(
   if (targetArch == PTOArch::A3) {
     auto msgTy = emitc::OpaqueType::get(ctx, "uint16_t");
     auto msgArgs = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, "FFTS_MODE_VAL"),
+        getFFTSModeCodegenArg(rewriter, fftsMode),
         IntegerAttr::get(IndexType::get(ctx), 0),
     });
     Value msgVal =
@@ -4246,6 +4254,9 @@ struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
     auto loc = op->getLoc();
     IntegerAttr eventIdAttr = op.getEventIdAttr();
     Value eventIdDyn = adaptor.getEventIdDyn();
+    int64_t fftsMode = 2;
+    if (IntegerAttr fftsModeAttr = op.getFftsModeAttr())
+      fftsMode = fftsModeAttr.getInt();
 
     if ((eventIdAttr != nullptr) == static_cast<bool>(eventIdDyn))
       return rewriter.notifyMatchFailure(
@@ -4254,10 +4265,10 @@ struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
     InterCoreSyncCallDesc desc;
     if (eventIdAttr) {
       desc = buildInterCoreSyncSetCall(rewriter, loc, targetArch, op.getPipe(),
-                                       eventIdAttr);
+                                       eventIdAttr, fftsMode);
     } else {
       desc = buildInterCoreSyncSetCallDyn(rewriter, loc, targetArch, op.getPipe(),
-                                          eventIdDyn);
+                                          eventIdDyn, fftsMode);
     }
     rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, desc.callee,
                                          /*args=*/desc.args,

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -266,39 +266,60 @@ def wait_flag(src_pipe, dst_pipe, event_id, *, loc=None, ip=None):
 # -----------------------------------------------------------------------------
 # Inter-core sync helpers (pto.sync.set / pto.sync.wait / pto.set_ffts)
 # -----------------------------------------------------------------------------
-def sync_set_dyn(pipe, event_id, *, loc=None, ip=None):
+def sync_set_dyn(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     ctx = loc.context if loc else _ods_ir.Context.current
     pipe_attr = _ensure_pipe_attr(pipe, ctx)
     event_val = _pto_ops_gen._get_op_result_or_value(event_id)
+    mode_attr = None
+    if ffts_mode != 2:
+        mode_attr = _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
     # Preferred unified-op path: pto.sync.set(pipe, event_id_dyn=%v)
     try:
         return _pto_ops_gen.sync_set(
-            pipe_attr, event_id=None, event_id_dyn=event_val, loc=loc, ip=ip
+            pipe_attr,
+            event_id=None,
+            ffts_mode=mode_attr,
+            event_id_dyn=event_val,
+            loc=loc,
+            ip=ip,
         )
     except TypeError:
-        # Backward compatibility: older generated bindings with dedicated op.
-        if hasattr(_pto_ops_gen, "sync_set_dyn"):
-            return _pto_ops_gen.sync_set_dyn(pipe_attr, event_val, loc=loc, ip=ip)
-        raise
+        attrs = {"pipe": pipe_attr}
+        if mode_attr is not None:
+            attrs["ffts_mode"] = mode_attr
+        return _ods_ir.Operation.create(
+            "pto.sync.set", attributes=attrs, operands=[event_val], loc=loc, ip=ip
+        )
 
 
-def sync_set(pipe, event_id, *, loc=None, ip=None):
+def sync_set(pipe, event_id, ffts_mode=2, *, loc=None, ip=None):
     ctx = loc.context if loc else _ods_ir.Context.current
     pipe_attr = _ensure_pipe_attr(pipe, ctx)
+    mode_attr = None
+    if ffts_mode != 2:
+        mode_attr = _ensure_i32_attr(ffts_mode, "ffts_mode", ctx)
     if _is_static_i32_event_id(event_id):
         event_attr = _ensure_i32_attr(event_id, "event_id", ctx)
         try:
             return _pto_ops_gen.sync_set(
-                pipe_attr, event_id=event_attr, event_id_dyn=None, loc=loc, ip=ip
-            )
-        except TypeError:
-            return _ods_ir.Operation.create(
-                "pto.sync.set",
-                attributes={"pipe": pipe_attr, "event_id": event_attr},
+                pipe_attr,
+                event_id=event_attr,
+                ffts_mode=mode_attr,
+                event_id_dyn=None,
                 loc=loc,
                 ip=ip,
             )
-    return sync_set_dyn(pipe_attr, event_id, loc=loc, ip=ip)
+        except TypeError:
+            attrs = {"pipe": pipe_attr, "event_id": event_attr}
+            if mode_attr is not None:
+                attrs["ffts_mode"] = mode_attr
+            return _ods_ir.Operation.create(
+                "pto.sync.set",
+                attributes=attrs,
+                loc=loc,
+                ip=ip,
+            )
+    return sync_set_dyn(pipe_attr, event_id, ffts_mode=ffts_mode, loc=loc, ip=ip)
 
 
 def sync_wait_dyn(pipe, event_id, *, loc=None, ip=None):

--- a/test/samples/Sync/test_intercore_sync_a3_modes.py
+++ b/test/samples/Sync/test_intercore_sync_a3_modes.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+from mlir.ir import Context, IndexType, InsertionPoint, IntegerType, Location, MemRefType, Module
+from mlir.dialects import func, pto
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+        with Location.unknown(ctx):
+            module = Module.create()
+
+            idx = IndexType.get(ctx)
+            i64 = IntegerType.get_signless(64, ctx)
+            ffts_ty = MemRefType.get([256], i64)
+            fn_ty = func.FunctionType.get([ffts_ty, idx], [])
+
+            with InsertionPoint(module.body):
+                fn = func.FuncOp("test_intercore_sync_a3_modes", fn_ty)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                pipe_mte3 = pto.PipeAttr.get(pto.PIPE.PIPE_MTE3, ctx)
+                pto.set_ffts(entry.arguments[0])
+                pto.sync_set(pipe_mte3, 3, ffts_mode=0)
+                pto.sync_set(pipe_mte3, entry.arguments[1], ffts_mode=1)
+                func.ReturnOp([])
+
+            module.operation.verify()
+            return module
+
+
+if __name__ == "__main__":
+    print(build())

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -219,6 +219,10 @@ process_one_dir() {
       echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a3"
       continue
     fi
+    if [[ "$base" == "test_intercore_sync_a3_modes" && "$(printf '%s' "$target_arch" | tr '[:upper:]' '[:lower:]')" != "a3" ]]; then
+      echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a3"
+      continue
+    fi
     if [[ "$base" == "test_intercore_sync_a3_missing_setffts" && "$(printf '%s' "$target_arch" | tr '[:upper:]' '[:lower:]')" != "a3" ]]; then
       echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a3"
       continue
@@ -504,6 +508,23 @@ process_one_dir() {
       fi
       if grep -Fq "wait_flag_dev(3)" "$cpp"; then
         echo -e "${A}(${base}.py)\tFAIL\tunexpected static wait_flag_dev(3) in dynamic test"
+        overall=1
+        continue
+      fi
+    fi
+    if [[ "$base" == "test_intercore_sync_a3_modes" ]]; then
+      if ! grep -Fq "set_ffts_base_addr(" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing set_ffts_base_addr() lowering"
+        overall=1
+        continue
+      fi
+      if ! grep -Fq "getFFTSMsg(0," "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing A3 getFFTSMsg(0, ...) lowering"
+        overall=1
+        continue
+      fi
+      if ! grep -Fq "getFFTSMsg(1," "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing A3 getFFTSMsg(1, ...) lowering"
         overall=1
         continue
       fi


### PR DESCRIPTION
Closes #369

## Summary
- add optional `ffts_mode` to `pto.sync.set`, defaulting to the legacy A3 `FFTS_MODE_VAL` path
- lower explicit A3 modes to `getFFTSMsg(0, ...)` / `getFFTSMsg(1, ...)` while keeping existing A5 lowering unchanged
- extend Python helpers and add a Sync regression sample plus `runop.sh` checks for the new lowering

## Verification
- built `ptoas`, `ptobc`, and `_pto` in a clean worktree against local LLVM/MLIR
- verified manual `.pto` lowering emits `getFFTSMsg(0, ...)` and `getFFTSMsg(1, ...)`
- verified default lowering still emits `getFFTSMsg(FFTS_MODE_VAL, ...)`
- verified verifier rejects `ffts_mode = 3`
- rebuilt Python bindings with `/usr/bin/python3` (CPython 3.9) to match the local `mlir_core` package and ran `test/samples/Sync/test_intercore_sync_a3_modes.py`
- verified the Python-generated `.pto` also lowers to `getFFTSMsg(0, ...)` and `getFFTSMsg(1, ...)`

## Notes
- the default shell `python3` on this machine is CPython 3.13, while the checked-out LLVM `mlir_core` package was built for CPython 3.9; Python sample verification therefore needs `/usr/bin/python3` on this host
