### PR TITLE
Fix PTOAS warning build failures

### DIFF
--- a/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
+++ b/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
@@ -58,8 +58,8 @@ private:
   // 核心数据结构 (定义在 SyncCommon.h 中)
   SyncIRs &syncIR_;
   Buffer2MemInfoMap &buffer2MemInfoMap_;
-  MemoryDependentAnalyzer &memAnalyzer_;
-  SyncAnalysisMode mode_;
+  [[maybe_unused]] MemoryDependentAnalyzer &memAnalyzer_;
+  [[maybe_unused]] SyncAnalysisMode mode_;
  
   // --- 递归遍历逻辑 ---
   void RecursionIR(Region *region);

--- a/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
+++ b/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
@@ -37,7 +37,10 @@ public:
       syncIR_(syncIR), 
       buffer2MemInfoMap_(buffer2MemInfoMap),
       memAnalyzer_(memDepAnalyzer),
-      mode_(syncAnalysisMode) { };
+      mode_(syncAnalysisMode) {
+    (void)memAnalyzer_;
+    (void)mode_;
+  };
  
   // 核心入口：执行 IR 分析和转换
   void Build();
@@ -58,8 +61,8 @@ private:
   // 核心数据结构 (定义在 SyncCommon.h 中)
   SyncIRs &syncIR_;
   Buffer2MemInfoMap &buffer2MemInfoMap_;
-  [[maybe_unused]] MemoryDependentAnalyzer &memAnalyzer_;
-  [[maybe_unused]] SyncAnalysisMode mode_;
+  MemoryDependentAnalyzer &memAnalyzer_;
+  SyncAnalysisMode mode_;
  
   // --- 递归遍历逻辑 ---
   void RecursionIR(Region *region);

--- a/lib/PTO/IR/PTOSyncUtils.cpp
+++ b/lib/PTO/IR/PTOSyncUtils.cpp
@@ -44,9 +44,8 @@ PIPE mlir::pto::mapSyncOpTypeToPipe(SyncOpType opType) {
   case SyncOpType::TVEC:
   case SyncOpType::TVECWAIT_EVENT:
     return PIPE::PIPE_V;
-  default:
-    return PIPE::PIPE_UNASSIGNED;
   }
