### PR TITLE
fix: avoid A3 mis-detection in sim validation

### DIFF
--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -170,6 +170,19 @@ if [[ "${RUN_MODE}" == "sim" ]]; then
 elif [[ "$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')" == *910b* ]]; then
   export PTOAS_BOARD_IS_A3=1
   log "Detected A3 board from npu-smi chip name: ${_board_chip}"
+else
+  for _sim_dir in "${ASCEND_HOME_PATH}/aarch64-linux/simulator" \
+                  "${ASCEND_HOME_PATH}/x86_64-linux/simulator" \
+                  "${ASCEND_HOME_PATH}/simulator" \
+                  "${ASCEND_HOME_PATH}/tools/simulator"; do
+    for _d in "${_sim_dir}"/Ascend910B*/lib; do
+      if [[ -d "$_d" ]]; then
+        export PTOAS_BOARD_IS_A3=1
+        log "Detected A3 board from simulator dir fallback: $_d"
+        break 2
+      fi
+    done
+  done
 fi
 log "SIM_SOC_VERSION=${SIM_SOC_VERSION}"
 log "PTOAS_BOARD_IS_A3=${PTOAS_BOARD_IS_A3}"

--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -142,46 +142,49 @@ export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64:${LD_LIBRARY_PATH:-}"
 
 # Some CANN installs do not provide a simulator directory named exactly
 # "Ascend910". Map it to a real directory so we can link/run camodel.
-SIM_SOC_VERSION="${SOC_VERSION}"
-if [[ "${SOC_VERSION}" == "Ascend910" ]]; then
-  if [[ -d "${ASCEND_HOME_PATH}/aarch64-linux/simulator/Ascend910A/lib" ]]; then
+SIM_SOC_VERSION="${SIM_SOC_VERSION_OVERRIDE:-${SOC_VERSION}}"
+if [[ "${SIM_SOC_VERSION}" == "Ascend910" ]]; then
+  if [[ -d "${ASCEND_HOME_PATH}/aarch64-linux/simulator/Ascend910A/lib" \
+     || -d "${ASCEND_HOME_PATH}/x86_64-linux/simulator/Ascend910A/lib" \
+     || -d "${ASCEND_HOME_PATH}/simulator/Ascend910A/lib" \
+     || -d "${ASCEND_HOME_PATH}/tools/simulator/Ascend910A/lib" ]]; then
     SIM_SOC_VERSION="Ascend910A"
-  elif [[ -d "${ASCEND_HOME_PATH}/aarch64-linux/simulator/Ascend910ProA/lib" ]]; then
+  elif [[ -d "${ASCEND_HOME_PATH}/aarch64-linux/simulator/Ascend910ProA/lib" \
+       || -d "${ASCEND_HOME_PATH}/x86_64-linux/simulator/Ascend910ProA/lib" \
+       || -d "${ASCEND_HOME_PATH}/simulator/Ascend910ProA/lib" \
+       || -d "${ASCEND_HOME_PATH}/tools/simulator/Ascend910ProA/lib" ]]; then
     SIM_SOC_VERSION="Ascend910ProA"
   fi
 fi
 
-# Detect A3 (Ascend910B) board for golden-script gating.
+# Detect A3 (Ascend910B) target for golden-script gating.
 # This is separate from SOC_VERSION/SIM_SOC_VERSION used for compilation
-# to avoid changing the compiler arch (dav-c220 vs dav-c310).
+# to avoid changing the compiler arch (dav-c220 vs dav-c310). Simulator runs
+# must key off the selected SIM target, not the mere presence of 910B sim libs.
 export PTOAS_BOARD_IS_A3=0
-if [[ "$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')" == *910b* ]]; then
+if [[ "${RUN_MODE}" == "sim" ]]; then
+  if [[ "$(printf '%s' "${SIM_SOC_VERSION}" | tr '[:upper:]' '[:lower:]')" == *910b* ]]; then
+    export PTOAS_BOARD_IS_A3=1
+    log "Detected A3 target from SIM_SOC_VERSION=${SIM_SOC_VERSION}"
+  fi
+elif [[ "$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')" == *910b* ]]; then
   export PTOAS_BOARD_IS_A3=1
   log "Detected A3 board from npu-smi chip name: ${_board_chip}"
 fi
-for _sim_dir in "${ASCEND_HOME_PATH}/aarch64-linux/simulator" \
-                "${ASCEND_HOME_PATH}/simulator" \
-                "${ASCEND_HOME_PATH}/tools/simulator"; do
-  for _d in "${_sim_dir}"/Ascend910B*/lib; do
-    if [[ -d "$_d" ]]; then
-      export PTOAS_BOARD_IS_A3=1
-      log "Detected A3 board (Ascend910B) from simulator dir: $_d"
-      break 2
-    fi
-  done
-done
 log "SIM_SOC_VERSION=${SIM_SOC_VERSION}"
+log "PTOAS_BOARD_IS_A3=${PTOAS_BOARD_IS_A3}"
 
 LD_LIBRARY_PATH_NPU="${LD_LIBRARY_PATH}"
 LD_LIBRARY_PATH_SIM="${LD_LIBRARY_PATH}"
 for d in \
   "${ASCEND_HOME_PATH}/aarch64-linux/simulator/${SIM_SOC_VERSION}/lib" \
+  "${ASCEND_HOME_PATH}/x86_64-linux/simulator/${SIM_SOC_VERSION}/lib" \
   "${ASCEND_HOME_PATH}/simulator/${SIM_SOC_VERSION}/lib" \
   "${ASCEND_HOME_PATH}/tools/simulator/${SIM_SOC_VERSION}/lib"; do
   [[ -d "$d" ]] && LD_LIBRARY_PATH_SIM="$d:${LD_LIBRARY_PATH_SIM}"
 done
 
-if [[ "${STAGE}" == "run" ]]; then
+if [[ "${STAGE}" == "run" && "${RUN_MODE}" == "npu" ]]; then
   log "=== NPU Device Check ==="
   id || true
   ls -l /dev/davinci* 2>/dev/null || true


### PR DESCRIPTION
## Summary
- derive `PTOAS_BOARD_IS_A3` from the selected sim target instead of installed simulator directories
- skip `/dev/davinci` checks for `RUN_MODE=sim`
- include `x86_64-linux/simulator` lookup and allow `SIM_SOC_VERSION_OVERRIDE`

## Why
A5 sim hosts can also ship Ascend910B simulator libraries. The previous script treated that as an A3 board signal and disabled A3-unstable custom golden cases such as `sels`, which is incorrect for `SIM_SOC_VERSION=Ascend950`.

## Validation
- `bash -n test/npu_validation/scripts/run_remote_npu_validation.sh`

## Note
- review-server monitor has been hotfixed separately so future manual `/run sim` jobs pick up the same behavior immediately.