### PR TITLE
fix: support canonical 2D NZ layout inference

### DIFF
--- a/include/PTO/IR/PTOLayoutUtils.h
+++ b/include/PTO/IR/PTOLayoutUtils.h
@@ -1,0 +1,27 @@
+//===- PTOLayoutUtils.h - Shared PTO layout inference helpers ---*- C++ -*-===//
+//
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_PTO_IR_PTOLAYOUTUTILS_H_
+#define MLIR_DIALECT_PTO_IR_PTOLAYOUTUTILS_H_
+
+#include "llvm/ADT/ArrayRef.h"
+
+#include <cstdint>
+
+namespace mlir::pto {
+
+bool isNZLayout(llvm::ArrayRef<int64_t> shape, llvm::ArrayRef<int64_t> strides,
+                unsigned elemBytes);
+
+} // namespace mlir::pto
+
+#endif // MLIR_DIALECT_PTO_IR_PTOLAYOUTUTILS_H_

--- a/include/PTO/IR/PTOLayoutUtils.h
+++ b/include/PTO/IR/PTOLayoutUtils.h
@@ -1,5 +1,3 @@
-//===- PTOLayoutUtils.h - Shared PTO layout inference helpers ---*- C++ -*-===//
-//
 // Copyright (c) 2026 Huawei Technologies Co., Ltd.
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
@@ -7,6 +5,8 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+//===- PTOLayoutUtils.h - Shared PTO layout inference helpers ---*- C++ -*-===//
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/PTO/IR/CMakeLists.txt
+++ b/lib/PTO/IR/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_mlir_dialect_library(PTOIR
   PTO.cpp
   PTOAttrs.cpp
+  PTOLayoutUtils.cpp
   PTOSyncUtils.cpp
   PTOTypeDefs.cpp
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOLayoutUtils.h"
 #include "PTO/IR/PTOSyncUtils.h"
 
 #include "mlir/AsmParser/AsmParser.h"
@@ -875,15 +876,8 @@ inferLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
   if (shape.size() != strides.size() || elemBytes == 0)
     return std::nullopt;
 
-  // NZ / fractal: rank>=5, check middle dims (sh3/sh4/sh5 per spec)
-  if (shape.size() >= 5) {
-    int64_t sh3 = shape[2], sh4 = shape[3], sh5 = shape[4];
-    int64_t st4 = strides[3], st5 = strides[4];
-    bool alignMatch = (sh3 == 16) && (sh3 * sh4 * elemBytes == 512);
-    bool strideMatch = (st5 == 1) && (st4 == sh5);
-    if (alignMatch && strideMatch)
-      return mlir::pto::Layout::NZ;
-  }
+  if (isNZLayout(shape, strides, elemBytes))
+    return mlir::pto::Layout::NZ;
 
   // ND: row-major contiguous
   bool isRowMajor = true;

--- a/lib/PTO/IR/PTOLayoutUtils.cpp
+++ b/lib/PTO/IR/PTOLayoutUtils.cpp
@@ -1,5 +1,3 @@
-//===- PTOLayoutUtils.cpp - Shared PTO layout inference helpers -----------===//
-//
 // Copyright (c) 2026 Huawei Technologies Co., Ltd.
 // This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
@@ -7,6 +5,8 @@
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
+//
+//===- PTOLayoutUtils.cpp - Shared PTO layout inference helpers -----------===//
 //
 //===----------------------------------------------------------------------===//
 
@@ -60,6 +60,11 @@ bool isCanonical2DNZLayout5D(ArrayRef<int64_t> shape5D,
 
   const int64_t c0 = 32 / elemBytes;
   if (shape5D[0] != 1)
+    return false;
+  // The degenerate [1, 1, 1, 16, c0] form is ambiguous with a plain 2D
+  // row-major tensor of shape (16 x c0). Keep that case on the existing ND/DN
+  // path unless the user specifies NZ explicitly.
+  if (shape5D[1] == 1 && shape5D[2] == 1)
     return false;
   if (shape5D[3] != 16 || shape5D[4] != c0)
     return false;

--- a/lib/PTO/IR/PTOLayoutUtils.cpp
+++ b/lib/PTO/IR/PTOLayoutUtils.cpp
@@ -1,0 +1,100 @@
+//===- PTOLayoutUtils.cpp - Shared PTO layout inference helpers -----------===//
+//
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/IR/PTOLayoutUtils.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <optional>
+
+using llvm::ArrayRef;
+using llvm::SmallVector;
+
+namespace mlir::pto {
+namespace {
+
+struct ShapeStride5D {
+  SmallVector<int64_t, 5> shape;
+  SmallVector<int64_t, 5> stride;
+};
+
+std::optional<ShapeStride5D> rightAlignTo5D(ArrayRef<int64_t> shape,
+                                            ArrayRef<int64_t> stride) {
+  if (shape.size() != stride.size())
+    return std::nullopt;
+  if (shape.empty() || shape.size() > 5)
+    return std::nullopt;
+
+  ShapeStride5D out;
+  out.shape.assign(5, 1);
+  out.stride.assign(5, 1);
+
+  const int rank = static_cast<int>(shape.size());
+  const int shift = 5 - rank;
+  for (int i = 0; i < rank; ++i) {
+    out.shape[shift + i] = shape[i];
+    out.stride[shift + i] = stride[i];
+  }
+
+  for (int i = shift - 1; i >= 0; --i)
+    out.stride[i] = out.shape[i + 1] * out.stride[i + 1];
+
+  return out;
+}
+
+bool isCanonical2DNZLayout5D(ArrayRef<int64_t> shape5D,
+                             ArrayRef<int64_t> stride5D,
+                             unsigned elemBytes) {
+  if (shape5D.size() != 5 || stride5D.size() != 5 || elemBytes == 0 ||
+      32 % elemBytes != 0)
+    return false;
+
+  const int64_t c0 = 32 / elemBytes;
+  if (shape5D[0] != 1)
+    return false;
+  if (shape5D[3] != 16 || shape5D[4] != c0)
+    return false;
+  if (stride5D[4] != 1 || stride5D[3] != shape5D[4])
+    return false;
+
+  for (int i = 2; i >= 0; --i) {
+    if (stride5D[i] != shape5D[i + 1] * stride5D[i + 1])
+      return false;
+  }
+
+  return true;
+}
+
+bool isLegacyNZLayout5D(ArrayRef<int64_t> shape5D, ArrayRef<int64_t> stride5D,
+                        unsigned elemBytes) {
+  if (shape5D.size() != 5 || stride5D.size() != 5 || elemBytes == 0)
+    return false;
+
+  int64_t sh3 = shape5D[2], sh4 = shape5D[3], sh5 = shape5D[4];
+  int64_t st4 = stride5D[3], st5 = stride5D[4];
+  bool alignMatch = (sh3 == 16) && (sh3 * sh4 * elemBytes == 512);
+  bool strideMatch = (st5 == 1) && (st4 == sh5);
+  return alignMatch && strideMatch;
+}
+
+} // namespace
+
+bool isNZLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
+                unsigned elemBytes) {
+  auto padded = rightAlignTo5D(shape, strides);
+  if (!padded)
+    return false;
+  return isCanonical2DNZLayout5D(padded->shape, padded->stride, elemBytes) ||
+         isLegacyNZLayout5D(padded->shape, padded->stride, elemBytes);
+}
+
+} // namespace mlir::pto

--- a/lib/PTO/Transforms/InferPTOLayout.cpp
+++ b/lib/PTO/Transforms/InferPTOLayout.cpp
@@ -21,6 +21,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOLayoutUtils.h"
 #include "PTO/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -151,16 +152,8 @@ static std::optional<Layout> inferMinor2DLayout(
 static std::optional<Layout> inferNZLayout(ArrayRef<int64_t> shape,
                                            ArrayRef<int64_t> stride,
                                            unsigned elemBytes) {
-  int64_t sh3 = shape[2];
-  int64_t sh4 = shape[3];
-  int64_t sh5 = shape[4];
-  int64_t st4 = stride[3];
-  int64_t st5 = stride[4];
-  bool alignMatch = (sh3 == 16) && (sh3 * sh4 * elemBytes == 512);
-  bool strideMatch = (st5 == 1) && (st4 == sh5);
-  if (alignMatch && strideMatch)
-    return Layout::NZ;
-  return std::nullopt;
+  return isNZLayout(shape, stride, elemBytes) ? std::optional(Layout::NZ)
+                                              : std::nullopt;
 }
 
 static std::optional<Layout> inferLayout5D(ArrayRef<int64_t> shape,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -12,6 +12,7 @@
 #include <climits>
 
 #include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOLayoutUtils.h"
 #include "PTO/IR/PTOSyncUtils.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -3072,9 +3073,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         elemBytes = 8;
 
       if (allStatic) {
-        if (finalShape[2] == 16 &&
-            finalShape[2] * finalShape[3] * elemBytes == 512 &&
-            finalStride[4] == 1 && finalStride[3] == finalShape[4]) {
+        if (isNZLayout(finalShape, finalStride, elemBytes)) {
           layoutTag = 2; // NZ
         } else {
           bool isRow = finalStride[4] == 1;
@@ -3274,8 +3273,7 @@ static std::string inferFallbackGlobalTensorLayout(ArrayRef<int64_t> shape5D,
                                                    ArrayRef<int64_t> stride5D,
                                                    StringRef elemTypeStr) {
   int elemBytes = getGlobalTensorElementBytes(elemTypeStr);
-  if (shape5D[2] == 16 && multiplyOrDynamic(shape5D[2], shape5D[3]) * elemBytes == 512 &&
-      stride5D[4] == 1 && stride5D[3] == shape5D[4]) {
+  if (isNZLayout(shape5D, stride5D, elemBytes)) {
     return "pto::Layout::NZ";
   }
 

--- a/test/lit/pto/issue527_nz_layout_inference.pto
+++ b/test/lit/pto/issue527_nz_layout_inference.pto
@@ -1,0 +1,46 @@
+// RUN: ptoas --pto-arch=a5 %s | FileCheck %s --check-prefix=INFER
+// RUN: ptoas --pto-arch=a5 --disable-infer-layout %s | FileCheck %s --check-prefix=FALLBACK
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @canonical_c2d_nz(%src: !pto.ptr<f16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c16 = arith.constant 16 : index
+    %c256 = arith.constant 256 : index
+    %c512 = arith.constant 512 : index
+    %c1024 = arith.constant 1024 : index
+    %view = pto.make_tensor_view %src, shape = [%c1, %c2, %c2, %c16, %c16], strides = [%c1024, %c512, %c256, %c16, %c1] : !pto.tensor_view<1x2x2x16x16xf16>
+    %part = pto.partition_view %view, offsets = [%c0, %c0, %c0, %c0, %c0], sizes = [%c1, %c2, %c2, %c16, %c16] : !pto.tensor_view<1x2x2x16x16xf16> -> !pto.partition_tensor_view<1x2x2x16x16xf16>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tload ins(%part : !pto.partition_tensor_view<1x2x2x16x16xf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @legacy_nz_compat(%src: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c8 = arith.constant 8 : index
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %c2048 = arith.constant 2048 : index
+    %view = pto.make_tensor_view %src, shape = [%c2, %c1, %c16, %c8, %c16], strides = [%c2048, %c2048, %c128, %c16, %c1] : !pto.tensor_view<2x1x16x8x16xf32>
+    %part = pto.partition_view %view, offsets = [%c0, %c0, %c0, %c0, %c0], sizes = [%c2, %c1, %c16, %c8, %c16] : !pto.tensor_view<2x1x16x8x16xf32> -> !pto.partition_tensor_view<2x1x16x8x16xf32>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=64, cols=64, v_row=64, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.tload ins(%part : !pto.partition_tensor_view<2x1x16x8x16xf32>) outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=64, cols=64, v_row=64, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// INFER-LABEL: AICORE void canonical_c2d_nz(
+// INFER: pto::Layout::NZ
+
+// INFER-LABEL: AICORE void legacy_nz_compat(
+// INFER: pto::Layout::NZ
+
+// FALLBACK-LABEL: AICORE void canonical_c2d_nz(
+// FALLBACK: pto::Layout::NZ
+
+// FALLBACK-LABEL: AICORE void legacy_nz_compat(
+// FALLBACK: pto::Layout::NZ

--- a/test/lit/pto/issue527_nz_layout_inference.pto
+++ b/test/lit/pto/issue527_nz_layout_inference.pto
@@ -31,6 +31,17 @@ module attributes {"pto.target_arch" = "a5"} {
     pto.tload ins(%part : !pto.partition_tensor_view<2x1x16x8x16xf32>) outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=64, cols=64, v_row=64, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
     return
   }
+
+  func.func @degenerate_nd_not_nz(%src: !pto.ptr<f16>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %view = pto.make_tensor_view %src, shape = [%c16, %c16], strides = [%c16, %c1] : !pto.tensor_view<16x16xf16>
+    %part = pto.partition_view %view, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<16x16xf16> -> !pto.partition_tensor_view<16x16xf16>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tload ins(%part : !pto.partition_tensor_view<16x16xf16>) outs(%tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
 }
 
 // INFER-LABEL: AICORE void canonical_c2d_nz(
@@ -39,8 +50,16 @@ module attributes {"pto.target_arch" = "a5"} {
 // INFER-LABEL: AICORE void legacy_nz_compat(
 // INFER: pto::Layout::NZ
 
+// INFER-LABEL: AICORE void degenerate_nd_not_nz(
+// INFER-NOT: pto::Layout::NZ
+// INFER: pto::Layout::ND
+
 // FALLBACK-LABEL: AICORE void canonical_c2d_nz(
 // FALLBACK: pto::Layout::NZ
 
 // FALLBACK-LABEL: AICORE void legacy_nz_compat(
 // FALLBACK: pto::Layout::NZ
+
+// FALLBACK-LABEL: AICORE void degenerate_nd_not_nz(
+// FALLBACK-NOT: pto::Layout::NZ
+// FALLBACK: pto::Layout::ND


### PR DESCRIPTION
## Summary
- add a shared NZ layout helper and use it in IR verification, the infer-layout pass, and EmitC fallback inference
- recognize the pto-isa canonical 2D NZ 5D form while preserving the legacy NZ pattern already accepted by PTOAS
- add a lit regression that covers both the canonical 2D NZ case and the legacy compatibility case, with and without `--disable-infer-layout`

## Validation
- `/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/llvm-lit -sv build-issue527/test/lit/pto/issue527_nz_layout_inference.pto`
- `/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/llvm-lit -sv build-issue527/test/lit/pto/infer_layout_ambiguous_minor2d_user_dn.pto build-issue527/test/lit/pto/tinsert_a5_vec_mat_mode_lowering.pto build-issue527/test/lit/pto/tci_i16_emitc.pto`