### PR TITLE
Improve print IR facilities

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -64,11 +64,6 @@ std::unique_ptr<Pass> createPTORemoveRedundantBarrierPass();
 std::unique_ptr<Pass> createPTOViewToMemrefPass();
 std::unique_ptr<Pass> createInferPTOLayoutPass();
 std::unique_ptr<Pass> createPTOA5NormalizeTMovPass();
-// Declare register function
-void registerPTOPasses();
-
-} // namespace pto
-} // namespace mlir
 
 //===----------------------------------------------------------------------===//
 // Registration
@@ -77,5 +72,9 @@ void registerPTOPasses();
 #undef GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION
 #include "PTO/Transforms/Passes.h.inc"
+
+} // namespace pto
+} // namespace mlir
+
 
 #endif // MLIR_DIALECT_PTO_TRANSFORMS_PASSES_H

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -231,4 +231,21 @@ def PTOVerifyTFree : Pass<"pto-verify-tfree", "func::FuncOp"> {
   ];
 }
 
+def PTOViewToMemref : Pass<"pto-view-to-memref", "ModuleOp"> {
+  let summary = "Lower PTO views to memref with Metadata Binding";
+  let description = [{
+    Lower PTO tile/view operations to memref-based IR while preserving tile
+    metadata through binding ops and SSA backtracking.
+  }];
+
+  let constructor = "mlir::pto::createPTOViewToMemrefPass()";
+
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::memref::MemRefDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::func::FuncDialect"
+  ];
+}
+
 #endif // MLIR_DIALECT_PTO_PASSES

--- a/lib/PTO/Transforms/InferPTOLayout.cpp
+++ b/lib/PTO/Transforms/InferPTOLayout.cpp
@@ -28,6 +28,13 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_INFERPTOLAYOUT
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
 using namespace mlir;
 using namespace mlir::pto;
 
@@ -524,7 +531,7 @@ static void inferReinterpretCastLayoutAttr(memref::ReinterpretCastOp op,
 }
 
 struct InferPTOLayoutPass
