### PR TITLE
Add direct pto.tsync -> TSYNC lowering and ptobc mapping

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2119,6 +2119,21 @@ def BarrierOp : PTO_Op<"barrier"> {
   let assemblyFormat = "$pipe attr-dict";
 }
 
+def TSyncOp : PTO_TOp<"tsync"> {
+  let summary = "Direct TSYNC mapping (variadic operands).";
+  let description = [{
+    Lowers directly to a `TSYNC(...)` intrinsic call with the same operand list.
+    This op is intentionally a thin bridge for explicit synchronization usage.
+  }];
+
+  let arguments = (ins Variadic<PTODpsType>:$events);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    `ins` `(` $events `:` type($events) `)` attr-dict
+  }];
+}
+
 
 //===----------------------------------------------------------------------===//
 // FFT Configuration Operation

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -4641,6 +4641,26 @@ struct PTOWaitFlagToEmitC : public OpConversionPattern<mlir::pto::WaitFlagOp> {
   }
 };
 
+struct PTOSyncToEmitC : public OpConversionPattern<mlir::pto::TSyncOp> {
+  using OpConversionPattern<mlir::pto::TSyncOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::TSyncOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value, 4> operands;
+    operands.reserve(adaptor.getEvents().size());
+    for (Value event : adaptor.getEvents())
+      operands.push_back(peelUnrealized(event));
+
+    rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), TypeRange{}, "TSYNC",
+        /*args=*/ArrayAttr{},
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange(operands));
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct PTOSyncFlagDynToEmitC : public ConversionPattern {
   PTOSyncFlagDynToEmitC(TypeConverter &typeConverter, MLIRContext *ctx,
                         StringRef opName, StringRef callee)
@@ -10163,6 +10183,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOSubSCToEmitC>(typeConverter, ctx);
   patterns.add<PTOSubCSToEmitC>(typeConverter, ctx);
   patterns.add<PTOWaitFlagToEmitC>(typeConverter, ctx);
+  patterns.add<PTOSyncToEmitC>(typeConverter, ctx);
   patterns.add<PTOGetBufToEmitC>(typeConverter, ctx);
   patterns.add<PTORlsBufToEmitC>(typeConverter, ctx);
   patterns.add<PTOSetFFTsToEmitC>(typeConverter, ctx);

--- a/test/basic/tsync_emitc.pto
+++ b/test/basic/tsync_emitc.pto
@@ -1,0 +1,13 @@
+// RUN: ptoas --pto-arch=a5 %s | FileCheck %s
+
+module {
+  func.func @tsync_emitc(%src0: memref<32x32xf32, #pto.address_space<gm>>,
+                         %src1: memref<32x32xf32, #pto.address_space<gm>>) {
+    pto.tsync ins(%src0, %src1 : memref<32x32xf32, #pto.address_space<gm>>, memref<32x32xf32, #pto.address_space<gm>>)
+
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void tsync_emitc(
+// CHECK: TSYNC(

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -162,6 +162,7 @@ inline constexpr OpInfo kOpTable[] = {
   {0x107A, "pto.trowargmin", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x107B, "pto.tcolargmax", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x107C, "pto.tcolargmin", 0, 0x00, 0x00, 3, 0, 0, 0x00},
+  {0x107D, "pto.tsync", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -335,6 +336,7 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.trowargmin", 0x107A)
     .Case("pto.tcolargmax", 0x107B)
     .Case("pto.tcolargmin", 0x107C)
+    .Case("pto.tsync", 0x107D)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -494,6 +496,7 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.trowargmin", OpcodeAndVariant{0x107A, 0, 0})
     .Case("pto.tcolargmax", OpcodeAndVariant{0x107B, 0, 0})
     .Case("pto.tcolargmin", OpcodeAndVariant{0x107C, 0, 0})
+    .Case("pto.tsync", OpcodeAndVariant{0x107D, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})


### PR DESCRIPTION
## Summary
- Add new PTO IR op `pto.tsync` as a direct bridge for explicit TSYNC usage.
- Add EmitC lowering `pto.tsync -> TSYNC(...)` with 1:1 variadic operand passthrough.
- Add `ptobc` v0 opcode mapping for `pto.tsync` (`0x107D`).
- Add regression test `test/basic/tsync_emitc.pto` to guard TSYNC emission.

## Motivation
- Architect request / feature parity: upstream did not provide explicit `pto.tsync` support path.
- Needed a minimal, direct lowering path to PTO-ISA TSYNC without semantic rewrite via high-level sync ops.

## Design
- IR: `TSyncOp` is defined as `PTO_TOp<"tsync">` with `Variadic<PTODpsType>:$events` and no results.
- Lowering: conversion pattern emits `emitc::CallOpaqueOp("TSYNC", operands)` and erases op.
- Bytecode: register `pto.tsync` in `tools/ptobc/generated/ptobc_opcodes_v0.h`:
  - op table entry
  - name -> opcode lookup
  - fullName -> opcode/variant lookup

## Testing
- Build:
  - `cmake -G Ninja -S . -B build -DLLVM_DIR=/Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/lib/cmake/llvm -DMLIR_DIR=/Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/lib/cmake/mlir -DPTO_ENABLE_PYTHON_BINDING=OFF -DCMAKE_BUILD_TYPE=Release`
  - `ninja -C build ptoas`
  - `ninja -C build ptobc`
- Targeted checks:
  - `build/tools/ptoas/ptoas --pto-arch=a5 test/basic/tsync_emitc.pto | FileCheck test/basic/tsync_emitc.pto`
  - `build/tools/ptoas/ptoas --pto-arch=a5 test/basic/tgemv_mx_emitc.pto | FileCheck test/basic/tgemv_mx_emitc.pto`
  - `build/tools/ptobc/ptobc encode/decode test/basic/tsync_emitc.pto` roundtrip keeps `pto.tsync`.

## Risk / Rollback
- Risk: low. New op is additive and follows direct opaque-call lowering style already used by similar TOps.
- Rollback: revert this PR (isolated to IR op definition, lowering registration, opcode table, and one new test).

## Reviewer Focus
- Verify `pto.tsync` assembly/parsing format and variadic type handling.
- Verify EmitC output emits `TSYNC(...)` with preserved operand order.
- Verify `ptobc` opcode table consistency for new `0x107D` entry.
- Verify regression test guards codegen output robustly.
