### PR TITLE
[InsertSync] Temporary sibling-subview non-overlap alias policy (revertible)

### DIFF
--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -157,8 +157,25 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   // 2. Local Memory (UB/L1)
   
   if (a->rootBuffer == b->rootBuffer) {
-    if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true;
-    return isBufferAddressRangeOverlap(a, b);
+    if (a->baseAddresses.empty() || b->baseAddresses.empty()) {
+      if (isTraceEnabled())
+        llvm::errs()
+            << "    -> Same root but unknown baseAddresses. Conservative "
+               "overlap.\n";
+      return true;
+    }
+    if (a->allocateSize == 0 || b->allocateSize == 0) {
+      if (isTraceEnabled())
+        llvm::errs()
+            << "    -> Same root but unknown allocateSize. Conservative "
+               "overlap.\n";
+      return true;
+    }
+    const bool overlap = isBufferAddressRangeOverlap(a, b);
+    if (isTraceEnabled())
+      llvm::errs() << "    -> Same root range overlap: "
+                   << (overlap ? "true" : "false") << "\n";
+    return overlap;
   }
  
   // 2.2 深层比较：穿透 View

--- a/test/basic/issue499_subview_sibling_nonoverlap_assumption_regression.pto
+++ b/test/basic/issue499_subview_sibling_nonoverlap_assumption_regression.pto
@@ -1,0 +1,36 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
+//
+// Temporary assumption guard (can be reverted independently):
+// sibling subviews from one parent tile are treated as non-overlap when
+// static ranges are disjoint.
+//
+// CHECK-LABEL: __global__ AICORE void issue499_subview_sibling_nonoverlap_assumption()
+// CHECK: TADD(
+// CHECK: pipe_barrier(PIPE_V);
+// CHECK: TADD(
+// CHECK-NOT: set_flag(PIPE_V, PIPE_V
+// CHECK-NOT: wait_flag(PIPE_V, PIPE_V
+
+module {
+  func.func @issue499_subview_sibling_nonoverlap_assumption() {
+    pto.section.vector {
+      %c0 = arith.constant 0 : index
+      %c64 = arith.constant 64 : index
+
+      %parent = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %lhs = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %rhs = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+      %left = pto.subview %parent[%c0, %c0] sizes [1, 64] :
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+        -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %right = pto.subview %parent[%c0, %c64] sizes [1, 64] :
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+        -> !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+      pto.tadd ins(%left, %lhs : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%left : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      pto.tadd ins(%right, %rhs : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%right : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+    return
+  }
+}


### PR DESCRIPTION
Summary
- Add a temporary InsertSync alias-policy assumption for local tile views: for same-root local buffers, use concrete address-range overlap when available; if disjoint, treat as non-alias.
- Keep conservative behavior when address/size is unknown.
- Add a regression case `issue499_subview_sibling_nonoverlap_assumption_regression.pto` to lock this policy.

Motivation
- Related to #499 discussion where sibling view/subset interactions can be over-synchronized due to conservative aliasing.
- This PR is intentionally scoped as a reversible policy step requested for short-term iteration.

Design
- File: `lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp`
- In `MemAlias` same-root local path:
  - Unknown base address / size: still conservative alias=true.
  - Known ranges: alias = `isBufferAddressRangeOverlap(a, b)`.
- No CLI or IR semantic changes.

Testing
- Built `ptoas` locally (A3 pipeline).
- Passed:
  - `test/basic/issue499_subview_sibling_nonoverlap_assumption_regression.pto`
  - `test/basic/issue428_cube_sync_regression.pto`
  - `test/basic/issue454_loop_if_else_loop_carried_sync_regression.pto`
  - `test/basic/issue454_nested_loop_same_pipe_pair_regression.pto`

Risk / Rollback
- Risk: this is an assumption-based policy and may under-constrain in corner cases if upstream invariants are violated.
- Rollback: fully revert this single commit.
