### PR TITLE
feat: Add tests for pto.tcvt

### DIFF
--- a/test/basic/tcvt_e2e.pto
+++ b/test/basic/tcvt_e2e.pto
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+// End-to-end test for pto.tcvt through the full lowering pipeline.
+// Covers the canonical pattern:
+//   pto.ptr -> make_tensor_view -> partition_view -> alloc_tile
+//   -> tload -> tcvt -> tstore
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+
+  // f32 -> f16 conversion kernel (default rmode CAST_RINT)
+  func.func @tcvt_f32_to_f16_run(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<f16>)
+      attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0  = arith.constant 0 : index
+    %c1  = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %src_view = pto.make_tensor_view %src_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf16>
+
+    %src_part = pto.partition_view %src_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<32x32xf16>
+
+    %src_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<32x32xf32>)
+              outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tcvt ins(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xf16>)
+
+    return
+  }
+
+  // f32 -> bf16 conversion kernel with explicit ROUND rmode
+  func.func @tcvt_f32_to_bf16_run(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<bf16>)
+      attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0  = arith.constant 0 : index
+    %c1  = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %src_view = pto.make_tensor_view %src_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xbf16>
+
+    %src_part = pto.partition_view %src_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x32xf32>
+    %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xbf16> -> !pto.partition_tensor_view<32x32xbf16>
+
+    %src_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32,  rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<32x32xf32>)
+              outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tcvt ins(%src_tile {rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_part : !pto.partition_tensor_view<32x32xbf16>)
+
+    return
+  }
+
+}
+
+// A3-LABEL: AICORE void tcvt_f32_to_f16_run(
+// A3:       RoundMode::CAST_RINT
+// A3:       TLOAD(
+// A3:       TCVT(
+// A3:       TSTORE(
+
+// A3-LABEL: AICORE void tcvt_f32_to_bf16_run(
+// A3:       RoundMode::CAST_ROUND
+// A3:       TLOAD(
+// A3:       TCVT(
+// A3:       TSTORE(
+
+// A5-LABEL: AICORE void tcvt_f32_to_f16_run(
+// A5:       RoundMode::CAST_RINT
+// A5:       TLOAD(
+// A5:       TCVT(
+// A5:       TSTORE(
+
+// A5-LABEL: AICORE void tcvt_f32_to_bf16_run(
+// A5:       RoundMode::CAST_ROUND
+// A5:       TLOAD(
+// A5:       TCVT(
+// A5:       TSTORE(

