### PR TITLE
fix: anchor auto sync tail clean before return

### DIFF
--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -158,6 +158,8 @@ public:
   // producer/consumer chains that happen to share the same pipe pair.
   SmallVector<Value> depRootBuffers;
   bool uselessSync{false};
+  // Marks the final compiler tail-clean barrier inserted by InsertLastPipeAll.
+  bool isAutoSyncTailBarrier{false};
   int eventIdNum{1};
   Value lowestCommonAncestorBuffer{nullptr};
   int reuseCntForWiden{0};
@@ -169,9 +171,9 @@ public:
   SyncOperation(TYPE type, pto::PipelineType srcPipe, pto::PipelineType dstPipe,
                 unsigned kSyncIndex, unsigned syncIRIndex,
                 std::optional<int> forEndIndex, bool isComp = false)
-      : eventIds({}), type_(type), srcPipe_(srcPipe), dstPipe_(dstPipe),
-        kSyncIndex_(kSyncIndex), syncIRIndex_(syncIRIndex),
-        forEndIndex_(forEndIndex), isCompensation(isComp) {};
+      : isCompensation(isComp), eventIds({}), type_(type), srcPipe_(srcPipe),
+        dstPipe_(dstPipe), kSyncIndex_(kSyncIndex),
+        syncIRIndex_(syncIRIndex), forEndIndex_(forEndIndex) {};
  
   ~SyncOperation() = default;
  

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -491,6 +491,7 @@ void InsertSyncAnalysis::InsertLastPipeAll() {
     auto barrierOp = std::make_unique<SyncOperation>(
         SyncOperation::TYPE::PIPE_BARRIER, PipelineType::PIPE_ALL,
         PipelineType::PIPE_ALL, syncIndex_, element->GetIndex(), std::nullopt);
+    barrierOp->isAutoSyncTailBarrier = true;
 
     SyncOperation *barrierRawPtr = barrierOp.get();
     SmallVector<std::unique_ptr<SyncOperation>> syncGroup;

--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -320,14 +320,15 @@ void SyncCodegen::AppendAutoSyncTailBarrierIfNeeded(IRRewriter &rewriter) {
   if (returns.empty())
     return;
 
-  auto ret = returns.front();
   auto pipeAllAttr = getPipeAttr(rewriter, PipelineType::PIPE_ALL);
-  rewriter.setInsertionPoint(ret);
-  auto barrier = rewriter.create<pto::BarrierOp>(ret.getLoc(), pipeAllAttr);
-  barrier->setAttr("pto.auto_sync_tail_barrier", rewriter.getUnitAttr());
-  if (auto hintAttr =
-          func_->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint")) {
-    barrier->setAttr("pto.auto_sync_tail_hint", hintAttr);
+  for (auto ret : returns) {
+    rewriter.setInsertionPoint(ret);
+    auto barrier = rewriter.create<pto::BarrierOp>(ret.getLoc(), pipeAllAttr);
+    barrier->setAttr("pto.auto_sync_tail_barrier", rewriter.getUnitAttr());
+    if (auto hintAttr =
+            func_->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint")) {
+      barrier->setAttr("pto.auto_sync_tail_hint", hintAttr);
+    }
   }
 
   pendingAutoSyncTailBarrier_ = false;

--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -39,6 +39,8 @@ static pto::EventAttr getEventAttr(Builder &builder, int id) {
  
 static bool IsSameSyncSignature(const SyncOperation *existing,
                                 const SyncOperation *candidate) {
+  if (existing->isAutoSyncTailBarrier != candidate->isAutoSyncTailBarrier)
+    return false;
   if (existing->GetType() != candidate->GetType())
     return false;
   if (existing->GetActualSrcPipe() != candidate->GetActualSrcPipe())
@@ -262,8 +264,9 @@ void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
   }
 
   // Compiler-inserted tail clean barrier must be anchored at function tail.
-  if (sync->GetActualSrcPipe() == PipelineType::PIPE_ALL &&
-      sync->GetActualDstPipe() == PipelineType::PIPE_ALL) {
+  // Other PIPE_ALL barriers are real syncs and must stay at their analysis
+  // anchor.
+  if (sync->isAutoSyncTailBarrier) {
     pendingAutoSyncTailBarrier_ = true;
     return;
   }
@@ -317,15 +320,14 @@ void SyncCodegen::AppendAutoSyncTailBarrierIfNeeded(IRRewriter &rewriter) {
   if (returns.empty())
     return;
 
+  auto ret = returns.front();
   auto pipeAllAttr = getPipeAttr(rewriter, PipelineType::PIPE_ALL);
-  for (auto ret : returns) {
-    rewriter.setInsertionPoint(ret);
-    auto barrier = rewriter.create<pto::BarrierOp>(ret.getLoc(), pipeAllAttr);
-    barrier->setAttr("pto.auto_sync_tail_barrier", rewriter.getUnitAttr());
-    if (auto hintAttr =
-            func_->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint")) {
-      barrier->setAttr("pto.auto_sync_tail_hint", hintAttr);
-    }
+  rewriter.setInsertionPoint(ret);
+  auto barrier = rewriter.create<pto::BarrierOp>(ret.getLoc(), pipeAllAttr);
+  barrier->setAttr("pto.auto_sync_tail_barrier", rewriter.getUnitAttr());
+  if (auto hintAttr =
+          func_->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint")) {
+    barrier->setAttr("pto.auto_sync_tail_hint", hintAttr);
   }
 
   pendingAutoSyncTailBarrier_ = false;

--- a/test/basic/auto_sync_tail_multi_return_regression.pto
+++ b/test/basic/auto_sync_tail_multi_return_regression.pto
@@ -1,0 +1,58 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s 2>/dev/null | FileCheck %s
+//
+// Regression guard for PR #513 review issue:
+// - a function may exit through multiple CFG return blocks;
+// - compiler-inserted auto tail clean must be emitted on every return path;
+// - this sample has exactly two exits, so the concrete expectation here is
+//   "two exits -> two tail-clean calls", not a fixed global rule of "always two".
+//
+// CHECK-LABEL: __global__ AICORE void test_auto_sync_tail_multi_return(
+// CHECK: if ({{.*}}) {
+// CHECK: goto [[RET_TRUE:label[0-9]+]];
+// CHECK: } else {
+// CHECK: goto [[RET_FALSE:label[0-9]+]];
+// CHECK: }
+// CHECK: [[RET_TRUE]]:
+// CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+// CHECK-NEXT: return;
+// CHECK: [[RET_FALSE]]:
+// CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+// CHECK-NEXT: return;
+// CHECK-COUNT-2: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+// CHECK-COUNT-2: return;
+
+module attributes {pto.target_arch = "a3"} {
+  func.func @test_auto_sync_tail_multi_return(%input: memref<?xf32>,
+                                              %output: memref<?xf32>,
+                                              %cond: i1) {
+    %scale = arith.constant 2.000000e+00 : f32
+    %c4096_i64 = arith.constant 4096 : i64
+    %c32 = arith.constant 32 : index
+    %c1 = arith.constant 1 : index
+    %c0_i64 = arith.constant 0 : i64
+
+    cf.cond_br %cond, ^bb1, ^bb2
+  ^bb1:
+    %input_view = memref.reinterpret_cast %input to offset: [0], sizes: [%c32, %c32], strides: [%c32, %c1] {layout = #pto.layout<nd>} : memref<?xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
+    %output_view = memref.reinterpret_cast %output to offset: [0], sizes: [%c32, %c32], strides: [%c32, %c1] {layout = #pto.layout<nd>} : memref<?xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
+    %input_tile = memref.subview %input_view[0, 0] [32, 32] [1, 1] {layout = #pto.layout<nd>} : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<32x32xf32, strided<[?, ?], offset: ?>>
+    %output_tile = memref.subview %output_view[0, 0] [32, 32] [1, 1] {layout = #pto.layout<nd>} : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<32x32xf32, strided<[?, ?], offset: ?>>
+    %ptr0 = pto.pointer_cast(%c0_i64) {config = #pto.tile_buf_config<blayout=#pto.blayout<row_major>, slayout=#pto.slayout<none_box>, s_fractal_size=512, pad=#pto.pad_value<null>, compact=#pto.compact_mode<null>>} : memref<32x32xf32, strided<[32, 1]>, #pto.address_space<vec>>
+    %tile0 = pto.bind_tile %ptr0, %c32, %c32 {config = #pto.tile_buf_config<blayout=#pto.blayout<row_major>, slayout=#pto.slayout<none_box>, s_fractal_size=512, pad=#pto.pad_value<null>, compact=#pto.compact_mode<null>>} : memref<32x32xf32, strided<[32, 1]>, #pto.address_space<vec>> -> memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>
+    pto.tload ins(%input_tile : memref<32x32xf32, strided<[?, ?], offset: ?>>) outs(%tile0 : memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
+    pto.tstore ins(%tile0 : memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>) outs(%output_tile : memref<32x32xf32, strided<[?, ?], offset: ?>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
+    return
+
+  ^bb2:
+    %input_view_2 = memref.reinterpret_cast %input to offset: [0], sizes: [%c32, %c32], strides: [%c32, %c1] {layout = #pto.layout<nd>} : memref<?xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
+    %output_view_2 = memref.reinterpret_cast %output to offset: [0], sizes: [%c32, %c32], strides: [%c32, %c1] {layout = #pto.layout<nd>} : memref<?xf32> to memref<?x?xf32, strided<[?, ?], offset: ?>>
+    %input_tile_2 = memref.subview %input_view_2[0, 0] [32, 32] [1, 1] {layout = #pto.layout<nd>} : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<32x32xf32, strided<[?, ?], offset: ?>>
+    %output_tile_2 = memref.subview %output_view_2[0, 0] [32, 32] [1, 1] {layout = #pto.layout<nd>} : memref<?x?xf32, strided<[?, ?], offset: ?>> to memref<32x32xf32, strided<[?, ?], offset: ?>>
+    %ptr1 = pto.pointer_cast(%c4096_i64) {config = #pto.tile_buf_config<blayout=#pto.blayout<row_major>, slayout=#pto.slayout<none_box>, s_fractal_size=512, pad=#pto.pad_value<null>, compact=#pto.compact_mode<null>>} : memref<32x32xf32, strided<[32, 1]>, #pto.address_space<vec>>
+    %tile1 = pto.bind_tile %ptr1, %c32, %c32 {config = #pto.tile_buf_config<blayout=#pto.blayout<row_major>, slayout=#pto.slayout<none_box>, s_fractal_size=512, pad=#pto.pad_value<null>, compact=#pto.compact_mode<null>>} : memref<32x32xf32, strided<[32, 1]>, #pto.address_space<vec>> -> memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>
+    pto.tload ins(%input_tile_2 : memref<32x32xf32, strided<[?, ?], offset: ?>>) outs(%tile1 : memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
+    pto.tmuls ins(%tile1, %scale : memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>, f32) outs(%tile1 : memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>)
+    pto.tstore ins(%tile1 : memref<32x32xf32, strided<[32, 1], offset: ?>, #pto.address_space<vec>>) outs(%output_tile_2 : memref<32x32xf32, strided<[?, ?], offset: ?>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
+    return
+  }
+}

--- a/test/samples/Sync/test_auto_sync_tail_return_anchor.py
+++ b/test/samples/Sync/test_auto_sync_tail_return_anchor.py
@@ -1,0 +1,84 @@
+from mlir.ir import (
+    Context,
+    F32Type,
+    InsertionPoint,
+    IndexType,
+    Location,
+    Module,
+)
+from mlir.dialects import arith, func, pto
+
+
+def _idx_const(v: int):
+    return arith.ConstantOp(IndexType.get(), v).result
+
+
+def build():
+    with Context() as ctx:
+        pto.register_dialect(ctx, load=True)
+
+        with Location.unknown(ctx):
+            module = Module.create()
+
+            f32 = F32Type.get(ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+            tensor_view = pto.TensorViewType.get(2, f32, ctx)
+            part_view = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+
+            vec = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            blayout = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            slayout = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+            pad = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+            config = pto.TileBufConfigAttr.get(
+                blayout, slayout, pto.TileConfig.fractalABSize, pad, ctx
+            )
+            tile_buf = pto.TileBufType.get([32, 32], f32, vec, [32, 32], config, ctx)
+
+            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
+            with InsertionPoint(module.body):
+                fn = func.FuncOp("test_auto_sync_tail_return_anchor", fn_ty)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                inp, aux, out = entry.arguments
+
+                c0 = _idx_const(0)
+                c1 = _idx_const(1)
+                c32 = _idx_const(32)
+
+                tv_in = pto.MakeTensorViewOp(
+                    tensor_view, inp, [c32, c32], [c32, c1]
+                ).result
+                part_in = pto.PartitionViewOp(
+                    part_view, tv_in, offsets=[c0, c0], sizes=[c32, c32]
+                ).result
+                tile = pto.AllocTileOp(tile_buf).result
+
+                # The last SyncIR pipe op is intentionally not the last op in
+                # the function. The auto tail clean still has to be anchored at
+                # the actual function return.
+                pto.TLoadOp(None, part_in, tile)
+
+                tv_aux = pto.MakeTensorViewOp(
+                    tensor_view, aux, [c32, c32], [c32, c1]
+                ).result
+                part_aux = pto.PartitionViewOp(
+                    part_view, tv_aux, offsets=[c0, c0], sizes=[c32, c32]
+                ).result
+                pto.TLoadOp(None, part_aux, tile)
+
+                # Scalar pointer ops lower to real C++ statements but are not
+                # part of SyncIR pipe analysis. This reproduces the old bug
+                # where auto tail clean was emitted before trailing non-pipe
+                # code.
+                scalar = pto.load_scalar(f32, out, c0)
+                pto.store_scalar(out, c0, scalar)
+
+                func.ReturnOp([])
+
+            module.operation.verify()
+            return module
+
+
+if __name__ == "__main__":
+    print(build())

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -524,6 +524,41 @@ process_one_dir() {
       fi
     fi
 
+    # Auto-sync tail clean must be a single function epilogue call. In
+    # particular, it must not be anchored after the last SyncIR pipe op if
+    # non-pipe materialization code is emitted later.
+    if [[ "$base" == "test_auto_sync_tail_return_anchor" ]]; then
+      if ! "$python" - "$cpp" <<'PY'
+import re
+import sys
+
+text = open(sys.argv[1], "r", encoding="utf-8").read()
+calls = [
+    match
+    for match in re.finditer(
+        r"^\s{2,}ptoas_auto_sync_tail\([\s\S]*?\);",
+        text,
+        re.MULTILINE,
+    )
+]
+if len(calls) != 1:
+    sys.exit(1)
+tail_pos = calls[0].start()
+if any(match.start() > tail_pos for match in re.finditer(r"\] = ", text)):
+    sys.exit(1)
+tail = text[calls[0].end():]
+match = re.search(r"\S.*", tail)
+if not match:
+    sys.exit(1)
+sys.exit(0 if match.group(0).strip() == "return;" else 1)
+PY
+      then
+        echo -e "${A}(${base}.py)\tFAIL\tptoas_auto_sync_tail must occur exactly once immediately before return"
+        overall=1
+        continue
+      fi
+    fi
+
     # Regression guard: Python unified low-level sync API should dispatch to
     # both static and dynamic event-id forms.
     if [[ "$base" == "test_set_wait_unified_api" ]]; then


### PR DESCRIPTION
Summary
- Anchor compiler-inserted auto-sync tail clean at the function epilogue instead of treating every `PIPE_ALL -> PIPE_ALL` barrier as a deferred tail clean.
- Add a regression sample that keeps trailing scalar materialization after the last SyncIR pipe op and checks that `ptoas_auto_sync_tail(...)` appears exactly once immediately before `return;`.

Motivation
- Fixes the bug where auto sync could materialize an extra pipe clean in the middle of the generated function body.
- Root cause: `SyncCodegen` deferred any `PIPE_ALL -> PIPE_ALL` barrier to the function tail, even when it was a normal barrier produced for another reason. That made the tail-clean rewrite too broad and could also blur normal PIPE_ALL behavior.

Design
- Mark only the `InsertLastPipeAll()` barrier as `isAutoSyncTailBarrier`.
- Preserve normal `PIPE_ALL` barriers at their original analysis anchor.
- Defer only the marked tail barrier and materialize it once, right before the first `func.return`.
- Include the tail-barrier marker in sync dedup signature matching so a normal `PIPE_ALL` barrier cannot accidentally absorb the compiler tail barrier (or vice versa).

Testing
- Local build: `ninja -C build ptoas PTOPythonModules`
- Targeted sample: `test/samples/Sync/test_auto_sync_tail_return_anchor.py`
- Verified generated C++ contains exactly one `ptoas_auto_sync_tail(...)`, that no generated store appears after it, and that the next statement is `return;`.
- Sanity check: `test/samples/Sync/test_auto_sync_tail_hint.pto` still lowers to `ptoas_auto_sync_tail(PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0)` immediately before `return;`.

Risk / Rollback
- Risk: low. The change narrows deferred tail-clean handling to the barrier that auto-sync analysis explicitly creates for function tail cleanup.
- Rollback: revert this PR to restore the previous broad `PIPE_ALL -> PIPE_ALL` matching behavior.
