### PR TITLE
[Issue #554] fix: align tcolarg verifier with backend input width constraints

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2782,9 +2782,14 @@ static LogicalResult verifyTColArgReductionOpCommon(Operation *op, Type srcTy,
   if (failed(verifyColReductionValidRegion(op, srcTy, dstTy,
                                            /*requireNonZeroSrc=*/true)))
     return failure();
-  auto srcElem = getElemTy(srcTy).dyn_cast<mlir::FloatType>();
-  if (!srcElem || (!srcElem.isF16() && !srcElem.isF32()))
-    return op->emitOpError("expects src element type to be f16 or f32");
+  Type srcElem = getElemTy(srcTy);
+  if (!srcElem.isIntOrFloat())
+    return op->emitOpError(
+        "expects src element type to be an integer or floating type");
+  unsigned srcElemBits = srcElem.getIntOrFloatBitWidth();
+  if (srcElemBits != 8 && srcElemBits != 16 && srcElemBits != 32)
+    return op->emitOpError(
+        "expects src element size to be 1, 2, or 4 bytes");
   auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
   if (!dstInt || dstInt.getWidth() != 32)
     return op->emitOpError("expects dst element type to be i32 or ui32");

--- a/test/lit/pto/issue554_tcolarg_ui16_emitc.pto
+++ b/test/lit/pto/issue554_tcolarg_ui16_emitc.pto
@@ -1,0 +1,28 @@
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+
+module {
+  func.func @issue554_tcolargmax_ui16() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @issue554_tcolargmin_ui16() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcolargmin ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A5-LABEL: AICORE void issue554_tcolargmax_ui16()
+// A5: TCOLARGMAX(
+// A5-LABEL: AICORE void issue554_tcolargmin_ui16()
+// A5: TCOLARGMIN(


### PR DESCRIPTION
## 问题背景
- pto.tcolargmax / pto.tcolargmin 的 verifier 之前将 src 限制为 f16/f32，与底层 TColReduceIdxCheck 的 1/2/4 字节输入约束不一致。
- 导致 ui16/ui32 等按后端约束本应合法的输入在前端 verifier 阶段被错误拒绝。

## 定位分析
- 类型限制集中在 verifyTColArgReductionOpCommon，原逻辑要求 src 必须是 FloatType 且仅允许 f16/f32。
- tmp 与 src 的同类型约束、dst 为 i32/ui32、以及 layout/valid-shape 相关约束本身合理，无需调整。

## 解决方案
- 将 tcolargmax/tcolargmin 的 src 类型检查放宽为：任意整数或浮点类型，且元素位宽仅允许 8/16/32（即 1/2/4 字节）。
- 保持 dst 必须是 i32/ui32 的约束不变。
- 新增回归测试 test/lit/pto/issue554_tcolarg_ui16_emitc.pto，覆盖：
- tcolargmax 使用 ui16 -> ui32
- tcolargmin 使用 ui16 -> i32
- 本地验证：llvm-lit --filter issue554_tcolarg_ui16_emitc|tcolargmax_emitc|tcolargmin_emitc 通过（3/3）。
