### PR TITLE
fix: disambiguate trsqrt tmp overload in emitc

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -7581,8 +7581,19 @@ struct PTORsqrtToEmitC : public OpConversionPattern<pto::TRsqrtOp> {
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
     SmallVector<Value, 3> operands{dst, src};
-    if (Value tmp = adaptor.getTmp())
-      operands.push_back(peelUnrealized(tmp));
+    if (Value tmp = adaptor.getTmp()) {
+      Value peeledTmp = peelUnrealized(tmp);
+      operands.push_back(peeledTmp);
+      auto *ctx = rewriter.getContext();
+      auto eventTy =
+          emitc::OpaqueType::get(ctx, "Event<Op::TLOAD, Op::TRSQRT>");
+      Value event =
+          rewriter
+              .create<emitc::VariableOp>(loc, eventTy,
+                                         emitc::OpaqueAttr::get(ctx, ""))
+              .getResult();
+      operands.push_back(event);
+    }
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TRSQRT",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},

--- a/test/basic/trsqrt_emitc.pto
+++ b/test/basic/trsqrt_emitc.pto
@@ -18,4 +18,5 @@ module {
 // A3: pto.trsqrt ins([[SRC1:%[0-9]+]], [[TMP:%[0-9]+]] : memref<1x16xf16
 // A3: outs([[DST1:%[0-9]+]] : memref<1x16xf16
 // A3: TRSQRT([[VDST0:v[0-9]+]], [[VSRC0:v[0-9]+]]);
-// A3: TRSQRT([[VDST1:v[0-9]+]], [[VSRC1:v[0-9]+]], [[VTMP:v[0-9]+]]);
+// A3: Event<Op::TLOAD, Op::TRSQRT> [[VEVT:v[0-9]+]];
+// A3: TRSQRT([[VDST1:v[0-9]+]], [[VSRC1:v[0-9]+]], [[VTMP:v[0-9]+]], [[VEVT]]);


### PR DESCRIPTION

问题说明
pto.trsqrt 在带 tmp 参数时，生成的 C++ 会错误匹配到 TRSQRT(dst, src, WaitEvents...) 重载，导致编译阶段把 tmp tile 当成 event 处理，报出 Tile 没有 Wait() 的错误。

原因分析
pto-isa 中 TRSQRT 同时存在无 tmp 和有 tmp 两个模板重载，PTOAS 之前发射的是 TRSQRT(dst, src, tmp)，模板推导不够明确，编译器找不到匹配的重载函数。

解决方案
构造TRSQRT(dst, src, tmp， event)这种没有歧义的case, 并与pto-isa沟通接口修改以兼容TRSQRT(dst, src, tmp) 的写法