### PR TITLE
fix: keep scalar bitwise src/dst in distinct storage

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2803,10 +2803,61 @@ verifyShiftLikeBinaryTileOpCommon(Operation *op, Type src0Ty, Type src1Ty,
   return e0;
 }
 
+struct StaticLocalTileStorage {
+  pto::AddressSpace addressSpace;
+  int64_t addr;
+};
+
+static bool isLocalStorageSpace(std::optional<pto::AddressSpace> addressSpace) {
+  return addressSpace && *addressSpace != pto::AddressSpace::GM &&
+         *addressSpace != pto::AddressSpace::Zero;
+}
+
+static std::optional<StaticLocalTileStorage>
+getStaticLocalTileStorage(Value value) {
+  if (!value || isa<BlockArgument>(value))
+    return std::nullopt;
+
+  if (auto bitcast = value.getDefiningOp<pto::BitcastOp>())
+    return getStaticLocalTileStorage(bitcast.getSrc());
+  if (auto reshape = value.getDefiningOp<pto::TReshapeOp>())
+    return getStaticLocalTileStorage(reshape.getSrc());
+  if (auto setValidShape = value.getDefiningOp<pto::SetValidShapeOp>())
+    return getStaticLocalTileStorage(setValidShape.getSource());
+  if (auto subview = value.getDefiningOp<pto::SubViewOp>()) {
+    // Only zero-offset subviews provably preserve the same base address.
+    for (Value offset : subview.getOffsets()) {
+      auto constOffset = getConstIndexValue(offset);
+      if (!constOffset || *constOffset != 0)
+        return std::nullopt;
+    }
+    return getStaticLocalTileStorage(subview.getSource());
+  }
+  if (auto allocTile = value.getDefiningOp<pto::AllocTileOp>()) {
+    auto addressSpace = getPTOMemorySpaceEnum(allocTile.getResult().getType());
+    if (!isLocalStorageSpace(addressSpace) || !allocTile.getAddr())
+      return std::nullopt;
+    auto addr = getConstantIntegerValue(allocTile.getAddr());
+    if (!addr)
+      return std::nullopt;
+    return StaticLocalTileStorage{*addressSpace, *addr};
+  }
+
+  return std::nullopt;
+}
+
+static bool haveProvenSameStaticLocalTileStorage(Value lhs, Value rhs) {
+  auto lhsStorage = getStaticLocalTileStorage(lhs);
+  auto rhsStorage = getStaticLocalTileStorage(rhs);
+  return lhsStorage && rhsStorage &&
+         lhsStorage->addressSpace == rhsStorage->addressSpace &&
+         lhsStorage->addr == rhsStorage->addr;
+}
+
 static FailureOr<Type> verifyDistinctRowMajorUnaryTileOpCommon(
     Operation *op, Value src, Value dst, StringRef srcName = "src",
     StringRef dstName = "dst") {
-  if (src == dst) {
+  if (src == dst || haveProvenSameStaticLocalTileStorage(src, dst)) {
     op->emitOpError("expects src and dst to use different storage");
     return failure();
   }

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -436,6 +436,15 @@ void MemLivenessAnalysis::RecursionIR(Region *region, Liveness live) {
           op, ptoDpsOp.getDpsInits(), stableValueOrder);
       genBuffers.append(scratchBuffers.begin(), scratchBuffers.end());
       UpdateOpGenInfo(curOpInfo, genBuffers);
+      // These scalar bitwise ops are lowered to ISA forms that require src
+      // and dst to reside in distinct local storage.
+      if (auto tandsOp = dyn_cast<pto::TAndSOp>(op)) {
+        RecordSemanticConflict(tandsOp.getSrc(), tandsOp.getDst());
+      } else if (auto torsOp = dyn_cast<pto::TOrSOp>(op)) {
+        RecordSemanticConflict(torsOp.getSrc(), torsOp.getDst());
+      } else if (auto txorsOp = dyn_cast<pto::TXorSOp>(op)) {
+        RecordSemanticConflict(txorsOp.getSrc(), txorsOp.getDst());
+      }
       for (const auto &conflictPair :
            getScratchConflictPairsFromEffects(op, ptoDpsOp.getDpsInits(),
                                               stableValueOrder)) {

--- a/test/lit/pto/issue614_scalar_bitwise_plan_memory_distinct.pto
+++ b/test/lit/pto/issue614_scalar_bitwise_plan_memory_distinct.pto
@@ -22,5 +22,5 @@ module {
 // CHECK-NOT: memref.alloc
 // CHECK-DAG: %[[ADDR0:.*]] = arith.constant 0 : i64
 // CHECK-DAG: %[[ADDR512:.*]] = arith.constant 512 : i64
-// CHECK-DAG: pto.pointer_cast(%[[ADDR0]]) : memref<16x16xi16, #pto.address_space<{{vec|ub}}>>
-// CHECK-DAG: pto.pointer_cast(%[[ADDR512]]) : memref<16x16xi16, #pto.address_space<{{vec|ub}}>>
+// CHECK-DAG: = pto.pointer_cast(%[[ADDR0]])
+// CHECK-DAG: = pto.pointer_cast(%[[ADDR512]])

--- a/test/lit/pto/issue614_scalar_bitwise_plan_memory_distinct.pto
+++ b/test/lit/pto/issue614_scalar_bitwise_plan_memory_distinct.pto
@@ -1,0 +1,26 @@
+// RUN: ptoas --mlir-print-ir-after=pto-plan-memory %s 2>&1 1>/dev/null | FileCheck %s
+
+module {
+  func.func @tands_plan_memory_distinct(%src_gm: memref<16x16xi16, #pto.address_space<gm>>,
+                                        %dst_gm: memref<16x16xi16, #pto.address_space<gm>>) {
+    %scalar = arith.constant 7 : i16
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_gm : memref<16x16xi16, #pto.address_space<gm>>)
+             outs(%src : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tands ins(%src, %scalar : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, i16)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst_gm : memref<16x16xi16, #pto.address_space<gm>>)
+    return
+  }
+}
+
+// CHECK: IR Dump After PlanMemory
+// CHECK: func.func @tands_plan_memory_distinct
+// CHECK-NOT: memref.alloc
+// CHECK-DAG: %[[ADDR0:.*]] = arith.constant 0 : i64
+// CHECK-DAG: %[[ADDR512:.*]] = arith.constant 512 : i64
+// CHECK-DAG: pto.pointer_cast(%[[ADDR0]]) : memref<16x16xi16, #pto.address_space<{{vec|ub}}>>
+// CHECK-DAG: pto.pointer_cast(%[[ADDR512]]) : memref<16x16xi16, #pto.address_space<{{vec|ub}}>>

--- a/test/lit/pto/issue614_tands_same_storage_verify.pto
+++ b/test/lit/pto/issue614_tands_same_storage_verify.pto
@@ -1,0 +1,19 @@
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @tands_same_storage_via_subview() {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %scalar = arith.constant 7 : i16
+    %tile = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %alias = pto.subview %tile[%c0, %c0] sizes [16, 16] :
+      !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tands ins(%tile, %scalar : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, i16)
+              outs(%alias : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tands' op expects src and dst to use different storage

--- a/test/samples/Mgather/mgather.py
+++ b/test/samples/Mgather/mgather.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -17,6 +17,7 @@ def build():
 
         with Location.unknown(ctx):
             m = Module.create()
+            m.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
 
             i32 = IntegerType.get_signless(32, ctx)
             ptr_i32 = pto.PtrType.get(i32, ctx)

--- a/test/samples/Mscatter/mscatter.py
+++ b/test/samples/Mscatter/mscatter.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -17,6 +17,7 @@ def build():
 
         with Location.unknown(ctx):
             m = Module.create()
+            m.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
 
             i32 = IntegerType.get_signless(32, ctx)
             ptr_i32 = pto.PtrType.get(i32, ctx)


### PR DESCRIPTION
## Summary
- teach PlanMemory to record semantic non-reuse pairs for `pto.tands`, `pto.tors`, and `pto.txors`
- tighten the shared scalar-bitwise verifier helper so different SSA values with the same proven local tile storage are also rejected
- add lit coverage for both the PlanMemory reuse regression and the verifier regression

## Details
This follows issue #614 direction 2: keep the ISA/frontend distinct-storage constraint and make PTOAS planning honor it.

PlanMemory already had semantic conflict tracking for scratch-vs-dst style cases, but it did not explicitly model the `src`/`dst` storage constraint for scalar bitwise ops. That allowed memory planning to potentially co-locate those buffers if liveness alone looked reusable.

The verifier side also only rejected `src == dst`, which missed aliasing forms such as zero-offset subviews of the same statically addressed local tile.

## Validation
- `git diff --check`
- compiled changed translation units in a local validation build:
  - `lib/PTO/IR/PTO.cpp.o`
  - `lib/PTO/Transforms/PTOPlanMemory.cpp.o`
- full local `ptoas` build is currently blocked by pre-existing unrelated `-Werror` failures in `PTOToEmitC.cpp`, `PTOTypeDefs.cpp`, and `PTOSyncUtils.cpp`
