### PR TITLE
tgemv.mx: enforce scaling-tile verify and strengthen test guards

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2112,6 +2112,17 @@ static LogicalResult verifyAccTileCommon(Operation *op, Type ty, StringRef name)
   }
 }
 
+static LogicalResult verifyScalingTileCommon(Operation *op, Type ty,
+                                             StringRef name) {
+  if (failed(verifyTileBufCommon(op, ty, name)))
+    return failure();
+  auto as = getPTOMemorySpaceEnum(ty);
+  if (!as || *as != pto::AddressSpace::SCALING)
+    return op->emitOpError() << "expects " << name
+                             << " to be in the scaling address space";
+  return success();
+}
+
 static LogicalResult verifyMatTileOperandsA2A3(Operation *op, Type lhsTy,
                                                Type rhsTy, Type dstTy) {
   if (failed(verifyTileBufCommon(op, lhsTy, "lhs")) ||
@@ -4397,8 +4408,8 @@ LogicalResult TGemvBiasOp::verify() {
 
 LogicalResult TGemvMxOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (failed(verifyTileBufCommon(*this, getAScale().getType(), "a_scale")) ||
-        failed(verifyTileBufCommon(*this, getBScale().getType(), "b_scale")) ||
+    if (failed(verifyScalingTileCommon(*this, getAScale().getType(), "a_scale")) ||
+        failed(verifyScalingTileCommon(*this, getBScale().getType(), "b_scale")) ||
         failed(verifyGemvTileOperands(*this, getA().getType(), getB().getType(),
                                       getDst().getType())))
       return failure();
@@ -4412,8 +4423,8 @@ LogicalResult TGemvMxOp::verify() {
 LogicalResult TGemvMxAccOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
     if (failed(verifyAccTileCommon(*this, getCIn().getType(), "c_in")) ||
-        failed(verifyTileBufCommon(*this, getAScale().getType(), "a_scale")) ||
-        failed(verifyTileBufCommon(*this, getBScale().getType(), "b_scale")) ||
+        failed(verifyScalingTileCommon(*this, getAScale().getType(), "a_scale")) ||
+        failed(verifyScalingTileCommon(*this, getBScale().getType(), "b_scale")) ||
         failed(verifyGemvTileOperands(*this, getA().getType(), getB().getType(),
                                       getDst().getType())))
       return failure();
@@ -4426,8 +4437,8 @@ LogicalResult TGemvMxAccOp::verify() {
 
 LogicalResult TGemvMxBiasOp::verify() {
   auto verifyA2A3 = [&]() -> LogicalResult {
-    if (failed(verifyTileBufCommon(*this, getAScale().getType(), "a_scale")) ||
-        failed(verifyTileBufCommon(*this, getBScale().getType(), "b_scale")) ||
+    if (failed(verifyScalingTileCommon(*this, getAScale().getType(), "a_scale")) ||
+        failed(verifyScalingTileCommon(*this, getBScale().getType(), "b_scale")) ||
         failed(verifyGemvTileOperands(*this, getA().getType(), getB().getType(),
                                       getDst().getType())) ||
         failed(verifyMatBiasTile(*this, getBias().getType(), getDst().getType(),

--- a/test/basic/tgemv_mx_emitc.pto
+++ b/test/basic/tgemv_mx_emitc.pto
@@ -15,4 +15,4 @@ module {
 }
 
 // CHECK-LABEL: __global__ AICORE void tgemv_mx_emitc()
-// CHECK: TGEMV_MX(
+// CHECK: TGEMV_MX({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});

--- a/test/basic/tgemv_mx_variants_emitc.pto
+++ b/test/basic/tgemv_mx_variants_emitc.pto
@@ -19,5 +19,5 @@ module {
 }
 
 // CHECK-LABEL: __global__ AICORE void tgemv_mx_variants_emitc()
-// CHECK: TGEMV_MX(
-// CHECK: TGEMV_MX(
+// CHECK: TGEMV_MX([[DST_ACC:v[0-9]+]], [[C_IN:v[0-9]+]], [[A:v[0-9]+]], [[A_SCALE:v[0-9]+]], [[B:v[0-9]+]], [[B_SCALE:v[0-9]+]]);
+// CHECK-NEXT: TGEMV_MX([[DST_BIAS:v[0-9]+]], [[A]], [[A_SCALE]], [[B]], [[B_SCALE]], [[BIAS:v[0-9]+]]);

--- a/test/basic/tgemv_mx_verify_scale_loc.pto
+++ b/test/basic/tgemv_mx_verify_scale_loc.pto
@@ -1,0 +1,16 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @tgemv_mx_invalid_scale_loc() {
+    %a = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f16, rows=1, cols=128, v_row=1, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %a_scale = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f16, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+    %b = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f16, rows=128, cols=16, v_row=128, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+    %b_scale = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=f16, rows=128, cols=16, v_row=128, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f16, rows=1, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+
+    pto.tgemv.mx ins(%a, %a_scale, %b, %b_scale : !pto.tile_buf<loc=left, dtype=f16, rows=1, cols=128, v_row=1, v_col=128, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=left, dtype=f16, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f16, rows=128, cols=16, v_row=128, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>, !pto.tile_buf<loc=scaling, dtype=f16, rows=128, cols=16, v_row=128, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=acc, dtype=f16, rows=1, cols=16, v_row=1, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tgemv.mx' op expects a_scale to be in the scaling address space


### PR DESCRIPTION
Summary
- Tighten `pto.tgemv.mx` verifier so `a_scale`/`b_scale` must be in `scaling` address space.
- Strengthen EmitC checks for `tgemv.mx` / `tgemv.mx.acc` / `tgemv.mx.bias` to guard argument-shape lowering.
- Add a negative verifier test that rejects invalid scale tile location.

Motivation
- Architect request: submit `tgemv.mx` OP support with stronger regression coverage.
- Existing coverage checked call presence only; it did not guard operand role/order or invalid scale-loc misuse.

Design
- Added `verifyScalingTileCommon(...)` in `PTO.cpp`.
- Applied this verifier to:
  - `TGemvMxOp`
  - `TGemvMxAccOp`
  - `TGemvMxBiasOp`
- Kept lowering strategy unchanged (1:1 mapping to `TGEMV_MX` overloads).
- Updated tests:
  - `test/basic/tgemv_mx_emitc.pto` (5-arg call shape)
  - `test/basic/tgemv_mx_variants_emitc.pto` (acc/bias call role/order)
  - `test/basic/tgemv_mx_verify_scale_loc.pto` (new negative case)

Testing
- Local build: `ninja -C build ptoas` (OK)
- Local checks:
  - `build/tools/ptoas/ptoas --pto-arch=a5 test/basic/tgemv_mx_emitc.pto | FileCheck test/basic/tgemv_mx_emitc.pto` (OK)
  - `build/tools/ptoas/ptoas --pto-arch=a5 test/basic/tgemv_mx_variants_emitc.pto | FileCheck test/basic/tgemv_mx_variants_emitc.pto` (OK)
  - `not build/tools/ptoas/ptoas --pto-arch=a5 test/basic/tgemv_mx_verify_scale_loc.pto | FileCheck test/basic/tgemv_mx_verify_scale_loc.pto` (OK)

Risk / Rollback
- Risk: programs that previously passed with non-`scaling` scale tiles for `tgemv.mx*` will now fail verification.
- Rollback: revert this PR commit.

Review Focus
- Verifier diagnostic correctness for scale operand address space.
- `tgemv.mx.acc` vs `tgemv.mx.bias` call-argument role/order checks in EmitC tests.
- No behavioral change in lowering target intrinsic (still `TGEMV_MX`).
