### PR TITLE
ci: unify pto-isa pin default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
           SKIP_CASES: ${{ github.event.inputs.skip_cases || '' }}
           RUN_ONLY_CASES: ${{ github.event.inputs.run_only_cases || '' }}
           PTO_ISA_REPO: ${{ github.event.inputs.pto_isa_repo || 'https://gitcode.com/cann/pto-isa.git' }}
-          PTO_ISA_COMMIT: ${{ github.event.inputs.pto_isa_commit || '5dbf1b2f6b8ea934f03e62367c2f540ece21134e' }}
+          PTO_ISA_COMMIT: ${{ github.event.inputs.pto_isa_commit || '662d7f2a916d6bbde3109ce4a16ed5c28f5d900a' }}
           REMOTE_HOST: ${{ github.event.inputs.remote_host || '101.245.68.6' }}
           REMOTE_USER: ${{ github.event.inputs.remote_user || 'zhongxuan' }}
           REMOTE_PORT: ${{ github.event.inputs.remote_port || '22' }}

--- a/.github/workflows/update_pto_isa_pin.yml
+++ b/.github/workflows/update_pto_isa_pin.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   update-pto-isa-pin:
-    if: github.repository == 'zhangstevenunity/PTOAS'
+    if: github.repository == 'hw-native-sys/PTOAS'
     runs-on: ubuntu-22.04
     env:
       AUTOMATION_TOKEN: ${{ secrets.WORKFLOW_BOT_TOKEN || secrets.RELEASE_BOT_TOKEN || '' }}


### PR DESCRIPTION
## Summary
- unify the remote board-validation fallback `PTO_ISA_COMMIT` with the `workflow_dispatch` default
- keep the runtime default aligned with the repo-pinned `docker/Dockerfile` commit

## Notes
- the repo already has a weekly pto-isa pin updater in `.github/workflows/update_pto_isa_pin.yml`
- that workflow currently runs only when `github.repository == "zhangstevenunity/PTOAS"`, so it does not auto-update pins in `hw-native-sys/PTOAS` or forks

## Verification
- `python3 .github/scripts/update_pto_isa_pin.py --commit 662d7f2a916d6bbde3109ce4a16ed5c28f5d900a --check`