### PR TITLE
fix(ptobc): add v0 support for tdequant

### DIFF
--- a/tools/ptobc/generated/ptobc_opcodes_v0.h
+++ b/tools/ptobc/generated/ptobc_opcodes_v0.h
@@ -177,6 +177,7 @@ inline constexpr OpInfo kOpTable[] = {
   {0x1072, "pto.subview", 0, 0x01, 0x02, 0, 1, 0, 0x00},
   {0x1073, "pto.trowexpanddiv", 0, 0x00, 0x02, 0, 0, 0, 0x00},
   {0x1074, "pto.trowexpandmul", 0, 0x00, 0x02, 0, 0, 0, 0x00},
+  {0x1075, "pto.tdequant", 0, 0x00, 0x00, 4, 0, 0, 0x00},
   {0x1076, "pto.taxpy", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x1077, "pto.thistogram", 0, 0x00, 0x00, 3, 0, 0, 0x00},
   {0x1078, "pto.tget_scale_addr", 0, 0x00, 0x00, 2, 0, 0, 0x00},
@@ -382,6 +383,7 @@ inline std::optional<uint16_t> lookupOpcodeByName(llvm::StringRef name) {
     .Case("pto.subview", 0x1072)
     .Case("pto.trowexpanddiv", 0x1073)
     .Case("pto.trowexpandmul", 0x1074)
+    .Case("pto.tdequant", 0x1075)
     .Case("pto.taxpy", 0x1076)
     .Case("pto.thistogram", 0x1077)
     .Case("pto.tget_scale_addr", 0x1078)
@@ -572,6 +574,7 @@ inline std::optional<OpcodeAndVariant> lookupOpcodeAndVariantByFullName(llvm::St
     .Case("pto.subview", OpcodeAndVariant{0x1072, 0, 0})
     .Case("pto.trowexpanddiv", OpcodeAndVariant{0x1073, 0, 0})
     .Case("pto.trowexpandmul", OpcodeAndVariant{0x1074, 0, 0})
+    .Case("pto.tdequant", OpcodeAndVariant{0x1075, 0, 0})
     .Case("pto.taxpy", OpcodeAndVariant{0x1076, 0, 0})
     .Case("pto.thistogram", OpcodeAndVariant{0x1077, 0, 0})
     .Case("pto.tget_scale_addr", OpcodeAndVariant{0x1078, 0, 0})

--- a/tools/ptobc/testdata/tdequant_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tdequant_v0_roundtrip.pto
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module {
+  func.func @tdequant_v0() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scale = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=8, v_row=32, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %offset = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=8, v_row=32, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tdequant ins(%src, %scale, %offset : !pto.tile_buf<loc=vec, dtype=i16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=8, v_row=32, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=8, v_row=32, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -98,3 +98,10 @@ add_test(NAME ptobc_tstore_fp_v0_encode
     TESTDATA_DIR=${PTObc_TESTDATA_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/tstore_fp_v0_encode.sh
 )
+
+add_test(NAME ptobc_tdequant_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/tdequant_v0_encode.sh
+)

--- a/tools/ptobc/tests/tdequant_v0_encode.sh
+++ b/tools/ptobc/tests/tdequant_v0_encode.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/tdequant_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_tdequant_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/tdequant_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/tdequant_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.tdequant ins(" "${ROUNDTRIP}" >/dev/null


### PR DESCRIPTION
## Summary
- add the missing `pto.tdequant` v0 opcode mapping so `ptobc encode` no longer rejects the op
- keep the opcode table, name lookup, and full-name lookup in sync
- add a dedicated `ptobc` roundtrip regression for `pto.tdequant`

## Validation
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_DIR=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/lib/cmake/llvm -DMLIR_DIR=/Users/laoda/llvm-workspace/llvm-project/llvm/build-shared/lib/cmake/mlir -Dpybind11_DIR=/Users/laoda/miniforge3/lib/python3.13/site-packages/pybind11/share/cmake/pybind11 -DPTOAS_ENABLE_WERROR=OFF`
- `cmake --build build --target ptobc -j8`
- `ctest --test-dir build -R 'ptobc_(trowexpandsub_v0_encode|tdequant_v0_encode)$' -V`

Related issue:
- GitCode issue 21: `https://gitcode.com/cann/pto-as/issues/21`
