### PR TITLE
Fix redundant sync for disjoint subviews

### DIFF
--- a/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
+++ b/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
@@ -73,6 +73,9 @@ private:
   
   // 处理 View/Alias (MakeTensorView, Subview, Mov)
   void UpdateAliasBufferInfo(Value result, Value source);
+  void UpdateConservativeAliasBufferInfo(Value result, Value source);
+  void UpdateMemrefSubViewAliasBufferInfo(memref::SubViewOp op);
+  void UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op);
  
   // --- 控制流处理 (SCF) ---
   void UpdateForOpInfo(scf::ForOp forOp);

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -36,6 +36,17 @@ static bool isValidPipeIndex(PipelineType pipe) {
   return static_cast<unsigned>(pipe) < kPipeStateSize;
 }
 
+static bool isTLoadCompound(const CompoundInstanceElement *compound) {
+  return compound && compound->elementOp && isa<pto::TLoadOp>(compound->elementOp);
+}
+
+static bool isTLoadToTLoadWAWExempt(const CompoundInstanceElement *nowCompound,
+                                    const CompoundInstanceElement *frontCompound) {
+  return isTLoadCompound(nowCompound) && isTLoadCompound(frontCompound) &&
+         nowCompound->kPipeValue == PipelineType::PIPE_MTE2 &&
+         frontCompound->kPipeValue == PipelineType::PIPE_MTE2;
+}
+
 // ==============================================================================
 // 1. Entry Point
 // ==============================================================================
@@ -317,8 +328,10 @@ bool InsertSyncAnalysis::IsMemInfoHasDependency(
                                           depBaseMemInfosVec);
   hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->useVec,
                                           depBaseMemInfosVec);
-  hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->defVec,
-                                          depBaseMemInfosVec);
+  if (!isTLoadToTLoadWAWExempt(nowCompound, frontCompound)) {
+    hasDependency |= memAnalyzer_.DepBetween(nowCompound->defVec, frontCompound->defVec,
+                                            depBaseMemInfosVec);
+  }
 
   // Special hazard: ACC (L0C) read/read cross-pipe ordering.
   //

--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -158,6 +158,7 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   
   if (a->rootBuffer == b->rootBuffer) {
     if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true;
+    if (a->allocateSize == 0 || b->allocateSize == 0) return true;
     return isBufferAddressRangeOverlap(a, b);
   }
  
