### PR TITLE
feat: add pto.tquant op with INT8_SYM/ASYM quantization support

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -6301,6 +6301,55 @@ pto.tmov.fp ins(%acc, %fp : !pto.tile_buf<...>, !pto.tile_buf<...>)
 
 ---
 
+##### `pto.tquant` - Quantize Tile with Scaling Tile
+
+**Summary:** Quantizes `f32` source tile elements into a lower-precision integer format using a scaling (`fp`) tile. The quantization mode is controlled by the `quant_type` attribute.
+
+**Semantics:**
+
+```
+dst[i, j] = Quantize(src[i, j]; fp, quant_type)
+```
+
+- `INT8_SYM`: symmetric quantization; `dst` element type must be `i8`.
+- `INT8_ASYM`: asymmetric quantization; `dst` element type must be `ui8`.
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `src` | `pto.tile_buf` | Source tile (`f32`) |
+| `fp` | `pto.tile_buf` | Scaling parameter tile |
+| `dst` | `pto.tile_buf` | Destination tile (`i8` for SYM, `ui8` for ASYM) |
+
+**Attributes:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `quant_type` | `#pto.quant_type` | `INT8_SYM` or `INT8_ASYM` |
+
+**Results:** None. Writes into `dst` via DPS pattern.
+
+**Constraints & Verification:**
+
+- `src` element type must be `f32`.
+- `dst` element type must be `i8` (`INT8_SYM`) or `ui8` (`INT8_ASYM`).
+- A2/A3: `src` and `dst` must use row-major layout.
+
+**Hardware Mapping:**
+
+- Executes on the **Vector pipeline** (`PIPE_V`)
+
+**Basic Example:**
+
+```mlir
+pto.tquant ins(%src, %fp : !pto.tile_buf<...>, !pto.tile_buf<...>)
+           outs(%dst : !pto.tile_buf<...>)
+           {quant_type = #pto<quant_type INT8_SYM>}
+```
+
+---
+
 ##### `pto.tstore_fp` - Store Accumulator with Scaling
 
 **Summary:** Stores an accumulator tile into global memory using a scaling (`fp`) tile.
@@ -7256,10 +7305,10 @@ pto.trap
 | Type Conversion | 1 | V |
 | Integer Sequence Generation | 1 | V |
 | Scalar Element Access | 2 | V |
-| MX Quantized | 2 | M/V |
+| MX Quantized | 3 | M/V |
 | Synchronization | 5 | - |
 | CV-Related | 2 | - |
 | Runtime Intrinsics | 4 | - (Pure) |
 | Debug | 3 | - |
 
-**Total: 106 operations**
+**Total: 107 operations**

--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -458,4 +458,18 @@ def TileBufConfigAttr : AttrDef<PTO_Dialect, "TileBufConfig"> {
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// QuantType
+//===----------------------------------------------------------------------===//
+
+def PTO_QuantTypeEnum : PTO_I32Enum<
+  "QuantType", "PTO quantization type", [
+    I32EnumAttrCase<"INT8_SYM",  0>,
+    I32EnumAttrCase<"INT8_ASYM", 1>
+  ]>;
+
+def PTO_QuantTypeAttr : EnumAttr<PTO_Dialect, PTO_QuantTypeEnum, "quant_type"> {
+  let summary = "quantization type attribute";
+}
+
 #endif // MLIR_DIALECT_PTO_IR_PTOATTRS

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3575,6 +3575,50 @@ def TPReluOp: PTO_TOp<"tprelu", [
   }];
 }
 //===----------------------------------------------------------------------===//
