### PR TITLE
fix: reject A2/A3 nosplit subblock-divergent pipe ops

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7873,6 +7873,9 @@ generated IR. The detailed design document is:
   logical pipe, and the `tpush` / `tpop` / `tfree` sequence for that pipe must
   be identical in order on both vector cores. They do not need to reach each
   operation at the same time; only the relative order must remain consistent.
+  In practice, for the same logical pipe on the vector side, these pipe ops
+  must not be nested under control flow whose condition or loop bounds depend
+  on `pto.get_subblock_idx`.
 
 ##### `pto.reserve_buffer` - Reserve Local Consumer FIFO Buffer
 

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -182,6 +182,9 @@ def PTOInferValidatePipeInit : Pass<"pto-infer-validate-pipe-init", "ModuleOp"> 
       compatibility with older IR that omitted init-level `nosplit`
     - propagates the resolved `nosplit` value across peer pipe init pairs so
       both ends of one logical pipe agree before EmitC lowering
+    - rejects A2/A3 vector-side `nosplit` pipe ops nested under
+      `pto.get_subblock_idx`-dependent control flow because both vector
+      subblocks must execute the same pipe sequence
   }];
 
   let constructor = "mlir::pto::createPTOInferValidatePipeInitPass()";

--- a/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
+++ b/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
@@ -308,6 +308,13 @@ static Operation *findSubblockDivergentAncestor(Operation *op,
       continue;
     }
 
+    if (auto whileOp = dyn_cast<scf::WhileOp>(ancestor)) {
+      if (dependsOnSubblockIdx(whileOp.getConditionOp().getCondition(), cache,
+                               visiting))
+        return ancestor;
+      continue;
+    }
+
     if (auto indexSwitchOp = dyn_cast<scf::IndexSwitchOp>(ancestor)) {
       if (dependsOnSubblockIdx(indexSwitchOp.getArg(), cache, visiting))
         return ancestor;

--- a/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
+++ b/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
@@ -14,11 +14,13 @@
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 #include <algorithm>
@@ -215,6 +217,159 @@ resolveNoSplitComponent(ArrayRef<PipeInitInfo *> component, OpBuilder &builder) 
   return success();
 }
 
