### PR TITLE
feat: id-based frontend multi-pipe design

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7828,6 +7828,9 @@ generated IR. The detailed design document is:
   pipe.
 - When `dir_mask = 3`, one `id` denotes one DIR_BOTH physical pipe covering
   both logical directions.
+- Lowered pipe components consume hardware flag ids per function:
+  one single-direction pipe uses 2 ids, and one `dir_mask = 3` pipe uses 4 ids.
+  The total usage in one function must fit within 16 hardware flag ids.
 
 `nosplit` platform restrictions:
 
@@ -7963,6 +7966,8 @@ pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
 - Must appear in Cube kernels
 - Multiple `pto.aic_initialize_pipe` ops are allowed in one Cube function, but
   `id` must be unique among frontend initialize ops in that function
+- The lowered pipes for one function must fit within 16 hardware flag ids in
+  total
 - If `nosplit = true`, all frontend data-transfer ops bound to the same logical
   pipe must use `split = 0`
 - If `nosplit = false`, all frontend data-transfer ops bound to the same
@@ -7997,6 +8002,8 @@ pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
 - Must appear in Vector kernels
 - Multiple `pto.aiv_initialize_pipe` ops are allowed in one Vector function,
   but `id` must be unique among frontend initialize ops in that function
+- The lowered pipes for one function must fit within 16 hardware flag ids in
+  total
 - If `nosplit = true`, all frontend data-transfer ops bound to the same logical
   pipe must use `split = 0`
 - If `nosplit = false`, all frontend data-transfer ops bound to the same

--- a/docs/designs/ptoas-tpush-tpop-design.md
+++ b/docs/designs/ptoas-tpush-tpop-design.md
@@ -47,18 +47,17 @@
 #### 语法
 
 ```mlir
-pto.aic_initialize_pipe(
-    DIR_MASK,
-    SLOT_SIZE,
-    GM_SLOT_BUFFER,
-    C2V_CONSUMER_BUF,
-    V2C_CONSUMER_BUF)
+pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
+  (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
+   c2v_consumer_buf = %c2v_consumer_buf : i32,
+   v2c_consumer_buf = %v2c_consumer_buf : i32)
 ```
 
 #### 参数
 
 | 参数 | 类型 | 说明 |
 |---|---|---|
+| `ID` | 编译期整数常量 | 前端逻辑 pipe 标识，要求 `>= 0` |
 | `DIR_MASK` | 编译期整数常量 | `1`、`2` 或 `3` |
 | `SLOT_SIZE` | 编译期整数常量 | 单 slot 字节数，定义为切分前完整 tile 字节数 |
 | `GM_SLOT_BUFFER` | `!pto.ptr<T>` 或空值 | A2/A3 路径使用的 GM 指针，A5 路径为空 |
