### PR TITLE
Add conservative barrier-all sync mode

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -43,6 +43,7 @@ std::unique_ptr<Pass> createPTOVerifyTFreePass();
 
 // Creates a pass for ...
 std::unique_ptr<Pass> createPTOInsertSyncPass();
+std::unique_ptr<Pass> createPTOInjectBarrierAllSyncPass();
 
 // Graph-based intra-core sync solver (coexists with PTOInsertSync).
 std::unique_ptr<Pass>

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -38,6 +38,25 @@ def PTOInsertSync : Pass<"pto-insert-sync", "func::FuncOp"> {
   ];
 }
 
+def PTOInjectBarrierAllSync : Pass<"pto-inject-barrier-all-sync", "func::FuncOp"> {
+  let summary = "Conservatively insert PIPE_ALL barriers for PTO dialect";
+  let description = [{
+    Inserts a `pto.barrier <PIPE_ALL>` before each PTO pipe operation that has
+    MemoryEffects read/write side effects. This mode does not reuse set/wait
+    dependency analysis and does not replace the internal synchronization
+    protocol of composite pipe ops such as `pto.tpush`, `pto.tpop`, and
+    `pto.tfree`; it only adds conservative barriers at operation boundaries.
+  }];
+
+  let constructor = "mlir::pto::createPTOInjectBarrierAllSyncPass()";
+
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::memref::MemRefDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 // Define PTOGraphSyncSolver Pass (graph-based intra-core sync solver).
 // Coexists with PTOInsertSync; selectable via the driver flag
 // `--enable-graph-sync-solver`. Minimal port of bishengir's GraphSyncSolver:

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@
 
 add_mlir_dialect_library(PTOTransforms
   InsertSync/PTOInsertSync.cpp
+  PTOInjectBarrierAllSync.cpp
   InsertSync/InsertSyncDebug.cpp
   PTOViewToMemref.cpp
   PTOToEmitC.cpp

--- a/lib/PTO/Transforms/PTOInjectBarrierAllSync.cpp
+++ b/lib/PTO/Transforms/PTOInjectBarrierAllSync.cpp
@@ -12,7 +12,10 @@
 #include "PTO/Transforms/Passes.h"
 #include "PTO/IR/PTO.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include <iterator>
 
 namespace mlir {
 namespace pto {
@@ -31,14 +34,23 @@ namespace {
 
 static bool hasReadOrWriteMemoryEffect(Operation *op) {
   auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!memEffect)
-    return false;
+  return memEffect && (memEffect.hasEffect<MemoryEffects::Read>() ||
+                       memEffect.hasEffect<MemoryEffects::Write>());
+}
 
-  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 4> effects;
-  memEffect.getEffects(effects);
-  return llvm::any_of(effects, [](const auto &effect) {
-    return isa<MemoryEffects::Read, MemoryEffects::Write>(effect.getEffect());
-  });
+static bool isPipeAllBarrier(Operation *op) {
+  auto barrier = dyn_cast_or_null<pto::BarrierOp>(op);
+  return barrier && barrier.getPipe().getPipe() == pto::PIPE::PIPE_ALL;
+}
+
+static bool hasPreviousPipeAllBarrier(Operation *op) {
+  Block *block = op->getBlock();
+  if (!block)
+    return false;
+  auto it = op->getIterator();
+  if (it == block->begin())
+    return false;
+  return isPipeAllBarrier(&*std::prev(it));
 }
 
 static bool shouldInjectBarrierAllBefore(Operation *op) {
@@ -55,20 +67,36 @@ struct PTOInjectBarrierAllSyncPass
           PTOInjectBarrierAllSyncPass> {
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    MLIRContext *ctx = func.getContext();
     SmallVector<Operation *> insertionPoints;
+    SmallVector<func::ReturnOp> tailInsertionPoints;
+    bool sawMemoryEffectingPipeOp = false;
 
     func.walk<WalkOrder::PreOrder>([&](Operation *op) {
-      if (shouldInjectBarrierAllBefore(op))
+      if (shouldInjectBarrierAllBefore(op)) {
+        sawMemoryEffectingPipeOp = true;
+        if (hasPreviousPipeAllBarrier(op))
+          return WalkResult::advance();
         insertionPoints.push_back(op);
+      }
       return WalkResult::advance();
     });
 
-    IRRewriter rewriter(ctx);
-    auto pipeAll = pto::PipeAttr::get(ctx, pto::PIPE::PIPE_ALL);
+    if (sawMemoryEffectingPipeOp) {
+      func.walk([&](func::ReturnOp ret) {
+        if (!hasPreviousPipeAllBarrier(ret))
+          tailInsertionPoints.push_back(ret);
+      });
+    }
+
+    OpBuilder builder(func.getContext());
+    auto pipeAll = pto::PipeAttr::get(func.getContext(), pto::PIPE::PIPE_ALL);
     for (Operation *op : insertionPoints) {
-      rewriter.setInsertionPoint(op);
-      rewriter.create<pto::BarrierOp>(op->getLoc(), pipeAll);
+      builder.setInsertionPoint(op);
+      builder.create<pto::BarrierOp>(op->getLoc(), pipeAll);
+    }
+    for (func::ReturnOp ret : tailInsertionPoints) {
+      builder.setInsertionPoint(ret);
+      builder.create<pto::BarrierOp>(ret.getLoc(), pipeAll);
     }
   }
 };

--- a/lib/PTO/Transforms/PTOInjectBarrierAllSync.cpp
+++ b/lib/PTO/Transforms/PTOInjectBarrierAllSync.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- PTOInjectBarrierAllSync.cpp - Conservative sync barriers -----------===//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/Transforms/Passes.h"
+#include "PTO/IR/PTO.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+namespace mlir {
+namespace pto {
+namespace func = ::mlir::func;
+
+#define GEN_PASS_DEF_PTOINJECTBARRIERALLSYNC
+#include "PTO/Transforms/Passes.h.inc"
+
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+static bool hasReadOrWriteMemoryEffect(Operation *op) {
+  auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
+  if (!memEffect)
+    return false;
+
+  SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 4> effects;
+  memEffect.getEffects(effects);
+  return llvm::any_of(effects, [](const auto &effect) {
+    return isa<MemoryEffects::Read, MemoryEffects::Write>(effect.getEffect());
+  });
+}
+
+static bool shouldInjectBarrierAllBefore(Operation *op) {
+  Dialect *dialect = op->getDialect();
+  if (!dialect ||
+      dialect->getNamespace() != pto::PTODialect::getDialectNamespace())
+    return false;
+
+  return isa<pto::OpPipeInterface>(op) && hasReadOrWriteMemoryEffect(op);
+}
+
+struct PTOInjectBarrierAllSyncPass
+    : public mlir::pto::impl::PTOInjectBarrierAllSyncBase<
+          PTOInjectBarrierAllSyncPass> {
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    MLIRContext *ctx = func.getContext();
+    SmallVector<Operation *> insertionPoints;
+
+    func.walk<WalkOrder::PreOrder>([&](Operation *op) {
+      if (shouldInjectBarrierAllBefore(op))
+        insertionPoints.push_back(op);
+      return WalkResult::advance();
+    });
+
+    IRRewriter rewriter(ctx);
+    auto pipeAll = pto::PipeAttr::get(ctx, pto::PIPE::PIPE_ALL);
+    for (Operation *op : insertionPoints) {
+      rewriter.setInsertionPoint(op);
+      rewriter.create<pto::BarrierOp>(op->getLoc(), pipeAll);
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOInjectBarrierAllSyncPass() {
+  return std::make_unique<PTOInjectBarrierAllSyncPass>();
+}

--- a/test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto
+++ b/test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto
@@ -14,6 +14,21 @@ module {
     // CHECK-NEXT: pto.tmov
     pto.tmov ins(%mat : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
              outs(%left : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: return
+    return
+  }
+
+  func.func @manual_pipe_all_barrier_not_duplicated(%src: memref<16x16xf32, #pto.address_space<gm>>) {
+    // CHECK-LABEL: func.func @manual_pipe_all_barrier_not_duplicated
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: pto.tload
+    %mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.barrier <PIPE_ALL>
+    pto.tload ins(%src : memref<16x16xf32, #pto.address_space<gm>>)
+              outs(%mat : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: return
     return
   }
 
@@ -35,6 +50,8 @@ module {
     // CHECK: pto.barrier <PIPE_ALL>
     // CHECK-NEXT: pto.tpush
     pto.tpush(%acc_tile, %pipe : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>, !pto.pipe) {split = 0}
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: return
     return
   }
 
@@ -59,6 +76,8 @@ module {
     // CHECK: pto.barrier <PIPE_ALL>
     // CHECK-NEXT: pto.tfree
     pto.tfree(%pipe : !pto.pipe) {split = 2}
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: return
     return
   }
 }
@@ -66,9 +85,11 @@ module {
 // CPP-LABEL: AICORE void cube_push_gm
 // CPP: pipe_barrier(PIPE_ALL);
 // CPP-NEXT: TPUSH
+// CPP: pipe_barrier(PIPE_ALL);
 
 // CPP-LABEL: AICORE void vector_pop_gm
 // CPP: pipe_barrier(PIPE_ALL);
 // CPP-NEXT: TPOP
 // CPP: pipe_barrier(PIPE_ALL);
 // CPP-NEXT: TFREE
+// CPP: pipe_barrier(PIPE_ALL);

--- a/test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto
+++ b/test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto
@@ -1,0 +1,74 @@
+// RUN: ptoas --pto-arch=a3 --enable-inject-barrier-all-sync --emit-pto-ir %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a3 --enable-inject-barrier-all-sync %s 2>&1 | FileCheck %s --check-prefix=CPP
+
+module {
+  func.func @regular_pipe_memory_ops(%src: memref<16x16xf32, #pto.address_space<gm>>) {
+    // CHECK-LABEL: func.func @regular_pipe_memory_ops
+    %mat = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %left = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: pto.tload
+    pto.tload ins(%src : memref<16x16xf32, #pto.address_space<gm>>)
+              outs(%mat : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: pto.tmov
+    pto.tmov ins(%mat : !pto.tile_buf<loc=mat, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+             outs(%left : !pto.tile_buf<loc=left, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @cube_push_gm(%gm_slot_buffer: memref<256xf32, #pto.address_space<gm>>,
+                          %c2v_consumer_buf: i32)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    // CHECK-LABEL: func.func @cube_push_gm
+    // CHECK-NOT: pto.barrier <PIPE_ALL>
+    // CHECK: %{{.*}} = pto.initialize_l2g2l_pipe
+    %pipe = pto.initialize_l2g2l_pipe {
+      dir_mask = 1,
+      slot_size = 1024,
+      slot_num = 8,
+      local_slot_num = 8,
+      flag_base = 0
+    }(%gm_slot_buffer : memref<256xf32, #pto.address_space<gm>>,
+      %c2v_consumer_buf : i32) -> !pto.pipe
+    %acc_tile = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: pto.tpush
+    pto.tpush(%acc_tile, %pipe : !pto.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=col_major, slayout=row_major, fractal=1024, pad=0>, !pto.pipe) {split = 0}
+    return
+  }
+
+  func.func @vector_pop_gm(%gm_slot_buffer: memref<256xf32, #pto.address_space<gm>>,
+                           %c2v_consumer_buf: i32)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    // CHECK-LABEL: func.func @vector_pop_gm
+    // CHECK-NOT: pto.barrier <PIPE_ALL>
+    // CHECK: %{{.*}} = pto.initialize_l2g2l_pipe
+    %pipe = pto.initialize_l2g2l_pipe {
+      dir_mask = 1,
+      slot_size = 1024,
+      slot_num = 8,
+      local_slot_num = 8,
+      flag_base = 0
+    }(%gm_slot_buffer : memref<256xf32, #pto.address_space<gm>>,
+      %c2v_consumer_buf : i32) -> !pto.pipe
+    %fifo_tile = pto.declare_tile -> !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: pto.tpop
+    pto.tpop(%fifo_tile, %pipe : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.pipe) {split = 1}
+    // CHECK: pto.barrier <PIPE_ALL>
+    // CHECK-NEXT: pto.tfree
+    pto.tfree(%pipe : !pto.pipe) {split = 2}
+    return
+  }
+}
+
+// CPP-LABEL: AICORE void cube_push_gm
+// CPP: pipe_barrier(PIPE_ALL);
+// CPP-NEXT: TPUSH
+
+// CPP-LABEL: AICORE void vector_pop_gm
+// CPP: pipe_barrier(PIPE_ALL);
+// CPP-NEXT: TPOP
+// CPP: pipe_barrier(PIPE_ALL);
+// CPP-NEXT: TFREE

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -183,11 +183,18 @@ static llvm::cl::opt<bool> enableInsertSync("enable-insert-sync",
                                             llvm::cl::desc("Enable automatic synchronization insertion pass"),
                                             llvm::cl::init(false));
 
+static llvm::cl::opt<bool> enableInjectBarrierAllSync(
+    "enable-inject-barrier-all-sync",
+    llvm::cl::desc("Enable conservative synchronization by inserting "
+                   "pto.barrier PIPE_ALL before memory-effecting PTO pipe ops"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> enableGraphSyncSolver(
     "enable-graph-sync-solver",
     llvm::cl::desc("Enable the graph-based intra-core sync solver "
                    "(experimental). Mutually exclusive with "
-                   "--enable-insert-sync."),
+                   "--enable-insert-sync and "
+                   "--enable-inject-barrier-all-sync."),
     llvm::cl::init(false));
 
 static llvm::cl::opt<int> graphSyncSolverEventIdMax(
@@ -1083,9 +1090,18 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  if (enableInsertSync && enableGraphSyncSolver) {
-    llvm::errs() << "Error: --enable-insert-sync and "
+  int enabledAutoSyncModes =
+      (enableInsertSync ? 1 : 0) + (enableInjectBarrierAllSync ? 1 : 0) +
+      (enableGraphSyncSolver ? 1 : 0);
+  if (enabledAutoSyncModes > 1) {
+    llvm::errs() << "Error: --enable-insert-sync, "
+                    "--enable-inject-barrier-all-sync, and "
                     "--enable-graph-sync-solver are mutually exclusive.\n";
+    return 1;
+  }
+  if (hasTAssign && enableInjectBarrierAllSync) {
+    llvm::errs() << "Error: pto.tassign requires "
+                    "--enable-inject-barrier-all-sync to be disabled.\n";
     return 1;
   }
   if (hasTAssign && enableGraphSyncSolver) {
@@ -1145,11 +1161,14 @@ int main(int argc, char **argv) {
   }
   pm.addPass(pto::createPTOResolveReservedBuffersPass());
 
-  // Conditionally add Sync pass based on flag. The two solvers are mutually
-  // exclusive (validated above); GraphSyncSolver is the experimental new
-  // path that lives next to PTOInsertSync.
+  // Conditionally add one automatic synchronization mode. Barrier-all is a
+  // conservative standalone pass; InsertSync and GraphSyncSolver are set/wait
+  // solvers.
   if (enableInsertSync)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertSyncPass());
+  else if (enableInjectBarrierAllSync)
+    pm.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOInjectBarrierAllSyncPass());
   else if (enableGraphSyncSolver) {
     PTOGraphSyncSolverOptions graphSyncOpts;
     graphSyncOpts.eventIdNumMax = graphSyncSolverEventIdMax;


### PR DESCRIPTION
Summary
- Add `--enable-inject-barrier-all-sync` to enable conservative synchronization insertion.
- Introduce a standalone `PTOInjectBarrierAllSync` pass that inserts `pto.barrier <PIPE_ALL>` before PTO pipe ops with read/write memory effects.
- Add a tail `PIPE_ALL` drain before function returns when the function contains qualifying pipe work.
- Keep this mode independent from the existing set/wait sync solvers and make the automatic sync modes mutually exclusive.
- Add lit coverage for regular memory-effecting pipe ops, TPUSH/TPOP/TFREE emission, tail drains, and existing barrier deduplication.

Motivation
- Architect request: provide an explicit conservative synchronization mode for PTOAS.

Design
- The new pass is off by default and only runs when `--enable-inject-barrier-all-sync` is set.
- The pass matches PTO dialect ops implementing `OpPipeInterface` and `MemoryEffectOpInterface` with read/write effects.
- The pass inserts boundary barriers and a final return-side drain; it does not rewrite composite pipe op internals.
- If the immediately preceding IR op is already `pto.barrier <PIPE_ALL>`, the pass does not insert a duplicate barrier at that point.

Testing
- `ninja -C build tools/ptoas/ptoas`
- `build/tools/ptoas/ptoas --pto-arch=a3 --enable-inject-barrier-all-sync --emit-pto-ir test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto 2>&1 | /Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto`
- `build/tools/ptoas/ptoas --pto-arch=a3 --enable-inject-barrier-all-sync test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto 2>&1 | /Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/inject_barrier_all_sync_tpush_tpop.pto --check-prefix=CPP`
- `build/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tpush_tpop_emitc.pto 2>&1 | /Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/tpush_tpop_emitc.pto --check-prefix=A3`

Risk / Rollback
- Risk is limited because the new mode is opt-in behind a new CLI flag.
- Rollback is to revert the PR or avoid enabling `--enable-inject-barrier-all-sync`.