### PR TITLE
Fix redundant PIPE_V barriers for long-repeat vector chains

### DIFF
--- a/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
+++ b/include/PTO/Transforms/InsertSync/InsertSyncAnalysis.h
@@ -139,7 +139,13 @@ private:
                      CompoundInstanceElement *frontCompound,
                      SyncRecordList &syncRecordList, 
                      unsigned recordListIndex);
- 
+
+  bool CanPrunePipeVBarrier(
+      const CompoundInstanceElement *nowCompound,
+      const CompoundInstanceElement *frontCompound,
+      const DepBaseMemInfoPairVec &depBaseMemInfosVec,
+      const std::optional<unsigned> &forEndIndex) const;
+
   /// 更新 SyncRecord (当插入新同步后)
   void UpdateAlreadySync(const SyncOps &syncVector,
                          SyncRecordList &syncRecordList,

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -171,15 +171,6 @@ static bool containsExactAccess(const SmallVector<const BaseMemInfo *> &infos,
   });
 }
 
-static const BaseMemInfo *
-findExactAccess(const SmallVector<const BaseMemInfo *> &infos,
-                const BaseMemInfo *access) {
-  auto it = llvm::find_if(infos, [&](const BaseMemInfo *info) {
-    return isSameExactAccess(info, access);
-  });
-  return it == infos.end() ? nullptr : *it;
-}
-
 } // namespace
 
 static constexpr unsigned kPipeStateSize =
