### PR TITLE
Implement compact tile_buf assembly syntax

### DIFF
--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -102,23 +102,24 @@ int32_t TileBufType::getCompactModeI32() const {
   return 0;
 }
 
-// ---- TileBufType custom asm ----
-// !pto.tile_buf<<loc=.., dtype=.., rows=.., cols=.., blayout=.., valid=..x.., slayout=.., fractal=.., pad=..>>
-Type TileBufType::parse(AsmParser &parser) {
-  MLIRContext *ctx = parser.getContext();
+namespace {
 
-  if (failed(parser.parseLess()))
-    return Type();
-
+struct ParsedTileBufFields {
   std::string locStr;
   Type dtype;
-  int64_t rows = 0, cols = 0;
-  int64_t vrow = -1, vcol = -1;
-  std::string blayoutStr, slayoutStr;
+  int64_t rows = 0;
+  int64_t cols = 0;
+  int64_t vrow = -1;
+  int64_t vcol = -1;
+  std::string blayoutStr;
+  std::string slayoutStr;
   int64_t fractal = 0;
-  uint32_t padInt;
+  uint32_t padInt = 0;
   uint32_t compactInt = 0;
+};
 
+static LogicalResult parseLegacyTileBufFields(AsmParser &parser,
+                                              ParsedTileBufFields &fields) {
   auto parseKeyEq = [&](StringRef expectedKey) -> LogicalResult {
     if (failed(parser.parseKeyword(expectedKey)))
       return failure();
@@ -127,176 +128,372 @@ Type TileBufType::parse(AsmParser &parser) {
     return success();
   };
 
-  // loc=Vec
-  {
-    if (failed(parseKeyEq("loc"))) return Type();
-    // Vec/Mat/Acc 不是类型/属性，直接当 keyword/string 读
-    if (failed(parser.parseKeywordOrString(&locStr))) return Type();
-    if (failed(parser.parseComma())) return Type();
+  if (failed(parser.parseEqual()))
+    return failure();
+  if (failed(parser.parseKeywordOrString(&fields.locStr)))
+    return failure();
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("dtype")))
+    return failure();
+  if (failed(parser.parseType(fields.dtype)))
+    return failure();
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("rows")))
+    return failure();
+  if (failed(parser.parseInteger(fields.rows)))
+    return failure();
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("cols")))
+    return failure();
+  if (failed(parser.parseInteger(fields.cols)))
+    return failure();
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("v_row")))
+    return failure();
+  if (succeeded(parser.parseOptionalQuestion())) {
+    fields.vrow = -1;
+  } else {
+    if (failed(parser.parseInteger(fields.vrow)))
+      return failure();
+    if (fields.vrow < -1) {
+      parser.emitError(parser.getCurrentLocation(),
+                       "v_row must be '?', -1, or a non-negative integer");
+      return failure();
+    }
+  }
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("v_col")))
+    return failure();
+  if (succeeded(parser.parseOptionalQuestion())) {
+    fields.vcol = -1;
+  } else {
+    if (failed(parser.parseInteger(fields.vcol)))
+      return failure();
+    if (fields.vcol < -1) {
+      parser.emitError(parser.getCurrentLocation(),
+                       "v_col must be '?', -1, or a non-negative integer");
+      return failure();
+    }
+  }
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("blayout")))
+    return failure();
+  if (failed(parser.parseKeywordOrString(&fields.blayoutStr)))
+    return failure();
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("slayout")))
+    return failure();
+  if (failed(parser.parseKeywordOrString(&fields.slayoutStr)))
+    return failure();
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("fractal")))
+    return failure();
+  if (failed(parser.parseInteger(fields.fractal)))
+    return failure();
+  if (failed(parser.parseComma()))
+    return failure();
+
+  if (failed(parseKeyEq("pad")))
+    return failure();
+  if (failed(parser.parseInteger(fields.padInt)))
+    return failure();
+
+  return success();
+}
+
+static LogicalResult parseCompactTileBufFields(AsmParser &parser,
+                                               StringRef firstToken,
+                                               ParsedTileBufFields &fields) {
+  fields.locStr = firstToken.str();
+
+  if (failed(parser.parseComma()))
+    return failure();
+
+  SmallVector<int64_t, 2> shape;
+  if (failed(parser.parseDimensionList(shape, /*allowDynamic=*/false)))
+    return failure();
+  if (failed(parser.parseType(fields.dtype)))
+    return failure();
+  if (shape.size() != 2) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "tile_buf compact syntax expects exactly two shape dims");
+    return failure();
   }
 
