### PR TITLE
fix: add pto.tfillpad_inplace; stop tfillpad from auto-lowering to TFILLPAD_INPLACE

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3640,6 +3640,34 @@ def TFillPadExpandOp : PTO_TOp<"tfillpad_expand", [
   }];
 }
 
+def TFillPadInplaceOp : PTO_TOp<"tfillpad_inplace", [
+  PTO_DpsInitOpInterface,
+  OpPipeInterface,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "In-place fill padding on shared backing storage: src supplies valid-region bounds, dst supplies target pad bounds (tilebuf, DPS)";
+
+  let arguments = (ins
+    PTODpsType:$src,
+    PTODpsType:$dst
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `ins`  `(` $src `:` qualified(type($src)) `)`
+    `outs` `(` $dst `:` qualified(type($dst) ) `)`
+    attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+  }];
+}
+
 def TGatherOp : PTO_TOp<"tgather", [
   AttrSizedOperandSegments,
   PTO_DpsInitOpInterface,

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4537,6 +4537,11 @@ mlir::LogicalResult mlir::pto::TFillPadExpandOp::verify() {
                             /*allowDstExpand=*/true, "tfillpad_expand");
 }
 
+mlir::LogicalResult mlir::pto::TFillPadInplaceOp::verify() {
+  return verifyTFillPadLike(getOperation(), getSrc().getType(), getDst().getType(),
+                            /*allowDstExpand=*/false, "tfillpad_inplace");
+}
+
 
 llvm::LogicalResult mlir::pto::TGatherOp::verify() {
   auto isSupportedGatherElemTypeA5Index = [&](Type ty) -> bool {
@@ -9788,6 +9793,7 @@ void TInsertFPOp::getEffects(
 
 PTO_DEFINE_UNARY_EFFECTS(TFillPadOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TFillPadExpandOp, getSrcMutable(), getDstMutable())
+PTO_DEFINE_UNARY_EFFECTS(TFillPadInplaceOp, getSrcMutable(), getDstMutable())
 
 void TGatherOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6696,12 +6696,33 @@ struct PTOFillPadToEmitC : public OpConversionPattern<pto::TFillPadOp> {
 
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
-    llvm::StringRef callee =
-        (op.getSrc() == op.getDst() || src == dst) ? "TFILLPAD_INPLACE"
-                                                   : "TFILLPAD";
 
     rewriter.create<emitc::CallOpaqueOp>(
-        loc, TypeRange{}, callee,
+        loc, TypeRange{}, "TFILLPAD",
+        /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange{dst, src});
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+//===----------------------------------------------------------------------===//
+// pto.tfillpad_inplace lowering -> TFILLPAD_INPLACE(dst, src)
+//===----------------------------------------------------------------------===//
+
+struct PTOFillPadInplaceToEmitC
+    : public OpConversionPattern<pto::TFillPadInplaceOp> {
+  using OpConversionPattern<pto::TFillPadInplaceOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::TFillPadInplaceOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+
+    Value src = peelUnrealized(adaptor.getSrc());
+    Value dst = peelUnrealized(adaptor.getDst());
+
+    rewriter.create<emitc::CallOpaqueOp>(
+        loc, TypeRange{}, "TFILLPAD_INPLACE",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
         /*operands=*/ValueRange{dst, src});
 
@@ -9852,7 +9873,8 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOPartAddToEmitC>(typeConverter, ctx);
   patterns.add<PTOExtractToEmitC, PTOExtractFPToEmitC, PTOInsertToEmitC,
                PTOInsertFPToEmitC>(typeConverter, ctx);
-  patterns.add<PTOFillPadToEmitC, PTOFillPadExpandToEmitC>(typeConverter, ctx);
+  patterns.add<PTOFillPadToEmitC, PTOFillPadInplaceToEmitC, PTOFillPadExpandToEmitC>(
+      typeConverter, ctx);
   patterns.add<PTOGatherToEmitC>(typeConverter, ctx);
   patterns.add<PTOGatherbToEmitC>(typeConverter, ctx);
   patterns.add<PTOMovFPToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -2314,6 +2314,32 @@ struct PTOViewToMemrefPass
             dst);
       }
 
+      SmallVector<mlir::pto::TFillPadInplaceOp, 8> fillpadInplaceOps;
+      func.walk(
+          [&](mlir::pto::TFillPadInplaceOp op) { fillpadInplaceOps.push_back(op); });
+
+      for (auto op : fillpadInplaceOps) {
+        IRRewriter rewriter(ctx);
+        rewriter.setInsertionPoint(op);
+
+        Value src = op.getSrc();
+        Value dst = op.getDst();
+
+        auto srcTy = dyn_cast<MemRefType>(src.getType());
+        auto dstTy = dyn_cast<MemRefType>(dst.getType());
+        if (!srcTy || !dstTy) {
+          op.emitError("ins/outs are not memref yet");
+          signalPassFailure();
+          return;
+        }
+
+        rewriter.replaceOpWithNewOp<pto::TFillPadInplaceOp>(
+            op,
+            TypeRange{},
+            src,
+            dst);
+      }
+
       // --- TSetValOp [Dst, Offset, Val] ---
       // Lower tile-world scalar write to memref-world SETVAL DPS op.
       SmallVector<mlir::pto::TSetValOp, 8> tsetvalops;

--- a/test/basic/tfillpad_inplace_alias_lowering.pto
+++ b/test/basic/tfillpad_inplace_alias_lowering.pto
@@ -3,8 +3,8 @@
 module {
   func.func @tfillpad_inplace_alias() {
     %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>
-    pto.tfillpad ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
-                 outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
+    pto.tfillpad_inplace ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
+                         outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
     return
   }
 }

--- a/test/basic/tfillpad_same_ssa_lowers_to_tfillpad.pto
+++ b/test/basic/tfillpad_same_ssa_lowers_to_tfillpad.pto
@@ -1,0 +1,14 @@
+// RUN: ptoas %s | FileCheck %s
+
+module {
+  func.func @tfillpad_same_ssa() {
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>
+    pto.tfillpad ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
+               outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tfillpad_same_ssa(
+// CHECK: TFILLPAD(
+// CHECK-NOT: TFILLPAD_INPLACE(

--- a/test/samples/Fillpad/fillpad_inplace.py
+++ b/test/samples/Fillpad/fillpad_inplace.py
@@ -49,7 +49,7 @@ def build():
 
                 tile = pto.AllocTileOp(tile_ty).result
                 pto.TLoadOp(None, sv0, tile)
-                pto.TFillPadOp(tile, tile)
+                pto.TFillPadInplaceOp(tile, tile)
                 pto.TStoreOp(None, tile, sv1)
                 func.ReturnOp([])
 

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -847,12 +847,12 @@ PY
 
     if [[ "$base" == "fillpad_inplace" ]]; then
       if ! grep -Fq "TFILLPAD_INPLACE(" "$cpp"; then
-        echo -e "${A}(${base}.py)\tFAIL\tmissing TFILLPAD_INPLACE() lowering for aliased pto.tfillpad"
+        echo -e "${A}(${base}.py)\tFAIL\tmissing TFILLPAD_INPLACE() lowering for pto.tfillpad_inplace"
         overall=1
         continue
       fi
       if grep -Fq "TFILLPAD_EXPAND(" "$cpp"; then
-        echo -e "${A}(${base}.py)\tFAIL\tpto.tfillpad alias path should not lower via TFILLPAD_EXPAND()"
+        echo -e "${A}(${base}.py)\tFAIL\tpto.tfillpad_inplace should not lower via TFILLPAD_EXPAND()"
         overall=1
         continue
       fi


### PR DESCRIPTION
Issue #470 
TFILLPAD_INPLACE requires same backing storage with distinct src/dst valid-region semantics; same SSA tfillpad must use TFILLPAD. Add explicit tfillpad_inplace op and lowering to TFILLPAD_INPLACE.