### PR TITLE
feat(pto): add indexed tconcat op (tconcatidx)

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -6419,6 +6419,61 @@ pto.tconcat ins(%a, %b : !pto.tile_buf<...>, !pto.tile_buf<...>)
 
 ---
 
+##### `pto.tconcatidx` - Indexed Tile Concatenation
+
+**Summary:** Concatenates two source tiles along the column dimension with per-row index control, where two additional index tiles specify the number of columns to copy from each source on a per-row basis.
+
+**Semantics:**
+
+For each row \(i\):
+- Read `idx0_num = src0Idx[i, 0]` and `idx1_num = src1Idx[i, 0]` as element counts
+- Copy the first `min(idx0_num, src0_valid_col, dst_valid_col)` columns from `src0` to `dst`
+- Copy the first `min(idx1_num, src1_valid_col, dst_valid_col - copied_from_src0)` columns from `src1` to `dst`
+
+**Arguments:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `src0` | `pto.tile_buf` | First source tile |
+| `src1` | `pto.tile_buf` | Second source tile |
+| `src0Idx` | `pto.tile_buf` | Per-row index for `src0` (column count to copy) |
+| `src1Idx` | `pto.tile_buf` | Per-row index for `src1` (column count to copy) |
+| `dst` | `pto.tile_buf` | Destination tile |
+
+**Results:** None. Writes into `dst` via DPS pattern.
+
+**Assembly Format:**
+
+```
+pto.tconcatidx ins(<src0>, <src1>, <src0Idx>, <src1Idx> :
+                   <src0_type>, <src1_type>, <src0Idx_type>, <src1Idx_type>)
+               outs(<dst> : <dst_type>)
+```
+
+**Constraints & Verification:**
+
+- `dst`, `src0`, `src1` must have the same data type, and must be one of: `i8/i16/i32/f16/f32/bf16`
+- `src0Idx`, `src1Idx` must have the same index type, and must be one of: `i8/i16/i32`
+- All tiles must use `loc=vec` and row-major layout
+- `validRow(src0) == validRow(src1) == validRow(dst)`
+- `validRow(src0Idx) == validRow(src1Idx) == validRow(dst)`
+- Index tile must have `valid_col >= 1`
+
+**Hardware Mapping:**
+
+- Executes on the **Vector pipeline** (`PIPE_V`)
+- Operates on data in the **VEC (UB)** memory space
+
+**Basic Example:**
+
+```mlir
+pto.tconcatidx ins(%src0, %src1, %idx0, %idx1 :
+  !pto.tile_buf<...>, !pto.tile_buf<...>, !pto.tile_buf<...>, !pto.tile_buf<...>)
+  outs(%dst : !pto.tile_buf<...>)
+```
+
+---
+
 ##### `pto.tgather` - Gather/Select Elements
 
 **Summary:** Gathers elements from a source tile using one of three PTO-ISA-compatible forms:

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2641,6 +2641,49 @@ def TConcatOp: PTO_TOp<"tconcat", [
   }];
 }
 
