### PR TITLE
fix: preserve tdivs dual operand order for PTO-ISA overloads

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -2717,8 +2717,8 @@ For each element (i, j):
 
 | Name | Type | Description |
 |------|------|-------------|
-| `src` | `AnyType` | Source tile buffer |
-| `scalar` | `ScalarType` (signless integer / float) | Scalar divisor (or dividend in reverse mode) |
+| `src/scalar` | `pto.tile_buf/scalar` | Source tile buffer or Scalar divisor (or dividend in reverse mode)|
+| `src/scalar` | `pto.tile_buf/scalar` | Source tile buffer or Scalar divisor (or dividend in reverse mode)|
 | `dst` | `pto.tile_buf` | Destination tile buffer |
 
 **Results:** None. Writes into `dst` via DPS pattern.

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3256,7 +3256,7 @@ def TDivSOp : PTO_TOp<"tdivs", [
 
   let arguments = (ins
     AnyType:$src,
-    ScalarType:$scalar,
+    AnyType:$scalar,
     PTODpsType:$dst
   );
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -397,8 +397,7 @@ void TensorViewType::print(::mlir::AsmPrinter &printer) const {
 // pto.tdivs custom asm to support both:
 //   pto.tdivs ins(%src, %scalar : !pto.tile_buf<...>, f32) outs(%dst : !pto.tile_buf<...>)
 //   pto.tdivs ins(%scalar, %src : f32, !pto.tile_buf<...>) outs(%dst : !pto.tile_buf<...>)
-// The operand order in the op remains (src, scalar, dst); order is determined
-// by the type of the first operand in the textual format.
+// The operand order in the op follows textual input order.
 //===----------------------------------------------------------------------===//
 
 ParseResult mlir::pto::TDivSOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -430,23 +429,11 @@ ParseResult mlir::pto::TDivSOp::parse(OpAsmParser &parser, OperationState &resul
     return parser.emitError(parser.getCurrentLocation(),
                             "expected outs type to be !pto.tile_buf<...>");
 
-  // Determine order based on types: if first operand is tile_buf, order is (tile, scalar)
-  // Otherwise, order is (scalar, tile)
-  const bool scalarFirst = (tile1 != nullptr);
-
-  if (!scalarFirst) {
-    // ins(%src, %scalar : tile_buf, scalar_ty)
-    // Operands in op: (src, scalar, dst)
-    if (parser.resolveOperand(op0, ty0, result.operands) ||
-        parser.resolveOperand(op1, ty1, result.operands))
-      return failure();
-  } else {
-    // ins(%scalar, %src : scalar_ty, tile_buf)
-    // Operands in op: (src, scalar, dst) - need to swap
-    if (parser.resolveOperand(op1, ty1, result.operands) ||
-        parser.resolveOperand(op0, ty0, result.operands))
-      return failure();
-  }
+  // Keep textual order so later lowering can distinguish the two APIs by the
+  // first ins operand type.
+  if (parser.resolveOperand(op0, ty0, result.operands) ||
+      parser.resolveOperand(op1, ty1, result.operands))
+    return failure();
 
   if (parser.resolveOperand(dst, dstTy, result.operands))
     return failure();
@@ -456,29 +443,9 @@ ParseResult mlir::pto::TDivSOp::parse(OpAsmParser &parser, OperationState &resul
 }
 
 void mlir::pto::TDivSOp::print(OpAsmPrinter &p) {
-  // Determine order based on operand types
-  // If src is tile_buf and scalar is not, print (src, scalar)
-  // If src is scalar and scalar is tile_buf, print (scalar, src)
-  auto srcType = getSrc().getType();
-  auto scalarType = getScalar().getType();
-  
-  bool srcIsTile = isa<mlir::pto::TileBufType>(srcType);
-  bool scalarIsTile = isa<mlir::pto::TileBufType>(scalarType);
-  
   p << " ins(";
-  if (srcIsTile && !scalarIsTile) {
-    // Print: (tile, scalar) - operands are already in correct order
-    p << getSrc() << ", " << getScalar() << " : "
-      << getSrc().getType() << ", " << getScalar().getType();
-  } else if (!srcIsTile && scalarIsTile) {
-    // Print: (scalar, tile) - need to swap operands in output
-    p << getScalar() << ", " << getSrc() << " : "
-      << getScalar().getType() << ", " << getSrc().getType();
-  } else {
-    // Default: assume src is tile (should not happen if types are correct)
-    p << getSrc() << ", " << getScalar() << " : "
-      << getSrc().getType() << ", " << getScalar().getType();
-  }
+  p << getSrc() << ", " << getScalar() << " : "
+    << getSrc().getType() << ", " << getScalar().getType();
   p << ") outs(" << getDst() << " : " << getDst().getType() << ")";
 
   p.printOptionalAttrDict((*this)->getAttrs());
@@ -3845,32 +3812,64 @@ LogicalResult mlir::pto::TDivOp::verify() {
 }
 
 mlir::LogicalResult mlir::pto::TDivSOp::verify() {
+  auto isTileLike = [](Type ty) -> bool {
+    return isa<mlir::pto::TileBufType, MemRefType, RankedTensorType,
+               mlir::pto::PartitionTensorViewType>(ty);
+  };
+  auto isScalarLike = [](Type ty) -> bool {
+    return ty.isa<IntegerType, FloatType>();
+  };
+
   auto verifyA2A3 = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
+    Type rhsTy = getScalar().getType();
     Type dstTy = getDst().getType();
-    if (failed(verifyScalarTileOp(*this, srcTy, dstTy, "src", "dst",
+
+    bool srcTile = isTileLike(srcTy);
+    bool rhsTile = isTileLike(rhsTy);
+    bool srcScalar = isScalarLike(srcTy);
+    bool rhsScalar = isScalarLike(rhsTy);
+
+    if (!(srcTile && rhsScalar) && !(srcScalar && rhsTile))
+      return emitOpError("expects one tile-like operand and one scalar operand in ins(...)");
+
+    Type tileTy = srcTile ? srcTy : rhsTy;
+    Type scalarTy = srcTile ? rhsTy : srcTy;
+
+    if (failed(verifyScalarTileOp(*this, tileTy, dstTy, "src", "dst",
                                   /*requireValidRowsEqual=*/true,
                                   /*requireValidColsEqual=*/true)))
       return failure();
-    Type scalarTy = getScalar().getType();
     if (!scalarTy.isa<IntegerType, FloatType>())
       return emitOpError("scalar must be a scalar type (integer/float)");
-    Type elem = getElemTy(srcTy);
+    Type elem = getElemTy(tileTy);
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
       return emitOpError("expects A2/A3 tdivs element type to be i32/i16/f16/f32");
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
     Type srcTy = getSrc().getType();
+    Type rhsTy = getScalar().getType();
     Type dstTy = getDst().getType();
-    if (failed(verifyScalarTileOp(*this, srcTy, dstTy, "src", "dst",
+
+    bool srcTile = isTileLike(srcTy);
+    bool rhsTile = isTileLike(rhsTy);
+    bool srcScalar = isScalarLike(srcTy);
+    bool rhsScalar = isScalarLike(rhsTy);
+
+    if (!(srcTile && rhsScalar) && !(srcScalar && rhsTile))
+      return emitOpError("expects one tile-like operand and one scalar operand in ins(...)");
+
+    Type tileTy = srcTile ? srcTy : rhsTy;
+    Type scalarTy = srcTile ? rhsTy : srcTy;
+
+    if (failed(verifyScalarTileOp(*this, tileTy, dstTy, "src", "dst",
                                   /*requireValidRowsEqual=*/true,
                                   /*requireValidColsEqual=*/true)))
       return failure();
-    Type scalarTy = getScalar().getType();
     if (!scalarTy.isa<IntegerType, FloatType>())
       return emitOpError("scalar must be a scalar type (integer/float)");
-    Type elem = getElemTy(srcTy);
+    Type elem = getElemTy(tileTy);
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isInteger(8) ||
           elem.isF16() || elem.isF32()))
       return emitOpError("expects A5 tdivs element type to be i32/i16/i8/f16/f32");

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6647,43 +6647,16 @@ struct PTODivSToEmitC : public OpConversionPattern<pto::TDivSOp> {
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
 
-    // Check types BEFORE conversion (using original op types, not adaptor types)
-    // The adaptor types may already be converted to emitc.opaque
-    Value origSrc = op.getSrc();
-    Value origScalar = op.getScalar();
-    
-    // Determine order based on original operand types
-    // Check if src is memref/tensor/partition_tensor_view/tile (not scalar)
-    bool srcIsMemref = (isa<MemRefType>(origSrc.getType()) || 
-                        isa<RankedTensorType>(origSrc.getType()) ||
-                        isa<mlir::pto::PartitionTensorViewType>(origSrc.getType()) ||
-                        isa<mlir::pto::TileBufType>(origSrc.getType()));
-    // Check if scalar is memref/tensor/partition_tensor_view/tile (not scalar)
-    bool scalarIsMemref = (isa<MemRefType>(origScalar.getType()) || 
-                           isa<RankedTensorType>(origScalar.getType()) ||
-                           isa<mlir::pto::PartitionTensorViewType>(origScalar.getType()) ||
-                           isa<mlir::pto::TileBufType>(origScalar.getType()));
-
     Value src    = peelUnrealized(adaptor.getSrc());
     Value scalar = peelUnrealized(adaptor.getScalar());
     Value dst    = peelUnrealized(adaptor.getDst());
-
-    if (srcIsMemref && !scalarIsMemref) {
-      // memref/scalar: TDIVS(dst, src, scalar) - normal order
-      rewriter.create<emitc::CallOpaqueOp>(
-          loc, TypeRange{}, "TDIVS",
-          ArrayAttr{}, ArrayAttr{},
-          ValueRange{dst, src, scalar});
-    } else if (!srcIsMemref && scalarIsMemref) {
-          // scalar/memref: TDIVS(dst, scalar, src) - swapped order
-      rewriter.create<emitc::CallOpaqueOp>(
-          loc, TypeRange{}, "TDIVS",
-          ArrayAttr{}, ArrayAttr{},
-          ValueRange{dst, scalar, src});
-    } else {
-      // This should not happen if verifier is correct, but provide a fallback
-      return op.emitError("TDivSOp: expected exactly one memref/tensor operand and one scalar operand");
-    }
+    // Preserve source order from textual parse:
+    // ins(tile, scalar)   -> TDIVS(dst, tile, scalar)
+    // ins(scalar, tile)   -> TDIVS(dst, scalar, tile)
+    rewriter.create<emitc::CallOpaqueOp>(
+        loc, TypeRange{}, "TDIVS",
+        ArrayAttr{}, ArrayAttr{},
+        ValueRange{dst, src, scalar});
 
     rewriter.eraseOp(op);
     return success();
@@ -6706,30 +6679,10 @@ struct PTOTDivSToEmitC : public OpConversionPattern<pto::TDivSOp> {
     Value src    = peelUnrealized(adaptor.getSrc());
     Value scalar = peelUnrealized(adaptor.getScalar());
     Value dst    = peelUnrealized(adaptor.getDst());
-
-    // Determine order based on operand types
-    bool srcIsTile = isa<mlir::pto::TileBufType>(src.getType());
-    bool scalarIsTile = isa<mlir::pto::TileBufType>(scalar.getType());
-
-    if (srcIsTile && !scalarIsTile) {
-      // tile/scalar: TDIVS(dst, src, scalar)
-      rewriter.create<emitc::CallOpaqueOp>(
-          loc, TypeRange{}, "TDIVS",
-          ArrayAttr{}, ArrayAttr{},
-          ValueRange{dst, src, scalar});
-    } else if (!srcIsTile && scalarIsTile) {
-      // scalar/tile: TDIVS(dst, scalar, src)
-      rewriter.create<emitc::CallOpaqueOp>(
-          loc, TypeRange{}, "TDIVS",
-          ArrayAttr{}, ArrayAttr{},
-          ValueRange{dst, scalar, src});
-    } else {
-      // Default: assume src is tile (should not happen if types are correct)
-      rewriter.create<emitc::CallOpaqueOp>(
-          loc, TypeRange{}, "TDIVS",
-          ArrayAttr{}, ArrayAttr{},
-          ValueRange{dst, src, scalar});
-    }
+    rewriter.create<emitc::CallOpaqueOp>(
+        loc, TypeRange{}, "TDIVS",
+        ArrayAttr{}, ArrayAttr{},
+        ValueRange{dst, src, scalar});
 
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -2510,13 +2510,12 @@ struct PTOViewToMemrefPass
         // Check types - they might still be TileBufType or already converted to MemRefType
         auto srcTy = dyn_cast<MemRefType>(src.getType());
         auto srcTileTy = dyn_cast<mlir::pto::TileBufType>(src.getType());
-        auto scaleTy = dyn_cast<FloatType>(scale.getType());
         auto scaleTileTy = dyn_cast<mlir::pto::TileBufType>(scale.getType());
         auto dstTy = dyn_cast<MemRefType>(dst.getType());
         auto dstTileTy = dyn_cast<mlir::pto::TileBufType>(dst.getType());
         
-        // Determine which operand is the tile/memref and which is the scalar
-        // TDivSOp expects (memref, scalar, dst) internally, so we need to ensure correct order
+        // Determine which operand is tile-like and which is scalar-like.
+        // Keep the original operand order (set by parser textual form).
         // Check if src is memref/tensor/tile (not scalar)
         bool srcIsMemref = (srcTy != nullptr || srcTileTy != nullptr || 
                             isa<RankedTensorType>(src.getType()) ||
@@ -2544,23 +2543,11 @@ struct PTOViewToMemrefPass
           signalPassFailure();
           return;
         }
-        Value memrefOperand, scalarOperand;
-        if (srcIsMemref) {
-          // Normal order: (src=tile/memref, scale=scalar, dst)
-          memrefOperand = src;
-          scalarOperand = scale;
-        } else {
-          // Swapped order: (src=scalar, scale=tile/memref, dst)
-          // Need to swap to (memref, scalar, dst) for TDivSOp
-          memrefOperand = scale;
-          scalarOperand = src;
-        }
-
         rewriter.replaceOpWithNewOp<pto::TDivSOp>(
             op,
             TypeRange{},
-            memrefOperand,
-            scalarOperand,
+            src,
+            scale,
             dst);
       }
 

--- a/test/basic/tdivs_dual_order_emitc.pto
+++ b/test/basic/tdivs_dual_order_emitc.pto
@@ -1,0 +1,20 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @tdivs_dual_order_emitc() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %cst = arith.constant 2.000000e+00 : f32
+
+    pto.tdivs ins(%src, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tdivs ins(%cst, %src : f32, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A3: TDIVS([[VDST:v[0-9]+]], [[VSRC:v[0-9]+]], [[VSCALAR:v[0-9]+]]);
+// A3: TDIVS([[VDST]], [[VSCALAR]], [[VSRC]]);

--- a/test/samples/Divs/divs.py
+++ b/test/samples/Divs/divs.py
@@ -64,6 +64,7 @@ def build():
                 pto.TLoadOp(None, sv0, tb0)  # result=None
                 pto.TLoadOp(None, sv1, tb1)  # result=None
 
+                # tile/scalar form: src_tile / scalar
                 pto.TDivSOp(tb0, scale, tb1)
 
                 # %8 = subview on output tensor_view

--- a/test/samples/Divs2/divs2.py
+++ b/test/samples/Divs2/divs2.py
@@ -8,7 +8,7 @@
 
 from mlir.ir import Context, Location, Module, InsertionPoint
 from mlir.dialects import func, arith, pto
-from mlir.ir import F32Type, IndexType, BoolAttr
+from mlir.ir import F32Type, IndexType
 
 
 def build():
@@ -58,7 +58,8 @@ def build():
                 pto.TLoadOp(None, sv0, tb0)
                 pto.TLoadOp(None, sv1, tb1)
 
-                op = pto.TDivSOp(tb0, scale, tb_out)
+                # scalar/tile form: scalar / src_tile
+                pto.TDivSOp(scale, tb0, tb_out)
 
                 sv2 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
                 pto.TStoreOp(None, tb_out, sv2)

--- a/test/samples/Divs2/divs2_golden.py
+++ b/test/samples/Divs2/divs2_golden.py
@@ -1,4 +1,11 @@
 #!/usr/bin/python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
 import numpy as np
 from pathlib import Path
 import sys
@@ -19,7 +26,7 @@ def main():
     buffers = default_buffers(meta)
     buffers[src_name] = src
     write_buffers(meta, buffers)
-    out = src / np.float32(3.14)
+    out = np.float32(3.14) / src
     write_golden(meta, {single_output(meta): np.asarray(out, dtype=np.float32)})
 
 


### PR DESCRIPTION
fix issue #506 
## 问题背景
- `pto.tdivs` 支持两种输入语义：`ins(tile_buf, scalar)` 与 `ins(scalar, tile_buf)`，应分别映射到 PTO-ISA 的两个 `TDIVS` 重载。
- 在 `--enable-insert-sync` 链路下，第二种形式会在中间转换后退化为同一顺序，导致最终生成 C++ 只剩一种调用形态。

## 定位分析
- 根因在 `PTOViewToMemref` 的 `TDivSOp` 重写阶段：重写时依赖固定槽位语义，导致 `scalar/tile` 形式在 pass 后被规范成 `tile/scalar`。
- 由于后续 `PTOToEmitC` 直接按 `TDivSOp` 当前操作数顺序发射 `TDIVS`，前序顺序丢失会直接体现在最终 C++ API 上。

## 解决方案
- 调整 `TDivSOp` 的 parse/verify/lowering 逻辑，保留文本输入顺序并按“一个 tile-like + 一个 scalar-like”进行校验，不再依赖固定槽位含义。
- 更新 `PTOViewToMemref` 与 `PTOToEmitC`，确保 `ins(tile, scalar)` 生成 `TDIVS(dst, src0, scalar)`，`ins(scalar, tile)` 生成 `TDIVS(dst, scalar, src0)`。
- 新增并增强回归：`test/basic/tdivs_dual_order_emitc.pto`（含 `--enable-insert-sync` 场景），并补充 `test/samples/Divs` / `Divs2` 分别覆盖两种语义及 golden。
