### PR TITLE
fix(release): rewrite packaged macOS dylib install names

### DIFF
--- a/docker/collect_ptoas_dist_mac.sh
+++ b/docker/collect_ptoas_dist_mac.sh
@@ -141,8 +141,52 @@ collect_dylibs() {
   done < <(otool -L "$bin" | awk 'NR>1 {print $1}')
 }
 
+packaged_dep_ref() {
+  local owner="$1"
+  local dep_base="$2"
+  case "$owner" in
+    "${PTOAS_DIST_DIR}/bin/"*)
+      echo "@loader_path/../lib/${dep_base}"
+      ;;
+    "${PTOAS_DEPS_DIR}/"*)
+      echo "@loader_path/${dep_base}"
+      ;;
+    *)
+      echo "@loader_path/${dep_base}"
+      ;;
+  esac
+}
+
+rewrite_packaged_install_names() {
+  local target dep base replacement
+  while IFS= read -r target; do
+    while IFS= read -r dep; do
+      [ -n "$dep" ] || continue
+      case "$dep" in
+        @loader_path/*|@rpath/*|@executable_path/*|/usr/lib/*|/System/Library/*)
+          continue
+          ;;
+      esac
+
+      base="$(basename "$dep")"
+      if [ ! -f "${PTOAS_DEPS_DIR}/${base}" ]; then
+        continue
+      fi
+
+      replacement="$(packaged_dep_ref "$target" "$base")"
+      if [ "$dep" != "$replacement" ]; then
+        echo "rewrite install name: ${target} :: ${dep} -> ${replacement}"
+        install_name_tool -change "$dep" "$replacement" "$target"
+      fi
+    done < <(otool -L "$target" | awk 'NR>1 {print $1}')
+  done < <(find "${PTOAS_DIST_DIR}/bin" "${PTOAS_DEPS_DIR}" -type f \( -name 'ptoas' -o -name '*.dylib' \))
+}
+
 echo "Collecting dylib dependencies..."
 collect_dylibs "${PTOAS_DIST_DIR}/bin/ptoas"
+
+echo "Rewriting packaged install names..."
+rewrite_packaged_install_names
 
 echo "Validating packaged dependency install names..."
 if ! python3 - "${PTOAS_DIST_DIR}" <<'PY'


### PR DESCRIPTION
## Summary
- add a post-collection pass that rewrites absolute non-system dylib references to packaged `@loader_path` references
- keep the portable dependency validation, but normalize the packaged Mach-O files before validating them
- log each rewritten install name so future packaging failures are easier to diagnose

## Why
Manual macOS wheel run `23724501658` still failed on `main` in `Build wheel (Python 3.11, aarch64)` during `Collect ptoas binary and dependencies`.

The new validation now works, and it caught a real packaging leak:
- `/Users/runner/work/PTOAS/PTOAS/ptoas-dist/lib/libLLVMSupport.dylib -> /opt/homebrew/opt/zstd/lib/libzstd.1.dylib`

That means dependency collection copied `libzstd.1.dylib`, but at least one packaged dylib still retained the original Homebrew absolute install name. This patch adds a final normalization pass over the packaged tree so those remaining absolute references are rewritten before validation.

## Validation
- `bash -n docker/collect_ptoas_dist_mac.sh`
- `git diff --check`
- inspected failing job log `69105423937` from run `23724501658`