-    : public PassWrapper<InferPTOLayoutPass, OperationPass<func::FuncOp>> {
+    : public mlir::pto::impl::InferPTOLayoutBase<InferPTOLayoutPass> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(InferPTOLayoutPass)
 
   void runOnOperation() override {

--- a/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
@@ -62,7 +62,6 @@ static bool hasGatherScatterLikeOps(func::FuncOp func) {
 struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSyncPass> {
   
   void runOnOperation() override {
-    llvm::errs() << "\n// === [PTOInsertSync] Start === //\n";
     func::FuncOp func = getOperation();
 
     // If the function already contains explicit synchronization ops (either
@@ -143,11 +142,6 @@ struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSy
     SyncCodegen codegen(syncIR, func, SyncAnalysisMode::NORMALSYNC);
     codegen.Run();
  
-    // 6. 最终结果打印
-    llvm::errs() << "\n// === [PTOInsertSync] Final Result === //\n";
-    func.print(llvm::errs());
-    llvm::errs() << "\n\n";
-    llvm::errs() << "// === [PTOInsertSync] End === //\n";
   }
 };
  

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -2163,9 +2163,6 @@ void PlanMemoryPass::runOnOperation() {
       return signalPassFailure();
     }
   }
-  llvm::errs() << "end PTO plan Mem!\n";
-  auto op = getOperation();
-  op->dump();
 }
 
 std::unique_ptr<Pass>

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -53,6 +53,9 @@
 #include <string>
 #include <type_traits>
 #include <utility>
+
+#define DEBUG_TYPE "pto-emitc"
+
 namespace mlir {
 #define GEN_PASS_DEF_EMITPTOMANUAL
 #include "PTO/Transforms/Passes.h.inc"
@@ -341,7 +344,7 @@ public:
     // 3. MemRef 转换 (Debug 重点)
     // ---------------------------------------------------------
     addConversion([this, Ctx](MemRefType type) -> std::optional<Type> {
-      llvm::errs() << "[Debug] Converting MemRef: " << type << "\n";
+      LLVM_DEBUG(llvm::dbgs() << "Converting MemRef: " << type << "\n");
 
       // A. 转换元素类型
       Type elemType = type.getElementType();
@@ -374,7 +377,7 @@ public:
       }
 
       std::string finalTypeStr = qualifier + " " + elemTypeStr;
-      llvm::errs() << "  [Success] -> " << finalTypeStr << "*\n";
+      LLVM_DEBUG(llvm::dbgs() << "  [Success] -> " << finalTypeStr << "*\n");
       
       return emitc::PointerType::get(emitc::OpaqueType::get(Ctx, finalTypeStr));
     });
@@ -10368,7 +10371,7 @@ struct EmitPTOManualPass
   }
 
   void runOnOperation() override {
-    llvm::errs() << "DEBUG: Start PTOToEmitC Pass\n";
+    LLVM_DEBUG(llvm::dbgs() << "DEBUG: Start PTOToEmitC Pass\n");
     MLIRContext *ctx = &getContext();
     ModuleOp mop = getOperation();
 

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -36,6 +36,8 @@
 #include <functional>
 #include <limits>
 
+#define DEBUG_TYPE "pto-view-to-memref"
+
 using namespace mlir;
 
 namespace mlir {
@@ -3362,7 +3364,7 @@ struct PTOViewToMemrefPass
     }
     
     // Debug Output
-    dumpPretty(mod.getOperation(), llvm::errs());
+    LLVM_DEBUG(llvm::dbgs() << mod.getOperation());
   }
 };
 

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -50,8 +50,6 @@ using namespace mlir;
 namespace mlir {
 namespace pto {
 
-#define GEN_PASS_DEF_PTOVIEWTOMEMREF
-
 static constexpr llvm::StringLiteral kLoweredSetValidShapeAttrName =
     "__pto.lowered_set_validshape";
 static constexpr llvm::StringLiteral kForceDynamicValidShapeAttrName =

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -28,6 +28,13 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOVIEWTOMEMREF
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
 #include "Utils.h" // 假设包含一些通用的工具函数
@@ -1142,20 +1149,8 @@ static LogicalResult lowerTileBufViewLikeOps(func::FuncOp func, MLIRContext *ctx
 // =============================================================================
 
 struct PTOViewToMemrefPass
-    : public PassWrapper<PTOViewToMemrefPass, OperationPass<ModuleOp>> {
+    : public mlir::pto::impl::PTOViewToMemrefBase<PTOViewToMemrefPass> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PTOViewToMemrefPass)
-
-  StringRef getArgument() const final { return "pto-view-to-memref"; }
-  StringRef getDescription() const final {
-    return "Lower PTO views to memref with Metadata Binding";
-  }
-
-  void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<mlir::pto::PTODialect,
-                    memref::MemRefDialect,
-                    arith::ArithDialect,
-                    func::FuncDialect>();
-  }
 
   void runOnOperation() override {
     ModuleOp mod = getOperation();

--- a/test/lit/pto/compact_left_blayout_parser_a3.pto
+++ b/test/lit/pto/compact_left_blayout_parser_a3.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch a3 %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch a3 --mlir-print-ir-after=pto-view-to-memref %s 2>&1 | FileCheck %s
 
 module attributes {"pto.target_arch" = "a3"} {
   func.func @compact_left_blayout_parser_a3() {

--- a/test/lit/pto/compact_left_blayout_parser_a5.pto
+++ b/test/lit/pto/compact_left_blayout_parser_a5.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch a5 %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch a5 --mlir-print-ir-after=pto-view-to-memref %s 2>&1 | FileCheck %s
 
 module attributes {"pto.target_arch" = "a5"} {
   func.func @compact_left_blayout_parser_a5() {

--- a/test/lit/pto/plan_memory_bind_tile_alias_liveness.pto
+++ b/test/lit/pto/plan_memory_bind_tile_alias_liveness.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @bind_tile_alias_liveness(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -25,7 +25,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @bind_tile_alias_liveness
 // CHECK-NOT: memref.alloc
 // CHECK-DAG: %c0_i64 = arith.constant 0 : i64

--- a/test/lit/pto/plan_memory_for_iter_args_yield.pto
+++ b/test/lit/pto/plan_memory_for_iter_args_yield.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @for_iter_args_yield(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -24,7 +24,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @for_iter_args_yield
 // CHECK-NOT: memref.alloc
 // CHECK: scf.for

--- a/test/lit/pto/plan_memory_fragmentation_hole_fit.pto
+++ b/test/lit/pto/plan_memory_fragmentation_hole_fit.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @fragmentation_hole_fit(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -141,7 +141,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @fragmentation_hole_fit
 // CHECK-NOT: memref.alloc
 // With 23 live UB buffers, there is exactly one remaining 8192B slot. The two

--- a/test/lit/pto/plan_memory_fragmentation_two_holes.pto
+++ b/test/lit/pto/plan_memory_fragmentation_two_holes.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @fragmentation_two_holes(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -149,7 +149,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @fragmentation_two_holes
 // CHECK-NOT: memref.alloc
 // With 22 live UB buffers, there are exactly two remaining 8192B slots at

--- a/test/lit/pto/plan_memory_if_in_loop.pto
+++ b/test/lit/pto/plan_memory_if_in_loop.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @if_in_loop(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -27,7 +27,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @if_in_loop
 // CHECK-NOT: memref.alloc
 // CHECK-DAG: %c0_i64 = arith.constant 0 : i64

--- a/test/lit/pto/plan_memory_if_yield.pto
+++ b/test/lit/pto/plan_memory_if_yield.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @if_yield(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -24,7 +24,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @if_yield
 // CHECK-NOT: memref.alloc
 // CHECK: scf.if

--- a/test/lit/pto/plan_memory_loop_in_if.pto
+++ b/test/lit/pto/plan_memory_loop_in_if.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @loop_in_if(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -27,7 +27,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @loop_in_if
 // CHECK-NOT: memref.alloc
 // CHECK: scf.if

--- a/test/lit/pto/plan_memory_loop_no_reuse_outer_live.pto
+++ b/test/lit/pto/plan_memory_loop_no_reuse_outer_live.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @loop_outer_live(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -29,7 +29,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @loop_outer_live
 // CHECK-NOT: memref.alloc
 // Expect a loop, and two planned buffers at distinct offsets.

--- a/test/lit/pto/plan_memory_nested_loops.pto
+++ b/test/lit/pto/plan_memory_nested_loops.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @nested_loops(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -35,7 +35,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @nested_loops
 // CHECK-NOT: memref.alloc
 // CHECK-DAG: %c0_i64 = arith.constant 0 : i64

--- a/test/lit/pto/plan_memory_no_reuse_overlap.pto
+++ b/test/lit/pto/plan_memory_no_reuse_overlap.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @no_reuse_overlap(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -20,7 +20,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @no_reuse_overlap
 // CHECK-NOT: memref.alloc
 // With overlapping lifetimes, offsets must differ.

--- a/test/lit/pto/plan_memory_peak_8_overlapping.pto
+++ b/test/lit/pto/plan_memory_peak_8_overlapping.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @peak_8_overlapping(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -50,7 +50,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @peak_8_overlapping
 // CHECK-NOT: memref.alloc
 // 8 live buffers implies a max offset of 7*8192 = 57344 bytes.

--- a/test/lit/pto/plan_memory_peak_exact_capacity.pto
+++ b/test/lit/pto/plan_memory_peak_exact_capacity.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @peak_exact_capacity(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -132,7 +132,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @peak_exact_capacity
 // CHECK-NOT: memref.alloc
 // 24 live buffers implies a max offset of 23*8192 = 188416 bytes.

--- a/test/lit/pto/plan_memory_reserve_buffer_prefix.pto
+++ b/test/lit/pto/plan_memory_reserve_buffer_prefix.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @reserve_prefix(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -19,7 +19,7 @@ module {
   }
 }
 
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @reserve_prefix(
 // CHECK: %c0_i64 = arith.constant 0 : i64
 // CHECK: %{{.*}} = pto.reserve_buffer{name = "fifo", size = 8192, location = <vec>, auto = true, base = 8192} -> i32

--- a/test/lit/pto/plan_memory_reuse_sequential.pto
+++ b/test/lit/pto/plan_memory_reuse_sequential.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 1>/dev/null | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
 
 module {
   func.func @reuse_sequential(%arg0: memref<16x16x16xf16, #pto.address_space<gm>>,
@@ -193,7 +193,7 @@ module {
 
 // Anchor checks after the PlanMemory debug marker (ptoas prints the module
 // before and after planning).
-// CHECK: end PTO plan Mem!
+// CHECK: IR Dump After PlanMemory
 // CHECK: func.func @reuse_sequential
 // CHECK-NOT: memref.alloc
 // Expect at least two distinct allocations to reuse offset 0.

--- a/test/lit/pto/record_wait_event.pto
+++ b/test/lit/pto/record_wait_event.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas %s 2>&1 | FileCheck %s
+// RUN: ptoas --mlir-print-ir-after=pto-lowering-sync-to-pipe %s 2>&1 | FileCheck %s
 
 module {
   func.func @sync_ops() {

--- a/test/lit/pto/tile_compact_mode_emitc.pto
+++ b/test/lit/pto/tile_compact_mode_emitc.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-view-to-memref %s 2>&1 | FileCheck %s --check-prefix=A3
 
 module {
   func.func @tile_compact_mode_emitc() {

--- a/test/lit/pto/tpush_tpop_dir_both.pto
+++ b/test/lit/pto/tpush_tpop_dir_both.pto
@@ -1,5 +1,5 @@
 // Test DIR_BOTH (dir_mask=3) lowering to single TPipe
-// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
 module {
 // CHECK-LABEL: func.func @cube_bidir(
   func.func @cube_bidir(

--- a/test/lit/pto/tquant_e2e.pto
+++ b/test/lit/pto/tquant_e2e.pto
@@ -1,5 +1,5 @@
-// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
-// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+// RUN: ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a5 %s -emit-pto-ir 2>&1 | FileCheck %s --check-prefix=A5
 module attributes {"pto.device-spec" = "Ascend910B3"} {
   func.func @tquant_sym_run(%src_ptr: !pto.ptr<f32>, %fp_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<i8>)
       attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {

--- a/test/lit/pto/trem_emitc.pto
+++ b/test/lit/pto/trem_emitc.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-view-to-memref %s 2>&1 | FileCheck %s --check-prefix=A3
 
 module {
   func.func @trem_tmp_form() {

--- a/test/lit/pto/trems_emitc.pto
+++ b/test/lit/pto/trems_emitc.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-view-to-memref %s 2>&1 | FileCheck %s --check-prefix=A3
 
 module {
   func.func @trems_tmp_form() {
@@ -11,6 +11,6 @@ module {
   }
 }
 
-// A3: pto.trems ins(%{{.*}}, %{{.*}}, %{{.*}} : memref<1x16xf32
-// A3: outs(%{{.*}} : memref<1x16xf32
+// A3: pto.trems ins(%{{.*}}, %{{.*}}, %{{[^)]*}} : memref<1x16xf32
+// A3-SAME: outs(%{{.*}} : memref<1x16xf32
 // A3: TREMS({{.*}}, {{.*}}, {{.*}}, {{.*}});

--- a/test/lit/pto/trsqrt_emitc.pto
+++ b/test/lit/pto/trsqrt_emitc.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-view-to-memref %s 2>&1 | FileCheck %s --check-prefix=A3
 
 module {
   func.func @trsqrt_forms() {

--- a/test/lit/pto/tsort32_emitc.pto
+++ b/test/lit/pto/tsort32_emitc.pto
@@ -1,4 +1,4 @@
-// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-view-to-memref %s 2>&1 | FileCheck %s --check-prefix=A3
 
 module {
   func.func @tsort32_forms() {

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -193,6 +193,11 @@ static llvm::cl::opt<bool> emitAddPtrTrace(
     llvm::cl::desc("Emit addptr trace comments in generated C++ output"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> emitMlirIR(
+    "emit-pto-ir",
+    llvm::cl::desc("Emit PTO IR after lowering instead of C++"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<std::string> ptoTargetArch(
     "pto-arch",
     llvm::cl::desc("Target Ascend architecture for codegen: a3 or a5 (default: a3)"),
@@ -920,6 +925,7 @@ int main(int argc, char **argv) {
   }
 
   // Parse command line options
+  mlir::registerPassManagerCLOptions();
   llvm::cl::ParseCommandLineOptions(argc, argv, "PTO Assembler (ptoas)\n");
 
   // Read whole input first (so we can auto-detect .ptobc by magic).
@@ -1081,16 +1087,11 @@ int main(int argc, char **argv) {
       return 1;
   }
 
-  // [Fix] ToolOutputFile Usage
-  std::error_code ec;
-  llvm::ToolOutputFile outputFile(outputFilename, ec, llvm::sys::fs::OF_None);
-  if (ec) {
-    llvm::errs() << ec.message() << "\n";
-    return 1;
-  }
-
   // Main PassManager
   PassManager pm(&context);
+
+  if (failed(applyPassManagerCLOptions(pm)))
+    return 1;
   
   pm.addNestedPass<mlir::func::FuncOp>(
       pto::createPTOAssignDefaultFrontendPipeIdPass());
@@ -1117,6 +1118,15 @@ int main(int argc, char **argv) {
   // Conditionally add Sync pass based on flag.
   if (enableInsertSync)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertSyncPass());
+  
+  if (emitMlirIR) {
+    if (failed(pm.run(*module))) {
+      llvm::errs() << "Error: Pass execution failed.\n";
+      return 1;
+    }
+    module->dump();
+    return 0;
+  }
 
   pm.addPass(createCSEPass());
   if (arch == "a3") {
@@ -1159,6 +1169,15 @@ int main(int argc, char **argv) {
   rewriteAddPtrTraceMarkers(cppOutput, emitAddPtrTrace);
   rewriteScalarConstantDecls(cppOutput);
   rewriteHoistedGlobalTensorDecls(cppOutput);
+  
+  // [Fix] ToolOutputFile Usage
+  std::error_code ec;
+  llvm::ToolOutputFile outputFile(outputFilename, ec, llvm::sys::fs::OF_None);
+  if (ec) {
+    llvm::errs() << ec.message() << "\n";
+    return 1;
+  }
+  
   outputFile.os() << cppOutput;
 
   outputFile.keep(); // Success, keep the file

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1124,12 +1124,21 @@ int main(int argc, char **argv) {
   if (enableInsertSync)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertSyncPass());
   
+
+  // [Fix] ToolOutputFile Usage
+  std::error_code ec;
+  llvm::ToolOutputFile outputFile(outputFilename, ec, llvm::sys::fs::OF_None);
+  if (ec) {
+    llvm::errs() << ec.message() << "\n";
+    return 1;
+  }
+
   if (emitMlirIR) {
     if (failed(pm.run(*module))) {
       llvm::errs() << "Error: Pass execution failed.\n";
       return 1;
     }
-    module->dump();
+    module->print(outputFile.os());
     return 0;
   }
 
@@ -1174,14 +1183,6 @@ int main(int argc, char **argv) {
   rewriteAddPtrTraceMarkers(cppOutput, emitAddPtrTrace);
   rewriteScalarConstantDecls(cppOutput);
   rewriteHoistedGlobalTensorDecls(cppOutput);
-  
-  // [Fix] ToolOutputFile Usage
-  std::error_code ec;
-  llvm::ToolOutputFile outputFile(outputFilename, ec, llvm::sys::fs::OF_None);
-  if (ec) {
-    llvm::errs() << ec.message() << "\n";
-    return 1;
-  }
   
   outputFile.os() << cppOutput;
 

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -924,6 +924,11 @@ int main(int argc, char **argv) {
     }
   }
 
+  // Register all passes so that --mlir-print-ir-after/before can resolve
+  // pass names like 'cse' at option-parse time.
+  mlir::registerAllPasses();
+  registerPTOPasses();
+
   // Parse command line options
   mlir::registerPassManagerCLOptions();
   llvm::cl::ParseCommandLineOptions(argc, argv, "PTO Assembler (ptoas)\n");


### PR DESCRIPTION
This PR improves the IR printing facilities of PTOAS, making it easier to debug and understand the generated IR. The main changes include:
 - Removing spurious debug printouts or explicitly mark the as debug with the LLVM_DEBUG macro, i.e. by default now only the cpp file is printed
 - Adding a CLI option to printout only pto ir (`-emit-pto-ir`)
 - Adding CLI options to control the printing of the IR, allowing users to enable or disable it as needed (see `--mlir-print-ir-after-all` for example).
 - Registering passes so that can be targeted, for example, `--mlir-print-ir-after=pass_name`
 - Minor fixes to accommodate the above changes
 - Minor fixes to the lit tests to reflect the above changes