### PR TITLE
fix(ir): make parser arch context-scoped and add issue487 lit regression

### DIFF
--- a/include/PTO/IR/PTO.h
+++ b/include/PTO/IR/PTO.h
@@ -70,6 +70,7 @@
 #include "PTO/IR/PTOOps.h.inc"
 
 namespace mlir {
+class MLIRContext;
 class TypeConverter;
 
 namespace pto {
@@ -101,15 +102,17 @@ enum class PTOParserTargetArch {
   A5,
 };
 
-void setPTOParserTargetArch(PTOParserTargetArch arch);
-PTOParserTargetArch getPTOParserTargetArch();
+void setPTOParserTargetArch(MLIRContext *context, PTOParserTargetArch arch);
+PTOParserTargetArch getPTOParserTargetArch(MLIRContext *context);
 
 class ScopedPTOParserTargetArch {
 public:
-  explicit ScopedPTOParserTargetArch(PTOParserTargetArch arch);
+  explicit ScopedPTOParserTargetArch(MLIRContext *context,
+                                     PTOParserTargetArch arch);
   ~ScopedPTOParserTargetArch();
 
 private:
+  MLIRContext *context;
   PTOParserTargetArch previousArch;
 };
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -253,7 +253,7 @@ static VerifierTargetArch getVerifierTargetArch(Operation *op) {
                             : VerifierTargetArch::A2A3;
   }
 
-  switch (getPTOParserTargetArch()) {
+  switch (getPTOParserTargetArch(op ? op->getContext() : nullptr)) {
   case PTOParserTargetArch::A5:
     return VerifierTargetArch::A5;
   case PTOParserTargetArch::A3:

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -14,31 +14,50 @@
 //===- PTOTypeDefs.cpp --------------------------------------------*- C++ -*-===//
 #include "PTO/IR/PTO.h"
 #include "mlir/IR/DialectImplementation.h"
+#include <mutex>
+#include <unordered_map>
 
 using namespace mlir;
 using namespace mlir::pto;
 
 namespace {
-thread_local PTOParserTargetArch currentParserTargetArch =
-    PTOParserTargetArch::Unspecified;
+std::mutex parserTargetArchMutex;
+std::unordered_map<const MLIRContext *, PTOParserTargetArch>
+    parserTargetArchByContext;
 }
 
-void mlir::pto::setPTOParserTargetArch(PTOParserTargetArch arch) {
-  currentParserTargetArch = arch;
+void mlir::pto::setPTOParserTargetArch(MLIRContext *context,
+                                       PTOParserTargetArch arch) {
+  if (!context)
+    return;
+
+  std::lock_guard<std::mutex> lock(parserTargetArchMutex);
+  if (arch == PTOParserTargetArch::Unspecified) {
+    parserTargetArchByContext.erase(context);
+    return;
+  }
+  parserTargetArchByContext[context] = arch;
 }
 
-PTOParserTargetArch mlir::pto::getPTOParserTargetArch() {
-  return currentParserTargetArch;
+PTOParserTargetArch mlir::pto::getPTOParserTargetArch(MLIRContext *context) {
+  if (!context)
+    return PTOParserTargetArch::Unspecified;
+
+  std::lock_guard<std::mutex> lock(parserTargetArchMutex);
+  auto it = parserTargetArchByContext.find(context);
+  if (it == parserTargetArchByContext.end())
+    return PTOParserTargetArch::Unspecified;
+  return it->second;
 }
 
 mlir::pto::ScopedPTOParserTargetArch::ScopedPTOParserTargetArch(
-    PTOParserTargetArch arch)
-    : previousArch(getPTOParserTargetArch()) {
-  setPTOParserTargetArch(arch);
+    MLIRContext *context, PTOParserTargetArch arch)
+    : context(context), previousArch(getPTOParserTargetArch(context)) {
+  setPTOParserTargetArch(context, arch);
 }
 
 mlir::pto::ScopedPTOParserTargetArch::~ScopedPTOParserTargetArch() {
-  setPTOParserTargetArch(previousArch);
+  setPTOParserTargetArch(context, previousArch);
 }
 
 static SmallVector<int64_t, 4> canonicalizeTileBufValidShape(ArrayRef<int64_t> validShape) {
@@ -419,7 +438,7 @@ static Type buildTileBufType(AsmParser &parser,
     if (memorySpace != AddressSpace::LEFT)
       return parsedBLayout;
 
-    switch (getPTOParserTargetArch()) {
+    switch (getPTOParserTargetArch(parser.getContext())) {
     case PTOParserTargetArch::A3:
       return BLayout::RowMajor;
     case PTOParserTargetArch::A5:

--- a/test/basic/issue487_tsel_i8_parser_arch_scope.pto
+++ b/test/basic/issue487_tsel_i8_parser_arch_scope.pto
@@ -1,0 +1,36 @@
+// RUN: ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s --check-prefix=A5
+// RUN: not ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s --check-prefix=A3
+
+// Keep module attr absent on purpose: this exercises parser-scope arch fallback.
+module {
+  func.func @f0() {
+    %mask = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp  = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst  = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tsel ins(%mask, %src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  // Keep >=2 func.func to trigger verifier's IsolatedFromAbove parallel branch.
+  func.func @f1() {
+    %mask = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp  = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst  = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tsel ins(%mask, %src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=2, cols=128, v_row=2, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A5-NOT: error: 'pto.tsel' op expects A2/A3 tsel src0, src1, and dst element type to be i16/i32/f16/f32
+// A5: AICORE void f0()
+// A5: AICORE void f1()
+
+// A3: error: 'pto.tsel' op expects A2/A3 tsel src0, src1, and dst element type to be i16/i32/f16/f32

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1038,8 +1038,8 @@ int main(int argc, char **argv) {
     llvm::SourceMgr sourceMgr;
     sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), llvm::SMLoc());
     pto::ScopedPTOParserTargetArch scopedParserArch(
-        arch == "a5" ? pto::PTOParserTargetArch::A5
-                     : pto::PTOParserTargetArch::A3);
+        &context, arch == "a5" ? pto::PTOParserTargetArch::A5
+                               : pto::PTOParserTargetArch::A3);
     module = parseSourceFile<ModuleOp>(sourceMgr, &context);
     if (!module) {
       llvm::errs() << "Error: Failed to parse MLIR.\n";


### PR DESCRIPTION
## Summary

This PR fixes parser-arch propagation for verifier fallback by replacing TLS parser-arch state with MLIRContext-scoped state.

- Replace `thread_local` parser target arch storage with `MLIRContext* -> PTOParserTargetArch` map guarded by mutex.
- Update parser-arch APIs/signatures to be context-aware.
- Update verifier fallback to read parser arch from `op->getContext()`.
- Update `ptoas` parse scope helper usage to pass `&context`.
- Add regression test for issue #487.

## Why

`getVerifierTargetArch()` can run during parse-time verification, and verifier may process `IsolatedFromAbove` children in parallel. TLS parser-arch is not shared across worker threads, which can cause A5 inputs to be mis-verified as A2/A3.

Using context-scoped arch state makes parser fallback deterministic across threads for the same MLIRContext.

## Test

- Build:
  - `cmake --build build --target ptoas -j 8`
- Regression checks:
  - `build/tools/ptoas/ptoas --pto-arch=a5 test/basic/issue487_tsel_i8_parser_arch_scope.pto -o - 2>&1 | FileCheck test/basic/issue487_tsel_i8_parser_arch_scope.pto --check-prefix=A5`
  - `build/tools/ptoas/ptoas --pto-arch=a3 test/basic/issue487_tsel_i8_parser_arch_scope.pto -o - 2>&1 | FileCheck test/basic/issue487_tsel_i8_parser_arch_scope.pto --check-prefix=A3`

Closes #487