-  // dtype=f16
-  {
-    if (failed(parseKeyEq("dtype"))) return Type();
-    if (failed(parser.parseType(dtype))) return Type();
-    if (failed(parser.parseComma())) return Type();
-  }
+  fields.rows = shape[0];
+  fields.cols = shape[1];
+  fields.vrow = fields.rows;
+  fields.vcol = fields.cols;
 
-  // rows=16
-  {
-    if (failed(parseKeyEq("rows"))) return Type();
-    if (failed(parser.parseInteger(rows))) return Type();
-    if (failed(parser.parseComma())) return Type();
+  auto defaultConfig = TileBufConfigAttr::getDefault(parser.getContext());
+  auto defaultBLayout = llvm::dyn_cast<BLayoutAttr>(defaultConfig.getBLayout());
+  auto defaultSLayout = llvm::dyn_cast<SLayoutAttr>(defaultConfig.getSLayout());
+  auto defaultPad = llvm::dyn_cast<PadValueAttr>(defaultConfig.getPad());
+  auto defaultCompact =
+      llvm::dyn_cast<CompactModeAttr>(defaultConfig.getCompactMode());
+  if (!defaultBLayout || !defaultSLayout || !defaultPad || !defaultCompact) {
+    parser.emitError(parser.getCurrentLocation(),
+                     "failed to load default tile_buf config");
+    return failure();
   }
+  fields.blayoutStr = stringifyBLayout(defaultBLayout.getValue()).str();
+  fields.slayoutStr = stringifySLayout(defaultSLayout.getValue()).str();
+  fields.fractal = defaultConfig.getSFractalSize().getInt();
+  fields.padInt = static_cast<uint32_t>(defaultPad.getValue());
+  fields.compactInt = static_cast<uint32_t>(defaultCompact.getValue());
 
-  // cols=16
-  {
-    if (failed(parseKeyEq("cols"))) return Type();
-    if (failed(parser.parseInteger(cols))) return Type();
-    if (failed(parser.parseComma())) return Type();
-  }
-   
-  {
-    // v_row=?/-1/16 , v_col=?/-1/8   （支持半动态）
-    if (failed(parseKeyEq("v_row"))) return Type();
+  bool seenValid = false;
+  bool seenBLayout = false;
+  bool seenSLayout = false;
+  bool seenFractal = false;
+  bool seenPad = false;
+  bool seenCompact = false;
 
-    // 解析 v_row：'?' -> -1，否则整数（允许 -1 兼容）
-    if (succeeded(parser.parseOptionalQuestion())) {
-        vrow = -1;
-    } else {
-        if (failed(parser.parseInteger(vrow))) return Type();
-        if (vrow < -1) {
-            parser.emitError(parser.getCurrentLocation(),
-                            "v_row must be '?', -1, or a non-negative integer");
-            return Type();
-        }
+  while (succeeded(parser.parseOptionalComma())) {
+    StringRef key;
+    if (failed(parser.parseKeyword(&key)))
+      return failure();
+    if (failed(parser.parseEqual()))
+      return failure();
+
+    if (key == "valid") {
+      if (seenValid) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "duplicate valid in tile_buf compact syntax");
+        return failure();
+      }
+      seenValid = true;
+
+      SmallVector<int64_t, 2> validShape;
+      if (failed(parser.parseDimensionList(validShape, /*allowDynamic=*/true,
+                                           /*withTrailingX=*/false)))
+        return failure();
+      if (validShape.size() != 2) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "tile_buf valid must have exactly two dims");
+        return failure();
+      }
+      fields.vrow = validShape[0];
+      fields.vcol = validShape[1];
+      continue;
     }
 
-    if (failed(parser.parseComma())) return Type();
-
-    if (failed(parseKeyEq("v_col"))) return Type();
-
-    // 解析 v_col：'?' -> -1，否则整数（允许 -1 兼容）
-    if (succeeded(parser.parseOptionalQuestion())) {
-        vcol = -1;
-    } else {
-        if (failed(parser.parseInteger(vcol))) return Type();
-        if (vcol < -1) {
-            parser.emitError(parser.getCurrentLocation(),
-                            "v_col must be '?', -1, or a non-negative integer");
-            return Type();
-        }
+    if (key == "blayout") {
+      if (seenBLayout) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "duplicate blayout in tile_buf compact syntax");
+        return failure();
+      }
+      seenBLayout = true;
+      if (failed(parser.parseKeywordOrString(&fields.blayoutStr)))
+        return failure();
+      continue;
     }
