### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -170,9 +170,9 @@ public:
   SyncOperation(TYPE type, pto::PipelineType srcPipe, pto::PipelineType dstPipe,
                 unsigned kSyncIndex, unsigned syncIRIndex,
                 std::optional<int> forEndIndex, bool isComp = false)
-      : eventIds({}), type_(type), srcPipe_(srcPipe), dstPipe_(dstPipe),
-        kSyncIndex_(kSyncIndex), syncIRIndex_(syncIRIndex),
-        forEndIndex_(forEndIndex), isCompensation(isComp) {};
+      : isCompensation(isComp), eventIds({}), type_(type), srcPipe_(srcPipe),
+        dstPipe_(dstPipe), kSyncIndex_(kSyncIndex), syncIRIndex_(syncIRIndex),
+        forEndIndex_(forEndIndex) {};
  
   ~SyncOperation() = default;
  

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -887,7 +887,7 @@ static void bindPTOModule(pybind11::module &m) {
                 throw std::runtime_error("valid_shape rank must match shape rank");
             }
             validShape.resize(lst.size());
-            for (ssize_t i = 0; i < lst.size(); ++i) {
+            for (py::ssize_t i = 0; i < static_cast<py::ssize_t>(lst.size()); ++i) {
                 py::object e = lst[i];
                 if (e.is_none()) {
                 validShape[i] = -1;  // None -> dynamic

--- a/lib/CAPI/Dialect/PTO.cpp
+++ b/lib/CAPI/Dialect/PTO.cpp
@@ -224,7 +224,7 @@ const int64_t *mlirPTOTileTypeGetShape(MlirType type, intptr_t *numDimsOut) {
 }
 
 bool mlirPTOTypeIsATileBufType(MlirType type) {
-  return unwrap(type).isa<mlir::pto::TileBufType>();
+  return mlir::isa<mlir::pto::TileBufType>(unwrap(type));
 }
 
 MlirType mlirPTOTileBufTypeGet(MlirContext ctx, intptr_t rank,
@@ -244,7 +244,7 @@ MlirType mlirPTOTileBufTypeGetWithConfig(MlirContext ctx, intptr_t rank,
                                          MlirAttribute memorySpace, MlirAttribute config) {
   MLIRContext *c = unwrap(ctx);
   auto shp = llvm::ArrayRef<int64_t>(shape, rank);
-  auto cfg = unwrap(config).dyn_cast_or_null<mlir::pto::TileBufConfigAttr>();
+  auto cfg = mlir::dyn_cast_or_null<mlir::pto::TileBufConfigAttr>(unwrap(config));
   if (!cfg) cfg = mlir::pto::TileBufConfigAttr::getDefault(c);
   auto ty = mlir::pto::TileBufType::get(c, shp, unwrap(elementType), unwrap(memorySpace), cfg);
   return wrap(ty);
@@ -543,7 +543,7 @@ MlirPTOCmpMode mlirPTOCmpModeAttrGetValue(MlirAttribute attr) {
 }
 
 bool mlirPTOAttrIsATileBufConfigAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::TileBufConfigAttr>();
+  return mlir::isa<mlir::pto::TileBufConfigAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTOTileBufConfigAttrGetDefault(MlirContext ctx) {
@@ -580,7 +580,7 @@ static mlir::pto::CompactModeAttr toCompactModeAttr(mlir::MLIRContext *c,
 }
 
 bool mlirPTOAttrIsACompactModeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::CompactModeAttr>();
+  return mlir::isa<mlir::pto::CompactModeAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTOCompactModeAttrGet(MlirContext ctx, int32_t value) {
@@ -595,7 +595,7 @@ int32_t mlirPTOCompactModeAttrGetValue(MlirAttribute attr) {
 }
 
 bool mlirPTOAttrIsAAccToVecModeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::AccToVecModeAttr>();
+  return mlir::isa<mlir::pto::AccToVecModeAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTOAccToVecModeAttrGet(MlirContext ctx, int32_t value) {
@@ -610,7 +610,7 @@ int32_t mlirPTOAccToVecModeAttrGetValue(MlirAttribute attr) {
 }
 
 bool mlirPTOAttrIsAReluPreModeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::ReluPreModeAttr>();
+  return mlir::isa<mlir::pto::ReluPreModeAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTOReluPreModeAttrGet(MlirContext ctx, int32_t value) {

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -8990,7 +8990,7 @@ static ParseResult parseStrideList(AsmParser &parser, SmallVectorImpl<int64_t> &
 // Printer Implementation
 // =============================================================================
 
-[[maybe_unused]] [[maybe_unused]] static void printLayout(AsmPrinter &printer, Attribute layoutAttr) {
+[[maybe_unused]] static void printLayout(AsmPrinter &printer, Attribute layoutAttr) {
   if (!layoutAttr) return;
   auto mapAttr = llvm::dyn_cast<AffineMapAttr>(layoutAttr);
   if (!mapAttr) { printer << ", " << layoutAttr; return; }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -66,7 +66,7 @@ static void printShapeAndElem(AsmPrinter &printer,
 // =============================================================================
 
 // 解析逻辑：解析形如 "32x32" 的维度列表
-static ParseResult parseShape(AsmParser &parser, SmallVectorImpl<int64_t> &shape) {
+[[maybe_unused]] static ParseResult parseShape(AsmParser &parser, SmallVectorImpl<int64_t> &shape) {
   // parseDimensionList 会解析 "dim x dim x ...", 遇到无法解析为维度的字符停止
   // 参数 allowDynamic=true (允许 ?), withTrailingX=false (不吞掉末尾的 x)
   if (parser.parseDimensionList(shape, /*allowDynamic=*/true, /*withTrailingX=*/false))
@@ -75,7 +75,7 @@ static ParseResult parseShape(AsmParser &parser, SmallVectorImpl<int64_t> &shape
 }
 
 // 打印逻辑：打印形如 "32x32" 的维度列表
-static void printShape(AsmPrinter &printer, ArrayRef<int64_t> shape) {
+[[maybe_unused]] static void printShape(AsmPrinter &printer, ArrayRef<int64_t> shape) {
   for (auto it = shape.begin(); it != shape.end(); ++it) {
     if (it != shape.begin()) printer << "x"; // 维度间的分隔符
     if (*it == ShapedType::kDynamic)
@@ -182,7 +182,7 @@ static bool isRowMajorTileBuf(Type ty);
 
 #include "PTO/IR/PTODialect.cpp.inc"
 
-static LogicalResult parseShapeAndElemStable(mlir::AsmParser &parser,
+[[maybe_unused]] static LogicalResult parseShapeAndElemStable(mlir::AsmParser &parser,
                                              llvm::SmallVectorImpl<int64_t> &shape,
                                              mlir::Type &elementType) {
   if (failed(parser.parseLess()))
@@ -431,7 +431,7 @@ static void printSyncEventOpCommon(OpAsmPrinter &p, Operation *op,
   p.printOptionalAttrDict(op->getAttrs(), {pipeAttrName, eventIdAttrName});
 }
 
-static mlir::Type parsePTOTypeAllowNoBang(mlir::OpAsmParser &parser) {
+[[maybe_unused]] static mlir::Type parsePTOTypeAllowNoBang(mlir::OpAsmParser &parser) {
   mlir::Type ty;
 
   mlir::OptionalParseResult opt = parser.parseOptionalType(ty);
@@ -1059,7 +1059,7 @@ static unsigned getElemByteSize(Type ty) {
   return getPTOStorageElemByteSize(ty);
 }
 
-static bool isSupportedLoadStoreElemTypeA2A3(Type ty) {
+[[maybe_unused]] static bool isSupportedLoadStoreElemTypeA2A3(Type ty) {
   if (ty.isF16() || ty.isBF16() || ty.isF32())
     return true;
   if (auto it = dyn_cast<IntegerType>(ty)) {
@@ -1647,7 +1647,7 @@ void mlir::pto::annotatePTOEntryFunctions(ModuleOp module) {
 //  - Otherwise (tile_view/tile etc): accept (so old IR can still parse).
 //===----------------------------------------------------------------------===//
 
-static LogicalResult verifyMemrefToTensorLoad(Operation *op, Value src, Value res) {
+[[maybe_unused]] static LogicalResult verifyMemrefToTensorLoad(Operation *op, Value src, Value res) {
   auto mr = dyn_cast<MemRefType>(src.getType());
   auto rt = dyn_cast<RankedTensorType>(res.getType());
   if (!mr)
@@ -1681,7 +1681,7 @@ static LogicalResult verifyMemrefToTensorLoad(Operation *op, Value src, Value re
   return success();
 }
 
-static LogicalResult verifyMemrefTensorStore(Operation *op, Value dst, Value src) {
+[[maybe_unused]] static LogicalResult verifyMemrefTensorStore(Operation *op, Value dst, Value src) {
   auto mr = dyn_cast<MemRefType>(dst.getType());
   if (!mr)
     return success(); // non-memref case: old tile IR allowed
@@ -2162,9 +2162,9 @@ LogicalResult pto::TAbsOp::verify() {
 // PTO.cpp
 
 static bool isPTOShapedLike(Type ty) {
-  return ty.isa<MemRefType, RankedTensorType,
+  return mlir::isa<MemRefType, RankedTensorType,
                 pto::TensorViewType, pto::TileBufType,
-                pto::PartitionTensorViewType>();
+                pto::PartitionTensorViewType>(ty);
 }
 
 static bool isTileLikeType(Type ty) {
@@ -2172,25 +2172,25 @@ static bool isTileLikeType(Type ty) {
 }
 
 static Type getElemTy(Type ty) {
-  if (auto mr = ty.dyn_cast<MemRefType>()) return mr.getElementType();
-  if (auto tt = ty.dyn_cast<RankedTensorType>()) return tt.getElementType();
-  if (auto tv = ty.dyn_cast<pto::TensorViewType>()) return tv.getElementType();
-  if (auto tb = ty.dyn_cast<pto::TileBufType>()) return tb.getElementType();
-  if (auto tv = ty.dyn_cast<pto::PartitionTensorViewType>()) return tv.getElementType();
+  if (auto mr = mlir::dyn_cast<MemRefType>(ty)) return mr.getElementType();
+  if (auto tt = mlir::dyn_cast<RankedTensorType>(ty)) return tt.getElementType();
+  if (auto tv = mlir::dyn_cast<pto::TensorViewType>(ty)) return tv.getElementType();
+  if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty)) return tb.getElementType();
+  if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty)) return tv.getElementType();
   return Type();
 }
 
 static SmallVector<int64_t, 4> getShapeVec(Type ty) {
   SmallVector<int64_t, 4> s;
-  if (auto mr = ty.dyn_cast<MemRefType>())
+  if (auto mr = mlir::dyn_cast<MemRefType>(ty))
     return SmallVector<int64_t,4>(mr.getShape().begin(), mr.getShape().end());
-  if (auto tt = ty.dyn_cast<RankedTensorType>())
+  if (auto tt = mlir::dyn_cast<RankedTensorType>(ty))
     return SmallVector<int64_t,4>(tt.getShape().begin(), tt.getShape().end());
-  if (auto tv = ty.dyn_cast<pto::TensorViewType>())
+  if (auto tv = mlir::dyn_cast<pto::TensorViewType>(ty))
     return SmallVector<int64_t,4>(tv.getShape().begin(), tv.getShape().end());
-  if (auto tb = ty.dyn_cast<pto::TileBufType>())
+  if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty))
     return SmallVector<int64_t,4>(tb.getShape().begin(), tb.getShape().end());
-  if (auto tv = ty.dyn_cast<pto::PartitionTensorViewType>())
+  if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty))
     return SmallVector<int64_t,4>(tv.getShape().begin(), tv.getShape().end());
   return {};
 }
@@ -2437,7 +2437,7 @@ static std::optional<pto::AddressSpace> getPTOMemorySpaceEnum(Type ty) {
   return std::nullopt;
 }
 
-static bool isRank2TileBuf(Type ty) {
+[[maybe_unused]] static bool isRank2TileBuf(Type ty) {
   auto tb = dyn_cast<pto::TileBufType>(ty);
   return tb && tb.getRank() == 2 && tb.getValidShape().size() == 2;
 }
@@ -2492,7 +2492,7 @@ static bool isSupportedMScatterAtomicPayloadElemType(Type ty,
     return ty.isF32() ||
            (intTy && intTy.getWidth() == 32);
   }
-  llvm_unreachable("unknown ScatterAtomicOp");
+  llvm_unreachable("Unknown ScatterAtomicOp");
 }
 
 static LogicalResult verifyMGatherMScatterMemOperand(Operation *op,
@@ -2695,7 +2695,7 @@ static LogicalResult verifyPartialValidPattern(Operation *op, Type src0Ty,
   return success();
 }
 
-static bool hasKnownZeroValidRegion(Type ty) {
+[[maybe_unused]] static bool hasKnownZeroValidRegion(Type ty) {
   auto valid = getValidShapeVec(ty);
   if (valid.size() != 2)
     return false;
@@ -2768,7 +2768,7 @@ verifyNumericScalarTileOpCommon(Operation *op, Type srcTy, Type dstTy,
                                 requireValidRowsEqual,
                                 /*requireValidColsEqual=*/true)))
     return failure();
-  if (!scalarTy.isa<IntegerType, FloatType>()) {
+  if (!mlir::isa<IntegerType, FloatType>(scalarTy)) {
     op->emitOpError("scalar must be a scalar type (integer/float)");
     return failure();
   }
@@ -2942,7 +2942,7 @@ static LogicalResult verifyTColArgReductionOpCommon(Operation *op, Type srcTy,
     return failure();
   Type srcElemTy = getElemTy(srcTy);
   unsigned srcElemBits = srcElemTy ? srcElemTy.getIntOrFloatBitWidth() : 0;
-  if (!(srcElemTy.isa<IntegerType, FloatType>() &&
+  if (!(mlir::isa<IntegerType, FloatType>(srcElemTy) &&
         (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
     return op->emitOpError(
         "expects src/tmp element type to be 1, 2, or 4 bytes wide");
@@ -3640,7 +3640,7 @@ LogicalResult pto::TCIOp::verify() {
   if (failed(verifyTileBufCommon(*this, dstTy, "dst")))
     return failure();
 
-  auto elemTy = getElemTy(dstTy).dyn_cast<IntegerType>();
+  auto elemTy = mlir::dyn_cast<IntegerType>(getElemTy(dstTy));
   if (!elemTy)
     return emitOpError("expects dst element type to be integer");
 
@@ -3648,7 +3648,7 @@ LogicalResult pto::TCIOp::verify() {
   if (bw != 16 && bw != 32)
     return emitOpError("expects dst element type to be i16/i32");
 
-  auto sTy = getOperand(0).getType().dyn_cast<IntegerType>();
+  auto sTy = mlir::dyn_cast<IntegerType>(getOperand(0).getType());
   if (!sTy)
     return emitOpError("expects S to be integer");
 
@@ -3671,7 +3671,7 @@ LogicalResult pto::TTriOp::verify() {
   if (failed(verifyVecTileCommon(*this, dstTy, "dst")))
     return failure();
 
-  auto diagonalTy = getDiagonal().getType().dyn_cast<IntegerType>();
+  auto diagonalTy = mlir::dyn_cast<IntegerType>(getDiagonal().getType());
   if (!diagonalTy)
     return emitOpError("expects diagonal to be an integer operand");
 
@@ -4050,8 +4050,6 @@ ParseResult mlir::pto::TColSumOp::parse(OpAsmParser &parser, OperationState &res
   if (parser.resolveOperand(src, srcTy, result.operands))
     return failure();
 
-  int32_t tmpSize = hasTmp ? 1 : 0;
-
   if (hasTmp) {
     if (parser.resolveOperand(tmp, tmpTy, result.operands))
       return failure();
@@ -4253,7 +4251,7 @@ mlir::LogicalResult mlir::pto::TDivSOp::verify() {
                mlir::pto::PartitionTensorViewType>(ty);
   };
   auto isScalarLike = [](Type ty) -> bool {
-    return ty.isa<IntegerType, FloatType>();
+    return mlir::isa<IntegerType, FloatType>(ty);
   };
 
   auto verifyByArch = [&](PTOArch targetArch) -> LogicalResult {
@@ -4276,7 +4274,7 @@ mlir::LogicalResult mlir::pto::TDivSOp::verify() {
                                   /*requireValidRowsEqual=*/true,
                                   /*requireValidColsEqual=*/true)))
       return failure();
-    if (!scalarTy.isa<IntegerType, FloatType>())
+    if (!mlir::isa<IntegerType, FloatType>(scalarTy))
       return emitOpError("scalar must be a scalar type (integer/float)");
     Type elem = getElemTy(tileTy);
     if (targetArch == PTOArch::A3 &&
@@ -5212,7 +5210,6 @@ mlir::LogicalResult mlir::pto::TGatherBOp::verify() {
     if (failed(elems))
       return failure();
     Type dstTy = getDst().getType();
-    Type srcElemTy = elems->first;
     Type dstElemTy = elems->second;
     if (!isRowMajorTileBuf(dstTy))
       return emitOpError() << "expects dst to use row-major layout";
@@ -5226,7 +5223,6 @@ mlir::LogicalResult mlir::pto::TGatherBOp::verify() {
     FailureOr<std::pair<Type, Type>> elems = verifyCommon();
     if (failed(elems))
       return failure();
-    Type srcElemTy = elems->first;
     Type dstElemTy = elems->second;
     auto dstBytes = getElemBytes(dstElemTy);
     if (!dstBytes || (*dstBytes != 1 && *dstBytes != 2 && *dstBytes != 4))
@@ -5814,7 +5810,7 @@ LogicalResult TGetValOp::verify() {
   if (shouldBypassDecodedMemrefVerifier(getOperation()))
     return success();
   Type srcTy = getSrc().getType();
-  if (!srcTy.isa<pto::TileBufType, MemRefType>())
+  if (!mlir::isa<pto::TileBufType, MemRefType>(srcTy))
     return emitOpError("expects src to be tile_buf or memref type");
 
   // Memory space must be vec (Ascend does not support getval from MAT etc.).
@@ -7081,8 +7077,8 @@ static std::optional<int64_t> getElemBytes(Type elemTy) {
   return std::nullopt;
 }
 
-static bool isTileBufOrMemref(Type ty) {
-  return ty.isa<MemRefType, pto::TileBufType>();
+[[maybe_unused]] static bool isTileBufOrMemref(Type ty) {
+  return mlir::isa<MemRefType, pto::TileBufType>(ty);
 }
 
 static constexpr llvm::StringLiteral kLoweredSetValidShapeAttrName =
@@ -7970,7 +7966,7 @@ mlir::LogicalResult mlir::pto::TRsqrtOp::verify() {
     return failure();
   if (failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst")))
     return failure();
-  auto ft = getElemTy(ts).dyn_cast<mlir::FloatType>();
+  auto ft = mlir::dyn_cast<mlir::FloatType>(getElemTy(ts));
   if (!ft || (!ft.isF16() && !ft.isF32()))
     return emitOpError("expects element type to be f16 or f32");
   if (auto tmp = getTmp()) {
@@ -8152,9 +8148,7 @@ mlir::LogicalResult mlir::pto::TSelSOp::verify() {
     FailureOr<Type> elemOr = verifyCommon();
     if (failed(elemOr))
       return failure();
-    Type tMask = getMask().getType();
     Type tSrc = getSrc().getType();
-    Type tTmp = getTmp().getType();
     Type tDst = getDst().getType();
     if (!isRowMajorTileBuf(tSrc) || !isRowMajorTileBuf(tDst))
       return emitOpError("expects src and dst to use row-major layout");
@@ -8571,7 +8565,7 @@ mlir::LogicalResult mlir::pto::TPrintOp::verify() {
 
 
 
-static LogicalResult verifyMatmulCommon(Operation *op, Value lhs, Value rhs,
+[[maybe_unused]] static LogicalResult verifyMatmulCommon(Operation *op, Value lhs, Value rhs,
                                        Value biasOpt, Type maybeDstElemTy,
                                        Type maybeResultElemTy) {
   // ---- case A: tensor/memref (ShapedType) ----
@@ -8697,7 +8691,7 @@ LogicalResult mlir::pto::TGemvAccOp::verify() {
 //===----------------------------------------------------------------------===//
 // inferReturnTypes() for matmul ops (keep your existing code)
 //===----------------------------------------------------------------------===
-static mlir::Type inferMatmulTileResult2DFromAB(MLIRContext *context, ValueRange operands) {
+[[maybe_unused]] static mlir::Type inferMatmulTileResult2DFromAB(MLIRContext *context, ValueRange operands) {
   if (operands.size() < 2)
     return mlir::Type();
 
@@ -8726,7 +8720,7 @@ static mlir::Type inferMatmulTileResult2DFromAB(MLIRContext *context, ValueRange
   return mlir::Type();
 }
 
-static RankedTensorType inferMatmulResult2DFromAB(ValueRange operands) {
+[[maybe_unused]] static RankedTensorType inferMatmulResult2DFromAB(ValueRange operands) {
   if (operands.size() < 2)
     return RankedTensorType();
 
@@ -8755,7 +8749,7 @@ static RankedTensorType inferMatmulResult2DFromAB(ValueRange operands) {
   return RankedTensorType();
 }
 
-static RankedTensorType inferAccReturnFromAccIn(ValueRange operands) {
+[[maybe_unused]] static RankedTensorType inferAccReturnFromAccIn(ValueRange operands) {
   if (operands.empty())
     return RankedTensorType();
   if (auto accRT = dyn_cast<RankedTensorType>(operands[0].getType()))
@@ -8836,7 +8830,7 @@ void TileType::print(AsmPrinter &printer) const {
 
 // Helper: 递归地将 Add 表达式拆解为单独的项列表
 static void flattenAddExpr(AffineExpr expr, SmallVectorImpl<AffineExpr> &terms) {
-  if (auto add = expr.dyn_cast<AffineBinaryOpExpr>()) {
+  if (auto add = llvm::dyn_cast<AffineBinaryOpExpr>(expr)) {
     if (add.getKind() == AffineExprKind::Add) {
       flattenAddExpr(add.getLHS(), terms);
       flattenAddExpr(add.getRHS(), terms);
@@ -8860,22 +8854,22 @@ static void decomposeStridedLayout(AffineMap map, SmallVectorImpl<int64_t> &stri
   // 3. 分析每一项
   for (auto term : terms) {
     // 情况 A: dN * Const 或 Const * dN
-    if (auto mul = term.dyn_cast<AffineBinaryOpExpr>()) {
+    if (auto mul = llvm::dyn_cast<AffineBinaryOpExpr>(term)) {
       if (mul.getKind() == AffineExprKind::Mul) {
         AffineExpr lhs = mul.getLHS();
         AffineExpr rhs = mul.getRHS();
 
         // 尝试匹配 LHS=Dim, RHS=Const
-        if (auto dim = lhs.dyn_cast<AffineDimExpr>()) {
-          if (auto cst = rhs.dyn_cast<AffineConstantExpr>()) {
+        if (auto dim = llvm::dyn_cast<AffineDimExpr>(lhs)) {
+          if (auto cst = llvm::dyn_cast<AffineConstantExpr>(rhs)) {
             strides[dim.getPosition()] = cst.getValue();
             continue;
           }
         }
         
         // 尝试匹配 LHS=Const, RHS=Dim (乘法交换律)
-        if (auto dim = rhs.dyn_cast<AffineDimExpr>()) {
-          if (auto cst = lhs.dyn_cast<AffineConstantExpr>()) {
+        if (auto dim = llvm::dyn_cast<AffineDimExpr>(rhs)) {
+          if (auto cst = llvm::dyn_cast<AffineConstantExpr>(lhs)) {
             strides[dim.getPosition()] = cst.getValue();
             continue;
           }
@@ -8883,7 +8877,7 @@ static void decomposeStridedLayout(AffineMap map, SmallVectorImpl<int64_t> &stri
       }
     }
     // 情况 B: 单独的 dN (隐含 Stride = 1)
-    else if (auto dim = term.dyn_cast<AffineDimExpr>()) {
+    else if (auto dim = llvm::dyn_cast<AffineDimExpr>(term)) {
       strides[dim.getPosition()] = 1;
     }
   }
@@ -8947,7 +8941,7 @@ static ParseResult parseStrideList(AsmParser &parser, SmallVectorImpl<int64_t> &
 }
 
 // The custom attribute parser for: strided<[64, 1], offset: [?, ?]>
-static ParseResult parseStridedLayout(AsmParser &parser, Attribute &layout) {
+[[maybe_unused]] static ParseResult parseStridedLayout(AsmParser &parser, Attribute &layout) {
   if (parser.parseLess()) return failure();
   
   // 1. Parse Strides
@@ -8996,7 +8990,7 @@ static ParseResult parseStridedLayout(AsmParser &parser, Attribute &layout) {
 // Printer Implementation
 // =============================================================================
 
-static void printLayout(AsmPrinter &printer, Attribute layoutAttr) {
+[[maybe_unused]] [[maybe_unused]] static void printLayout(AsmPrinter &printer, Attribute layoutAttr) {
   if (!layoutAttr) return;
   auto mapAttr = llvm::dyn_cast<AffineMapAttr>(layoutAttr);
   if (!mapAttr) { printer << ", " << layoutAttr; return; }
@@ -9283,11 +9277,11 @@ static LogicalResult computeInnerShape(TileBufConfigAttr cfg, Type elemTy,
   }
 
   int64_t elemBytes = -1;
-  if (auto ft = elemTy.dyn_cast<FloatType>()) {
+  if (auto ft = mlir::dyn_cast<FloatType>(elemTy)) {
     if (ft.isF16() || ft.isBF16()) elemBytes = 2;
     else if (ft.isF32()) elemBytes = 4;
     else if (ft.isF64()) elemBytes = 8;
-  } else if (auto it = elemTy.dyn_cast<IntegerType>()) {
+  } else if (auto it = mlir::dyn_cast<IntegerType>(elemTy)) {
     int64_t bytes = it.getWidth() / 8;
     elemBytes = bytes > 0 ? bytes : 1;
   }
@@ -9457,7 +9451,7 @@ using namespace mlir::pto;
 // Helper Functions
 // =============================================================================
  
-static AddressSpace getAddressSpace(Value val) {
+[[maybe_unused]] static AddressSpace getAddressSpace(Value val) {
   auto type = llvm::dyn_cast<MemRefType>(val.getType());
   if (!type) return AddressSpace::Zero; // Default
  
@@ -10656,14 +10650,14 @@ static FailureOr<Operation *> lookupFrontendInitOpById(Operation *op,
   unsigned matchedInitCount = 0;
   funcOp.walk([&](Operation *candidate) {
     if (auto aic = dyn_cast<AicInitializePipeOp>(candidate)) {
-      if (aic.getId() == id) {
+      if (aic.getId() == static_cast<uint32_t>(id)) {
         matchedInit = candidate;
         ++matchedInitCount;
       }
       return WalkResult::advance();
     }
     if (auto aiv = dyn_cast<AivInitializePipeOp>(candidate)) {
-      if (aiv.getId() == id) {
+      if (aiv.getId() == static_cast<uint32_t>(id)) {
         matchedInit = candidate;
         ++matchedInitCount;
       }
@@ -10908,7 +10902,7 @@ static LogicalResult verifyTensorEntryMatchesInternalPipeInit(Operation *op,
            << "expects pipe entry element type to match initialize_l2g2l_pipe "
               "gm_addr element type";
   }
-  if (slotShape.size() != entryViewTy.getRank()) {
+  if (slotShape.size() != static_cast<size_t>(entryViewTy.getRank())) {
     return op->emitOpError()
            << "expects pipe entry rank to match initialize_l2g2l_pipe gm_addr "
               "rank";
@@ -11299,7 +11293,7 @@ LogicalResult InitializeL2G2LPipeOp::verify() {
     int32_t localSlotNum = localSlotNumAttr.getInt();
     if (localSlotNum <= 0)
       return emitOpError("expects 'local_slot_num' to be greater than 0");
-    if (localSlotNum > getSlotNum())
+    if (static_cast<uint32_t>(localSlotNum) > getSlotNum())
       return emitOpError(
           "expects 'local_slot_num' to be less than or equal to slot_num");
   }

--- a/lib/PTO/Transforms/InferPTOMemScope.cpp
+++ b/lib/PTO/Transforms/InferPTOMemScope.cpp
@@ -166,7 +166,7 @@ struct InferPTOMemScopePass
 
 private:
   LogicalResult fixDeviceCallSite(func::FuncOp op);
-  LogicalResult fixHostFuncSignature(func::FuncOp op);
+  [[maybe_unused]] LogicalResult fixHostFuncSignature(func::FuncOp op);
 };
 } // namespace
 
@@ -324,7 +324,7 @@ LogicalResult InferPTOMemScopePass::fixDeviceCallSite(func::FuncOp op) {
 /// updated the memref type of the BlockArgument of or the return operation
 /// within the function (if they are updated at all). So we need to use those
 /// information to update the function's type.
-LogicalResult InferPTOMemScopePass::fixHostFuncSignature(func::FuncOp op) {
+[[maybe_unused]] LogicalResult InferPTOMemScopePass::fixHostFuncSignature(func::FuncOp op) {
   // Skip external host functions because we know nothing about it.
   if (op.isExternal())
     return success();

--- a/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCodegen.cpp
@@ -242,7 +242,6 @@ void SyncCodegen::updatePlaceHolderOpInsertSync(PlaceHolderInstanceElement *plac
   else if (placeHolder->elementOp == placeHolder->parentIfOp) {
       // 之前的 Translator 逻辑把 Normal Placeholder 也映射到了 ifOp
       // 我们需要修正它指向 Yield
-      auto ifOp = dyn_cast<scf::IfOp>(placeHolder->elementOp);
       // 判断是 Then 还是 Else
       // 简单判断：看 index。或者 Translator 里直接存 Yield Op。
       // 这里假设 Translator 存的是 IfOp，我们需要找到对应的 Yield。

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -576,7 +576,7 @@ void MemLivenessAnalysis::RecursiveIfOp(scf::IfOp ifOp, Liveness live) {
   //        scf.yield %alloc0: memref<16xf16, #pto.address_space<ub>>
   //      else:
   //        scf.yield %alloc1 : memref<16xf16, #pto.address_space<ub>>
-  auto curIfThen = UpdateLinearOperation(ifOp.getOperation());
+  UpdateLinearOperation(ifOp.getOperation());
   RecursionIR(&ifOp.getThenRegion(), live);
   auto curIfElse = UpdateLinearOperation(ifOp.getOperation());
   UpdateIfOpBufferAlias(ifOp, ifOp.thenYield());
@@ -1579,6 +1579,9 @@ MemPlan::GetBufferSpaceInfo(pto::AddressSpace &space) const {
     return std::make_pair(biasAlignSize, biasSpaceSize);
   case pto::AddressSpace::SCALING:
     return std::make_pair(scalingAlignSize, scalingSpaceSize);
+  case pto::AddressSpace::Zero:
+  case pto::AddressSpace::GM:
+    return std::make_pair(size_t{0}, size_t{0});
   }
 
   llvm_unreachable("Temporarily unsupported memory buffer space !");

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -9,6 +9,9 @@
 //===- PTOToEmitC.cpp - PTO to EmitC conversion pass ----------------------===//
 //===----------------------------------------------------------------------===//
 
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+// https://discourse.llvm.org/t/matchandrewrite-hiding-virtual-functions/84933/8
+
 #include <cassert>
 #include <climits>
 
@@ -1263,8 +1266,6 @@ struct ArithExtUIToEmitC : public OpConversionPattern<arith::ExtUIOp> {
       return success();
     }
 
-    auto uSrcTy =
-        getUnsignedIntOpaqueType(rewriter.getContext(), srcIntTy.getWidth());
     auto uDstTy =
         getUnsignedIntOpaqueType(rewriter.getContext(), dstIntTy.getWidth());
     Value srcU =
@@ -1379,8 +1380,6 @@ struct ArithUIToFPToEmitC : public OpConversionPattern<arith::UIToFPOp> {
       rewriter.replaceOpWithNewOp<emitc::CastOp>(op, dstTy, adaptor.getIn());
       return success();
     }
-    auto uSrcTy =
-        getUnsignedIntOpaqueType(rewriter.getContext(), srcIntTy.getWidth());
     Value srcU =
         castSignlessIntToUnsignedSameWidth(rewriter, loc, adaptor.getIn(),
                                            srcIntTy.getWidth());
@@ -2548,7 +2547,7 @@ struct AffineApplyMulConstToEmitC
 
 enum class KernelKind { VecAdd, Matmul, Unknown };
 
-static KernelKind inferKernelKind(func::FuncOp f) {
+[[maybe_unused]] static KernelKind inferKernelKind(func::FuncOp f) {
   bool hasAdd = false;
   bool hasMM  = false;
   f.walk([&](Operation *op) {
@@ -2561,7 +2560,7 @@ static KernelKind inferKernelKind(func::FuncOp f) {
   return KernelKind::Unknown;
 }
 
-static void inferTileMNK(func::FuncOp f, int &M, int &N, int &K) {
+[[maybe_unused]] static void inferTileMNK(func::FuncOp f, int &M, int &N, int &K) {
   M = 32; N = 32; K = 32;
   SmallVector<memref::SubViewOp, 4> subs;
   f.walk([&](memref::SubViewOp sv) { subs.push_back(sv); });
@@ -2745,7 +2744,7 @@ static std::optional<Role> inferSubviewRoleFromUser(Operation *user, Value resul
   return std::nullopt;
 }
 
-static Role inferSubviewRole(memref::SubViewOp sv) {
+[[maybe_unused]] static Role inferSubviewRole(memref::SubViewOp sv) {
   Value result = sv.getResult();
   for (Operation *user : result.getUsers()) {
     if (auto role = inferSubviewRoleFromUser(user, result))
@@ -4096,7 +4095,7 @@ struct PTOTStoreToTSTORE : public OpConversionPattern<pto::TStoreOp> {
     const bool reluNonDefault = reluPreMode != pto::ReluPreMode::NoRelu;
 
     auto getOpaqueTok = [&](Value v, StringRef name) -> FailureOr<std::string> {
-      if (auto ot = v.getType().dyn_cast<emitc::OpaqueType>())
+      if (auto ot = mlir::dyn_cast<emitc::OpaqueType>(v.getType()))
         return ot.getValue().str();
       return rewriter.notifyMatchFailure(op, (name + " must be emitc::OpaqueType").str());
     };
@@ -4410,7 +4409,7 @@ static std::string getAutoSyncTailModeToken(Operation *op) {
   return kAutoSyncTailModeBarrierAllToken.str();
 }
 
-static std::string getPipeName(pto::PIPE pipe) {
+[[maybe_unused]] static std::string getPipeName(pto::PIPE pipe) {
   switch (pipe) {
     case pto::PIPE::PIPE_S: return "PIPE_S";
     case pto::PIPE::PIPE_V: return "PIPE_V";
@@ -5568,6 +5567,10 @@ struct PTOBuildAsyncSessionToEmitC
                         .getResult();
 
     auto u32Ty = emitc::OpaqueType::get(ctx, "uint32_t");
+<<<<<<< HEAD
+=======
+    [[maybe_unused]] auto u64Ty = emitc::OpaqueType::get(ctx, "uint64_t");
+>>>>>>> 308fc7b (fix compiler warnings)
 
     auto makeU32Const = [&](uint64_t value) -> Value {
       return makeEmitCOpaqueConstant(rewriter, loc, u32Ty,
@@ -6246,8 +6249,8 @@ struct PTOPartitionViewToEmitC
       return rewriter.notifyMatchFailure(
           op, "expected tensor_view source and partition_tensor_view result");
 
-    if (op.getOffsets().size() != srcTy.getRank() ||
-        op.getSizes().size() != srcTy.getRank())
+    if (op.getOffsets().size() != static_cast<size_t>(srcTy.getRank()) ||
+        op.getSizes().size() != static_cast<size_t>(srcTy.getRank()))
       return rewriter.notifyMatchFailure(op, "rank mismatch");
 
     for (auto [idx, value] : llvm::enumerate(op.getSizes())) {
@@ -6560,6 +6563,10 @@ struct ReinterpretCastToEmitC : public OpConversionPattern<memref::ReinterpretCa
     case pto::AddressSpace::GM:
       roleTok = "TileType::Vec";
       break;
+    case pto::AddressSpace::Zero:
+    case pto::AddressSpace::SCALING:
+      roleTok = "TileType::Vec";
+      break;
     }
 
     // Shape (fallback to 32x32).
@@ -6823,7 +6830,7 @@ struct PTOTCIToEmitC : public OpConversionPattern<pto::TCIOp> {
     std::string descTok = op.getDescending() ? "1" : "0";
 
     ArrayAttr targs;
-    if (auto ot = dst.getType().dyn_cast<emitc::OpaqueType>()) {
+    if (auto ot = mlir::dyn_cast<emitc::OpaqueType>(dst.getType())) {
       std::string tileTok = ot.getValue().str(); // "Tile<...>"
       targs = rewriter.getArrayAttr({
           emitc::OpaqueAttr::get(ctx, tileTok),
@@ -6863,7 +6870,6 @@ struct PTOColExpandToEmitC : public OpConversionPattern<pto::TColExpandOp> {
   LogicalResult matchAndRewrite(pto::TColExpandOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = rewriter.getContext();
 
     Value dst = peelUnrealized(adaptor.getDst());
     Value src = peelUnrealized(adaptor.getSrc());
@@ -7046,7 +7052,7 @@ struct PTOTTriToEmitC : public OpConversionPattern<pto::TTriOp> {
     Value diagonal = peelUnrealized(adaptor.getDiagonal());
 
     ArrayAttr templateArgs;
-    if (auto dstOT = dst.getType().dyn_cast<emitc::OpaqueType>()) {
+    if (auto dstOT = mlir::dyn_cast<emitc::OpaqueType>(dst.getType())) {
       templateArgs = rewriter.getArrayAttr({
           emitc::OpaqueAttr::get(ctx, dstOT.getValue().str()),
           emitc::OpaqueAttr::get(ctx, std::to_string(op.getUpperOrLower())),
@@ -7084,8 +7090,6 @@ struct PTOCmpToEmitC : public OpConversionPattern<pto::TCmpOp> {
     auto modeTy = emitc::OpaqueType::get(ctx, "CmpMode");
     Value modeVal = rewriter.create<emitc::ConstantOp>(
         loc, modeTy, emitc::OpaqueAttr::get(ctx, tok));
-
-    auto argsAttr = rewriter.getArrayAttr({});
 
     rewriter.create<emitc::CallOpaqueOp>(
         loc,
@@ -7140,7 +7144,6 @@ struct PTOColMaxToEmitC : public OpConversionPattern<pto::TColMaxOp> {
   LogicalResult matchAndRewrite(pto::TColMaxOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = rewriter.getContext();
 
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
@@ -7185,7 +7188,6 @@ struct PTOColMinToEmitC : public OpConversionPattern<pto::TColMinOp> {
   LogicalResult matchAndRewrite(pto::TColMinOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto *ctx = rewriter.getContext();
 
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
@@ -7681,7 +7683,7 @@ struct PTOFillPadExpandToEmitC
 // - Mask form : TGATHER<dstTileTok, srcTileTok, pto::MaskPattern::Pxxxx>(dst, src0)
 //===----------------------------------------------------------------------===//
 
-static std::string maskPatternTok(mlir::pto::MaskPatternAttr a) {
+[[maybe_unused]] static std::string maskPatternTok(mlir::pto::MaskPatternAttr a) {
 
   auto v = a.getValue(); // enum
   return (std::string("pto::MaskPattern::") + mlir::pto::stringifyMaskPattern(v).str());
@@ -7699,7 +7701,7 @@ struct PTOGatherToEmitC : public OpConversionPattern<pto::TGatherOp> {
     Value src0 = peelUnrealized(adaptor.getSrc());
 
     auto getOpaqueTok = [&](Value v, StringRef name) -> FailureOr<std::string> {
-      if (auto ot = v.getType().dyn_cast<emitc::OpaqueType>())
+      if (auto ot = mlir::dyn_cast<emitc::OpaqueType>(v.getType()))
         return ot.getValue().str();
       return rewriter.notifyMatchFailure(op, (name + " must be emitc::OpaqueType (tile)").str());
     };
@@ -7992,8 +7994,8 @@ struct PTOMovToEmitC : public OpConversionPattern<pto::TMovOp> {
     if (op.getPreQuantScalar())
       preQuantScalar = peelUnrealized(adaptor.getPreQuantScalar());
 
-    auto dstOT = dst.getType().dyn_cast<emitc::OpaqueType>();
-    auto srcOT = src.getType().dyn_cast<emitc::OpaqueType>();
+    auto dstOT = mlir::dyn_cast<emitc::OpaqueType>(dst.getType());
+    auto srcOT = mlir::dyn_cast<emitc::OpaqueType>(src.getType());
     if (!dstOT || !srcOT)
       return rewriter.notifyMatchFailure(
           op, "tmov lowering expects opaque dst/src types");
@@ -8036,7 +8038,7 @@ struct PTOMovToEmitC : public OpConversionPattern<pto::TMovOp> {
     StringRef callee = "TMOV";
 
     if (hasFp) {
-      auto fpOT = fp.getType().dyn_cast<emitc::OpaqueType>();
+      auto fpOT = mlir::dyn_cast<emitc::OpaqueType>(fp.getType());
       if (!fpOT)
         return rewriter.notifyMatchFailure(
             op, "tmov fp lowering expects opaque fp type");
@@ -8101,9 +8103,9 @@ struct PTOMovFPToEmitC : public OpConversionPattern<pto::TMovFPOp> {
 
     // TMOV_FP<DstTileData, AccTile, FbTile>(dstTileData, cTile, fbTile)
     ArrayAttr templateArgs;
-    auto dstOT = dst.getType().dyn_cast<emitc::OpaqueType>();
-    auto srcOT = src.getType().dyn_cast<emitc::OpaqueType>();
-    auto fpOT  = fp.getType().dyn_cast<emitc::OpaqueType>();
+    auto dstOT = mlir::dyn_cast<emitc::OpaqueType>(dst.getType());
+    auto srcOT = mlir::dyn_cast<emitc::OpaqueType>(src.getType());
+    auto fpOT  = mlir::dyn_cast<emitc::OpaqueType>(fp.getType());
     if (dstOT && srcOT && fpOT) {
       templateArgs = rewriter.getArrayAttr({
           emitc::OpaqueAttr::get(ctx, dstOT.getValue().str()),
@@ -8141,7 +8143,7 @@ struct PTOQuantToEmitC : public OpConversionPattern<pto::TQuantOp> {
     Value offsetPtr;
     if (op.getOffset()) {
       Value offset = peelUnrealized(adaptor.getOffset());
-      auto offsetOT = offset.getType().dyn_cast<emitc::OpaqueType>();
+      auto offsetOT = mlir::dyn_cast<emitc::OpaqueType>(offset.getType());
       if (offsetOT) {
         offsetPtr = rewriter
                         .create<emitc::ApplyOp>(
@@ -8156,9 +8158,9 @@ struct PTOQuantToEmitC : public OpConversionPattern<pto::TQuantOp> {
             ? "pto::QuantType::INT8_SYM"
             : "pto::QuantType::INT8_ASYM";
     ArrayAttr templateArgs;
-    auto dstOT = dst.getType().dyn_cast<emitc::OpaqueType>();
-    auto srcOT = src.getType().dyn_cast<emitc::OpaqueType>();
-    auto fpOT  = fp.getType().dyn_cast<emitc::OpaqueType>();
+    auto dstOT = mlir::dyn_cast<emitc::OpaqueType>(dst.getType());
+    auto srcOT = mlir::dyn_cast<emitc::OpaqueType>(src.getType());
+    auto fpOT  = mlir::dyn_cast<emitc::OpaqueType>(fp.getType());
     if (dstOT && srcOT && fpOT) {
       templateArgs = rewriter.getArrayAttr({
           emitc::OpaqueAttr::get(ctx, quantTypeStr),
@@ -8198,9 +8200,9 @@ struct PTODequantToEmitC : public OpConversionPattern<pto::TDequantOp> {
 
     // TDEQUANT<DstTile, SrcTile, ParaTile>(dst, src, scale, offset)
     ArrayAttr templateArgs;
-    auto dstOT   = dst.getType().dyn_cast<emitc::OpaqueType>();
-    auto srcOT   = src.getType().dyn_cast<emitc::OpaqueType>();
-    auto scaleOT = scale.getType().dyn_cast<emitc::OpaqueType>();
+    auto dstOT   = mlir::dyn_cast<emitc::OpaqueType>(dst.getType());
+    auto srcOT   = mlir::dyn_cast<emitc::OpaqueType>(src.getType());
+    auto scaleOT = mlir::dyn_cast<emitc::OpaqueType>(scale.getType());
     if (dstOT && srcOT && scaleOT) {
       templateArgs = rewriter.getArrayAttr({
           emitc::OpaqueAttr::get(ctx, dstOT.getValue().str()),
@@ -8256,8 +8258,8 @@ struct PTOMrgSortToEmitC : public OpConversionPattern<pto::TMrgSortOp> {
       for (Value v : adaptor.getSrcs())
         srcs.push_back(peelUnrealized(v));
 
-      auto dstOT = dst.getType().dyn_cast<emitc::OpaqueType>();
-      auto tmpOT = tmp.getType().dyn_cast<emitc::OpaqueType>();
+      auto dstOT = mlir::dyn_cast<emitc::OpaqueType>(dst.getType());
+      auto tmpOT = mlir::dyn_cast<emitc::OpaqueType>(tmp.getType());
       if (!dstOT || !tmpOT || srcs.size() < 2 || srcs.size() > 4)
         return op.emitOpError("format2 expects dst/tmp tilebufs and 2 to 4 srcs");
 
@@ -8266,7 +8268,7 @@ struct PTOMrgSortToEmitC : public OpConversionPattern<pto::TMrgSortOp> {
       targs.push_back(emitc::OpaqueAttr::get(ctx, dstOT.getValue().str()));
       targs.push_back(emitc::OpaqueAttr::get(ctx, tmpOT.getValue().str()));
       for (Value v : srcs) {
-        auto ot = v.getType().dyn_cast<emitc::OpaqueType>();
+        auto ot = mlir::dyn_cast<emitc::OpaqueType>(v.getType());
         if (!ot)
           return op.emitOpError("format2 expects tilebuf srcs");
         targs.push_back(emitc::OpaqueAttr::get(ctx, ot.getValue().str()));

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5567,10 +5567,6 @@ struct PTOBuildAsyncSessionToEmitC
                         .getResult();
 
     auto u32Ty = emitc::OpaqueType::get(ctx, "uint32_t");
-<<<<<<< HEAD
-=======
-    [[maybe_unused]] auto u64Ty = emitc::OpaqueType::get(ctx, "uint64_t");
->>>>>>> 308fc7b (fix compiler warnings)
 
     auto makeU32Const = [&](uint64_t value) -> Value {
       return makeEmitCOpaqueConstant(rewriter, loc, u32Ty,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6560,8 +6560,10 @@ struct ReinterpretCastToEmitC : public OpConversionPattern<memref::ReinterpretCa
       roleTok = "TileType::Vec";
       break;
     case pto::AddressSpace::Zero:
-    case pto::AddressSpace::SCALING:
       roleTok = "TileType::Vec";
+      break;
+    case pto::AddressSpace::SCALING:
+      roleTok = "TileType::Scaling";
       break;
     }
 

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -340,7 +340,7 @@ static void collectAffineAddTerms(AffineExpr root,
   SmallVector<AffineExpr, 4> pending{root};
   while (!pending.empty()) {
     AffineExpr current = pending.pop_back_val();
-    auto addExpr = current.dyn_cast<AffineBinaryOpExpr>();
+    auto addExpr = llvm::dyn_cast<AffineBinaryOpExpr>(current);
     if (!addExpr || addExpr.getKind() != AffineExprKind::Add) {
       terms.push_back(current);
       continue;
@@ -352,19 +352,19 @@ static void collectAffineAddTerms(AffineExpr root,
 
 static bool tryAssignAffineStride(AffineExpr expr,
                                   MutableArrayRef<int64_t> strides) {
-  if (auto dim = expr.dyn_cast<AffineDimExpr>()) {
+  if (auto dim = llvm::dyn_cast<AffineDimExpr>(expr)) {
     strides[dim.getPosition()] = 1;
     return true;
   }
 
-  auto mulExpr = expr.dyn_cast<AffineBinaryOpExpr>();
+  auto mulExpr = llvm::dyn_cast<AffineBinaryOpExpr>(expr);
   if (!mulExpr || mulExpr.getKind() != AffineExprKind::Mul)
     return false;
 
   auto assignStride = [&](AffineExpr dimExpr,
                           AffineExpr constantExpr) -> bool {
-    auto dim = dimExpr.dyn_cast<AffineDimExpr>();
-    auto constant = constantExpr.dyn_cast<AffineConstantExpr>();
+    auto dim = llvm::dyn_cast<AffineDimExpr>(dimExpr);
+    auto constant = llvm::dyn_cast<AffineConstantExpr>(constantExpr);
     if (!dim || !constant)
       return false;
     strides[dim.getPosition()] = constant.getValue();
@@ -374,7 +374,7 @@ static bool tryAssignAffineStride(AffineExpr expr,
          assignStride(mulExpr.getRHS(), mulExpr.getLHS());
 }
 
-static void decomposeStridedLayout(AffineMap map,
+[[maybe_unused]] static void decomposeStridedLayout(AffineMap map,
                                    SmallVectorImpl<int64_t> &strides) {
   strides.assign(map.getNumDims(), 0);
   if (map.getNumResults() != 1)
@@ -494,7 +494,7 @@ static Value clampSubViewValidDim(IRRewriter &rewriter, Location loc,
   return rewriter.create<arith::SelectOp>(loc, lt, v, sizeVal);
 }
 
-static void dumpPretty(Operation *op, llvm::raw_ostream &os) {
+[[maybe_unused]] static void dumpPretty(Operation *op, llvm::raw_ostream &os) {
   OpPrintingFlags flags;
   flags.useLocalScope();            
   AsmState state(op, flags);
@@ -614,7 +614,7 @@ static void markForceDynamicValidShape(Operation *op, bool force,
   op->removeAttr(kForceDynamicValidShapeAttrName);
 }
 
-static void rewriteFunctionSignature(func::FuncOp func, MLIRContext *ctx) {
+[[maybe_unused]] static void rewriteFunctionSignature(func::FuncOp func, MLIRContext *ctx) {
   Block &entry = func.front();
   auto fnTy = func.getFunctionType();
 
@@ -633,7 +633,7 @@ static void rewriteFunctionSignature(func::FuncOp func, MLIRContext *ctx) {
   func.setFunctionType(FunctionType::get(ctx, newInputs, newResults));
 }
 
-static LogicalResult lowerAllocTileOps(func::FuncOp func, MLIRContext *ctx) {
+[[maybe_unused]] static LogicalResult lowerAllocTileOps(func::FuncOp func, MLIRContext *ctx) {
   SmallVector<mlir::pto::AllocTileOp, 8> allocTiles;
   func.walk([&](mlir::pto::AllocTileOp op) { allocTiles.push_back(op); });
 
@@ -690,7 +690,7 @@ static LogicalResult lowerAllocTileOps(func::FuncOp func, MLIRContext *ctx) {
   return success();
 }
 
-static LogicalResult lowerDeclareTileOps(func::FuncOp func, MLIRContext *ctx) {
+[[maybe_unused]] static LogicalResult lowerDeclareTileOps(func::FuncOp func, MLIRContext *ctx) {
   SmallVector<mlir::pto::DeclareTileOp, 8> declaredTiles;
   func.walk([&](mlir::pto::DeclareTileOp op) { declaredTiles.push_back(op); });
 
@@ -730,7 +730,7 @@ static LogicalResult lowerDeclareTileOps(func::FuncOp func, MLIRContext *ctx) {
   return success();
 }
 
-static LogicalResult lowerMakeTensorViewOps(func::FuncOp func, MLIRContext *ctx) {
+[[maybe_unused]] static LogicalResult lowerMakeTensorViewOps(func::FuncOp func, MLIRContext *ctx) {
   SmallVector<mlir::pto::MakeTensorViewOp, 8> makeViews;
   func.walk([&](mlir::pto::MakeTensorViewOp op) { makeViews.push_back(op); });
 
@@ -791,7 +791,7 @@ static LogicalResult lowerMakeTensorViewOps(func::FuncOp func, MLIRContext *ctx)
   return success();
 }
 
-static LogicalResult lowerTensorViewDimOps(func::FuncOp func, MLIRContext *ctx) {
+[[maybe_unused]] static LogicalResult lowerTensorViewDimOps(func::FuncOp func, MLIRContext *ctx) {
   SmallVector<mlir::pto::GetTensorViewDimOp, 8> tvDims;
   func.walk([&](mlir::pto::GetTensorViewDimOp op) { tvDims.push_back(op); });
 
@@ -808,7 +808,7 @@ static LogicalResult lowerTensorViewDimOps(func::FuncOp func, MLIRContext *ctx) 
   return success();
 }
 
-static LogicalResult foldAddPtrIntoScalarOps(func::FuncOp func, MLIRContext *ctx) {
+[[maybe_unused]] static LogicalResult foldAddPtrIntoScalarOps(func::FuncOp func, MLIRContext *ctx) {
   SmallVector<mlir::pto::LoadScalarOp, 8> loadScalars;
   func.walk([&](mlir::pto::LoadScalarOp op) { loadScalars.push_back(op); });
   for (auto op : loadScalars) {
@@ -1687,9 +1687,6 @@ struct PTOViewToMemrefPass
           IRRewriter rewriter(ctx);
           rewriter.setInsertionPoint(op);
           
-          Value src0 = op->getOperand(0);
-          auto config = lookupConfig(src0);
-          
           rewriter.replaceOpWithNewOp<pto::TAddOp>(
               op, TypeRange{}, 
               op->getOperand(0), op->getOperand(1), op->getOperand(2));
@@ -1704,8 +1701,6 @@ struct PTOViewToMemrefPass
         Value lhs = op->getOperand(0);
         Value rhs = op->getOperand(1);
         Value dst = op->getOperand(2);
-
-        auto config = lookupConfig(lhs);
 
         rewriter.replaceOpWithNewOp<pto::TMatmulOp>(op, TypeRange{}, lhs, rhs, dst);
       }
@@ -1775,8 +1770,6 @@ struct PTOViewToMemrefPass
         Value lhs = op->getOperand(0);
         Value rhs = op->getOperand(1);
         Value dst = op->getOperand(2);
-
-        auto config = lookupConfig(lhs);
 
         rewriter.replaceOpWithNewOp<pto::TGemvOp>(
           op, TypeRange{}, lhs, rhs, dst);

--- a/tools/ptobc/src/leb128.cpp
+++ b/tools/ptobc/src/leb128.cpp
@@ -79,7 +79,7 @@ size_t readSLEB128(const uint8_t* data, size_t size, int64_t& value) {
 
   // sign extend
   if ((shift < kInt64BitWidth) && (byte & kLeb128SignBit)) {
-    value |= (-1ll) << shift;
+    value |= static_cast<int64_t>(~uint64_t(0) << shift);
   }
   return i + 1;
 }


### PR DESCRIPTION
This PR fixes compiler warnings making it easier to fix errors and reducing noise.
Most of the fixes belong to 4 categories
- type mismatch
- deprecated mlir cast style
- cases not handeld in switch statements
- unused variables/functions

Perhaps is worth considering adding a "error on warning" in the CI.