### PR TITLE
[Sync] keep fallback pipe-all barriers local

### DIFF
--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -162,6 +162,7 @@ public:
   Value lowestCommonAncestorBuffer{nullptr};
   int reuseCntForWiden{0};
   bool reallocatedLoopHeadTailSync{false};
+  bool autoSyncTailBarrier{false};
   TCoreType syncCoreType{TCoreType::CUBE_OR_VECTOR};
   Value block_sync_event_value{nullptr};
  
@@ -207,6 +208,8 @@ public:
  
   // 设置为 PipeAll (用于资源耗尽时的降级)
   void SetPipeAll();
+  bool IsAutoSyncTailBarrier() const { return autoSyncTailBarrier; }
+  void MarkAutoSyncTailBarrier() { autoSyncTailBarrier = true; }
  
 private:
   TYPE type_;

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -496,6 +496,7 @@ void InsertSyncAnalysis::InsertLastPipeAll() {
     auto barrierOp = std::make_unique<SyncOperation>(
         SyncOperation::TYPE::PIPE_BARRIER, PipelineType::PIPE_ALL,
         PipelineType::PIPE_ALL, syncIndex_, element->GetIndex(), std::nullopt);
+    barrierOp->MarkAutoSyncTailBarrier();
 
     SyncOperation *barrierRawPtr = barrierOp.get();
     SmallVector<std::unique_ptr<SyncOperation>> syncGroup;

--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -45,6 +45,8 @@ static bool IsSameSyncSignature(const SyncOperation *existing,
     return false;
   if (existing->GetActualDstPipe() != candidate->GetActualDstPipe())
     return false;
+  if (existing->IsAutoSyncTailBarrier() != candidate->IsAutoSyncTailBarrier())
+    return false;
   if (candidate->isSyncSetType() || candidate->isSyncWaitType())
     return existing->eventIds == candidate->eventIds;
   return true;
@@ -283,9 +285,10 @@ void SyncCodegen::CreateBarrierOp(IRRewriter &rewriter, Operation *op,
     return;
   }
 
-  // Compiler-inserted tail clean barrier must be anchored at function tail.
-  if (sync->GetActualSrcPipe() == PipelineType::PIPE_ALL &&
-      sync->GetActualDstPipe() == PipelineType::PIPE_ALL) {
+  // Only the compiler-inserted tail clean barrier is deferred to function tail.
+  // Other PIPE_ALL barriers, including event-id-exhaustion fallbacks, must stay
+  // at their original program point to preserve local ordering.
+  if (sync->IsAutoSyncTailBarrier()) {
     pendingAutoSyncTailBarrier_ = true;
     return;
   }

--- a/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
@@ -126,6 +126,7 @@ SyncOperation::GetMatchSync(unsigned index) const {
   res->depRootBuffers = this->depRootBuffers;
   res->eventIdNum = this->eventIdNum;
   res->isCompensation = this->isCompensation;
+  res->autoSyncTailBarrier = this->autoSyncTailBarrier;
   res->SetDepSyncIRIndex(this->GetDepSyncIRIndex());
   return res;
 }

--- a/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
+++ b/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
@@ -5,6 +5,8 @@
 //   still be waited before the next K-loop TLOADs.
 // - if event ids are exhausted, fallback PIPE_ALL barriers must remain at the
 //   original K-loop wait positions instead of being deferred to function tail.
+// - fallback pairs must not leave a synthetic MTE1->MTE2 set/wait half around
+//   the local barrier: the barrier itself is the paired conservative fallback.
 // - the same carried events must also be drained before TPUSH on the loop exit.
 //
 // CHECK-LABEL: AICORE void scope3_incore_0_aic(
@@ -22,8 +24,14 @@
 // CHECK-NEXT: TLOAD(
 // CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2]]);
 // CHECK-NEXT: TLOAD(
+// CHECK-NOT: set_flag(PIPE_MTE1, PIPE_MTE2
+// CHECK-NOT: wait_flag(PIPE_MTE1, PIPE_MTE2
+// CHECK-NOT: ptoas_auto_sync_tail
 // CHECK: pipe_barrier(PIPE_ALL);
 // CHECK-NEXT: TLOAD(
+// CHECK-NOT: set_flag(PIPE_MTE1, PIPE_MTE2
+// CHECK-NOT: wait_flag(PIPE_MTE1, PIPE_MTE2
+// CHECK-NOT: ptoas_auto_sync_tail
 // CHECK: pipe_barrier(PIPE_ALL);
 // CHECK-NEXT: TLOAD(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH:[0-9]+]]);
@@ -34,6 +42,8 @@
 // CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD3]]);
 // CHECK-NEXT: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH]]);
 // CHECK-NEXT: TPUSH
+// CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+// CHECK-NEXT: return;
 
 module attributes {pto.target_arch = "a2a3"} {
   func.func @scope3_incore_0_aic(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<bf16>, %arg2: !pto.ptr<bf16>, %arg3: !pto.ptr<bf16>, %arg4: !pto.ptr<f32>, %arg5: index, %arg6: index) attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {

--- a/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
+++ b/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
@@ -3,6 +3,8 @@
 // Regression guard for issue #564:
 // - loop-carried PIPE_MTE1 -> PIPE_MTE2 sync discovered before the K-loop must
 //   still be waited before the next K-loop TLOADs.
+// - if event ids are exhausted, fallback PIPE_ALL barriers must remain at the
+//   original K-loop wait positions instead of being deferred to function tail.
 // - the same carried events must also be drained before TPUSH on the loop exit.
 //
 // CHECK-LABEL: AICORE void scope3_incore_0_aic(
@@ -19,6 +21,10 @@
 // CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD0]]);
 // CHECK-NEXT: TLOAD(
 // CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2]]);
+// CHECK-NEXT: TLOAD(
+// CHECK: pipe_barrier(PIPE_ALL);
+// CHECK-NEXT: TLOAD(
+// CHECK: pipe_barrier(PIPE_ALL);
 // CHECK-NEXT: TLOAD(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH:[0-9]+]]);
 // CHECK-NEXT: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[POST:[0-9]+]]);


### PR DESCRIPTION
Summary
- Mark only the auto-sync tail clean barrier as tail-deferred.
- Keep event-id-exhaustion fallback PIPE_ALL barriers at their original sync insertion point.
- Add issue564 regression checks that fallback PIPE_ALL barriers stay in the K-loop, do not leave orphan MTE1->MTE2 set/wait halves, and are not emitted as the tail clean helper.

Motivation
- Event id exhaustion can conservatively degrade an unallocated set/wait pair into a PIPE_ALL barrier.
- The existing codegen path treated every PIPE_ALL barrier as the function-tail auto clean barrier, so local fallback barriers were swallowed and moved to function tail.
- That removes the local loop ordering the fallback was supposed to preserve.

Design
- Add an explicit autoSyncTailBarrier marker to SyncOperation.
- Set the marker only for InsertLastPipeAll tail clean.
- Preserve the marker when creating the matching sync operation and include it in sync dedup signatures.
- Defer only marked tail clean barriers; all other PIPE_ALL barriers are emitted locally.

Testing
- Local targeted FileCheck: issue564_k_loop_mte1_mte2_wait_regression.pto
- Local: ninja -C build check-pto (136/136 passed)

Scope
- This PR intentionally only fixes PIPE_ALL fallback codegen placement.
- It does not change loop syncFinder/alreadySync propagation policy.