+  return PIPE::PIPE_UNASSIGNED;
 }
 
 bool mlir::pto::isConcreteSyncPipe(PIPE pipe) {

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -530,6 +530,9 @@ Type TileBufType::parse(AsmParser &parser) {
 static llvm::StringRef stringifyLocFromMemorySpace(mlir::Attribute memorySpace) {
   auto asAttr = llvm::dyn_cast_or_null<AddressSpaceAttr>(memorySpace);
   switch (asAttr.getAddressSpace()) {
+    case AddressSpace::Zero:
+    case AddressSpace::GM:
+      return "illegal";
     case AddressSpace::MAT: return "mat";
     case AddressSpace::LEFT: return "left";
     case AddressSpace::RIGHT: return "right";
@@ -537,8 +540,8 @@ static llvm::StringRef stringifyLocFromMemorySpace(mlir::Attribute memorySpace) 
     case AddressSpace::VEC: return "vec";
     case AddressSpace::BIAS: return "bias";
     case AddressSpace::SCALING: return "scaling";
-    default: return "illegal";
   }
+  return "illegal";
 }
 
 static llvm::StringRef stringifyLocFromPad(mlir::Attribute pad) {
@@ -550,9 +553,8 @@ static llvm::StringRef stringifyLocFromPad(mlir::Attribute pad) {
     case PadValue::Zero: return "1";
     case PadValue::Max: return "2";
     case PadValue::Min: return "3";
-    default:
-      return "9999";
   }
+  return "9999";
 }
 
 static llvm::StringRef stringifyCompactModeInt(mlir::Attribute compactMode) {
@@ -567,9 +569,8 @@ static llvm::StringRef stringifyCompactModeInt(mlir::Attribute compactMode) {
     return "1";
   case CompactMode::RowPlusOne:
     return "2";
-  default:
-    return "9999";
   }
+  return "9999";
 }
 
 static void printTileBufDim(AsmPrinter &printer, int64_t dim) {

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -117,9 +117,9 @@ static const char *addrSpaceQualifier(pto::AddressSpace as) {
   return "__gm__";
 }
 
-static constexpr llvm::StringLiteral kLoweredSetValidShapeAttrName =
+[[maybe_unused]] static constexpr llvm::StringLiteral kLoweredSetValidShapeAttrName =
     "__pto.lowered_set_validshape";
-static constexpr llvm::StringLiteral kLoweredSetValidShapeConfigAttrName =
+[[maybe_unused]] static constexpr llvm::StringLiteral kLoweredSetValidShapeConfigAttrName =
     "__pto.lowered_set_validshape_config";
 static constexpr llvm::StringLiteral kForceDynamicValidShapeAttrName =
     "__pto.force_dynamic_valid_shape";
@@ -479,8 +479,8 @@ public:
     // ---------------------------------------------------------
     // 2. PTO 特殊类型 (透传或转换)
     // ---------------------------------------------------------
-    addConversion([Ctx](emitc::OpaqueType type) { return type; });
-    addConversion([Ctx](emitc::PointerType type) { return type; });
+    addConversion([](emitc::OpaqueType type) { return type; });
+    addConversion([](emitc::PointerType type) { return type; });
 
     // ---------------------------------------------------------
     // 2.5 PtrType 转换 (指针类型)
@@ -3124,7 +3124,8 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
           }
         }
 
-        auto typedPtrTy = emitc::OpaqueType::get(ctx, qualifier + " " + castElemTypeStr + "*");
+        auto typedPtrTy = emitc::PointerType::get(
+            emitc::OpaqueType::get(ctx, qualifier + " " + castElemTypeStr));
         Value typedSourcePtr = rewriter.create<emitc::CastOp>(loc, typedPtrTy, sourcePtr);
         newPtr = rewriter.create<emitc::AddOp>(loc, typedPtrTy, typedSourcePtr, totalOffset);
       } else {
@@ -3659,7 +3660,8 @@ static Value maybeWrapGlobalMemrefAsGlobalTensor(
 static Value castToGMBytePointer(ConversionPatternRewriter &rewriter,
                                  Location loc, Value value) {
   auto *ctx = rewriter.getContext();
-  auto targetTy = emitc::OpaqueType::get(ctx, "__gm__ uint8_t*");
+  auto targetTy =
+      emitc::PointerType::get(emitc::OpaqueType::get(ctx, "__gm__ uint8_t"));
   if (value.getType() == targetTy)
     return value;
 
@@ -4379,9 +4381,9 @@ static ArrayAttr buildAccPhaseTemplateArgs(ConversionPatternRewriter &rewriter,
   case pto::AccPhase::Final:
     tmpl = "AccPhase::Final";
     break;
-  default:
-    llvm_unreachable("unknown AccPhase");
   }
+  if (tmpl.empty())
+    return ArrayAttr{};
   return rewriter.getArrayAttr(
       {emitc::OpaqueAttr::get(rewriter.getContext(), tmpl)});
 }
@@ -4806,7 +4808,7 @@ static LogicalResult extractSyncTripletTokens(Operation *op,
 static inline std::string pipeTokFromPipeEnum(mlir::pto::PIPE p) {
   return mlir::pto::stringifyPIPE(p).str();
 }
-static inline std::string evtTokFromEventEnum(mlir::pto::EVENT e) {
+[[maybe_unused]] static inline std::string evtTokFromEventEnum(mlir::pto::EVENT e) {
   return mlir::pto::stringifyEVENT(e).str();
 }
 static inline std::string pipeTokFromPipeAttr(mlir::pto::PipeAttr a) {
@@ -5719,7 +5721,8 @@ struct PTOInitializeL2LPipeToEmitC
     auto emitPipeTy =
         cast<Type>(getTypeConverter()->convertType(op.getPipe().getType()));
 
-    auto gmPtrTy = emitc::OpaqueType::get(ctx, "__gm__ void *");
+    auto gmPtrTy =
+        emitc::PointerType::get(emitc::OpaqueType::get(ctx, "__gm__ void"));
     Value nullGm =
         makeEmitCOpaqueConstant(rewriter, op.getLoc(), gmPtrTy, "nullptr");
     auto i32Ty = emitc::OpaqueType::get(ctx, "int32_t");
@@ -11095,7 +11098,6 @@ public:
       case arith::CmpIPredicate::ule: emitcPred = emitc::CmpPredicate::le; break;
       case arith::CmpIPredicate::ugt: emitcPred = emitc::CmpPredicate::gt; break;
       case arith::CmpIPredicate::uge: emitcPred = emitc::CmpPredicate::ge; break;
-      default: return failure();
     }
 
     Type resTy = getTypeConverter()->convertType(op.getType());

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -11080,7 +11080,7 @@ public:
 
     // 将 arith.cmpi 转换为 emitc.cmp
     // 映射 Predicate: eq -> equal, slt -> less, etc.
-    emitc::CmpPredicate emitcPred;
+    emitc::CmpPredicate emitcPred = emitc::CmpPredicate::eq;
     const bool isUnsignedPred =
         op.getPredicate() == arith::CmpIPredicate::ult ||
         op.getPredicate() == arith::CmpIPredicate::ule ||


### PR DESCRIPTION
修复 macOS/Clang 和gitcode/gcc下 ninja -C build install 的 -Werror 构建失败。

主要清理了几处会被 Clang 视为错误的编译告警：

1. 去掉已覆盖全部枚举值的 switch 中多余的 default 分支，并补充必要的兜底返回
2. 补全 AddressSpace 的 Zero / GM 分支映射，消除未处理枚举告警
3. 删除 PTOToEmitC 中未使用的 lambda capture
4. 将当前未使用但保留设计意图的字段、常量和辅助函数显式标记为 [[maybe_unused]]