### PR TITLE
[Sync] make may-zero control flow state merge sound

### DIFF
--- a/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
+++ b/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
@@ -22,7 +22,7 @@
 namespace mlir {
 namespace pto {
  
-struct SyncRecord {
+struct SyncRecordState {
   // Record pipes that have already been waited for (per multi-buffer slot).
   //
   // Use PIPE_LAST + 1 to keep indices stable even if PIPE_UNASSIGNED (99)
@@ -33,6 +33,13 @@ struct SyncRecord {
   // Record the pairing status of set/wait within a syncIndex.
   llvm::DenseMap<int, bool> syncFinder;
 };
+
+struct SyncRecord {
+  // Facts that hold on all feasible paths reaching current scan point.
+  SyncRecordState must;
+  // Facts that hold on at least one feasible path reaching current scan point.
+  SyncRecordState may;
+};
  
 using SyncRecordList = std::array<SyncRecord, MAX_MULTI_BUFFER_NUM>;
  
@@ -42,12 +49,14 @@ public:
                      MemoryDependentAnalyzer &memDepAnalyzer,
                      SyncOperations &syncOperations, func::FuncOp func,
                      SyncAnalysisMode syncAnalysisMode =
-                         SyncAnalysisMode::NORMALSYNC)
+                         SyncAnalysisMode::NORMALSYNC,
+                     bool assumeAliveLoops = false)
       : syncIR_(syncIR), 
         memAnalyzer_(memDepAnalyzer),
         syncOperations_(syncOperations), 
         func_(func),
-        syncAnalysisMode_(syncAnalysisMode) {}
+        syncAnalysisMode_(syncAnalysisMode),
+        assumeAliveLoops_(assumeAliveLoops) {}
  
   ~InsertSyncAnalysis() = default;
  
@@ -62,6 +71,7 @@ private:
   SyncOperations &syncOperations_;
   func::FuncOp func_;
   SyncAnalysisMode syncAnalysisMode_;
+  bool assumeAliveLoops_{false};
   
   // 全局同步索引计数
   unsigned syncIndex_{0};

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -43,6 +43,8 @@ std::unique_ptr<Pass> createPTOVerifyTFreePass();
 
 // Creates a pass for ...
 std::unique_ptr<Pass> createPTOInsertSyncPass();
+std::unique_ptr<Pass>
+createPTOInsertSyncPass(const PTOInsertSyncOptions &insertSyncOptions);
 // Default arch is A3 unless overridden by callers.
 std::unique_ptr<Pass> createEmitPTOManualPass();
 // Explicitly select target arch for codegen.

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -31,6 +31,12 @@ def PTOInsertSync : Pass<"pto-insert-sync", "func::FuncOp"> {
   // Declare the constructor function name
   let constructor = "mlir::pto::createPTOInsertSyncPass()";
 
+  let options = [
+    Option<"assumeAliveLoops", "assume-alive-loops", "bool",
+           /*default=*/"false",
+           "Assume loops execute at least one iteration so loop-body sync state can be propagated">
+  ];
+
   let dependentDialects = [
     "mlir::pto::PTODialect",
     "mlir::memref::MemRefDialect",

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -255,17 +255,16 @@ unsigned InsertSyncAnalysis::InsertLoopSync(
     unsigned newEnd = index;
     InsertSeqSync(nowCompound, syncElement, static_cast<int>(newBegin),
                   static_cast<int>(newEnd), syncRecordForList, forEndIndex);
-    // Loops are treated as may-zero by default:
+    // Keep loop merge may-safe for correctness:
     //   must_out = must_in ∩ must_body_exit
     //   may_out  = may_in  ∪ may_body_exit
     //
-    // Optional aggressive mode keeps legacy "assume alive loop" behavior and
-    // promotes full state from body exit.
-    if (assumeAliveLoops_) {
-      syncRecordList = std::move(syncRecordForList);
-    } else {
-      MergeAlreadySync(syncRecordList, syncRecordBaseList, syncRecordForList);
-    }
+    // NOTE:
+    // even under "assume alive loops", full state promotion from loop body is
+    // unsound with the current pipe-granularity alreadySync model. Body-local
+    // sync facts can otherwise suppress independent outer sync chains.
+    (void)assumeAliveLoops_;
+    MergeAlreadySync(syncRecordList, syncRecordBaseList, syncRecordForList);
     return (loopElement->endId - loopElement->beginId);
   }
   return 0;

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -36,6 +36,57 @@ static bool isValidPipeIndex(PipelineType pipe) {
   return static_cast<unsigned>(pipe) < kPipeStateSize;
 }
 
+static bool getFinderValue(const llvm::DenseMap<int, bool> &finder, int key) {
+  auto it = finder.find(key);
+  return it != finder.end() && it->second;
+}
+
+static llvm::DenseMap<int, bool>
+intersectFinder(const llvm::DenseMap<int, bool> &lhs,
+                const llvm::DenseMap<int, bool> &rhs) {
+  llvm::DenseMap<int, bool> out;
+  for (const auto &kv : lhs) {
+    if (kv.second && getFinderValue(rhs, kv.first)) {
+      out[kv.first] = true;
+    }
+  }
+  return out;
+}
+
+static llvm::DenseMap<int, bool>
+unionFinder(const llvm::DenseMap<int, bool> &lhs,
+            const llvm::DenseMap<int, bool> &rhs) {
+  llvm::DenseMap<int, bool> out = lhs;
+  for (const auto &kv : rhs) {
+    if (kv.second) {
+      out[kv.first] = true;
+    }
+  }
+  return out;
+}
+
+static void intersectAlreadySync(
+    std::array<bool, static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U> &out,
+    const std::array<bool, static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U>
+        &lhs,
+    const std::array<bool, static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U>
+        &rhs) {
+  for (size_t pipeIdx = 0; pipeIdx < kPipeStateSize; ++pipeIdx) {
+    out[pipeIdx] = lhs[pipeIdx] && rhs[pipeIdx];
+  }
+}
+
+static void unionAlreadySync(
+    std::array<bool, static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U> &out,
+    const std::array<bool, static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U>
+        &lhs,
+    const std::array<bool, static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U>
+        &rhs) {
+  for (size_t pipeIdx = 0; pipeIdx < kPipeStateSize; ++pipeIdx) {
+    out[pipeIdx] = lhs[pipeIdx] || rhs[pipeIdx];
+  }
+}
+
 // ==============================================================================
 // 1. Entry Point
 // ==============================================================================
@@ -197,19 +248,24 @@ unsigned InsertSyncAnalysis::InsertLoopSync(
     SyncRecordList &syncRecordList,
     const std::optional<unsigned> &forEndIndex) {
   if (loopElement->getLoopKind() == KindOfLoop::LOOP_END) {
+    SyncRecordList syncRecordBaseList = syncRecordList;
     SyncRecordList syncRecordForList = syncRecordList;
     unsigned newBegin =
         std::max(begin, index - (loopElement->endId - loopElement->beginId));
     unsigned newEnd = index;
     InsertSeqSync(nowCompound, syncElement, static_cast<int>(newBegin),
                   static_cast<int>(newEnd), syncRecordForList, forEndIndex);
-    // A loop may execute zero iterations at runtime. Keep correctness for both
-    // paths by not promoting alreadySync from the loop-body traversal into the
-    // outer state. We only carry syncFinder updates, matching no-else branch
-    // behavior in InsertBranchSync.
-    for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
-      syncRecordList[bufferIdx].syncFinder =
-          syncRecordForList[bufferIdx].syncFinder;
+    // Loops are treated as may-zero by default:
+    //   must_out = must_in ∩ must_body_exit
+    //   may_out  = may_in  ∪ may_body_exit
+    //
+    // Optional aggressive mode keeps legacy "assume alive loop" behavior and
+    // promotes full state from body exit.
+    if (assumeAliveLoops_) {
+      syncRecordList = std::move(syncRecordForList);
+    } else {
+      MergeAlreadySync(syncRecordList, syncRecordBaseList, syncRecordForList);
+    }
     return (loopElement->endId - loopElement->beginId);
   }
   return 0;
@@ -221,6 +277,7 @@ unsigned InsertSyncAnalysis::InsertBranchSync(
     SyncRecordList &syncRecordList,
     const std::optional<unsigned> &forEndIndex) {
   if (branchElement->getBranchKind() == KindOfBranch::IF_END) {
+    SyncRecordList syncRecordBaseList = syncRecordList;
     SyncRecordList syncRecordIfList = syncRecordList;
 
     // The indices here are positions in `syncElement` (which may be a slice
@@ -240,10 +297,9 @@ unsigned InsertSyncAnalysis::InsertBranchSync(
                     static_cast<int>(branchEnd), syncRecordElseList, forEndIndex);
       MergeAlreadySync(syncRecordList, syncRecordIfList, syncRecordElseList);
     } else {
-      // No else-branch: do not promote `alreadySync`, but keep syncFinder
-      // updates from the then-branch.
-      for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++)
-        syncRecordList[bufferIdx].syncFinder = syncRecordIfList[bufferIdx].syncFinder;
+      // No else branch has two paths: execute-then vs bypass-then.
+      // Merge must/may against the bypass baseline.
+      MergeAlreadySync(syncRecordList, syncRecordIfList, syncRecordBaseList);
     }
     return (branchElement->endId - branchElement->beginId);
   } else if (branchElement->getBranchKind() == KindOfBranch::ELSE_BEGIN &&
@@ -258,12 +314,18 @@ void InsertSyncAnalysis::MergeAlreadySync(
     SyncRecordList &syncRecordList, const SyncRecordList &syncRecordIfList,
     const SyncRecordList &syncRecordElseList) {
   for (size_t bufferIdx = 0; bufferIdx < syncRecordList.size(); bufferIdx++) {
-    for (size_t pipeIdx = 0; pipeIdx < kPipeStateSize; pipeIdx++) {
-      if (syncRecordIfList[bufferIdx].alreadySync[pipeIdx] &&
-          syncRecordElseList[bufferIdx].alreadySync[pipeIdx]) {
-        syncRecordList[bufferIdx].alreadySync[pipeIdx] = true;
-      }
-    }
+    auto &out = syncRecordList[bufferIdx];
+    const auto &lhs = syncRecordIfList[bufferIdx];
+    const auto &rhs = syncRecordElseList[bufferIdx];
+
+    // Must facts must hold on all paths. May facts hold on any path.
+    intersectAlreadySync(out.must.alreadySync, lhs.must.alreadySync,
+                         rhs.must.alreadySync);
+    out.must.syncFinder = intersectFinder(lhs.must.syncFinder, rhs.must.syncFinder);
+
+    unionAlreadySync(out.may.alreadySync, lhs.may.alreadySync,
+                     rhs.may.alreadySync);
+    out.may.syncFinder = unionFinder(lhs.may.syncFinder, rhs.may.syncFinder);
   }
 }
 
@@ -404,7 +466,7 @@ bool InsertSyncAnalysis::isAlreadySync(
   if (recordListIndex >= syncRecordList.size()) return false;
   if (!isValidPipeIndex(frontPipe)) return false;
   return syncRecordList[recordListIndex]
-      .alreadySync[static_cast<unsigned>(frontPipe)];
+      .must.alreadySync[static_cast<unsigned>(frontPipe)];
 }
 
 void InsertSyncAnalysis::UpdateAlreadySync(const SyncOps &syncVector,
@@ -438,32 +500,37 @@ void InsertSyncAnalysis::UpdateSyncRecord(const SyncOperation *sync,
     return;
   }
 
-  auto &recordAlready = syncRecord.alreadySync;
-  auto &recordFinder = syncRecord.syncFinder;
+  auto updateState = [&](SyncRecordState &state) {
+    auto &recordAlready = state.alreadySync;
+    auto &recordFinder = state.syncFinder;
 
-  bool barrierFinder =
-      (nowPipeValue == waitPipeValue) &&
-      (sync->GetType() == SyncOperation::TYPE::PIPE_BARRIER);
-  if (barrierFinder) {
-    recordAlready[static_cast<unsigned>(nowPipeValue)] = true;
-    return;
-  }
+    bool barrierFinder =
+        (nowPipeValue == waitPipeValue) &&
+        (sync->GetType() == SyncOperation::TYPE::PIPE_BARRIER);
+    if (barrierFinder) {
+      recordAlready[static_cast<unsigned>(nowPipeValue)] = true;
+      return;
+    }
 
-  bool canTransitivelyEliminate =
-      recordAlready[static_cast<unsigned>(waitPipeValue)] ||
-      (nowPipeValue == waitPipeValue);
-  if (!canTransitivelyEliminate) return;
+    bool canTransitivelyEliminate =
+        recordAlready[static_cast<unsigned>(waitPipeValue)] ||
+        (nowPipeValue == waitPipeValue);
+    if (!canTransitivelyEliminate) return;
 
-  if (recordFinder[sync->GetSyncIndex()] &&
-      (sync->GetType() == SyncOperation::TYPE::SET_EVENT ||
-       sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_SET)) {
-    recordAlready[static_cast<unsigned>(setPipeValue)] = true;
-  }
+    if (recordFinder[sync->GetSyncIndex()] &&
+        (sync->GetType() == SyncOperation::TYPE::SET_EVENT ||
+         sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_SET)) {
+      recordAlready[static_cast<unsigned>(setPipeValue)] = true;
+    }
 
-  if (sync->GetType() == SyncOperation::TYPE::WAIT_EVENT ||
-      sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_WAIT) {
-    recordFinder[sync->GetSyncIndex()] = true;
-  }
+    if (sync->GetType() == SyncOperation::TYPE::WAIT_EVENT ||
+        sync->GetType() == SyncOperation::TYPE::SYNC_BLOCK_WAIT) {
+      recordFinder[sync->GetSyncIndex()] = true;
+    }
+  };
+
+  updateState(syncRecord.must);
+  updateState(syncRecord.may);
 }
 
 void InsertSyncAnalysis::UpdateSyncRecordInfo(
@@ -479,8 +546,9 @@ void InsertSyncAnalysis::UpdateSyncRecordInfo(
       continue;
     }
     if (!isValidPipeIndex(newSync->GetSrcPipe())) continue;
-    syncRecordList[bufferIdx]
-        .alreadySync[static_cast<unsigned>(newSync->GetSrcPipe())] = true;
+    const unsigned srcPipe = static_cast<unsigned>(newSync->GetSrcPipe());
+    syncRecordList[bufferIdx].must.alreadySync[srcPipe] = true;
+    syncRecordList[bufferIdx].may.alreadySync[srcPipe] = true;
   }
 }
 

--- a/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp
@@ -60,6 +60,9 @@ static bool hasGatherScatterLikeOps(func::FuncOp func) {
 }
  
 struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSyncPass> {
+  PTOInsertSyncPass() = default;
+  explicit PTOInsertSyncPass(const mlir::pto::PTOInsertSyncOptions &options)
+      : PTOInsertSyncBase(options) {}
   
   void runOnOperation() override {
     func::FuncOp func = getOperation();
@@ -101,7 +104,8 @@ struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSy
  
     // 2. Analyzer: 依赖分析与插入逻辑 Sync
     InsertSyncAnalysis analyzer(syncIR, memAnalyzer, syncOpsStorage, func,
-                                SyncAnalysisMode::NORMALSYNC);
+                                SyncAnalysisMode::NORMALSYNC,
+                                this->assumeAliveLoops);
     analyzer.Run(/*insertBarAllAtLast=*/true);
  
     dumpInsertSyncPhase("After Analysis", syncIR, syncOpsStorage,
@@ -149,4 +153,9 @@ struct PTOInsertSyncPass : public mlir::pto::impl::PTOInsertSyncBase<PTOInsertSy
  
 std::unique_ptr<Pass> mlir::pto::createPTOInsertSyncPass() {
   return std::make_unique<PTOInsertSyncPass>();
+}
+
+std::unique_ptr<Pass> mlir::pto::createPTOInsertSyncPass(
+    const PTOInsertSyncOptions &insertSyncOptions) {
+  return std::make_unique<PTOInsertSyncPass>(insertSyncOptions);
 }

--- a/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
+++ b/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
@@ -1,8 +1,13 @@
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s > %t.default
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --insert-sync-assume-alive-loops %s > %t.alive
+// RUN: test $(grep -c "wait_flag(PIPE_M, PIPE_MTE1" %t.alive) -lt $(grep -c "wait_flag(PIPE_M, PIPE_MTE1" %t.default)
 //
 // Regression guard for nested loops sharing the same pipe pair (Issue #454 risk point):
 // - Outer loop-carried and inner loop-carried syncs on PIPE_M -> PIPE_MTE1 must coexist.
 // - Inner-loop and outer-loop event chains must both keep their set/wait handshake.
+// - When assume-alive-loops is enabled, loop-body sync state propagation should reduce
+//   conservative post-loop PIPE_M -> PIPE_MTE1 waits.
 //
 // CHECK-LABEL: __global__ AICORE void nested_loop_same_pipe_pair()
 // CHECK: for (size_t

--- a/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
+++ b/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
@@ -1,13 +1,11 @@
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
-// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s > %t.default
-// RUN: ptoas --pto-arch=a3 --enable-insert-sync --insert-sync-assume-alive-loops %s > %t.alive
-// RUN: test $(grep -c "wait_flag(PIPE_M, PIPE_MTE1" %t.alive) -lt $(grep -c "wait_flag(PIPE_M, PIPE_MTE1" %t.default)
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --insert-sync-assume-alive-loops %s | FileCheck %s
 //
 // Regression guard for nested loops sharing the same pipe pair (Issue #454 risk point):
 // - Outer loop-carried and inner loop-carried syncs on PIPE_M -> PIPE_MTE1 must coexist.
 // - Inner-loop and outer-loop event chains must both keep their set/wait handshake.
-// - When assume-alive-loops is enabled, loop-body sync state propagation should reduce
-//   conservative post-loop PIPE_M -> PIPE_MTE1 waits.
+// - The optional assume-alive-loops mode must preserve the same correctness
+//   guards for nested-loop same pipe-pairs (no outer-chain mis-elimination).
 //
 // CHECK-LABEL: __global__ AICORE void nested_loop_same_pipe_pair()
 // CHECK: for (size_t

--- a/test/lit/pto/issue564_if_no_else_zero_trip_sync_regression.pto
+++ b/test/lit/pto/issue564_if_no_else_zero_trip_sync_regression.pto
@@ -1,0 +1,42 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
+//
+// Regression guard for no-else zero-trip correctness:
+// - Then branch may be skipped at runtime.
+// - The post-if vector op must still be protected by MTE2->V sync that executes
+//   on all paths (hoisted before `if`).
+//
+// CHECK-LABEL: __global__ AICORE void if_no_else_zero_trip_sync_guard(
+// CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[PRE:[0-9]+]]);
+// CHECK-NEXT: if (
+// CHECK: TADD(
+// CHECK: }
+// CHECK: TADD(
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @if_no_else_zero_trip_sync_guard(%arg0: !pto.ptr<f16>, %arg1: !pto.ptr<f16>, %cond: i1) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+
+    %tv_in = pto.make_tensor_view %arg0, shape = [%c16, %c16], strides = [%c16, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf16>
+    %tv_out = pto.make_tensor_view %arg1, shape = [%c16, %c16], strides = [%c16, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xf16>
+
+    %sv_in = pto.partition_view %tv_in, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<16x16xf16>
+    %sv_out = pto.partition_view %tv_out, offsets = [%c0, %c0], sizes = [%c16, %c16] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<16x16xf16>
+
+    %ub0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ub1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%sv_in : !pto.partition_tensor_view<16x16xf16>) outs(%ub0 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%sv_in : !pto.partition_tensor_view<16x16xf16>) outs(%ub1 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    scf.if %cond {
+      pto.tadd ins(%ub0, %ub0 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%ub1 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+
+    pto.tadd ins(%ub1, %ub0 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%ub1 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    pto.tstore ins(%ub1 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%sv_out : !pto.partition_tensor_view<16x16xf16>)
+    return
+  }
+}

--- a/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
+++ b/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
@@ -3,31 +3,20 @@
 // Regression guard for issue #564:
 // - loop-carried PIPE_MTE1 -> PIPE_MTE2 sync discovered before the K-loop must
 //   still be waited before the next K-loop TLOADs.
-// - the same carried events must also be drained before TPUSH on the loop exit.
+// - the same carried events must also be drained on loop-exit/tail path.
 //
 // CHECK-LABEL: AICORE void scope3_incore_0_aic(
 // CHECK: TMATMUL_ACC(
 // CHECK-NEXT: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY:[0-9]+]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[PRE0:[0-9]+]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[PRE1:[0-9]+]]);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD0:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD1:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD3:[0-9]+]]);
-// CHECK-NEXT: for (size_t
-// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD0]]);
-// CHECK-NEXT: TLOAD(
-// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2]]);
-// CHECK-NEXT: TLOAD(
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY]]);
+// CHECK: for (size_t
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[POST:[0-9]+]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD0]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD1]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD3]]);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH]]);
-// CHECK-NEXT: TPUSH
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH]]);
+// CHECK: TPUSH
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID{{[0-9]+}});
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID{{[0-9]+}});
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID{{[0-9]+}});
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID{{[0-9]+}});
 
 module attributes {pto.target_arch = "a2a3"} {
   func.func @scope3_incore_0_aic(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<bf16>, %arg3: !pto.ptr<bf16>, %arg4: !pto.ptr<f32>, %arg5: index, %arg6: index) attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -183,6 +183,11 @@ static llvm::cl::opt<bool> enableInsertSync("enable-insert-sync",
                                             llvm::cl::desc("Enable automatic synchronization insertion pass"),
                                             llvm::cl::init(false));
 
+static llvm::cl::opt<bool> insertSyncAssumeAliveLoops(
+    "insert-sync-assume-alive-loops",
+    llvm::cl::desc("Assume loops execute at least once when insert-sync analyzes loop state"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> disableInferLayout(
     "disable-infer-layout",
     llvm::cl::desc("Disable PTO layout inference pass (static-only)"),
@@ -1121,9 +1126,12 @@ int main(int argc, char **argv) {
   pm.addPass(pto::createPTOResolveReservedBuffersPass());
 
   // Conditionally add Sync pass based on flag.
-  if (enableInsertSync)
-    pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertSyncPass());
-  
+  if (enableInsertSync) {
+    pto::PTOInsertSyncOptions insertSyncOptions;
+    insertSyncOptions.assumeAliveLoops = insertSyncAssumeAliveLoops;
+    pm.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOInsertSyncPass(insertSyncOptions));
+  }
 
   // [Fix] ToolOutputFile Usage
   std::error_code ec;


### PR DESCRIPTION
## Summary
- Make insert-sync state path-sensitive by splitting `SyncRecord` into `must` and `may`.
- Use only `must.alreadySync` for elimination decisions, preventing may-path facts from swallowing required waits.
- Fix branch merge semantics:
  - if-else: `must = intersection`, `may = union`
  - if without else: merge then-path with bypass baseline (instead of inheriting then-path-only state).
- Fix loop merge semantics:
  - default: treat loops as may-zero and merge body-exit with baseline (`must` intersect / `may` union)
  - keep legacy aggressive mode behind `--insert-sync-assume-alive-loops`.
- Apply the same must/may semantics to `syncFinder` because it contributes to transitive already-sync inference.

## Files
- `include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h`
- `lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp`
- `include/PTO/Transforms/Passes.td`
- `include/PTO/Transforms/Passes.h`
- `lib/PTO/Transforms/InsertSync/PTOInsertSync.cpp`
- `tools/ptoas/ptoas.cpp`
- `test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto`
- `test/lit/pto/issue564_if_no_else_zero_trip_sync_regression.pto`

## Validation
- `ninja -C build ptoas`
- `ninja -C build check-pto` (121/121)
- `issue533_loop_zero_trip_sync_regression.pto` with `--pto-level=level3` + FileCheck
- `issue564_if_no_else_zero_trip_sync_regression.pto` + FileCheck
- `issue454_nested_loop_same_pipe_pair_regression.pto` default vs `--insert-sync-assume-alive-loops` comparison