+def TConcatidxOp: PTO_TOp<"tconcatidx", [
+  PTO_DpsInitOpInterface,
+  OpPipeInterface,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "TCONCAT (indexed): Concatenate two tiles along the column dimension with per-row index control.";
+  let description = [{
+    Indexed form of tconcat. Takes two additional index tiles (src0Idx, src1Idx)
+    that specify the number of columns to copy from each source on a per-row basis.
+
+    Semantics (per row):
+      idx0_num = src0Idx[row, 0]
+      idx1_num = src1Idx[row, 0]
+      copy from src0: min(idx0_num, src0_valid_col, dst_valid_col) columns
+      copy from src1: min(idx1_num, src1_valid_col, dst_valid_col - copied_from_src0) columns
+  }];
+
+  let arguments = (ins
+    PTODpsType:$src0,
+    PTODpsType:$src1,
+    PTODpsType:$src0Idx,
+    PTODpsType:$src1Idx,
+    PTODpsType:$dst
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `ins` `(` $src0 `,` $src1 `,` $src0Idx `,` $src1Idx `:`
+      qualified(type($src0)) `,` qualified(type($src1)) `,`
+      qualified(type($src0Idx)) `,` qualified(type($src1Idx)) `)`
+    `outs` `(` $dst `:` qualified(type($dst) ) `)`
+    attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
+  }];
+}
+
 def TAndSOp : PTO_TOp<"tands", [
   PTO_DpsInitOpInterface,
   OpPipeInterface,

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3305,6 +3305,139 @@ mlir::LogicalResult mlir::pto::TConcatOp::verify() {
   return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
+LogicalResult pto::TConcatidxOp::verify() {
+  auto verifyCommon = [&]() -> FailureOr<std::pair<Type, Type>> {
+    Type t0 = getSrc0().getType();
+    Type t1 = getSrc1().getType();
+    Type ti0 = getSrc0Idx().getType();
+    Type ti1 = getSrc1Idx().getType();
+    Type td = getDst().getType();
+    if (failed(verifyTileBufCommon(*this, t0, "src0")) ||
+        failed(verifyTileBufCommon(*this, t1, "src1")) ||
+        failed(verifyTileBufCommon(*this, ti0, "src0Idx")) ||
+        failed(verifyTileBufCommon(*this, ti1, "src1Idx")) ||
+        failed(verifyTileBufCommon(*this, td, "dst")))
+      return failure();
+
+    // Check data element type consistency.
+    Type e0 = getElemTy(t0);
+    Type e1 = getElemTy(t1);
+    Type ed = getElemTy(td);
+    if (!e0 || !e1 || !ed) {
+      emitOpError("failed to get element type for data operands");
+      return failure();
+    }
+    if (e0 != e1 || e0 != ed) {
+      emitOpError("expects src0, src1, and dst to have the same element type");
+      return failure();
+    }
+
+    // Check index element type consistency.
+    Type ei0 = getElemTy(ti0);
+    Type ei1 = getElemTy(ti1);
+    if (!ei0 || !ei1) {
+      emitOpError("failed to get element type for index operands");
+      return failure();
+    }
+    if (ei0 != ei1) {
+      emitOpError("expects src0Idx and src1Idx to have the same element type");
+      return failure();
+    }
+
+    // All five tiles must be rank-2.
+    auto v0  = getValidShapeVec(getSrc0());
+    auto v1  = getValidShapeVec(getSrc1());
+    auto vi0 = getValidShapeVec(getSrc0Idx());
+    auto vi1 = getValidShapeVec(getSrc1Idx());
+    auto vd  = getValidShapeVec(getDst());
+    if (v0.size() != 2 || v1.size() != 2 || vi0.size() != 2 ||
+        vi1.size() != 2 || vd.size() != 2)
+      return emitOpError("expects all operands to have rank-2 valid_shape");
+
+    // validRow must match dst (when known).
+    auto checkValidRow = [&](const auto &v, StringRef name) -> LogicalResult {
+      if (v[0] != ShapedType::kDynamic && vd[0] != ShapedType::kDynamic &&
+          v[0] != vd[0])
+        return emitOpError("expects ") << name << " valid row to match dst valid row";
+      return success();
+    };
+    if (failed(checkValidRow(v0, "src0")) ||
+        failed(checkValidRow(v1, "src1")) ||
+        failed(checkValidRow(vi0, "src0Idx")) ||
+        failed(checkValidRow(vi1, "src1Idx")))
+      return failure();
+
+    // Index tile must have cols >= 1 (when known).
+    if (vi0[1] != ShapedType::kDynamic && vi0[1] < 1)
+      return emitOpError("expects src0Idx valid_col >= 1");
+    if (vi1[1] != ShapedType::kDynamic && vi1[1] < 1)
+      return emitOpError("expects src1Idx valid_col >= 1");
+
+    return std::make_pair(e0, ei0);
+  };
+
+  auto verifyElementTypes = [&](Type dataElem, Type idxElem) -> LogicalResult {
+    // Data element type: f16, f32, bf16, i8, i16, i32 (signless).
+    if (!dataElem.isF16() && !dataElem.isF32() && !dataElem.isBF16()) {
+      auto it = mlir::dyn_cast<IntegerType>(dataElem);
+      if (!it || !it.isSignless() ||
+          (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32))
+        return emitOpError()
+               << "expects data element type to be i8, i16, i32, f16, f32, or bf16";
+    }
+
+    // Index element type: i8, i16, i32 (signless).
+    auto it = mlir::dyn_cast<IntegerType>(idxElem);
+    if (!it || !it.isSignless() ||
+        (it.getWidth() != 8 && it.getWidth() != 16 && it.getWidth() != 32))
+      return emitOpError()
+             << "expects index element type to be i8, i16, or i32";
+    return success();
+  };
+
+  auto verifyLocVec = [&](Type ty, StringRef name) -> LogicalResult {
+    auto as = getPTOMemorySpaceEnum(ty);
+    if (!as || *as != pto::AddressSpace::VEC)
+      return emitOpError() << "expects " << name << " to use loc=vec";
+    return success();
+  };
+
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    auto elemOr = verifyCommon();
+    if (failed(elemOr))
+      return failure();
+    if (failed(verifyLocVec(getSrc0().getType(), "src0")) ||
+        failed(verifyLocVec(getSrc1().getType(), "src1")) ||
+        failed(verifyLocVec(getSrc0Idx().getType(), "src0Idx")) ||
+        failed(verifyLocVec(getSrc1Idx().getType(), "src1Idx")) ||
+        failed(verifyLocVec(getDst().getType(), "dst")))
+      return failure();
+    return verifyElementTypes(elemOr->first, elemOr->second);
+  };
+
+  auto verifyA5 = [&]() -> LogicalResult {
+    auto elemOr = verifyCommon();
+    if (failed(elemOr))
+      return failure();
+    if (failed(verifyLocVec(getSrc0().getType(), "src0")) ||
+        failed(verifyLocVec(getSrc1().getType(), "src1")) ||
+        failed(verifyLocVec(getSrc0Idx().getType(), "src0Idx")) ||
+        failed(verifyLocVec(getSrc1Idx().getType(), "src1Idx")) ||
+        failed(verifyLocVec(getDst().getType(), "dst")))
+      return failure();
+    if (!isRowMajorTileBuf(getSrc0().getType()) ||
+        !isRowMajorTileBuf(getSrc1().getType()) ||
+        !isRowMajorTileBuf(getSrc0Idx().getType()) ||
+        !isRowMajorTileBuf(getSrc1Idx().getType()) ||
+        !isRowMajorTileBuf(getDst().getType()))
+      return emitOpError(
+          "expects all operands to use row-major layout");
+    return verifyElementTypes(elemOr->first, elemOr->second);
+  };
+
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
+}
+
 LogicalResult pto::TAndSOp::verify() {
   auto verifyCommon = [&]() -> FailureOr<Type> {
     return verifyDistinctRowMajorUnaryTileOpCommon(getOperation(), getSrc(),
@@ -9378,6 +9511,16 @@ void TMovOp::getEffects(SmallVectorImpl<SideEffects::EffectInstance<MemoryEffect
     PTO_ADD_WRITE(dstOperand);                                                      \
   }
 
+#define PTO_DEFINE_QUATERNARY_EFFECTS(OpClass, op0, op1, op2, op3, dstOperand)      \
+  void OpClass::getEffects(                                                         \
+      SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) { \
+    PTO_ADD_READ(op0);                                                              \
+    PTO_ADD_READ(op1);                                                              \
+    PTO_ADD_READ(op2);                                                              \
+    PTO_ADD_READ(op3);                                                              \
+    PTO_ADD_WRITE(dstOperand);                                                      \
+  }
+
 void LoadScalarOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getPtrMutable());
@@ -9451,6 +9594,7 @@ void TAxpyOp::getEffects(
 
 PTO_DEFINE_BINARY_EFFECTS(TAndOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())
 PTO_DEFINE_BINARY_EFFECTS(TConcatOp, getSrc0Mutable(), getSrc1Mutable(), getDstMutable())
+PTO_DEFINE_QUATERNARY_EFFECTS(TConcatidxOp, getSrc0Mutable(), getSrc1Mutable(), getSrc0IdxMutable(), getSrc1IdxMutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TAndSOp, getSrcMutable(), getDstMutable())
 
 // TCI: Write(dst) (generates sequence)

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6065,6 +6065,26 @@ struct PTOConcatToEmitC : public OpConversionPattern<pto::TConcatOp> {
     return success();
   }
 };
+struct PTOConcatidxToEmitC : public OpConversionPattern<pto::TConcatidxOp> {
+  using OpConversionPattern<pto::TConcatidxOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(pto::TConcatidxOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    Value src0 = peelUnrealized(adaptor.getSrc0());
+    Value src1 = peelUnrealized(adaptor.getSrc1());
+    Value src0Idx = peelUnrealized(adaptor.getSrc0Idx());
+    Value src1Idx = peelUnrealized(adaptor.getSrc1Idx());
+    Value dst  = peelUnrealized(adaptor.getDst());
+
+    rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), TypeRange{}, "TCONCAT",
+        ArrayAttr{}, ArrayAttr{},
+        ValueRange{dst, src0, src1, src0Idx, src1Idx});
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
 struct PTOAndSToEmitC : public OpConversionPattern<pto::TAndSOp> {
   using OpConversionPattern<pto::TAndSOp>::OpConversionPattern;
 
@@ -10264,7 +10284,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOTDivSToEmitC>(typeConverter, ctx);
   patterns.add<PTOFModToEmitC>(typeConverter, ctx);
   patterns.add<PTORemToEmitC>(typeConverter, ctx);
-  patterns.add<PTOConcatToEmitC>(typeConverter, ctx);
+  patterns.add<PTOConcatToEmitC, PTOConcatidxToEmitC>(typeConverter, ctx);
   patterns.add<PTORecipToEmitC>(typeConverter, ctx);
   patterns.add<PTOMulsToEmitC>(typeConverter, ctx);
   patterns.add<PTOExpToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -2036,6 +2036,40 @@ struct PTOViewToMemrefPass
             dst);
       }
 
+      SmallVector<mlir::pto::TConcatidxOp, 8> concatIdxs;
+      func.walk([&](mlir::pto::TConcatidxOp op) { concatIdxs.push_back(op); });
+
+      IRRewriter rewriter(ctx);
+      for (auto op : concatIdxs) {
+        rewriter.setInsertionPoint(op);
+
+        Value src0 = op.getSrc0();
+        Value src1 = op.getSrc1();
+        Value src0Idx = op.getSrc0Idx();
+        Value src1Idx = op.getSrc1Idx();
+        Value dst = op.getDst();
+
+        auto src0Ty = dyn_cast<MemRefType>(src0.getType());
+        auto src1Ty = dyn_cast<MemRefType>(src1.getType());
+        auto src0IdxTy = dyn_cast<MemRefType>(src0Idx.getType());
+        auto src1IdxTy = dyn_cast<MemRefType>(src1Idx.getType());
+        auto dstTy = dyn_cast<MemRefType>(dst.getType());
+        if (!src0Ty || !src1Ty || !src0IdxTy || !src1IdxTy || !dstTy) {
+          op.emitError("ins/outs are not memref yet");
+          signalPassFailure();
+          return;
+        }
+
+        rewriter.replaceOpWithNewOp<pto::TConcatidxOp>(
+            op,
+            TypeRange{},
+            src0,
+            src1,
+            src0Idx,
+            src1Idx,
+            dst);
+      }
+
       SmallVector<mlir::pto::TAndSOp, 8> andsops;
       func.walk([&](mlir::pto::TAndSOp op) { andsops.push_back(op); });
 

--- a/test/basic/tconcatidx.pto
+++ b/test/basic/tconcatidx.pto
@@ -1,0 +1,189 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s
+
+// TileLang ST kernels for both the plain concat template (`template_tconcat`)
+// and the indexed concat template (`template_tconcatidx`).
+// Keep the testcase in the same high-level authoring shape as other tile-op
+// expansion STs: make_tensor_view + partition_view + alloc_tile + tload/tstore.
+
+module {
+  func.func @TCONCAT_f32_16x64(
+      %src0_ptr: !pto.ptr<f32>,
+      %src1_ptr: !pto.ptr<f32>,
+      %dst_ptr: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+
+    %src0_view = pto.make_tensor_view %src0_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %src1_view = pto.make_tensor_view %src1_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c16, %c64],
+      strides = [%c1024, %c1024, %c1024, %c64, %c1]
+      : !pto.tensor_view<1x1x1x16x64xf32>
+
+    %src0_part = pto.partition_view %src0_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %src1_part = pto.partition_view %src1_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c16, %c64]
+      : !pto.tensor_view<1x1x1x16x64xf32> -> !pto.partition_tensor_view<1x1x1x16x64xf32>
+
+    %src0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=32,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%src0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=32,
+                                         blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=32,
+                                         blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%dst_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tconcat ins(%src0, %src1 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=32,
+                    blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=32,
+                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64,
+                                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
+    return
+  }
+
+  func.func @TCONCAT_IDX_f32_8x64(
+      %src0_ptr: !pto.ptr<f32>,
+      %src1_ptr: !pto.ptr<f32>,
+      %idx0_ptr: !pto.ptr<i32>,
+      %idx1_ptr: !pto.ptr<i32>,
+      %dst_ptr: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c64 = arith.constant 64 : index
+    %c512 = arith.constant 512 : index
+
+    %src0_view = pto.make_tensor_view %src0_ptr,
+      shape = [%c1, %c1, %c1, %c8, %c64],
+      strides = [%c512, %c512, %c512, %c64, %c1]
+      : !pto.tensor_view<1x1x1x8x64xf32>
+    %src1_view = pto.make_tensor_view %src1_ptr,
+      shape = [%c1, %c1, %c1, %c8, %c64],
+      strides = [%c512, %c512, %c512, %c64, %c1]
+      : !pto.tensor_view<1x1x1x8x64xf32>
+    %idx0_view = pto.make_tensor_view %idx0_ptr,
+      shape = [%c1, %c1, %c1, %c8, %c1],
+      strides = [%c8, %c8, %c8, %c1, %c1]
+      : !pto.tensor_view<1x1x1x8x1xi32>
+    %idx1_view = pto.make_tensor_view %idx1_ptr,
+      shape = [%c1, %c1, %c1, %c8, %c1],
+      strides = [%c8, %c8, %c8, %c1, %c1]
+      : !pto.tensor_view<1x1x1x8x1xi32>
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c1, %c1, %c8, %c64],
+      strides = [%c512, %c512, %c512, %c64, %c1]
+      : !pto.tensor_view<1x1x1x8x64xf32>
+
+    %src0_part = pto.partition_view %src0_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c8, %c64]
+      : !pto.tensor_view<1x1x1x8x64xf32> -> !pto.partition_tensor_view<1x1x1x8x64xf32>
+    %src1_part = pto.partition_view %src1_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c8, %c64]
+      : !pto.tensor_view<1x1x1x8x64xf32> -> !pto.partition_tensor_view<1x1x1x8x64xf32>
+    %idx0_part = pto.partition_view %idx0_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c8, %c1]
+      : !pto.tensor_view<1x1x1x8x1xi32> -> !pto.partition_tensor_view<1x1x1x8x1xi32>
+    %idx1_part = pto.partition_view %idx1_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c8, %c1]
+      : !pto.tensor_view<1x1x1x8x1xi32> -> !pto.partition_tensor_view<1x1x1x8x1xi32>
+    %dst_part = pto.partition_view %dst_view,
+      offsets = [%c0, %c0, %c0, %c0, %c0],
+      sizes = [%c1, %c1, %c1, %c8, %c64]
+      : !pto.tensor_view<1x1x1x8x64xf32> -> !pto.partition_tensor_view<1x1x1x8x64xf32>
+
+    %src0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx0 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx1 = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                      blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0_part : !pto.partition_tensor_view<1x1x1x8x64xf32>)
+              outs(%src0 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                                         blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1_part : !pto.partition_tensor_view<1x1x1x8x64xf32>)
+              outs(%src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                                         blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%idx0_part : !pto.partition_tensor_view<1x1x1x8x1xi32>)
+              outs(%idx0 : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+                                         blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%idx1_part : !pto.partition_tensor_view<1x1x1x8x1xi32>)
+              outs(%idx1 : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+                                         blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%dst_part : !pto.partition_tensor_view<1x1x1x8x64xf32>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tconcatidx ins(%src0, %src1, %idx0, %idx1 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                    blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+      !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                    blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+      !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+                    blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+      !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=1, v_row=8, v_col=1,
+                    blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                                blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=64, v_row=8, v_col=64,
+                                        blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x8x64xf32>)
+    return
+  }
+}


