### PR TITLE
ci: add -Werror to PTOAS build

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -154,7 +154,8 @@ jobs:
             -Dpybind11_DIR=$(${PY_PATH}/bin/python -m pybind11 --cmakedir) \
             -DMLIR_PYTHON_PACKAGE_DIR=${LLVM_BUILD_DIR}/tools/mlir/python_packages/mlir_core \
             -DPTOAS_RELEASE_VERSION_OVERRIDE=${PTOAS_VERSION} \
-            -DCMAKE_INSTALL_PREFIX=${PTO_INSTALL_DIR}
+            -DCMAKE_INSTALL_PREFIX=${PTO_INSTALL_DIR} \
+            -DCMAKE_BUILD_TYPE=Release
           ninja -C build
           ninja -C build install
 

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -156,7 +156,8 @@ jobs:
             -Dpybind11_DIR=$(python -m pybind11 --cmakedir) \
             -DMLIR_PYTHON_PACKAGE_DIR=${LLVM_BUILD_DIR}/tools/mlir/python_packages/mlir_core \
             -DPTOAS_RELEASE_VERSION_OVERRIDE=${PTOAS_VERSION} \
-            -DCMAKE_INSTALL_PREFIX=${PTO_INSTALL_DIR}
+            -DCMAKE_INSTALL_PREFIX=${PTO_INSTALL_DIR} \
+            -DCMAKE_BUILD_TYPE=Release
           ninja -C build
           ninja -C build install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DMLIR_PYTHON_PACKAGE_DIR="${LLVM_DIR}/tools/mlir/python_packages/mlir_core" \
             -DCMAKE_INSTALL_PREFIX="${PTO_INSTALL_DIR}" \
+            -DCMAKE_CXX_FLAGS="-Werror" \
             -DCMAKE_BUILD_TYPE=Release
           ninja -C build ptoas
           ninja -C build ptobc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,6 @@ jobs:
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DMLIR_PYTHON_PACKAGE_DIR="${LLVM_DIR}/tools/mlir/python_packages/mlir_core" \
             -DCMAKE_INSTALL_PREFIX="${PTO_INSTALL_DIR}" \
-            -DCMAKE_CXX_FLAGS="-Werror" \
             -DCMAKE_BUILD_TYPE=Release
           ninja -C build ptoas
           ninja -C build ptobc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,17 @@ include(AddMLIR)
 # =========================================================
 # 3. 配置构建环境
 # =========================================================
+# Keep warning policy in CMake so CI, wheel, and external build entrypoints
+# all enforce the same diagnostics contract.
+option(PTOAS_ENABLE_WERROR "Treat PTOAS warnings as errors" ON)
+if(PTOAS_ENABLE_WERROR)
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror>)
+  elseif(MSVC)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/WX>)
+  endif()
+endif()
+
 # macOS: 移除已废弃的 -undefined suppress，避免 ld 警告（保留 -undefined dynamic_lookup 即可）
 if(APPLE)
   foreach(_var CMAKE_SHARED_MODULE_CREATE_CXX_FLAGS CMAKE_MODULE_LINKER_FLAGS)

--- a/lib/CAPI/Dialect/PTO.cpp
+++ b/lib/CAPI/Dialect/PTO.cpp
@@ -625,7 +625,7 @@ int32_t mlirPTOReluPreModeAttrGetValue(MlirAttribute attr) {
 }
 
 bool mlirPTOAttrIsAAtomicTypeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::AtomicTypeAttr>();
+  return mlir::isa<mlir::pto::AtomicTypeAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTOAtomicTypeAttrGet(MlirContext ctx, int32_t value) {
@@ -640,7 +640,7 @@ int32_t mlirPTOAtomicTypeAttrGetValue(MlirAttribute attr) {
 }
 
 bool mlirPTOAttrIsANotifyOpAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::NotifyOpAttr>();
+  return mlir::isa<mlir::pto::NotifyOpAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTONotifyOpAttrGet(MlirContext ctx, int32_t value) {
@@ -655,7 +655,7 @@ int32_t mlirPTONotifyOpAttrGetValue(MlirAttribute attr) {
 }
 
 bool mlirPTOAttrIsAWaitCmpAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::WaitCmpAttr>();
+  return mlir::isa<mlir::pto::WaitCmpAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTOWaitCmpAttrGet(MlirContext ctx, int32_t value) {
@@ -670,7 +670,7 @@ int32_t mlirPTOWaitCmpAttrGetValue(MlirAttribute attr) {
 }
 
 bool mlirPTOAttrIsAReduceOpAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::pto::ReduceOpAttr>();
+  return mlir::isa<mlir::pto::ReduceOpAttr>(unwrap(attr));
 }
 
 MlirAttribute mlirPTOReduceOpAttrGet(MlirContext ctx, int32_t value) {

--- a/lib/PTO/IR/PTOAttrs.cpp
+++ b/lib/PTO/IR/PTOAttrs.cpp
@@ -144,7 +144,7 @@ Attribute TileBufConfigAttr::parse(AsmParser &p, Type) {
       sl = toSLayoutAttr(ctx, a);
       if (!sl) return {};
     } else if (key == "s_fractal_size") {
-      int32_t v;
+      int32_t v = 0;
       if (p.parseInteger(v)) return {};
       sz = IntegerAttr::get(IntegerType::get(ctx, 32), v);
     } else if (key == "pad") {

--- a/lib/PTO/Transforms/InferPTOLayout.cpp
+++ b/lib/PTO/Transforms/InferPTOLayout.cpp
@@ -385,9 +385,9 @@ static std::optional<Layout> inferMakeTensorViewLayout(
     MakeTensorViewOp op, ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
     bool &isAmbiguous) {
   auto pref = collectPreferredLayoutFromConsumers(op.getResult());
-  auto preferredForAmbiguous =
-      (!pref.conflict && isMinorColsOne(shape)) ? pref.preferred
-                                                : std::nullopt;
+  std::optional<Layout> preferredForAmbiguous = std::nullopt;
+  if (!pref.conflict && isMinorColsOne(shape))
+    preferredForAmbiguous = pref.preferred;
   return inferLayout5D(
       shape, strides,
       elemByteSize(

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -1474,6 +1474,7 @@ void MemPlan::MemLifeDebugInfo(StorageEntry *storageEntry) {
     }
   }
   for (auto &bufferLife : storageEntry->bufferLifeVec) {
+    (void)bufferLife;
     LDBG("bufferLife : "
          << "allocTime : " << bufferLife->allocTime
          << " , freeTime : " << bufferLife->freeTime << "\n");
@@ -2079,11 +2080,14 @@ void MemPlan::ReportAllocatedEntryDebugInfo(StorageEntry *rootStorageEntry) {
         (entry->alignedConstBits + kBitsToByte - 1) / kBitsToByte;
     uint64_t offsetByte =
         (entry->bitsOffset + kBitsToByte - 1) / kBitsToByte;
+    (void)needByte;
+    (void)offsetByte;
     ReportCurEntryDebugInfo(entry);
     LDBG(", offset: " << offsetByte);
     LDBG(", extent: " << needByte);
     LDBG(", buffer life: ");
     for (auto &bufferLife : entry->bufferLifeVec) {
+      (void)bufferLife;
       LDBG("[" << bufferLife->allocTime << "-" << bufferLife->freeTime
                << "], ");
     }


### PR DESCRIPTION
  Summary
  - add `-Werror` to the PTOAS configure step in GitHub CI
  - keep the LLVM external build unchanged so only PTOAS warnings fail the CI build

  ## Testing
  - not run locally