### PR TITLE
fix: use HistByte template args for thistogram emitc

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5228,8 +5228,8 @@ struct PTOHistogramToEmitC : public OpConversionPattern<pto::THistogramOp> {
     Value idx = peelUnrealized(adaptor.getIdx());
     Value dst = peelUnrealized(adaptor.getDst());
 
-    auto templateArgs = rewriter.getArrayAttr(
-        {emitc::OpaqueAttr::get(ctx, op.getIsMSB() ? "true" : "false")});
+    auto templateArgs = rewriter.getArrayAttr({emitc::OpaqueAttr::get(
+        ctx, op.getIsMSB() ? "HistByte::BYTE_1" : "HistByte::BYTE_0")});
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "THISTOGRAM",
         /*args=*/ArrayAttr{}, /*templateArgs=*/templateArgs,

--- a/test/lit/pto/thistogram_emitc.pto
+++ b/test/lit/pto/thistogram_emitc.pto
@@ -16,5 +16,5 @@ module {
 }
 
 // CHECK-LABEL: __global__ AICORE void thistogram_emitc()
-// CHECK: THISTOGRAM<true>(
-// CHECK: THISTOGRAM<false>(
+// CHECK: THISTOGRAM<HistByte::BYTE_1>(
+// CHECK: THISTOGRAM<HistByte::BYTE_0>(


### PR DESCRIPTION
Fixes #633

Summary
- lower `pto.thistogram` to `THISTOGRAM<HistByte::BYTE_1>` / `THISTOGRAM<HistByte::BYTE_0>` instead of `THISTOGRAM<true>` / `THISTOGRAM<false>`
- update the emitc regression to check the enum-based template arguments

## Testing
- `/Users/laoda/pto/PTOAS-main-check/build/tools/ptoas/ptoas --pto-arch=a5 /Users/laoda/pto/PTOAS_issue633_fix/test/lit/pto/thistogram_emitc.pto 2>&1 | /Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/bin/FileCheck /Users/laoda/pto/PTOAS_issue633_fix/test/lit/pto/thistogram_emitc.pto`