@@ -74,12 +73,10 @@ pto.aic_initialize_pipe(
 #### 语法
 
 ```mlir
-pto.aiv_initialize_pipe(
-    DIR_MASK,
-    SLOT_SIZE,
-    GM_SLOT_BUFFER,
-    C2V_CONSUMER_BUF,
-    V2C_CONSUMER_BUF)
+pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
+  (gm_slot_buffer = %gm_buf : !pto.ptr<f32>,
+   c2v_consumer_buf = %c2v_consumer_buf : i32,
+   v2c_consumer_buf = %v2c_consumer_buf : i32)
 ```
 
 参数语义与 `pto.aic_initialize_pipe` 相同。
@@ -89,7 +86,7 @@ pto.aiv_initialize_pipe(
 #### `pto.tpush_to_aiv`
 
 ```mlir
-pto.tpush_to_aiv(%tile) { split = 0 }
+pto.tpush_to_aiv(%tile) {id = 0, split = 0}
 ```
 
 - 仅出现在 Cube kernel 中
@@ -98,7 +95,7 @@ pto.tpush_to_aiv(%tile) { split = 0 }
 #### `pto.tpush_to_aic`
 
 ```mlir
-pto.tpush_to_aic(%tile) { split = 0 }
+pto.tpush_to_aic(%tile) {id = 0, split = 0}
 ```
 
 - 仅出现在 Vector kernel 中
@@ -107,7 +104,7 @@ pto.tpush_to_aic(%tile) { split = 0 }
 #### `pto.tpop_from_aic`
 
 ```mlir
-%tile = pto.tpop_from_aic { split = 0 } -> !pto.tile_buf<...>
+%tile = pto.tpop_from_aic {id = 0, split = 0} -> !pto.tile_buf<...>
 ```
 
 - 仅出现在 Vector kernel 中
@@ -116,7 +113,7 @@ pto.tpush_to_aic(%tile) { split = 0 }
 #### `pto.tpop_from_aiv`
 
 ```mlir
-%tile = pto.tpop_from_aiv { split = 0 } -> !pto.tile_buf<...>
+%tile = pto.tpop_from_aiv {id = 0, split = 0} -> !pto.tile_buf<...>
 ```
 
 - 仅出现在 Cube kernel 中
@@ -125,7 +122,7 @@ pto.tpush_to_aic(%tile) { split = 0 }
 #### `pto.tfree_from_aic`
 
 ```mlir
-pto.tfree_from_aic { split = 0 }
+pto.tfree_from_aic {id = 0, split = 0}
 ```
 
 - 仅出现在 Vector kernel 中
@@ -134,13 +131,13 @@ pto.tfree_from_aic { split = 0 }
 #### `pto.tfree_from_aiv`
 
 ```mlir
-pto.tfree_from_aiv { split = 0 }
+pto.tfree_from_aiv {id = 0, split = 0}
 ```
 
 - 仅出现在 Cube kernel 中
 - 表示 V2C 方向 consumer free
 
-以上前端数据传输接口中的 `split` 均为编译期常量属性，不是运行时 SSA operand。
+以上前端数据传输接口中的 `id` 和 `split` 均为编译期常量属性，不是运行时 SSA operand。
 
 - 取值使用 `TileSplitAxis` 枚举语义：`0/1/2` 分别对应 `TILE_NO_SPLIT`、`TILE_UP_DOWN`、`TILE_LEFT_RIGHT`
 - lowering 到 PTOAS 内部 IR 时，`split` 继续以属性形式保留
@@ -188,7 +185,7 @@ pto.tfree_from_aiv { split = 0 }
 - 结果类型为 `i32`
 - 结果值表示该 buffer 当前可用的基址
 - 当前可用基址可来自显式 `base`，也可来自 plan memory 回填后的解析地址
-- 在当前约束下，每个函数最多一条 `reserve_buffer`
+- 单函数允许存在多条 `reserve_buffer`，但 `name` 必须唯一
 - 编译路径与 `auto` 的合法组合只有两种：
   - 启用 local address planning：`auto = true`，且不带 `base`
   - 跳过 local address planning：`auto = false`，且显式提供 `base`
@@ -215,29 +212,37 @@ pto.tfree_from_aiv { split = 0 }
 
 - 结果类型为 `i32`
 - 结果值表示从 peer `reserve_buffer` 导入的已解析基址
+- 单函数允许存在多条 `import_reserved_buffer`，但 `(name, peer_func)` 必须唯一
 
 ### 3.5 前端层约束
 
 > **约束来源说明**：以下约束是当前软件方案的设计选择，而非硬件限制。
-> 当前 `tpush_to_aic` / `tpush_to_aiv` / `tpop_from_aic` / `tpop_from_aiv` /
-> `tfree_from_aic` / `tfree_from_aiv` 等前端接口上不携带 pipe 参数，因此在
-> lowering 时只能将函数内的所有 push/pop/free 绑定到同一条 pipe。这决定了每个
-> 函数最多只能存在一条初始化语句（即一条 pipe）。如果后续需要支持多条 pipe 并行
-> 通信，前端接口方案需要重新设计（例如在 push/pop/free 上显式引用 pipe handle）。
+> 当前前端方案通过 `id` 在 push/pop/free 与 initialize 之间建立绑定关系，
+> 因此单函数可以包含多条前端 initialize 语句，包括同方向多条逻辑 pipe。
+> 每条 initialize 的 `id` 必须唯一，且数据传输 op 只能引用同函数内一条匹配的 initialize。
+> 若同一函数内存在多条同方向 pipe，它们需要通过不同的 consumer FIFO
+> 标识区分，即绑定到不同的 `reserve_buffer` / `import_reserved_buffer`
+>（或显式不同的 local address）。
+> 硬件 flag 资源总量仍有限制：单向 pipe 占 2 个 hardware flag id，`dir_mask = 3`
+> 的双向 pipe 占 4 个 hardware flag id，因此单函数内所有 lowered pipe 的总占用
+> 必须落在 16 个 hardware flag id 以内。
 
 前端 IR 需满足以下约束：
 
-- 每个 Cube function 最多一条 `pto.aic_initialize_pipe`
-- 每个 Vector function 最多一条 `pto.aiv_initialize_pipe`
-- 每个函数内最多一条 C2V 逻辑 pipe 和一条 V2C 逻辑 pipe
-- 每个函数最多一条 `reserve_buffer`
-- 每个函数最多一条 `import_reserved_buffer`
+- 前端 initialize 的 `id` 在函数内必须唯一
+- `tpush/tpop/tfree` 的 `id` 必须在同函数内匹配且仅匹配一条 frontend initialize
+- C2V 方向数据 op（`tpush_to_aiv`/`tpop_from_aic`/`tfree_from_aic`）要求匹配的 init `dir_mask` 为 `1` 或 `3`
+- V2C 方向数据 op（`tpush_to_aic`/`tpop_from_aiv`/`tfree_from_aiv`）要求匹配的 init `dir_mask` 为 `2` 或 `3`
+- 单函数内 lowered pipe 的 hardware flag id 总占用必须不超过 16
+- 单函数允许多条 `reserve_buffer`
+- 单函数允许多条 `import_reserved_buffer`
 - `DIR_MASK` 只允许 `1`、`2`、`3`
 - `SLOT_SIZE > 0`
 - `reserve_buffer.size == SLOT_SIZE * SLOT_NUM`
 - C2V consumer 的 `reserve_buffer.location` 必须是 `VEC`
 - V2C consumer 的 `reserve_buffer.location` 必须是 `MAT`
 - `reserve_buffer.name` 在本函数内必须唯一
+- `import_reserved_buffer` 的 `(name, peer_func)` 在本函数内必须唯一
 - op 级约束：`reserve_buffer.auto = false` 时必须提供 `base`
 - op 级约束：`reserve_buffer.auto = true` 时必须不提供 `base`
 - 启用 local address planning 的编译流程：`reserve_buffer` 只允许 `auto = true`
@@ -571,14 +576,14 @@ pto.tfree(%pipe) { split = 0 }
 
 1. 先按现有逻辑完成普通 local buffer 的 `MemPlan`
 2. 再收集该地址空间内已经分配完成的 local 区间
-3. 在剩余空洞中按地址空间对齐要求寻找一段可容纳 `reserve_buffer.size` 的连续区间
-4. 将该区间起始地址回填为这条唯一 `reserve_buffer` 的 `base`
+3. 对该地址空间内每条 `reserve_buffer`，按稳定顺序在剩余空洞中寻找一段满足大小与对齐要求的连续区间
+4. 将找到的区间起始地址分别回填为对应 `reserve_buffer` 的 `base`
 
 即：
 
 - 普通 `memref.alloc` / tile buffer 等 local 内存仍先由既有 `MemPlan` 按原逻辑分配
 - `reserve_buffer` 不参与普通 local buffer 的 inplace / reuse 规划
-- `reserve_buffer` 在普通 local buffer 分配完成后，再作为独立的一段连续 local 区间进行 hole 分配
+- `reserve_buffer` 在普通 local buffer 分配完成后，再作为独立的一段连续 local 区间进行 hole 分配；多条 `reserve_buffer` 会逐条占用不重叠区间
 - `reserve_buffer` 不保证位于地址空间起始地址，也不保证形成预留前缀；其语义仅为“在该地址空间中为 consumer slot buffer 找到一段对齐且连续的可用地址”
 - 若整体容量足够但 `MemPlan` 结果将空间打散，导致不存在满足大小和对齐要求的连续空洞，则 `reserve_buffer` 分配失败并报错
 
@@ -645,13 +650,11 @@ pass 在模块级按两步执行：
   - `dir_mask = 3`（DIR_BOTH）：一条 pipe 携带两个地址，分别归入两个逻辑方向——`local_addr` 归入 C2V（方向 1），`peer_local_addr` 归入 V2C（方向 2）
 - 将 peer 两侧引用到同一逻辑 pipe 的内部 init op 归并到同一组
 - 若某条 init 未显式提供 `flag_base`，则其 `local_addr` 必须来自 `reserve_buffer` 或 `import_reserved_buffer`
-- 对每个逻辑 pipe 分组，要求必须形成完整 peer init pair：恰好两条 init，且分别来自 peer 两侧函数；若 peer 信息不完整则直接报错
-- 在同一组内，若任一侧已显式提供 `flag_base`，则该值作为该组最终值；若两侧显式值冲突则报错
-- 若同组两侧都未显式提供 `flag_base`，则按默认规则回填：
-  - 单向场景：`flag_base = 0`
-  - 双向场景：C2V 组 `flag_base = 0`，V2C 组 `flag_base = 2`
-- “双向场景”指同一对 peer 函数之间同时存在 C2V 和 V2C 两个逻辑 pipe 分组；DIR_BOTH 的一条物理 pipe 天然产生这两个分组
-- 完成分组决策后，将最终 `flag_base` 回填到该组内所有尚未显式填写的 init op，保证 peer 两侧一致
+- 以这些逻辑 pipe 分组为边建立 peer component；每个 component 必须恰好包含两条、且分别来自 peer 两侧函数的兼容 init op，否则直接报错
+- “兼容”指两侧 init 的 `dir_mask`、`slot_size`、`slot_num` 以及 `local_slot_num` 一致；因此 `DIR_BOTH` 与拆分后的单向 pipe 不能在同一条 peer 通道上混用
+- 在同一 component 内，若任一侧已显式提供 `flag_base`，则该值作为该 component 最终值；若两侧显式值冲突则报错
+- 若 component 内两侧都未显式提供 `flag_base`，则由 flag 分配器为该 component 选择一段与同函数其它 pipe component 不重叠的 flag 区间
+- 完成分配后，将最终 `flag_base` 回填到该 component 内所有尚未显式填写的 init op，保证 peer 两侧一致
 
 第二步的实现方式是：
 
@@ -682,8 +685,9 @@ pass 在模块级按两步执行：
 - `peer_func` 无法解析到函数
 - 在 peer function 中找不到同名 `reserve_buffer`
 - 某条未显式提供 `flag_base` 的内部 init，其 `local_addr` 不来自 `reserve_buffer` / `import_reserved_buffer`
-- 基于 `reserve_buffer` / `import_reserved_buffer` 建立的某个逻辑 pipe 分组，未形成完整 peer init pair
+- 基于 `reserve_buffer` / `import_reserved_buffer` 建立的某个 peer component，未形成完整兼容的 peer init pair
 - peer `flag_base` 已显式给定但两侧取值冲突
+- 同一函数内两个不同 pipe component 的 flag 区间重叠
 
 ## 8. flag 分配规则
 
@@ -692,27 +696,28 @@ pass 在模块级按两步执行：
 - `flag_base` 由 PTOAS flag 分配阶段在内部 init op 上填写
 - 在 flag 分配完成前，内部 init op 可以暂时不携带 `flag_base`
 - peer 两侧同一逻辑 pipe 必须使用同一个 `flag_base`
+- 同一函数内不同 pipe component 的 flag 区间必须互不重叠
+- 硬件只提供 16 个 flag id，因此单函数内所有 pipe component 的 flag 区间总占用必须落在 `[0, 16)` 内
 
 ### 8.2 单向场景
 
-当前规划中，当 `DIR_MASK = 1` 或 `2` 且函数内仅有该唯一逻辑 pipe 时，可采用：
+当前规划中，单向 pipe component 每条占用一对逻辑 flag：
 
-- 该方向唯一逻辑 pipe 的 `flag_base = 0`
-- 该 pipe 占用逻辑 flag 对：`0` 和 `1`
+- 若该函数内没有更早分配的 pipe component，则首条单向 pipe 的 `flag_base = 0`
+- 后续单向 pipe 继续按偶数递增分配，例如 `0`、`2`、`4` ...
+- 每条单向 pipe component 占用逻辑 flag 对：`flag_base` 和 `flag_base + 1`
+- 因此若函数内全是单向 pipe，最多可容纳 8 条
 
 ### 8.3 双向场景
 
-当前规划中，当 `DIR_MASK = 3`（DIR_BOTH）时，虽然物理上只有一条 pipe，但 resolve pass 将其拆为两个逻辑方向分别分配 `flag_base`：
+当前规划中，当 `DIR_MASK = 3`（DIR_BOTH）时，单条物理 pipe component 固定占用两组逻辑 flag：
 
-- C2V 方向：`flag_base = 0`
-- V2C 方向：`flag_base = 2`
+- 若该 component 的 `flag_base = B`，则它占用 `B/B+1` 与 `B+2/B+3`
+- 因而 `DIR_BOTH` component 的 flag 宽度等价于两个单向 component
+- 因此若函数内全是 `DIR_BOTH` pipe，最多可容纳 4 条
+- 若单向与双向混用，则总规则仍是所有 component 的 flag 宽度之和不超过 16
 
-因此双向固定占用两组逻辑 flag：
-
-- C2V：`0` / `1`
-- V2C：`2` / `3`
-
-对于单条 DIR_BOTH pipe，最终 `flag_base` 取 C2V 方向的值（`0`），底层 pto-isa `TPipe<flagBase, Direction::DIR_BOTH, ...>` 会自动管理两个方向的 flag 对。
+对于单条 DIR_BOTH pipe，最终写回到内部 init op 的仍是该 component 的起始 `flag_base`，底层 pto-isa `TPipe<flagBase, Direction::DIR_BOTH, ...>` 会自动管理两个方向的 flag 对。
 
 ### 8.4 与地址传播的关系
 
@@ -735,6 +740,7 @@ pass 在模块级按两步执行：
 - `reserve_buffer.size == SLOT_SIZE * SLOT_NUM`
 - `reserve_buffer.location` 与 consumer 函数类型匹配
 - `reserve_buffer.name` 在函数内唯一
+- `import_reserved_buffer` 的 `(name, peer_func)` 在函数内唯一
 - `reserve_buffer.auto = false` 时必须带 `base`
 - `reserve_buffer.auto = true` 时必须不带 `base`
 - driver / pipeline 级约束：启用规划的编译流程只接受 `auto = true`

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1364,6 +1364,7 @@ def AicInitializePipeOp : PTO_Op<"aic_initialize_pipe"> {
   let summary = "Frontend Cube-kernel pipe initialization";
 
   let arguments = (ins
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$dir_mask,
       I32Attr:$slot_size,
       OptionalAttr<BoolAttr>:$nosplit,
@@ -1376,7 +1377,8 @@ def AicInitializePipeOp : PTO_Op<"aic_initialize_pipe"> {
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `{` `dir_mask` `=` $dir_mask `,`
+    `{` (`id` `=` $id^ `,`)?
+        `dir_mask` `=` $dir_mask `,`
         `slot_size` `=` $slot_size
         (`,` `nosplit` `=` $nosplit^)?
         `}`
@@ -1393,6 +1395,7 @@ def AivInitializePipeOp : PTO_Op<"aiv_initialize_pipe"> {
   let summary = "Frontend Vector-kernel pipe initialization";
 
   let arguments = (ins
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$dir_mask,
       I32Attr:$slot_size,
       OptionalAttr<BoolAttr>:$nosplit,
@@ -1405,7 +1408,8 @@ def AivInitializePipeOp : PTO_Op<"aiv_initialize_pipe"> {
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `{` `dir_mask` `=` $dir_mask `,`
+    `{` (`id` `=` $id^ `,`)?
+        `dir_mask` `=` $dir_mask `,`
         `slot_size` `=` $slot_size
         (`,` `nosplit` `=` $nosplit^)?
         `}`
@@ -1423,6 +1427,7 @@ def TPushToAivOp : PTO_TOp<"tpush_to_aiv"> {
 
   let arguments = (ins
       PTODpsType:$tile,
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$split
   );
 
@@ -1431,7 +1436,7 @@ def TPushToAivOp : PTO_TOp<"tpush_to_aiv"> {
 
   let assemblyFormat = [{
     `(` $tile `:` qualified(type($tile)) `)`
-    `{` `split` `=` $split `}` attr-dict
+    `{` (`id` `=` $id^ `,`)? `split` `=` $split `}` attr-dict
   }];
 }
 
@@ -1440,6 +1445,7 @@ def TPushToAicOp : PTO_TOp<"tpush_to_aic"> {
 
   let arguments = (ins
       PTODpsType:$tile,
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$split
   );
 
@@ -1448,7 +1454,7 @@ def TPushToAicOp : PTO_TOp<"tpush_to_aic"> {
 
   let assemblyFormat = [{
     `(` $tile `:` qualified(type($tile)) `)`
-    `{` `split` `=` $split `}` attr-dict
+    `{` (`id` `=` $id^ `,`)? `split` `=` $split `}` attr-dict
   }];
 }
 
@@ -1458,6 +1464,7 @@ def TPopFromAicOp : PTO_TOp<"tpop_from_aic", [AttrSizedOperandSegments]> {
   let arguments = (ins
       Optional<Index>:$valid_row,
       Optional<Index>:$valid_col,
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$split
   );
 
@@ -1465,7 +1472,7 @@ def TPopFromAicOp : PTO_TOp<"tpop_from_aic", [AttrSizedOperandSegments]> {
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    (`(` $valid_row^ `,` $valid_col `)`)? `{` `split` `=` $split `}` attr-dict
+    (`(` $valid_row^ `,` $valid_col `)`)? `{` (`id` `=` $id^ `,`)? `split` `=` $split `}` attr-dict
     `->` qualified(type($tile))
   }];
 }
@@ -1476,6 +1483,7 @@ def TPopFromAivOp : PTO_TOp<"tpop_from_aiv", [AttrSizedOperandSegments]> {
   let arguments = (ins
       Optional<Index>:$valid_row,
       Optional<Index>:$valid_col,
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$split
   );
 
@@ -1483,7 +1491,7 @@ def TPopFromAivOp : PTO_TOp<"tpop_from_aiv", [AttrSizedOperandSegments]> {
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    (`(` $valid_row^ `,` $valid_col `)`)? `{` `split` `=` $split `}` attr-dict
+    (`(` $valid_row^ `,` $valid_col `)`)? `{` (`id` `=` $id^ `,`)? `split` `=` $split `}` attr-dict
     `->` qualified(type($tile))
   }];
 }
@@ -1492,6 +1500,7 @@ def TFreeFromAicOp : PTO_TOp<"tfree_from_aic"> {
   let summary = "Frontend C2V consumer free in Vector kernel";
 
   let arguments = (ins
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$split
   );
 
@@ -1499,7 +1508,7 @@ def TFreeFromAicOp : PTO_TOp<"tfree_from_aic"> {
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `{` `split` `=` $split `}` attr-dict
+    `{` (`id` `=` $id^ `,`)? `split` `=` $split `}` attr-dict
   }];
 }
 
@@ -1507,6 +1516,7 @@ def TFreeFromAivOp : PTO_TOp<"tfree_from_aiv"> {
   let summary = "Frontend V2C consumer free in Cube kernel";
 
   let arguments = (ins
+      DefaultValuedOptionalAttr<I32Attr, "0">:$id,
       I8Attr:$split
   );
 
@@ -1514,7 +1524,7 @@ def TFreeFromAivOp : PTO_TOp<"tfree_from_aiv"> {
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    `{` `split` `=` $split `}` attr-dict
+    `{` (`id` `=` $id^ `,`)? `split` `=` $split `}` attr-dict
   }];
 }
 

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -34,6 +34,7 @@ namespace pto {
 #include "PTO/Transforms/Passes.h.inc"
 
 std::unique_ptr<Pass> createLoweringSyncToPipePass();
+std::unique_ptr<Pass> createPTOAssignDefaultFrontendPipeIdPass();
 std::unique_ptr<Pass> createPTOLowerFrontendPipeOpsPass();
 std::unique_ptr<Pass> createPTOInferValidatePipeInitPass();
 std::unique_ptr<Pass> createPTOResolveReservedBuffersPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -152,6 +152,23 @@ def PTOLowerFrontendPipeOps : Pass<"pto-lower-frontend-pipe-ops", "func::FuncOp"
   ];
 }
 
+def PTOAssignDefaultFrontendPipeId : Pass<"pto-assign-default-frontend-pipe-id", "func::FuncOp"> {
+  let summary = "Materialize default id = 0 on frontend TPUSH/TPOP pipe ops";
+  let description = [{
+    Preserves backward compatibility with older frontend pipe syntax that
+    omitted `id`. This pass rewrites missing `id` attrs on
+    `aic/aiv_initialize_pipe`, `tpush_to_*`, `tpop_from_*`, and
+    `tfree_from_*` to an explicit `id = 0` before frontend pipe lowering.
+  }];
+
+  let constructor = "mlir::pto::createPTOAssignDefaultFrontendPipeIdPass()";
+
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::func::FuncDialect"
+  ];
+}
+
 def PTOInferValidatePipeInit : Pass<"pto-infer-validate-pipe-init", "ModuleOp"> {
   let summary = "Infer and validate internal pipe init nosplit configuration";
   let description = [{

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -10356,10 +10356,24 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
   if (!funcOp)
     return op.emitOpError("must be nested under a func.func");
 
-  unsigned sameInitCount = 0;
-  funcOp.walk([&](InitOpT) { ++sameInitCount; });
-  if (sameInitCount > 1)
-    return op.emitOpError("requires at most one matching initialize_pipe op per function");
+  if (op.getId() < 0)
+    return op.emitOpError("expects 'id' to be non-negative");
+
+  unsigned sameIdInitCount = 0;
+  funcOp.walk([&](Operation *candidate) {
+    if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
+      if (aic.getId() == op.getId())
+        ++sameIdInitCount;
+      return;
+    }
+    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate))
+      if (aiv.getId() == op.getId())
+        ++sameIdInitCount;
+  });
+  if (sameIdInitCount > 1) {
+    return op.emitOpError(
+        "requires 'id' to be unique across frontend initialize_pipe ops in the function");
+  }
 
   int8_t dirMask = op.getDirMask();
   if (dirMask != 1 && dirMask != 2 && dirMask != 3)
@@ -10400,11 +10414,6 @@ LogicalResult ReserveBufferOp::verify() {
   if (auto baseAttr = getBaseAttr(); baseAttr && baseAttr.getInt() < 0)
     return emitOpError("expects 'base' to be non-negative when present");
 
-  unsigned reserveCount = 0;
-  funcOp.walk([&](ReserveBufferOp) { ++reserveCount; });
-  if (reserveCount > 1)
-    return emitOpError("expects at most one reserve_buffer in the function");
-
   unsigned sameNameCount = 0;
   funcOp.walk([&](ReserveBufferOp reserveOp) {
     if (reserveOp.getName() == getName())
@@ -10421,15 +10430,22 @@ LogicalResult ImportReservedBufferOp::verify() {
   if (!funcOp)
     return emitOpError("must be nested under a func.func");
 
-  unsigned importCount = 0;
-  funcOp.walk([&](ImportReservedBufferOp) { ++importCount; });
-  if (importCount > 1)
-    return emitOpError("expects at most one import_reserved_buffer in the function");
-
   auto peerFunc = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
       getOperation(), getPeerFuncAttr());
   if (!peerFunc)
     return emitOpError("expects 'peer_func' to reference an existing func.func");
+
+  unsigned sameImportCount = 0;
+  funcOp.walk([&](ImportReservedBufferOp importOp) {
+    if (importOp.getName() == getName() &&
+        importOp.getPeerFuncAttr() == getPeerFuncAttr()) {
+      ++sameImportCount;
+    }
+  });
+  if (sameImportCount > 1) {
+    return emitOpError(
+        "requires (name, peer_func) to be unique within the function");
+  }
 
   if (!findReserveBufferByName(peerFunc, getName()))
     return emitOpError("expects matching peer reserve_buffer to exist");
@@ -10440,18 +10456,86 @@ LogicalResult ImportReservedBufferOp::verify() {
 static LogicalResult verifyFrontendSplitOp(Operation *op,
                                            FunctionKernelKind expected,
                                            StringRef kernelName,
+                                           int32_t id,
                                            int64_t split) {
   if (failed(verifyFrontendKernelKind(op, expected, kernelName)))
     return failure();
+  if (id < 0)
+    return op->emitOpError("expects 'id' to be non-negative");
   return verifySplitAttr(op, split);
+}
+
+static FailureOr<int8_t> lookupFrontendInitDirMaskById(Operation *op,
+                                                       func::FuncOp funcOp,
+                                                       int32_t id) {
+  int8_t matchedDirMask = 0;
+  unsigned matchedInitCount = 0;
+  funcOp.walk([&](Operation *candidate) {
+    if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
+      if (aic.getId() == id) {
+        matchedDirMask = aic.getDirMask();
+        ++matchedInitCount;
+      }
+      return WalkResult::advance();
+    }
+    if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate)) {
+      if (aiv.getId() == id) {
+        matchedDirMask = aiv.getDirMask();
+        ++matchedInitCount;
+      }
+      return WalkResult::advance();
+    }
+    return WalkResult::advance();
+  });
+
+  if (matchedInitCount == 0) {
+    op->emitOpError() << "expects 'id' = " << id
+                      << " to match a frontend initialize_pipe op in the same function";
+    return failure();
+  }
+  if (matchedInitCount > 1) {
+    op->emitOpError() << "expects 'id' = " << id
+                      << " to match exactly one frontend initialize_pipe op in the same function";
+    return failure();
+  }
+  return matchedDirMask;
+}
+
+static LogicalResult verifyFrontendDataOpDirection(Operation *op, int32_t id,
+                                                   bool expectC2V) {
+  auto funcOp = op->getParentOfType<func::FuncOp>();
+  if (!funcOp)
+    return op->emitOpError("must be nested under a func.func");
+
+  auto dirMaskOr = lookupFrontendInitDirMaskById(op, funcOp, id);
+  if (failed(dirMaskOr))
+    return failure();
+
+  int8_t dirMask = *dirMaskOr;
+  if (expectC2V && dirMask != 1 && dirMask != 3) {
+    return op->emitOpError()
+           << "expects 'id' = " << id
+           << " to reference initialize_pipe with dir_mask = 1 or 3";
+  }
+  if (!expectC2V && dirMask != 2 && dirMask != 3) {
+    return op->emitOpError()
+           << "expects 'id' = " << id
+           << " to reference initialize_pipe with dir_mask = 2 or 3";
+  }
+  return success();
 }
 
 template <typename FrontendPopOpT>
 static LogicalResult verifyFrontendPopOp(FrontendPopOpT op,
                                          FunctionKernelKind expected,
-                                         StringRef kernelName) {
+                                         StringRef kernelName,
+                                         bool expectC2V) {
   if (failed(verifyFrontendSplitOp(op.getOperation(), expected, kernelName,
+                                   op.getId(),
                                    op.getSplit())))
+    return failure();
+  if (failed(verifyFrontendDataOpDirection(op.getOperation(), op.getId(),
+                                           expectC2V)))
     return failure();
 
   bool hasValidRow = static_cast<bool>(op.getValidRow());
@@ -10475,6 +10559,7 @@ static LogicalResult verifyFrontendPopOp(FrontendPopOpT op,
 static LogicalResult verifyPipeShape(Operation *op, int8_t dirMask, int32_t slotSize,
                                      int32_t slotNum,
                                      std::optional<int32_t> flagBase) {
+  constexpr int32_t kMaxHardwareFlagIds = 16;
   if (dirMask != 1 && dirMask != 2 && dirMask != 3)
     return op->emitOpError("expects 'dir_mask' to be 1, 2, or 3");
   if (slotSize <= 0)
@@ -10483,6 +10568,14 @@ static LogicalResult verifyPipeShape(Operation *op, int8_t dirMask, int32_t slot
     return op->emitOpError("expects 'slot_num' to be 4 or 8");
   if (flagBase && *flagBase < 0)
     return op->emitOpError("expects 'flag_base' to be non-negative when present");
+  if (flagBase) {
+    int32_t flagWidth = dirMask == 3 ? 4 : 2;
+    if (*flagBase + flagWidth > kMaxHardwareFlagIds) {
+      return op->emitOpError()
+             << "requires 'flag_base' and dir_mask to fit within "
+             << kMaxHardwareFlagIds << " hardware flag ids";
+    }
+  }
 
   return success();
 }
@@ -10596,31 +10689,45 @@ LogicalResult AivInitializePipeOp::verify() {
 }
 
 LogicalResult TPushToAivOp::verify() {
-  return verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Cube,
-                               "cube", getSplit());
+  if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Cube,
+                                   "cube", getId(), getSplit())))
+    return failure();
+  return verifyFrontendDataOpDirection(getOperation(), getId(),
+                                       /*expectC2V=*/true);
 }
 
 LogicalResult TPushToAicOp::verify() {
-  return verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Vector,
-                               "vector", getSplit());
+  if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Vector,
+                                   "vector", getId(), getSplit())))
+    return failure();
+  return verifyFrontendDataOpDirection(getOperation(), getId(),
+                                       /*expectC2V=*/false);
 }
 
 LogicalResult TPopFromAicOp::verify() {
-  return verifyFrontendPopOp(*this, FunctionKernelKind::Vector, "vector");
+  return verifyFrontendPopOp(*this, FunctionKernelKind::Vector, "vector",
+                             /*expectC2V=*/true);
 }
 
 LogicalResult TPopFromAivOp::verify() {
-  return verifyFrontendPopOp(*this, FunctionKernelKind::Cube, "cube");
+  return verifyFrontendPopOp(*this, FunctionKernelKind::Cube, "cube",
+                             /*expectC2V=*/false);
 }
 
 LogicalResult TFreeFromAicOp::verify() {
-  return verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Vector,
-                               "vector", getSplit());
+  if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Vector,
+                                   "vector", getId(), getSplit())))
+    return failure();
+  return verifyFrontendDataOpDirection(getOperation(), getId(),
+                                       /*expectC2V=*/true);
 }
 
 LogicalResult TFreeFromAivOp::verify() {
-  return verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Cube,
-                               "cube", getSplit());
+  if (failed(verifyFrontendSplitOp(getOperation(), FunctionKernelKind::Cube,
+                                   "cube", getId(), getSplit())))
+    return failure();
+  return verifyFrontendDataOpDirection(getOperation(), getId(),
+                                       /*expectC2V=*/false);
 }
 
 LogicalResult InitializeL2G2LPipeOp::verify() {

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mlir_dialect_library(PTOTransforms
   PTOA5NormalizeTMovPass.cpp
   BufferizableOpInterfaceImpl.cpp
   ConvertToPTOOp.cpp
+  PTOAssignDefaultFrontendPipeIdPass.cpp
   PTOLowerFrontendPipeOpsPass.cpp
   PTOInferValidatePipeInitPass.cpp
   PTOResolveReservedBuffersPass.cpp

--- a/lib/PTO/Transforms/PTOAssignDefaultFrontendPipeIdPass.cpp
+++ b/lib/PTO/Transforms/PTOAssignDefaultFrontendPipeIdPass.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOASSIGNDEFAULTFRONTENDPIPEID
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+template <typename OpT>
+static void assignDefaultIdIfMissing(OpT op, IntegerAttr zeroAttr) {
+  if (!op.getIdAttr())
+    op.setIdAttr(zeroAttr);
+}
+
+struct PTOAssignDefaultFrontendPipeIdPass
+    : public mlir::pto::impl::PTOAssignDefaultFrontendPipeIdBase<
+          PTOAssignDefaultFrontendPipeIdPass> {
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    Builder builder(funcOp.getContext());
+    auto zeroAttr = builder.getI32IntegerAttr(0);
+
+    funcOp.walk([&](Operation *op) {
+      if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
+        assignDefaultIdIfMissing(init, zeroAttr);
+        return WalkResult::advance();
+      }
+      if (auto init = dyn_cast<AivInitializePipeOp>(op)) {
+        assignDefaultIdIfMissing(init, zeroAttr);
+        return WalkResult::advance();
+      }
+      if (auto push = dyn_cast<TPushToAivOp>(op)) {
+        assignDefaultIdIfMissing(push, zeroAttr);
+        return WalkResult::advance();
+      }
+      if (auto push = dyn_cast<TPushToAicOp>(op)) {
+        assignDefaultIdIfMissing(push, zeroAttr);
+        return WalkResult::advance();
+      }
+      if (auto pop = dyn_cast<TPopFromAicOp>(op)) {
+        assignDefaultIdIfMissing(pop, zeroAttr);
+        return WalkResult::advance();
+      }
+      if (auto pop = dyn_cast<TPopFromAivOp>(op)) {
+        assignDefaultIdIfMissing(pop, zeroAttr);
+        return WalkResult::advance();
+      }
+      if (auto free = dyn_cast<TFreeFromAicOp>(op)) {
+        assignDefaultIdIfMissing(free, zeroAttr);
+        return WalkResult::advance();
+      }
+      if (auto free = dyn_cast<TFreeFromAivOp>(op)) {
+        assignDefaultIdIfMissing(free, zeroAttr);
+        return WalkResult::advance();
+      }
+      return WalkResult::advance();
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOAssignDefaultFrontendPipeIdPass() {
+  return std::make_unique<PTOAssignDefaultFrontendPipeIdPass>();
+}

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -12,6 +12,7 @@
 #include "mlir/IR/Dominance.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/DenseMap.h"
 
 namespace mlir {
 namespace pto {
@@ -31,6 +32,8 @@ struct FrontendPipeHandles {
   Value v2cPipe;
   Operation *anchorOp = nullptr;
 };
+
+using FrontendPipeHandleMap = llvm::DenseMap<int32_t, FrontendPipeHandles>;
 
 template <typename InitOpT>
 static LogicalResult requireFrontendGmSlotBuffer(InitOpT initOp) {
@@ -130,45 +133,6 @@ static FailureOr<FrontendPipeHandles> lowerFrontendInitOp(InitOpT initOp,
   }
 }
 
-struct FrontendInitOps {
-  AicInitializePipeOp aicInit;
-  AivInitializePipeOp aivInit;
-  unsigned aicInitCount = 0;
-  unsigned aivInitCount = 0;
-};
-
-static FrontendInitOps collectFrontendInitOps(func::FuncOp funcOp) {
-  FrontendInitOps initOps;
-  funcOp.walk([&](Operation *op) {
-    if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
-      ++initOps.aicInitCount;
-      if (!initOps.aicInit)
-        initOps.aicInit = init;
-      return WalkResult::advance();
-    }
-    if (auto init = dyn_cast<AivInitializePipeOp>(op)) {
-      ++initOps.aivInitCount;
-      if (!initOps.aivInit)
-        initOps.aivInit = init;
-    }
-    return WalkResult::advance();
-  });
-  return initOps;
-}
-
-static LogicalResult validateFrontendInitOps(func::FuncOp funcOp,
-                                             const FrontendInitOps &initOps) {
-  if (initOps.aicInitCount > 1)
-    return funcOp.emitOpError("requires at most one pto.aic_initialize_pipe");
-  if (initOps.aivInitCount > 1)
-    return funcOp.emitOpError("requires at most one pto.aiv_initialize_pipe");
-  if (initOps.aicInit && initOps.aivInit) {
-    return funcOp.emitOpError("cannot mix pto.aic_initialize_pipe and "
-                              "pto.aiv_initialize_pipe in one function");
-  }
-  return success();
-}
-
 template <typename InitOpT>
 static void propagateFrontendNoSplitAttr(InitOpT initOp,
                                          const FrontendPipeHandles &handles) {
@@ -202,16 +166,71 @@ static FailureOr<FrontendPipeHandles> lowerAndEraseFrontendInit(InitOpT initOp,
   return *loweredOr;
 }
 
-static FailureOr<FrontendPipeHandles> lowerInitIfPresent(func::FuncOp funcOp,
-                                                         IRRewriter &rewriter) {
-  FrontendInitOps initOps = collectFrontendInitOps(funcOp);
-  if (failed(validateFrontendInitOps(funcOp, initOps)))
+static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
+                                                           IRRewriter &rewriter) {
+  FrontendPipeHandleMap handlesById;
+  SmallVector<Operation *> frontendInitOps;
+  llvm::DenseMap<int32_t, Operation *> initOpById;
+  bool hasDuplicateId = false;
+  bool hasAicInit = false;
+  bool hasAivInit = false;
+
+  funcOp.walk([&](Operation *op) {
+    if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
+      hasAicInit = true;
+      frontendInitOps.push_back(op);
+      auto [it, inserted] = initOpById.try_emplace(init.getId(), op);
+      if (!inserted) {
+        op->emitOpError()
+            << "requires unique initialize_pipe id in function (duplicate id = "
+            << init.getId() << ")";
+        hasDuplicateId = true;
+      }
+      return WalkResult::advance();
+    }
+    if (auto init = dyn_cast<AivInitializePipeOp>(op)) {
+      hasAivInit = true;
+      frontendInitOps.push_back(op);
+      auto [it, inserted] = initOpById.try_emplace(init.getId(), op);
+      if (!inserted) {
+        op->emitOpError()
+            << "requires unique initialize_pipe id in function (duplicate id = "
+            << init.getId() << ")";
+        hasDuplicateId = true;
+      }
+      return WalkResult::advance();
+    }
+    return WalkResult::advance();
+  });
+
+  if (hasDuplicateId)
     return failure();
-  if (initOps.aicInit)
-    return lowerAndEraseFrontendInit(initOps.aicInit, rewriter);
-  if (initOps.aivInit)
-    return lowerAndEraseFrontendInit(initOps.aivInit, rewriter);
-  return FrontendPipeHandles{};
+
+  if (hasAicInit && hasAivInit) {
+    funcOp.emitOpError("cannot mix pto.aic_initialize_pipe and "
+                       "pto.aiv_initialize_pipe in one function");
+    return failure();
+  }
+
+  for (Operation *op : frontendInitOps) {
+    if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
+      int32_t id = init.getId();
+      auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
+      if (failed(loweredOr))
+        return failure();
+      handlesById.try_emplace(id, *loweredOr);
+      continue;
+    }
+
+    auto init = cast<AivInitializePipeOp>(op);
+    int32_t id = init.getId();
+    auto loweredOr = lowerAndEraseFrontendInit(init, rewriter);
+    if (failed(loweredOr))
+      return failure();
+    handlesById.try_emplace(id, *loweredOr);
+  }
+
+  return handlesById;
 }
 
 static bool hasFrontendPipeOps(func::FuncOp funcOp) {
@@ -228,7 +247,7 @@ static bool hasFrontendPipeOps(func::FuncOp funcOp) {
 }
 
 static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
-                                          const FrontendPipeHandles &handles,
+                                          const FrontendPipeHandleMap &handlesById,
                                           IRRewriter &rewriter) {
   DominanceInfo dom(funcOp);
   SmallVector<Operation *> frontendOps;
@@ -238,23 +257,35 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
       frontendOps.push_back(op);
   });
 
-  for (Operation *op : frontendOps) {
-    if (!handles.anchorOp) {
-      op->emitOpError("requires a frontend initialize_pipe op in the same function");
+  auto lookupHandles = [&](Operation *op, int32_t id)
+      -> FailureOr<const FrontendPipeHandles *> {
+    auto it = handlesById.find(id);
+    if (it == handlesById.end()) {
+      op->emitOpError()
+          << "requires matching frontend initialize_pipe(id = " << id
+          << ") in the same function";
       return failure();
     }
-    if (!dom.dominates(handles.anchorOp, op)) {
-      op->emitOpError(
-          "requires a dominating frontend initialize_pipe op");
+    const FrontendPipeHandles &handles = it->second;
+    if (!handles.anchorOp || !dom.dominates(handles.anchorOp, op)) {
+      op->emitOpError()
+          << "requires dominating frontend initialize_pipe(id = " << id << ")";
       return failure();
     }
+    return &handles;
+  };
 
+  for (Operation *op : frontendOps) {
     rewriter.setInsertionPoint(op);
 
     if (auto push = dyn_cast<TPushToAivOp>(op)) {
+      auto handlesOr = lookupHandles(op, push.getId());
+      if (failed(handlesOr))
+        return failure();
+      const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.c2vPipe) {
-        op->emitOpError(
-            "requires the dominating initialize_pipe op to enable C2V");
+        op->emitOpError() << "requires initialize_pipe(id = " << push.getId()
+                          << ") to enable C2V";
         return failure();
       }
       rewriter.replaceOpWithNewOp<TPushOp>(push, push.getTile(), handles.c2vPipe,
@@ -263,9 +294,13 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto push = dyn_cast<TPushToAicOp>(op)) {
+      auto handlesOr = lookupHandles(op, push.getId());
+      if (failed(handlesOr))
+        return failure();
+      const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.v2cPipe) {
-        op->emitOpError(
-            "requires the dominating initialize_pipe op to enable V2C");
+        op->emitOpError() << "requires initialize_pipe(id = " << push.getId()
+                          << ") to enable V2C";
         return failure();
       }
       rewriter.replaceOpWithNewOp<TPushOp>(push, push.getTile(), handles.v2cPipe,
@@ -274,9 +309,13 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto pop = dyn_cast<TPopFromAicOp>(op)) {
+      auto handlesOr = lookupHandles(op, pop.getId());
+      if (failed(handlesOr))
+        return failure();
+      const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.c2vPipe) {
-        op->emitOpError(
-            "requires the dominating initialize_pipe op to enable C2V");
+        op->emitOpError() << "requires initialize_pipe(id = " << pop.getId()
+                          << ") to enable C2V";
         return failure();
       }
       auto decl = rewriter.create<DeclareTileOp>(pop.getLoc(),
@@ -292,9 +331,13 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto pop = dyn_cast<TPopFromAivOp>(op)) {
+      auto handlesOr = lookupHandles(op, pop.getId());
+      if (failed(handlesOr))
+        return failure();
+      const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.v2cPipe) {
-        op->emitOpError(
-            "requires the dominating initialize_pipe op to enable V2C");
+        op->emitOpError() << "requires initialize_pipe(id = " << pop.getId()
+                          << ") to enable V2C";
         return failure();
       }
       auto decl = rewriter.create<DeclareTileOp>(pop.getLoc(),
@@ -310,9 +353,13 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     if (auto free = dyn_cast<TFreeFromAicOp>(op)) {
+      auto handlesOr = lookupHandles(op, free.getId());
+      if (failed(handlesOr))
+        return failure();
+      const FrontendPipeHandles &handles = **handlesOr;
       if (!handles.c2vPipe) {
-        op->emitOpError(
-            "requires the dominating initialize_pipe op to enable C2V");
+        op->emitOpError() << "requires initialize_pipe(id = " << free.getId()
+                          << ") to enable C2V";
         return failure();
       }
       rewriter.replaceOpWithNewOp<TFreeOp>(free, handles.c2vPipe,
@@ -321,9 +368,13 @@ static LogicalResult lowerFrontendDataOps(func::FuncOp funcOp,
     }
 
     auto free = cast<TFreeFromAivOp>(op);
+    auto handlesOr = lookupHandles(op, free.getId());
+    if (failed(handlesOr))
+      return failure();
+    const FrontendPipeHandles &handles = **handlesOr;
     if (!handles.v2cPipe) {
-      op->emitOpError(
-          "requires the dominating initialize_pipe op to enable V2C");
+      op->emitOpError() << "requires initialize_pipe(id = " << free.getId()
+                        << ") to enable V2C";
       return failure();
     }
     rewriter.replaceOpWithNewOp<TFreeOp>(free, handles.v2cPipe,

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -123,58 +123,59 @@ struct ReserveBufferPlan {
   int64_t alignBytes = 1;
 };
 
-static LogicalResult analyzeReserveBufferPlan(func::FuncOp funcOp,
-                                              ReserveBufferPlan &plan) {
+using ReserveBufferPlans = SmallVector<ReserveBufferPlan>;
+
+static LogicalResult analyzeReserveBufferPlans(func::FuncOp funcOp,
+                                               ReserveBufferPlans &plans) {
   SmallVector<ReserveBufferOp> reserveOps;
   funcOp.walk(
       [&](ReserveBufferOp reserveOp) { reserveOps.push_back(reserveOp); });
 
   if (reserveOps.empty())
     return success();
-  if (reserveOps.size() > 1) {
-    return funcOp.emitOpError(
-        "expects at most one pto.reserve_buffer per function");
-  }
 
-  ReserveBufferOp reserveOp = reserveOps.front();
-  AddressSpace as = reserveOp.getLocation().getAddressSpace();
-  auto spec = getLocalMemSpec(reserveOp.getOperation(), as);
-  if (spec.capacityBits <= 0 || spec.alignBytes <= 0)
-    return reserveOp.emitOpError("unsupported reserve_buffer location");
+  for (ReserveBufferOp reserveOp : reserveOps) {
+    AddressSpace as = reserveOp.getLocation().getAddressSpace();
+    auto spec = getLocalMemSpec(reserveOp.getOperation(), as);
+    if (spec.capacityBits <= 0 || spec.alignBytes <= 0)
+      return reserveOp.emitOpError("unsupported reserve_buffer location");
 
-  int64_t capacityBytes = spec.capacityBits / 8;
-  int64_t sizeBytes = reserveOp.getSize();
-  bool autoAlloc = reserveOp.getAutoAlloc();
-  plan.mode = autoAlloc ? ReserveBufferMode::Auto : ReserveBufferMode::Manual;
-  plan.reserveOp = reserveOp;
-  plan.addressSpace = as;
-  plan.sizeBytes = sizeBytes;
-  plan.capacityBytes = capacityBytes;
-  plan.alignBytes = spec.alignBytes;
+    int64_t capacityBytes = spec.capacityBits / 8;
+    int64_t sizeBytes = reserveOp.getSize();
+    bool autoAlloc = reserveOp.getAutoAlloc();
 
-  // Auto mode only declares that one contiguous region must be reserved.
-  // The concrete base is filled later from a hole in the target local space.
-  if (autoAlloc) {
-    if (reserveOp.getBaseAttr()) {
-      return reserveOp.emitOpError(
-          "expects 'base' to be absent when 'auto' is true");
+    ReserveBufferPlan &plan = plans.emplace_back();
+    plan.mode = autoAlloc ? ReserveBufferMode::Auto : ReserveBufferMode::Manual;
+    plan.reserveOp = reserveOp;
+    plan.addressSpace = as;
+    plan.sizeBytes = sizeBytes;
+    plan.capacityBytes = capacityBytes;
+    plan.alignBytes = spec.alignBytes;
+
+    // Auto mode only declares that one contiguous region must be reserved.
+    // The concrete base is filled later from a hole in the target local space.
+    if (autoAlloc) {
+      if (reserveOp.getBaseAttr()) {
+        return reserveOp.emitOpError(
+            "expects 'base' to be absent when 'auto' is true");
+      }
+      continue;
     }
-    return success();
-  }
 
-  // In manual mode, reserve_buffer.base is already fixed by the frontend or an
-  // earlier stage. Only basic validation is needed here.
-  auto baseAttr = reserveOp.getBaseAttr();
-  if (!baseAttr)
-    return reserveOp.emitOpError("expects 'base' when 'auto' is false");
+    // In manual mode, reserve_buffer.base is already fixed by the frontend or
+    // an earlier stage. Only basic validation is needed here.
+    auto baseAttr = reserveOp.getBaseAttr();
+    if (!baseAttr)
+      return reserveOp.emitOpError("expects 'base' when 'auto' is false");
 
-  int64_t baseBytes = baseAttr.getInt();
-  if (baseBytes % spec.alignBytes != 0) {
-    return reserveOp.emitOpError(
-        "expects 'base' to satisfy the address-space alignment");
-  }
-  if (baseBytes + sizeBytes > capacityBytes) {
-    return reserveOp.emitOpError("exceeds available local memory capacity");
+    int64_t baseBytes = baseAttr.getInt();
+    if (baseBytes % spec.alignBytes != 0) {
+      return reserveOp.emitOpError(
+          "expects 'base' to satisfy the address-space alignment");
+    }
+    if (baseBytes + sizeBytes > capacityBytes) {
+      return reserveOp.emitOpError("exceeds available local memory capacity");
+    }
   }
 
   return success();
@@ -185,19 +186,14 @@ struct OccupiedByteRange {
   int64_t end = 0;
 };
 
-static LogicalResult assignAutoReserveBufferBase(
-    ReserveBufferPlan &plan,
+static LogicalResult assignAutoReserveBufferBases(
+    ReserveBufferPlans &plans,
     const std::map<Value, BufferInfo, ValueComparator> &bufferInfos,
     const DenseMap<Value, SmallVector<uint64_t>> &buffer2Offsets) {
-  if (plan.mode != ReserveBufferMode::Auto || !plan.reserveOp)
-    return success();
-
-  SmallVector<OccupiedByteRange> occupied;
+  std::map<AddressSpace, SmallVector<OccupiedByteRange>> occupiedByAddressSpace;
   for (const auto &it : bufferInfos) {
     Value buffer = it.first;
     const BufferInfo &bufferInfo = it.second;
-    if (bufferInfo.bufferScope != plan.addressSpace)
-      continue;
 
     auto offsetsIt = buffer2Offsets.find(buffer);
     if (offsetsIt == buffer2Offsets.end())
@@ -207,51 +203,66 @@ static LogicalResult assignAutoReserveBufferBase(
     // Reconstruct the already occupied byte ranges from the planned local
     // buffers, then place reserve_buffer into the first aligned hole.
     int64_t occupiedSizeBytes =
-        alignUpBytes(ceilDivBitsToBytes(bufferInfo.constBits), plan.alignBytes);
+        alignUpBytes(ceilDivBitsToBytes(bufferInfo.constBits), /*align=*/1);
     for (uint64_t offsetBytes : offsetsIt->second) {
-      occupied.push_back(OccupiedByteRange{static_cast<int64_t>(offsetBytes),
-                                           static_cast<int64_t>(offsetBytes) +
-                                               occupiedSizeBytes});
+      occupiedByAddressSpace[bufferInfo.bufferScope].push_back(
+          OccupiedByteRange{static_cast<int64_t>(offsetBytes),
+                            static_cast<int64_t>(offsetBytes) + occupiedSizeBytes});
     }
   }
 
-  llvm::sort(occupied,
-             [](const OccupiedByteRange &lhs, const OccupiedByteRange &rhs) {
-               return lhs.begin < rhs.begin;
-             });
+  auto normalizeRanges = [](SmallVector<OccupiedByteRange> &ranges) {
+    llvm::sort(ranges,
+               [](const OccupiedByteRange &lhs, const OccupiedByteRange &rhs) {
+                 return lhs.begin < rhs.begin;
+               });
 
-  // Merge overlapping or adjacent occupied ranges first so the later scan only
-  // needs to reason about real holes between disjoint intervals.
-  SmallVector<OccupiedByteRange> merged;
-  for (const OccupiedByteRange &range : occupied) {
-    if (merged.empty() || range.begin > merged.back().end) {
-      merged.push_back(range);
+    SmallVector<OccupiedByteRange> merged;
+    for (const OccupiedByteRange &range : ranges) {
+      if (merged.empty() || range.begin > merged.back().end) {
+        merged.push_back(range);
+        continue;
+      }
+      merged.back().end = std::max(merged.back().end, range.end);
+    }
+    ranges.swap(merged);
+  };
+
+  for (auto &it : occupiedByAddressSpace)
+    normalizeRanges(it.second);
+
+  for (ReserveBufferPlan &plan : plans) {
+    if (plan.mode != ReserveBufferMode::Auto || !plan.reserveOp)
       continue;
+
+    SmallVector<OccupiedByteRange> &occupied =
+        occupiedByAddressSpace[plan.addressSpace];
+
+    // First-fit search: try address 0 first, then keep moving the candidate to
+    // the end of the current occupied interval until a large-enough aligned
+    // hole is found.
+    int64_t candidateBase = 0;
+    for (const OccupiedByteRange &range : occupied) {
+      candidateBase = alignUpBytes(candidateBase, plan.alignBytes);
+      if (candidateBase + plan.sizeBytes <= range.begin)
+        break;
+      candidateBase = std::max(candidateBase, range.end);
     }
-    merged.back().end = std::max(merged.back().end, range.end);
-  }
-
-  // First-fit search: try address 0 first, then keep moving the candidate to
-  // the end of the current occupied interval until a large-enough aligned hole
-  // is found.
-  int64_t candidateBase = 0;
-  for (const OccupiedByteRange &range : merged) {
     candidateBase = alignUpBytes(candidateBase, plan.alignBytes);
-    if (candidateBase + plan.sizeBytes <= range.begin)
-      break;
-    candidateBase = std::max(candidateBase, range.end);
-  }
-  candidateBase = alignUpBytes(candidateBase, plan.alignBytes);
 
-  if (candidateBase + plan.sizeBytes > plan.capacityBytes) {
-    return plan.reserveOp.emitOpError(
-        "failed to allocate local memory hole for reserve_buffer");
-  }
+    if (candidateBase + plan.sizeBytes > plan.capacityBytes) {
+      return plan.reserveOp.emitOpError(
+          "failed to allocate local memory hole for reserve_buffer");
+    }
 
-  plan.reserveOp->setAttr(
-      "base",
-      IntegerAttr::get(IntegerType::get(plan.reserveOp.getContext(), 32),
-                       candidateBase));
+    plan.reserveOp->setAttr(
+        "base",
+        IntegerAttr::get(IntegerType::get(plan.reserveOp.getContext(), 32),
+                         candidateBase));
+    occupied.push_back(
+        OccupiedByteRange{candidateBase, candidateBase + plan.sizeBytes});
+    normalizeRanges(occupied);
+  }
   return success();
 }
 
@@ -2101,17 +2112,20 @@ private:
 void PlanMemoryPass::runOnOperation() {
   ModuleOp moduleOp = getOperation();
   for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
-    ReserveBufferPlan reservePlan;
+    ReserveBufferPlans reservePlans;
     if (this->memMode == MemPlanMode::LOCAL_MEM_PLAN &&
-        failed(analyzeReserveBufferPlan(funcOp, reservePlan))) {
+        failed(analyzeReserveBufferPlans(funcOp, reservePlans))) {
       return signalPassFailure();
     }
-    if (this->memMode == MemPlanMode::LOCAL_MEM_PLAN &&
-        reservePlan.mode == ReserveBufferMode::Manual) {
-      reservePlan.reserveOp.emitOpError(
-          "pto.reserve_buffer with explicit 'base' (auto = false) is not "
-          "supported in PlanMemory; use --pto-level=level3 or set auto = true");
-      return signalPassFailure();
+    if (this->memMode == MemPlanMode::LOCAL_MEM_PLAN) {
+      for (ReserveBufferPlan &reservePlan : reservePlans) {
+        if (reservePlan.mode != ReserveBufferMode::Manual)
+          continue;
+        reservePlan.reserveOp.emitOpError(
+            "pto.reserve_buffer with explicit 'base' (auto = false) is not "
+            "supported in PlanMemory; use --pto-level=level3 or set auto = true");
+        return signalPassFailure();
+      }
     }
 
     MemLivenessAnalysis memLiveness(funcOp, this->memMode);
@@ -2138,8 +2152,8 @@ void PlanMemoryPass::runOnOperation() {
     // normal local buffers are planned first, then reserve_buffer claims one
     // aligned hole in its target address space.
     if (this->memMode == MemPlanMode::LOCAL_MEM_PLAN &&
-        failed(assignAutoReserveBufferBase(reservePlan, memLiveness.bufferInfos,
-                                           memPlan.GetBuffer2Offsets()))) {
+        failed(assignAutoReserveBufferBases(reservePlans, memLiveness.bufferInfos,
+                                            memPlan.GetBuffer2Offsets()))) {
       return signalPassFailure();
     }
 

--- a/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
+++ b/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
@@ -15,11 +15,16 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+#include <algorithm>
 #include <map>
 #include <optional>
 #include <set>
 #include <string>
 #include <tuple>
+#include <type_traits>
 
 namespace mlir {
 namespace pto {
@@ -32,6 +37,8 @@ using namespace mlir;
 using namespace mlir::pto;
 
 namespace {
+
+constexpr int32_t kMaxHardwareFlagIds = 16;
 
 struct PipePeerKey {
   std::string ownerFunc;
@@ -50,10 +57,29 @@ struct PipeInitInfo {
   Operation *op = nullptr;
   func::FuncOp funcOp;
   int8_t dirMask = 0;
+  int32_t slotSize = 0;
+  int32_t slotNum = 0;
+  std::optional<int32_t> localSlotNum;
 };
 
-using PipeInitGroups = std::map<PipePeerKey, SmallVector<PipeInitInfo>>;
-using PipeParticipants = std::map<PipePeerKey, std::set<std::string>>;
+struct PipeComponent {
+  SmallVector<Operation *> ops;
+  std::set<std::string> participants;
+  int8_t dirMask = 0;
+  int32_t slotSize = 0;
+  int32_t slotNum = 0;
+  std::optional<int32_t> localSlotNum;
+  unsigned flagWidth = 0;
+  std::optional<int32_t> explicitFlagBase;
+};
+
+struct FlagInterval {
+  int32_t begin = 0;
+  int32_t end = 0;
+};
+
+using PipeInitGroups = std::map<PipePeerKey, SmallVector<Operation *>>;
+using PipeFlagUsage = std::map<std::string, SmallVector<FlagInterval>>;
 
 template <typename InitOpT> static Value getLocalAddrOperand(InitOpT op) {
   // Hide the concrete init-op type and expose the local address operand
@@ -88,7 +114,6 @@ static std::string getFuncSymbol(func::FuncOp funcOp) {
   return funcOp.getSymName().str();
 }
 
-
 static std::optional<PipePeerKey> getPipePeerKey(Value localAddr,
                                                  func::FuncOp currentFunc) {
   // reserve_buffer identifies the local owner directly, while
@@ -108,36 +133,33 @@ static std::optional<PipePeerKey> getPipePeerKey(Value localAddr,
   return std::nullopt;
 }
 
-static bool hasCompletePeerInitPair(const SmallVector<PipeInitInfo> &inits,
-                                    const std::set<std::string> &participants) {
-  // A peer-aware logical pipe is only well-defined when exactly two init ops
-  // participate: one in the reserve owner and one in the peer importer.
-  if (participants.size() != 2 || inits.size() != 2)
-    return false;
-
-  std::set<std::string> initFuncs;
-  for (const PipeInitInfo &info : inits)
-    initFuncs.insert(getFuncSymbol(info.funcOp));
-  return initFuncs.size() == 2;
-}
-
 template <typename InitOpT>
-static LogicalResult collectPeerAwareInit(InitOpT initOp,
-                                          PipeInitGroups &keyedInits,
-                                          PipeParticipants &keyedParticipants) {
+static PipeInitInfo buildPipeInitInfo(InitOpT initOp) {
   PipeInitInfo info;
   info.op = initOp.getOperation();
   info.funcOp = initOp->template getParentOfType<func::FuncOp>();
   info.dirMask = initOp.getDirMask();
+  info.slotSize = initOp.getSlotSize();
+  info.slotNum = initOp.getSlotNum();
+  if constexpr (std::is_same_v<InitOpT, InitializeL2G2LPipeOp>) {
+    if (auto attr = initOp.getLocalSlotNumAttr())
+      info.localSlotNum = attr.getInt();
+  }
+  return info;
+}
+
+template <typename InitOpT>
+static LogicalResult collectPeerAwareInit(InitOpT initOp,
+                                          SmallVectorImpl<PipeInitInfo> &initInfos,
+                                          PipeInitGroups &keyedInits) {
+  PipeInitInfo info = buildPipeInitInfo(initOp);
 
   auto recordAddr = [&](Value addr, int8_t effectiveDirMask) {
     auto key = getPipePeerKey(addr, info.funcOp);
     if (!key)
       return false;
     key->dirMask = effectiveDirMask;
-    keyedInits[*key].push_back(info);
-    keyedParticipants[*key].insert(getFuncSymbol(info.funcOp));
-    keyedParticipants[*key].insert(key->ownerFunc);
+    keyedInits[*key].push_back(info.op);
     return true;
   };
 
@@ -150,6 +172,8 @@ static LogicalResult collectPeerAwareInit(InitOpT initOp,
     recorded = recordAddr(getLocalAddrOperand(initOp), info.dirMask);
   }
 
+  if (recorded)
+    initInfos.push_back(info);
   if (recorded || getFlagBaseAttr(initOp))
     return success();
 
@@ -158,68 +182,195 @@ static LogicalResult collectPeerAwareInit(InitOpT initOp,
       "pto.import_reserved_buffer when 'flag_base' is not explicit");
 }
 
-static LogicalResult validatePeerInitGroups(const PipeInitGroups &keyedInits,
-                                            const PipeParticipants &keyedParticipants) {
-  for (const auto &it : keyedInits) {
-    if (hasCompletePeerInitPair(it.second, keyedParticipants.at(it.first)))
-      continue;
-    return it.second.front().op->emitOpError(
-        "requires a complete peer init pair when local_addr comes from "
-        "pto.reserve_buffer or pto.import_reserved_buffer");
+static IntegerAttr getFlagBaseAttr(Operation *op) {
+  if (auto initOp = dyn_cast<InitializeL2LPipeOp>(op))
+    return initOp.getFlagBaseAttr();
+  return cast<InitializeL2G2LPipeOp>(op).getFlagBaseAttr();
+}
+
+static void setFlagBaseAttr(Operation *op, IntegerAttr attr) {
+  if (auto initOp = dyn_cast<InitializeL2LPipeOp>(op)) {
+    if (!initOp.getFlagBaseAttr())
+      setFlagBaseAttr(initOp, attr);
+    return;
   }
+  auto initOp = cast<InitializeL2G2LPipeOp>(op);
+  if (!initOp.getFlagBaseAttr())
+    setFlagBaseAttr(initOp, attr);
+}
+
+static bool samePipeInitSignature(const PipeInitInfo &lhs,
+                                  const PipeInitInfo &rhs) {
+  return std::tie(lhs.dirMask, lhs.slotSize, lhs.slotNum, lhs.localSlotNum) ==
+         std::tie(rhs.dirMask, rhs.slotSize, rhs.slotNum, rhs.localSlotNum);
+}
+
+static FailureOr<SmallVector<PipeComponent>>
+buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
+                         const PipeInitGroups &keyedInits) {
+  llvm::DenseMap<Operation *, SmallVector<Operation *>> adjacency;
+  llvm::DenseMap<Operation *, const PipeInitInfo *> infoByOp;
+  for (const PipeInitInfo &info : initInfos) {
+    adjacency[info.op];
+    infoByOp[info.op] = &info;
+  }
+
+  for (const auto &it : keyedInits) {
+    SmallVector<Operation *> uniqueOps;
+    for (Operation *op : it.second) {
+      if (std::find(uniqueOps.begin(), uniqueOps.end(), op) == uniqueOps.end())
+        uniqueOps.push_back(op);
+    }
+    for (size_t i = 0; i < uniqueOps.size(); ++i) {
+      for (size_t j = i + 1; j < uniqueOps.size(); ++j) {
+        adjacency[uniqueOps[i]].push_back(uniqueOps[j]);
+        adjacency[uniqueOps[j]].push_back(uniqueOps[i]);
+      }
+    }
+  }
+
+  SmallVector<PipeComponent> components;
+  llvm::SmallPtrSet<Operation *, 16> visited;
+  for (const PipeInitInfo &rootInfo : initInfos) {
+    if (!visited.insert(rootInfo.op).second)
+      continue;
+
+    SmallVector<Operation *> stack{rootInfo.op};
+    PipeComponent component;
+    while (!stack.empty()) {
+      Operation *current = stack.pop_back_val();
+      component.ops.push_back(current);
+      for (Operation *neighbor : adjacency[current]) {
+        if (visited.insert(neighbor).second)
+          stack.push_back(neighbor);
+      }
+    }
+
+    if (component.ops.size() != 2) {
+      return rootInfo.op->emitOpError(
+          "requires a complete compatible peer init pair when local_addr comes "
+          "from pto.reserve_buffer or pto.import_reserved_buffer");
+    }
+
+    const PipeInitInfo &lhs = *infoByOp[component.ops[0]];
+    const PipeInitInfo &rhs = *infoByOp[component.ops[1]];
+    if (!samePipeInitSignature(lhs, rhs)) {
+      return component.ops.front()->emitOpError(
+          "requires peer pipe init ops to agree on direction and pipe shape");
+    }
+
+    component.dirMask = lhs.dirMask;
+    component.slotSize = lhs.slotSize;
+    component.slotNum = lhs.slotNum;
+    component.localSlotNum = lhs.localSlotNum;
+    component.flagWidth = component.dirMask == 3 ? 4u : 2u;
+
+    for (Operation *op : component.ops) {
+      const PipeInitInfo &info = *infoByOp[op];
+      component.participants.insert(getFuncSymbol(info.funcOp));
+      if (auto flagBaseAttr = getFlagBaseAttr(op)) {
+        if (component.explicitFlagBase &&
+            *component.explicitFlagBase != flagBaseAttr.getInt()) {
+          return op->emitOpError(
+              "conflicting explicit flag_base across peer pipe inits");
+        }
+        component.explicitFlagBase = flagBaseAttr.getInt();
+      }
+    }
+    if (component.participants.size() != 2) {
+      return component.ops.front()->emitOpError(
+          "requires a complete compatible peer init pair when local_addr comes "
+          "from pto.reserve_buffer or pto.import_reserved_buffer");
+    }
+
+    components.push_back(std::move(component));
+  }
+
+  return components;
+}
+
+static bool overlaps(const FlagInterval &lhs, const FlagInterval &rhs) {
+  return lhs.begin < rhs.end && rhs.begin < lhs.end;
+}
+
+static int32_t alignToEven(int32_t value) {
+  return value % 2 == 0 ? value : value + 1;
+}
+
+static LogicalResult reserveComponentFlagBase(const PipeComponent &component,
+                                              int32_t base,
+                                              PipeFlagUsage &usedByFunc) {
+  FlagInterval interval{base, base + static_cast<int32_t>(component.flagWidth)};
+  if (interval.end > kMaxHardwareFlagIds) {
+    return component.ops.front()->emitOpError()
+           << "requires all pipe components in a function to fit within "
+           << kMaxHardwareFlagIds << " hardware flag ids";
+  }
+  for (const std::string &funcName : component.participants) {
+    for (const FlagInterval &used : usedByFunc[funcName]) {
+      if (!overlaps(interval, used))
+        continue;
+      return component.ops.front()->emitOpError(
+          "conflicting flag_base across peer pipe init components in the same function");
+    }
+  }
+
+  for (const std::string &funcName : component.participants)
+    usedByFunc[funcName].push_back(interval);
   return success();
 }
 
-static FailureOr<int32_t> chooseFlagBaseForPeerGroup(
-    const SmallVector<PipeInitInfo> &inits) {
-  std::optional<int32_t> chosenBase;
-  for (const PipeInitInfo &info : inits) {
-    IntegerAttr flagBaseAttr;
-    if (auto initOp = dyn_cast<InitializeL2LPipeOp>(info.op))
-      flagBaseAttr = getFlagBaseAttr(initOp);
-    else
-      flagBaseAttr = getFlagBaseAttr(cast<InitializeL2G2LPipeOp>(info.op));
-
-    if (!flagBaseAttr)
-      continue;
-    if (chosenBase && *chosenBase != flagBaseAttr.getInt()) {
-      return info.op->emitOpError(
-          "conflicting explicit flag_base across peer pipe inits");
+static FailureOr<int32_t> chooseFlagBaseForComponent(const PipeComponent &component,
+                                                     PipeFlagUsage &usedByFunc) {
+  if (component.explicitFlagBase) {
+    if (failed(reserveComponentFlagBase(component, *component.explicitFlagBase,
+                                        usedByFunc))) {
+      return failure();
     }
-    chosenBase = flagBaseAttr.getInt();
+    return *component.explicitFlagBase;
   }
-  return chosenBase.value_or(0);
-}
 
-static void assignMissingFlagBases(const SmallVector<PipeInitInfo> &inits,
-                                   IntegerAttr flagBaseAttr) {
-  for (const PipeInitInfo &info : inits) {
-    if (auto initOp = dyn_cast<InitializeL2LPipeOp>(info.op)) {
-      if (!getFlagBaseAttr(initOp))
-        setFlagBaseAttr(initOp, flagBaseAttr);
-      continue;
+  int32_t candidateBase = 0;
+  while (true) {
+    candidateBase = alignToEven(candidateBase);
+    FlagInterval candidate{candidateBase,
+                           candidateBase +
+                               static_cast<int32_t>(component.flagWidth)};
+    bool conflict = false;
+    int32_t nextCandidate = candidateBase + 2;
+    for (const std::string &funcName : component.participants) {
+      for (const FlagInterval &used : usedByFunc[funcName]) {
+        if (!overlaps(candidate, used))
+          continue;
+        conflict = true;
+        nextCandidate = std::max(nextCandidate, alignToEven(used.end));
+      }
     }
-
-    auto initOp = cast<InitializeL2G2LPipeOp>(info.op);
-    if (!getFlagBaseAttr(initOp))
-      setFlagBaseAttr(initOp, flagBaseAttr);
+    if (!conflict)
+      break;
+    candidateBase = nextCandidate;
   }
+
+  if (failed(reserveComponentFlagBase(component, candidateBase, usedByFunc)))
+    return failure();
+  return candidateBase;
 }
 
 struct PTOResolveReservedBuffersPass
     : public mlir::pto::impl::PTOResolveReservedBuffersBase<
           PTOResolveReservedBuffersPass> {
   LogicalResult assignPeerAwareFlagBases(ModuleOp moduleOp) {
-    // Group internal pipe init ops by their logical pipe identity, then fill
-    // missing flag_base attrs so both sides of the same logical pipe agree.
+    // Build peer-connected pipe-init components, assign one consistent
+    // flag_base per component, and reserve non-overlapping flag ranges per
+    // function so multiple frontend pipes can coexist safely.
+    SmallVector<PipeInitInfo> initInfos;
     PipeInitGroups keyedInits;
-    PipeParticipants keyedParticipants;
     LogicalResult status = success();
 
     auto collectInit = [&](auto initOp) {
       if (failed(status))
         return;
-      status = collectPeerAwareInit(initOp, keyedInits, keyedParticipants);
+      status = collectPeerAwareInit(initOp, initInfos, keyedInits);
     };
 
     moduleOp.walk([&](InitializeL2LPipeOp initOp) { collectInit(initOp); });
@@ -227,17 +378,19 @@ struct PTOResolveReservedBuffersPass
     if (failed(status))
       return failure();
 
-    if (failed(validatePeerInitGroups(keyedInits, keyedParticipants)))
+    auto componentsOr = buildPeerAwareComponents(initInfos, keyedInits);
+    if (failed(componentsOr))
       return failure();
 
     OpBuilder builder(moduleOp.getContext());
-    for (const auto &it : keyedInits) {
-      const auto &inits = it.second;
-      auto chosenBaseOr = chooseFlagBaseForPeerGroup(inits);
+    PipeFlagUsage usedByFunc;
+    for (const PipeComponent &component : *componentsOr) {
+      auto chosenBaseOr = chooseFlagBaseForComponent(component, usedByFunc);
       if (failed(chosenBaseOr))
         return failure();
       auto flagBaseAttr = builder.getI32IntegerAttr(*chosenBaseOr);
-      assignMissingFlagBases(inits, flagBaseAttr);
+      for (Operation *op : component.ops)
+        setFlagBaseAttr(op, flagBaseAttr);
     }
 
     return success();

--- a/test/basic/tpush_tpop_frontend_default_id_compat_a5.pto
+++ b/test/basic/tpush_tpop_frontend_default_id_compat_a5.pto
@@ -1,4 +1,4 @@
-// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
 
 module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
@@ -12,12 +12,16 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
     %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 1}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
+
+    %mat_tile = pto.tpop_from_aiv {split = 0}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tfree_from_aiv {split = 0}
     return
   }
 
@@ -32,15 +36,24 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
-    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
-    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
+    %recv_tile = pto.tpop_from_aic {split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tfree_from_aic {id = 0, split = 0}
+    pto.tfree_from_aic {split = 0}
     return
   }
 }
 
-// CHECK: error: 'pto.initialize_l2l_pipe' op conflicting pipe split usage across peer pipe init ops
+// A5-LABEL: AICORE void cube_kernel(
+// A5: TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, true>
+// A5: TPUSH<TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, true>
+// A5: TPOP<TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, true>
+// A5: TFREE<TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, true>
+
+// A5-LABEL: AICORE void vector_kernel(
+// A5: TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, true>
+// A5: TPOP<TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, true>
+// A5: TFREE<TPipe<0, Direction::DIR_BOTH, 1024, 4, 2, true>

--- a/test/basic/tpush_tpop_frontend_multi_id_a5.pto
+++ b/test/basic/tpush_tpop_frontend_multi_id_a5.pto
@@ -1,0 +1,85 @@
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+module {
+  func.func @cube_kernel()
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+
+    %v2c_local = pto.reserve_buffer {
+      name = "v2c_fifo",
+      size = 4096,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+    %c2v_import = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
+
+    // id = 10: C2V only
+    pto.aic_initialize_pipe {id = 10, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    // id = 20: V2C only
+    pto.aic_initialize_pipe {id = 20, dir_mask = 2, slot_size = 1024}
+      (c2v_consumer_buf = %c0_i32 : i32,
+       v2c_consumer_buf = %v2c_local : i32)
+
+    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 10, split = 0}
+
+    %mat_tile = pto.tpop_from_aiv {id = 20, split = 0}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tfree_from_aiv {id = 20, split = 0}
+    return
+  }
+
+  func.func @vector_kernel()
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i32 = arith.constant 0 : i32
+
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    %v2c_import = pto.import_reserved_buffer {
+      name = "v2c_fifo",
+      peer_func = @cube_kernel
+    } -> i32
+
+    // id = 10: C2V only
+    pto.aiv_initialize_pipe {id = 10, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_local : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    // id = 20: V2C only
+    pto.aiv_initialize_pipe {id = 20, dir_mask = 2, slot_size = 1024}
+      (c2v_consumer_buf = %c0_i32 : i32,
+       v2c_consumer_buf = %v2c_import : i32)
+
+    %vec_src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush_to_aic(%vec_src : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 20, split = 0}
+
+    %recv_tile = pto.tpop_from_aic {id = 10, split = 0}
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tfree_from_aic {id = 10, split = 0}
+    return
+  }
+}
+
+// A5-LABEL: AICORE void cube_kernel(
+// A5: Direction::DIR_C2V
+// A5: Direction::DIR_V2C
+// A5: TPUSH<TPipe<
+// A5: TPOP<TPipe<
+// A5: TFREE<TPipe<
+
+// A5-LABEL: AICORE void vector_kernel(
+// A5: Direction::DIR_C2V
+// A5: Direction::DIR_V2C
+// A5: TPUSH<TPipe<
+// A5: TPOP<TPipe<
+// A5: TFREE<TPipe<

--- a/test/basic/tpush_tpop_frontend_same_direction_conflict_a5.pto
+++ b/test/basic/tpush_tpop_frontend_same_direction_conflict_a5.pto
@@ -1,0 +1,31 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+    %c2v_import = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
+
+    pto.aic_initialize_pipe {id = 10, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 20, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    return
+  }
+
+  func.func @vector_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    return
+  }
+}
+
+// CHECK: error: 'pto.initialize_l2l_pipe' op requires a complete compatible peer init pair when local_addr comes from pto.reserve_buffer or pto.import_reserved_buffer

--- a/test/basic/tpush_tpop_frontend_same_direction_multi_a5.pto
+++ b/test/basic/tpush_tpop_frontend_same_direction_multi_a5.pto
@@ -1,0 +1,77 @@
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+module {
+  func.func @cube_kernel()
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+
+    %c2v_import0 = pto.import_reserved_buffer {
+      name = "c2v_fifo_0",
+      peer_func = @vector_kernel
+    } -> i32
+    %c2v_import1 = pto.import_reserved_buffer {
+      name = "c2v_fifo_1",
+      peer_func = @vector_kernel
+    } -> i32
+
+    pto.aic_initialize_pipe {id = 10, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_import0 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 20, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_import1 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %tile0 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    %tile1 = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush_to_aiv(%tile0 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 10, split = 0}
+    pto.tpush_to_aiv(%tile1 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 20, split = 0}
+    return
+  }
+
+  func.func @vector_kernel()
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i32 = arith.constant 0 : i32
+
+    %c2v_local0 = pto.reserve_buffer {
+      name = "c2v_fifo_0",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    %c2v_local1 = pto.reserve_buffer {
+      name = "c2v_fifo_1",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+
+    pto.aiv_initialize_pipe {id = 10, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_local0 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 20, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_local1 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %recv0 = pto.tpop_from_aic {id = 10, split = 0}
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %recv1 = pto.tpop_from_aic {id = 20, split = 0}
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tfree_from_aic {id = 10, split = 0}
+    pto.tfree_from_aic {id = 20, split = 0}
+    return
+  }
+}
+
+// A5-LABEL: AICORE void cube_kernel(
+// A5: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_C2V, 1024, 8, 2, true>(
+// A5: auto {{v[0-9]+}} = TPipe<2, Direction::DIR_C2V, 1024, 8, 2, true>(
+// A5: TPUSH<TPipe<0, Direction::DIR_C2V, 1024, 8, 2, true>
+// A5: TPUSH<TPipe<2, Direction::DIR_C2V, 1024, 8, 2, true>
+
+// A5-LABEL: AICORE void vector_kernel(
+// A5: auto {{v[0-9]+}} = TPipe<0, Direction::DIR_C2V, 1024, 8, 2, true>(
+// A5: auto {{v[0-9]+}} = TPipe<2, Direction::DIR_C2V, 1024, 8, 2, true>(
+// A5: TPOP<TPipe<0, Direction::DIR_C2V, 1024, 8, 2, true>
+// A5: TPOP<TPipe<2, Direction::DIR_C2V, 1024, 8, 2, true>
+// A5: TFREE<TPipe<0, Direction::DIR_C2V, 1024, 8, 2, true>
+// A5: TFREE<TPipe<2, Direction::DIR_C2V, 1024, 8, 2, true>

--- a/test/lit/pto/issue481_addptr_gm_slot_buffer.pto
+++ b/test/lit/pto/issue481_addptr_gm_slot_buffer.pto
@@ -9,7 +9,7 @@ module {
     %2 = arith.muli %1, %c2048 : index
     %3 = pto.addptr %arg0, %2 : <f32> -> <f32>
     %4 = pto.import_reserved_buffer{name = "c2v_fifo", peer_func = @vector_kernel} -> i32
-    pto.aic_initialize_pipe{dir_mask = 1, slot_size = 1024} (gm_slot_buffer = %3 : !pto.ptr<f32>, c2v_consumer_buf = %4 : i32, v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe{id = 0, dir_mask = 1, slot_size = 1024} (gm_slot_buffer = %3 : !pto.ptr<f32>, c2v_consumer_buf = %4 : i32, v2c_consumer_buf = %c0_i32 : i32)
     return
   }
 
@@ -21,8 +21,8 @@ module {
     %2 = arith.muli %1, %c2048 : index
     %3 = pto.addptr %arg0, %2 : <f32> -> <f32>
     %4 = pto.reserve_buffer{name = "c2v_fifo", size = 8192, location = <vec>, auto = true} -> i32
-    pto.aiv_initialize_pipe{dir_mask = 1, slot_size = 1024} (gm_slot_buffer = %3 : !pto.ptr<f32>, c2v_consumer_buf = %4 : i32, v2c_consumer_buf = %c0_i32 : i32)
-    pto.tfree_from_aic{split = 1}
+    pto.aiv_initialize_pipe{id = 0, dir_mask = 1, slot_size = 1024} (gm_slot_buffer = %3 : !pto.ptr<f32>, c2v_consumer_buf = %4 : i32, v2c_consumer_buf = %c0_i32 : i32)
+    pto.tfree_from_aic{id = 0, split = 1}
     return
   }
 

--- a/test/lit/pto/resolve_reserved_buffers_reject_flag_id_overflow_a5.pto
+++ b/test/lit/pto/resolve_reserved_buffers_reject_flag_id_overflow_a5.pto
@@ -1,0 +1,49 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %fifo0 = pto.reserve_buffer {name = "fifo0", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo1 = pto.reserve_buffer {name = "fifo1", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo2 = pto.reserve_buffer {name = "fifo2", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo3 = pto.reserve_buffer {name = "fifo3", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo4 = pto.reserve_buffer {name = "fifo4", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo5 = pto.reserve_buffer {name = "fifo5", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo6 = pto.reserve_buffer {name = "fifo6", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo7 = pto.reserve_buffer {name = "fifo7", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %fifo8 = pto.reserve_buffer {name = "fifo8", size = 4096, location = #pto.address_space<mat>, auto = true} -> i32
+    %p0 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo0 : i32) -> !pto.pipe
+    %p1 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo1 : i32) -> !pto.pipe
+    %p2 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo2 : i32) -> !pto.pipe
+    %p3 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo3 : i32) -> !pto.pipe
+    %p4 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo4 : i32) -> !pto.pipe
+    %p5 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo5 : i32) -> !pto.pipe
+    %p6 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo6 : i32) -> !pto.pipe
+    %p7 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo7 : i32) -> !pto.pipe
+    %p8 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo8 : i32) -> !pto.pipe
+    return
+  }
+
+  func.func @vector_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %fifo0 = pto.import_reserved_buffer {name = "fifo0", peer_func = @cube_kernel} -> i32
+    %fifo1 = pto.import_reserved_buffer {name = "fifo1", peer_func = @cube_kernel} -> i32
+    %fifo2 = pto.import_reserved_buffer {name = "fifo2", peer_func = @cube_kernel} -> i32
+    %fifo3 = pto.import_reserved_buffer {name = "fifo3", peer_func = @cube_kernel} -> i32
+    %fifo4 = pto.import_reserved_buffer {name = "fifo4", peer_func = @cube_kernel} -> i32
+    %fifo5 = pto.import_reserved_buffer {name = "fifo5", peer_func = @cube_kernel} -> i32
+    %fifo6 = pto.import_reserved_buffer {name = "fifo6", peer_func = @cube_kernel} -> i32
+    %fifo7 = pto.import_reserved_buffer {name = "fifo7", peer_func = @cube_kernel} -> i32
+    %fifo8 = pto.import_reserved_buffer {name = "fifo8", peer_func = @cube_kernel} -> i32
+    %p0 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo0 : i32) -> !pto.pipe
+    %p1 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo1 : i32) -> !pto.pipe
+    %p2 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo2 : i32) -> !pto.pipe
+    %p3 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo3 : i32) -> !pto.pipe
+    %p4 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo4 : i32) -> !pto.pipe
+    %p5 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo5 : i32) -> !pto.pipe
+    %p6 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo6 : i32) -> !pto.pipe
+    %p7 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo7 : i32) -> !pto.pipe
+    %p8 = pto.initialize_l2l_pipe {dir_mask = 1, slot_size = 1024, slot_num = 8}(%fifo8 : i32) -> !pto.pipe
+    return
+  }
+}
+
+// CHECK: error: 'pto.initialize_l2l_pipe' op requires all pipe components in a function to fit within 16 hardware flag ids

--- a/test/lit/pto/resolve_reserved_buffers_reject_incomplete_peer_group_a5.pto
+++ b/test/lit/pto/resolve_reserved_buffers_reject_incomplete_peer_group_a5.pto
@@ -25,4 +25,4 @@ module {
   }
 }
 
-// CHECK: error: 'pto.initialize_l2l_pipe' op requires a complete peer init pair when local_addr comes from pto.reserve_buffer or pto.import_reserved_buffer
+// CHECK: error: 'pto.initialize_l2l_pipe' op requires a complete compatible peer init pair when local_addr comes from pto.reserve_buffer or pto.import_reserved_buffer

--- a/test/lit/pto/resolve_reserved_buffers_reject_mixed_dir_both_split_a5.pto
+++ b/test/lit/pto/resolve_reserved_buffers_reject_mixed_dir_both_split_a5.pto
@@ -2,6 +2,8 @@
 
 module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+
     %v2c_local = pto.reserve_buffer {
       name = "v2c_fifo",
       size = 4096,
@@ -12,12 +14,13 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
-      (c2v_consumer_buf = %c2v_import : i32,
-       v2c_consumer_buf = %v2c_local : i32)
 
-    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 1}
+    pto.aic_initialize_pipe {id = 10, dir_mask = 1, slot_size = 1024}
+      (c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 20, dir_mask = 2, slot_size = 1024}
+      (c2v_consumer_buf = %c0_i32 : i32,
+       v2c_consumer_buf = %v2c_local : i32)
     return
   }
 
@@ -32,15 +35,12 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
+
     pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
-
-    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
-      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }
 
-// CHECK: error: 'pto.initialize_l2l_pipe' op conflicting pipe split usage across peer pipe init ops
+// CHECK: error: 'pto.initialize_l2l_pipe' op requires a complete compatible peer init pair when local_addr comes from pto.reserve_buffer or pto.import_reserved_buffer

--- a/test/lit/pto/test_tpush_tpop_roundtrip_nosplit_a5.pto
+++ b/test/lit/pto/test_tpush_tpop_roundtrip_nosplit_a5.pto
@@ -30,11 +30,11 @@ module {
       name = "c2v_fifo",
       peer_func = @test_tpush_tpop_roundtrip_nosplit_a5_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
-    %mat_tile = pto.tpop_from_aiv {split = 0}
+    %mat_tile = pto.tpop_from_aiv {id = 0, split = 0}
       -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %identity_mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %left_tile = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
@@ -49,8 +49,8 @@ module {
     pto.tmov ins(%identity_mat : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%right_tile : !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
     pto.tmatmul ins(%left_tile, %right_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
 
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
-    pto.tfree_from_aiv {split = 0}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
+    pto.tfree_from_aiv {id = 0, split = 0}
     return
   }
 
@@ -73,7 +73,7 @@ module {
       name = "v2c_fifo",
       peer_func = @test_tpush_tpop_roundtrip_nosplit_a5_cube
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
@@ -85,16 +85,16 @@ module {
     %gm_src_tile_view = pto.partition_view %gm_src_view, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
     pto.tload ins(%gm_src_tile_view : !pto.partition_tensor_view<16x16xf32>) outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tmov ins(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%src_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
-    pto.tpush_to_aic(%src_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {split = 0}
+    pto.tpush_to_aic(%src_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {id = 0, split = 0}
 
-    %recv_tile = pto.tpop_from_aic {split = 0}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tmov ins(%recv_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%recv_tile_store : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     %gm_out_view = pto.make_tensor_view %gm_out, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<?x?xf32>
     %gm_out_tile_view = pto.partition_view %gm_out_view, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
     pto.tstore ins(%recv_tile_store : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%gm_out_tile_view : !pto.partition_tensor_view<16x16xf32>)
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }

--- a/test/lit/pto/tpush_tpop_dir_both.pto
+++ b/test/lit/pto/tpush_tpop_dir_both.pto
@@ -22,7 +22,7 @@ module {
       location = #pto.address_space<mat>,
       auto = true
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_reserve : i32)
 
@@ -37,15 +37,15 @@ module {
     pto.tmov ins(%mat_a_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%left_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
 
     // Pop right matrix from vector (V2C direction)
-    %received = pto.tpop_from_aiv {split = 1}
+    %received = pto.tpop_from_aiv {id = 0, split = 1}
       -> !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     pto.tmov ins(%received : !pto.tile_buf<loc=mat, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%right_tile : !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
-    pto.tfree_from_aiv {split = 1}
+    pto.tfree_from_aiv {id = 0, split = 1}
 
     pto.tmatmul ins(%left_tile, %right_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
 
     // Push result to vector (C2V direction)
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 1}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 1}
     return
   }
 
@@ -62,7 +62,7 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_bidir
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
@@ -70,15 +70,15 @@ module {
     %vec_nd = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %vec_nz = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     pto.tmov ins(%vec_nd : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%vec_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
-    pto.tpush_to_aic(%vec_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {split = 1}
+    pto.tpush_to_aic(%vec_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {id = 0, split = 1}
 
     // Pop result from cube (C2V direction), acc 16x16 split=1 gives 8x16 per half
     %vec_print = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %result_tile = pto.tpop_from_aic {split = 1}
+    %result_tile = pto.tpop_from_aic {id = 0, split = 1}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tmov ins(%result_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tprint ins(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tfree_from_aic {split = 1}
+    pto.tfree_from_aic {id = 0, split = 1}
     return
   }
 }

--- a/test/lit/pto/tpush_tpop_dynamic_validshape_a5.pto
+++ b/test/lit/pto/tpush_tpop_dynamic_validshape_a5.pto
@@ -13,13 +13,13 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
-    %mat_tile = pto.tpop_from_aiv(%vr, %vc) {split = 2}
+    %mat_tile = pto.tpop_from_aiv(%vr, %vc) {id = 0, split = 2}
       -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=64, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=512, pad=0>
-    pto.tfree_from_aiv {split = 2}
+    pto.tfree_from_aiv {id = 0, split = 2}
     return
   }
 
@@ -35,13 +35,13 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
-    %recv_tile = pto.tpop_from_aic(%vr, %vc) {split = 2}
+    %recv_tile = pto.tpop_from_aic(%vr, %vc) {id = 0, split = 2}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tfree_from_aic {split = 2}
+    pto.tfree_from_aic {id = 0, split = 2}
     return
   }
 }

--- a/test/lit/pto/tpush_tpop_dynamic_validshape_default_a5.pto
+++ b/test/lit/pto/tpush_tpop_dynamic_validshape_default_a5.pto
@@ -12,13 +12,13 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
-    %mat_tile = pto.tpop_from_aiv {split = 2}
+    %mat_tile = pto.tpop_from_aiv {id = 0, split = 2}
       -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=64, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=512, pad=0>
-    pto.tfree_from_aiv {split = 2}
+    pto.tfree_from_aiv {id = 0, split = 2}
     return
   }
 
@@ -33,13 +33,13 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
-    %recv_tile = pto.tpop_from_aic {split = 2}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 2}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tfree_from_aic {split = 2}
+    pto.tfree_from_aic {id = 0, split = 2}
     return
   }
 }

--- a/test/lit/pto/tpush_tpop_dynamic_validshape_invalid.pto
+++ b/test/lit/pto/tpush_tpop_dynamic_validshape_invalid.pto
@@ -12,7 +12,7 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
     return
@@ -30,13 +30,13 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
-    %recv_tile = pto.tpop_from_aic(%vr, %vc) {split = 0}
+    %recv_tile = pto.tpop_from_aic(%vr, %vc) {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }

--- a/test/lit/pto/tpush_tpop_frontend_lowering_a3.pto
+++ b/test/lit/pto/tpush_tpop_frontend_lowering_a3.pto
@@ -14,19 +14,19 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
        c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
     %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    %mat_tile = pto.tpop_from_aiv {split = 0}
+    %mat_tile = pto.tpop_from_aiv {id = 0, split = 0}
       -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %left_tile = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>
     pto.tmov ins(%mat_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%left_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
-    pto.tfree_from_aiv {split = 0}
+    pto.tfree_from_aiv {id = 0, split = 0}
     return
   }
 
@@ -42,19 +42,19 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
        c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
     %vec_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tpush_to_aic(%vec_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {split = 0}
+    pto.tpush_to_aic(%vec_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0, split = 0}
 
-    %recv_tile = pto.tpop_from_aic {split = 0}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %neg_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tneg ins(%recv_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%neg_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 

--- a/test/lit/pto/tpush_tpop_frontend_lowering_a5.pto
+++ b/test/lit/pto/tpush_tpop_frontend_lowering_a5.pto
@@ -12,18 +12,18 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
     %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
 
-    %mat_tile = pto.tpop_from_aiv {split = 0}
+    %mat_tile = pto.tpop_from_aiv {id = 0, split = 0}
       -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %left_tile = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     pto.tmov ins(%mat_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%left_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
-    pto.tfree_from_aiv {split = 0}
+    pto.tfree_from_aiv {id = 0, split = 0}
     return
   }
 
@@ -38,20 +38,20 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
     %vec_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %vec_tile_nz = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     pto.tmov ins(%vec_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%vec_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
-    pto.tpush_to_aic(%vec_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {split = 0}
+    pto.tpush_to_aic(%vec_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {id = 0, split = 0}
 
-    %recv_tile = pto.tpop_from_aic {split = 0}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %neg_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tneg ins(%recv_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%neg_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }

--- a/test/lit/pto/tpush_tpop_frontend_nosplit_a5.pto
+++ b/test/lit/pto/tpush_tpop_frontend_nosplit_a5.pto
@@ -12,12 +12,12 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024, nosplit = true}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024, nosplit = true}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
     %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     return
   }
 
@@ -32,13 +32,13 @@ module {
       name = "v2c_fifo",
       peer_func = @cube_kernel
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024, nosplit = true}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024, nosplit = true}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
-    %recv_tile = pto.tpop_from_aic {split = 0}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }

--- a/test/lit/pto/tpush_tpop_frontend_nosplit_conflict_a5.pto
+++ b/test/lit/pto/tpush_tpop_frontend_nosplit_conflict_a5.pto
@@ -6,12 +6,12 @@ module {
       name = "c2v_fifo",
       peer_func = @vector_kernel
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024, nosplit = false}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = false}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c2v_import : i32)
 
     %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     return
   }
 
@@ -22,13 +22,13 @@ module {
       location = #pto.address_space<vec>,
       auto = true
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024, nosplit = false}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = false}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %c2v_local : i32)
 
-    %recv_tile = pto.tpop_from_aic {split = 0}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }

--- a/test/samples/Sync/test_frontend_pipe_flag_id_overflow_invalid.pto
+++ b/test/samples/Sync/test_frontend_pipe_flag_id_overflow_invalid.pto
@@ -1,0 +1,107 @@
+module attributes {"pto.device-spec" = "Ascend910B1"} {
+  func.func @cube_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+
+    %fifo0 = pto.import_reserved_buffer {name = "fifo0", peer_func = @vector_kernel} -> i32
+    %fifo1 = pto.import_reserved_buffer {name = "fifo1", peer_func = @vector_kernel} -> i32
+    %fifo2 = pto.import_reserved_buffer {name = "fifo2", peer_func = @vector_kernel} -> i32
+    %fifo3 = pto.import_reserved_buffer {name = "fifo3", peer_func = @vector_kernel} -> i32
+    %fifo4 = pto.import_reserved_buffer {name = "fifo4", peer_func = @vector_kernel} -> i32
+    %fifo5 = pto.import_reserved_buffer {name = "fifo5", peer_func = @vector_kernel} -> i32
+    %fifo6 = pto.import_reserved_buffer {name = "fifo6", peer_func = @vector_kernel} -> i32
+    %fifo7 = pto.import_reserved_buffer {name = "fifo7", peer_func = @vector_kernel} -> i32
+    %fifo8 = pto.import_reserved_buffer {name = "fifo8", peer_func = @vector_kernel} -> i32
+
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo0 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 1, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo1 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 2, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo2 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 3, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo3 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 4, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo4 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 5, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo5 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 6, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo6 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 7, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo7 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aic_initialize_pipe {id = 8, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo8 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    return
+  }
+
+  func.func @vector_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i32 = arith.constant 0 : i32
+
+    %fifo0 = pto.reserve_buffer {name = "fifo0", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo1 = pto.reserve_buffer {name = "fifo1", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo2 = pto.reserve_buffer {name = "fifo2", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo3 = pto.reserve_buffer {name = "fifo3", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo4 = pto.reserve_buffer {name = "fifo4", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo5 = pto.reserve_buffer {name = "fifo5", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo6 = pto.reserve_buffer {name = "fifo6", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo7 = pto.reserve_buffer {name = "fifo7", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+    %fifo8 = pto.reserve_buffer {name = "fifo8", size = 4096, location = #pto.address_space<vec>, auto = true} -> i32
+
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo0 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 1, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo1 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 2, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo2 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 3, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo3 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 4, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo4 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 5, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo5 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 6, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo6 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 7, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo7 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    pto.aiv_initialize_pipe {id = 8, dir_mask = 1, slot_size = 1024}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %fifo8 : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+    return
+  }
+}

--- a/test/samples/TPushTPop/a3/test1/kernel.pto
+++ b/test/samples/TPushTPop/a3/test1/kernel.pto
@@ -26,7 +26,7 @@ module {
       name = "c2v_fifo",
       peer_func = @matmul_tpush_tpop_print_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
        c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
@@ -50,7 +50,7 @@ module {
 
     pto.tmatmul ins(%left_tile, %right_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
 
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     return
   }
 
@@ -63,17 +63,17 @@ module {
       location = #pto.address_space<vec>,
       auto = true
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
        c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
     %vec_print = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fifo_tile = pto.tpop_from_aic {split = 0}
+    %fifo_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tmov ins(%fifo_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tprint ins(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }

--- a/test/samples/TPushTPop/a3/test2/kernel.pto
+++ b/test/samples/TPushTPop/a3/test2/kernel.pto
@@ -28,7 +28,7 @@ module {
       name = "c2v_fifo",
       peer_func = @matmul_tpush_tpop_loop4_print_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
        c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
@@ -53,7 +53,7 @@ module {
       pto.tload ins(%gm_b_iter : !pto.partition_tensor_view<16x16xf32>) outs(%mat_b_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
       pto.tmov ins(%mat_b_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%right_tile : !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
       pto.tmatmul ins(%left_tile, %right_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
-      pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
+      pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
     }
     return
   }
@@ -70,18 +70,18 @@ module {
       location = #pto.address_space<vec>,
       auto = true
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
        c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
     %vec_print = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     scf.for %i = %c0 to %c4 step %c1 {
-      %fifo_tile = pto.tpop_from_aic {split = 0}
+      %fifo_tile = pto.tpop_from_aic {id = 0, split = 0}
         -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
       pto.tmov ins(%fifo_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       pto.tprint ins(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-      pto.tfree_from_aic {split = 0}
+      pto.tfree_from_aic {id = 0, split = 0}
     }
     return
   }

--- a/test/samples/TPushTPop/test1/kernel.pto
+++ b/test/samples/TPushTPop/test1/kernel.pto
@@ -23,7 +23,7 @@ module {
       name = "c2v_fifo",
       peer_func = @matmul_tpush_tpop_print_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
@@ -46,7 +46,7 @@ module {
 
     pto.tmatmul ins(%left_tile, %right_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
 
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 1}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 1}
     return
   }
 
@@ -59,16 +59,16 @@ module {
       location = #pto.address_space<vec>,
       auto = true
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
     %vec_print = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fifo_tile = pto.tpop_from_aic {split = 1}
+    %fifo_tile = pto.tpop_from_aic {id = 0, split = 1}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tmov ins(%fifo_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tprint ins(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tfree_from_aic {split = 1}
+    pto.tfree_from_aic {id = 0, split = 1}
     return
   }
 }

--- a/test/samples/TPushTPop/test2/kernel.pto
+++ b/test/samples/TPushTPop/test2/kernel.pto
@@ -25,7 +25,7 @@ module {
       name = "c2v_fifo",
       peer_func = @matmul_tpush_tpop_loop4_print_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
@@ -49,7 +49,7 @@ module {
       pto.tload ins(%gm_b_iter : !pto.partition_tensor_view<16x16xf32>) outs(%mat_b_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
       pto.tmov ins(%mat_b_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%right_tile : !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
       pto.tmatmul ins(%left_tile, %right_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
-      pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 1}
+      pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 1}
     }
     return
   }
@@ -66,17 +66,17 @@ module {
       location = #pto.address_space<vec>,
       auto = true
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
     %vec_print = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     scf.for %i = %c0 to %c4 step %c1 {
-      %fifo_tile = pto.tpop_from_aic {split = 1}
+      %fifo_tile = pto.tpop_from_aic {id = 0, split = 1}
         -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
       pto.tmov ins(%fifo_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       pto.tprint ins(%vec_print : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-      pto.tfree_from_aic {split = 1}
+      pto.tfree_from_aic {id = 0, split = 1}
     }
     return
   }

--- a/test/samples/TPushTPop/test3/kernel.pto
+++ b/test/samples/TPushTPop/test3/kernel.pto
@@ -28,11 +28,11 @@ module {
       name = "c2v_fifo",
       peer_func = @round_trip_tpush_tpop_print_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %v2c_local : i32)
 
-    %mat_tile = pto.tpop_from_aiv {split = 0}
+    %mat_tile = pto.tpop_from_aiv {id = 0, split = 0}
       -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %identity_mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
     %left_tile = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
@@ -47,8 +47,8 @@ module {
     pto.tmov ins(%identity_mat : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%right_tile : !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
     pto.tmatmul ins(%left_tile, %right_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
 
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 0}
-    pto.tfree_from_aiv {split = 0}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
+    pto.tfree_from_aiv {id = 0, split = 0}
     return
   }
 
@@ -69,7 +69,7 @@ module {
       name = "v2c_fifo",
       peer_func = @round_trip_tpush_tpop_print_cube
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 3, slot_size = 1024}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 3, slot_size = 1024}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
@@ -81,13 +81,13 @@ module {
     %gm_src_tile_view = pto.partition_view %gm_src_view, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x16xf32>
     pto.tload ins(%gm_src_tile_view : !pto.partition_tensor_view<16x16xf32>) outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tmov ins(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%src_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
-    pto.tpush_to_aic(%src_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {split = 0}
+    pto.tpush_to_aic(%src_tile_nz : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>) {id = 0, split = 0}
 
-    %recv_tile = pto.tpop_from_aic {split = 0}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tmov ins(%recv_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%recv_tile_print : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tprint ins(%recv_tile_print : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tfree_from_aic {split = 0}
+    pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }

--- a/test/samples/TPushTPop/test4/kernel.pto
+++ b/test/samples/TPushTPop/test4/kernel.pto
@@ -37,7 +37,7 @@ module {
       name = "scope3_incore_4_incore_0_c2v_slot_buffer",
       peer_func = @scope3_incore_4_incore_0_tpush_tpop_add_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 8192}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 8192}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
@@ -60,7 +60,7 @@ module {
 
       %acc_tile = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
       pto.tmatmul ins(%lhs_left, %rhs_right : !pto.tile_buf<loc=left, dtype=bf16, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=bf16, rows=64, cols=128, v_row=64, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
-      pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 1}
+      pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 1}
     }
     return
   }
@@ -91,7 +91,7 @@ module {
       auto = false,
       base = 0
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 8192}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 8192}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
@@ -104,12 +104,12 @@ module {
       %gm_tile_view = pto.partition_view %gm_out_view, offsets = [%subblock_row, %col_offset], sizes = [%c8, %c128] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<8x128xf32>
       pto.tload ins(%gm_tile_view : !pto.partition_tensor_view<8x128xf32>) outs(%gm_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
-      %recv_tile = pto.tpop_from_aic {split = 1}
+      %recv_tile = pto.tpop_from_aic {id = 0, split = 1}
         -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
       %sum_tile = pto.alloc_tile addr = %c65536_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
       pto.tadd ins(%gm_tile, %recv_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%sum_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-      pto.tfree_from_aic {split = 1}
+      pto.tfree_from_aic {id = 0, split = 1}
       pto.tstore ins(%sum_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%gm_tile_view : !pto.partition_tensor_view<8x128xf32>)
     }
     return

--- a/test/samples/TPushTPop/test5/kernel.pto
+++ b/test/samples/TPushTPop/test5/kernel.pto
@@ -33,7 +33,7 @@ module {
       name = "tpush_tpop_left_right_slot_buffer",
       peer_func = @tpush_tpop_left_right_add_vector
     } -> i32
-    pto.aic_initialize_pipe {dir_mask = 1, slot_size = 8192}
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 8192}
       (c2v_consumer_buf = %c2v_import : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
@@ -53,7 +53,7 @@ module {
 
     %acc_tile = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
     pto.tmatmul ins(%lhs_left, %rhs_right : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f32, rows=64, cols=128, v_row=64, v_col=128, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {split = 2}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 2}
     return
   }
 
@@ -81,7 +81,7 @@ module {
       auto = false,
       base = 0
     } -> i32
-    pto.aiv_initialize_pipe {dir_mask = 1, slot_size = 8192}
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 8192}
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %c0_i32 : i32)
 
@@ -90,11 +90,11 @@ module {
     %gm_tile_view = pto.partition_view %gm_out_view, offsets = [%c0, %col_offset], sizes = [%c16, %c64] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x64xf32>
     %gm_tile = pto.alloc_tile addr = %c65536_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tload ins(%gm_tile_view : !pto.partition_tensor_view<16x64xf32>) outs(%gm_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    %recv_tile = pto.tpop_from_aic {split = 2}
+    %recv_tile = pto.tpop_from_aic {id = 0, split = 2}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %sum_tile = pto.alloc_tile addr = %c65536_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tadd ins(%gm_tile, %recv_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%sum_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tfree_from_aic {split = 2}
+    pto.tfree_from_aic {id = 0, split = 2}
     pto.tstore ins(%sum_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%gm_tile_view : !pto.partition_tensor_view<16x64xf32>)
     return
   }

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -1094,6 +1094,10 @@ PY
         *-pto-ir.pto) continue ;;
       esac
       base="$(basename "$f" .pto)"
+      local expect_fail=0
+      case "$base" in
+        *_invalid|*_xfail) expect_fail=1 ;;
+      esac
       if [[ ( "$base" == "test_tmov_col_major_16x1_align_a5" || \
               "$base" == "test_tmov_row_major_1x16_control_a5" || \
               "$base" == "decode_projection_incore_0" || \
@@ -1117,17 +1121,26 @@ PY
             "$base" == "test_tmov_col_major_16x1_align_a5" || \
             "$base" == "test_tmov_row_major_1x16_control_a5" || \
             "$base" == "decode_projection_incore_0" || \
-            "$base" == "rmsnorm_incore_0" ]]; then
+            "$base" == "rmsnorm_incore_0" || \
+            "$base" == "test_frontend_pipe_flag_id_overflow_invalid" ]]; then
         sample_use_ptobc_roundtrip=0
       fi
       if [[ $sample_use_ptobc_roundtrip -eq 1 ]]; then
         # Allow generic escape for ops that are not yet in the compact v0 opcode table.
         if ! PTOBC_ALLOW_GENERIC=1 "$ptobc" encode "$f" -o "$ptobc_file" >/dev/null 2>&1; then
+          if [[ $expect_fail -eq 1 ]]; then
+            echo -e "${A}(${base}.pto)\tXFAIL\tptobc encode failed as expected"
+            continue
+          fi
           echo -e "${A}(${base}.pto)\tFAIL\tptobc encode failed: $(basename "$f")"
           overall=1
           continue
         fi
         if ! "$ptobc" decode "$ptobc_file" -o "$decoded_pto" >/dev/null 2>&1; then
+          if [[ $expect_fail -eq 1 ]]; then
+            echo -e "${A}(${base}.pto)\tXFAIL\tptobc decode failed as expected"
+            continue
+          fi
           echo -e "${A}(${base}.pto)\tFAIL\tptobc decode failed: $(basename "$ptobc_file")"
           overall=1
           continue
@@ -1136,8 +1149,25 @@ PY
       fi
 
       local -a ptoas_cmd=("${ptoas_cmd_base[@]}" "$pto_input" -o "$cpp")
-      if ! "${ptoas_cmd[@]}" >/dev/null 2>&1; then
+      local ptoas_log="${out_subdir}/${base}-ptoas.log"
+      if ! "${ptoas_cmd[@]}" >"${ptoas_log}" 2>&1; then
+        if [[ $expect_fail -eq 1 ]]; then
+          if [[ "$base" == "test_frontend_pipe_flag_id_overflow_invalid" ]]; then
+            if ! grep -Fq "fit within 16 hardware flag ids" "${ptoas_log}"; then
+              echo -e "${A}(${base}.pto)\tFAIL\texpected hardware flag budget diagnostic not found"
+              overall=1
+              continue
+            fi
+          fi
+          echo -e "${A}(${base}.pto)\tXFAIL\tptoas failed as expected"
+          continue
+        fi
         echo -e "${A}(${base}.pto)\tFAIL\tptoas failed: $(basename "$f")"
+        overall=1
+        continue
+      fi
+      if [[ $expect_fail -eq 1 ]]; then
+        echo -e "${A}(${base}.pto)\tFAIL\texpected failure but succeeded"
         overall=1
         continue
       fi

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1093,6 +1093,8 @@ int main(int argc, char **argv) {
   PassManager pm(&context);
   
   pm.addNestedPass<mlir::func::FuncOp>(
+      pto::createPTOAssignDefaultFrontendPipeIdPass());
+  pm.addNestedPass<mlir::func::FuncOp>(
       pto::createPTOLowerFrontendPipeOpsPass());
   //pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addPass(pto::createPTOInferValidatePipeInitPass());

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -163,6 +163,16 @@ inline constexpr OpInfo kOpTable[] = {
   {0x107B, "pto.tcolargmax", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x107C, "pto.tcolargmin", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x107D, "pto.tsync", 0, 0x00, 0x02, 0, 0, 0, 0x00},
+  {0x107E, "pto.reserve_buffer", 0, 0x01, 0x00, 0, 1, 0, 0x00},
+  {0x107F, "pto.import_reserved_buffer", 0, 0x01, 0x00, 0, 1, 0, 0x00},
+  {0x1080, "pto.aic_initialize_pipe", 0, 0x00, 0x02, 0, 0, 0, 0x00},
+  {0x1081, "pto.aiv_initialize_pipe", 0, 0x00, 0x02, 0, 0, 0, 0x00},
+  {0x1082, "pto.tpush_to_aiv", 0, 0x00, 0x00, 1, 0, 0, 0x00},
+  {0x1083, "pto.tpush_to_aic", 0, 0x00, 0x00, 1, 0, 0, 0x00},
+  {0x1084, "pto.tpop_from_aic", 0, 0x01, 0x02, 0, 1, 0, 0x00},
+  {0x1085, "pto.tpop_from_aiv", 0, 0x01, 0x02, 0, 1, 0, 0x00},
+  {0x1086, "pto.tfree_from_aic", 0, 0x00, 0x00, 0, 0, 0, 0x00},
+  {0x1087, "pto.tfree_from_aiv", 0, 0x00, 0x00, 0, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -337,6 +347,16 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.tcolargmax", 0x107B)
     .Case("pto.tcolargmin", 0x107C)
     .Case("pto.tsync", 0x107D)
+    .Case("pto.reserve_buffer", 0x107E)
+    .Case("pto.import_reserved_buffer", 0x107F)
+    .Case("pto.aic_initialize_pipe", 0x1080)
+    .Case("pto.aiv_initialize_pipe", 0x1081)
+    .Case("pto.tpush_to_aiv", 0x1082)
+    .Case("pto.tpush_to_aic", 0x1083)
+    .Case("pto.tpop_from_aic", 0x1084)
+    .Case("pto.tpop_from_aiv", 0x1085)
+    .Case("pto.tfree_from_aic", 0x1086)
+    .Case("pto.tfree_from_aiv", 0x1087)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -497,6 +517,16 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.tcolargmax", OpcodeAndVariant{0x107B, 0, 0})
     .Case("pto.tcolargmin", OpcodeAndVariant{0x107C, 0, 0})
     .Case("pto.tsync", OpcodeAndVariant{0x107D, 0, 0})
+    .Case("pto.reserve_buffer", OpcodeAndVariant{0x107E, 0, 0})
+    .Case("pto.import_reserved_buffer", OpcodeAndVariant{0x107F, 0, 0})
+    .Case("pto.aic_initialize_pipe", OpcodeAndVariant{0x1080, 0, 0})
+    .Case("pto.aiv_initialize_pipe", OpcodeAndVariant{0x1081, 0, 0})
+    .Case("pto.tpush_to_aiv", OpcodeAndVariant{0x1082, 0, 0})
+    .Case("pto.tpush_to_aic", OpcodeAndVariant{0x1083, 0, 0})
+    .Case("pto.tpop_from_aic", OpcodeAndVariant{0x1084, 0, 0})
+    .Case("pto.tpop_from_aiv", OpcodeAndVariant{0x1085, 0, 0})
+    .Case("pto.tfree_from_aic", OpcodeAndVariant{0x1086, 0, 0})
+    .Case("pto.tfree_from_aiv", OpcodeAndVariant{0x1087, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})

--- a/tools/ptobc/testdata/frontend_pipe_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/frontend_pipe_v0_roundtrip.pto
@@ -1,5 +1,3 @@
-// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
-
 module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
     %v2c_local = pto.reserve_buffer {
@@ -17,7 +15,11 @@ module {
        v2c_consumer_buf = %v2c_local : i32)
 
     %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
-    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 1}
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
+
+    %mat_tile = pto.tpop_from_aiv {id = 0, split = 0}
+      -> !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tfree_from_aiv {id = 0, split = 0}
     return
   }
 
@@ -36,11 +38,12 @@ module {
       (c2v_consumer_buf = %c2v_local : i32,
        v2c_consumer_buf = %v2c_import : i32)
 
+    %vec_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tpush_to_aic(%vec_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {id = 0, split = 0}
+
     %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
       -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tfree_from_aic {id = 0, split = 0}
     return
   }
 }
-
-// CHECK: error: 'pto.initialize_l2l_pipe' op conflicting pipe split usage across peer pipe init ops

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -56,3 +56,10 @@ add_test(NAME ptobc_recent_ops_v0_encode
     TESTDATA_DIR=${PTObc_TESTDATA_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/recent_ops_v0_encode.sh
 )
+
+add_test(NAME ptobc_frontend_pipe_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/frontend_pipe_v0_encode.sh
+)

--- a/tools/ptobc/tests/frontend_pipe_v0_encode.sh
+++ b/tools/ptobc/tests/frontend_pipe_v0_encode.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/frontend_pipe_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_frontend_pipe_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/frontend_pipe_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/frontend_pipe_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.reserve_buffer" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.import_reserved_buffer" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.aic_initialize_pipe" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.aiv_initialize_pipe" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tpush_to_aiv" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tpush_to_aic" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tpop_from_aiv" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tpop_from_aic" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tfree_from_aiv" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.tfree_from_aic" "${ROUNDTRIP}" >/dev/null


### PR DESCRIPTION
Refs #488

## Summary
- update the TPUSH/TPOP frontend design doc to support multiple pipes per function via frontend `id` attributes
- relax the single-`reserve_buffer`/single-`import_reserved_buffer` assumptions in the design
- document the resulting lowering, address planning, verifier, and flag allocation changes

## Testing
- not run (documentation-only change)