+// TQuantOp
+//===----------------------------------------------------------------------===//
+
+def TQuantOp : PTO_TOp<"tquant", [
+  PTO_DpsInitOpInterface,
+  OpPipeInterface,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "TQUANT: Quantize a tile using a scaling (fp) tile.";
+
+  let description = [{
+    Converts src tile elements to a lower-precision format using the scaling
+    parameters held in the fp tile, writing results into dst.
+
+    For INT8_ASYM an additional offset tile must be supplied in ins.
+
+    DPS form (INT8_SYM):
+      pto.tquant ins(%src, %fp : <src_type>, <fp_type>)
+                 outs(%dst : <dst_type>) {quant_type = #pto<quant_type INT8_SYM>}
+    DPS form (INT8_ASYM):
+      pto.tquant ins(%src, %fp, %offset : <src_type>, <fp_type>, <offset_type>)
+                 outs(%dst : <dst_type>) {quant_type = #pto<quant_type INT8_ASYM>}
+  }];
+
+  let arguments = (ins
+    PTODpsType:$src,
+    PTODpsType:$fp,
+    Optional<PTODpsType>:$offset,
+    PTODpsType:$dst,
+    PTO_QuantTypeAttr:$quant_type
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+  }];
+}
+//===----------------------------------------------------------------------===//
 // PTOOps.td  (add TRECIP TBDPS/tile buffer op)
 //===----------------------------------------------------------------------===//
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -5168,6 +5168,142 @@ mlir::LogicalResult mlir::pto::TPReluOp::verify() {
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
+ParseResult mlir::pto::TQuantOp::parse(OpAsmParser &parser,
+                                       OperationState &result) {
+  OpAsmParser::UnresolvedOperand src, fp, offset, dst;
+  Type srcTy, fpTy, offsetTy, dstTy;
+  bool hasOffset = false;
+
+  if (parser.parseKeyword("ins") || parser.parseLParen() ||
+      parser.parseOperand(src) || parser.parseComma() ||
+      parser.parseOperand(fp))
+    return failure();
+  if (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseOperand(offset))
+      return failure();
+    hasOffset = true;
+  }
+  if (parser.parseColon() ||
+      parser.parseType(srcTy) || parser.parseComma() ||
+      parser.parseType(fpTy))
+    return failure();
+  if (hasOffset) {
+    if (parser.parseComma() || parser.parseType(offsetTy))
+      return failure();
+  }
+  if (parser.parseRParen())
+    return failure();
+  if (parser.parseKeyword("outs") || parser.parseLParen() ||
+      parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
+      parser.parseRParen())
+    return failure();
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  if (parser.resolveOperand(src, srcTy, result.operands) ||
+      parser.resolveOperand(fp, fpTy, result.operands))
+    return failure();
+  if (hasOffset) {
+    if (parser.resolveOperand(offset, offsetTy, result.operands))
+      return failure();
+  }
+  if (parser.resolveOperand(dst, dstTy, result.operands))
+    return failure();
+
+  result.addAttribute(
+      "operandSegmentSizes",
+      parser.getBuilder().getDenseI32ArrayAttr({1, 1, hasOffset ? 1 : 0, 1}));
+  return success();
+}
+
+void mlir::pto::TQuantOp::print(OpAsmPrinter &p) {
+  p << " ins(" << getSrc() << ", " << getFp();
+  if (getOffset()) {
+    p << ", " << getOffset();
+    p << " : " << getSrc().getType() << ", " << getFp().getType() << ", "
+      << getOffset().getType() << ")";
+  } else {
+    p << " : " << getSrc().getType() << ", " << getFp().getType() << ")";
+  }
+  p << " outs(" << getDst() << " : " << getDst().getType() << ")";
+  p.printOptionalAttrDict((*this)->getAttrs(),
+                          /*elidedAttrs=*/{"operandSegmentSizes"});
+}
+
+mlir::LogicalResult mlir::pto::TQuantOp::verify() {
+  // Structural checks: always run regardless of operand representation
+  // (applies both before and after PTOViewToMemref lowering).
+  auto verifyStructural = [&]() -> LogicalResult {
+    // dst elem type and offset presence must be consistent with quant_type.
+    Type dstTy = getDst().getType();
+    Type dstElemTy = getElemTy(dstTy);
+    auto dstIntTy = dyn_cast<IntegerType>(dstElemTy);
+    if (getQuantType() == mlir::pto::QuantType::INT8_SYM) {
+      if (!dstIntTy || dstIntTy.getWidth() != 8 ||
+          !(dstIntTy.isSignless() || dstIntTy.isSigned()))
+        return emitOpError()
+               << "expects dst element type i8 for INT8_SYM quantization";
+      if (getOffset())
+        return emitOpError()
+               << "INT8_SYM quantization must not have an offset operand";
+    } else {
+      // INT8_ASYM
+      if (!dstIntTy || dstIntTy.getWidth() != 8 || !dstIntTy.isUnsigned())
+        return emitOpError()
+               << "expects dst element type ui8 for INT8_ASYM quantization";
+      if (!getOffset())
+        return emitOpError()
+               << "INT8_ASYM quantization requires an offset operand";
+    }
+    return success();
+  };
+
+  if (failed(verifyStructural()))
+    return failure();
+
+  // Layout/tile-buffer checks: only meaningful for pre-lowering tile types.
+  // Skip when operands are already plain MemRefs (post PTOViewToMemref).
+  if (shouldBypassDecodedMemrefVerifier(getOperation()))
+    return success();
+
+  auto verifyCommon = [&]() -> LogicalResult {
+    Type srcTy = getSrc().getType();
+    Type fpTy  = getFp().getType();
+    Type dstTy = getDst().getType();
+    if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
+        failed(verifyTileBufCommon(*this, fpTy, "fp")) ||
+        failed(verifyTileBufCommon(*this, dstTy, "dst")))
+      return failure();
+    // src must be f32 (ISA static_assert)
+    if (!getElemTy(srcTy).isF32())
+      return emitOpError() << "expects src to have element type f32";
+    if (getOffset()) {
+      Type offsetTy = getOffset().getType();
+      if (failed(verifyTileBufCommon(*this, offsetTy, "offset")))
+        return failure();
+      if (!getElemTy(offsetTy).isF32())
+        return emitOpError() << "expects offset to have element type f32";
+    }
+    return success();
+  };
+
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    if (failed(verifyCommon()))
+      return failure();
+    Type srcTy = getSrc().getType();
+    Type dstTy = getDst().getType();
+    if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy))
+      return emitOpError() << "expects A2/A3 src and dst to use row-major layout";
+    return success();
+  };
+
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyCommon();
+  };
+
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
 mlir::LogicalResult mlir::pto::TRecipOp::verify() {
   if (shouldBypassDecodedMemrefVerifier(getOperation()))
     return success();
@@ -7820,6 +7956,15 @@ void TPReluOp::getEffects(
   PTO_ADD_WRITE(getDstMutable());
 }
 
+void TQuantOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_READ(getSrcMutable());
+  PTO_ADD_READ(getFpMutable());
+  auto offsetRange = getOffsetMutable();
+  if (!offsetRange.empty())
+    PTO_ADD_READ(offsetRange[0]);
+  PTO_ADD_WRITE(getDstMutable());
+}
 PTO_DEFINE_UNARY_EFFECTS(TRecipOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TReluOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_BINARY_EFFECTS(TRemOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6180,6 +6180,65 @@ struct PTOMovFPToEmitC : public OpConversionPattern<pto::TMovFPOp> {
     return success();
   }
 };
+
+struct PTOQuantToEmitC : public OpConversionPattern<pto::TQuantOp> {
+  using OpConversionPattern<pto::TQuantOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::TQuantOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+
+    Value dst = peelUnrealized(adaptor.getDst());
+    Value src = peelUnrealized(adaptor.getSrc());
+    Value fp  = peelUnrealized(adaptor.getFp());
+
+    // Optional offset (INT8_ASYM only): passed as pointer (&offset)
+    Value offsetPtr;
+    if (op.getOffset()) {
+      Value offset = peelUnrealized(adaptor.getOffset());
+      auto offsetOT = offset.getType().dyn_cast<emitc::OpaqueType>();
+      if (offsetOT) {
+        offsetPtr = rewriter
+                        .create<emitc::ApplyOp>(
+                            loc, emitc::PointerType::get(offsetOT), "&", offset)
+                        .getResult();
+      }
+    }
+
+    // TQUANT<QuantType, DstTile, SrcTile, FpTile>(dst, src, fp[, &offset])
+    std::string quantTypeStr =
+        op.getQuantType() == pto::QuantType::INT8_SYM
+            ? "pto::QuantType::INT8_SYM"
+            : "pto::QuantType::INT8_ASYM";
+    ArrayAttr templateArgs;
+    auto dstOT = dst.getType().dyn_cast<emitc::OpaqueType>();
+    auto srcOT = src.getType().dyn_cast<emitc::OpaqueType>();
+    auto fpOT  = fp.getType().dyn_cast<emitc::OpaqueType>();
+    if (dstOT && srcOT && fpOT) {
+      templateArgs = rewriter.getArrayAttr({
+          emitc::OpaqueAttr::get(ctx, quantTypeStr),
+          emitc::OpaqueAttr::get(ctx, dstOT.getValue().str()),
+          emitc::OpaqueAttr::get(ctx, srcOT.getValue().str()),
+          emitc::OpaqueAttr::get(ctx, fpOT.getValue().str()),
+      });
+    } else {
+      templateArgs = ArrayAttr{};
+    }
+
+    SmallVector<Value> operands{dst, src, fp};
+    if (offsetPtr)
+      operands.push_back(offsetPtr);
+
+    rewriter.create<emitc::CallOpaqueOp>(
+        loc, TypeRange{}, "TQUANT",
+        /*args=*/ArrayAttr{}, /*templateArgs=*/templateArgs,
+        /*operands=*/operands);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
 //===----------------------------------------------------------------------===//
 // PTOConvert.cpp  (add lowering + patterns.add for TMRGSORT DPS/memref op)
 //===----------------------------------------------------------------------===//
@@ -8465,6 +8524,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOGatherToEmitC>(typeConverter, ctx);
   patterns.add<PTOGatherbToEmitC>(typeConverter, ctx);
   patterns.add<PTOMovFPToEmitC>(typeConverter, ctx);
+  patterns.add<PTOQuantToEmitC>(typeConverter, ctx);
   patterns.add<PTOOrsToEmitC>(typeConverter, ctx);
   patterns.add<PTOLogToEmitC>(typeConverter, ctx);
   patterns.add<FuncToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -2601,6 +2601,42 @@ struct PTOViewToMemrefPass
             dst);
       }
 
