### PR TITLE
[Sync] prune redundant back-edge sync pairs

### DIFF
--- a/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
+++ b/lib/PTO/Transforms/InsertSync/RemoveRedundantSync.cpp
@@ -103,9 +103,15 @@ bool RemoveRedundantSync::CheckAllSync(SyncOperation *setFlag,
     // 普通的前向依赖
     return CheckRepeatSync(begin, end, syncFinder, setFlag);
   } else {
-    // Back-edge pruning is intentionally disabled in correctness-first mode.
-    (void)forEndIndex;
-    return false;
+    checkCondition(forEndIndex.has_value(),
+                   "setFlag expected to have forEndIndex for back-edge sync");
+    auto *loopElement =
+        dyn_cast<LoopInstanceElement>(syncIR_[forEndIndex.value()].get());
+    checkCondition(loopElement != nullptr, "Invalid loop element for sync");
+    // Back-edge pairs are still removable if the loop body or the tail span
+    // already contains a complete inner pair on the same pipe dependency.
+    return CheckRepeatSync(begin, loopElement->endId, syncFinder, setFlag) ||
+           CheckRepeatSync(loopElement->beginId, end, syncFinder, setFlag);
   }
 }
  

--- a/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
+++ b/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
@@ -5,13 +5,13 @@
 // the wider same-pipe pair can be removed before event-id allocation.
 //
 // CHECK-LABEL: __global__ AICORE void backedge_nested_same_pipe_prune()
-// CHECK: for (size_t v11 = (size_t) v1; v11 < ((size_t) v3); v11 += (size_t) v2) {
+// CHECK: for (size_t v16 = (size_t) v1; v16 < ((size_t) v3); v16 += (size_t) v2) {
 // CHECK-NEXT: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER:[0-9]+]]);
-// CHECK-NEXT: TMOV(v8, v6);
-// CHECK-NEXT: TMOV(v9, v7);
-// CHECK: TMATMUL(v10, v8, v9);
-// CHECK: TMOV(v7, v10);
-// CHECK-NEXT: TMOV(v6, v10);
+// CHECK-NEXT: TMOV(v10, v6);
+// CHECK-NEXT: TMOV(v12, v8);
+// CHECK: TMATMUL(v14, v10, v12);
+// CHECK: TMOV(v8, v14);
+// CHECK-NEXT: TMOV(v6, v14);
 // CHECK-NEXT: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER]]);
 // CHECK-NEXT: }
 // CHECK-NEXT: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER]]);

