### PR TITLE
feat: support tcvt saturation mode

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7392,12 +7392,12 @@ Rounding modes for type conversion (`pto.tcvt`) operations.
 
 ##### `pto.tcvt` - Elementwise Type Conversion
 
-**Summary:** Converts each element to a new type with a specified rounding mode.
+**Summary:** Converts each element to a new type with a specified rounding mode and optional saturation mode.
 
 **Semantics:**
 
 ```
-dst[i, j] = cast(src[i, j], rmode)
+dst[i, j] = saturate(cast(src[i, j], rmode), satmode)
 ```
 
 **Arguments:**
@@ -7407,12 +7407,14 @@ dst[i, j] = cast(src[i, j], rmode)
 | `src` | `pto.tile_buf` | Source tile |
 | `dst` | `pto.tile_buf` | Destination tile (different element type) |
 | `rmode` | `RoundModeAttr` (default: `CAST_RINT`) | Rounding mode |
+| `satmode` | `SaturationModeAttr` (default: `OFF`) | Saturation mode |
 
 **Results:** None. Writes into `dst` via DPS pattern.
 
 **Constraints & Verification:**
 
 - `dst` and `src` must be compatible in shape/valid region as required by the implementation.
+- `satmode = ON` requests destination-range clamping after rounding; `OFF` preserves the target's non-saturating conversion path.
 - **A2/A3 and A5 notes:**
   - The current implementation does not add extra compile-time or runtime checks for the type pair; unsupported conversions are target-defined.
 
@@ -7423,7 +7425,7 @@ dst[i, j] = cast(src[i, j], rmode)
 **Basic Example:**
 
 ```mlir
-pto.tcvt ins(%src {rmode = #pto<round_mode FLOOR>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+pto.tcvt ins(%src {rmode = #pto<round_mode FLOOR>, satmode = #pto<saturation_mode ON>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
          outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 ```
 

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3569,14 +3569,13 @@ def TCvtOp : PTO_TOp<"tcvt", [
   OpPipeInterface,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]> {
-  let summary = "Elementwise type conversion with optional tmp tile and saturation mode (tilebuf, DPS)";
+  let summary = "Elementwise type conversion with optional saturation mode (tilebuf, DPS)";
 
   let arguments = (ins
     PTODpsType:$src,
     PTODpsType:$dst,
-    Optional<PTODpsType>:$tmp,
     DefaultValuedAttr<PTO_RoundModeAttr, "::mlir::pto::RoundMode::CAST_RINT">:$rmode,
-    OptionalAttr<PTO_SaturationModeAttr>:$sat_mode
+    DefaultValuedAttr<PTO_SaturationModeAttr, "::mlir::pto::SaturationMode::OFF">:$sat_mode
   );
 
   let results = (outs);

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -4688,8 +4688,6 @@ llvm::LogicalResult mlir::pto::TCvtOp::verify() {
   if (failed(verifyTileBufCommon(*this, srcTy, "src")) ||
       failed(verifyTileBufCommon(*this, dstTy, "dst")))
     return failure();
-  if (getTmp() && failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp")))
-    return failure();
   if (getShapeVec(srcTy) != getShapeVec(dstTy))
     return emitOpError("expects src and dst to have compatible shapes");
   if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
@@ -6556,39 +6554,43 @@ LogicalResult MGatherOp::verify() {
 
 void mlir::pto::TCvtOp::print(OpAsmPrinter &p) {
   p << " ins(" << getSrc();
-  if (getTmp())
-    p << ", " << getTmp();
-  p.printOptionalAttrDict((*this)->getAttrs());
+  Builder builder(getContext());
+  NamedAttrList attrs;
+  for (auto attr : (*this)->getAttrs()) {
+    if (attr.getName() == "sat_mode") {
+      attrs.set(builder.getStringAttr("satmode"), attr.getValue());
+      continue;
+    }
+    attrs.set(attr.getName(), attr.getValue());
+  }
+  p.printOptionalAttrDict(attrs.getAttrs());
   p << " : " << getSrc().getType();
-  if (getTmp())
-    p << ", " << getTmp().getType();
   p << ") outs(" << getDst() << " : " << getDst().getType() << ")";
 }
 
 ParseResult mlir::pto::TCvtOp::parse(OpAsmParser &parser, OperationState &result) {
-  OpAsmParser::UnresolvedOperand src, tmp, dst;
-  Type srcTy, tmpTy, dstTy;
-  bool hasTmp = false;
+  OpAsmParser::UnresolvedOperand src, dst;
+  Type srcTy, dstTy;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
     return failure();
-  if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(tmp))
-      return failure();
-    hasTmp = true;
+  NamedAttrList attrs;
+  if (parser.parseOptionalAttrDict(attrs) || parser.parseColonType(srcTy))
+    return failure();
+  if (auto satmode = attrs.get("satmode")) {
+    attrs.erase("satmode");
+    if (attrs.get("sat_mode"))
+      return parser.emitError(parser.getCurrentLocation(),
+                              "cannot specify both satmode and sat_mode");
+    attrs.set("sat_mode", satmode);
   }
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColonType(srcTy))
-    return failure();
-  if (hasTmp && (parser.parseComma() || parser.parseType(tmpTy)))
-    return failure();
+  result.attributes = attrs;
   if (parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) || parser.parseRParen())
     return failure();
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
       parser.resolveOperand(dst, dstTy, result.operands))
-    return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
     return failure();
   return success();
 }