-    if (failed(parser.parseComma())) return Type();
+
+    if (key == "slayout") {
+      if (seenSLayout) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "duplicate slayout in tile_buf compact syntax");
+        return failure();
+      }
+      seenSLayout = true;
+      if (failed(parser.parseKeywordOrString(&fields.slayoutStr)))
+        return failure();
+      continue;
+    }
+
+    if (key == "fractal") {
+      if (seenFractal) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "duplicate fractal in tile_buf compact syntax");
+        return failure();
+      }
+      seenFractal = true;
+      if (failed(parser.parseInteger(fields.fractal)))
+        return failure();
+      continue;
+    }
+
+    if (key == "pad") {
+      if (seenPad) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "duplicate pad in tile_buf compact syntax");
+        return failure();
+      }
+      seenPad = true;
+      if (failed(parser.parseInteger(fields.padInt)))
+        return failure();
+      continue;
+    }
+
+    if (key == "compact") {
+      if (seenCompact) {
+        parser.emitError(parser.getCurrentLocation(),
+                         "duplicate compact in tile_buf compact syntax");
+        return failure();
+      }
+      seenCompact = true;
+      if (failed(parser.parseInteger(fields.compactInt)))
+        return failure();
+      continue;
+    }
+
+    parser.emitError(parser.getCurrentLocation(),
+                     "unknown key in tile_buf compact syntax: ")
+        << key;
+    return failure();
   }
 
