### PR TITLE
fix: lower mrgsort executed vector constants in EmitC

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -2116,7 +2116,7 @@ static FailureOr<std::string> buildEmitCOpaqueConstantLiteral(Type targetType,
       if (!first)
         os << ", ";
       first = false;
-      os << elem.getSExtValue();
+      os << elem.getZExtValue();
     }
     os << "}";
     os.flush();

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -27,6 +27,7 @@
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 
 #include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -411,6 +412,8 @@ static Value makeEmitCIntConstant(ConversionPatternRewriter &rewriter,
                                   Location loc, Type type, int64_t value);
 static Value emitCCast(ConversionPatternRewriter &rewriter, Location loc,
                        Type dstType, Value src);
+static FailureOr<std::string> buildEmitCOpaqueConstantLiteral(Type targetType,
+                                                              Attribute valueAttr);
 static Value castSignlessIntToUnsignedSameWidth(ConversionPatternRewriter &rewriter,
                                                 Location loc, Value v,
                                                 unsigned bitWidth);
@@ -2089,6 +2092,40 @@ static Value makeEmitCIntConstant(ConversionPatternRewriter &rewriter,
   return makeEmitCOpaqueConstant(rewriter, loc, type, std::to_string(value));
 }
 
+static FailureOr<std::string> buildEmitCOpaqueConstantLiteral(Type targetType,
+                                                              Attribute valueAttr) {
+  auto opaqueTy = dyn_cast<emitc::OpaqueType>(targetType);
+  if (!opaqueTy)
+    return failure();
+
+  if (opaqueTy.getValue() == "pto::MrgSortExecutedNumList") {
+    auto dense = dyn_cast_or_null<DenseIntElementsAttr>(valueAttr);
+    if (!dense)
+      return failure();
+
+    auto vecTy = dyn_cast<VectorType>(dense.getType());
+    if (!vecTy || vecTy.getRank() != 1 || vecTy.getNumElements() != 4 ||
+        !vecTy.getElementType().isInteger(16))
+      return failure();
+
+    std::string literal;
+    llvm::raw_string_ostream os(literal);
+    os << "pto::MrgSortExecutedNumList{";
+    bool first = true;
+    for (APInt elem : dense.getValues<APInt>()) {
+      if (!first)
+        os << ", ";
+      first = false;
+      os << elem.getSExtValue();
+    }
+    os << "}";
+    os.flush();
+    return literal;
+  }
+
+  return failure();
+}
+
 static Value emitCCast(ConversionPatternRewriter &rewriter, Location loc,
                        Type dstType, Value src) {
   if (src.getType() == dstType)
@@ -2307,51 +2344,60 @@ struct ArithTruncIToEmitC : public OpConversionPattern<arith::TruncIOp> {
   }
 };
 
