### PR TITLE
fix(release): allow same-version reruns

### DIFF
--- a/.github/scripts/compute_ptoas_version.py
+++ b/.github/scripts/compute_ptoas_version.py
@@ -6,6 +6,12 @@ import re
 import sys
 
 
+PROJECT_VERSION_RE = re.compile(
+    r"project\s*\(\s*ptoas\s+VERSION\s+([0-9]+\.[0-9]+)\s*\)"
+)
+VERSION_RE = re.compile(r"[0-9]+\.[0-9]+")
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Compute the ptoas CLI version from the top-level CMakeLists.txt."
@@ -30,7 +36,7 @@ def parse_args() -> argparse.Namespace:
 
 def read_base_version(cmake_file: pathlib.Path) -> str:
     content = cmake_file.read_text(encoding="utf-8")
-    match = re.search(r"project\s*\(\s*ptoas\s+VERSION\s+([0-9]+\.[0-9]+)\s*\)", content)
+    match = PROJECT_VERSION_RE.search(content)
     if not match:
         raise ValueError(
             f"could not find 'project(ptoas VERSION x.y)' in {cmake_file}"
@@ -46,23 +52,44 @@ def bump_version(base_version: str) -> str:
 
 
 def normalize_tag(tag: str) -> str:
-    return tag[1:] if tag.startswith("v") else tag
+    normalized = tag[1:] if tag.startswith("v") else tag
+    if not VERSION_RE.fullmatch(normalized):
+        raise ValueError(f"invalid PTOAS release tag '{tag}'")
+    return normalized
+
+
+def compute_version(base_version: str, mode: str, check_tag: str | None = None) -> str:
+    if mode == "dev":
+        version = base_version
+    else:
+        next_release_version = bump_version(base_version)
+        version = next_release_version
+
+        if check_tag is not None:
+            normalized_tag = normalize_tag(check_tag.strip())
+            valid_versions = (next_release_version, base_version)
+            if normalized_tag not in valid_versions:
+                raise ValueError(
+                    "release tag "
+                    f"'{check_tag}' does not match next release version "
+                    f"'{next_release_version}' or current base version "
+                    f"'{base_version}'"
+                )
+            version = normalized_tag
+
+    return version
 
 
 def main() -> int:
     args = parse_args()
     cmake_file = pathlib.Path(args.cmake_file)
     base_version = read_base_version(cmake_file)
-    version = bump_version(base_version) if args.mode == "release" else base_version
 
-    if args.check_tag is not None:
-        normalized_tag = normalize_tag(args.check_tag.strip())
-        if normalized_tag != version:
-            print(
-                f"release tag '{args.check_tag}' does not match computed version '{version}'",
-                file=sys.stderr,
-            )
-            return 1
+    try:
+        version = compute_version(base_version, args.mode, args.check_tag)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
     print(version)
     return 0

--- a/.github/scripts/test_compute_ptoas_version.py
+++ b/.github/scripts/test_compute_ptoas_version.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+SCRIPT_PATH = pathlib.Path(__file__).with_name("compute_ptoas_version.py")
+
+
+def write_cmake(path: pathlib.Path, version: str) -> None:
+    path.write_text(f"cmake_minimum_required(VERSION 3.20.0)\nproject(ptoas VERSION {version})\n", encoding="utf-8")
+
+
+def run_ok(*args: str) -> str:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def run_fail(*args: str) -> str:
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 0:
+        raise AssertionError("expected failure, but command succeeded")
+    return completed.stderr.strip()
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cmake_file = pathlib.Path(tmpdir) / "CMakeLists.txt"
+
+        write_cmake(cmake_file, "0.10")
+        assert run_ok("--cmake-file", str(cmake_file), "--mode", "dev") == "0.10"
+        assert run_ok("--cmake-file", str(cmake_file), "--mode", "release") == "0.11"
+        assert (
+            run_ok(
+                "--cmake-file",
+                str(cmake_file),
+                "--mode",
+                "release",
+                "--check-tag",
+                "v0.11",
+            )
+            == "0.11"
+        )
+
+        write_cmake(cmake_file, "0.21")
+        assert (
+            run_ok(
+                "--cmake-file",
+                str(cmake_file),
+                "--mode",
+                "release",
+                "--check-tag",
+                "v0.21",
+            )
+            == "0.21"
+        )
+        assert (
+            run_ok(
+                "--cmake-file",
+                str(cmake_file),
+                "--mode",
+                "release",
+                "--check-tag",
+                "v0.22",
+            )
+            == "0.22"
+        )
+
+        error = run_fail(
+            "--cmake-file",
+            str(cmake_file),
+            "--mode",
+            "release",
+            "--check-tag",
+            "v0.20",
+        )
+        assert "does not match next release version '0.22' or current base version '0.21'" in error
+
+    print("compute_ptoas_version.py tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -47,6 +47,10 @@ jobs:
           echo "PY_VER=$PY_VER" >> $GITHUB_ENV
           echo "PY_PATH=/opt/python/$PY_VER" >> $GITHUB_ENV
 
+      - name: Self-check release version script
+        run: |
+          ${PY_PATH}/bin/python .github/scripts/test_compute_ptoas_version.py
+
       - name: Compute PTOAS CLI version
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "release" ]; then

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -44,6 +44,10 @@ jobs:
         run: |
           echo "PY_PATH=$(python -c 'import sys; print(sys.prefix)')" >> $GITHUB_ENV
 
+      - name: Self-check release version script
+        run: |
+          python .github/scripts/test_compute_ptoas_version.py
+
       - name: Compute PTOAS CLI version
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "release" ]; then


### PR DESCRIPTION
## Summary
- allow release builds to accept either the normal next release version or the current base version when validating `GITHUB_REF_NAME`
- add a script-level self-check for `.github/scripts/compute_ptoas_version.py`
- run that self-check in both Linux and macOS wheel workflows

## Why
The current release workflow wedges on same-version reruns.

Example with current `main`:
- `CMakeLists.txt` base version is `0.21`
- re-creating release `v0.21` currently fails in `Compute PTOAS CLI version`
- the script only accepts the computed next version `0.22`

That breaks the common recovery path where a release needs to be recreated after the base version has already been synced to the released version.

## Validation
- `python3 .github/scripts/test_compute_ptoas_version.py`
- `python3 .github/scripts/compute_ptoas_version.py --mode release --check-tag v0.21`
- `python3 .github/scripts/compute_ptoas_version.py --mode release --check-tag v0.22`
- `python3 .github/scripts/compute_ptoas_version.py --mode release --check-tag v0.20` (fails as expected)
