### PR TITLE
fix(pto): classify mscatter as vector pipe

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2660,7 +2660,7 @@ def MScatterOp : PTO_TOp<"mscatter", [
 
   let extraClassDeclaration = [{
     static StringRef getIntrinsicName() { return "MSCATTER"; }
-    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_MTE3; }
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getMemMutable(); }
   }];
 }

--- a/test/lit/pto/issue664_mscatter_pipe_selection.pto
+++ b/test/lit/pto/issue664_mscatter_pipe_selection.pto
@@ -1,0 +1,63 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a5 --enable-insert-sync %s | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @mscatter_pipe_selection(%src: !pto.ptr<f32>, %idx: !pto.ptr<i32>,
+                                     %out: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
+    %c256 = arith.constant 256 : index
+
+    %src_view = pto.make_tensor_view %src,
+                shape = [%c8, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xf32>
+    %idx_view = pto.make_tensor_view %idx,
+                shape = [%c8, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %out,
+                shape = [%c256], strides = [%c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?xf32>
+
+    %src_part = pto.partition_view %src_view,
+                offsets = [%c0, %c0], sizes = [%c8, %c32]
+              : !pto.tensor_view<?x?xf32>
+                -> !pto.partition_tensor_view<8x32xf32>
+    %idx_part = pto.partition_view %idx_view,
+                offsets = [%c0, %c0], sizes = [%c8, %c32]
+              : !pto.tensor_view<?x?xi32>
+                -> !pto.partition_tensor_view<8x32xi32>
+    %out_part = pto.partition_view %out_view,
+                offsets = [%c0], sizes = [%c256]
+              : !pto.tensor_view<?xf32>
+                -> !pto.partition_tensor_view<256xf32>
+
+    %src_tile = pto.alloc_tile addr = %c0_i64
+              : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_tile = pto.alloc_tile addr = %c1024_i64
+              : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<8x32xf32>)
+              outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%idx_part : !pto.partition_tensor_view<8x32xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.mscatter ins(%src_tile, %idx_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                 outs(%out_part : !pto.partition_tensor_view<256xf32>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void mscatter_pipe_selection(
+// CHECK: TLOAD(
+// CHECK: TLOAD(
+// CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK-NOT: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK-NOT: wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+// CHECK: MSCATTER(

--- a/test/lit/pto/issue664_mscatter_pipe_selection_gss.pto
+++ b/test/lit/pto/issue664_mscatter_pipe_selection_gss.pto
@@ -1,0 +1,63 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a5 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @mscatter_pipe_selection(%src: !pto.ptr<f32>, %idx: !pto.ptr<i32>,
+                                     %out: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
+    %c256 = arith.constant 256 : index
+
+    %src_view = pto.make_tensor_view %src,
+                shape = [%c8, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xf32>
+    %idx_view = pto.make_tensor_view %idx,
+                shape = [%c8, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %out,
+                shape = [%c256], strides = [%c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?xf32>
+
+    %src_part = pto.partition_view %src_view,
+                offsets = [%c0, %c0], sizes = [%c8, %c32]
+              : !pto.tensor_view<?x?xf32>
+                -> !pto.partition_tensor_view<8x32xf32>
+    %idx_part = pto.partition_view %idx_view,
+                offsets = [%c0, %c0], sizes = [%c8, %c32]
+              : !pto.tensor_view<?x?xi32>
+                -> !pto.partition_tensor_view<8x32xi32>
+    %out_part = pto.partition_view %out_view,
+                offsets = [%c0], sizes = [%c256]
+              : !pto.tensor_view<?xf32>
+                -> !pto.partition_tensor_view<256xf32>
+
+    %src_tile = pto.alloc_tile addr = %c0_i64
+              : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_tile = pto.alloc_tile addr = %c1024_i64
+              : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<8x32xf32>)
+              outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%idx_part : !pto.partition_tensor_view<8x32xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.mscatter ins(%src_tile, %idx_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                 outs(%out_part : !pto.partition_tensor_view<256xf32>)
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void mscatter_pipe_selection(
+// CHECK: TLOAD(
+// CHECK: TLOAD(
+// CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID{{[0-9]+}});
+// CHECK-NOT: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID{{[0-9]+}});
+// CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID{{[0-9]+}});
+// CHECK-NOT: wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID{{[0-9]+}});
+// CHECK: MSCATTER(


### PR DESCRIPTION
Summary
- Classify `pto.mscatter` as `PIPE_V` in the op pipe interface.
- Add issue #664 regression coverage for both `--enable-insert-sync` and `--enable-graph-sync-solver`.

Motivation
- Fixes #664.
- `MSCATTER` consumes source/index tiles on the vector pipe, so auto-sync must order preceding `TLOAD` producers with `PIPE_MTE2 -> PIPE_V` instead of `PIPE_MTE2 -> PIPE_MTE3`.

Design
- Keep the fix localized to the op pipe classification consumed by both sync insertion paths.
- The regression checks that generated code emits `set/wait_flag(PIPE_MTE2, PIPE_V, ...)` before `MSCATTER` and does not emit the old `PIPE_MTE2 -> PIPE_MTE3` pair there.

Testing
- Local: `ninja -C build ptoas` with `PTOAS_ENABLE_WERROR=OFF` due to existing main-branch warnings on this macOS toolchain.
- Local: `llvm-lit -v --filter issue664 build/test/lit` (2/2 PASS).
- Additional: generated C++ inspected for both sync paths; both emit `set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0); wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0); MSCATTER(...)`.

Risk / Rollback
- Risk: limited to auto-sync pipe inference for `pto.mscatter`.
- Rollback: revert this PR.