-		struct ArithConstantToEmitC : public OpConversionPattern<arith::ConstantOp> {
-		  using OpConversionPattern<arith::ConstantOp>::OpConversionPattern;
-		
-		  LogicalResult matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
-		                                ConversionPatternRewriter &rewriter) const override {
-	    Type newType = getTypeConverter()->convertType(op.getType());
-	    if (!newType) return failure();
-	
-	    // `adaptor.getValue()` may be null if attribute conversion isn't defined.
-	    // Use the original attribute as fallback and always cast null-safely.
-	    Attribute valueAttr = adaptor.getValue();
-	    if (!valueAttr) valueAttr = op.getValue();
+struct ArithConstantToEmitC : public OpConversionPattern<arith::ConstantOp> {
+  using OpConversionPattern<arith::ConstantOp>::OpConversionPattern;
 
-		    if (auto floatAttr = dyn_cast_or_null<FloatAttr>(valueAttr)) {
-		      SmallString<32> valStr;
-		      floatAttr.getValue().toString(valStr);
-		      llvm::StringRef s(valStr);
-		      // Ensure the literal parses as a floating-point constant in C/C++.
-		      // `APFloat::toString` may emit "1" for integral values; make it "1.0".
-		      const bool hasFloatMarker =
-		          s.contains('.') || s.contains('e') || s.contains('E') ||
-		          s.contains('p') || s.contains('P') || s.starts_with("0x") ||
-		          s.starts_with("0X") || s.starts_with("nan") ||
-		          s.starts_with("-nan") || s.starts_with("inf") ||
-		          s.starts_with("-inf");
-		      if (!hasFloatMarker)
-		        valStr.append(".0");
-		      // Suffix: keep `f` for f16/f32; omit for f64.
-		      if (!floatAttr.getType().isF64())
-		        valStr.append("f");
-		      auto constAttr = emitc::OpaqueAttr::get(rewriter.getContext(), valStr);
-		      rewriter.replaceOpWithNewOp<emitc::ConstantOp>(op, newType, constAttr);
-		      return success();
-		    }
-	
-	    if (auto intAttr = dyn_cast_or_null<IntegerAttr>(valueAttr)) {
-	      std::string valStr = std::to_string(intAttr.getValue().getSExtValue());
-	      auto constAttr = emitc::OpaqueAttr::get(rewriter.getContext(), valStr);
-	      rewriter.replaceOpWithNewOp<emitc::ConstantOp>(op, newType, constAttr);
-	      return success();
-	    }
-	
-	    return failure();
-	  }
-	};
+  LogicalResult matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Type newType = getTypeConverter()->convertType(op.getType());
+    if (!newType)
+      return failure();
+
+    // `adaptor.getValue()` may be null if attribute conversion isn't defined.
+    // Use the original attribute as fallback and always cast null-safely.
+    Attribute valueAttr = adaptor.getValue();
+    if (!valueAttr)
+      valueAttr = op.getValue();
+
+    if (auto opaqueLiteral = buildEmitCOpaqueConstantLiteral(newType, valueAttr);
+        succeeded(opaqueLiteral)) {
+      auto constAttr = emitc::OpaqueAttr::get(rewriter.getContext(), *opaqueLiteral);
+      rewriter.replaceOpWithNewOp<emitc::ConstantOp>(op, newType, constAttr);
+      return success();
+    }
+
+    if (auto floatAttr = dyn_cast_or_null<FloatAttr>(valueAttr)) {
+      SmallString<32> valStr;
+      floatAttr.getValue().toString(valStr);
+      llvm::StringRef s(valStr);
+      // Ensure the literal parses as a floating-point constant in C/C++.
+      // `APFloat::toString` may emit "1" for integral values; make it "1.0".
+      const bool hasFloatMarker =
+          s.contains('.') || s.contains('e') || s.contains('E') ||
+          s.contains('p') || s.contains('P') || s.starts_with("0x") ||
+          s.starts_with("0X") || s.starts_with("nan") ||
+          s.starts_with("-nan") || s.starts_with("inf") ||
+          s.starts_with("-inf");
+      if (!hasFloatMarker)
+        valStr.append(".0");
+      // Suffix: keep `f` for f16/f32; omit for f64.
+      if (!floatAttr.getType().isF64())
+        valStr.append("f");
+      auto constAttr = emitc::OpaqueAttr::get(rewriter.getContext(), valStr);
+      rewriter.replaceOpWithNewOp<emitc::ConstantOp>(op, newType, constAttr);
+      return success();
+    }
+
+    if (auto intAttr = dyn_cast_or_null<IntegerAttr>(valueAttr)) {
+      std::string valStr = std::to_string(intAttr.getValue().getSExtValue());
+      auto constAttr = emitc::OpaqueAttr::get(rewriter.getContext(), valStr);
+      rewriter.replaceOpWithNewOp<emitc::ConstantOp>(op, newType, constAttr);
+      return success();
+    }
+
+    return failure();
+  }
+};
 //===----------------------------------------------------------------------===//
 // pto.mgather lowering -> MGATHER(dst, src, indexes)  (pto-isa)
 //===----------------------------------------------------------------------===//

