### PR TITLE
fix: address codecheck magic literals

### DIFF
--- a/lib/PTO/IR/PTOTypeUtils.cpp
+++ b/lib/PTO/IR/PTOTypeUtils.cpp
@@ -13,6 +13,10 @@
 using namespace mlir;
 using namespace mlir::pto;
 
+namespace {
+constexpr unsigned kBitsPerByte = 8;
+} // namespace
+
 bool mlir::pto::isPTOFloat8Type(Type t) {
   return t.isFloat8E4M3() || t.isFloat8E4M3FN() || t.isFloat8E4M3FNUZ() ||
          t.isFloat8E4M3B11FNUZ() || t.isFloat8E5M2() || t.isFloat8E5M2FNUZ();
@@ -32,8 +36,8 @@ unsigned mlir::pto::getPTOStorageElemByteSize(Type t) {
   if (isPTOLowPrecisionType(t))
     return 1;
   if (auto floatTy = dyn_cast<FloatType>(t))
-    return floatTy.getWidth() / 8;
+    return floatTy.getWidth() / kBitsPerByte;
   if (auto intTy = dyn_cast<IntegerType>(t))
-    return intTy.getWidth() / 8;
+    return intTy.getWidth() / kBitsPerByte;
   return 0;
 }

--- a/lib/PTO/Transforms/AllocToPointerCast.cpp
+++ b/lib/PTO/Transforms/AllocToPointerCast.cpp
@@ -26,6 +26,12 @@ using namespace mlir::pto;
 namespace {} // namespace
 
 namespace {
+constexpr uint64_t kDefaultAllocAlignmentBytes = 4096;
+constexpr uint64_t kF16ByteSize = 2;
+constexpr uint64_t kF32ByteSize = 4;
+constexpr unsigned kBitsPerByte = 8;
+constexpr size_t kDynamicValidShapeRank = 2;
+
 static TileBufConfigAttr inferBindTileConfig(memref::AllocOp op) {
   TileBufConfigAttr configAttr;
   for (Operation *user : op.getResult().getUsers()) {
@@ -49,7 +55,6 @@ static SmallVector<uint64_t> getAllocatedOffsets(memref::AllocOp op,
                                                  BaseMemRefType memRefType,
                                                  const DenseMap<Value, SmallVector<uint64_t>> &buffer2Offsets,
                                                  uint64_t &fallbackNextOffset) {
-  constexpr uint64_t kAlign = 4096;
   auto iter = buffer2Offsets.find(op.getResult());
   SmallVector<uint64_t> offsets;
   if (iter != buffer2Offsets.end())
@@ -58,16 +63,16 @@ static SmallVector<uint64_t> getAllocatedOffsets(memref::AllocOp op,
   if (offsets.empty()) {
     // Estimate buffer size (best-effort). Most PTO tile buffers are 32x32 and
     // naturally align to 4096 bytes.
-    uint64_t bytes = kAlign;
+    uint64_t bytes = kDefaultAllocAlignmentBytes;
     if (auto memrefTy = dyn_cast<MemRefType>(memRefType)) {
       uint64_t elemBytes = 0;
       Type elemTy = memrefTy.getElementType();
       if (elemTy.isF16())
-        elemBytes = 2;
+        elemBytes = kF16ByteSize;
       else if (elemTy.isF32())
-        elemBytes = 4;
+        elemBytes = kF32ByteSize;
       else if (auto it = dyn_cast<IntegerType>(elemTy))
-        elemBytes = it.getWidth() / 8;
+        elemBytes = it.getWidth() / kBitsPerByte;
 
       if (elemBytes != 0) {
         uint64_t numel = 1;
@@ -83,9 +88,12 @@ static SmallVector<uint64_t> getAllocatedOffsets(memref::AllocOp op,
           bytes = numel * elemBytes;
       }
     }
-    uint64_t stride = ((bytes + kAlign - 1) / kAlign) * kAlign;
+    uint64_t stride = ((bytes + kDefaultAllocAlignmentBytes - 1) /
+                       kDefaultAllocAlignmentBytes) *
+                      kDefaultAllocAlignmentBytes;
     uint64_t off = fallbackNextOffset;
-    fallbackNextOffset += std::max<uint64_t>(stride, kAlign);
+    fallbackNextOffset +=
+        std::max<uint64_t>(stride, kDefaultAllocAlignmentBytes);
     offsets.push_back(off);
   }
   return offsets;
@@ -95,7 +103,7 @@ static std::pair<Value, Value> getDynamicValidShapeValues(memref::AllocOp op) {
   Value vRow;
   Value vCol;
   auto dynSizes = op.getDynamicSizes();
-  if (dynSizes.size() >= 2) {
+  if (dynSizes.size() >= kDynamicValidShapeRank) {
     vRow = dynSizes[0];
     vCol = dynSizes[1];
   } else if (dynSizes.size() == 1) {

--- a/lib/PTO/Transforms/InferPTOMemScope.cpp
+++ b/lib/PTO/Transforms/InferPTOMemScope.cpp
@@ -320,7 +320,6 @@ LogicalResult InferPTOMemScopePass::fixDeviceCallSite(func::FuncOp op) {
 }
 
 /// Update the function type for the host function.
-///
 /// Because we propagate information from the call site to the caller, we only
 /// updated the memref type of the BlockArgument of or the return operation
 /// within the function (if they are updated at all). So we need to use those
@@ -426,7 +425,8 @@ LogicalResult pto::inferAndPropagateMemScopeForGpuFunc(gpu::GPUFuncOp op) {
       continue;
     }
 
-    // TODO: handle case when ub arguments are passed in the GPUFuncOp
+    // GPUFuncOp arguments are currently treated as GM unless a caller-provided
+    // scope overrides them.
     if (failed(helper.Run(arg, gmSpaceAttr))) {
       return op->emitOpError()
              << "Failed to propagate memory scope for argument #"

--- a/lib/PTO/Transforms/InsertSync/MoveSyncState.cpp
+++ b/lib/PTO/Transforms/InsertSync/MoveSyncState.cpp
@@ -13,21 +13,21 @@
 
 #include "PTO/Transforms/InsertSync/MoveSyncState.h"
 #include "llvm/ADT/STLExtras.h" // For llvm::reverse
- 
+
 #define DEBUG_TYPE "pto-inject-sync"
- 
+
 using namespace mlir;
 using namespace mlir::pto;
- 
+
 void MoveSyncState::Run() {
   MoveOutBranchSync();
   MoveForSync();
 }
- 
+
 // ============================================================================
 // Branch (If/Else) Logic
 // ============================================================================
- 
+
 void MoveSyncState::MoveOutBranchSync() {
   for (auto &e : syncIR_) {
     if (auto *branchElement = dyn_cast<BranchInstanceElement>(e.get())) {
@@ -35,7 +35,7 @@ void MoveSyncState::MoveOutBranchSync() {
       if (branchElement->getBranchKind() == KindOfBranch::IF_BEGIN) {
         std::pair<unsigned, unsigned> bound = {branchElement->beginId,
                                                branchElement->endId};
-        
+
         // 1. 遍历 THEN 分支内的指令
         for (unsigned i = branchElement->beginId + 1;
              i < branchElement->branchId; i++) {
@@ -43,12 +43,12 @@ void MoveSyncState::MoveOutBranchSync() {
               syncIR_[i].get(),
               {branchElement->beginId, branchElement->branchId}, bound);
         }
- 
+
         // 如果没有 ELSE 分支，跳过
         if (branchElement->endId == branchElement->branchId) {
           continue;
         }
- 
+
         // 2. 遍历 ELSE 分支内的指令
         for (unsigned i = branchElement->branchId + 1; i < branchElement->endId;
              i++) {
@@ -60,18 +60,17 @@ void MoveSyncState::MoveOutBranchSync() {
     }
   }
 }
- 
+
 void MoveSyncState::PlanMoveOutBranchSync(
     InstanceElement *e, std::pair<unsigned int, unsigned int> pair,
     std::pair<unsigned int, unsigned int> bound) {
-  
   // 处理 PipeBefore (Wait/Barrier) - 保持优化 (Hoist Wait)
   SyncOps newPipeBefore;
   for (auto &s : e->pipeBefore) {
     PlanMoveOutIfWaitSync(newPipeBefore, s, pair, bound);
   }
   e->pipeBefore = newPipeBefore;
- 
+
   // 处理 PipeAfter (Set) - Sink Set out of If/Else when the matched Wait is
   // outside the branch region.
   //
@@ -85,30 +84,28 @@ void MoveSyncState::PlanMoveOutBranchSync(
   }
   e->pipeAfter = newPipeAfter;
 }
- 
+
 void MoveSyncState::PlanMoveOutIfWaitSync(
     SyncOps &newPipeBefore, SyncOperation *s,
     std::pair<unsigned int, unsigned int> pair,
     std::pair<unsigned int, unsigned int> bound) {
-  
   // 只处理 WaitEvent
   if (s->GetType() != SyncOperation::TYPE::WAIT_EVENT &&
       s->GetType() != SyncOperation::TYPE::SYNC_BLOCK_WAIT) {
     newPipeBefore.push_back(s);
     return;
   }
- 
+
   auto &syncPair = syncOperations_[s->GetSyncIndex()];
   checkCondition(!syncPair.empty(), "expected syncPair not to be empty");
-  
+
   // 找到配对的 Set 操作
   auto *setSync = syncPair[0].get();
- 
+
   // 如果 Set 操作在 If 块的外部 (index < pair.first 或 index > pair.second)
   // 那么这个 Wait 可以被提至 If 之前 (bound.first)
   if ((setSync->GetSyncIRIndex() >= pair.second) ||
       (setSync->GetSyncIRIndex() <= pair.first)) {
-    
     // [Optimization]: Hoist Wait out of If
     checkSyncIRIndex(syncIR_, bound.first);
     syncIR_[bound.first]->pipeBefore.push_back(s); // 移到 IfBegin 之前
@@ -118,29 +115,27 @@ void MoveSyncState::PlanMoveOutIfWaitSync(
     newPipeBefore.push_back(s);
   }
 }
- 
+
 void MoveSyncState::PlanMoveOutIfSetSync(
     SyncOps &newPipeAfter, SyncOperation *s,
     std::pair<unsigned int, unsigned int> pair,
     std::pair<unsigned int, unsigned int> bound) {
-  
   if (s->GetType() != SyncOperation::TYPE::SET_EVENT &&
       s->GetType() != SyncOperation::TYPE::SYNC_BLOCK_SET) {
     newPipeAfter.push_back(s);
     return;
   }
- 
+
   auto &syncPair = syncOperations_[s->GetSyncIndex()];
   checkCondition(syncPair.size() > 1, "expected syncPair size > 1");
-  
+
   // 找到配对的 Wait 操作
   auto *waitSync = syncPair[1].get();
- 
+
   // 如果 Wait 操作在 If 块的外部
   // 那么这个 Set 可以沉降到 If 之后 (bound.second)
   if ((waitSync->GetSyncIRIndex() >= pair.second) ||
       (waitSync->GetSyncIRIndex() <= pair.first)) {
-    
     // [Optimization]: Sink Set out of If
     checkSyncIRIndex(syncIR_, bound.second);
     syncIR_[bound.second]->pipeAfter.push_front(s); // 移到 IfEnd 之后
@@ -149,11 +144,11 @@ void MoveSyncState::PlanMoveOutIfSetSync(
     newPipeAfter.push_back(s);
   }
 }
- 
+
 // ============================================================================
 // Loop Optimization Logic
 // ============================================================================
- 
+
 void MoveSyncState::MoveForSync() {
   for (auto &e : syncIR_) {
     if (auto *forCompound = dyn_cast<LoopInstanceElement>(e.get())) {
@@ -170,19 +165,19 @@ void MoveSyncState::MoveForSync() {
     }
   }
 }
- 
+
 void MoveSyncState::MoveOutSync(InstanceElement *e,
                                 std::pair<unsigned int, unsigned int> pair) {
   checkCondition(pair.first < e->GetIndex() && e->GetIndex() < pair.second,
                  "MoveOutSync expected element to be within pair bounds");
-  
+
   // 处理 PipeBefore (Wait/Barrier)
   SyncOps newPipeBefore;
   for (auto &s : e->pipeBefore) {
     PlanMoveOutWaitSync(newPipeBefore, s, pair);
   }
   e->pipeBefore = newPipeBefore;
- 
+
   // 处理 PipeAfter (Set)
   SyncOps newPipeAfter;
   for (auto &s : llvm::reverse(e->pipeAfter)) {
@@ -190,11 +185,10 @@ void MoveSyncState::MoveOutSync(InstanceElement *e,
   }
   e->pipeAfter = newPipeAfter;
 }
- 
+
 void MoveSyncState::PlanMoveOutWaitSync(
     SyncOps &newPipeBefore, SyncOperation *s,
     std::pair<unsigned int, unsigned int> pair) {
-  
   if (s->GetType() != SyncOperation::TYPE::WAIT_EVENT &&
       s->GetType() != SyncOperation::TYPE::SYNC_BLOCK_WAIT) {
     newPipeBefore.push_back(s);
@@ -208,33 +202,31 @@ void MoveSyncState::PlanMoveOutWaitSync(
     newPipeBefore.push_back(s);
     return;
   }
- 
+
   auto &syncPair = syncOperations_[s->GetSyncIndex()];
   checkCondition(!syncPair.empty(), "expected syncPair not to be empty");
   auto *setSync = syncPair[0].get();
- 
+
   // 如果 Set 操作在 Loop 外部 (index > loop_end 或 index < loop_begin)
   // 说明依赖不来自循环内部（非 Loop-Carried Dependency）
   // 可以将 Wait 提至 Loop Begin 之前
   if ((setSync->GetSyncIRIndex() > pair.second) ||
       (setSync->GetSyncIRIndex() < pair.first)) {
-    
     // [Optimization]: Hoist Wait out of Loop
     checkSyncIRIndex(syncIR_, pair.first);
     // pair.first 是 LoopBegin 节点
-    syncIR_[pair.first]->pipeBefore.push_back(s); 
+    syncIR_[pair.first]->pipeBefore.push_back(s);
     s->SetSyncIRIndex(pair.first);
     return;
   }
-  
+
   // 否则依赖来自循环内部，必须在循环内等待
   newPipeBefore.push_back(s);
 }
- 
+
 void MoveSyncState::PlanMoveOutSetSync(
     SyncOps &newPipeAfter, SyncOperation *s,
     const std::pair<unsigned int, unsigned int> pair) {
-  
   if (s->GetType() != SyncOperation::TYPE::SET_EVENT &&
       s->GetType() != SyncOperation::TYPE::SYNC_BLOCK_SET) {
     newPipeAfter.push_back(s);
@@ -248,24 +240,23 @@ void MoveSyncState::PlanMoveOutSetSync(
     newPipeAfter.push_back(s);
     return;
   }
- 
+
   auto &syncPair = syncOperations_[s->GetSyncIndex()];
   checkCondition(syncPair.size() > 1, "expected syncPair size > 1");
   auto *waitSync = syncPair[1].get();
- 
+
   // 如果 Wait 操作在 Loop 外部
   // 说明循环内产生的信号，只在循环外被消费
   // 可以将 Set 沉降到 Loop End 之后
   if ((waitSync->GetSyncIRIndex() > pair.second) ||
       (waitSync->GetSyncIRIndex() < pair.first)) {
-    
     // [Optimization]: Sink Set out of Loop
     checkSyncIRIndex(syncIR_, pair.second);
     // pair.second 是 LoopEnd 节点
-    syncIR_[pair.second]->pipeAfter.push_front(s); 
+    syncIR_[pair.second]->pipeAfter.push_front(s);
     s->SetSyncIRIndex(pair.second);
     return;
   }
-  
+
   newPipeAfter.push_back(s);
 }

--- a/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
@@ -22,12 +22,19 @@
 #include <memory>
 #include <utility>
 #include <map>
- 
+
 #define DEBUG_TYPE "pto-inject-sync"
- 
+
 using namespace mlir;
 using namespace mlir::pto;
- 
+
+namespace {
+constexpr size_t kSingleUnitFlagCondition = 1;
+constexpr size_t kDualUnitFlagConditions = 2;
+constexpr size_t kFirstConditionIndex = 0;
+constexpr size_t kSecondConditionIndex = 1;
+} // namespace
+
 SmallVector<const void *>
 mlir::pto::canonicalizeSyncDepRoots(const SmallVector<Value> &roots) {
   SmallVector<const void *> result;
@@ -62,7 +69,7 @@ bool SyncOperation::operator==(const SyncOperation &other) const {
   }
   return false;
 }
- 
+
 std::string SyncOperation::TypeName(SyncOperation::TYPE t) {
   static std::map<TYPE, std::string> typeNameMap = {
       {TYPE::SET_EVENT, "set_flag"},
@@ -81,7 +88,7 @@ std::string SyncOperation::TypeName(SyncOperation::TYPE t) {
   llvm_unreachable("Not supported sync type");
   return "";
 }
- 
+
 std::string SyncOperation::GetCoreTypeName(TCoreType t) const {
   static std::map<TCoreType, std::string> coreTypeNameMap = {
       {TCoreType::CUBE, "CUBE"},
@@ -95,7 +102,7 @@ std::string SyncOperation::GetCoreTypeName(TCoreType t) const {
   llvm_unreachable("Not supported sync type");
   return "";
 }
- 
+
 std::unique_ptr<SyncOperation>
 SyncOperation::GetMatchSync(unsigned index) const {
   TYPE newType{TYPE::PIPE_BARRIER};
@@ -111,7 +118,7 @@ SyncOperation::GetMatchSync(unsigned index) const {
   if (syncIt != syncPair.cend()) {
     newType = syncIt->second;
   }
- 
+
   auto res =
       std::make_unique<SyncOperation>(newType, this->srcPipe_, this->dstPipe_,
                                       kSyncIndex_, index, this->forEndIndex_);
@@ -122,7 +129,7 @@ SyncOperation::GetMatchSync(unsigned index) const {
   res->SetDepSyncIRIndex(this->GetDepSyncIRIndex());
   return res;
 }
- 
+
 void SyncOperation::SetPipeAll() {
   // set current sync to pipe_all
   this->type_ = TYPE::PIPE_BARRIER;
@@ -130,23 +137,23 @@ void SyncOperation::SetPipeAll() {
   this->srcPipe_ = PipelineType::PIPE_ALL;
   this->dstPipe_ = PipelineType::PIPE_ALL;
 }
- 
+
 bool SyncOperation::isSyncSetType() const {
   auto type = this->GetType();
   return type == TYPE::SET_EVENT || type == TYPE::SYNC_BLOCK_SET;
 }
- 
+
 bool SyncOperation::isSyncWaitType() const {
   auto type = this->GetType();
   return type == TYPE::WAIT_EVENT || type == TYPE::SYNC_BLOCK_WAIT;
 }
- 
+
 bool SyncOperation::isBarrierType() const {
   auto type = this->GetType();
   return type == TYPE::PIPE_BARRIER || type == TYPE::PIPE_BARRIER_CUBE ||
          type == TYPE::PIPE_BARRIER_VECTOR;
 }
- 
+
 bool InstanceElement::RemoveSync(SyncOps &syncVector,
                                  const SyncOperation *sync) {
   auto it = std::find(syncVector.begin(), syncVector.end(), sync);
@@ -156,7 +163,7 @@ bool InstanceElement::RemoveSync(SyncOps &syncVector,
   syncVector.erase(it);
   return true;
 }
- 
+
 std::unique_ptr<InstanceElement>
 LoopInstanceElement::CloneFor(KindOfLoop loopKind) const {
   unsigned index =
@@ -168,7 +175,7 @@ LoopInstanceElement::CloneFor(KindOfLoop loopKind) const {
   res->elementOp = elementOp;
   return res;
 }
- 
+
 std::unique_ptr<BranchInstanceElement>
 BranchInstanceElement::CloneBranch(KindOfBranch branchKind) const {
   if (branchKind == KindOfBranch::ELSE_BEGIN) {
@@ -190,37 +197,37 @@ BranchInstanceElement::CloneBranch(KindOfBranch branchKind) const {
   res->elementOp = elementOp;
   return res;
 }
- 
+
 std::unique_ptr<PlaceHolderInstanceElement>
 PlaceHolderInstanceElement::Clone() const {
   return std::make_unique<PlaceHolderInstanceElement>(this->kIndex,
                                                       this->parentScopeId);
 }
- 
+
 bool LoopInstanceElement::classof(const InstanceElement *e) {
   checkCondition(e != nullptr,
                  "give a nullptr for LoopInstanceElement'sconst classof");
   return e->GetKind() == KindTy::LOOP;
 }
- 
+
 bool CompoundInstanceElement::classof(const InstanceElement *e) {
   checkCondition(e != nullptr,
                  "give a nullptr for CompoundInstanceElement's classof");
   return e->GetKind() == KindTy::COMPOUND;
 }
- 
+
 bool BranchInstanceElement::classof(const InstanceElement *e) {
   checkCondition(e != nullptr,
                  "give a nullptr for BranchInstanceElement's classof");
   return e->GetKind() == KindTy::BRANCH;
 }
- 
+
 bool PlaceHolderInstanceElement::classof(const InstanceElement *e) {
   checkCondition(e != nullptr,
                  "give a nullptr for PlaceHolderInstanceElement's classof");
   return e->GetKind() == KindTy::PLACE_HOLDER;
 }
- 
+
 UNIT_FLAG CompoundInstanceElement::getUnitFlagMode() const {
   static DenseMap<std::pair<UNIT_FLAG, UNIT_FLAG>, UNIT_FLAG> possibleStates = {
       {std::make_pair(UNIT_FLAG::DISABLED, UNIT_FLAG::DISABLED),
@@ -253,7 +260,7 @@ UNIT_FLAG CompoundInstanceElement::getUnitFlagMode() const {
   }
   return it->second;
 }
- 
+
 Value getIsNotDeadLoopValue(scf::ForOp forOp, Location loc,
                             OpBuilder &rewriter) {
   Value upperBound = forOp.getUpperBound();
@@ -261,12 +268,12 @@ Value getIsNotDeadLoopValue(scf::ForOp forOp, Location loc,
   return rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
                                         lowerBound, upperBound);
 }
- 
+
 std::optional<mlir::Value>
 CompoundInstanceElement::getUnitFlagCond(Location loc, OpBuilder &rewriter) {
   OpBuilder::InsertionGuard guard(rewriter);
   SmallVector<Value> conditions;
-  
+
   if (linkedUnitFlagCompAsWait &&
       (linkedUnitFlagCompAsWait->unitFlagModeAsSet ==
            UNIT_FLAG::ENABLED_ONLY_LAST_ITER ||
@@ -291,21 +298,22 @@ CompoundInstanceElement::getUnitFlagCond(Location loc, OpBuilder &rewriter) {
       conditions.push_back(cond);
     }
   }
- 
+
   if (conditions.empty()) {
     return nullptr;
-  } else if (conditions.size() == 1) {
-    return conditions[0];
-  } else if (conditions.size() == 2) {
+  } else if (conditions.size() == kSingleUnitFlagCondition) {
+    return conditions[kFirstConditionIndex];
+  } else if (conditions.size() == kDualUnitFlagConditions) {
     rewriter.setInsertionPoint(elementOp);
-    return rewriter.create<arith::OrIOp>(loc, conditions[0], conditions[1]);
+    return rewriter.create<arith::OrIOp>(
+        loc, conditions[kFirstConditionIndex], conditions[kSecondConditionIndex]);
   } else {
     llvm_unreachable("unexpected/unhandled number of unit-flag conditions.");
   }
 }
- 
+
 namespace mlir::pto {
- 
+
 bool checkAllParentLoopsAreForLoops(Operation *op) {
   while ((op = op->getParentOfType<LoopLikeOpInterface>())) {
     if (!isa<scf::ForOp>(op)) {
@@ -314,17 +322,17 @@ bool checkAllParentLoopsAreForLoops(Operation *op) {
   }
   return true;
 }
- 
+
 void checkSyncIRIndex(const SyncIRs &syncIR, int index) {
   if (index < 0 || index >= static_cast<int>(syncIR.size())) {
     llvm_unreachable("index out of bounds when accessing syncIR");
   }
 }
- 
+
 void checkCondition(bool condition, const std::string &message) {
   if (!condition) {
     llvm_unreachable(message.c_str());
   }
 }
- 
+
 } // namespace mlir::pto

--- a/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
+++ b/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
@@ -24,6 +24,12 @@ using namespace mlir::pto;
 
 namespace {
 
+constexpr size_t kTileRank2D = 2;
+constexpr size_t kFirstTileDim = 0;
+constexpr size_t kSecondTileDim = 1;
+constexpr unsigned kRiskyOpReserveSize = 8;
+constexpr unsigned kTMovOperandReserveSize = 4;
+
 static bool isVecTileType(pto::TileBufType type) {
   auto asAttr = dyn_cast_or_null<pto::AddressSpaceAttr>(type.getMemorySpace());
   return asAttr && asAttr.getAddressSpace() == pto::AddressSpace::VEC;
@@ -74,19 +80,22 @@ static pto::TileBufConfigAttr buildRowMajorConfig(MLIRContext *ctx,
 static FailureOr<pto::TileBufType>
 buildRowMajorReinterpretType(MLIRContext *ctx, pto::TileBufType srcType) {
   ArrayRef<int64_t> shape = srcType.getShape();
-  if (shape.size() != 2)
+  if (shape.size() != kTileRank2D)
     return failure();
-  if (shape[0] == ShapedType::kDynamic || shape[1] == ShapedType::kDynamic)
+  if (shape[kFirstTileDim] == ShapedType::kDynamic ||
+      shape[kSecondTileDim] == ShapedType::kDynamic)
     return failure();
 
-  SmallVector<int64_t, 2> swappedShape{shape[1], shape[0]};
+  SmallVector<int64_t, kTileRank2D> swappedShape{shape[kSecondTileDim],
+                                                 shape[kFirstTileDim]};
 
-  SmallVector<int64_t, 2> swappedValid;
+  SmallVector<int64_t, kTileRank2D> swappedValid;
   ArrayRef<int64_t> validShape = srcType.getValidShape();
   if (validShape.empty()) {
     swappedValid = swappedShape;
-  } else if (validShape.size() == 2) {
-    swappedValid.assign({validShape[1], validShape[0]});
+  } else if (validShape.size() == kTileRank2D) {
+    swappedValid.assign({validShape[kSecondTileDim],
+                         validShape[kFirstTileDim]});
   } else {
     return failure();
   }
@@ -107,7 +116,7 @@ struct PTOA5NormalizeTMovPass
     if (!isTargetArchA5(func.getOperation()))
       return;
 
-    SmallVector<pto::TMovOp, 8> riskyOps;
+    SmallVector<pto::TMovOp, kRiskyOpReserveSize> riskyOps;
     func.walk([&](pto::TMovOp op) {
       if (isA5RiskyVecVecColMajorTMov(op))
         riskyOps.push_back(op);
@@ -135,14 +144,15 @@ struct PTOA5NormalizeTMovPass
           rewriter.create<pto::TReshapeOp>(op.getLoc(), *srcRowTy, op.getSrc());
       auto dstRow =
           rewriter.create<pto::TReshapeOp>(op.getLoc(), *dstRowTy, op.getDst());
-      SmallVector<Value, 4> newOperands(op->operand_begin(), op->operand_end());
-      if (newOperands.size() < 2) {
+      SmallVector<Value, kTMovOperandReserveSize> newOperands(
+          op->operand_begin(), op->operand_end());
+      if (newOperands.size() < kTileRank2D) {
         op.emitOpError("unexpected operand count while normalizing TMOV");
         signalPassFailure();
         return;
       }
-      newOperands[0] = srcRow.getResult();
-      newOperands[1] = dstRow.getResult();
+      newOperands[kFirstTileDim] = srcRow.getResult();
+      newOperands[kSecondTileDim] = dstRow.getResult();
 
       OperationState state(op.getLoc(), pto::TMovOp::getOperationName());
       state.addOperands(newOperands);

--- a/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
+++ b/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
@@ -39,6 +39,12 @@ using namespace mlir::pto;
 
 namespace {
 
+constexpr size_t kMinPeerPipeInitCount = 2;
+constexpr int8_t kC2VDirMask = 1;
+constexpr int8_t kV2CDirMask = 2;
+constexpr int8_t kBidirectionalDirMask = 3;
+constexpr unsigned kVisitedInitReserveSize = 16;
+
 struct PipePeerKey {
   std::string ownerFunc;
   std::string reserveName;
@@ -241,10 +247,10 @@ struct PTOInferValidatePipeInitPass
         keyedInits[*key].push_back(info.op);
       };
 
-      if (info.dirMask == 3) {
-        recordAddr(getLocalAddrOperand(initOp), /*c2v=*/1);
+      if (info.dirMask == kBidirectionalDirMask) {
+        recordAddr(getLocalAddrOperand(initOp), kC2VDirMask);
         if (Value peerAddr = initOp.getPeerLocalAddr())
-          recordAddr(peerAddr, /*v2c=*/2);
+          recordAddr(peerAddr, kV2CDirMask);
         return;
       }
 
@@ -260,7 +266,7 @@ struct PTOInferValidatePipeInitPass
         if (std::find(uniqueOps.begin(), uniqueOps.end(), op) == uniqueOps.end())
           uniqueOps.push_back(op);
       }
-      if (uniqueOps.size() < 2)
+      if (uniqueOps.size() < kMinPeerPipeInitCount)
         continue;
 
       for (size_t i = 0; i < uniqueOps.size(); ++i) {
@@ -276,7 +282,7 @@ struct PTOInferValidatePipeInitPass
       infoByOp[info.op] = &info;
 
     OpBuilder builder(moduleOp.getContext());
-    llvm::SmallPtrSet<Operation *, 16> visited;
+    llvm::SmallPtrSet<Operation *, kVisitedInitReserveSize> visited;
     for (PipeInitInfo &rootInfo : initInfos) {
       if (!visited.insert(rootInfo.op).second)
         continue;

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -27,6 +27,12 @@ using namespace mlir::pto;
 
 namespace {
 
+constexpr int8_t kC2VDirMask = 1;
+constexpr int8_t kV2CDirMask = 2;
+constexpr int8_t kBidirectionalDirMask = 3;
+constexpr int32_t kSingleDirectionSlotNum = 8;
+constexpr int32_t kBidirectionalSlotNum = 4;
+
 struct FrontendPipeHandles {
   Value c2vPipe;
   Value v2cPipe;
@@ -78,13 +84,13 @@ lowerSingleDirectionFrontendInit(InitOpT initOp, IRRewriter &rewriter,
                                  PTOArch arch, Type pipeTy, int8_t dirMask,
                                  Value localAddr) {
   auto pipeOr =
-      createFrontendPipe(initOp, rewriter, arch, pipeTy, dirMask, /*slotNum=*/8,
-                         localAddr);
+      createFrontendPipe(initOp, rewriter, arch, pipeTy, dirMask,
+                         kSingleDirectionSlotNum, localAddr);
   if (failed(pipeOr))
     return failure();
 
   FrontendPipeHandles handles;
-  if (dirMask == 1)
+  if (dirMask == kC2VDirMask)
     handles.c2vPipe = *pipeOr;
   else
     handles.v2cPipe = *pipeOr;
@@ -97,7 +103,8 @@ static FailureOr<FrontendPipeHandles>
 lowerBidirectionalFrontendInit(InitOpT initOp, IRRewriter &rewriter,
                                PTOArch arch, Type pipeTy) {
   auto pipeOr = createFrontendPipe(initOp, rewriter, arch, pipeTy,
-                                   /*dirMask=*/3, /*slotNum=*/4,
+                                   kBidirectionalDirMask,
+                                   kBidirectionalSlotNum,
                                    initOp.getC2vConsumerBuf(),
                                    initOp.getV2cConsumerBuf());
   if (failed(pipeOr))
@@ -118,15 +125,15 @@ static FailureOr<FrontendPipeHandles> lowerFrontendInitOp(InitOpT initOp,
   PTOArch arch = getTargetArch(initOp.getOperation());
 
   switch (initOp.getDirMask()) {
-  case 1:
+  case kC2VDirMask:
     return lowerSingleDirectionFrontendInit(initOp, rewriter, arch, pipeTy,
-                                            /*dirMask=*/1,
+                                            kC2VDirMask,
                                             initOp.getC2vConsumerBuf());
-  case 2:
+  case kV2CDirMask:
     return lowerSingleDirectionFrontendInit(initOp, rewriter, arch, pipeTy,
-                                            /*dirMask=*/2,
+                                            kV2CDirMask,
                                             initOp.getV2cConsumerBuf());
-  case 3:
+  case kBidirectionalDirMask:
     return lowerBidirectionalFrontendInit(initOp, rewriter, arch, pipeTy);
   default:
     return FrontendPipeHandles{};

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -42,12 +42,24 @@ using namespace pto;
 
 namespace {
 
+constexpr int64_t kBitsPerByte = 8;
+constexpr unsigned kI32BitWidth = 32;
+constexpr unsigned kMemoryEffectReserveSize = 8;
+constexpr int kSingleBufferCount = 1;
+constexpr int kDoubleBufferCount = 2;
+constexpr int64_t kA5VecLocalMemBits = 2031616;
+constexpr int64_t kA3VecLocalMemBits = 1572864;
+constexpr int64_t kMatLocalMemBits = 4194304;
+constexpr int64_t kLocalMemAlignmentBytes = 256;
+
 struct LocalMemSpec {
   int64_t capacityBits = 0;
   int64_t alignBytes = 1;
 };
 
-static int64_t ceilDivBitsToBytes(int64_t bits) { return (bits + 7) / 8; }
+static int64_t ceilDivBitsToBytes(int64_t bits) {
+  return (bits + kBitsPerByte - 1) / kBitsPerByte;
+}
 
 static int64_t alignUpBytes(int64_t value, int64_t align) {
   int64_t safeAlign = std::max<int64_t>(align, 1);
@@ -62,10 +74,11 @@ static int64_t alignUpBytes(int64_t value, int64_t align) {
 static LocalMemSpec getLocalMemSpec(Operation *op, AddressSpace as) {
   switch (as) {
   case AddressSpace::VEC:
-    return isTargetArchA5(op) ? LocalMemSpec{2031616, 256}
-                              : LocalMemSpec{1572864, 256};
+    return isTargetArchA5(op)
+               ? LocalMemSpec{kA5VecLocalMemBits, kLocalMemAlignmentBytes}
+               : LocalMemSpec{kA3VecLocalMemBits, kLocalMemAlignmentBytes};
   case AddressSpace::MAT:
-    return LocalMemSpec{4194304, 256};
+    return LocalMemSpec{kMatLocalMemBits, kLocalMemAlignmentBytes};
   default:
     return LocalMemSpec{};
   }
@@ -91,7 +104,9 @@ static SmallVector<Value> getScratchBuffersFromEffects(Operation *op,
   if (!memEffect)
     return scratchBuffers;
 
-  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 8> effects;
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>,
+              kMemoryEffectReserveSize>
+      effects;
   memEffect.getEffects(effects);
   for (const auto &effect : effects) {
     if (!isa<MemoryEffects::Write>(effect.getEffect()))
@@ -156,7 +171,7 @@ static LogicalResult analyzeReserveBufferPlans(func::FuncOp funcOp,
     if (spec.capacityBits <= 0 || spec.alignBytes <= 0)
       return reserveOp.emitOpError("unsupported reserve_buffer location");
 
-    int64_t capacityBytes = spec.capacityBits / 8;
+    int64_t capacityBytes = spec.capacityBits / kBitsPerByte;
     int64_t sizeBytes = reserveOp.getSize();
     bool autoAlloc = reserveOp.getAutoAlloc();
 
@@ -273,8 +288,9 @@ static LogicalResult assignAutoReserveBufferBases(
 
     plan.reserveOp->setAttr(
         "base",
-        IntegerAttr::get(IntegerType::get(plan.reserveOp.getContext(), 32),
-                         candidateBase));
+        IntegerAttr::get(
+            IntegerType::get(plan.reserveOp.getContext(), kI32BitWidth),
+            candidateBase));
     occupied.push_back(
         OccupiedByteRange{candidateBase, candidateBase + plan.sizeBytes});
     normalizeRanges(occupied);
@@ -291,7 +307,6 @@ void MemLivenessAnalysis::build() {
   RecursionIR(&funcRegion, live);
   // the lifetime of the buffer.
   GenerateBufferLife();
-  //InitializeInplacePairList();
 }
 
 bool MemLivenessAnalysis::isLocalMemPlan() const {
@@ -1472,7 +1487,7 @@ void MemPlan::ReorderContinuousPingPongEntry(
                         reorderedStorageEntryVec.end(), storageEntry);
     if (it == reorderedStorageEntryVec.end()) {
       reorderedStorageEntryVec.push_back(storageEntry);
-      if (storageEntry->multiBufferNum == 2 &&
+      if (storageEntry->multiBufferNum == kDoubleBufferCount &&
           storageEntry->relationPongEntry) {
         // Ping Pong continuous save.
         reorderedStorageEntryVec.push_back(storageEntry->relationPongEntry);
@@ -1500,7 +1515,7 @@ MemPlan::GetBufferSpaceInfo(pto::AddressSpace &space) const {
   case pto::AddressSpace::SCALING:
     return std::make_pair(scalingAlignSize, scalingSpaceSize);
   }
-  
+
   llvm_unreachable("Temporarily unsupported memory buffer space !");
 }
 
@@ -1623,8 +1638,8 @@ bool MemPlan::VerifyConflictStage1(MemBoundList &outline, PlanRecHis &his,
   StorageEntry *multiRelationPongEntry =
       GetMultiRelationPongEntry(reuseBoundStorageEntry);
   if (multiRelationPongEntry) {
-    if (e->multiBufferNum == 1 ||
-        (e->multiBufferNum == 2 && e->relationPongEntry &&
+    if (e->multiBufferNum == kSingleBufferCount ||
+        (e->multiBufferNum == kDoubleBufferCount && e->relationPongEntry &&
          (e->relationPongEntry->bitsOffset != 0))) {
       auto parentLoop1 = GetBufferParentLoop(e->inplaceBuffers);
       auto parentLoop2 =
@@ -1652,7 +1667,7 @@ bool MemPlan::VerifyConflictStage1(MemBoundList &outline, PlanRecHis &his,
 
 StorageEntry *
 MemPlan::GetMultiRelationPongEntry(const StorageEntry *reuseBoundStorageEntry) {
-  if (reuseBoundStorageEntry->multiBufferNum == 2 &&
+  if (reuseBoundStorageEntry->multiBufferNum == kDoubleBufferCount &&
       reuseBoundStorageEntry->relationPongEntry &&
       (reuseBoundStorageEntry->relationPongEntry->bitsOffset != 0)) {
     // If the reuseBoundStorageEntry itself requires db, directly match and
@@ -1688,7 +1703,7 @@ void MemPlan::SpecAllocRelationPongEntry(MemBoundList &outline, PlanRecHis &his,
       if (iter != pingEntry2RelationPongEntry.end()) {
         pongStorageEntry = iter->second.get();
       }
-      if (e->multiBufferNum == 2 && e->relationPongEntry) {
+      if (e->multiBufferNum == kDoubleBufferCount && e->relationPongEntry) {
         pongStorageEntry = e->relationPongEntry;
       }
       if (!pongStorageEntry)
@@ -1714,7 +1729,7 @@ bool MemPlan::IsBufferLifeVecConflict(PlanRecord &r, uint64_t offset,
 }
 
 void MemPlan::PlanRelationPongEntryAddress(uint64_t offset, StorageEntry *e) {
-  if (e->multiBufferNum == 1) {
+  if (e->multiBufferNum == kSingleBufferCount) {
     std::unique_ptr<StorageEntry> entry = std::make_unique<StorageEntry>();
     entry->bufInfo = e->bufInfo;
     entry->bufferLifeVec = e->bufferLifeVec;
@@ -1723,7 +1738,7 @@ void MemPlan::PlanRelationPongEntryAddress(uint64_t offset, StorageEntry *e) {
     entry->multiBufferNum = e->multiBufferNum;
     entry->bitsOffset = offset;
     pingEntry2RelationPongEntry[e] = std::move(entry);
-  } else if (e->multiBufferNum == 2) {
+  } else if (e->multiBufferNum == kDoubleBufferCount) {
     e->relationPongEntry->bitsOffset = offset;
   } else {
     llvm_unreachable("Does not support multi buffer num greater than 2 !");
@@ -2111,7 +2126,8 @@ void MemPlan::RollBackForAllocFailInner(StatusWrapper &statusWrapper,
       pingEntry2RelationPongEntry.erase(iter);
     }
     if (r.isDirectlyRollback ||
-        (r.entry->multiBufferNum == 2 && !r.entry->relationPongEntry)) {
+        (r.entry->multiBufferNum == kDoubleBufferCount &&
+         !r.entry->relationPongEntry)) {
       continue;
     }
     si->childIdx = r.childIdx;

--- a/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
+++ b/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
@@ -39,6 +39,15 @@ using namespace mlir::pto;
 namespace {
 
 constexpr int32_t kMaxHardwareFlagIds = 16;
+constexpr size_t kPeerPipeInitOpCount = 2;
+constexpr size_t kPeerPipeParticipantCount = 2;
+constexpr int32_t kFlagAlignment = 2;
+constexpr int8_t kC2VDirMask = 1;
+constexpr int8_t kV2CDirMask = 2;
+constexpr int8_t kBidirectionalDirMask = 3;
+constexpr unsigned kSingleDirectionFlagWidth = 2;
+constexpr unsigned kBidirectionalFlagWidth = 4;
+constexpr unsigned kVisitedInitReserveSize = 16;
 
 struct PipePeerKey {
   std::string ownerFunc;
@@ -164,10 +173,10 @@ static LogicalResult collectPeerAwareInit(InitOpT initOp,
   };
 
   bool recorded = false;
-  if (info.dirMask == 3) {
+  if (info.dirMask == kBidirectionalDirMask) {
     Value peerAddr = initOp.getPeerLocalAddr();
-    recorded = recordAddr(getLocalAddrOperand(initOp), /*c2v=*/1);
-    recorded = (peerAddr && recordAddr(peerAddr, /*v2c=*/2)) || recorded;
+    recorded = recordAddr(getLocalAddrOperand(initOp), kC2VDirMask);
+    recorded = (peerAddr && recordAddr(peerAddr, kV2CDirMask)) || recorded;
   } else {
     recorded = recordAddr(getLocalAddrOperand(initOp), info.dirMask);
   }
@@ -230,7 +239,7 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
   }
 
   SmallVector<PipeComponent> components;
-  llvm::SmallPtrSet<Operation *, 16> visited;
+  llvm::SmallPtrSet<Operation *, kVisitedInitReserveSize> visited;
   for (const PipeInitInfo &rootInfo : initInfos) {
     if (!visited.insert(rootInfo.op).second)
       continue;
@@ -246,7 +255,7 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
       }
     }
 
-    if (component.ops.size() != 2) {
+    if (component.ops.size() != kPeerPipeInitOpCount) {
       return rootInfo.op->emitOpError(
           "requires a complete compatible peer init pair when local_addr comes "
           "from pto.reserve_buffer or pto.import_reserved_buffer");
@@ -263,7 +272,9 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
     component.slotSize = lhs.slotSize;
     component.slotNum = lhs.slotNum;
     component.localSlotNum = lhs.localSlotNum;
-    component.flagWidth = component.dirMask == 3 ? 4u : 2u;
+    component.flagWidth = component.dirMask == kBidirectionalDirMask
+                              ? kBidirectionalFlagWidth
+                              : kSingleDirectionFlagWidth;
 
     for (Operation *op : component.ops) {
       const PipeInitInfo &info = *infoByOp[op];
@@ -277,7 +288,7 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
         component.explicitFlagBase = flagBaseAttr.getInt();
       }
     }
-    if (component.participants.size() != 2) {
+    if (component.participants.size() != kPeerPipeParticipantCount) {
       return component.ops.front()->emitOpError(
           "requires a complete compatible peer init pair when local_addr comes "
           "from pto.reserve_buffer or pto.import_reserved_buffer");
@@ -294,7 +305,7 @@ static bool overlaps(const FlagInterval &lhs, const FlagInterval &rhs) {
 }
 
 static int32_t alignToEven(int32_t value) {
-  return value % 2 == 0 ? value : value + 1;
+  return value % kFlagAlignment == 0 ? value : value + (kFlagAlignment - 1);
 }
 
 static LogicalResult reserveComponentFlagBase(const PipeComponent &component,

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -17,6 +17,29 @@
 
 namespace ptobc::v0 {
 
+inline constexpr uint8_t kVariantDefault = 0;
+inline constexpr uint8_t kVariantAcc = 1;
+inline constexpr uint8_t kVariantBias = 2;
+inline constexpr uint8_t kVariantMx = 3;
+inline constexpr uint8_t kVariantMxAcc = 4;
+inline constexpr uint8_t kVariantMxBias = 5;
+inline constexpr uint8_t kSectionCubeVariant = 0;
+inline constexpr uint8_t kSectionVectorVariant = 1;
+inline constexpr uint8_t kHasVariant = 1;
+
+inline constexpr int kTgemvOperandCount = 3;
+inline constexpr int kTgemvAccOperandCount = 4;
+inline constexpr int kTgemvBiasOperandCount = 4;
+inline constexpr int kTgemvMxOperandCount = 5;
+inline constexpr int kTgemvMxAccOperandCount = 6;
+inline constexpr int kTgemvMxBiasOperandCount = 6;
+inline constexpr int kTmatmulOperandCount = 3;
+inline constexpr int kTmatmulAccOperandCount = 4;
+inline constexpr int kTmatmulBiasOperandCount = 4;
+inline constexpr int kTmatmulMxOperandCount = 5;
+inline constexpr int kTmatmulMxAccOperandCount = 6;
+inline constexpr int kTmatmulMxBiasOperandCount = 6;
+
 struct OpInfo {
   uint16_t opcode;
   const char *name;
@@ -530,20 +553,34 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})
-    .Case("pto.section.cube", OpcodeAndVariant{0x0006, 1, 0})
-    .Case("pto.section.vector", OpcodeAndVariant{0x0006, 1, 1})
-    .Case("pto.tgemv", OpcodeAndVariant{0x102A, 1, 0})
-    .Case("pto.tgemv.acc", OpcodeAndVariant{0x102A, 1, 1})
-    .Case("pto.tgemv.bias", OpcodeAndVariant{0x102A, 1, 2})
-    .Case("pto.tgemv.mx", OpcodeAndVariant{0x102A, 1, 3})
-    .Case("pto.tgemv.mx.acc", OpcodeAndVariant{0x102A, 1, 4})
-    .Case("pto.tgemv.mx.bias", OpcodeAndVariant{0x102A, 1, 5})
-    .Case("pto.tmatmul", OpcodeAndVariant{0x1032, 1, 0})
-    .Case("pto.tmatmul.acc", OpcodeAndVariant{0x1032, 1, 1})
-    .Case("pto.tmatmul.bias", OpcodeAndVariant{0x1032, 1, 2})
-    .Case("pto.tmatmul.mx", OpcodeAndVariant{0x1033, 1, 0})
-    .Case("pto.tmatmul.mx.acc", OpcodeAndVariant{0x1033, 1, 1})
-    .Case("pto.tmatmul.mx.bias", OpcodeAndVariant{0x1033, 1, 2})
+    .Case("pto.section.cube",
+          OpcodeAndVariant{0x0006, kHasVariant, kSectionCubeVariant})
+    .Case("pto.section.vector",
+          OpcodeAndVariant{0x0006, kHasVariant, kSectionVectorVariant})
+    .Case("pto.tgemv",
+          OpcodeAndVariant{0x102A, kHasVariant, kVariantDefault})
+    .Case("pto.tgemv.acc",
+          OpcodeAndVariant{0x102A, kHasVariant, kVariantAcc})
+    .Case("pto.tgemv.bias",
+          OpcodeAndVariant{0x102A, kHasVariant, kVariantBias})
+    .Case("pto.tgemv.mx",
+          OpcodeAndVariant{0x102A, kHasVariant, kVariantMx})
+    .Case("pto.tgemv.mx.acc",
+          OpcodeAndVariant{0x102A, kHasVariant, kVariantMxAcc})
+    .Case("pto.tgemv.mx.bias",
+          OpcodeAndVariant{0x102A, kHasVariant, kVariantMxBias})
+    .Case("pto.tmatmul",
+          OpcodeAndVariant{0x1032, kHasVariant, kVariantDefault})
+    .Case("pto.tmatmul.acc",
+          OpcodeAndVariant{0x1032, kHasVariant, kVariantAcc})
+    .Case("pto.tmatmul.bias",
+          OpcodeAndVariant{0x1032, kHasVariant, kVariantBias})
+    .Case("pto.tmatmul.mx",
+          OpcodeAndVariant{0x1033, kHasVariant, kVariantDefault})
+    .Case("pto.tmatmul.mx.acc",
+          OpcodeAndVariant{0x1033, kHasVariant, kVariantAcc})
+    .Case("pto.tmatmul.mx.bias",
+          OpcodeAndVariant{0x1033, kHasVariant, kVariantBias})
     .Default(std::nullopt);
 }
 
@@ -554,32 +591,32 @@ inline const char *fullNameFromOpcodeVariant(uint16_t opcode, uint8_t variant) {
   switch (opcode) {
   case 0x0006:
     switch (variant) {
-    case 0: return "pto.section.cube";
-    case 1: return "pto.section.vector";
+    case kSectionCubeVariant: return "pto.section.cube";
+    case kSectionVectorVariant: return "pto.section.vector";
     default: return info->name;
     }
   case 0x102A:
     switch (variant) {
-    case 0: return "pto.tgemv";
-    case 1: return "pto.tgemv.acc";
-    case 2: return "pto.tgemv.bias";
-    case 3: return "pto.tgemv.mx";
-    case 4: return "pto.tgemv.mx.acc";
-    case 5: return "pto.tgemv.mx.bias";
+    case kVariantDefault: return "pto.tgemv";
+    case kVariantAcc: return "pto.tgemv.acc";
+    case kVariantBias: return "pto.tgemv.bias";
+    case kVariantMx: return "pto.tgemv.mx";
+    case kVariantMxAcc: return "pto.tgemv.mx.acc";
+    case kVariantMxBias: return "pto.tgemv.mx.bias";
     default: return info->name;
     }
   case 0x1032:
     switch (variant) {
-    case 0: return "pto.tmatmul";
-    case 1: return "pto.tmatmul.acc";
-    case 2: return "pto.tmatmul.bias";
+    case kVariantDefault: return "pto.tmatmul";
+    case kVariantAcc: return "pto.tmatmul.acc";
+    case kVariantBias: return "pto.tmatmul.bias";
     default: return info->name;
     }
   case 0x1033:
     switch (variant) {
-    case 0: return "pto.tmatmul.mx";
-    case 1: return "pto.tmatmul.mx.acc";
-    case 2: return "pto.tmatmul.mx.bias";
+    case kVariantDefault: return "pto.tmatmul.mx";
+    case kVariantAcc: return "pto.tmatmul.mx.acc";
+    case kVariantBias: return "pto.tmatmul.mx.bias";
     default: return info->name;
     }
   default: return info->name;
@@ -590,26 +627,26 @@ inline std::optional<int> lookupOperandsByVariant(uint16_t opcode, uint8_t varia
   switch (opcode) {
   case 0x102A:
     switch (variant) {
-    case 0: return 3;
-    case 1: return 4;
-    case 2: return 4;
-    case 3: return 5;
-    case 4: return 6;
-    case 5: return 6;
+    case kVariantDefault: return kTgemvOperandCount;
+    case kVariantAcc: return kTgemvAccOperandCount;
+    case kVariantBias: return kTgemvBiasOperandCount;
+    case kVariantMx: return kTgemvMxOperandCount;
+    case kVariantMxAcc: return kTgemvMxAccOperandCount;
+    case kVariantMxBias: return kTgemvMxBiasOperandCount;
     default: return std::nullopt;
     }
   case 0x1032:
     switch (variant) {
-    case 0: return 3;
-    case 1: return 4;
-    case 2: return 4;
+    case kVariantDefault: return kTmatmulOperandCount;
+    case kVariantAcc: return kTmatmulAccOperandCount;
+    case kVariantBias: return kTmatmulBiasOperandCount;
     default: return std::nullopt;
     }
   case 0x1033:
     switch (variant) {
-    case 0: return 5;
-    case 1: return 6;
-    case 2: return 6;
+    case kVariantDefault: return kTmatmulMxOperandCount;
+    case kVariantAcc: return kTmatmulMxAccOperandCount;
+    case kVariantBias: return kTmatmulMxBiasOperandCount;
     default: return std::nullopt;
     }
   default: return std::nullopt;

--- a/tools/ptobc/src/leb128.cpp
+++ b/tools/ptobc/src/leb128.cpp
@@ -17,11 +17,20 @@
 
 namespace ptobc {
 
+namespace {
+constexpr unsigned kLeb128PayloadBits = 7;
+constexpr uint8_t kLeb128PayloadMask = 0x7fu;
+constexpr uint8_t kLeb128ContinuationBit = 0x80u;
+constexpr uint8_t kLeb128SignBit = 0x40u;
+constexpr unsigned kInt64MaxShift = 63;
+constexpr unsigned kInt64BitWidth = 64;
+} // namespace
+
 void writeULEB128(uint64_t value, std::vector<uint8_t>& out) {
   do {
-    uint8_t byte = static_cast<uint8_t>(value & 0x7fu);
-    value >>= 7;
-    if (value != 0) byte |= 0x80u;
+    uint8_t byte = static_cast<uint8_t>(value & kLeb128PayloadMask);
+    value >>= kLeb128PayloadBits;
+    if (value != 0) byte |= kLeb128ContinuationBit;
     out.push_back(byte);
   } while (value != 0);
 }
@@ -29,13 +38,13 @@ void writeULEB128(uint64_t value, std::vector<uint8_t>& out) {
 void writeSLEB128(int64_t value, std::vector<uint8_t>& out) {
   bool more = true;
   while (more) {
-    uint8_t byte = static_cast<uint8_t>(value & 0x7f);
-    int64_t sign = byte & 0x40;
-    value >>= 7;
+    uint8_t byte = static_cast<uint8_t>(value & kLeb128PayloadMask);
+    int64_t sign = byte & kLeb128SignBit;
+    value >>= kLeb128PayloadBits;
     if ((value == 0 && sign == 0) || (value == -1 && sign != 0)) {
       more = false;
     } else {
-      byte |= 0x80;
+      byte |= kLeb128ContinuationBit;
     }
     out.push_back(byte);
   }
@@ -46,10 +55,10 @@ size_t readULEB128(const uint8_t* data, size_t size, uint64_t& value) {
   unsigned shift = 0;
   for (size_t i = 0; i < size; ++i) {
     uint8_t byte = data[i];
-    value |= (uint64_t(byte & 0x7fu) << shift);
-    if ((byte & 0x80u) == 0) return i + 1;
-    shift += 7;
-    if (shift > 63) throw std::runtime_error("ULEB128 too large");
+    value |= (uint64_t(byte & kLeb128PayloadMask) << shift);
+    if ((byte & kLeb128ContinuationBit) == 0) return i + 1;
+    shift += kLeb128PayloadBits;
+    if (shift > kInt64MaxShift) throw std::runtime_error("ULEB128 too large");
   }
   throw std::runtime_error("Unexpected EOF in ULEB128");
 }
@@ -61,15 +70,15 @@ size_t readSLEB128(const uint8_t* data, size_t size, int64_t& value) {
   size_t i = 0;
   for (; i < size; ++i) {
     byte = data[i];
-    value |= (int64_t(byte & 0x7f) << shift);
-    shift += 7;
-    if ((byte & 0x80u) == 0) break;
-    if (shift > 63) throw std::runtime_error("SLEB128 too large");
+    value |= (int64_t(byte & kLeb128PayloadMask) << shift);
+    shift += kLeb128PayloadBits;
+    if ((byte & kLeb128ContinuationBit) == 0) break;
+    if (shift > kInt64MaxShift) throw std::runtime_error("SLEB128 too large");
   }
   if (i == size) throw std::runtime_error("Unexpected EOF in SLEB128");
 
   // sign extend
-  if ((shift < 64) && (byte & 0x40u)) {
+  if ((shift < kInt64BitWidth) && (byte & kLeb128SignBit)) {
     value |= (-1ll) << shift;
   }
   return i + 1;

--- a/tools/ptobc/src/ptobc_format.cpp
+++ b/tools/ptobc/src/ptobc_format.cpp
@@ -21,6 +21,16 @@
 
 namespace ptobc {
 
+namespace {
+constexpr unsigned kBitsPerByte = 8;
+constexpr uint32_t kByteMask = 0xffu;
+constexpr unsigned kU32SecondByteShift = kBitsPerByte;
+constexpr unsigned kU32ThirdByteShift = 2 * kBitsPerByte;
+constexpr unsigned kU32FourthByteShift = 3 * kBitsPerByte;
+constexpr char kPTOBCMagic[] = {'P', 'T', 'O', 'B', 'C', '\0'};
+constexpr size_t kPTOBCMagicSize = sizeof(kPTOBCMagic);
+} // namespace
+
 void Buffer::append(const void* p, size_t n) {
   const uint8_t* b = reinterpret_cast<const uint8_t*>(p);
   bytes.insert(bytes.end(), b, b + n);
@@ -29,15 +39,15 @@ void Buffer::append(const void* p, size_t n) {
 void Buffer::appendU8(uint8_t v) { bytes.push_back(v); }
 
 void Buffer::appendU16LE(uint16_t v) {
-  bytes.push_back(uint8_t(v & 0xff));
-  bytes.push_back(uint8_t((v >> 8) & 0xff));
+  bytes.push_back(uint8_t(v & kByteMask));
+  bytes.push_back(uint8_t((v >> kU32SecondByteShift) & kByteMask));
 }
 
 void Buffer::appendU32LE(uint32_t v) {
-  bytes.push_back(uint8_t(v & 0xff));
-  bytes.push_back(uint8_t((v >> 8) & 0xff));
-  bytes.push_back(uint8_t((v >> 16) & 0xff));
-  bytes.push_back(uint8_t((v >> 24) & 0xff));
+  bytes.push_back(uint8_t(v & kByteMask));
+  bytes.push_back(uint8_t((v >> kU32SecondByteShift) & kByteMask));
+  bytes.push_back(uint8_t((v >> kU32ThirdByteShift) & kByteMask));
+  bytes.push_back(uint8_t((v >> kU32FourthByteShift) & kByteMask));
 }
 
 uint64_t StringTable::intern(const std::string& s) {
@@ -176,8 +186,7 @@ std::vector<uint8_t> PTOBCFile::serialize() const {
   }
 
   Buffer out;
-  const char magic[6] = {'P','T','O','B','C','\0'};
-  out.append(magic, 6);
+  out.append(kPTOBCMagic, kPTOBCMagicSize);
   out.appendU16LE(kVersionV0);
   out.appendU16LE(kFlagsV0);
   out.appendU32LE(uint32_t(payload.size()));


### PR DESCRIPTION
## Summary
- Replace codecheck-reported magic literals in ptobc opcode variant handling, LEB128/bytecode serialization, memory planning, pipe lowering, and pipe reserved-buffer validation with named constants.
- Remove the stale commented-out memory-planning call and clean up codecheck-reported empty/TODO comments and leading blank lines in touched sync code.
- Keep behavior unchanged; this is a readability/codecheck cleanup.

## Verification
- `git diff --check`
- `cmake -G Ninja -S . -B build-codecheck -DLLVM_DIR=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/lib/cmake/llvm -DMLIR_DIR=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/lib/cmake/mlir -DPython3_EXECUTABLE=python3 -Dpybind11_DIR=/Users/laoda/miniforge3/lib/python3.13/site-packages/pybind11/share/cmake/pybind11 -DMLIR_ENABLE_BINDINGS_PYTHON=ON -DMLIR_PYTHON_PACKAGE_DIR=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/tools/mlir/python_packages/mlir_core`
- `ninja -C build-codecheck`
- `PTOBC_BIN=$PWD/build-codecheck/tools/ptobc/ptobc PTOAS_BIN=$PWD/build-codecheck/tools/ptoas/ptoas TESTDATA_DIR=$PWD/tools/ptobc/testdata OUT_DIR=$PWD/build-codecheck/ptobc_ptoas_smoke_out bash tools/ptobc/tests/ptobc_to_ptoas_smoke.sh`
- `PTOBC_BIN=$PWD/build-codecheck/tools/ptobc/ptobc TESTDATA_DIR=$PWD/tools/ptobc/testdata OUT_DIR=$PWD/build-codecheck/ptobc_trowexpandsub_out bash tools/ptobc/tests/trowexpandsub_v0_encode.sh`

Note: `tools/ptobc/tests/recent_ops_v0_encode.sh` currently fails on this Mac default target because its input contains A5-only `pto.tgemv.mx`; this is unrelated to the codecheck cleanup.
