### PR TITLE
fix: honor parser arch in verifier during parse

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -4485,7 +4485,8 @@ pto.tcmp ins(<src0>, <src1> {cmpMode = <mode>} : <type0>, <type1>)
   - Output type must be `i8`.
   - `src0/src1/dst` must use `loc=vec`.
   - Valid bounds: `src valid row <= src.rows` and `src valid column <= src.cols`.
-  - `src0` and `dst` must have the same valid region: `src0 valid row == dst valid row` and `src0 valid column == dst valid column`.
+  - `src0` and `dst` must have the same valid region: 
+      `src0 valid row == src1 valid row == dst valid row` and `src0 valid column == src1 valid column`.
 - **Implementation checks (A5)**:
   - Input type must be one of: `i32`, `i16`, `i8`, `f32`, `f16`.
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -248,8 +248,10 @@ bool mlir::pto::isTargetArchA5(Operation *op) {
 }
 
 static VerifierTargetArch getVerifierTargetArch(Operation *op) {
-  return archName->equals_insensitive("a5") ? VerifierTargetArch::A5
+  if (auto archName = getVerifierArchName(op)) {
+    return archName->equals_insensitive("a5") ? VerifierTargetArch::A5
                             : VerifierTargetArch::A2A3;
+  }
 
   switch (getPTOParserTargetArch()) {
   case PTOParserTargetArch::A5:
@@ -2637,17 +2639,20 @@ LogicalResult pto::TCmpOp::verify() {
       return emitOpError("expects src0 and src1 to have the same element type");
     if (!(e0.isInteger(32) || e0.isF16() || e0.isF32()))
       return emitOpError("expects A2/A3 tcmp input element type to be i32/f16/f32");
-    if (auto it = dyn_cast<IntegerType>(ed)) {
-      if (it.getWidth() != 8)
-        return emitOpError("expects dst element type to be i8");
-    } else {
+    if (!ed.isInteger(8))
       return emitOpError("expects dst element type to be i8");
-    }
 
-    if (getShapeVec(t0) != getShapeVec(t1) || getShapeVec(t0) != getShapeVec(td))
-      return emitOpError("expects src0, src1, and dst to have the same shape");
-    if (failed(verifyTileBufSameValidShape(*this, t0, td, "src0", "dst")))
-      return failure();
+    auto valid0 = getValidShapeVec(t0);
+    auto valid1 = getValidShapeVec(t1);
+    auto validd = getValidShapeVec(td);
+    if (valid0.size() != 2 || valid1.size() != 2 || validd.size() != 2)
+      return emitOpError("expects src0, src1, and dst to have rank-2 valid_shape");
+    if (!hasCompatibleKnownExtent(valid0[0], valid1[0]))
+      return emitOpError("expects src0 and src1 to have the same valid row");
+    if (!hasCompatibleKnownExtent(valid0[1], valid1[1]))
+      return emitOpError("expects src0 and src1 to have the same valid column");
+    if (!hasCompatibleKnownExtent(valid0[0], validd[0]))
+      return emitOpError("expects src0 valid row to equal dst valid row");
     return success();
   };
 


### PR DESCRIPTION
#388 
问题原因：
 在verify阶段还未接受到arch信息

解决方案：
将arch信息在verify时传入

https://gitcode.com/cann/pto-as/issues/7
与pto-isa确认tcmp的constriants