### PR TITLE
fix: avoid addptr typed-cast assertion in memref lowering

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -1180,11 +1180,14 @@ LogicalResult mlir::pto::PartitionViewOp::verify() {
 }
 
 LogicalResult mlir::pto::AddPtrOp::verify() {
-  auto ptrTy = dyn_cast<mlir::pto::PtrType>(getPtr().getType());
+  Value ptr = getOperation()->getOperand(0);
+  Value result = getOperation()->getResult(0);
+
+  auto ptrTy = dyn_cast<mlir::pto::PtrType>(ptr.getType());
   if (!ptrTy)
     return emitOpError("ptr operand must be !pto.ptr<...>");
 
-  auto resTy = dyn_cast<mlir::pto::PtrType>(getResult().getType());
+  auto resTy = dyn_cast<mlir::pto::PtrType>(result.getType());
   if (!resTy)
     return emitOpError("result must be !pto.ptr<...>");
 

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -1590,7 +1590,7 @@ struct PTOViewToMemrefPass
           bool eligible = !op->use_empty();
           for (Operation *user : op->getUsers()) {
             auto init = dyn_cast<mlir::pto::InitializeL2G2LPipeOp>(user);
-            if (!init || init.getGmAddr() != op.getResult()) {
+            if (!init || init.getGmAddr() != op->getResult(0)) {
               eligible = false;
               break;
             }
@@ -1604,12 +1604,12 @@ struct PTOViewToMemrefPass
           rewriter.setInsertionPoint(op);
           Location loc = op.getLoc();
 
-          Value base = op.getPtr();
-          Value totalOffset = ensureIndex(rewriter, loc, op.getOffset(), op);
+          Value base = op->getOperand(0);
+          Value totalOffset = ensureIndex(rewriter, loc, op->getOperand(1), op);
           while (auto add = base.getDefiningOp<mlir::pto::AddPtrOp>()) {
-            Value off = ensureIndex(rewriter, loc, add.getOffset(), add);
+            Value off = ensureIndex(rewriter, loc, add->getOperand(1), add);
             totalOffset = rewriter.create<arith::AddIOp>(loc, totalOffset, off);
-            base = add.getPtr();
+            base = add->getOperand(0);
           }
 
           auto baseMrTy = dyn_cast<MemRefType>(base.getType());


### PR DESCRIPTION
问题背景
在 issue #497 场景中，pto.addptr 参与 gm_slot_buffer 初始化时，ptoas 在 assertions build 下触发 llvm::cast 断言（Casting.h:566），导致编译中断。

定位分析
根因是 AddPtrOp 的 typed getter（如 getPtr/getResult）会执行 cast<TypedValue<PtrType>>。在 PTOViewToMemref 将 ptr 重写为 memref 的过程中，addptr 相关值可能短暂不是 PtrType，这时再走 typed getter 就会触发 incompatible type 断言。

解决方案
将 addptr 相关访问改为原始 operand/result 读取，避免 typed cast：

PTOViewToMemref 中 addptr 折叠逻辑改为 op->getOperand(i) / op->getResult(0)；
AddPtrOp::verify() 改为从 getOperation()->getOperand/Result 取类型再校验；
在 build-assert 下复验 issue #497 最小复现，已通过且不再 core dump。