+      SmallVector<mlir::pto::TQuantOp, 8> quantops;
+      func.walk([&](mlir::pto::TQuantOp op) { quantops.push_back(op); });
+
+      for (auto op : quantops) {
+        IRRewriter rewriter(ctx);
+        rewriter.setInsertionPoint(op);
+
+        Value src = op.getSrc();
+        Value fp = op.getFp();
+        Value offset = op.getOffset();
+        Value dst = op.getDst();
+
+        auto srcTy = dyn_cast<MemRefType>(src.getType());
+        auto fpTy = dyn_cast<MemRefType>(fp.getType());
+        auto dstTy = dyn_cast<MemRefType>(dst.getType());
+        if (!srcTy || !fpTy || !dstTy) {
+          op.emitError("ins/outs are not memref yet");
+          signalPassFailure();
+          return;
+        }
+        if (offset && !dyn_cast<MemRefType>(offset.getType())) {
+          op.emitError("offset is not memref yet");
+          signalPassFailure();
+          return;
+        }
+
+        rewriter.replaceOpWithNewOp<pto::TQuantOp>(
+            op,
+            TypeRange{},
+            src,
+            fp,
+            offset,
+            dst,
+            op.getQuantTypeAttr());
+      }
+
       SmallVector<mlir::pto::TMrgSortOp, 8> mrgsortops;
       func.walk([&](mlir::pto::TMrgSortOp op) { mrgsortops.push_back(op); });
 