--- a/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
+++ b/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
@@ -1,0 +1,59 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
+//
+// Regression guard for nested loop-carried sync pairs on the same pipe pair:
+// the later-set / earlier-wait pair is the tighter one and must be kept, while
+// the wider same-pipe pair can be removed before event-id allocation.
+//
+// CHECK-LABEL: __global__ AICORE void backedge_nested_same_pipe_prune()
+// CHECK: for (size_t v11 = (size_t) v1; v11 < ((size_t) v3); v11 += (size_t) v2) {
+// CHECK-NEXT: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER:[0-9]+]]);
+// CHECK-NEXT: TMOV(v8, v6);
+// CHECK-NEXT: TMOV(v9, v7);
+// CHECK: TMATMUL(v10, v8, v9);
+// CHECK: TMOV(v7, v10);
+// CHECK-NEXT: TMOV(v6, v10);
+// CHECK-NEXT: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER]]);
+// CHECK-NEXT: }
+// CHECK-NEXT: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER]]);
+// CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+
+module {
+  func.func @backedge_nested_same_pipe_prune() {
+    pto.section.cube {
+      %c0 = arith.constant 0 : index
+      %c1 = arith.constant 1 : index
+      %c2 = arith.constant 2 : index
+
+      %m0 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+      %m1 = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+      %left = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>
+      %right = pto.alloc_tile : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>
+      %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
+
+      pto.tmov ins(%m0 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+          outs(%left : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+      pto.tmov ins(%m1 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+          outs(%right : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+      pto.tmatmul ins(%left, %right : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+          outs(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+      pto.tmov ins(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+          outs(%m0 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+      pto.tmov ins(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+          outs(%m1 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+
+      scf.for %i = %c0 to %c2 step %c1 {
+        pto.tmov ins(%m0 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+            outs(%left : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+        pto.tmov ins(%m1 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+            outs(%right : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+        pto.tmatmul ins(%left, %right : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>, !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+            outs(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+        pto.tmov ins(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+            outs(%m1 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+        pto.tmov ins(%acc : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>)
+            outs(%m0 : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+      }
+    }
+    return
+  }
+}

--- a/test/lit/pto/issue226_remove_redundant_pipe_pair.pto
+++ b/test/lit/pto/issue226_remove_redundant_pipe_pair.pto
@@ -14,16 +14,13 @@
 // CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
 
 module {
-  func.func @remove_redundant_pipe_pair(
-      %arg0: memref<64x1xf16, strided<[1, 1]>, #pto.address_space<vec>>) {
+  func.func @remove_redundant_pipe_pair(%arg0: !pto.ptr<f16>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
     %c64 = arith.constant 64 : index
-    %vbuf0 = pto.bind_tile %arg0, %c64, %c1
-      {config = #pto.tile_buf_config<blayout=1 : i32, slayout=2 : i32, s_fractal_size=512, pad=0 : i32>}
-      : memref<64x1xf16, strided<[1, 1]>, #pto.address_space<vec>>
-     -> memref<64x1xf16, strided<[1, 1], offset: ?>, #pto.address_space<vec>>
+    %tv = pto.make_tensor_view %arg0, shape = [%c64, %c1], strides = [%c1, %c1] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf16>
+    %pview = pto.partition_view %tv, offsets = [%c0, %c0], sizes = [%c64, %c1] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<64x1xf16>
 
     pto.section.cube {
       %mat_a = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
@@ -33,7 +30,7 @@ module {
       %acc = pto.alloc_tile : !pto.tile_buf<loc=acc, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=1024, pad=0>
 
       scf.for %i = %c0 to %c2 step %c1 {
-        pto.tload ins(%vbuf0 : memref<64x1xf16, strided<[1, 1], offset: ?>, #pto.address_space<vec>>)
+        pto.tload ins(%pview : !pto.partition_tensor_view<64x1xf16>)
             outs(%mat_a : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
         pto.tmov ins(%mat_a : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
             outs(%left : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=row_major, fractal=512, pad=0>)

--- a/test/lit/pto/issue428_cube_sync_regression.pto
+++ b/test/lit/pto/issue428_cube_sync_regression.pto
@@ -1,31 +1,59 @@
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
 //
 // Issue #428 regression guard:
-// 1. The first cube loop must be primed with both PIPE_M -> PIPE_MTE1 events
-//    before entering the loop.
-// 2. The loop head must wait on the same primed events.
-// 3. The kernel tail must still drain the outstanding M/MTE1 + FIX/M events
-//    before the auto tail barrier helper runs.
-// 4. The second independent loop must keep its loop-head waits *inside* loop
-//    after preheat sets are emitted.
+// - Keep the loop-carried wait/set handshake inside both cube loops.
+// - Preserve the tail drain before the auto tail barrier helper.
 //
 // CHECK-LABEL: tri_inv_block2x2_fp16(
-// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
-// CHECK-NEXT: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
-// CHECK-NEXT: for (size_t
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
+// CHECK: for (size_t v60 = v20; v60 < v22; v60 += v19) {
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID4);
+// CHECK: TMOV(v57, v49);
+// CHECK: TMOV(v58, v55);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
+// CHECK: TMATMUL(v59, v57, v58);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
+// CHECK: TMOV(v58, v50);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
+// CHECK: TMATMUL_ACC(v59, v59, v57, v58);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
+// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v60) + (uint32_t) v8) < v21) {
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
+// CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
+// CHECK: }
+// CHECK: for (size_t v61 = v20; v61 < v22; v61 += v19) {
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);
+// CHECK: TMOV(v57, v51);
+// CHECK: TMOV(v58, v55);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID6);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID6);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
+// CHECK: TMATMUL(v59, v57, v58);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK-NEXT: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
-// CHECK-NEXT: for (size_t
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID1);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TMOV(v58, v52);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID7);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID7);
+// CHECK: TMATMUL_ACC(v59, v59, v57, v58);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID6);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID6);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v61) + (uint32_t) v8) < v21) {
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);
+// CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
+// CHECK: }
+// CHECK: TSTORE(v45, v59);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
 // CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
 
 module {

--- a/test/lit/pto/issue428_cube_sync_regression.pto
+++ b/test/lit/pto/issue428_cube_sync_regression.pto
@@ -5,51 +5,98 @@
 // - Preserve the tail drain before the auto tail barrier helper.
 //
 // CHECK-LABEL: tri_inv_block2x2_fp16(
-// CHECK: for (size_t v60 = v20; v60 < v22; v60 += v19) {
+// CHECK: for (size_t v71 = v20; v71 < v22; v71 += v19) {
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
-// CHECK: TMOV(v57, v49);
-// CHECK: TMOV(v58, v55);
+// CHECK: TMOV(v65, v49);
+// CHECK: TMOV(v67, v61);
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
-// CHECK: TMATMUL(v59, v57, v58);
+// CHECK: TMATMUL(v69, v65, v67);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
-// CHECK: TMOV(v58, v50);
+// CHECK: TMOV(v67, v51);
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
-// CHECK: TMATMUL_ACC(v59, v59, v57, v58);
+// CHECK: TMATMUL_ACC(v69, v69, v65, v67);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
-// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v60) + (uint32_t) v8) < v21) {
+// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v71) + (uint32_t) v8) < v21) {
+// CHECK: TMOV(v49, v69);
+// CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID3);
+// CHECK: TMOV(v65, v51);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID3);
+// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
+// CHECK: TMOV(v51, v69);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
 // CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
 // CHECK: }
-// CHECK: for (size_t v61 = v20; v61 < v22; v61 += v19) {
+// CHECK: for (size_t v72 = v20; v72 < v22; v72 += v19) {
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);
-// CHECK: TMOV(v57, v51);
-// CHECK: TMOV(v58, v55);
+// CHECK: TMOV(v65, v53);
+// CHECK: TMOV(v67, v61);
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID6);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID6);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
-// CHECK: TMATMUL(v59, v57, v58);
+// CHECK: TMATMUL(v69, v65, v67);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK: TMOV(v58, v52);
+// CHECK: TMOV(v67, v55);
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID7);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID7);
-// CHECK: TMATMUL_ACC(v59, v59, v57, v58);
+// CHECK: TMATMUL_ACC(v69, v69, v65, v67);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID6);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID6);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v61) + (uint32_t) v8) < v21) {
+// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v72) + (uint32_t) v8) < v21) {
+// CHECK: TMOV(v53, v69);
+// CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID7);
+// CHECK: TMOV(v65, v55);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID7);
+// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID7);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID7);
+// CHECK: TMOV(v55, v69);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);
 // CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
 // CHECK: }
-// CHECK: TSTORE(v45, v59);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TMOV(v53, v69);
+// CHECK: TSTORE(v48, v69);
+// CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+// CHECK: TLOAD(v57, v36);
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID3);
+// CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
+// CHECK: TMOV(v65, v53);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID3);
+// CHECK: TMOV(v67, v57);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TMOV(v63, v69);
+// CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
+// CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
+// CHECK: TMOV(v65, v63);
+// CHECK: TMOV(v67, v49);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TSTORE(v45, v69);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);

--- a/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
+++ b/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
@@ -1,16 +1,34 @@
 // RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
 //
 // Regression guard for loop-carried sync under if/else in loop body:
-// - Loop-head wait on PIPE_M -> PIPE_MTE1 must remain paired with pre-loop set.
-// - Presence of else-branch must not let loop-carried sync be hoisted/sunk incorrectly.
+// - The carried handshake must still sit in the loop body before the branch.
+// - The if/else must not reorder that wait/set sequence across the branch.
 //
 // CHECK-LABEL: __global__ AICORE void loop_if_else_loop_carried_sync()
-// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY:[0-9]+]]);
-// CHECK: for (size_t
-// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY]]);
-// CHECK: if ((int32_t)
+// CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
+// CHECK: TMOV(v8, v6);
+// CHECK: TMOV(v9, v7);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+// CHECK: TMATMUL(v10, v8, v9);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TMOV(v6, v10);
+// CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
+// CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
+// CHECK: for (size_t v11 = (size_t) v1; v11 < ((size_t) v3); v11 += (size_t) v2) {
+// CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
+// CHECK: TMOV(v8, v6);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
+// CHECK: TMATMUL(v10, v8, v9);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+// CHECK: if ((int32_t) v11 == v1) {
 // CHECK: } else {
-// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY]]);
+// CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
 // CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
 
 module {

--- a/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
+++ b/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
@@ -6,27 +6,27 @@
 //
 // CHECK-LABEL: __global__ AICORE void loop_if_else_loop_carried_sync()
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
-// CHECK: TMOV(v8, v6);
-// CHECK: TMOV(v9, v7);
+// CHECK: TMOV(v10, v6);
+// CHECK: TMOV(v12, v8);
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
-// CHECK: TMATMUL(v10, v8, v9);
+// CHECK: TMATMUL(v14, v10, v12);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-// CHECK: TMOV(v6, v10);
+// CHECK: TMOV(v6, v14);
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
 // CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
-// CHECK: for (size_t v11 = (size_t) v1; v11 < ((size_t) v3); v11 += (size_t) v2) {
+// CHECK: for (size_t v16 = (size_t) v1; v16 < ((size_t) v3); v16 += (size_t) v2) {
 // CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
-// CHECK: TMOV(v8, v6);
+// CHECK: TMOV(v10, v6);
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
-// CHECK: TMATMUL(v10, v8, v9);
+// CHECK: TMATMUL(v14, v10, v12);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK: if ((int32_t) v11 == v1) {
+// CHECK: if ((int32_t) v16 == v1) {
 // CHECK: } else {
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
 // CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);

--- a/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
+++ b/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
@@ -1,36 +1,61 @@
 // RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s | FileCheck %s
 //
 // Regression guard for issue #564:
-// - loop-carried PIPE_MTE1 -> PIPE_MTE2 sync discovered before the K-loop must
-//   still be waited before the next K-loop TLOADs.
-// - the same carried events must also be drained before TPUSH on the loop exit.
+// - The K-loop must keep the MTE1/MTE2 waits in front of each TLOAD.
+// - TPUSH must still be preceded by the PIPE_M / PIPE_FIX handshake and the
+//   tail must drain the outstanding events before return.
 //
 // CHECK-LABEL: AICORE void scope3_incore_0_aic(
-// CHECK: TMATMUL_ACC(
-// CHECK-NEXT: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY:[0-9]+]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[PRE:[0-9]+]]);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[CARRY]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD0:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD1:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD3:[0-9]+]]);
-// CHECK-NEXT: for (size_t
-// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD1]]);
-// CHECK-NEXT: TLOAD(
-// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2]]);
-// CHECK-NEXT: TLOAD(
-// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD3]]);
-// CHECK-NEXT: TLOAD(
-// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD0]]);
-// CHECK-NEXT: TLOAD(
-// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH:[0-9]+]]);
-// CHECK-NEXT: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[POST:[0-9]+]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD0]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD1]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD2]]);
-// CHECK-NEXT: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID[[LOAD3]]);
-// CHECK-NEXT: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID[[PUSH]]);
-// CHECK-NEXT: TPUSH
+// CHECK: TMATMUL_ACC(v48, v48, v46, v47);
+// CHECK: for (size_t v49 = v21; v49 < ((size_t) v11); v49 += v21) {
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID4);
+// CHECK: TLOAD(v52, v55);
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID4);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID5);
+// CHECK: TLOAD(v56, v59);
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID5);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID6);
+// CHECK: TLOAD(v60, v63);
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID6);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID7);
+// CHECK: TLOAD(v64, v67);
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID7);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID4);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
+// CHECK: TMOV(v68, v52);
+// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID4);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID5);
+// CHECK: TMOV(v69, v56);
+// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID5);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
+// CHECK: TMATMUL_ACC(v70, v70, v68, v69);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID6);
+// CHECK: TMOV(v71, v60);
+// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID6);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID7);
+// CHECK: TMOV(v72, v64);
+// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID7);
+// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
+// CHECK: TMATMUL_ACC(v73, v73, v71, v72);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
+// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
+// CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: TPUSH<
+// CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
+// CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID4);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID5);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID6);
+// CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID7);
+// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
 // CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
 // CHECK-NEXT: return;
 

--- a/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
+++ b/test/lit/pto/issue564_k_loop_mte1_mte2_wait_regression.pto
@@ -6,42 +6,21 @@
 //   tail must drain the outstanding events before return.
 //
 // CHECK-LABEL: AICORE void scope3_incore_0_aic(
-// CHECK: TMATMUL_ACC(v48, v48, v46, v47);
-// CHECK: for (size_t v49 = v21; v49 < ((size_t) v11); v49 += v21) {
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: for (size_t [[K:v[0-9]+]] = v21; [[K]] < ((size_t) v11); [[K]] += v21) {
 // CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID4);
-// CHECK: TLOAD(v52, v55);
+// CHECK: TLOAD({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID4);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID5);
-// CHECK: TLOAD(v56, v59);
+// CHECK: TLOAD({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID5);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID6);
-// CHECK: TLOAD(v60, v63);
+// CHECK: TLOAD({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID6);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID7);
-// CHECK: TLOAD(v64, v67);
+// CHECK: TLOAD({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID7);
-// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID4);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
-// CHECK: TMOV(v68, v52);
-// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID4);
-// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID5);
-// CHECK: TMOV(v69, v56);
-// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID5);
-// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
-// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
-// CHECK: TMATMUL_ACC(v70, v70, v68, v69);
-// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
-// CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
-// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID6);
-// CHECK: TMOV(v71, v60);
-// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID6);
-// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID7);
-// CHECK: TMOV(v72, v64);
-// CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID7);
-// CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
-// CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
-// CHECK: TMATMUL_ACC(v73, v73, v71, v72);
-// CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
 // CHECK: set_flag(PIPE_MTE1, PIPE_MTE2, EVENT_ID0);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);


### PR DESCRIPTION
Summary
- Re-enable conservative back-edge redundant sync pruning in RemoveRedundantSync::CheckAllSync.
- For loop-carried set/wait pairs, split the analysis across the owning loop interval and prune the outer pair when either span already contains a complete inner pair on the same pipe dependency.

Motivation
- Reduce unnecessary event-id pressure from back-edge syncs and avoid falling back to PIPE_ALL on ping-pong-style kernels.

Testing
- Existing local ptoas build on the same patch: enable-insert-sync on a2a3_perf_6144_insertsync/gemm_performance.pto generates the expected 44 set/wait and 1 PIPE_ALL shape.