-  // blayout=RowMajor
-  {
-    if (failed(parseKeyEq("blayout"))) return Type();
-    if (failed(parser.parseKeywordOrString(&blayoutStr))) return Type();
-    if (failed(parser.parseComma())) return Type();
+  return success();
+}
+
+static Type buildTileBufType(AsmParser &parser,
+                             const ParsedTileBufFields &fields) {
+  MLIRContext *ctx = parser.getContext();
+
+  if (fields.rows < 0 || fields.cols < 0) {
+    parser.emitError(parser.getNameLoc(), "rows/cols must be non-negative");
+    return Type();
   }
 
-
-  // slayout=NoneBox
-  {
-    if (failed(parseKeyEq("slayout"))) return Type();
-    if (failed(parser.parseKeywordOrString(&slayoutStr))) return Type();
-    if (failed(parser.parseComma())) return Type();
+  auto memorySpace = ::llvm::StringSwitch<::std::optional<AddressSpace>>(
+                         fields.locStr)
+                         .Case("mat", AddressSpace::MAT)
+                         .Case("left", AddressSpace::LEFT)
+                         .Case("right", AddressSpace::RIGHT)
+                         .Case("acc", AddressSpace::ACC)
+                         .Case("vec", AddressSpace::VEC)
+                         .Case("bias", AddressSpace::BIAS)
+                         .Case("scaling", AddressSpace::SCALING)
+                         .Default(::std::nullopt);
+  if (!memorySpace.has_value()) {
+    parser.emitError(parser.getNameLoc(), "unknown loc: ") << fields.locStr;
+    return Type();
   }
 
-  // fractal=512
-  {
-    if (failed(parseKeyEq("fractal"))) return Type();
-    if (failed(parser.parseInteger(fractal))) return Type();
-    if (failed(parser.parseComma())) return Type();
+  auto bl = symbolizeBLayout(fields.blayoutStr);
+  auto sl = symbolizeSLayout(fields.slayoutStr);
+  auto pv = symbolizePadValue(fields.padInt);
+  auto compact = symbolizeCompactMode(fields.compactInt);
+  if (!bl.has_value()) {
+    parser.emitError(parser.getNameLoc(), "unknown blayout: ")
+        << fields.blayoutStr;
+    return Type();
+  }
+  if (!sl.has_value()) {
+    parser.emitError(parser.getNameLoc(), "unknown slayout: ")
+        << fields.slayoutStr;
+    return Type();
+  }
+  if (!pv.has_value()) {
+    parser.emitError(parser.getNameLoc(), "unknown pad: ") << fields.padInt;
+    return Type();
+  }
+  if (!compact.has_value()) {
+    parser.emitError(parser.getNameLoc(), "unknown compact: ")
+        << fields.compactInt;
+    return Type();
   }
 
-  // pad=0
-  {
-    if (failed(parseKeyEq("pad"))) return Type();
-    if (failed(parser.parseInteger(padInt))) return Type();
+  auto normalizeParserBLayout = [&](AddressSpace memorySpace,
+                                    BLayout parsedBLayout) -> BLayout {
+    // LEFT tiles are parser-normalized from the scoped target arch rather than
+    // from the textual blayout spelling. This preserves the longstanding
+    // --pto-arch behavior for both legacy and compact tile_buf syntax.
+    if (memorySpace != AddressSpace::LEFT)
+      return parsedBLayout;
+
+    switch (getPTOParserTargetArch()) {
+    case PTOParserTargetArch::A3:
+      return BLayout::RowMajor;
+    case PTOParserTargetArch::A5:
+      return BLayout::ColMajor;
+    case PTOParserTargetArch::Unspecified:
+      return parsedBLayout;
+    }
+
+    return parsedBLayout;
+  };
+
+  BLayout effectiveBLayout =
+      normalizeParserBLayout(memorySpace.value(), bl.value());
+
+  auto blAttr = BLayoutAttr::get(ctx, effectiveBLayout);
+  auto slAttr = SLayoutAttr::get(ctx, sl.value());
+  auto fractalAttr =
+      IntegerAttr::get(IntegerType::get(ctx, 32), fields.fractal);
+  auto padAttr = PadValueAttr::get(ctx, pv.value());
+  auto compactAttr = CompactModeAttr::get(ctx, compact.value());
+  auto memorySpaceAttr = AddressSpaceAttr::get(ctx, memorySpace.value());
+  auto cfg = TileBufConfigAttr::get(ctx, blAttr, slAttr, fractalAttr, padAttr,
+                                    compactAttr);
+
+  SmallVector<int64_t, 2> shape{fields.rows, fields.cols};
+  SmallVector<int64_t, 2> validShape{fields.vrow, fields.vcol};
+  auto canonicalValidShape = canonicalizeTileBufValidShape(validShape);
+
+  return TileBufType::get(ctx, shape, fields.dtype, memorySpaceAttr,
+                          llvm::ArrayRef<int64_t>(canonicalValidShape), cfg);
+}
+
+} // namespace
+
+// ---- TileBufType custom asm ----
+// !pto.tile_buf<<loc=.., dtype=.., rows=.., cols=.., blayout=.., valid=..x..,
+//                slayout=.., fractal=.., pad=.., compact=..>>
+Type TileBufType::parse(AsmParser &parser) {
+  if (failed(parser.parseLess()))
+    return Type();
+
+  std::string firstToken;
+  if (failed(parser.parseKeywordOrString(&firstToken)))
+    return Type();
+
+  ParsedTileBufFields fields;
+  const bool isLegacySyntax = firstToken == "loc";
+  if (isLegacySyntax) {
+    if (failed(parseLegacyTileBufFields(parser, fields)))
+      return Type();
+  } else {
+    if (failed(parseCompactTileBufFields(parser, firstToken, fields)))
+      return Type();
   }
 
-  if (succeeded(parser.parseOptionalComma())) {
-    if (failed(parseKeyEq("compact"))) return Type();
-    if (failed(parser.parseInteger(compactInt))) return Type();
+  if (isLegacySyntax && succeeded(parser.parseOptionalComma())) {
+    auto parseKeyEq = [&](StringRef expectedKey) -> LogicalResult {
+      if (failed(parser.parseKeyword(expectedKey)))
+        return failure();
+      if (failed(parser.parseEqual()))
+        return failure();
+      return success();
+    };
+
+    if (failed(parseKeyEq("compact")))
+      return Type();
+    if (failed(parser.parseInteger(fields.compactInt)))
+      return Type();
   }
 
   if (failed(parser.parseGreater()))
     return Type();
 
-  // -------- 语义校验/构造 --------
-  if (rows < 0 || cols < 0) {
-    parser.emitError(parser.getNameLoc(), "rows/cols must be non-negative");
-    return Type();
-  }
-
-  auto memorySpace = ::llvm::StringSwitch<::std::optional<AddressSpace>>(locStr)
-        .Case("mat", AddressSpace::MAT)
-        .Case("left", AddressSpace::LEFT)
-        .Case("right", AddressSpace::RIGHT)
-        .Case("acc", AddressSpace::ACC)
-        .Case("vec", AddressSpace::VEC)
-        .Case("bias", AddressSpace::BIAS)
-        .Case("scaling", AddressSpace::SCALING)
-        .Default(::std::nullopt);
-  if (!memorySpace.has_value()) {
-    parser.emitError(parser.getNameLoc(), "unknown loc: ") << locStr;
-    return Type();
-  }
-
-  auto bl = symbolizeBLayout(blayoutStr);
-  auto sl = symbolizeSLayout(slayoutStr);
-  auto pv = symbolizePadValue(padInt);
-  auto compact = symbolizeCompactMode(compactInt);
-  if (!bl.has_value()) {
-    parser.emitError(parser.getNameLoc(), "unknown blayout: ") << blayoutStr;
-    return Type();
-  }
-  if (!sl.has_value()) {
-    parser.emitError(parser.getNameLoc(), "unknown slayout: ") << slayoutStr;
-    return Type();
-  }
-  if (!pv.has_value()) {
-    parser.emitError(parser.getNameLoc(), "unknown pad: ") << padInt;
-    return Type();
-  }
-  if (!compact.has_value()) {
-    parser.emitError(parser.getNameLoc(), "unknown compact: ") << compactInt;
-    return Type();
-  }
-
-  BLayout effectiveBLayout = bl.value();
-  if (memorySpace.value() == AddressSpace::LEFT) {
-    switch (getPTOParserTargetArch()) {
-    case PTOParserTargetArch::A3:
-      effectiveBLayout = BLayout::RowMajor;
-      break;
-    case PTOParserTargetArch::A5:
-      effectiveBLayout = BLayout::ColMajor;
-      break;
-    case PTOParserTargetArch::Unspecified:
-      break;
-    }
-  }
-
-  auto blAttr = BLayoutAttr::get(ctx, effectiveBLayout);
-  auto slAttr = SLayoutAttr::get(ctx, sl.value());
-  auto fractalAttr =
-      IntegerAttr::get(IntegerType::get(ctx, 32), fractal);
-  auto padAttr = PadValueAttr::get(ctx, pv.value());
-  auto compactAttr = CompactModeAttr::get(ctx, compact.value());
-  auto memorySpaceAttr = AddressSpaceAttr::get(ctx, memorySpace.value());
-  auto cfg =
-      TileBufConfigAttr::get(ctx, blAttr, slAttr, fractalAttr, padAttr, compactAttr);
-
-  SmallVector<int64_t, 2> shape{rows, cols};
-  SmallVector<int64_t, 2> validShape{vrow, vcol};
-  auto canonicalValidShape = canonicalizeTileBufValidShape(validShape);
-
-  return TileBufType::get(ctx, shape, dtype, memorySpaceAttr,
-                          llvm::ArrayRef<int64_t>(canonicalValidShape), cfg);
+  return buildTileBufType(parser, fields);
 }
 
 static llvm::StringRef stringifyLocFromMemorySpace(mlir::Attribute memorySpace) {
@@ -329,60 +526,93 @@ static llvm::StringRef stringifyLocFromPad(mlir::Attribute pad) {
 
 static llvm::StringRef stringifyCompactModeInt(mlir::Attribute compactMode) {
   auto compactAttr = llvm::dyn_cast_or_null<CompactModeAttr>(compactMode);
-  if (!compactAttr) return "9999";
+  if (!compactAttr)
+    return "9999";
 
   switch (compactAttr.getValue()) {
-    case CompactMode::Null: return "0";
-    case CompactMode::Normal: return "1";
-    case CompactMode::RowPlusOne: return "2";
-    default:
-      return "9999";
+  case CompactMode::Null:
+    return "0";
+  case CompactMode::Normal:
+    return "1";
+  case CompactMode::RowPlusOne:
+    return "2";
+  default:
+    return "9999";
   }
 }
 
+static void printTileBufDim(AsmPrinter &printer, int64_t dim) {
+  if (dim == ShapedType::kDynamic)
+    printer << "?";
+  else
+    printer << dim;
+}
+
 void mlir::pto::TileBufType::print(mlir::AsmPrinter &printer) const {
-    auto shape = getShape();
-    int64_t rows = shape.size() > 0 ? shape[0] : 0;
-    int64_t cols = shape.size() > 1 ? shape[1] : 0;
+  auto shape = getShape();
+  int64_t rows = shape.size() > 0 ? shape[0] : ShapedType::kDynamic;
+  int64_t cols = shape.size() > 1 ? shape[1] : ShapedType::kDynamic;
 
-    auto cfg = getConfigAttr();
-    if (!cfg) cfg = mlir::pto::TileBufConfigAttr::getDefault(getContext());
+  auto cfg = getConfigAttr();
+  if (!cfg)
+    cfg = mlir::pto::TileBufConfigAttr::getDefault(getContext());
+  auto defaultCfg = TileBufConfigAttr::getDefault(getContext());
 
-    llvm::StringRef locStr = stringifyLocFromMemorySpace(getMemorySpace());
+  llvm::StringRef locStr = stringifyLocFromMemorySpace(getMemorySpace());
+  auto blayout = llvm::dyn_cast<BLayoutAttr>(cfg.getBLayout());
+  auto slayout = llvm::dyn_cast<SLayoutAttr>(cfg.getSLayout());
+  auto pad = llvm::dyn_cast<PadValueAttr>(cfg.getPad());
+  auto compact = llvm::dyn_cast<CompactModeAttr>(cfg.getCompactMode());
+  auto defaultBLayout = llvm::dyn_cast<BLayoutAttr>(defaultCfg.getBLayout());
+  auto defaultSLayout = llvm::dyn_cast<SLayoutAttr>(defaultCfg.getSLayout());
+  auto defaultPad = llvm::dyn_cast<PadValueAttr>(defaultCfg.getPad());
+  auto defaultCompact =
+      llvm::dyn_cast<CompactModeAttr>(defaultCfg.getCompactMode());
 
-    printer << "<"
-            << "loc=" << locStr
-            << ", dtype=";
-    printer.printType(getElementType());
+  auto vs = getValidShape();
+  int64_t vrow = rows;
+  int64_t vcol = cols;
+  if (vs.size() >= 2) {
+    vrow = vs[0];
+    vcol = vs[1];
+  }
 
-    auto blayout = llvm::dyn_cast<BLayoutAttr>(cfg.getBLayout());
-    auto slayout = llvm::dyn_cast<SLayoutAttr>(cfg.getSLayout());
+  const bool printValid = vrow != rows || vcol != cols;
+  const bool printBLayout =
+      blayout && defaultBLayout && blayout.getValue() != defaultBLayout.getValue();
+  const bool printSLayout =
+      slayout && defaultSLayout && slayout.getValue() != defaultSLayout.getValue();
+  const bool printFractal =
+      cfg.getSFractalSize().getInt() != defaultCfg.getSFractalSize().getInt();
+  const bool printPad =
+      pad && defaultPad && pad.getValue() != defaultPad.getValue();
+  const bool printCompact =
+      compact && defaultCompact &&
+      compact.getValue() != defaultCompact.getValue();
 
-    auto vs = getValidShape(); // ArrayRef<int64_t>
-    int64_t vrow = rows;
-    int64_t vcol = cols;
+  printer << "<" << locStr << ", ";
+  printTileBufDim(printer, rows);
+  printer << "x";
+  printTileBufDim(printer, cols);
+  printer << "x";
+  printer.printType(getElementType());
 
-    if (vs.size() >= 2) {
-        vrow = vs[0];
-        vcol = vs[1];
-    }
-    printer << ", rows=" << rows
-            << ", cols=" << cols;
-    printer << ", v_row=";
-    if (vrow < 0) printer << "?";
-    else printer << vrow;
+  if (printValid) {
+    printer << ", valid=";
+    printTileBufDim(printer, vrow);
+    printer << "x";
+    printTileBufDim(printer, vcol);
+  }
+  if (printBLayout)
+    printer << ", blayout=" << stringifyBLayout(blayout.getValue());
+  if (printSLayout)
+    printer << ", slayout=" << stringifySLayout(slayout.getValue());
+  if (printFractal)
+    printer << ", fractal=" << cfg.getSFractalSize().getInt();
+  if (printPad)
+    printer << ", pad=" << stringifyLocFromPad(cfg.getPad());
+  if (printCompact)
+    printer << ", compact=" << stringifyCompactModeInt(cfg.getCompactMode());
 
-    printer << ", v_col=";
-    if (vcol < 0) printer << "?";
-    else printer << vcol;
-
-    printer << ", blayout=" << stringifyBLayout(blayout.getValue())
-        << ", slayout=" << stringifySLayout(slayout.getValue())
-        << ", fractal=" << cfg.getSFractalSize().getInt()
-        << ", pad=" << stringifyLocFromPad(cfg.getPad());
-    if (auto compact = llvm::dyn_cast<CompactModeAttr>(cfg.getCompactMode())) {
-      if (compact.getValue() != CompactMode::Null)
-        printer << ", compact=" << stringifyCompactModeInt(compact);
-    }
-    printer << ">";
+  printer << ">";
 }

--- a/test/basic/compact_left_blayout_parser_a3.pto
+++ b/test/basic/compact_left_blayout_parser_a3.pto
@@ -1,0 +1,11 @@
+// RUN: ptoas --pto-arch a3 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a3"} {
+  func.func @compact_left_blayout_parser_a3() {
+    %0 = pto.alloc_tile : !pto.tile_buf<left, 32x32xf32, slayout=row_major>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @compact_left_blayout_parser_a3() {
+// CHECK: #pto.tile_buf_config<blayout=#pto.blayout<row_major>, slayout=#pto.slayout<row_major>, s_fractal_size=512, pad=#pto.pad_value<null>, compact=#pto.compact_mode<null>>

--- a/test/basic/compact_left_blayout_parser_a5.pto
+++ b/test/basic/compact_left_blayout_parser_a5.pto
@@ -1,0 +1,11 @@
+// RUN: ptoas --pto-arch a5 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @compact_left_blayout_parser_a5() {
+    %0 = pto.alloc_tile : !pto.tile_buf<left, 32x32xf32, slayout=row_major>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @compact_left_blayout_parser_a5() {
+// CHECK: #pto.tile_buf_config<blayout=#pto.blayout<col_major>, slayout=#pto.slayout<row_major>, s_fractal_size=512, pad=#pto.pad_value<null>, compact=#pto.compact_mode<null>>

--- a/test/basic/left_blayout_parser_a3.pto
+++ b/test/basic/left_blayout_parser_a3.pto
@@ -1,6 +1,6 @@
 // RUN: ptoas --pto-arch a3 %s | FileCheck %s
 
-module {
+module attributes {"pto.target_arch" = "a3"} {
   func.func @left_blayout_parser_a3() {
     %c0 = arith.constant 0 : index
     %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
@@ -10,4 +10,5 @@ module {
   }
 }
 
-// CHECK: left_blayout_parser_a3
+// CHECK-LABEL: __global__ AICORE void left_blayout_parser_a3() {
+// CHECK: Tile<TileType::Left, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null>

--- a/test/basic/left_blayout_parser_a5.pto
+++ b/test/basic/left_blayout_parser_a5.pto
@@ -1,6 +1,6 @@
 // RUN: ptoas --pto-arch a5 %s | FileCheck %s
 
-module {
+module attributes {"pto.target_arch" = "a5"} {
   func.func @left_blayout_parser_a5() {
     %c0 = arith.constant 0 : index
     %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
@@ -10,4 +10,5 @@ module {
   }
 }
 
-// CHECK: left_blayout_parser_a5
+// CHECK-LABEL: __global__ AICORE void left_blayout_parser_a5() {
+// CHECK: Tile<TileType::Left, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null>

--- a/test/python/compact_tile_buf_asm.py
+++ b/test/python/compact_tile_buf_asm.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+from mlir.ir import Context, F32Type, MLIRError, Module
+from mlir.dialects import pto
+
+
+def expect_equal(actual: str, expected: str, label: str) -> None:
+    if actual != expected:
+        raise AssertionError(
+            f"{label} mismatch\nexpected: {expected}\nactual:   {actual}"
+        )
+
+
+def expect_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(
+            f"{label} missing substring\nneedle: {needle}\ntext:\n{text}"
+        )
+
+
+def expect_not_contains(text: str, needle: str, label: str) -> None:
+    if needle in text:
+        raise AssertionError(
+            f"{label} unexpectedly contained substring\nneedle: {needle}\ntext:\n{text}"
+        )
+
+
+def expect_parse_error(ctx: Context, asm: str, needle: str, label: str) -> None:
+    try:
+        Module.parse(asm, ctx)
+    except MLIRError as err:
+        if needle not in str(err):
+            raise AssertionError(
+                f"{label} error mismatch\nexpected substring: {needle}\nactual: {err}"
+            ) from err
+        return
+    raise AssertionError(f"{label} unexpectedly parsed successfully")
+
+
+def main() -> None:
+    with Context() as ctx:
+        pto.register_dialect(ctx)
+
+        vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+        col_major = pto.BLayoutAttr.get(pto.BLayout.ColMajor, ctx)
+        row_major = pto.SLayoutAttr.get(pto.SLayout.RowMajor, ctx)
+        zero_pad = pto.PadValueAttr.get(pto.PadValue.Zero, ctx)
+        cfg = pto.TileBufConfigAttr.get(col_major, row_major, 1024, zero_pad, ctx)
+
+        default_ty = pto.TileBufType.get([1, 16], F32Type.get(ctx), vec, context=ctx)
+        expect_equal(
+            str(default_ty),
+            "!pto.tile_buf<vec, 1x16xf32>",
+            "default compact print",
+        )
+
+        valid_ty = pto.TileBufType.get(
+            [16, 128],
+            F32Type.get(ctx),
+            vec,
+            valid_shape=[16, 1],
+            context=ctx,
+        )
+        expect_equal(
+            str(valid_ty),
+            "!pto.tile_buf<vec, 16x128xf32, valid=16x1>",
+            "valid suffix print",
+        )
+
+        non_default_cfg_ty = pto.TileBufType.get(
+            [8, 8],
+            F32Type.get(ctx),
+            vec,
+            config=cfg,
+            context=ctx,
+        )
+        expect_equal(
+            str(non_default_cfg_ty),
+            "!pto.tile_buf<vec, 8x8xf32, blayout=col_major, slayout=row_major, fractal=1024, pad=1>",
+            "non-default config suffix print",
+        )
+
+        compact_cfg_ty = pto.TileBufType.get(
+            [8, 8],
+            F32Type.get(ctx),
+            vec,
+            config=pto.TileBufConfigAttr.get(
+                col_major,
+                row_major,
+                1024,
+                zero_pad,
+                ctx,
+                compact_mode=pto.CompactMode.RowPlusOne,
+            ),
+            context=ctx,
+        )
+        expect_equal(
+            str(compact_cfg_ty),
+            "!pto.tile_buf<vec, 8x8xf32, blayout=col_major, slayout=row_major, fractal=1024, pad=1, compact=2>",
+            "non-default compact suffix print",
+        )
+
+        legacy_module = Module.parse(
+            """
+module {
+  func.func @legacy(
+      %arg0: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128,
+                           v_row=16, v_col=1, blayout=col_major,
+                           slayout=none_box, fractal=512, pad=0>) {
+    return
+  }
+}
+""",
+            ctx,
+        )
+        legacy_text = str(legacy_module)
+        expect_contains(
+            legacy_text,
+            "!pto.tile_buf<vec, 16x128xf32, valid=16x1, blayout=col_major>",
+            "legacy parse reprint",
+        )
+        expect_not_contains(legacy_text, "loc=", "legacy parse reprint")
+        expect_not_contains(legacy_text, "v_row=", "legacy parse reprint")
+        expect_not_contains(legacy_text, "v_col=", "legacy parse reprint")
+
+        compact_module = Module.parse(
+            """
+module {
+  func.func @compact(
+      %arg0: !pto.tile_buf<vec, 16x128xf32, valid=16x1, blayout=col_major>) {
+    return
+  }
+}
+""",
+            ctx,
+        )
+        expect_contains(
+            str(compact_module),
+            "!pto.tile_buf<vec, 16x128xf32, valid=16x1, blayout=col_major>",
+            "compact parse roundtrip",
+        )
+
+        compact_mode_module = Module.parse(
+            """
+module {
+  func.func @compact_mode(
+      %arg0: !pto.tile_buf<vec, 16x128xf32, compact=2, blayout=col_major>) {
+    return
+  }
+}
+""",
+            ctx,
+        )
+        expect_contains(
+            str(compact_mode_module),
+            "!pto.tile_buf<vec, 16x128xf32, blayout=col_major, compact=2>",
+            "compact mode parse roundtrip",
+        )
+
+        expect_parse_error(
+            ctx,
+            """
+module {
+  func.func @dup_valid(
+      %arg0: !pto.tile_buf<vec, 16x128xf32, valid=16x1, valid=16x2>) {
+    return
+  }
+}
+""",
+            "duplicate valid in tile_buf compact syntax",
+            "duplicate valid rejection",
+        )
+        expect_parse_error(
+            ctx,
+            """
+module {
+  func.func @dynamic_base(%arg0: !pto.tile_buf<vec, ?x16xf32>) {
+    return
+  }
+}
+""",
+            "expected static shape",
+            "dynamic base shape rejection",
+        )
+        expect_parse_error(
+            ctx,
+            """
+module {
+  func.func @bad_valid_rank(
+      %arg0: !pto.tile_buf<vec, 16x128xf32, valid=16x1x2>) {
+    return
+  }
+}
+""",
+            "tile_buf valid must have exactly two dims",
+            "valid rank rejection",
+        )
+
+    print("compact_tile_buf_asm: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#381

## Summary
- switch `!pto.tile_buf` custom assembly printing to compact canonical syntax
- keep the parser backward-compatible with the legacy keyed syntax
- preserve arch-sensitive `loc=left` parser normalization and add focused regressions

## Testing
- `python3 test/python/compact_tile_buf_asm.py`
- `./build/tools/ptoas/ptoas --pto-arch a3 test/basic/left_blayout_parser_a3.pto | /home/zhangzhendong/.local/bin/FileCheck test/basic/left_blayout_parser_a3.pto`
- `./build/tools/ptoas/ptoas --pto-arch a5 test/basic/left_blayout_parser_a5.pto | /home/zhangzhendong/.local/bin/FileCheck test/basic/left_blayout_parser_a5.pto`
- `./build/tools/ptoas/ptoas --pto-arch a3 test/basic/compact_left_blayout_parser_a3.pto 2>&1 | /home/zhangzhendong/.local/bin/FileCheck test/basic/compact_left_blayout_parser_a3.pto`
- `./build/tools/ptoas/ptoas --pto-arch a5 test/basic/compact_left_blayout_parser_a5.pto 2>&1 | /home/zhangzhendong/.local/bin/FileCheck test/basic/compact_left_blayout_parser_a5.pto`