--- a/test/basic/tquant.pto
+++ b/test/basic/tquant.pto
@@ -1,0 +1,42 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @tquant_sym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %fp  = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %dst = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
+
+    pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
+                               memref<16x16xf32, #pto.address_space<vec>>)
+               outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
+               {quant_type = #pto<quant_type INT8_SYM>}
+
+    return
+  }
+
+  func.func @tquant_asym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src    = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %fp     = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+    %dst    = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
+
+    pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
+                                        memref<16x16xf32, #pto.address_space<vec>>,
+                                        memref<16x16xf32, #pto.address_space<vec>>)
+               outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
+               {quant_type = #pto<quant_type INT8_ASYM>}
+
+    return
+  }
+}
+
+// A3-LABEL: AICORE void tquant_sym(
+// A3: TQUANT<pto::QuantType::INT8_SYM
+// A3-LABEL: AICORE void tquant_asym(
+// A3: TQUANT<pto::QuantType::INT8_ASYM
+
+// A5-LABEL: AICORE void tquant_sym(
+// A5: TQUANT<pto::QuantType::INT8_SYM
+// A5-LABEL: AICORE void tquant_asym(
+// A5: TQUANT<pto::QuantType::INT8_ASYM

--- a/test/basic/tquant_e2e.pto
+++ b/test/basic/tquant_e2e.pto
@@ -1,0 +1,69 @@
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @tquant_sym_run(%src_ptr: !pto.ptr<f32>, %fp_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<i8>)
+      attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0  = arith.constant 0 : index
+    %c1  = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %src_view = pto.make_tensor_view %src_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %fp_view  = pto.make_tensor_view %fp_ptr,  shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xi8>
+
+    %src_part = pto.partition_view %src_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %fp_part  = pto.partition_view %fp_view,  offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xi8>  -> !pto.partition_tensor_view<32x32xi8>
+
+    %src_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp_tile  = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8,  rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<32x32xf32>) outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%fp_part  : !pto.partition_tensor_view<32x32xf32>) outs(%fp_tile  : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tquant ins(%src_tile, %fp_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                                         !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {quant_type = #pto<quant_type INT8_SYM>}
+
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_part : !pto.partition_tensor_view<32x32xi8>)
+
+    return
+  }
+
+  func.func @tquant_asym_run(%src_ptr: !pto.ptr<f32>, %fp_ptr: !pto.ptr<f32>, %offset_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<ui8>)
+      attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0  = arith.constant 0 : index
+    %c1  = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %src_view    = pto.make_tensor_view %src_ptr,    shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %fp_view     = pto.make_tensor_view %fp_ptr,     shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %offset_view = pto.make_tensor_view %offset_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst_view    = pto.make_tensor_view %dst_ptr,    shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xui8>
+
+    %src_part    = pto.partition_view %src_view,    offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x32xf32>
+    %fp_part     = pto.partition_view %fp_view,     offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x32xf32>
+    %offset_part = pto.partition_view %offset_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x32xf32>
+    %dst_part    = pto.partition_view %dst_view,    offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xui8>  -> !pto.partition_tensor_view<32x32xui8>
+
+    %src_tile    = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp_tile     = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %offset_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile    = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part    : !pto.partition_tensor_view<32x32xf32>) outs(%src_tile    : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%fp_part     : !pto.partition_tensor_view<32x32xf32>) outs(%fp_tile     : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%offset_part : !pto.partition_tensor_view<32x32xf32>) outs(%offset_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tquant ins(%src_tile, %fp_tile, %offset_tile :
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {quant_type = #pto<quant_type INT8_ASYM>}
+
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_part : !pto.partition_tensor_view<32x32xui8>)
+
+    return
+  }
+}