@@ -527,36 +518,25 @@ bool InsertSyncAnalysis::CanPrunePipeVBarrier(
   // a vector-pipe barrier once the producer repeat is large enough. Keep the
   // check conservative: all dependency pairs for this candidate must describe
   // the exact same access.
-  SmallVector<const BaseMemInfo *, 2> rawAccesses;
+  SmallVector<const BaseMemInfo *, 2> producerAccesses;
   for (const auto &pair : depBaseMemInfosVec) {
     if (!isSameExactAccess(pair.first, pair.second)) return false;
 
     if (containsExactAccess(nowCompound->useVec, pair.first) &&
         containsExactAccess(frontCompound->defVec, pair.second)) {
-      if (!llvm::is_contained(rawAccesses, pair.second))
-        rawAccesses.push_back(pair.second);
+      if (!llvm::is_contained(producerAccesses, pair.second))
+        producerAccesses.push_back(pair.second);
     } else {
       return false;
     }
   }
-  if (rawAccesses.empty()) return false;
+  if (producerAccesses.empty()) return false;
 
-  for (const BaseMemInfo *rawAccess : rawAccesses) {
-    const CompoundInstanceElement *nearestProducer = nullptr;
-    const BaseMemInfo *nearestProducerAccess = nullptr;
-    for (int index = static_cast<int>(nowCompound->GetIndex()) - 1; index >= 0;
-         --index) {
-      auto *compound = dyn_cast<CompoundInstanceElement>(syncIR_[index].get());
-      if (!compound || compound->kPipeValue != PipelineType::PIPE_V) continue;
-      nearestProducerAccess = findExactAccess(compound->defVec, rawAccess);
-      if (!nearestProducerAccess) continue;
-      nearestProducer = compound;
-      break;
-    }
-
-    if (!nearestProducer || !nearestProducerAccess) return false;
-
-    auto repeat = getRepeatCountForAccess(nearestProducerAccess->baseBuffer);
+  // The caller is analyzing this specific front->now dependency. Do not look
+  // for a later text-order writer here; it may belong to a different branch
+  // path or a zero-trip loop body.
+  for (const BaseMemInfo *producerAccess : producerAccesses) {
+    auto repeat = getRepeatCountForAccess(producerAccess->baseBuffer);
     if (!repeat || *repeat < kPipeVPruneMinRepeat) return false;
   }
 

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -53,6 +53,8 @@ static std::optional<RepeatAccessShape> getKnownRepeatAccessShapeFromType(Type t
     if (fullShape[0] < 0 || fullShape[1] < 0 || validShape[0] < 0 ||
         validShape[1] < 0)
       return std::nullopt;
+    if (validShape[0] > fullShape[0] || validShape[1] > fullShape[1])
+      return std::nullopt;
     return RepeatAccessShape{
         SmallVector<int64_t, 2>{fullShape[0], fullShape[1]},
         SmallVector<int64_t, 2>{validShape[0], validShape[1]},
@@ -87,7 +89,9 @@ static std::optional<RepeatAccessShape> getKnownRepeatAccessShape(Value access) 
     auto row = getConstantIndex(bind.getValidRow());
     auto col = getConstantIndex(bind.getValidCol());
     if (row && col) {
-      if (*row < 0 || *col < 0) return std::nullopt;
+      if (*row < 0 || *col < 0 || *row > shape->fullShape[0] ||
+          *col > shape->fullShape[1])
+        return std::nullopt;
       shape->validShape = SmallVector<int64_t, 2>{*row, *col};
     } else if (bind.getValidRow() || bind.getValidCol()) {
       return std::nullopt;

--- a/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/InsertSync/InsertSyncAnalysis.cpp
@@ -12,12 +12,17 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 #include "PTO/Transforms/InsertSync/InsertSyncAnalysis.h"
+#include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -28,6 +33,150 @@ using namespace mlir;
 using namespace mlir::pto;
 
 namespace mlir::pto {
+
+namespace {
+
+static constexpr uint64_t kVectorRegisterSizeInBytes = 256U;
+static constexpr unsigned kPipeVPruneMinRepeat = 16U;
+
+struct RepeatAccessShape {
+  SmallVector<int64_t, 2> fullShape;
+  SmallVector<int64_t, 2> validShape;
+  Type elementType;
+};
+
+static std::optional<RepeatAccessShape> getKnownRepeatAccessShapeFromType(Type ty) {
+  if (auto tileTy = dyn_cast<TileBufType>(ty)) {
+    ArrayRef<int64_t> fullShape = tileTy.getShape();
+    ArrayRef<int64_t> validShape = tileTy.getValidShape();
+    if (fullShape.size() != 2 || validShape.size() != 2) return std::nullopt;
+    if (fullShape[0] < 0 || fullShape[1] < 0 || validShape[0] < 0 ||
+        validShape[1] < 0)
+      return std::nullopt;
+    return RepeatAccessShape{
+        SmallVector<int64_t, 2>{fullShape[0], fullShape[1]},
+        SmallVector<int64_t, 2>{validShape[0], validShape[1]},
+        tileTy.getElementType()};
+  }
+
+  if (auto memRefTy = dyn_cast<MemRefType>(ty)) {
+    if (!memRefTy.hasStaticShape() || memRefTy.getRank() != 2)
+      return std::nullopt;
+    auto shape = memRefTy.getShape();
+    return RepeatAccessShape{SmallVector<int64_t, 2>{shape[0], shape[1]},
+                             SmallVector<int64_t, 2>{shape[0], shape[1]},
+                             memRefTy.getElementType()};
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<int64_t> getConstantIndex(Value value) {
+  if (!value) return std::nullopt;
+  APInt intValue;
+  if (!matchPattern(value, m_ConstantInt(&intValue))) return std::nullopt;
+  return intValue.getSExtValue();
+}
+
+static std::optional<RepeatAccessShape> getKnownRepeatAccessShape(Value access) {
+  if (!access) return std::nullopt;
+  auto shape = getKnownRepeatAccessShapeFromType(access.getType());
+  if (!shape) return std::nullopt;
+
+  if (auto bind = access.getDefiningOp<BindTileOp>()) {
+    auto row = getConstantIndex(bind.getValidRow());
+    auto col = getConstantIndex(bind.getValidCol());
+    if (row && col) {
+      if (*row < 0 || *col < 0) return std::nullopt;
+      shape->validShape = SmallVector<int64_t, 2>{*row, *col};
+    } else if (bind.getValidRow() || bind.getValidCol()) {
+      return std::nullopt;
+    }
+  }
+
+  return shape;
+}
+
+static std::optional<BLayout> getKnownBLayout(Type ty) {
+  if (auto tileTy = dyn_cast<TileBufType>(ty)) {
+    int32_t layout = tileTy.getBLayoutValueI32();
+    if (layout == static_cast<int32_t>(BLayout::RowMajor))
+      return BLayout::RowMajor;
+    if (layout == static_cast<int32_t>(BLayout::ColMajor))
+      return BLayout::ColMajor;
+  }
+
+  if (auto memRefTy = dyn_cast<MemRefType>(ty)) {
+    SmallVector<int64_t> strides;
+    int64_t offset = 0;
+    if (failed(getStridesAndOffset(memRefTy, strides, offset)) ||
+        strides.size() != 2) {
+      return std::nullopt;
+    }
+    ArrayRef<int64_t> shape = memRefTy.getShape();
+    if (strides[1] == 1 && strides[0] == shape[1]) return BLayout::RowMajor;
+    if (strides[0] == 1 && strides[1] == shape[0]) return BLayout::ColMajor;
+  }
+
+  return std::nullopt;
+}
+
+static bool isProvenContiguousAccess(Value access,
+                                     const RepeatAccessShape &shape) {
+  auto layout = getKnownBLayout(access.getType());
+  if (!layout) return false;
+
+  int64_t fullRow = shape.fullShape[0];
+  int64_t fullCol = shape.fullShape[1];
+  int64_t validRow = shape.validShape[0];
+  int64_t validCol = shape.validShape[1];
+
+  if (*layout == BLayout::RowMajor)
+    return validCol == fullCol || validRow == 1;
+  if (*layout == BLayout::ColMajor)
+    return validRow == fullRow || validCol == 1;
+  return false;
+}
+
+static std::optional<unsigned> getRepeatCountForAccess(Value access) {
+  if (!access) return std::nullopt;
+  auto shape = getKnownRepeatAccessShape(access);
+  if (!shape || !isProvenContiguousAccess(access, *shape)) return std::nullopt;
+
+  unsigned elemBytes = pto::getPTOStorageElemByteSize(shape->elementType);
+  if (elemBytes == 0) return std::nullopt;
+
+  uint64_t validElems = static_cast<uint64_t>(shape->validShape[0]) *
+                        static_cast<uint64_t>(shape->validShape[1]);
+  uint64_t elemsPerRepeat = kVectorRegisterSizeInBytes / elemBytes;
+  if (elemsPerRepeat == 0) return std::nullopt;
+
+  uint64_t repeat = (validElems + elemsPerRepeat - 1U) / elemsPerRepeat;
+  if (repeat > std::numeric_limits<unsigned>::max()) return std::nullopt;
+  return static_cast<unsigned>(repeat);
+}
+
+static bool isSameExactAccess(const BaseMemInfo *lhs, const BaseMemInfo *rhs) {
+  return lhs && rhs && *lhs == *rhs;
+}
+
+static bool containsExactAccess(const SmallVector<const BaseMemInfo *> &infos,
+                                const BaseMemInfo *access) {
+  return llvm::any_of(infos, [&](const BaseMemInfo *info) {
+    return isSameExactAccess(info, access);
+  });
+}
+
+static const BaseMemInfo *
+findExactAccess(const SmallVector<const BaseMemInfo *> &infos,
+                const BaseMemInfo *access) {
+  auto it = llvm::find_if(infos, [&](const BaseMemInfo *info) {
+    return isSameExactAccess(info, access);
+  });
+  return it == infos.end() ? nullptr : *it;
+}
+
+} // namespace
 
 static constexpr unsigned kPipeStateSize =
     static_cast<unsigned>(PipelineType::PIPE_LAST) + 1U;
@@ -305,6 +454,10 @@ void InsertSyncAnalysis::MemAnalyze(
     return;
   }
 
+  if (CanPrunePipeVBarrier(nowCompound, frontCompound, depVec, forEndIndex)) {
+    return;
+  }
+
   if (forEndIndex.has_value()) {
     int eventIdNum = GetEventIdNum(depVec);
     for (int i = 1; i < eventIdNum; i++) {
@@ -351,6 +504,59 @@ bool InsertSyncAnalysis::IsMemInfoHasDependency(
   }
 
   return hasDependency;
+}
+
+bool InsertSyncAnalysis::CanPrunePipeVBarrier(
+    const CompoundInstanceElement *nowCompound,
+    const CompoundInstanceElement *frontCompound,
+    const DepBaseMemInfoPairVec &depBaseMemInfosVec,
+    const std::optional<unsigned> &forEndIndex) const {
+  if (forEndIndex.has_value()) return false;
+  if (!nowCompound || !frontCompound) return false;
+  if (nowCompound->kPipeValue != PipelineType::PIPE_V ||
+      frontCompound->kPipeValue != PipelineType::PIPE_V) {
+    return false;
+  }
+
+  // PIPE_V has a hardware-safe same-access chain case: exact same-access
+  // dependencies from the producer result to the consumer source do not require
+  // a vector-pipe barrier once the producer repeat is large enough. Keep the
+  // check conservative: all dependency pairs for this candidate must describe
+  // the exact same access.
+  SmallVector<const BaseMemInfo *, 2> rawAccesses;
+  for (const auto &pair : depBaseMemInfosVec) {
+    if (!isSameExactAccess(pair.first, pair.second)) return false;
+
+    if (containsExactAccess(nowCompound->useVec, pair.first) &&
+        containsExactAccess(frontCompound->defVec, pair.second)) {
+      if (!llvm::is_contained(rawAccesses, pair.second))
+        rawAccesses.push_back(pair.second);
+    } else {
+      return false;
+    }
+  }
+  if (rawAccesses.empty()) return false;
+
+  for (const BaseMemInfo *rawAccess : rawAccesses) {
+    const CompoundInstanceElement *nearestProducer = nullptr;
+    const BaseMemInfo *nearestProducerAccess = nullptr;
+    for (int index = static_cast<int>(nowCompound->GetIndex()) - 1; index >= 0;
+         --index) {
+      auto *compound = dyn_cast<CompoundInstanceElement>(syncIR_[index].get());
+      if (!compound || compound->kPipeValue != PipelineType::PIPE_V) continue;
+      nearestProducerAccess = findExactAccess(compound->defVec, rawAccess);
+      if (!nearestProducerAccess) continue;
+      nearestProducer = compound;
+      break;
+    }
+
+    if (!nearestProducer || !nearestProducerAccess) return false;
+
+    auto repeat = getRepeatCountForAccess(nearestProducerAccess->baseBuffer);
+    if (!repeat || *repeat < kPipeVPruneMinRepeat) return false;
+  }
+
+  return true;
 }
 
 void InsertSyncAnalysis::InsertSyncOperation(

--- a/test/lit/pto/issue646_pipev_repeat_prune.pto
+++ b/test/lit/pto/issue646_pipev_repeat_prune.pto
@@ -1,0 +1,91 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  // CHECK-LABEL: AICORE void pipev_repeat16_skip(
+  // CHECK: TADD(
+  // CHECK-NOT: pipe_barrier(PIPE_V);
+  // CHECK: TROWEXPANDDIV(
+  func.func @pipev_repeat16_skip() {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %acc = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scale = pto.alloc_tile addr = %c8192_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%acc, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpanddiv ins(%acc, %scale : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  // CHECK-LABEL: AICORE void pipev_repeat15_keep(
+  // CHECK: TADD(
+  // CHECK: pipe_barrier(PIPE_V);
+  // CHECK: TROWEXPANDDIV(
+  func.func @pipev_repeat15_keep() {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %acc = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=15, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=15, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scale = pto.alloc_tile addr = %c12288_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=15, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%acc, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=15, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=15, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=15, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpanddiv ins(%acc, %scale : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=15, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=15, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=15, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  // CHECK-LABEL: AICORE void pipev_noncontiguous_repeat_keep(
+  // CHECK: TADD(
+  // CHECK: pipe_barrier(PIPE_V);
+  // CHECK: TROWEXPANDDIV(
+  func.func @pipev_noncontiguous_repeat_keep() {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %acc = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=15, v_col=65, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=15, v_col=65, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scale = pto.alloc_tile addr = %c8192_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=15, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%acc, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=15, v_col=65, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=15, v_col=65, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=15, v_col=65, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpanddiv ins(%acc, %scale : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=15, v_col=65, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=15, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=15, v_col=65, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  // CHECK-LABEL: AICORE void pipev_interleaved_disjoint_skip(
+  // CHECK: TADD(
+  // CHECK: TADD(
+  // CHECK-NOT: pipe_barrier(PIPE_V);
+  // CHECK: TROWEXPANDDIV(
+  func.func @pipev_interleaved_disjoint_skip() {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %acc = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scale = pto.alloc_tile addr = %c8192_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile addr = %c12288_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp_src = pto.alloc_tile addr = %c16384_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%acc, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tadd ins(%tmp, %tmp_src : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpanddiv ins(%acc, %scale : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  // CHECK-LABEL: AICORE void pipev_mixed_tmp_waw_keep(
+  // CHECK: TROWEXPANDMUL(
+  // CHECK: pipe_barrier(PIPE_V);
+  // CHECK: TROWEXPANDDIV(
+  func.func @pipev_mixed_tmp_waw_keep() {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %acc = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scale = pto.alloc_tile addr = %c4096_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile addr = %c8192_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %scale2 = pto.alloc_tile addr = %c12288_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowexpandmul ins(%acc, %scale, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trowexpanddiv ins(%acc, %scale2, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%acc : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}


### PR DESCRIPTION
Summary
- Prune redundant same-pipe PIPE_V barriers for exact same-access vector producer/consumer chains when the producer repeat is at least 16.
- Keep the pruning conservative: loop back-edges, non-exact accesses, repeat < 16, and vmla/vmadd pairs still keep their barriers.
- Add lit coverage for repeat >= 16 pruning, repeat < 16 retention, and interleaved disjoint vector chains.

Motivation
- Fixes #646.

Design
- The decision is made during insert-sync analysis after a dependency is found and before emitting the sync operation.
- Repeat is derived from known valid tile shape and element byte width: ceil(valid_row * valid_col / (256 / sizeof(T))).
- For interleaved vector work, the analysis looks at the nearest previous PIPE_V producer of the same exact access, so unrelated vector work does not force the barrier to remain.

Testing
- ninja -C build-issue667 ptoas
- /Users/lishengtao/Workspace/PTO/llvm-project/build-shared/bin/llvm-lit -v build-issue667/test/lit --filter 'issue646_pipev_repeat_prune|issue667_(subview_disjoint|tload_overlap)|issue533_loop_zero_trip_sync_regression|issue667|tinsert_a3_pipe_selection|tinsert_a2a3_vec_vec_pipe_selection|issue664_mscatter_pipe_selection'
- Regenerated the issue #646 sample with --pto-arch=a3 --enable-insert-sync; PIPE_V barrier count dropped from 135 to 87 and the final normalize barrier before TROWEXPANDDIV is removed.

Risk / Rollback
- Risk is limited to same-pipe vector barrier pruning for exact same-access long-repeat chains.
- Rollback by reverting this PR.

Review Focus
- Confirm the repeat computation matches the hardware repeat definition.
- Confirm the exact-access and nearest-producer checks are conservative enough for interleaved vector sequences.
- Confirm vmla/vmadd and loop back-edge cases remain protected.