### PR TITLE
Fix tcolargmax/tcolargmin verifier element-width constraints

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2782,9 +2782,12 @@ static LogicalResult verifyTColArgReductionOpCommon(Operation *op, Type srcTy,
   if (failed(verifyColReductionValidRegion(op, srcTy, dstTy,
                                            /*requireNonZeroSrc=*/true)))
     return failure();
-  auto srcElem = getElemTy(srcTy).dyn_cast<mlir::FloatType>();
-  if (!srcElem || (!srcElem.isF16() && !srcElem.isF32()))
-    return op->emitOpError("expects src element type to be f16 or f32");
+  Type srcElemTy = getElemTy(srcTy);
+  unsigned srcElemBits = srcElemTy ? srcElemTy.getIntOrFloatBitWidth() : 0;
+  if (!(srcElemTy.isa<IntegerType, FloatType>() &&
+        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+    return op->emitOpError(
+        "expects src/tmp element type to be 1, 2, or 4 bytes wide");
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
   if (!dstInt || dstInt.getWidth() != 32)
     return op->emitOpError("expects dst element type to be i32 or ui32");

--- a/test/lit/pto/issue554_tcolarg_invalid_width.pto
+++ b/test/lit/pto/issue554_tcolarg_invalid_width.pto
@@ -1,0 +1,16 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @issue554_tcolargmax_i64_rejected() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i64, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tcolargmax' op expects src/tmp element type to be 1, 2, or 4 bytes wide

--- a/test/lit/pto/issue554_tcolarg_types.pto
+++ b/test/lit/pto/issue554_tcolarg_types.pto
@@ -1,0 +1,24 @@
+// RUN: ptoas --pto-arch=a3 %s >/dev/null
+// RUN: ptoas --pto-arch=a5 %s >/dev/null
+
+module {
+  func.func @issue554_tcolargmax_ui16() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @issue554_tcolargmin_ui32() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmin ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- align `pto.tcolargmax` and `pto.tcolargmin` verifier checks with the backend `TColReduceIdxCheck` element-width contract
- allow integer and floating-point src/tmp element types that are 1, 2, or 4 bytes wide
- add positive and negative regressions for the widened verifier behavior

## Testing
- `ninja -C build ptoas`
- `./build/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/issue554_tcolarg_types.pto >/dev/null`
- `./build/tools/ptoas/ptoas --pto-arch=a5 test/lit/pto/issue554_tcolarg_types.pto >/dev/null`
- `./build/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/issue554_tcolarg_invalid_width.pto` (fails as expected)
- `./build/tools/ptoas/ptoas --pto-arch=a5 test/lit/pto/issue554_tcolarg_invalid_width.pto` (fails as expected)

Close: hw-native-sys/PTOAS#554