--- a/test/basic/tmrgsort_executed_constant_emitc.pto
+++ b/test/basic/tmrgsort_executed_constant_emitc.pto
@@ -1,0 +1,23 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @tmrgsort_executed_constant_emitc() {
+    %ex_full = arith.constant dense<[128, 64, 0, 0]> : vector<4xi16>
+    %ex_zero = arith.constant dense<0> : vector<4xi16>
+
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tmrgsort ins(%src0, %src1 {exhausted = false} : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %tmp, %ex_full : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, vector<4xi16>)
+    pto.tmrgsort ins(%src0, %src1 {exhausted = true} : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %tmp, %ex_zero : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, vector<4xi16>)
+    return
+  }
+}
+
+// A3-LABEL: __global__ AICORE void tmrgsort_executed_constant_emitc()
+// A3-DAG: pto::MrgSortExecutedNumList [[EXFULL:v[0-9]+]] = pto::MrgSortExecutedNumList{128, 64, 0, 0};
+// A3-DAG: pto::MrgSortExecutedNumList [[EXZERO:v[0-9]+]] = pto::MrgSortExecutedNumList{0, 0, 0, 0};
+// A3: TMRGSORT<{{.*}}, false>({{.*}}, [[EXFULL]], {{.*}});
+// A3: TMRGSORT<{{.*}}, true>({{.*}}, [[EXZERO]], {{.*}});

--- a/test/basic/tmrgsort_executed_constant_emitc.pto
+++ b/test/basic/tmrgsort_executed_constant_emitc.pto
@@ -3,6 +3,7 @@
 module {
   func.func @tmrgsort_executed_constant_emitc() {
     %ex_full = arith.constant dense<[128, 64, 0, 0]> : vector<4xi16>
+    %ex_high = arith.constant dense<[50000, 40000, 32768, 65535]> : vector<4xi16>
     %ex_zero = arith.constant dense<0> : vector<4xi16>
 
     %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
@@ -11,6 +12,7 @@ module {
     %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tmrgsort ins(%src0, %src1 {exhausted = false} : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %tmp, %ex_full : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, vector<4xi16>)
+    pto.tmrgsort ins(%src0, %src1 {exhausted = false} : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %tmp, %ex_high : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, vector<4xi16>)
     pto.tmrgsort ins(%src0, %src1 {exhausted = true} : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %tmp, %ex_zero : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=256, v_row=1, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>, vector<4xi16>)
     return
   }
@@ -18,6 +20,8 @@ module {
 
 // A3-LABEL: __global__ AICORE void tmrgsort_executed_constant_emitc()
 // A3-DAG: pto::MrgSortExecutedNumList [[EXFULL:v[0-9]+]] = pto::MrgSortExecutedNumList{128, 64, 0, 0};
+// A3-DAG: pto::MrgSortExecutedNumList [[EXHIGH:v[0-9]+]] = pto::MrgSortExecutedNumList{50000, 40000, 32768, 65535};
 // A3-DAG: pto::MrgSortExecutedNumList [[EXZERO:v[0-9]+]] = pto::MrgSortExecutedNumList{0, 0, 0, 0};
 // A3: TMRGSORT<{{.*}}, false>({{.*}}, [[EXFULL]], {{.*}});
+// A3: TMRGSORT<{{.*}}, false>({{.*}}, [[EXHIGH]], {{.*}});
 // A3: TMRGSORT<{{.*}}, true>({{.*}}, [[EXZERO]], {{.*}});


### PR DESCRIPTION
## Summary
- lower `arith.constant` vector<4xi16> values to `pto::MrgSortExecutedNumList` literals in EmitC
- keep the change scoped to the existing EmitC constant lowering path
- add a basic regression covering both `dense<[...]>` and `dense<0>` executed-list constants

## Repro
Current `origin/main` rejects valid `tmrgsort` format2 cases such as:

```mlir
%ex = arith.constant dense<[128, 64, 0, 0]> : vector<4xi16>
pto.tmrgsort ... outs(%dst, %tmp, %ex : ..., ..., vector<4xi16>)
```

with:

```text
error: failed to legalize operation 'arith.constant' that was explicitly marked illegal\n```\n\n## Validation\n- `cmake --build build --target pto-opt --parallel 8`\n- `build/tools/ptoas/ptoas --pto-level=level3 /Users/laoda/Downloads/mrgsort2_kernel.pto -o /tmp/mrgsort2_kernel_fixed.cpp`\n- `build/tools/ptoas/ptoas --pto-arch=a3 test/basic/tmrgsort_executed_constant_emitc.pto 2>&1 | /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck test/basic/tmrgsort_executed_constant_emitc.pto --check-prefix=A3`