### PR DESCRIPTION
## Summary

Add `pto.tconcatidx` to the PTO dialect, supporting the indexed concat form that takes two additional index tile operands (`src0Idx`, `src1Idx`) to control per-row column counts during concatenation.

Closes #550.

## Changes

| Layer | File | Description |
|-------|------|-------------|
| ODS | `include/PTO/IR/PTOOps.td` | `TConcatidxOp` with 5 operands (src0, src1, src0Idx, src1Idx, dst) |
| Verifier | `lib/PTO/IR/PTO.cpp` | type consistency, loc=vec, row-major, valid_row alignment, index cols >= 1, element type checks |
| EmitC lowering | `lib/PTO/Transforms/PTOToEmitC.cpp` | generates `TCONCAT(dst, src0, src1, src0Idx, src1Idx)` |
| ViewToMemref | `lib/PTO/Transforms/PTOViewToMemref.cpp` | memref type refresh |
| Docs | `docs/PTO_IR_manual.md` | standalone `pto.tconcatidx` section |
| Test | `test/basic/tconcatidx.pto` | lit regression for both plain and indexed forms |

## IR shape

```mlir
pto.tconcatidx ins(%src0, %src1, %idx0, %idx1 :
  !pto.tile_buf<loc=vec, dtype=f32, ...>,
  !pto.tile_buf<loc=vec, dtype=f32, ...>,
  !pto.tile_buf<loc=vec, dtype=i32, ...>,
  !pto.tile_buf<loc=vec, dtype=i32, ...>)
  outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, ...>)
```

## Verified constraints

- Data types: `i8/i16/i32/f16/f32/bf16` (signless)
- Index types: `i8/i16/i32` (signless)
- All tiles `loc=vec`, row-major, rank-2
- `validRow` matches across all tiles
- Index tile `valid_col >= 1`
- Semantics: `min(idxN_num, srcN_valid_col, dst_valid_col)` to guard source bounds

## Test plan

- [x] Build passes
- [x] `ptoas test/basic/tconcatidx.pto` parses and verifies both forms
- [x] EmitC generates `TCONCAT(dst, src0, src1, src0Idx, src1Idx)`
- [x] Existing concat sample continues to work