+static bool isVectorKernel(func::FuncOp funcOp) {
+  auto kernelKindAttr = funcOp->getAttrOfType<FunctionKernelKindAttr>(
+      FunctionKernelKindAttr::name);
+  return kernelKindAttr &&
+         kernelKindAttr.getKernelKind() == FunctionKernelKind::Vector;
+}
+
+static bool dependsOnSubblockIdx(Value value, llvm::DenseMap<Value, bool> &cache,
+                                 llvm::DenseSet<Value> &visiting);
+
+static bool anyDependsOnSubblockIdx(ValueRange values,
+                                    llvm::DenseMap<Value, bool> &cache,
+                                    llvm::DenseSet<Value> &visiting) {
+  return llvm::any_of(values, [&](Value value) {
+    return dependsOnSubblockIdx(value, cache, visiting);
+  });
+}
+
+static bool blockArgDependsOnSubblockIdx(BlockArgument blockArg,
+                                         llvm::DenseMap<Value, bool> &cache,
+                                         llvm::DenseSet<Value> &visiting) {
+  Block *block = blockArg.getOwner();
+  Operation *parentOp = block->getParentOp();
+  if (isa_and_nonnull<func::FuncOp>(parentOp))
+    return false;
+
+  if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
+    if (blockArg.getArgNumber() == 0) {
+      return anyDependsOnSubblockIdx(
+          ValueRange{forOp.getLowerBound(), forOp.getUpperBound(),
+                     forOp.getStep()},
+          cache, visiting);
+    }
+    unsigned iterIdx = blockArg.getArgNumber() - 1;
+    if (iterIdx < forOp.getInitArgs().size())
+      return dependsOnSubblockIdx(forOp.getInitArgs()[iterIdx], cache,
+                                  visiting);
+    return false;
+  }
+
+  if (auto whileOp = dyn_cast<scf::WhileOp>(parentOp))
+    return anyDependsOnSubblockIdx(whileOp.getOperands(), cache, visiting);
+
+  return false;
+}
+
+static bool dependsOnSubblockIdx(Value value, llvm::DenseMap<Value, bool> &cache,
+                                 llvm::DenseSet<Value> &visiting) {
+  if (auto it = cache.find(value); it != cache.end())
+    return it->second;
+
+  if (!visiting.insert(value).second)
+    return false;
+
+  bool result = false;
+  if (auto blockArg = dyn_cast<BlockArgument>(value)) {
+    result = blockArgDependsOnSubblockIdx(blockArg, cache, visiting);
+  } else if (Operation *defOp = value.getDefiningOp()) {
+    if (isa<GetSubBlockIdxOp>(defOp)) {
+      result = true;
+    } else {
+      result = anyDependsOnSubblockIdx(defOp->getOperands(), cache, visiting);
+    }
+  }
+
+  visiting.erase(value);
+  cache[value] = result;
+  return result;
+}
+
+static Operation *findSubblockDivergentAncestor(Operation *op,
+                                                llvm::DenseMap<Value, bool> &cache,
+                                                llvm::DenseSet<Value> &visiting) {
+  for (Operation *ancestor = op->getParentOp(); ancestor;
+       ancestor = ancestor->getParentOp()) {
+    if (auto ifOp = dyn_cast<scf::IfOp>(ancestor)) {
+      if (dependsOnSubblockIdx(ifOp.getCondition(), cache, visiting))
+        return ancestor;
+      continue;
+    }
+
+    if (auto forOp = dyn_cast<scf::ForOp>(ancestor)) {
+      if (anyDependsOnSubblockIdx(
+              ValueRange{forOp.getLowerBound(), forOp.getUpperBound(),
+                         forOp.getStep()},
+              cache, visiting)) {
+        return ancestor;
+      }
+      continue;
+    }
+
+    if (auto indexSwitchOp = dyn_cast<scf::IndexSwitchOp>(ancestor)) {
+      if (dependsOnSubblockIdx(indexSwitchOp.getArg(), cache, visiting))
+        return ancestor;
+      continue;
+    }
+  }
+
+  return nullptr;
+}
+
+static LogicalResult
+validateA2A3NoSplitSubblockControl(ArrayRef<PipeInitInfo *> component) {
+  llvm::DenseMap<Value, bool> subblockDependencyCache;
+  llvm::DenseSet<Value> dependencyVisiting;
+
+  for (PipeInitInfo *info : component) {
+    if (!isVectorKernel(info->funcOp))
+      continue;
+    if (getTargetArch(info->op) != PTOArch::A3)
+      continue;
+
+    bool noSplit = false;
+    if (auto initOp = dyn_cast<InitializeL2LPipeOp>(info->op)) {
+      noSplit = initOp.getNosplitAttr() && initOp.getNosplitAttr().getValue();
+      if (!noSplit)
+        continue;
+
+      for (Operation *user : initOp.getPipe().getUsers()) {
+        if (!isa<TPushOp, TPopOp, TFreeOp>(user))
+          continue;
+        if (!findSubblockDivergentAncestor(user, subblockDependencyCache,
+                                           dependencyVisiting))
+          continue;
+        return user->emitOpError(
+            "A2/A3 nosplit pipe ops must not be nested under "
+            "subblock-dependent control flow; both vector subblocks must "
+            "execute the same tpush/tpop/tfree sequence in the same order");
+      }
+      continue;
+    }
+
+    auto initOp = cast<InitializeL2G2LPipeOp>(info->op);
+    noSplit = initOp.getNosplitAttr() && initOp.getNosplitAttr().getValue();
+    if (!noSplit)
+      continue;
+
+    for (Operation *user : initOp.getPipe().getUsers()) {
+      if (!isa<TPushOp, TPopOp, TFreeOp>(user))
+        continue;
+      if (!findSubblockDivergentAncestor(user, subblockDependencyCache,
+                                         dependencyVisiting))
+        continue;
+      return user->emitOpError(
+          "A2/A3 nosplit pipe ops must not be nested under "
+          "subblock-dependent control flow; both vector subblocks must "
+          "execute the same tpush/tpop/tfree sequence in the same order");
+    }
+  }
+
+  return success();
+}
+
 struct PTOInferValidatePipeInitPass
     : public mlir::pto::impl::PTOInferValidatePipeInitBase<
           PTOInferValidatePipeInitPass> {
@@ -293,6 +448,11 @@ struct PTOInferValidatePipeInitPass
       }
 
       if (failed(resolveNoSplitComponent(component, builder))) {
+        signalPassFailure();
+        return;
+      }
+
+      if (failed(validateA2A3NoSplitSubblockControl(component))) {
         signalPassFailure();
         return;
       }