--- a/test/basic/tquant_verify_invalid.pto
+++ b/test/basic/tquant_verify_invalid.pto
@@ -1,0 +1,79 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+// Negative tests for pto.tquant verifier.
+
+// -----------------------------------------------------------------------
+// INT8_ASYM without offset -> error
+// -----------------------------------------------------------------------
+// CHECK-LABEL: @tquant_asym_no_offset
+// CHECK: error: INT8_ASYM quantization requires an offset operand
+func.func @tquant_asym_no_offset() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %fp  = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %dst = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
+
+  pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
+                             memref<16x16xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
+             {quant_type = #pto<quant_type INT8_ASYM>}
+
+  return
+}
+
+// -----------------------------------------------------------------------
+// INT8_SYM with offset -> error
+// -----------------------------------------------------------------------
+// CHECK-LABEL: @tquant_sym_with_offset
+// CHECK: error: INT8_SYM quantization must not have an offset operand
+func.func @tquant_sym_with_offset() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %src    = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %fp     = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %dst    = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
+
+  pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
+                                      memref<16x16xf32, #pto.address_space<vec>>,
+                                      memref<16x16xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
+             {quant_type = #pto<quant_type INT8_SYM>}
+
+  return
+}
+
+// -----------------------------------------------------------------------
+// INT8_SYM with ui8 dst -> error
+// -----------------------------------------------------------------------
+// CHECK-LABEL: @tquant_sym_wrong_dst
+// CHECK: error: expects dst element type i8 for INT8_SYM quantization
+func.func @tquant_sym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %fp  = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %dst = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
+
+  pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
+                             memref<16x16xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
+             {quant_type = #pto<quant_type INT8_SYM>}
+
+  return
+}
+
+// -----------------------------------------------------------------------
+// INT8_ASYM with i8 dst -> error
+// -----------------------------------------------------------------------
+// CHECK-LABEL: @tquant_asym_wrong_dst
+// CHECK: error: expects dst element type ui8 for INT8_ASYM quantization
+func.func @tquant_asym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %src    = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %fp     = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
+  %dst    = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
+
+  pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
+                                      memref<16x16xf32, #pto.address_space<vec>>,
+                                      memref<16x16xf32, #pto.address_space<vec>>)
+             outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
+             {quant_type = #pto<quant_type INT8_ASYM>}
+
+  return
+}