@@ -174,7 +175,11 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   if (realRootA == realRootB && realRootA != nullptr) {
       if (isTraceEnabled())
         llvm::errs() << "      -> MATCH! Real roots are the same.\n";
-      return true;
+      if (a->baseAddresses.empty() || b->baseAddresses.empty())
+        return true;
+      if (a->allocateSize == 0 || b->allocateSize == 0)
+        return true;
+      return isBufferAddressRangeOverlap(a, b);
   } else {
       if (isTraceEnabled())
         llvm::errs() << "      -> Mismatch. Real roots differ.\n";
@@ -192,7 +197,9 @@ bool MemoryDependentAnalyzer::isGMBufferOverlap(const BaseMemInfo *a,
     if (realRootA != realRootB) {
         return false;
     }
-    return true; 
+    if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true;
+    if (a->allocateSize == 0 || b->allocateSize == 0) return true;
+    return isBufferAddressRangeOverlap(a, b);
   }
  
   if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true; 

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -12,6 +12,7 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 #include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
+#include "PTO/IR/PTOTypeUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -22,11 +23,167 @@
 #include "mlir/IR/Matchers.h"
 // [P0 新增] 引入副作用接口和 PTO 接口
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include <optional>
  
 #define DEBUG_TYPE "pto-ir-translator"
  
 using namespace mlir;
 using namespace mlir::pto;
+
+static bool getConstIndexValue(Value value, int64_t &out) {
+  while (true) {
+    if (auto castOp = value.getDefiningOp<arith::IndexCastOp>()) {
+      value = castOp.getIn();
+      continue;
+    }
+    if (auto extOp = value.getDefiningOp<arith::ExtSIOp>()) {
+      value = extOp.getIn();
+      continue;
+    }
+    if (auto extOp = value.getDefiningOp<arith::ExtUIOp>()) {
+      value = extOp.getIn();
+      continue;
+    }
+    if (auto truncOp = value.getDefiningOp<arith::TruncIOp>()) {
+      value = truncOp.getIn();
+      continue;
+    }
+    break;
+  }
+  if (auto constIndex = value.getDefiningOp<arith::ConstantIndexOp>()) {
+    out = constIndex.value();
+    return true;
+  }
+  if (auto constInt = value.getDefiningOp<arith::ConstantIntOp>()) {
+    out = constInt.value();
+    return true;
+  }
+  auto constOp = value.getDefiningOp<arith::ConstantOp>();
+  auto intAttr =
+      constOp ? dyn_cast<IntegerAttr>(constOp.getValue()) : IntegerAttr();
+  if (!intAttr) return false;
+  out = intAttr.getInt();
+  return true;
+}
+
+static bool isStaticRank2Shape(ArrayRef<int64_t> shape) {
+  return shape.size() == 2 &&
+         llvm::none_of(shape, [](int64_t dim) {
+           return dim == ShapedType::kDynamic;
+         });
+}
+
+static int64_t getTileMajorStride(pto::TileBufType type) {
+  ArrayRef<int64_t> shape = type.getShape();
+  int64_t rows = shape[0];
+  int64_t cols = shape[1];
+  bool rowMajor =
+      type.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
+  int64_t stride = rowMajor ? cols : rows;
+  if (type.getCompactModeI32() == static_cast<int32_t>(pto::CompactMode::RowPlusOne))
+    ++stride;
+  return stride;
+}
+
+static std::optional<SmallVector<uint64_t>>
+getPtoSubViewBaseAddresses(pto::SubViewOp op, pto::TileBufType sourceType,
+                           int64_t elemBytes) {
+  if (!isStaticRank2Shape(sourceType.getShape())) return std::nullopt;
+  if (sourceType.getSLayoutValueI32() !=
+      static_cast<int32_t>(pto::SLayout::NoneBox))
+    return std::nullopt;
+  if (op.getOffsets().size() != 2) return std::nullopt;
+
+  int64_t rowOffset = 0;
+  int64_t colOffset = 0;
+  if (!getConstIndexValue(op.getOffsets()[0], rowOffset) ||
+      !getConstIndexValue(op.getOffsets()[1], colOffset))
+    return std::nullopt;
+  if (rowOffset < 0 || colOffset < 0) return std::nullopt;
+
+  auto sizesAttr = op.getSizes();
+  if (!sizesAttr || sizesAttr.size() != 2) return std::nullopt;
+  int64_t rowSize = cast<IntegerAttr>(sizesAttr[0]).getInt();
+  int64_t colSize = cast<IntegerAttr>(sizesAttr[1]).getInt();
+  if (rowSize <= 0 || colSize <= 0) return std::nullopt;
+
+  bool rowMajor =
+      sourceType.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
+  int64_t majorStride = getTileMajorStride(sourceType);
+
+  SmallVector<uint64_t> addresses;
+  if (rowMajor) {
+    addresses.reserve(static_cast<size_t>(rowSize));
+    for (int64_t row = 0; row < rowSize; ++row) {
+      int64_t elemOffset = (rowOffset + row) * majorStride + colOffset;
+      addresses.push_back(static_cast<uint64_t>(elemOffset * elemBytes));
+    }
+  } else {
+    addresses.reserve(static_cast<size_t>(colSize));
+    for (int64_t col = 0; col < colSize; ++col) {
+      int64_t elemOffset = (colOffset + col) * majorStride + rowOffset;
+      addresses.push_back(static_cast<uint64_t>(elemOffset * elemBytes));
+    }
+  }
+
+  return addresses;
+}
+
+static std::optional<SmallVector<uint64_t>>
+getMemrefSubViewBaseAddresses(memref::SubViewOp op, MemRefType sourceType,
+                              int64_t elemBytes) {
+  if (!sourceType.hasStaticShape() || sourceType.getRank() != 2)
+    return std::nullopt;
+
+  SmallVector<int64_t> strides;
+  int64_t baseOffset = ShapedType::kDynamic;
+  if (failed(mlir::getStridesAndOffset(sourceType, strides, baseOffset)) ||
+      strides.size() != 2 ||
+      llvm::is_contained(strides, ShapedType::kDynamic))
+    return std::nullopt;
+
+  ArrayRef<int64_t> staticOffsets = op.getStaticOffsets();
+  ArrayRef<int64_t> staticSizes = op.getStaticSizes();
+  ArrayRef<int64_t> staticSubViewStrides = op.getStaticStrides();
+  if (staticOffsets.size() != 2 || staticSizes.size() != 2 ||
+      staticSubViewStrides.size() != 2)
+    return std::nullopt;
+  if (llvm::is_contained(staticOffsets, ShapedType::kDynamic) ||
+      llvm::is_contained(staticSizes, ShapedType::kDynamic) ||
+      llvm::is_contained(staticSubViewStrides, ShapedType::kDynamic))
+    return std::nullopt;
+  if (staticSubViewStrides[0] != 1 || staticSubViewStrides[1] != 1)
+    return std::nullopt;
+
+  int64_t rowOffset = staticOffsets[0];
+  int64_t colOffset = staticOffsets[1];
+  int64_t rowSize = staticSizes[0];
+  int64_t colSize = staticSizes[1];
+  if (rowOffset < 0 || colOffset < 0 || rowSize <= 0 || colSize <= 0)
+    return std::nullopt;
+
+  SmallVector<uint64_t> addresses;
+  if (strides[1] == 1) {
+    addresses.reserve(static_cast<size_t>(rowSize));
+    for (int64_t row = 0; row < rowSize; ++row) {
+      int64_t elemOffset =
+          (rowOffset + row) * strides[0] + colOffset * strides[1];
+      addresses.push_back(static_cast<uint64_t>(elemOffset * elemBytes));
+    }
+  } else if (strides[0] == 1) {
+    addresses.reserve(static_cast<size_t>(colSize));
+    for (int64_t col = 0; col < colSize; ++col) {
+      int64_t elemOffset =
+          rowOffset * strides[0] + (colOffset + col) * strides[1];
+      addresses.push_back(static_cast<uint64_t>(elemOffset * elemBytes));
+    }
+  } else {
+    return std::nullopt;
+  }
+
+  return addresses;
+}
  
 // [辅助函数] 尝试从 Operation 中计算相对于 Source 的字节偏移量和新大小
 // 返回值: pair<offsetInBytes, sizeInBytes>
@@ -159,8 +316,11 @@ void PTOIRTranslator::RecursionIR(Region *region) {
     else if (auto subViewOp = dyn_cast<pto::PartitionViewOp>(op)) {
       UpdateAliasBufferInfo(subViewOp.getResult(), subViewOp.getSource());
     } 
+    else if (auto subViewOp = dyn_cast<pto::SubViewOp>(op)) {
+      UpdateTileSubViewAliasBufferInfo(subViewOp);
+    }
     else if (auto memrefSubView = dyn_cast<memref::SubViewOp>(op)) {
-      UpdateAliasBufferInfo(memrefSubView.getResult(), memrefSubView.getSource());
+      UpdateMemrefSubViewAliasBufferInfo(memrefSubView);
     }
     else if (auto castOp = dyn_cast<memref::ReinterpretCastOp>(op)) {
       UpdateAliasBufferInfo(castOp.getResult(), castOp.getSource());
@@ -578,6 +738,134 @@ void PTOIRTranslator::UpdateAliasBufferInfo(Value result, Value source) {
         newInfo->allocateSize = newSize;
     }
  
+    resultMemInfoVec.emplace_back(std::move(newInfo));
+  }
+}
+
+void PTOIRTranslator::UpdateConservativeAliasBufferInfo(Value result,
+                                                        Value source) {
+  if (!result || !source) return;
+  if (!buffer2MemInfoMap_.contains(source)) return;
+
+  auto &resultMemInfoVec = buffer2MemInfoMap_[result];
+  for (auto &parentInfo : buffer2MemInfoMap_[source])
+    resultMemInfoVec.emplace_back(parentInfo->clone(result));
+}
+
+void PTOIRTranslator::UpdateMemrefSubViewAliasBufferInfo(memref::SubViewOp op) {
+  Value result = op.getResult();
+  Value source = op.getSource();
+  if (!result || !source) return;
+  if (!buffer2MemInfoMap_.contains(source)) return;
+
+  auto sourceType = dyn_cast<MemRefType>(source.getType());
+  if (!sourceType) {
+    UpdateConservativeAliasBufferInfo(result, source);
+    return;
+  }
+
+  unsigned elemBytes = pto::getPTOStorageElemByteSize(sourceType.getElementType());
+  auto subViewAddresses =
+      elemBytes == 0 ? std::nullopt
+                     : getMemrefSubViewBaseAddresses(
+                           op, sourceType, static_cast<int64_t>(elemBytes));
+  if (!subViewAddresses || subViewAddresses->empty()) {
+    UpdateConservativeAliasBufferInfo(result, source);
+    return;
+  }
+
+  SmallVector<int64_t> strides;
+  int64_t baseOffset = ShapedType::kDynamic;
+  if (failed(mlir::getStridesAndOffset(sourceType, strides, baseOffset)) ||
+      strides.size() != 2) {
+    UpdateConservativeAliasBufferInfo(result, source);
+    return;
+  }
+
+  ArrayRef<int64_t> staticSizes = op.getStaticSizes();
+  uint64_t segmentSize = 0;
+  if (strides[1] == 1) {
+    segmentSize = static_cast<uint64_t>(
+        staticSizes[1] * static_cast<int64_t>(elemBytes));
+  } else if (strides[0] == 1) {
+    segmentSize = static_cast<uint64_t>(
+        staticSizes[0] * static_cast<int64_t>(elemBytes));
+  } else {
+    UpdateConservativeAliasBufferInfo(result, source);
+    return;
+  }
+
+  for (auto &parentInfo : buffer2MemInfoMap_[source]) {
+    if (!parentInfo || parentInfo->baseAddresses.size() != 1 ||
+        parentInfo->allocateSize == 0) {
+      UpdateConservativeAliasBufferInfo(result, source);
+      return;
+    }
+  }
+
+  auto &resultMemInfoVec = buffer2MemInfoMap_[result];
+  for (auto &parentInfo : buffer2MemInfoMap_[source]) {
+    auto newInfo = parentInfo->clone(result);
+    SmallVector<uint64_t> addresses;
+    addresses.reserve(subViewAddresses->size());
+    uint64_t parentBase = parentInfo->baseAddresses[0];
+    for (uint64_t offset : *subViewAddresses)
+      addresses.push_back(parentBase + offset);
+    newInfo->baseAddresses = std::move(addresses);
+    newInfo->allocateSize = segmentSize;
+    resultMemInfoVec.emplace_back(std::move(newInfo));
+  }
+}
+
+void PTOIRTranslator::UpdateTileSubViewAliasBufferInfo(pto::SubViewOp op) {
+  Value result = op.getResult();
+  Value source = op.getSource();
+  if (!result || !source) return;
+  if (!buffer2MemInfoMap_.contains(source)) return;
+
+  auto sourceType = dyn_cast<pto::TileBufType>(source.getType());
+  if (!sourceType) {
+    UpdateConservativeAliasBufferInfo(result, source);
+    return;
+  }
+
+  unsigned elemBytes = pto::getPTOStorageElemByteSize(sourceType.getElementType());
+  auto subViewAddresses =
+      elemBytes == 0 ? std::nullopt
+                     : getPtoSubViewBaseAddresses(
+                           op, sourceType, static_cast<int64_t>(elemBytes));
+  if (!subViewAddresses || subViewAddresses->empty()) {
+    UpdateConservativeAliasBufferInfo(result, source);
+    return;
+  }
+
+  auto sizesAttr = op.getSizes();
+  int64_t rowSize = cast<IntegerAttr>(sizesAttr[0]).getInt();
+  int64_t colSize = cast<IntegerAttr>(sizesAttr[1]).getInt();
+  bool rowMajor =
+      sourceType.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
+  uint64_t segmentSize =
+      static_cast<uint64_t>((rowMajor ? colSize : rowSize) *
+                            static_cast<int64_t>(elemBytes));
+
+  for (auto &parentInfo : buffer2MemInfoMap_[source]) {
+    if (!parentInfo || parentInfo->baseAddresses.size() != 1 ||
+        parentInfo->allocateSize == 0) {
+      UpdateConservativeAliasBufferInfo(result, source);
+      return;
+    }
+  }
+
+  auto &resultMemInfoVec = buffer2MemInfoMap_[result];
+  for (auto &parentInfo : buffer2MemInfoMap_[source]) {
+    auto newInfo = parentInfo->clone(result);
+    SmallVector<uint64_t> addresses;
+    addresses.reserve(subViewAddresses->size());
+    uint64_t parentBase = parentInfo->baseAddresses[0];
+    for (uint64_t offset : *subViewAddresses)
+      addresses.push_back(parentBase + offset);
+    newInfo->baseAddresses = std::move(addresses);
+    newInfo->allocateSize = segmentSize;
     resultMemInfoVec.emplace_back(std::move(newInfo));
   }
 }

--- a/test/lit/pto/issue667_subview_disjoint_no_mte2_barrier.pto
+++ b/test/lit/pto/issue667_subview_disjoint_no_mte2_barrier.pto
@@ -1,0 +1,52 @@
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s | FileCheck %s
+
+module {
+  func.func @issue667_subview_disjoint_no_mte2_barrier(
+      %src0: memref<16x128xf32, #pto.address_space<gm>>,
+      %src1: memref<16x128xf32, #pto.address_space<gm>>,
+      %src2: memref<16x128xf32, #pto.address_space<gm>>,
+      %src3: memref<16x128xf32, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %c128 = arith.constant 128 : index
+    %c256 = arith.constant 256 : index
+    %c384 = arith.constant 384 : index
+    %c0_i64 = arith.constant 0 : i64
+
+    %tile = pto.alloc_tile addr = %c0_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %s0 = pto.subview %tile[%c0, %c0] sizes [16, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s1 = pto.subview %tile[%c0, %c128] sizes [16, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s2 = pto.subview %tile[%c0, %c256] sizes [16, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s3 = pto.subview %tile[%c0, %c384] sizes [16, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%s0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%s1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src2 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%s2 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src3 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%s3 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void issue667_subview_disjoint_no_mte2_barrier(
+// CHECK-NOT: pipe_barrier(PIPE_MTE2);
+// CHECK: TLOAD(
+// CHECK-NOT: pipe_barrier(PIPE_MTE2);
+// CHECK: TLOAD(
+// CHECK-NOT: pipe_barrier(PIPE_MTE2);
+// CHECK: TLOAD(
+// CHECK-NOT: pipe_barrier(PIPE_MTE2);
+// CHECK: TLOAD(
+// CHECK-NOT: pipe_barrier(PIPE_MTE2);

--- a/test/lit/pto/issue667_tload_overlap_no_mte2_barrier.pto
+++ b/test/lit/pto/issue667_tload_overlap_no_mte2_barrier.pto
@@ -1,0 +1,55 @@
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s | FileCheck %s
+
+module {
+  func.func @issue667_tload_overlap_does_not_need_mte2_barrier(
+      %src0: memref<16x128xf32, #pto.address_space<gm>>,
+      %src1: memref<16x128xf32, #pto.address_space<gm>>) {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c0_i64 = arith.constant 0 : i64
+
+    %tile = pto.alloc_tile addr = %c0_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %s0 = pto.subview %tile[%c0, %c0] sizes [16, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %s1 = pto.subview %tile[%c0, %c64] sizes [16, 128] :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=512, v_row=16, v_col=512, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      -> !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%s0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%s1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @issue667_vector_overlap_keeps_pipe_v_barrier() {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %cst = arith.constant 2.000000e+00 : f32
+
+    %src0 = pto.alloc_tile addr = %c0_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile addr = %c4096_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c0_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tmuls ins(%src0, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%src1, %cst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void issue667_tload_overlap_does_not_need_mte2_barrier(
+// CHECK: TLOAD(
+// CHECK-NOT: pipe_barrier(PIPE_MTE2);
+// CHECK: TLOAD(
+// CHECK-LABEL: AICORE void issue667_vector_overlap_keeps_pipe_v_barrier(
+// CHECK: TMULS(
+// CHECK: pipe_barrier(PIPE_V);
+// CHECK: TMULS(


### PR DESCRIPTION
Summary
- Track precise static ranges for supported rank-2 tile and memref subviews during InsertSync alias analysis.
- Keep conservative alias behavior when subview offsets, sizes, layouts, or strides cannot be proven statically.
- Do not treat TLOAD/TLOAD write-after-write on the MTE2 pipe as a sync hazard; load/load sequencing does not require a same-pipe MTE2 barrier.
- Add coverage for disjoint subviews, overlapping TLOAD/TLOAD reuse, and overlapping non-load vector writes that must still keep a barrier.

Motivation
- Fixes #667.
- Automatic sync was treating disjoint subviews of the same root buffer as aliases, and also serialized TLOAD/TLOAD reuse with unnecessary MTE2 barriers. Both hurt pipelined performance.

Design
- For supported static rank-2 tile subviews, model each contiguous row/column segment as a byte range based on tile layout.
- For supported static rank-2 memref.subview operations, model contiguous row/column segments when the source layout has a contiguous dimension and the subview stride is unit.
- Fall back to the existing conservative alias behavior for unsupported or dynamic cases.
- Skip only the TLOAD/TLOAD WAW dependency path on PIPE_MTE2; RAW/WAR checks and non-load WAW barriers are unchanged.

Testing
- Local: ninja -C build-issue667 ptoas
- Local: llvm-lit -v build-issue667/test/lit --filter 'issue667_(subview_disjoint|tload_overlap)'
- Local: llvm-lit -v build-issue667/test/lit --filter 'issue667|tinsert_a3_pipe_selection|tinsert_a2a3_vec_vec_pipe_selection'
- Manual issue case: MTE2 barriers reduced from 129 to 0 on fa_tile512.mlir with --pto-arch=a3 --enable-insert-sync.

Risk / Rollback
- Risk is limited to InsertSync alias refinement for static subviews and the TLOAD/TLOAD MTE2 WAW exemption; unsupported forms stay conservative.
- Rollback by reverting this PR.