--- a/test/lit/pto/issue499_nosplit_subblock_if_a3.pto
+++ b/test/lit/pto/issue499_nosplit_subblock_if_a3.pto
@@ -1,0 +1,47 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+    %c2v_import = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
+    return
+  }
+
+  func.func @vector_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i32 = arith.constant 0 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c2v_local : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %subblock_idx = pto.get_subblock_idx
+    %is_first = arith.cmpi eq, %subblock_idx, %c0_i64 : i64
+    scf.if %is_first {
+      %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
+        -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      pto.tfree_from_aic {id = 0, split = 0}
+    }
+    return
+  }
+}
+
+// CHECK: A2/A3 nosplit pipe ops must not be nested under subblock-dependent control flow

--- a/test/lit/pto/issue499_nosplit_subblock_loop_a3.pto
+++ b/test/lit/pto/issue499_nosplit_subblock_loop_a3.pto
@@ -1,0 +1,49 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+    %c2v_import = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
+    return
+  }
+
+  func.func @vector_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c2v_local : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %subblock_idx = pto.get_subblock_idx
+    %subblock_idx_index = arith.index_cast %subblock_idx : i64 to index
+    %upper = arith.addi %subblock_idx_index, %c1 : index
+    scf.for %iter = %c0 to %upper step %c1 {
+      %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
+        -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      pto.tfree_from_aic {id = 0, split = 0}
+    }
+    return
+  }
+}
+
+// CHECK: A2/A3 nosplit pipe ops must not be nested under subblock-dependent control flow

--- a/test/lit/pto/issue499_nosplit_subblock_while_a3.pto
+++ b/test/lit/pto/issue499_nosplit_subblock_while_a3.pto
@@ -1,0 +1,54 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0_i32 = arith.constant 0 : i32
+    %c2v_import = pto.import_reserved_buffer {
+      name = "c2v_fifo",
+      peer_func = @vector_kernel
+    } -> i32
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c2v_import : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    pto.tpush_to_aiv(%acc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>) {id = 0, split = 0}
+    return
+  }
+
+  func.func @vector_kernel(%gm_slot_buffer: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c2v_local = pto.reserve_buffer {
+      name = "c2v_fifo",
+      size = 4096,
+      location = #pto.address_space<vec>,
+      auto = true
+    } -> i32
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024, nosplit = true}
+      (gm_slot_buffer = %gm_slot_buffer : !pto.ptr<f32>,
+       c2v_consumer_buf = %c2v_local : i32,
+       v2c_consumer_buf = %c0_i32 : i32)
+
+    %subblock_idx = pto.get_subblock_idx
+    %upper = arith.index_cast %subblock_idx : i64 to index
+    %final = scf.while (%iter = %c0) : (index) -> (index) {
+      %keep_going = arith.cmpi sle, %iter, %upper : index
+      scf.condition(%keep_going) %iter : index
+    } do {
+    ^bb0(%iter_body: index):
+      %recv_tile = pto.tpop_from_aic {id = 0, split = 0}
+        -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      pto.tfree_from_aic {id = 0, split = 0}
+      %next_iter = arith.addi %iter_body, %c1 : index
+      scf.yield %next_iter : index
+    }
+    return
+  }
+}
+
+// CHECK: A2/A3 nosplit pipe ops must not be nested under subblock-dependent control flow


### PR DESCRIPTION
## Summary
- add an A2/A3 nosplit guard in `PTOInferValidatePipeInitPass` for vector-side pipe ops nested under `pto.get_subblock_idx`-dependent control flow
- document the new restriction for A2/A3 nosplit pipes
- add negative lit tests for both `scf.if` and `scf.for` subblock-divergent cases

## Validation
- `ninja -C build ptoas`
- manual FileCheck for `test/lit/pto/issue499_nosplit_subblock_if_a3.pto`
- manual FileCheck for `test/lit/pto/issue499_nosplit_subblock_loop_a3.pto`
- manual FileCheck for `test/lit/pto/tpush_tpop_frontend_lowering_a3.pto`
- manual FileCheck for `test/lit/pto/tpush_tpop_frontend_nosplit_conflict_a5.pto`