### PR DESCRIPTION
Adds `pto.tquant`, a DPS tile op that quantizes an `f32` tile into `i8`/`ui8` using a scaling parameter tile. Implements the pto-isa `TQUANT` intrinsic across all compiler layers.

- New `QuantType` enum attr with two modes:
  - `INT8_SYM` — 2-operand form: `ins(%src, %fp)`, `i8` dst
  - `INT8_ASYM` — 3-operand form: `ins(%src, %fp, %offset)`, `ui8` dst
- Custom assembly format handles the optional `offset` operand
- Verifier enforces mode-operand consistency:
  - `INT8_SYM` rejects offset, requires `i8` dst
  - `INT8_ASYM` requires offset (`f32`), requires `ui8` dst
- A2/A3 verifier enforces row-major layout; A5 is layout-agnostic
- EmitC emits `TQUANT<pto::QuantType::INT8_SYM/ASYM, DstTile, SrcTile, FpTile>(dst, src, fp[, &offset])`

## Test plan

- [x] `ptoas --pto-arch=a3 test/basic/tquant.pto` — FileCheck passes (INT8_SYM and INT8_ASYM with offset)
- [x] `ptoas --pto-arch=a5 test/basic/tquant.pto` — FileCheck passes
- [x] `ptoas --pto-arch=(a3/a5) test/basic/tqaunt_verify_invalid.pto` outputs:
```bash
'pto.tquant' op INT8_ASYM quantization requires an offset operand
'pto.tquant' op INT8_SYM quantization must not have an offset operand
'pto.tquant' op expects dst element type i8 for INT8_SYM quantization
'pto.tquant' op expects dst element type ui8 for INT8_ASYM quantization
```
- [x] Generated C++ compiles with bisheng against pto-isa headers (`dav-2201`)
- [x] End-to-end numerical accuracy verified on A3 hardware (INT8_SYM) via `test/basic/tquant_e2e.pto`:

| src | scale | expected i8 | result |
|-----|-------|-------------|--------|
| 4.0 | 0.25 | 1 | ✅ |
| 2.0 | 0.50 | 1 | ✅ |
| 10.0 | 1.00 | 10 | ✅ |
| 127.0 | 1.00 | 127 | ✅ |
| -4.0 | 0.25 | -1 | ✅ |
| 0.0 | 1.00 | 0 | ✅ |

- [x] End-to-end numerical accuracy verified on A3 hardware (INT8_ASYM) via `test/basic/tquant_e2e.pto`:

| src | scale | offset | expected ui8 | result |
|-----|-------|--------|--------------|--------|
| 4.0 | 0.25 | 0.0 | 1 | ✅ |
| 10.0 | 1.00 | 0.0 | 10 | ✅ |
| 4.0 | 1.00 | 10.0 | 14 | ✅ |
| 200.0 | 1.00 | 0.0 | 200 | ✅ |
| 255.0 | 1.00 | 0.0 | 255 | ✅ |
| 0.0 | 1.00 | 0.0 | 0 | ✅ |

> **Note:** multi-function `.pto` modules require explicit `pto.entry` on each kernel — without it only a single-function module is auto-detected as an entry and gets `__global__ AICORE`. Both functions in `tquant_e2e.pto` are annotated accordingly.

To reproduce:
```bash
build/tools/ptoas/ptoas \
  --pto-arch=a3 \
  --enable-insert-sync \
  test/basic/tquant_e2e.pto \
  -o /mounted_home/tquant_e2e_a3.cpp

bisheng \
  -I/sources/pto-isa/include \
  -I/sources/pto-isa/include/pto \
  -fPIC -shared -O2 -std=c++17 \
  -xcce -Xhost-start -Xhost-end \
  --npu-arch=dav-2201 -DMEMORY_BASE \
  /mounted_home/tquant_caller.cpp \
  -o /mounted_home/tquant_e2e_a3.so

python test_quantop.py
```

