### PR TITLE
fix: allow interleaved tpop/tfree on same pipe

### DIFF
--- a/test/basic/issue489_interleaved_tpop_tfree_a3.pto
+++ b/test/basic/issue489_interleaved_tpop_tfree_a3.pto
@@ -1,0 +1,39 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s 2>&1 | FileCheck %s
+
+module {
+  func.func @vector_pop_interleaved(%gm_slot_buffer: memref<256xf32, #pto.address_space<gm>>,
+                                    %c2v_consumer_buf: i32) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %pipe = pto.initialize_l2g2l_pipe {
+      dir_mask = 1,
+      slot_size = 1024,
+      slot_num = 8,
+      local_slot_num = 8,
+      flag_base = 0
+    }(%gm_slot_buffer : memref<256xf32, #pto.address_space<gm>>, %c2v_consumer_buf : i32) -> !pto.pipe
+
+    %tile0 = pto.declare_tile -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tile1 = pto.declare_tile -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %neg0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %neg1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tpop(%tile0, %pipe : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.pipe) {split = 1}
+    pto.tpop(%tile1, %pipe : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.pipe) {split = 1}
+
+    pto.tneg ins(%tile0 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%neg0 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tneg ins(%tile1 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%neg1 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tfree(%pipe : !pto.pipe) {split = 2}
+    pto.tfree(%pipe : !pto.pipe) {split = 2}
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void vector_pop_interleaved(
+// CHECK: TPOP<TPipe<0, Direction::DIR_C2V, 1024, 8, 8>, Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_UP_DOWN>(
+// CHECK: TPOP<TPipe<0, Direction::DIR_C2V, 1024, 8, 8>, Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_UP_DOWN>(
+// CHECK: TNEG(
+// CHECK: TNEG(
+// CHECK: TFREE<TPipe<0, Direction::DIR_C2V, 1024, 8, 8>, TileSplitAxis::TILE_LEFT_RIGHT>(
+// CHECK: TFREE<TPipe<0, Direction::DIR_C2V, 1024, 8, 8>, TileSplitAxis::TILE_LEFT_RIGHT>(

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1135,7 +1135,6 @@ int main(int argc, char **argv) {
   
   pm.addNestedPass<mlir::func::FuncOp>(
       pto::createPTOLowerFrontendPipeOpsPass());
-  pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());
   
   if (!disableInferLayout)


### PR DESCRIPTION
resolve issue #489 
问题背景
issue #489 中，合法的同一 pipe 交错消费时序（如 tpop, tpop, use, use, tfree, tfree）会被编译流程拒绝。

原因
PTOVerifyTFreePass 之前强制“同一 pipe 在第一次 tfree 前只能有一个 outstanding tpop”，把多 outstanding 的合法场景误判为非法。

解决方案
将校验逻辑改为“按 block、按 pipe 进行 tpop/tfree 的 FIFO 配对”：

允许同一 pipe 存在多个 outstanding tpop；
tfree 依次匹配最早未释放的 tpop；
保留原有“tfree 后不允许继续使用对应 tile”的安全检查；
新增回归用例 test/basic/issue489_interleaved_tpop_tfree_a3.pto 覆盖该场景。