@@ -10339,9 +10341,6 @@ void TColSumOp::getEffects(
 void TCvtOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  auto tmp = getTmpMutable();
-  if (!tmp.empty())
-    PTO_ADD_WRITE(tmp[0]);
   PTO_ADD_WRITE(getDstMutable());
 }
 void TRandomOp::getEffects(

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -7646,7 +7646,7 @@ static std::string saturationModeTok(mlir::pto::SaturationModeAttr attr) {
   case SM::ON:  return "SaturationMode::ON";
   case SM::OFF: return "SaturationMode::OFF";
   }
-  return "SaturationMode::ON";
+  return "SaturationMode::OFF";
 }
 struct PTOCvtToEmitC : public OpConversionPattern<pto::TCvtOp> {
   using OpConversionPattern<pto::TCvtOp>::OpConversionPattern;
@@ -7658,7 +7658,6 @@ struct PTOCvtToEmitC : public OpConversionPattern<pto::TCvtOp> {
 
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
-    Value tmp = adaptor.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value{};
 
     pto::RoundModeAttr rmAttr = op.getRmodeAttr();
     std::string rmTok = rmAttr ? roundModeTok(rmAttr)
@@ -7667,17 +7666,14 @@ struct PTOCvtToEmitC : public OpConversionPattern<pto::TCvtOp> {
     Value rmodeVal = rewriter.create<emitc::ConstantOp>(
         loc, rmodeTy, emitc::OpaqueAttr::get(ctx, rmTok));
 
-    SmallVector<Value, 5> operands{dst, src};
-    if (tmp)
-      operands.push_back(tmp);
-    operands.push_back(rmodeVal);
+    auto satModeTy = emitc::OpaqueType::get(ctx, "SaturationMode");
+    auto satAttr = op.getSatModeAttr();
+    std::string satTok = satAttr ? saturationModeTok(satAttr)
+                                 : std::string("SaturationMode::OFF");
+    Value satModeVal = rewriter.create<emitc::ConstantOp>(
+        loc, satModeTy, emitc::OpaqueAttr::get(ctx, satTok));
 
-    if (auto satAttr = op.getSatModeAttr()) {
-      auto satModeTy = emitc::OpaqueType::get(ctx, "SaturationMode");
-      Value satModeVal = rewriter.create<emitc::ConstantOp>(
-          loc, satModeTy, emitc::OpaqueAttr::get(ctx, saturationModeTok(satAttr)));
-      operands.push_back(satModeVal);
-    }
+    SmallVector<Value, 4> operands{dst, src, rmodeVal, satModeVal};
 
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TCVT",

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -2449,17 +2449,11 @@ struct PTOViewToMemrefPass
 
         Value src = op.getSrc();
         Value dst = op.getDst();
-        Value tmp = op.getTmp();
 
         auto srcTy = dyn_cast<MemRefType>(src.getType());
         auto dstTy = dyn_cast<MemRefType>(dst.getType());
         if (!srcTy || !dstTy) {
           op.emitError("ins/outs are not memref yet");
-          signalPassFailure();
-          return;
-        }
-        if (tmp && !dyn_cast<MemRefType>(tmp.getType())) {
-          op.emitError("tmp is not memref yet");
           signalPassFailure();
           return;
         }
@@ -2472,7 +2466,6 @@ struct PTOViewToMemrefPass
             TypeRange{},
             src,
             dst,
-            tmp,
             rmodeAttr,
             satModeAttr);
 

--- a/test/lit/pto/tcvt_emitc.pto
+++ b/test/lit/pto/tcvt_emitc.pto
@@ -14,7 +14,7 @@
 //   - f32 -> f16 with the default rmode (CAST_RINT, attribute elided)
 //   - f32 -> bf16 with an explicit ROUND rmode
 //   - f32 -> i16 with explicit saturation mode
-//   - f32 -> i16 with tmp tile + explicit saturation mode
+//   - f32 -> i16 with explicit saturation mode
 
 module attributes {"pto.device-spec" = "Ascend910B3"} {
 
@@ -51,21 +51,20 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
     %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tcvt ins(%src {rmode = #pto<round_mode TRUNC>, sat_mode = #pto<saturation_mode OFF>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tcvt ins(%src {rmode = #pto<round_mode TRUNC>, satmode = #pto<saturation_mode OFF>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              outs(%dst : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     return
   }
 
   // -----------------------------------------------------------------------
-  // f32 -> i16 with tmp tile + explicit ON saturation mode
+  // f32 -> i16 with explicit ON saturation mode
   // -----------------------------------------------------------------------
-  func.func @tcvt_f32_to_i16_with_tmp() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @tcvt_f32_to_i16_sat_on() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
     %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tcvt ins(%src, %tmp {rmode = #pto<round_mode ROUND>, sat_mode = #pto<saturation_mode ON>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tcvt ins(%src {rmode = #pto<round_mode ROUND>, satmode = #pto<saturation_mode ON>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              outs(%dst : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     return
@@ -86,7 +85,7 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
 // A3:       RoundMode::CAST_TRUNC
 // A3:       TCVT(
 
-// A3-LABEL: AICORE void tcvt_f32_to_i16_with_tmp(
+// A3-LABEL: AICORE void tcvt_f32_to_i16_sat_on(
 // A3:       SaturationMode::ON
 // A3:       RoundMode::CAST_ROUND
 // A3:       TCVT(
@@ -104,7 +103,7 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
 // A5:       RoundMode::CAST_TRUNC
 // A5:       TCVT(
 
-// A5-LABEL: AICORE void tcvt_f32_to_i16_with_tmp(
+// A5-LABEL: AICORE void tcvt_f32_to_i16_sat_on(
 // A5:       SaturationMode::ON
 // A5:       RoundMode::CAST_ROUND
 // A5:       TCVT(

--- a/test/samples/Cvt/tcvt.py
+++ b/test/samples/Cvt/tcvt.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 """
-Elementwise type conversion: f32 -> i16 using pto.tcvt with tmp tile and
+Elementwise type conversion: f32 -> i16 using pto.tcvt with
 explicit saturation mode.
 
 Kernel signature:
@@ -98,10 +98,9 @@ def build():
 
                 tb_src = pto.AllocTileOp(tile_buf_f32).result
                 tb_dst = pto.AllocTileOp(tile_buf_i16).result
-                tb_tmp = pto.AllocTileOp(tile_buf_f32).result
 
                 pto.TLoadOp(None, sv_src, tb_src)
-                pto.TCvtOp(tb_src, tb_dst, tmp=tb_tmp, rmode=rmode_attr, sat_mode=sat_attr)
+                pto.TCvtOp(tb_src, tb_dst, rmode=rmode_attr, sat_mode=sat_attr)
                 pto.TStoreOp(None, tb_dst, sv_dst)
 
                 func.ReturnOp([])

--- a/test/samples/Cvt/tcvt_golden.py
+++ b/test/samples/Cvt/tcvt_golden.py
@@ -8,7 +8,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 """
-Golden generator for the tcvt sample (f32 -> i16 with tmp tile and sat_mode=ON).
+Golden generator for the tcvt sample (f32 -> i16 with sat_mode=ON).
 
 The input range intentionally stays inside int16 bounds so saturation mode is
 still exercised in lowering without making the numeric golden depend on

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -405,16 +405,12 @@ process_one_dir() {
     # these A5 repro/control samples, but ptobc v0 currently rejects this
     # form with "operand count mismatch for op: pto.alloc_tile".
     #
-    # tcvt.py intentionally exercises the new pto.tcvt(tmp, sat_mode) form for
-    # sample/board coverage. ptobc v0 still assumes the legacy 2-operand shape
-    # and currently fails with "operand count mismatch for op: pto.tcvt".
-    # Keep the sample in runop coverage, but bypass the bytecode roundtrip until
-    # ptobc learns the expanded operand layout.
+    # tcvt.py exercises explicit sat_mode coverage. Keep it in the generic
+    # roundtrip path once ptobc v0 understands the current tcvt schema.
     if [[ "$base" == "test_tmov_col_major_16x1_align_a5" || \
           "$base" == "test_tmov_row_major_1x16_control_a5" || \
           "$base" == "decode_projection_incore_0" || \
-          "$base" == "rmsnorm_incore_0" || \
-          "$base" == "tcvt" ]]; then
+          "$base" == "rmsnorm_incore_0" ]]; then
       sample_use_ptobc_roundtrip=0
     fi
     if [[ $sample_use_ptobc_roundtrip -eq 1 ]]; then

--- a/tools/ptobc/testdata/tcvt_satmode_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tcvt_satmode_v0_roundtrip.pto
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module {
+  func.func @tcvt_satmode_v0() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcvt ins(%src {rmode = #pto<round_mode TRUNC>, satmode = #pto<saturation_mode ON>} : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=i16, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -105,3 +105,10 @@ add_test(NAME ptobc_tdequant_v0_encode
     TESTDATA_DIR=${PTObc_TESTDATA_DIR}
     ${CMAKE_CURRENT_LIST_DIR}/tdequant_v0_encode.sh
 )
+
+add_test(NAME ptobc_tcvt_satmode_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/tcvt_satmode_v0_encode.sh
+)

--- a/tools/ptobc/tests/tcvt_satmode_v0_encode.sh
+++ b/tools/ptobc/tests/tcvt_satmode_v0_encode.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/tcvt_satmode_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_tcvt_satmode_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/tcvt_satmode_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/tcvt_satmode_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+grep -F "pto.tcvt ins(" "${ROUNDTRIP}" >/dev/null
+grep -F "satmode = #pto<saturation_mode ON>" "${ROUNDTRIP}" >/dev/null
+grep -F "rmode = #pto<round_mode TRUNC>" "${ROUNDTRIP}" >/dev/null


### PR DESCRIPTION
## Summary
- add optional saturation mode support to `pto.tcvt` with default `OFF`
- align `TCvtOp` schema and lowering with current pto-isa `TCVT(dst, src, rmode, satmode)` shape
- add ptobc v0 roundtrip coverage for `satmode`

## Details
- drop the half-landed `tmp` operand from `TCvtOp`
- accept issue syntax `satmode = #pto<saturation_mode ...>` in textual IR and print back the same spelling
- lower `pto.tcvt` to `TCVT(dst, src, RoundMode::..., SaturationMode::...)`
- restore `test/samples/Cvt/tcvt.py` to the generic ptobc roundtrip path

## Validation
- `cmake --build build-issue671-verify --target ptobc -j8`
- `ctest --test-dir build-issue671-verify -R ptobc_tcvt_satmode_v0_encode --output-on-failure`
- manual roundtrip check with `build-issue671-verify/tools/ptobc/ptobc encode/decode`

## Notes
- local `pto-opt` full build is currently blocked by unrelated repository-wide `-Werror` warnings on this macOS toolchain, but the tcvt-touched files (`PTO.cpp`, `PTOViewToMemref.cpp`, `PTOToEmitC.cpp`) were exercised in a relaxed local validation build.
