### PR TITLE
fix: preserve unsigned scalar type in TCI emitc lowering

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6029,7 +6029,11 @@ struct PTOTCIToEmitC : public OpConversionPattern<pto::TCIOp> {
     // scalar type, not the converted EmitC value type.
     std::string scalarTok = "int32_t";
     if (auto it = dyn_cast<IntegerType>(op->getOperand(0).getType())) {
-      scalarTok = (it.getWidth() == 16) ? "int16_t" : "int32_t";
+      bool isUnsigned = it.isUnsigned();
+      if (it.getWidth() == 16)
+        scalarTok = isUnsigned ? "uint16_t" : "int16_t";
+      else
+        scalarTok = isUnsigned ? "uint32_t" : "int32_t";
     }
 
     // descending -> "0"/"1"

--- a/test/lit/pto/tci_ui32_emitc.pto
+++ b/test/lit/pto/tci_ui32_emitc.pto
@@ -1,0 +1,19 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @tci_ui32_kernel(%dst: memref<32xui32, #pto.address_space<gm>>) {
+    %c5_i32 = arith.constant 5 : i32
+    %c5_ui32 = builtin.unrealized_conversion_cast %c5_i32 : i32 to ui32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %src = memref.reinterpret_cast %dst to offset: [%c0], sizes: [%c1, %c32], strides: [%c32, %c1] {layout = #pto.layout<nd>} : memref<32xui32, #pto.address_space<gm>> to memref<1x32xui32, strided<[32, 1], offset: ?>, #pto.address_space<gm>>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tci ins(%c5_ui32 : ui32) outs(%tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%src : memref<1x32xui32, strided<[32, 1], offset: ?>, #pto.address_space<gm>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
+    return
+  }
+}
+
+// A3: TCI<{{.*}}, uint32_t, 0>(
+// A3-NOT: TCI<{{.*}}, int32_t, 0>(


### PR DESCRIPTION
**问题背景**
pto.tci 的 ui32 输入被降到了 TCI<..., int32_t, ...>，unsigned 语义丢失。

**定位分析**
输入 .pto 中 ins 是 ui32，前端类型没问题。
问题出在 EmitC lowering：PTOTCIToEmitC 里模板参数 scalarTok 只按位宽映射为 int16_t/int32_t，没有区分 signed/unsigned。
因此 ui32 也被错误写成了 int32_t 模板参数。

**解决方法**
修改 lib/PTO/Transforms/PTOToEmitC.cpp：在 PTOTCIToEmitC 中按 IntegerType 的 signed/unsigned + 位宽选择模板类型：
ui16 -> uint16_t
ui32 -> uint32_t
i16/i32 保持原样
