### PR TITLE
[Issue #546] fix: reject non-lowerable mat tfillpad tile mismatch

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -6909,8 +6909,7 @@ For padded elements: dst = PadVal(dst)
 - `dst.pad` must not be `null`.
 - `src` and `dst` element sizes must match, and the element size must be `1`, `2`, or `4` bytes.
 - `dst.rows/cols` must match `src.rows/cols`.
-- `dst.rows >= src.rows` and `dst.cols >= src.cols`.
-- For `mat` tiles, the current implementation only supports `blayout=col_major`, `slayout=row_major`, and `pad=zero`.
+- For `loc=mat`, `src` and `dst` must be lowerable to the same `TFILLPAD` tile specialization, i.e. `validShape` and `pad` must be identical.
 
 **Hardware Mapping:**
 
@@ -6947,7 +6946,8 @@ Constraint: dst.rows >= src.rows and dst.cols >= src.cols
 
 **Constraints & Verification:**
 
-- The operation has a custom verifier
+- The operation has a custom verifier.
+- For `loc=mat`, cross-layer behavior with heterogeneous (`src`/`dst`) expand shape is not finalized in this release; `tfillpad_expand` is not covered by the `tfillpad`-specific lowerability check.
 
 **Hardware Mapping:**
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4580,6 +4580,48 @@ static mlir::LogicalResult verifyTFillPadLike(Operation *op, Type srcTy, Type ds
   if (!(srcB == 1 || srcB == 2 || srcB == 4))
     return op->emitError("expects element size to be 1, 2, or 4 bytes");
 
+  // pto.tfillpad lowers to TFILLPAD(dst, src). For loc=mat, pto-isa only
+  // exposes the homogeneous overload, so src/dst must use the same Tile<...>
+  // specialization (including valid_shape and pad).
+  if (opName == "tfillpad") {
+    auto srcTb = mlir::dyn_cast<mlir::pto::TileBufType>(srcTy);
+    auto dstTb = mlir::dyn_cast<mlir::pto::TileBufType>(dstTy);
+    auto srcSpace = getPTOMemorySpaceEnum(srcTy);
+    auto dstSpace = getPTOMemorySpaceEnum(dstTy);
+    if (srcTb && dstTb && srcSpace && dstSpace &&
+        *srcSpace == mlir::pto::AddressSpace::MAT &&
+        *dstSpace == mlir::pto::AddressSpace::MAT && srcTb != dstTb) {
+      auto dimToStr = [](int64_t dim) -> std::string {
+        return dim == ShapedType::kDynamic ? "?" : std::to_string(dim);
+      };
+      SmallVector<std::string, 4> mismatchFields;
+      auto srcValid = getValidShapeVec(srcTy);
+      auto dstValid = getValidShapeVec(dstTy);
+      if (srcValid.size() == 2 && dstValid.size() == 2) {
+        if (srcValid[0] != dstValid[0])
+          mismatchFields.push_back("v_row (" + dimToStr(srcValid[0]) + " vs " +
+                                   dimToStr(dstValid[0]) + ")");
+        if (srcValid[1] != dstValid[1])
+          mismatchFields.push_back("v_col (" + dimToStr(srcValid[1]) + " vs " +
+                                   dimToStr(dstValid[1]) + ")");
+      }
+      if (srcTb.getPadValueI32() != dstTb.getPadValueI32())
+        mismatchFields.push_back("pad (" + std::to_string(srcTb.getPadValueI32()) +
+                                 " vs " + std::to_string(dstTb.getPadValueI32()) +
+                                 ")");
+
+      auto diag = op->emitError()
+                  << "expects src/dst tile types to be lowerable to TFILLPAD "
+                     "for loc=mat";
+      if (!mismatchFields.empty())
+        diag << "; mismatching fields: " << llvm::join(mismatchFields, ", ");
+      diag << "\n  src: " << srcTy;
+      diag << "\n  dst: " << dstTy;
+      diag << "\n  note: heterogeneous TFILLPAD overload is only available for loc=vec";
+      return failure();
+    }
+  }
+
   if (auto dstTileTy = mlir::dyn_cast<mlir::pto::TileBufType>(dstTy)) {
     auto padAttr = mlir::dyn_cast<mlir::pto::PadValueAttr>(dstTileTy.getPadValueAttr());
     if (!padAttr || padAttr.getValue() == mlir::pto::PadValue::Null)

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4583,6 +4583,9 @@ static mlir::LogicalResult verifyTFillPadLike(Operation *op, Type srcTy, Type ds
   // pto.tfillpad lowers to TFILLPAD(dst, src). For loc=mat, pto-isa only
   // exposes the homogeneous overload, so src/dst must use the same Tile<...>
   // specialization (including valid_shape and pad).
+  // Note: tfillpad_expand is intentionally not covered here because its
+  // cross-layer ABI contract for loc=mat heterogeneous shape expansion is not
+  // finalized yet.
   if (opName == "tfillpad") {
     auto srcTb = mlir::dyn_cast<mlir::pto::TileBufType>(srcTy);
     auto dstTb = mlir::dyn_cast<mlir::pto::TileBufType>(dstTy);

--- a/test/basic/issue546_tfillpad_mat_mismatch_diag.pto
+++ b/test/basic/issue546_tfillpad_mat_mismatch_diag.pto
@@ -1,0 +1,15 @@
+// RUN: not ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @issue546_tfillpad_mat_mismatch(
+      %src: !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=64, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=512, pad=0>,
+      %dst: !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=1>) {
+    pto.tfillpad ins(%src : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=64, v_row=?, v_col=?, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+                 outs(%dst : !pto.tile_buf<loc=mat, dtype=bf16, rows=16, cols=64, v_row=16, v_col=64, blayout=col_major, slayout=row_major, fractal=512, pad=1>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tfillpad' op expects src/dst tile types to be lowerable to TFILLPAD for loc=mat
+// CHECK-SAME: mismatching fields: v_row (? vs 16), v_col (? vs 64), pad (0 vs 1)
+// CHECK: note: heterogeneous TFILLPAD overload is only available for loc=vec


### PR DESCRIPTION
## 问题背景
- issue #546 中，pto.tfillpad 在 src/dst 为 loc=mat 且 tile 类型不一致（典型为 v_row/v_col/pad 不一致）时，前端未报错，最终在 C++ 编译阶段报 TFILLPAD 模板匹配失败，定位困难。

## 定位分析
- pto.tfillpad 的 verifier 仅检查了静态 shape 与元素字节宽，未覆盖会影响 Tile<...> 模板特化的一致性字段。
- EmitC 会直接降为 TFILLPAD(dst, src)。对于 loc=mat，仅有同构重载可用，src/dst Tile 类型不一致时无法匹配。
- tfillpad_expand 在 loc=mat 的跨层 ABI（异构 src/dst expand）约束尚未最终定版，本次不改变其行为边界。

## 解决方案
- 在 verifyTFillPadLike 中新增 pto.tfillpad + loc=mat 的 lowerability 检查：当 src/dst TileBufType 不一致时，前端直接报错。
- 诊断中显式列出不一致字段（v_row/v_col/pad）并附带 src/dst 类型与提示（heterogeneous TFILLPAD 仅支持 loc=vec）。
- 同步文档：更新 docs/PTO_IR_manual.md 与 ReleaseNotes.md，明确 loc=mat 下 tfillpad 要求 src/dst 的 validShape 与 pad 完全一致。
- 对 tfillpad_expand 在文档和代码注释中补充当前范围说明，避免误解为已覆盖同类校验。
- 回归验证：cmake --build build --target check-pto -j8（124/124 通过）。