Scripts used for testing:
- `tquant_caller.cpp`
```cpp
#include "tquant_e2e_a3.cpp"

extern "C" void call_tquant_sym(
    void *stream,
    uint8_t *src,
    uint8_t *fp,
    uint8_t *dst)
{
    tquant_sym_run<<<20, nullptr, stream>>>(
        reinterpret_cast<float *>(src),
        reinterpret_cast<float *>(fp),
        reinterpret_cast<int8_t *>(dst));
}

extern "C" void call_tquant_asym(
    void *stream,
    uint8_t *src,
    uint8_t *fp,
    uint8_t *offset,
    uint8_t *dst)
{
    tquant_asym_run<<<20, nullptr, stream>>>(
        reinterpret_cast<float *>(src),
        reinterpret_cast<float *>(fp),
        reinterpret_cast<float *>(offset),
        reinterpret_cast<uint8_t *>(dst));
}

```
- `test_quantop.py`
```python
import ctypes
import torch
import torch_npu

device = "npu:0"
torch.npu.set_device(device)

lib = ctypes.CDLL("/mounted_home/tquant_e2e_a3.so")

fn_sym = lib.call_tquant_sym
fn_sym.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
fn_sym.restype = None

fn_asym = lib.call_tquant_asym
fn_asym.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p]
fn_asym.restype = None

def run_sym(src_val, scale_val):
    src = torch.full((32, 32), src_val, dtype=torch.float32, device=device)
    fp  = torch.full((32, 32), scale_val, dtype=torch.float32, device=device)
    dst = torch.full((32, 32), -1, dtype=torch.int8, device=device)
    stream_ptr = torch.npu.current_stream()._as_parameter_
    torch.npu.synchronize()
    fn_sym(stream_ptr,
           ctypes.c_void_p(src.data_ptr()),
           ctypes.c_void_p(fp.data_ptr()),
           ctypes.c_void_p(dst.data_ptr()))
    torch.npu.synchronize()
    return dst

def run_asym(src_val, scale_val, offset_val):
    src    = torch.full((32, 32), src_val,    dtype=torch.float32, device=device)
    fp     = torch.full((32, 32), scale_val,  dtype=torch.float32, device=device)
    offset = torch.full((32, 32), offset_val, dtype=torch.float32, device=device)
    dst    = torch.full((32, 32), 255,        dtype=torch.uint8,   device=device)
    stream_ptr = torch.npu.current_stream()._as_parameter_
    torch.npu.synchronize()
    fn_asym(stream_ptr,
            ctypes.c_void_p(src.data_ptr()),
            ctypes.c_void_p(fp.data_ptr()),
            ctypes.c_void_p(offset.data_ptr()),
            ctypes.c_void_p(dst.data_ptr()))
    torch.npu.synchronize()
    return dst

sym_cases = [
    # (src,    scale,  expected_i8)
    (4.0,    0.25,    1),    # 4.0 * 0.25 = 1.0
    (2.0,    0.5,     1),    # 2.0 * 0.5  = 1.0
    (10.0,   1.0,    10),    # 10.0 * 1.0 = 10.0
    (127.0,  1.0,   127),    # max i8
    (-4.0,   0.25,   -1),    # -4.0 * 0.25 = -1.0
    (0.0,    1.0,     0),    # zero
]

asym_cases = [
    # (src,    scale,  offset,  expected_ui8)   expected = round(src * scale + offset)
    (4.0,    0.25,    0.0,    1),    # 4.0 * 0.25 + 0.0 = 1.0
    (10.0,   1.0,     0.0,   10),    # 10.0 * 1.0 + 0.0 = 10.0
    (4.0,    1.0,    10.0,   14),    # 4.0 * 1.0 + 10.0 = 14.0
    (200.0,  1.0,     0.0,  200),    # large positive
    (255.0,  1.0,     0.0,  255),    # max ui8
    (0.0,    1.0,     0.0,    0),    # zero
]

all_passed = True

print("=== INT8_SYM ===")
for src_val, scale_val, expected in sym_cases:
    dst = run_sym(src_val, scale_val)
    ok = (dst == expected).all()
    all_passed = all_passed and ok
    print(f"src={src_val:6.1f} scale={scale_val:.2f} -> expected={expected:4d}  got={dst[0,0].item():4d}  {'PASS' if ok else 'FAIL'}")

print()
print("=== INT8_ASYM ===")
for src_val, scale_val, offset_val, expected in asym_cases:
    dst = run_asym(src_val, scale_val, offset_val)
    ok = (dst == expected).all()
    all_passed = all_passed and ok
    print(f"src={src_val:6.1f} scale={scale_val:.2f} offset={offset_val:.1f} -> expected={expected:4d}  got={dst[0,0].item():4d}  {'PASS' if ok else 'FAIL'}")

print()
print("ALL PASSED" if all_passed else "SOME TESTS FAILED")

```