### PR TITLE
fix: mark mgather and mscatter python samples as A5

### DIFF
--- a/test/samples/Mgather/mgather.py
+++ b/test/samples/Mgather/mgather.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -17,6 +17,7 @@ def build():
 
         with Location.unknown(ctx):
             m = Module.create()
+            m.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
 
             i32 = IntegerType.get_signless(32, ctx)
             ptr_i32 = pto.PtrType.get(i32, ctx)

--- a/test/samples/Mscatter/mscatter.py
+++ b/test/samples/Mscatter/mscatter.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -17,6 +17,7 @@ def build():
 
         with Location.unknown(ctx):
             m = Module.create()
+            m.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
 
             i32 = IntegerType.get_signless(32, ctx)
             ptr_i32 = pto.PtrType.get(i32, ctx)


### PR DESCRIPTION
## Summary
- set `pto.target_arch = "a5"` in the `Mgather` python sample
- set `pto.target_arch = "a5"` in the `Mscatter` python sample
- keep the fix scoped to the two A5-only sample generators

## Why
`pto.mgather` and `pto.mscatter` are A5-only ops. These two python samples called `m.operation.verify()` without an A5 module target, so the Python frontend verifier rejected them before `ptoas` ran, even under the A5 monitor.

## Validation
- `python3 -m py_compile test/samples/Mgather/mgather.py test/samples/Mscatter/mscatter.py`
- `git diff --check`
- full runtime verification was not possible on this machine because the local MLIR Python runtime is not installed