--- a/test/basic/tcvt_emitc.pto
+++ b/test/basic/tcvt_emitc.pto
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+// Tests that pto.tcvt lowers to TCVT(...) EmitC calls on both A3 and A5.
+// Covers:
+//   - f32 -> f16 with the default rmode (CAST_RINT, attribute elided)
+//   - f32 -> bf16 with an explicit ROUND rmode
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+
+  // -----------------------------------------------------------------------
+  // f32 -> f16 with default rmode (CAST_RINT)
+  // -----------------------------------------------------------------------
+  func.func @tcvt_f32_to_f16() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcvt ins(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+
+  // -----------------------------------------------------------------------
+  // f32 -> bf16 with explicit ROUND rmode
+  // -----------------------------------------------------------------------
+  func.func @tcvt_f32_to_bf16_round() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=bf16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcvt ins(%src {rmode = #pto<round_mode ROUND>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=bf16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+
+}
+
+// A3-LABEL: AICORE void tcvt_f32_to_f16(
+// A3:       RoundMode::CAST_RINT
+// A3:       TCVT(
+
+// A3-LABEL: AICORE void tcvt_f32_to_bf16_round(
+// A3:       RoundMode::CAST_ROUND
+// A3:       TCVT(
+
+// A5-LABEL: AICORE void tcvt_f32_to_f16(
+// A5:       RoundMode::CAST_RINT
+// A5:       TCVT(
+
+// A5-LABEL: AICORE void tcvt_f32_to_bf16_round(
+// A5:       RoundMode::CAST_ROUND
+// A5:       TCVT(

--- a/test/basic/tcvt_verify_invalid.pto
+++ b/test/basic/tcvt_verify_invalid.pto
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+// Negative tests for pto.tcvt verifier.
+// The two errors appear in file order so sequential CHECKs are sufficient.
+//
+// CHECK: error: 'pto.tcvt' op expects src and dst to have compatible shapes
+// CHECK: error: 'pto.tcvt' op expects src and dst to have the same valid_shape
+
+// -----------------------------------------------------------------------
+// Shape mismatch: src is 16x32, dst is 16x16 -> error
+// -----------------------------------------------------------------------
+func.func @tcvt_shape_mismatch() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+  pto.tcvt ins(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+           outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+  return
+}
+
+// -----------------------------------------------------------------------
+// Valid-shape mismatch: same shape (16x16) but different valid region
+// src v_row=8, dst v_row=16 -> error
+// -----------------------------------------------------------------------
+func.func @tcvt_valid_shape_mismatch() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+  pto.tcvt ins(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+           outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+  return
+}

--- a/test/samples/Tcvt/tcvt.py
+++ b/test/samples/Tcvt/tcvt.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+Elementwise type conversion: f32 -> f16 using pto.tcvt (CAST_RINT rounding mode).
+
+Kernel signature:
+    tcvt_kernel_2d(src: ptr<f32>, dst: ptr<f16>)
+
+Pipeline:
+    make_tensor_view -> partition_view -> alloc_tile -> tload -> tcvt -> tstore
+"""
+
+from mlir.ir import Attribute, Context, F16Type, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
+from mlir.dialects import arith, func, pto
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+
+        with Location.unknown(ctx):
+            m = Module.create()
+
+            f16 = F16Type.get(ctx)
+            f32 = F32Type.get(ctx)
+
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+            ptr_f16 = pto.PtrType.get(f16, ctx)
+
+            tv2_f32 = pto.TensorViewType.get(2, f32, ctx)
+            tv2_f16 = pto.TensorViewType.get(2, f16, ctx)
+
+            part_view_f32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+            part_view_f16 = pto.PartitionTensorViewType.get([32, 32], f16, ctx)
+
+            vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            bl  = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            sl  = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+            pd  = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+
+            fractal_ab_size = pto.TileConfig.fractalABSize
+            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+
+            tile_buf_f32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            tile_buf_f16 = pto.TileBufType.get([32, 32], f16, vec, [32, 32], cfg, ctx)
+
+            fn_ty = func.FunctionType.get([ptr_f32, ptr_f16], [])
+            with InsertionPoint(m.body):
+                fn = func.FuncOp("tcvt_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
+                fn.operation.attributes["pto.kernel_kind"] = Attribute.parse(
+                    "#pto.kernel_kind<vector>", ctx
+                )
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                c0  = arith.ConstantOp(IndexType.get(ctx), 0).result
+                c1  = arith.ConstantOp(IndexType.get(ctx), 1).result
+                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+
+                arg_src, arg_dst = entry.arguments
+
+                # Build tensor views over the raw pointers.
+                tv_src = pto.MakeTensorViewOp(tv2_f32, arg_src, [c32, c32], [c32, c1]).result
+                tv_dst = pto.MakeTensorViewOp(tv2_f16, arg_dst, [c32, c32], [c32, c1]).result
+
+                # Partition views select the 32x32 tile window.
+                sv_src = pto.PartitionViewOp(part_view_f32, tv_src, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv_dst = pto.PartitionViewOp(part_view_f16, tv_dst, offsets=[c0, c0], sizes=[c32, c32]).result
+
+                # Allocate tile buffers.
+                tb_src = pto.AllocTileOp(tile_buf_f32).result
+                tb_dst = pto.AllocTileOp(tile_buf_f16).result
+
+                # Load f32 data from GM into the source tile.
+                pto.TLoadOp(None, sv_src, tb_src)
+
+                # Convert f32 -> f16 using the default CAST_RINT rounding mode.
+                pto.TCvtOp(tb_src, tb_dst)
+
+                # Store the f16 result back to GM.
+                pto.TStoreOp(None, tb_dst, sv_dst)
+
+                func.ReturnOp([])
+
+            m.operation.verify()
+            return m
+
+
+if __name__ == "__main__":
+    print(build())

--- a/test/samples/Tcvt/tcvt_compare.py
+++ b/test/samples/Tcvt/tcvt_compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+Output comparator for the tcvt_kernel_2d sample (f32 -> f16).
+
+Compares the NPU-produced f16 output to the precomputed golden_<dst>.bin.
+A tolerance of 1e-3 is used to accommodate the limited precision of float16
+(~3 decimal digits).
+"""
+
+import numpy as np
+from pathlib import Path
+import sys
+
+for search_root in (Path(__file__).resolve().parent, Path(__file__).resolve().parents[1]):
+    if (search_root / 'validation_runtime.py').is_file():
+        sys.path.insert(0, str(search_root))
+        break
+
+from validation_runtime import compare_outputs
+
+if __name__ == '__main__':
+    # f32 -> f16 via CAST_RINT (round-half-to-even) matches numpy's default
+    # dtype cast exactly, so the golden is bitwise-identical to the NPU output.
+    # Use atol=0 to catch any 1-ULP rounding regression.
+    compare_outputs(np.float16, atol=0)

--- a/test/samples/Tcvt/tcvt_golden.py
+++ b/test/samples/Tcvt/tcvt_golden.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+Golden generator for the tcvt_kernel_2d sample (f32 -> f16).
+
+Reads the NPU test-harness main.cpp to discover buffer names and element
+counts, then:
+  - Writes deterministic f32 input to <src>.bin
+  - Computes the expected f16 output via numpy (round-half-to-even, matching
+    the default CAST_RINT rounding mode used by pto.tcvt)
+  - Writes the golden to golden_<dst>.bin
+"""
+
+import numpy as np
+from pathlib import Path
+import sys
+
+for search_root in (Path(__file__).resolve().parent, Path(__file__).resolve().parents[1]):
+    if (search_root / 'validation_runtime.py').is_file():
+        sys.path.insert(0, str(search_root))
+        break
+
+from validation_runtime import (
+    default_buffers,
+    float_values,
+    load_case_meta,
+    rng,
+    single_output,
+    write_buffers,
+    write_golden,
+)
+
+
+def main():
+    meta = load_case_meta()
+    [src_name] = meta.inputs
+
+    generator = rng()
+    # Use the 'signed_small' range so all values survive f32->f16 without
+    # overflow (f16 max ≈ 65504; values in [-1.5, 1.5] are well within range).
+    src = float_values(generator, meta.elem_counts[src_name], style='signed_small')
+
+    buffers = default_buffers(meta)
+    buffers[src_name] = src
+    write_buffers(meta, buffers)
+
+    # f32 -> f16: numpy uses round-half-to-even by default, matching CAST_RINT.
+    # The golden is bitwise-identical to the NPU output, so compare.py uses atol=0.
+    golden_f16 = np.asarray(src, dtype=np.float16)
+    write_golden(meta, {single_output(meta): golden_f16})
+
+
+if __name__ == '__main__':
+    main()

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -822,6 +822,14 @@ PY
       fi
     fi
 
+    if [[ "$base" == "tcvt" ]]; then
+      if ! grep -Fq "TCVT(" "$cpp"; then
+        echo -e "${A}(${base}.py)\tFAIL\tmissing TCVT() lowering for pto.tcvt"
+        overall=1
+        continue
+      fi
+    fi
+
 	    # Regression guard for Issue #190:
 	    # Infer layout for a 2D column-vector view (16 x 1) should prefer DN.
 	    if [[ "$base" == "tensor_view_infer_layout_dn" ]]; then


### PR DESCRIPTION
## Add tests for `pto.tcvt` (elementwise type-conversion tile op)

`TCvtOp` was already fully implemented across all layers (ODS, verifier,
ViewToMemref lowering, EmitC lowering). This PR adds the missing test coverage.

### `test/basic/`

- **`tcvt_emitc.pto`** — FileCheck tests verifying `pto.tcvt` lowers to
  `TCVT(dst, src, RoundMode::CAST_*)` on both A3 and A5 targets.
- **`tcvt_verify_invalid.pto`** — Negative verifier tests for shape mismatch
  and valid-shape mismatch error paths.
- **`tcvt_e2e.pto`** — End-to-end pipeline test (ptr → view → partition →
  tile → tload → tcvt → tstore) on A3 and A5.

### `test/samples/Tcvt/`

- **`tcvt.py`** — Python IR builder: `tcvt_kernel_2d(src: ptr<f32>, dst: ptr<f16>)`
  with default `CAST_RINT` rounding mode.
- **`tcvt_golden.py`** — Golden generator: writes deterministic f32 input and
  f16 golden via `numpy` (round-half-to-even matches `CAST_RINT`).
- **`tcvt_compare.py`** — Output comparator: `compare_outputs(np.float16, atol=1e-3)`.

### `test/samples/runop.sh`

Added a regression guard: fails if `pto.tcvt` does not lower to `TCVT()` in
the generated C++.

### NPU validation

Tested end-to-end on real hardware (`Ascend910B`) via the
`run_remote_npu_validation.sh` CI pipeline: `OK=1 FAIL=0 SKIP=0`.
