### PR TITLE
fix: avoid false A5 tprelu vec overflow

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -9954,7 +9954,11 @@ void TPReluOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrc0Mutable());
   PTO_ADD_READ(getSrc1Mutable());
-  PTO_ADD_WRITE(getTmpMutable());
+  // A5 pto-isa TPRELU implementation does not consume tmp; modeling tmp as a
+  // write-only scratch on A5 incorrectly inflates local-memory planning and
+  // can trigger false vec-overflow diagnostics.
+  if (getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 

--- a/test/lit/pto/issue531_tprelu_vec_overflow_a5.pto
+++ b/test/lit/pto/issue531_tprelu_vec_overflow_a5.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 %s -o - 2>&1 | FileCheck %s
+
+// Regression for issue #531:
+// A5 TPRELU should not treat tmp as a required scratch write in local-memory
+// planning, otherwise this shape triggers a false vec overflow.
+// CHECK-NOT: vec overflow
+// CHECK: AICORE void TPRELU_OVERFLOW()
+
+module {
+  func.func @TPRELU_OVERFLOW() {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=256, cols=200, v_row=256, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}


### PR DESCRIPTION
## 问题背景
- issue #531 反馈：A5 下 `pto.tprelu` 在 `256x200` 最小复现用例会报 `vec overflow`，而该场景不应因为 `tmp` 触发额外本地内存压力。
- 现象在 `hw/main` 上可稳定复现，错误为 `requires 2048000 bits while 2031616 bits avaliable`。

## 定位分析
- 内存规划 pass 会将 PTO_DPS op 中“被标记为 write 且不是 dps init 的 operand”当作 scratch buffer 纳入本地内存规划。
- `TPReluOp::getEffects` 之前对所有架构都声明 `tmp` 为 write，因此 A5 也会把 `tmp` 计入 vec 内存峰值，导致与 `dst` 叠加后触发假性 overflow。
- 对照 A5 pto-isa `TPrelu.hpp`，A5 `TPRELU_IMPL` 并不实际使用 `tmp`，因此该写入建模在 A5 上是过度约束。

## 解决方案
- 修改 `lib/PTO/IR/PTO.cpp`：在 `TPReluOp::getEffects` 中按架构区分，A5 不再将 `tmp` 声明为 write effect（A2/A3 保持不变）。
- 新增回归测试 `test/lit/pto/issue531_tprelu_vec_overflow_a5.pto`，覆盖 issue 复现形状并断言 A5 编译不再出现 `vec overflow`。
- 验证：
  - `./build/tools/ptoas/ptoas --pto-arch=a5 issue531_repro.pto -o -`（复现用例转为通过）
  - `cmake --build build --target check-pto -j8`（120/120 通过）
