### PR TITLE
fix: add ptobc v0 entries for tconcat set_validshape and trowprod

### DIFF
--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -189,7 +189,8 @@ inline constexpr OpInfo kOpTable[] = {
   {0x4001, "scf.if", 0, 0x00, 0x00, 1, 0, 2, 0x00},
   {0x4002, "scf.yield", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x6000, "func.func", 0, 0x00, 0x00, 0, 0, 0, 0x00},
-  {0x6001, "func.return", 0, 0x00, 0x00, 0, 0, 0, 0x00},
+  {0x6001, "func.return", 0, 0x00, 0x02, 0, 0, 0, 0x00},
+  {0x6002, "func.call", 0, 0x02, 0x02, 0, 0, 0, 0x00},
 };
 
 inline const OpInfo *lookupByOpcode(uint16_t opcode) {
@@ -217,6 +218,7 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("arith.subi", 0x2008)
     .Case("func.func", 0x6000)
     .Case("func.return", 0x6001)
+    .Case("func.call", 0x6002)
     .Case("pto.addptr", 0x1000)
     .Case("pto.alloc_tile", 0x1001)
     .Case("pto.barrier", 0x1002)
@@ -394,6 +396,7 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("arith.subi", OpcodeAndVariant{0x2008, 0, 0})
     .Case("func.func", OpcodeAndVariant{0x6000, 0, 0})
     .Case("func.return", OpcodeAndVariant{0x6001, 0, 0})
+    .Case("func.call", OpcodeAndVariant{0x6002, 0, 0})
     .Case("pto.addptr", OpcodeAndVariant{0x1000, 0, 0})
     .Case("pto.alloc_tile", OpcodeAndVariant{0x1001, 0, 0})
     .Case("pto.barrier", OpcodeAndVariant{0x1002, 0, 0})

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -175,6 +175,7 @@ inline constexpr OpInfo kOpTable[] = {
   {0x1087, "pto.tfree_from_aiv", 0, 0x00, 0x00, 0, 0, 0, 0x00},
   {0x1088, "pto.set_validshape", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x1089, "pto.tconcat", 0, 0x00, 0x00, 3, 0, 0, 0x00},
+  {0x108A, "pto.trowprod", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -361,6 +362,7 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.tfree_from_aiv", 0x1087)
     .Case("pto.set_validshape", 0x1088)
     .Case("pto.tconcat", 0x1089)
+    .Case("pto.trowprod", 0x108A)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -533,6 +535,7 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.tfree_from_aiv", OpcodeAndVariant{0x1087, 0, 0})
     .Case("pto.set_validshape", OpcodeAndVariant{0x1088, 0, 0})
     .Case("pto.tconcat", OpcodeAndVariant{0x1089, 0, 0})
+    .Case("pto.trowprod", OpcodeAndVariant{0x108A, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})

--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -173,6 +173,8 @@ inline constexpr OpInfo kOpTable[] = {
   {0x1085, "pto.tpop_from_aiv", 0, 0x01, 0x02, 0, 1, 0, 0x00},
   {0x1086, "pto.tfree_from_aic", 0, 0x00, 0x00, 0, 0, 0, 0x00},
   {0x1087, "pto.tfree_from_aiv", 0, 0x00, 0x00, 0, 0, 0, 0x00},
+  {0x1088, "pto.set_validshape", 0, 0x00, 0x00, 3, 0, 0, 0x00},
+  {0x1089, "pto.tconcat", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x2000, "arith.addi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2001, "arith.ceildivsi", 0, 0x01, 0x00, 2, 1, 0, 0x00},
   {0x2002, "arith.cmpi", 0, 0x01, 0x00, 2, 1, 0, 0x01},
@@ -357,6 +359,8 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.tpop_from_aiv", 0x1085)
     .Case("pto.tfree_from_aic", 0x1086)
     .Case("pto.tfree_from_aiv", 0x1087)
+    .Case("pto.set_validshape", 0x1088)
+    .Case("pto.tconcat", 0x1089)
     .Case("scf.for", 0x4000)
     .Case("scf.if", 0x4001)
     .Case("scf.yield", 0x4002)
@@ -527,6 +531,8 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.tpop_from_aiv", OpcodeAndVariant{0x1085, 0, 0})
     .Case("pto.tfree_from_aic", OpcodeAndVariant{0x1086, 0, 0})
     .Case("pto.tfree_from_aiv", OpcodeAndVariant{0x1087, 0, 0})
+    .Case("pto.set_validshape", OpcodeAndVariant{0x1088, 0, 0})
+    .Case("pto.tconcat", OpcodeAndVariant{0x1089, 0, 0})
     .Case("scf.for", OpcodeAndVariant{0x4000, 0, 0})
     .Case("scf.if", OpcodeAndVariant{0x4001, 0, 0})
     .Case("scf.yield", OpcodeAndVariant{0x4002, 0, 0})

--- a/tools/ptobc/src/mlir_encode.cpp
+++ b/tools/ptobc/src/mlir_encode.cpp
@@ -495,6 +495,12 @@ void Encoder::encodeKnownOp(mlir::Operation &op, Buffer &out,
     }
     for (auto result : op.getResults())
       writeULEB128(internType(file, result.getType()), out.bytes);
+  } else if (info.result_type_mode == 0x02) {
+    writeULEB128(op.getNumResults(), out.bytes);
+    for (auto result : op.getResults())
+      writeULEB128(internType(file, result.getType()), out.bytes);
+  } else if (info.result_type_mode != 0x00) {
+    throw std::runtime_error("unknown result_type_mode in v0 schema");
   }
 
   if (op.getNumRegions() != info.num_regions) {

--- a/tools/ptobc/src/ptobc_decode_print.cpp
+++ b/tools/ptobc/src/ptobc_decode_print.cpp
@@ -559,18 +559,31 @@ static mlir::Operation *buildKnownOpFromReader(BuildCtx &bc, Reader &r,
   auto operandIds = readKnownOperandIds(bc, r, opcode, variant, *info, imms);
   auto operands = materializeOperands(bc, operandIds);
 
+  uint64_t numResults = info->num_results;
   llvm::SmallVector<mlir::Type, 4> resultTypes;
-  resultTypes.reserve(info->num_results);
-  if (info->result_type_mode == 0x01) {
-    for (unsigned i = 0; i < info->num_results; ++i)
-      resultTypes.push_back(getType(bc, r.readULEB()));
-  } else {
-    for (unsigned i = 0; i < info->num_results; ++i)
+  switch (info->result_type_mode) {
+  case 0x00:
+    resultTypes.reserve(numResults);
+    for (uint64_t i = 0; i < numResults; ++i)
       resultTypes.push_back(mlir::NoneType::get(bc.ctx));
+    break;
+  case 0x01:
+    resultTypes.reserve(numResults);
+    for (uint64_t i = 0; i < numResults; ++i)
+      resultTypes.push_back(getType(bc, r.readULEB()));
+    break;
+  case 0x02:
+    numResults = r.readULEB();
+    resultTypes.reserve(numResults);
+    for (uint64_t i = 0; i < numResults; ++i)
+      resultTypes.push_back(getType(bc, r.readULEB()));
+    break;
+  default:
+    throw std::runtime_error("unknown result_type_mode");
   }
 
   const size_t resStart = bc.values.size();
-  for (unsigned i = 0; i < info->num_results; ++i)
+  for (uint64_t i = 0; i < numResults; ++i)
     bc.values.push_back(mlir::Value());
 
   const char *opNameC = ptobc::v0::fullNameFromOpcodeVariant(opcode, variant);
@@ -588,7 +601,7 @@ static mlir::Operation *buildKnownOpFromReader(BuildCtx &bc, Reader &r,
   mlir::Operation *op = mlir::Operation::create(state);
   block.getOperations().push_back(op);
   registerDecodedOp(bc, opId, op);
-  assignDecodedResults(bc, resStart, op, info->num_results);
+  assignDecodedResults(bc, resStart, op, numResults);
   for (unsigned i = 0; i < info->num_regions; ++i)
     buildRegionInto(bc, r, op->getRegion(i));
   return op;

--- a/tools/ptobc/testdata/func_call_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/func_call_v0_roundtrip.pto
@@ -1,0 +1,17 @@
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%arg0: i32) attributes {pto.entry} {
+    %0 = func.call @helper(%arg0) : (i32) -> i32
+    func.call @sink(%0) : (i32) -> ()
+    return
+  }
+
+  func.func private @helper(%arg0: i32) -> i32 attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c1 = arith.constant 1 : i32
+    %0 = arith.addi %arg0, %c1 : i32
+    return %0 : i32
+  }
+
+  func.func private @sink(%arg0: i32) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    return
+  }
+}

--- a/tools/ptobc/testdata/tconcat_set_validshape_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tconcat_set_validshape_v0_roundtrip.pto
@@ -18,6 +18,9 @@ module {
     %dyn = pto.alloc_tile valid_row = %c32 valid_col = %c32
       : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reduce_src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reduce_tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reduce_dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tconcat ins(%src0, %src1
       : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
@@ -28,6 +31,11 @@ module {
     pto.set_validshape %dyn, %c16, %c24
       : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
                       blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowprod ins(%reduce_src, %reduce_tmp
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%reduce_dst
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 }

--- a/tools/ptobc/testdata/tconcat_set_validshape_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tconcat_set_validshape_v0_roundtrip.pto
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module {
+  func.func @tconcat_set_validshape_v0() {
+    %c16 = arith.constant 16 : index
+    %c24 = arith.constant 24 : index
+    %c32 = arith.constant 32 : index
+
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dyn = pto.alloc_tile valid_row = %c32 valid_col = %c32
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tconcat ins(%src0, %src1
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=16, v_row=32, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.set_validshape %dyn, %c16, %c24
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -50,6 +50,13 @@ add_test(NAME ptobc_tprint_v0_encode
     ${CMAKE_CURRENT_LIST_DIR}/tprint_v0_encode.sh
 )
 
+add_test(NAME ptobc_func_call_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/func_call_v0_encode.sh
+)
+
 add_test(NAME ptobc_recent_ops_v0_encode
   COMMAND ${CMAKE_COMMAND} -E env
     PTOBC_BIN=$<TARGET_FILE:ptobc>

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -63,3 +63,10 @@ add_test(NAME ptobc_frontend_pipe_v0_encode
     TESTDATA_DIR=${PTObc_TESTDATA_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/frontend_pipe_v0_encode.sh
 )
+
+add_test(NAME ptobc_tconcat_set_validshape_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/tconcat_set_validshape_v0_encode.sh
+)

--- a/tools/ptobc/tests/func_call_v0_encode.sh
+++ b/tools/ptobc/tests/func_call_v0_encode.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/func_call_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_func_call_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/func_call_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/func_call_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "call @helper(" "${ROUNDTRIP}" >/dev/null
+grep -F "call @sink(" "${ROUNDTRIP}" >/dev/null
+grep -F "func.func private @helper" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.kernel_kind = #pto.kernel_kind<cube>" "${ROUNDTRIP}" >/dev/null
+grep -F "func.func private @sink" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.kernel_kind = #pto.kernel_kind<vector>" "${ROUNDTRIP}" >/dev/null
+grep -F "return %1 : i32" "${ROUNDTRIP}" >/dev/null

--- a/tools/ptobc/tests/tconcat_set_validshape_v0_encode.sh
+++ b/tools/ptobc/tests/tconcat_set_validshape_v0_encode.sh
@@ -33,3 +33,4 @@ ROUNDTRIP="${OUT_DIR}/tconcat_set_validshape_v0_roundtrip.roundtrip.pto"
 
 grep -F "pto.tconcat ins(" "${ROUNDTRIP}" >/dev/null
 grep -F "pto.set_validshape " "${ROUNDTRIP}" >/dev/null
+grep -F "pto.trowprod ins(" "${ROUNDTRIP}" >/dev/null

--- a/tools/ptobc/tests/tconcat_set_validshape_v0_encode.sh
+++ b/tools/ptobc/tests/tconcat_set_validshape_v0_encode.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/tconcat_set_validshape_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_tconcat_set_validshape_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/tconcat_set_validshape_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/tconcat_set_validshape_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.tconcat ins(" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.set_validshape " "${ROUNDTRIP}" >/dev/null


### PR DESCRIPTION
## Summary
- add v0 ptobc opcode/schema entries for `pto.tconcat`, `pto.set_validshape`, and `pto.trowprod`
- add a dedicated ptobc roundtrip regression covering all three ops
- keep `pto.build_async_session` out of scope for this PR

## Verification
- `ninja -C build-ptobc ptobc`
- `ctest --test-dir build-ptobc -R ptobc_tconcat_set_validshape_v0_encode --output-on-failure`
- manual roundtrip of `test/samples/Concat/concat-pto-ir.pto` and the dedicated ptobc testdata with the rebuilt `ptobc`
