### PR TITLE
ci(mac): stabilize x86_64 delocate wheel repair

### DIFF
--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_wheel:
     name: Build wheel (Python ${{ matrix.python }}, ${{ matrix.arch }})
-    runs-on: ${{ matrix.arch == 'x86_64' && 'macos-26-intel' || 'macos-26' }}
+    runs-on: ${{ matrix.arch == 'x86_64' && 'macos-15-intel' || 'macos-26' }}
     strategy:
       fail-fast: false
       matrix:
@@ -34,6 +34,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Select runner metadata
+        id: runner-meta
+        run: |
+          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+            echo "label=macos-15-intel" >> "$GITHUB_OUTPUT"
+          else
+            echo "label=macos-26" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -81,7 +90,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-shared
-          key: llvm-${{ env.LLVM_TAG }}-macos-26-${{ matrix.arch }}-${{ matrix.python }}-v1
+          key: llvm-${{ env.LLVM_TAG }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-v1
 
       - name: Prepare LLVM source
         run: |
@@ -100,7 +109,7 @@ jobs:
           echo "LLVM cache miss while running on PR/release."
           echo "PR/release runs are cache-consumers only and should reuse cache generated on the default branch."
           echo "Please run this workflow on the default branch first to populate cache key:"
-          echo "llvm-${{ env.LLVM_TAG }}-macos-26-${{ matrix.arch }}-${{ matrix.python }}-v1"
+          echo "llvm-${{ env.LLVM_TAG }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-v1"
 
       - name: Build LLVM/MLIR
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -122,7 +131,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-shared
-          key: llvm-${{ env.LLVM_TAG }}-macos-26-${{ matrix.arch }}-${{ matrix.python }}-v1
+          key: llvm-${{ env.LLVM_TAG }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-v1
 
       - name: Build PTOAS
         run: |
@@ -163,6 +172,7 @@ jobs:
 
       - name: Repair wheel with delocate
         run: |
+          set -euo pipefail
           export PY_PACKAGE_DIR=$LLVM_BUILD_DIR/tools/mlir/python_packages/mlir_core
           cd $PY_PACKAGE_DIR
           if [ "${{ matrix.arch }}" = "x86_64" ]; then
@@ -177,10 +187,62 @@ jobs:
             printf '  %s\n' "${wheels[@]}"
             exit 1
           fi
+
+          echo "Runner label: ${{ steps.runner-meta.outputs.label }}"
+          echo "Wheel size:"
+          du -sh "${wheels[0]}"
+          echo "dist contents:"
+          ls -lh dist
+          echo "delocate dependency summary:"
+          delocate-listdeps "${wheels[0]}" || true
+
           delocate-wheel \
             --require-archs "${REQUIRED_ARCH}" \
             --wheel-dir wheelhouse \
-            "${wheels[0]}"
+            "${wheels[0]}" &
+          delocate_pid=$!
+
+          (
+            sleep 4500
+            if kill -0 "$delocate_pid" 2>/dev/null; then
+              echo "ERROR: delocate-wheel exceeded 75 minutes, terminating pid ${delocate_pid}"
+              kill -TERM "$delocate_pid" 2>/dev/null || true
+              sleep 15
+              kill -KILL "$delocate_pid" 2>/dev/null || true
+            fi
+          ) &
+          watchdog_pid=$!
+
+          while kill -0 "$delocate_pid" 2>/dev/null; do
+            echo "[$(date '+%Y-%m-%d %H:%M:%S')] delocate still running (pid=${delocate_pid})"
+            ps -o pid=,ppid=,%cpu=,%mem=,etime=,command= -p "$delocate_pid" || true
+            du -sh dist wheelhouse 2>/dev/null || true
+            sleep 60
+          done
+
+          set +e
+          wait "$delocate_pid"
+          rc=$?
+          set -e
+
+          kill "$watchdog_pid" 2>/dev/null || true
+          wait "$watchdog_pid" 2>/dev/null || true
+
+          if [ "$rc" -ne 0 ]; then
+            echo "delocate-wheel failed with rc=${rc}"
+            echo "Active Python processes:"
+            ps -ax -o pid=,ppid=,%cpu=,%mem=,etime=,command= | grep -E '[d]elocate|[p]ython' || true
+            echo "Filesystem usage:"
+            df -h .
+            echo "dist contents after failure:"
+            ls -lh dist || true
+            echo "wheelhouse contents after failure:"
+            ls -lh wheelhouse || true
+            exit "$rc"
+          fi
+
+          echo "wheelhouse contents:"
+          ls -lh wheelhouse
 
       - name: Test wheel installation
         run: |


### PR DESCRIPTION
## Summary
- move macOS x86_64 wheel jobs off `macos-26-intel` to `macos-15-intel`
- key LLVM cache entries by the effective runner label to avoid cross-image cache reuse
- add delocate preflight logging, periodic heartbeat output, timeout watchdog, and failure diagnostics

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build_wheel_mac.yml"); puts "YAML OK"'`