### PR TITLE
InsertSync: guard sync motion by branch predicate domain

### DIFF
--- a/include/PTO/Transforms/InsertSync/MoveSyncState.h
+++ b/include/PTO/Transforms/InsertSync/MoveSyncState.h
@@ -60,6 +60,14 @@ private:
  
   void PlanMoveOutSetSync(SyncOps &newPipeAfter, SyncOperation *s,
                           const std::pair<unsigned int, unsigned int> pair);
+
+  // Branch-predicate guard: sync motion must stay within the same effective
+  // execution predicate as its dependency anchor.
+  SmallVector<int, 8> GetBranchPredicateKey(unsigned int syncIRIndex) const;
+  bool HasSameBranchPredicate(unsigned int lhsIndex,
+                              unsigned int rhsIndex) const;
+  bool CanMoveToPredicateCompatibleAnchor(const SyncOperation *sync,
+                                          unsigned int targetIndex) const;
 };
  
 } // namespace pto

--- a/lib/PTO/Transforms/InsertSync/MoveSyncState.cpp
+++ b/lib/PTO/Transforms/InsertSync/MoveSyncState.cpp
@@ -18,6 +18,80 @@
  
 using namespace mlir;
 using namespace mlir::pto;
+
+SmallVector<int, 8>
+MoveSyncState::GetBranchPredicateKey(unsigned int syncIRIndex) const {
+  SmallVector<int, 8> key;
+  if (syncIRIndex >= syncIR_.size()) {
+    return key;
+  }
+
+  for (const auto &element : syncIR_) {
+    auto *branch = dyn_cast<BranchInstanceElement>(element.get());
+    if (!branch || branch->getBranchKind() != KindOfBranch::IF_BEGIN) {
+      continue;
+    }
+    if (!(branch->beginId < branch->endId)) {
+      continue;
+    }
+    if (syncIRIndex <= branch->beginId || syncIRIndex >= branch->endId) {
+      continue;
+    }
+
+    // Encode each enclosing if's side into a stable token:
+    //   token*4+0 => then-side
+    //   token*4+1 => else-side
+    //   token*4+2 => else-boundary marker
+    const int token = static_cast<int>(branch->beginId) + 1;
+    if (syncIRIndex < branch->branchId) {
+      key.push_back(token * 4 + 0);
+    } else if (syncIRIndex > branch->branchId) {
+      key.push_back(token * 4 + 1);
+    } else {
+      key.push_back(token * 4 + 2);
+    }
+  }
+  return key;
+}
+
+bool MoveSyncState::HasSameBranchPredicate(unsigned int lhsIndex,
+                                           unsigned int rhsIndex) const {
+  if (lhsIndex >= syncIR_.size() || rhsIndex >= syncIR_.size()) {
+    return false;
+  }
+  return GetBranchPredicateKey(lhsIndex) == GetBranchPredicateKey(rhsIndex);
+}
+
+bool MoveSyncState::CanMoveToPredicateCompatibleAnchor(
+    const SyncOperation *sync, unsigned int targetIndex) const {
+  if (!sync || targetIndex >= syncIR_.size()) {
+    return false;
+  }
+
+  // Prefer matching against the peer set/wait's execution predicate.
+  const auto syncIndex = sync->GetSyncIndex();
+  if (syncIndex < syncOperations_.size()) {
+    const auto &syncPair = syncOperations_[syncIndex];
+    if (syncPair.size() >= 2) {
+      const SyncOperation *peer = nullptr;
+      if (sync->isSyncSetType()) {
+        peer = syncPair[1].get();
+      } else if (sync->isSyncWaitType()) {
+        peer = syncPair[0].get();
+      }
+      if (peer && peer->GetSyncIRIndex() < syncIR_.size()) {
+        return HasSameBranchPredicate(peer->GetSyncIRIndex(), targetIndex);
+      }
+    }
+  }
+
+  // Fallback for barrier-like syncs where only dep anchor is available.
+  const unsigned depIndex = sync->GetDepSyncIRIndex();
+  if (depIndex >= syncIR_.size()) {
+    return false;
+  }
+  return HasSameBranchPredicate(depIndex, targetIndex);
+}
  
 void MoveSyncState::Run() {
   MoveOutBranchSync();
@@ -108,6 +182,10 @@ void MoveSyncState::PlanMoveOutIfWaitSync(
   // 那么这个 Wait 可以被提至 If 之前 (bound.first)
   if ((setSync->GetSyncIRIndex() >= pair.second) ||
       (setSync->GetSyncIRIndex() <= pair.first)) {
+    if (!CanMoveToPredicateCompatibleAnchor(s, bound.first)) {
+      newPipeBefore.push_back(s);
+      return;
+    }
     
     // [Optimization]: Hoist Wait out of If
     checkSyncIRIndex(syncIR_, bound.first);
@@ -140,6 +218,10 @@ void MoveSyncState::PlanMoveOutIfSetSync(
   // 那么这个 Set 可以沉降到 If 之后 (bound.second)
   if ((waitSync->GetSyncIRIndex() >= pair.second) ||
       (waitSync->GetSyncIRIndex() <= pair.first)) {
+    if (!CanMoveToPredicateCompatibleAnchor(s, bound.second)) {
+      newPipeAfter.push_back(s);
+      return;
+    }
     
     // [Optimization]: Sink Set out of If
     checkSyncIRIndex(syncIR_, bound.second);
@@ -218,6 +300,10 @@ void MoveSyncState::PlanMoveOutWaitSync(
   // 可以将 Wait 提至 Loop Begin 之前
   if ((setSync->GetSyncIRIndex() > pair.second) ||
       (setSync->GetSyncIRIndex() < pair.first)) {
+    if (!CanMoveToPredicateCompatibleAnchor(s, pair.first)) {
+      newPipeBefore.push_back(s);
+      return;
+    }
     
     // [Optimization]: Hoist Wait out of Loop
     checkSyncIRIndex(syncIR_, pair.first);
@@ -258,6 +344,10 @@ void MoveSyncState::PlanMoveOutSetSync(
   // 可以将 Set 沉降到 Loop End 之后
   if ((waitSync->GetSyncIRIndex() > pair.second) ||
       (waitSync->GetSyncIRIndex() < pair.first)) {
+    if (!CanMoveToPredicateCompatibleAnchor(s, pair.second)) {
+      newPipeAfter.push_back(s);
+      return;
+    }
     
     // [Optimization]: Sink Set out of Loop
     checkSyncIRIndex(syncIR_, pair.second);

--- a/test/basic/issue_nested_if_predicate_sync_motion_guard.pto
+++ b/test/basic/issue_nested_if_predicate_sync_motion_guard.pto
@@ -1,0 +1,35 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
+//
+// Regression guard for nested-if sync motion:
+// - The set/wait pair that protects inner-if tmatmul must stay inside the
+//   outer-if predicate region.
+// - It must not be hoisted above the outer-if where cond0 may be false.
+//
+// CHECK-LABEL: __global__ AICORE void issue_nested_if_predicate_sync_motion_guard(
+// CHECK-NOT: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID
+// CHECK-NOT: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID
+// CHECK: if (v1) {
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID[[ID:[0-9]+]]);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID[[ID]]);
+// CHECK: if (v2) {
+
+module {
+  func.func @issue_nested_if_predicate_sync_motion_guard(%cond0: i1, %cond1: i1) {
+    pto.section.cube {
+      %m0 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+      %m1 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+      %l0 = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+      %r0 = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+      %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+
+      pto.tmov ins(%m1 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%r0 : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+      scf.if %cond0 {
+        pto.tmov ins(%m0 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>) outs(%l0 : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+        scf.if %cond1 {
+          pto.tmatmul ins(%l0, %r0 : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Summary
- Add predicate-domain guard in `MoveSyncState` so sync motion (hoist/sink) only happens when target anchor is in the same effective branch predicate domain as the sync's paired peer (`set`/`wait`).
- Add regression test `issue_nested_if_predicate_sync_motion_guard.pto` to lock nested-if behavior.

Background
- In complex nested-if scenarios, moving `wait`/`set` across the nearest enclosing control-flow predicate can cause mismatch risk (e.g. outer-if false path executes moved sync while original producer path does not).
- This PR makes motion conservative for predicate crossing while preserving existing legal loop/if motion opportunities inside the same predicate domain.

Design
- New helpers in `MoveSyncState`:
  - `GetBranchPredicateKey(syncIRIndex)`
  - `HasSameBranchPredicate(lhs, rhs)`
  - `CanMoveToPredicateCompatibleAnchor(sync, targetIndex)`
- Motion paths guarded:
  - `PlanMoveOutIfWaitSync`
  - `PlanMoveOutIfSetSync`
  - `PlanMoveOutWaitSync`
  - `PlanMoveOutSetSync`

Validation
- Built `ptoas` locally on this branch.
- Targeted checks:
  - New nested-if repro: generated C++ shows `set_flag/wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0)` remain inside outer `if` before inner `if`.
  - Existing regressions re-generated and inspected:
    - `issue454_loop_if_else_loop_carried_sync_regression.pto`
    - `issue454_nested_loop_same_pipe_pair_regression.pto`

Notes
- Environment lacks `FileCheck` binary in this worktree, so validation used generated C++ structural inspection (`rg` on emitted output).
