### PR TITLE
[Fix] Align A5 expanddiv verifier with pto-isa integer support

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3342,10 +3342,11 @@ LogicalResult pto::TColExpandAddOp::verify() {
 }
 LogicalResult pto::TColExpandDivOp::verify() {
   auto verifyByArch = [&](PTOArch targetArch) -> LogicalResult {
+    bool allowIntegerTypes = (targetArch == PTOArch::A5);
     return verifyTColExpandBinaryLikeOp(getOperation(), getSrc0().getType(),
                                         getSrc1().getType(), getDst().getType(),
                                         targetArch, "tcolexpanddiv",
-                                        /*allowIntegerTypes=*/false);
+                                        /*allowIntegerTypes=*/allowIntegerTypes);
   };
   auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
   auto verifyA5 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A5); };
@@ -7580,7 +7581,7 @@ void mlir::pto::TRowExpandMinOp::print(OpAsmPrinter &p) {
 }
 
 mlir::LogicalResult mlir::pto::TRowExpandDivOp::verify() {
-  auto verifyCommon = [&]() -> LogicalResult {
+  auto verifyByArch = [&](PTOArch targetArch) -> LogicalResult {
     Type src0Ty = getSrc0().getType();
     Type src1Ty = getSrc1().getType();
     Type dstTy = getDst().getType();
@@ -7597,15 +7598,21 @@ mlir::LogicalResult mlir::pto::TRowExpandDivOp::verify() {
       return emitOpError("expects src0 and src1 to have the same element type");
     if (!isRowMajorTileBuf(dstTy))
       return emitOpError("expects dst to use row-major layout");
-    auto elemTy = getElemTy(src0Ty).dyn_cast<mlir::FloatType>();
-    if (!elemTy || (!elemTy.isF16() && !elemTy.isF32()))
+    Type elem = getElemTy(src0Ty);
+    bool supported =
+        elem.isF16() || elem.isF32() ||
+        (targetArch == PTOArch::A5 &&
+         (elem.isInteger(8) || elem.isInteger(16) || elem.isInteger(32)));
+    if (!supported) {
+      if (targetArch == PTOArch::A5)
+        return emitOpError(
+            "expects A5 trowexpanddiv element type to be i8/i16/i32/f16/f32");
       return emitOpError("expects element type to be f16 or f32");
+    }
     return mlir::success();
   };
-  auto verifyA2A3 = [&]() -> LogicalResult {
-    return verifyCommon();
-  };
-  auto verifyA5 = [&]() -> LogicalResult { return verifyCommon(); };
+  auto verifyA2A3 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A3); };
+  auto verifyA5 = [&]() -> LogicalResult { return verifyByArch(PTOArch::A5); };
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 

--- a/test/basic/issue522_expanddiv_a5_int_types.pto
+++ b/test/basic/issue522_expanddiv_a5_int_types.pto
@@ -1,0 +1,51 @@
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=A5
+// RUN: not ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @expanddiv_i8() {
+    %src0_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @expanddiv_i16() {
+    %src0_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @expanddiv_i32() {
+    %src0_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_col = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolexpanddiv ins(%src0_col, %src1_col : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_col : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    %src0_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst_row = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpanddiv ins(%src0_row, %src1_row : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_row : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A5-LABEL: AICORE void expanddiv_i8()
+// A5-LABEL: AICORE void expanddiv_i16()
+// A5-LABEL: AICORE void expanddiv_i32()
+// A5: TCOLEXPANDDIV(
+// A5: TROWEXPANDDIV(
+
+// A3: error: 'pto.tcolexpanddiv' op expects tcolexpanddiv element type to be f16 or f32


### PR DESCRIPTION
## 问题背景
- issue #522 反馈：`pto.tcolexpanddiv` 在 A5 下校验错误地拒绝了整型（i16/i32）输入，导致与 pto-isa A5 API 能力不一致。
- 同时检查了同类 row/col expand/reduce 的 A5 类型约束，确认本次同类缺口也存在于 `trowexpanddiv`。

## 定位分析
- PTOAS 中 `TColExpandDivOp::verify()` 固定走 `allowIntegerTypes=false`，因此在 A5 也只接受 f16/f32。
- PTOAS 中 `TRowExpandDivOp::verify()` 也仅允许 f16/f32。
- 对照 pto-isa A5 对应实现（`TColExpandBinOp.hpp` / `TRowExpandDiv.hpp`），A5 路径支持整型输入，本地 ST 用例亦覆盖整型场景。

## 解决方案
- 修改 `lib/PTO/IR/PTO.cpp`：
  - `TColExpandDivOp::verify()` 改为按 arch 分支：A5 允许 `i8/i16/i32/f16/f32`，A2/A3 保持原有浮点限制。
  - `TRowExpandDivOp::verify()` 改为按 arch 分支：A5 允许 `i8/i16/i32/f16/f32`，A2/A3 保持原有浮点限制。
- 新增回归用例 `test/basic/issue522_expanddiv_a5_int_types.pto`：
  - A5 正例覆盖 `tcolexpanddiv/trowexpanddiv` 的 `i8/i16/i32`。
  - A3 负例校验仍会按预期拒绝整数输入。
- 本地验证：
  - `./build/tools/ptoas/ptoas --pto-arch=a5 --enable-insert-sync test/basic/issue522_expanddiv_a5_int_types.pto -o - | FileCheck ... --check-prefix=A5`
