### PR TITLE
docs: fix GitHub workspace path and pybind guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## 2. 目录结构 (Directory Structure)
 
 ```text
-pto-as/
+PTOAS/
 ├── include/
 │   └── PTO/               # PTO Dialect 的头文件与 TableGen 定义 (.td)
 ├── lib/
@@ -46,15 +46,15 @@ pto-as/
 
 ```bash
 # ================= 配置区域 (请修改这里) =================
-# 设置您的工作根目录 (建议创建一个专门的目录存放 LLVM 和 ptoas)
+# 设置您的工作根目录 (建议创建一个专门的目录存放 LLVM 和 PTOAS)
 export WORKSPACE_DIR=$HOME/llvm-workspace
 
 # LLVM 源码与构建路径
 export LLVM_SOURCE_DIR=$WORKSPACE_DIR/llvm-project
 export LLVM_BUILD_DIR=$LLVM_SOURCE_DIR/build-shared
 
-# pto-as 源码与安装路径
-export PTO_SOURCE_DIR=$WORKSPACE_DIR/pto-as
+# PTOAS 源码与安装路径
+export PTO_SOURCE_DIR=$WORKSPACE_DIR/PTOAS
 export PTO_INSTALL_DIR=$PTO_SOURCE_DIR/install
 # =======================================================
 
@@ -71,9 +71,13 @@ mkdir -p $WORKSPACE_DIR
 * **Python**: 3.8+
 * **Python Packages**: `pybind11`, `numpy`
 ```bash
-pip3 install pybind11 numpy
+python3 -m pip install pybind11==2.12.0 numpy
 
 ```
+
+> 说明：当前 LLVM/MLIR Python 绑定与 `pybind11` 3.x 不兼容。
+> 如果编译 LLVM 时遇到 `def_property family does not currently support keep_alive` 等报错，
+> 请先执行上面的降级命令。
 
 
 
@@ -104,12 +108,12 @@ ninja -C $LLVM_BUILD_DIR
 
 ```
 
-### 3.3 第二步：构建 ptoas (Out-of-Tree)
+### 3.3 第二步：构建 PTOAS (Out-of-Tree)
 
-下载 ptoas 源码并基于刚刚编译好的 LLVM 19 进行构建。
+下载 PTOAS 源码并基于刚刚编译好的 LLVM 19 进行构建。
 
 ```bash
-# 1. 下载 ptoas 源码
+# 1. 下载 PTOAS 源码
 cd $WORKSPACE_DIR
 git clone https://github.com/hw-native-sys/PTOAS.git
 cd $PTO_SOURCE_DIR


### PR DESCRIPTION
## Summary
- update the README workspace example to use the GitHub clone directory name 
- pin the documented  install command to 
- add a short note for the known  3.x  build error

## Testing
- doc-only change
- 
