### PR TITLE
[Issue #556] fix: prevent live tpop results from being CSE-aliased

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1794,7 +1794,7 @@ def TPushOp : PTO_TOp<"tpush", [
   }];
 }
 
-def DeclareTileOp : PTO_Op<"declare_tile", [Pure]> {
+def DeclareTileOp : PTO_Op<"declare_tile"> {
   let summary = "Declare a tile value whose address will be assigned later";
 
   let results = (outs PTODpsType:$tile);
@@ -1871,7 +1871,7 @@ def EventIdArraySetOp : PTO_Op<"eventid_array_set"> {
   }];
 }
 
-def DeclareTileMemRefOp : PTO_Op<"declare_tile_memref", [Pure]> {
+def DeclareTileMemRefOp : PTO_Op<"declare_tile_memref"> {
   let summary = "Internal memref placeholder for a tile whose address is assigned later";
   let description = [{
     Internal lowering op used by PTOViewToMemref. This op does not allocate

--- a/test/lit/pto/issue556_tpop_live_values_no_alias.pto
+++ b/test/lit/pto/issue556_tpop_live_values_no_alias.pto
@@ -1,0 +1,38 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @issue556_tpop_live_values_no_alias(%gm_slot_buffer: !pto.ptr<f16>,
+                                                %c2v_consumer_buf: i32,
+                                                %v2c_consumer_buf: i32)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 512}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f16>,
+       c2v_consumer_buf = %c2v_consumer_buf : i32,
+       v2c_consumer_buf = %v2c_consumer_buf : i32)
+
+    %pop0 = pto.tpop_from_aiv {id = 0, split = 1}
+      -> !pto.tile_buf<loc=mat, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pop1 = pto.tpop_from_aiv {id = 0, split = 1}
+      -> !pto.tile_buf<loc=mat, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %left = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+    %right = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+
+    pto.tmov ins(%pop0 : !pto.tile_buf<loc=mat, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%left : !pto.tile_buf<loc=left, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+    pto.tmov ins(%pop1 : !pto.tile_buf<loc=mat, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%right : !pto.tile_buf<loc=right, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+
+    pto.tfree_from_aiv {id = 0, split = 1}
+    pto.tfree_from_aiv {id = 0, split = 1}
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void issue556_tpop_live_values_no_alias(
+// CHECK: Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[POP0:v[0-9]+]];
+// CHECK: Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[POP1:v[0-9]+]];
+// CHECK: TPOP<TPipe<0, Direction::DIR_V2C, 512, 8, 8, false>, Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_UP_DOWN>({{v[0-9]+}}, [[POP0]]);
+// CHECK: TPOP<TPipe<0, Direction::DIR_V2C, 512, 8, 8, false>, Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_UP_DOWN>({{v[0-9]+}}, [[POP1]]);
+// CHECK: TMOV({{v[0-9]+}}, [[POP0]]);
+// CHECK: TMOV({{v[0-9]+}}, [[POP1]]);

--- a/test/lit/pto/issue556_tpop_live_values_no_alias.pto
+++ b/test/lit/pto/issue556_tpop_live_values_no_alias.pto
@@ -1,14 +1,22 @@
 // RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
 
 module {
-  func.func @issue556_tpop_live_values_no_alias(%gm_slot_buffer: !pto.ptr<f16>,
-                                                %c2v_consumer_buf: i32,
-                                                %v2c_consumer_buf: i32)
-      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 512}
+  func.func @issue556_tpop_live_values_no_alias(%gm_slot_buffer: !pto.ptr<f16>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c2v_import = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @issue556_peer_vector
+    } -> i32
+    %v2c_local = pto.reserve_buffer {
+      name = "v2c_fifo",
+      size = 4096,
+      location = #pto.address_space<mat>,
+      auto = true
+    } -> i32
+    pto.aic_initialize_pipe {id = 0, dir_mask = 2, slot_size = 512}
       (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f16>,
-       c2v_consumer_buf = %c2v_consumer_buf : i32,
-       v2c_consumer_buf = %v2c_consumer_buf : i32)
+       c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %v2c_local : i32)
 
     %pop0 = pto.tpop_from_aiv {id = 0, split = 1}
       -> !pto.tile_buf<loc=mat, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
@@ -27,12 +35,31 @@ module {
     pto.tfree_from_aiv {id = 0, split = 1}
     return
   }
+
+  func.func private @issue556_peer_vector(%gm_slot_buffer: !pto.ptr<f16>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    %v2c_import = pto.import_reserved_buffer {
+      name = "v2c_fifo",
+      peer_func = @issue556_tpop_live_values_no_alias
+    } -> i32
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 512}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f16>,
+       c2v_consumer_buf = %c2v_local : i32,
+       v2c_consumer_buf = %v2c_import : i32)
+    return
+  }
 }
 
 // CHECK-LABEL: AICORE void issue556_tpop_live_values_no_alias(
 // CHECK: Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[POP0:v[0-9]+]];
-// CHECK: Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[POP1:v[0-9]+]];
 // CHECK: TPOP<TPipe<0, Direction::DIR_V2C, 512, 8, 8, false>, Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_UP_DOWN>({{v[0-9]+}}, [[POP0]]);
+// CHECK: Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[POP1:v[0-9]+]];
 // CHECK: TPOP<TPipe<0, Direction::DIR_V2C, 512, 8, 8, false>, Tile<TileType::Mat, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>, TileSplitAxis::TILE_UP_DOWN>({{v[0-9]+}}, [[POP1]]);
 // CHECK: TMOV({{v[0-9]+}}, [[POP0]]);
 // CHECK: TMOV({{v[0-9]+}}, [[POP1]]);


### PR DESCRIPTION
fix Issue #556
## 问题背景
- `pto.tpop_from_aiv` 的两个同时存活结果在生成 C++ 时可能被错误合并到同一 tile 变量，导致后一个 `TPOP` 覆盖前一个结果。
- 该问题会破坏后续分别消费两个 pop 结果（如连续 `TMOV`）的语义正确性。

## 定位分析
- `tools/ptoas/ptoas.cpp` 在 `PTOViewToMemref` 之后、`EmitPTO` 之前执行了 `CSE`。
- tpop_from_aiv 先被降成 declare_tile + tpop，declare_tile 再被降成 declare_tile_memref + bind_tile
- `pto.declare_tile` / `pto.declare_tile_memref` 之前被标记为 `Pure`，导致这些“应当具备唯一句柄语义”的占位符 op 在 CSE 下可被错误合并。
- 结果是两个逻辑上独立的 live pop 值最终共享同一个 EmitC tile 变量，出现别名覆盖。

## 解决方案
- 将 `DeclareTileOp` 与 `DeclareTileMemRefOp` 从 `Pure` 改为非 `Pure`，避免在 CSE 中被等价折叠。
- 新增回归测试 `test/lit/pto/issue556_tpop_live_values_no_alias.pto`，覆盖两个连续 `tpop_from_aiv` 同时存活并分别 `tmov` 的场景，检查生成 C++ 中使用两个不同 tile 变量。
