### PR TITLE
fix: align thistogram HistByte support with PTO-ISA

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -4579,6 +4579,10 @@ The exact accumulation performed inside the selected bin is target-defined by th
 | `dst` | `pto.tile_buf` | Destination histogram tile |
 | `byte` | `I32Attr` (default: `1`) | Selects `THISTOGRAM<HistByte::BYTE_<byte>>`, valid range `[0, 3]` |
 
+Legacy inputs using `isMSB` are accepted for compatibility: `isMSB = false`
+maps to `byte = 0`, and `isMSB = true` maps to `byte = 1`. Specifying both
+`byte` and a conflicting legacy `isMSB` is rejected.
+
 **Results:** None. Writes into `dst` via DPS pattern.
 
 **Assembly Format:**

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -4554,26 +4554,30 @@ pto.trowprod ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=i16, rows=16, cols=16
 
 ##### `pto.thistogram` - Row-wise Histogram Accumulation
 
-**Summary:** Updates a 256-bin histogram row in `dst` using each source row and a per-row index selector. This op is only supported on A5.
+**Summary:** Updates a 256-bin histogram row in `dst` using A5 `THISTOGRAM` modes selected by the `byte` attribute.
 
 **Semantics:**
 
 ```
-For each row i:
-    bin = idx[i, 0]
-    dst[i, bin] = histogram_update(dst[i, bin], src[i, :])
+For `src : ui16`, each row updates one histogram bin selected by `idx[i, 0]`.
+
+For `src : ui32`, the exact filtering behavior is defined by the backend `THISTOGRAM<HistByte::BYTE_n>` intrinsic:
+- `byte = 3`: histogram byte 3 directly
+- `byte = 2`: histogram byte 2, filtered by byte 3
+- `byte = 1`: histogram byte 1, filtered by bytes 3 and 2
+- `byte = 0`: histogram byte 0, filtered by bytes 3, 2, and 1
 ```
 
-The exact accumulation performed inside the selected bin is target-defined by the hardware `THISTOGRAM` intrinsic. The `isMSB` attribute selects the intrinsic mode.
+The exact accumulation performed inside the selected bin is target-defined by the hardware `THISTOGRAM` intrinsic. The `byte` attribute maps directly to `HistByte::BYTE_<byte>`.
 
 **Arguments:**
 
 | Name | Type | Description |
 |------|------|-------------|
-| `src` | `pto.tile_buf` | Source tile buffer, one logical row per histogram update |
-| `idx` | `pto.tile_buf` | Per-row bin selector tile |
+| `src` | `pto.tile_buf` | Source tile buffer (`ui16` or `ui32`) |
+| `idx` | `pto.tile_buf` | Selector/filter tile interpreted according to `src` dtype and `byte` |
 | `dst` | `pto.tile_buf` | Destination histogram tile |
-| `isMSB` | `BoolAttr` (default: `true`) | Selects the `THISTOGRAM<...>` intrinsic mode |
+| `byte` | `I32Attr` (default: `1`) | Selects `THISTOGRAM<HistByte::BYTE_<byte>>`, valid range `[0, 3]` |
 
 **Results:** None. Writes into `dst` via DPS pattern.
 
@@ -4582,7 +4586,7 @@ The exact accumulation performed inside the selected bin is target-defined by th
 ```
 pto.thistogram ins(<src>, <idx> : <src_type>, <idx_type>)
                outs(<dst> : <dst_type>)
-               {isMSB = true}
+               {byte = 1 : i32}
 ```
 
 **Constraints & Verification:**
@@ -4592,15 +4596,22 @@ pto.thistogram ins(<src>, <idx> : <src_type>, <idx_type>)
 - **Implementation checks (A5)**
   - `src`, `idx`, and `dst` must all be `tile_buf` values in `loc=vec`.
   - `src` and `dst` must use `row_major + none_box` layout.
-  - `idx` must use DN-style layout (`col_major + none_box`).
-  - `src` element type must be `ui16`.
+  - `src` element type must be `ui16` or `ui32`.
   - `idx` element type must be `ui8`.
   - `dst` element type must be `ui32`.
+  - `byte` must be in `[0, 3]`.
   - `src`, `idx`, and `dst` must all be rank-2 tiles.
-  - `idx` rows and valid rows must match `src`.
   - `dst` rows and valid rows must match `src`.
-  - `idx` must have exactly one column.
   - `dst` shape[1] and valid_shape[1] must be at least `256`.
+  - When `src` is `ui16`:
+    - `byte` must be `0` or `1`.
+    - `idx` must use DN-style layout (`col_major + none_box`).
+    - `idx` rows and valid rows must match `src`.
+    - `idx` must have exactly one column.
+  - When `src` is `ui32`:
+    - `idx` must use `row_major + none_box` layout.
+    - `idx` cols and valid cols must match `src`.
+    - `idx` rows / valid rows must be `1` for `byte = 3` or `2`, `2` for `byte = 1`, and `3` for `byte = 0`.
 
 **Hardware Mapping:**
 
@@ -4618,7 +4629,7 @@ pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=8, cols=
                    fractal=512, pad=0>)
                outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256,
                    v_row=8, v_col=256, blayout=row_major, slayout=none_box,
-                   fractal=512, pad=0>) {isMSB = false}
+                   fractal=512, pad=0>) {byte = 0 : i32}
 ```
 
 ---

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2775,7 +2775,7 @@ def THistogramOp : PTO_TOp<"thistogram", [
     PTODpsType:$src,
     PTODpsType:$idx,
     PTODpsType:$dst,
-    DefaultValuedOptionalAttr<BoolAttr, "true">:$isMSB
+    DefaultValuedOptionalAttr<I32Attr, "1">:$byte
   );
 
   let results = (outs);

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -6663,8 +6663,15 @@ LogicalResult THistogramOp::verify() {
     return it && it.getWidth() == width;
   };
   int64_t byte = 1;
-  if (auto byteAttr = getByteAttr())
+  auto byteAttr = getByteAttr();
+  if (byteAttr)
     byte = byteAttr.getInt();
+  if (auto legacyIsMSB = (*this)->getAttrOfType<BoolAttr>("isMSB")) {
+    int64_t legacyByte = legacyIsMSB.getValue() ? 1 : 0;
+    if (byteAttr && byte != legacyByte)
+      return emitOpError("does not allow conflicting 'byte' and legacy 'isMSB' attributes");
+    byte = legacyByte;
+  }
   if (byte < 0 || byte > 3)
     return emitOpError("expects byte to be in range [0, 3]");
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -6662,6 +6662,9 @@ LogicalResult THistogramOp::verify() {
     auto it = dyn_cast<IntegerType>(ty);
     return it && it.getWidth() == width;
   };
+  auto byte = getByte();
+  if (byte < 0 || byte > 3)
+    return emitOpError("expects byte to be in range [0, 3]");
 
   auto verifyA2A3 = [&]() -> LogicalResult {
     return emitOpError("thistogram is only supported on A5");
@@ -6697,13 +6700,11 @@ LogicalResult THistogramOp::verify() {
     if (dstTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
         dstTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
       return emitOpError("expects dst to use row_major + none_box layout");
-    if (idxTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
-        idxTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
-      return emitOpError(
-          "expects idx to use DN layout (col_major + none_box)");
 
-    if (!isIntegerWidth(getElemTy(srcTy), 16))
-      return emitOpError("expects src element type to be ui16");
+    bool srcIsUi16 = isIntegerWidth(getElemTy(srcTy), 16);
+    bool srcIsUi32 = isIntegerWidth(getElemTy(srcTy), 32);
+    if (!srcIsUi16 && !srcIsUi32)
+      return emitOpError("expects src element type to be ui16 or ui32");
     if (!isIntegerWidth(getElemTy(idxTy), 8))
       return emitOpError("expects idx element type to be ui8");
     if (!isIntegerWidth(getElemTy(dstTy), 32))
@@ -6720,15 +6721,40 @@ LogicalResult THistogramOp::verify() {
       return emitOpError(
           "expects src, idx, and dst to have rank-2 shape and valid_shape");
 
-    if (!hasCompatibleKnownExtent(srcShape[0], idxShape[0]) ||
-        !hasCompatibleKnownExtent(srcValid[0], idxValid[0]))
-      return emitOpError("expects idx rows and valid rows to match src");
     if (!hasCompatibleKnownExtent(srcShape[0], dstShape[0]) ||
         !hasCompatibleKnownExtent(srcValid[0], dstValid[0]))
       return emitOpError("expects dst rows and valid rows to match src");
 
-    if (!isKnownUnitExtent(idxShape[1]) || !isKnownUnitExtent(idxValid[1]))
-      return emitOpError("expects idx to have exactly one column");
+    if (srcIsUi16) {
+      if (byte > 1)
+        return emitOpError("expects byte to be 0 or 1 when src element type is ui16");
+      if (idxTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
+          idxTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+        return emitOpError(
+            "expects idx to use DN layout (col_major + none_box) when src element type is ui16");
+      if (!hasCompatibleKnownExtent(srcShape[0], idxShape[0]) ||
+          !hasCompatibleKnownExtent(srcValid[0], idxValid[0]))
+        return emitOpError("expects idx rows and valid rows to match src when src element type is ui16");
+      if (!isKnownUnitExtent(idxShape[1]) || !isKnownUnitExtent(idxValid[1]))
+        return emitOpError("expects idx to have exactly one column when src element type is ui16");
+    } else {
+      if (idxTB.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::RowMajor) ||
+          idxTB.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::NoneBox))
+        return emitOpError(
+            "expects idx to use row_major + none_box layout when src element type is ui32");
+      if (!hasCompatibleKnownExtent(srcShape[1], idxShape[1]) ||
+          !hasCompatibleKnownExtent(srcValid[1], idxValid[1]))
+        return emitOpError("expects idx cols and valid cols to match src when src element type is ui32");
+
+      int64_t expectedIdxRows = 1;
+      if (byte == 1)
+        expectedIdxRows = 2;
+      else if (byte == 0)
+        expectedIdxRows = 3;
+      if (!hasCompatibleKnownExtent(idxShape[0], expectedIdxRows) ||
+          !hasCompatibleKnownExtent(idxValid[0], expectedIdxRows))
+        return emitOpError("expects idx rows/valid rows to match the byte-selected filter depth when src element type is ui32");
+    }
     if (dstShape[1] != ShapedType::kDynamic && dstShape[1] < 256)
       return emitOpError("expects dst shape[1] to be at least 256");
     if (dstValid[1] != ShapedType::kDynamic && dstValid[1] < 256)

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -6662,7 +6662,9 @@ LogicalResult THistogramOp::verify() {
     auto it = dyn_cast<IntegerType>(ty);
     return it && it.getWidth() == width;
   };
-  auto byte = getByte();
+  int64_t byte = 1;
+  if (auto byteAttr = getByteAttr())
+    byte = byteAttr.getInt();
   if (byte < 0 || byte > 3)
     return emitOpError("expects byte to be in range [0, 3]");
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5736,8 +5736,16 @@ struct PTOHistogramToEmitC : public OpConversionPattern<pto::THistogramOp> {
 
     StringRef histByte = "HistByte::BYTE_1";
     int64_t byte = 1;
-    if (auto byteAttr = op.getByteAttr())
+    auto byteAttr = op.getByteAttr();
+    if (byteAttr)
       byte = byteAttr.getInt();
+    if (auto legacyIsMSB = op->getAttrOfType<BoolAttr>("isMSB")) {
+      int64_t legacyByte = legacyIsMSB.getValue() ? 1 : 0;
+      if (byteAttr && byte != legacyByte)
+        return rewriter.notifyMatchFailure(
+            op, "conflicting 'byte' and legacy 'isMSB' attributes");
+      byte = legacyByte;
+    }
     switch (byte) {
     case 0:
       histByte = "HistByte::BYTE_0";

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5734,8 +5734,26 @@ struct PTOHistogramToEmitC : public OpConversionPattern<pto::THistogramOp> {
     Value idx = peelUnrealized(adaptor.getIdx());
     Value dst = peelUnrealized(adaptor.getDst());
 
-    auto templateArgs = rewriter.getArrayAttr({emitc::OpaqueAttr::get(
-        ctx, op.getIsMSB() ? "HistByte::BYTE_1" : "HistByte::BYTE_0")});
+    StringRef histByte = "HistByte::BYTE_1";
+    switch (op.getByte()) {
+    case 0:
+      histByte = "HistByte::BYTE_0";
+      break;
+    case 1:
+      histByte = "HistByte::BYTE_1";
+      break;
+    case 2:
+      histByte = "HistByte::BYTE_2";
+      break;
+    case 3:
+      histByte = "HistByte::BYTE_3";
+      break;
+    default:
+      return rewriter.notifyMatchFailure(op, "expected byte to be in range [0, 3]");
+    }
+
+    auto templateArgs =
+        rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, histByte)});
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "THISTOGRAM",
         /*args=*/ArrayAttr{}, /*templateArgs=*/templateArgs,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5735,7 +5735,10 @@ struct PTOHistogramToEmitC : public OpConversionPattern<pto::THistogramOp> {
     Value dst = peelUnrealized(adaptor.getDst());
 
     StringRef histByte = "HistByte::BYTE_1";
-    switch (op.getByte()) {
+    int64_t byte = 1;
+    if (auto byteAttr = op.getByteAttr())
+      byte = byteAttr.getInt();
+    switch (byte) {
     case 0:
       histByte = "HistByte::BYTE_0";
       break;

--- a/test/lit/pto/thistogram_emitc.pto
+++ b/test/lit/pto/thistogram_emitc.pto
@@ -10,7 +10,7 @@ module {
     pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
                    outs(%dst0 : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
-                   outs(%dst1 : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {isMSB = false}
+                   outs(%dst1 : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = 0 : i32}
     return
   }
 }

--- a/test/lit/pto/thistogram_emitc_u32.pto
+++ b/test/lit/pto/thistogram_emitc_u32.pto
@@ -1,0 +1,31 @@
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @thistogram_emitc_u32() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx3 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=2, cols=32, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=3, cols=32, v_row=3, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst3 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst2 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.thistogram ins(%src, %idx3 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst3 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = 3 : i32}
+    pto.thistogram ins(%src, %idx2 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst2 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = 2 : i32}
+    pto.thistogram ins(%src, %idx1 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=2, cols=32, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst1 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.thistogram ins(%src, %idx0 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=3, cols=32, v_row=3, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst0 : !pto.tile_buf<loc=vec, dtype=ui32, rows=8, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = 0 : i32}
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void thistogram_emitc_u32()
+// CHECK: THISTOGRAM<HistByte::BYTE_3>(
+// CHECK: THISTOGRAM<HistByte::BYTE_2>(
+// CHECK: THISTOGRAM<HistByte::BYTE_1>(
+// CHECK: THISTOGRAM<HistByte::BYTE_0>(

--- a/test/lit/pto/thistogram_legacy_ismsb_emitc.pto
+++ b/test/lit/pto/thistogram_legacy_ismsb_emitc.pto
@@ -1,0 +1,20 @@
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @thistogram_legacy_ismsb_emitc() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst0 : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {isMSB = false}
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst1 : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {isMSB = true}
+    return
+  }
+}
+
+// CHECK-LABEL: __global__ AICORE void thistogram_legacy_ismsb_emitc()
+// CHECK: THISTOGRAM<HistByte::BYTE_0>(
+// CHECK: THISTOGRAM<HistByte::BYTE_1>(

--- a/test/lit/pto/thistogram_verify_conflicting_legacy_ismsb_a5.pto
+++ b/test/lit/pto/thistogram_verify_conflicting_legacy_ismsb_a5.pto
@@ -1,0 +1,14 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @thistogram_verify_conflicting_legacy_ismsb_a5() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = 1 : i32, isMSB = false}
+    return
+  }
+}
+
+// CHECK: error: 'pto.thistogram' op does not allow conflicting 'byte' and legacy 'isMSB' attributes

--- a/test/lit/pto/thistogram_verify_invalid_byte_a5.pto
+++ b/test/lit/pto/thistogram_verify_invalid_byte_a5.pto
@@ -1,0 +1,14 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @thistogram_verify_invalid_byte_a5() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = 4 : i32}
+    return
+  }
+}
+
+// CHECK: error: 'pto.thistogram' op expects byte to be in range [0, 3]

--- a/test/lit/pto/thistogram_verify_invalid_ui16_byte_a5.pto
+++ b/test/lit/pto/thistogram_verify_invalid_ui16_byte_a5.pto
@@ -1,0 +1,14 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @thistogram_verify_invalid_ui16_byte_a5() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = 2 : i32}
+    return
+  }
+}
+
+// CHECK: error: 'pto.thistogram' op expects byte to be 0 or 1 when src element type is ui16

--- a/test/lit/pto/thistogram_verify_negative_byte_a5.pto
+++ b/test/lit/pto/thistogram_verify_negative_byte_a5.pto
@@ -1,0 +1,14 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @thistogram_verify_negative_byte_a5() {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.thistogram ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=ui16, rows=32, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=1, v_row=8, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=32, cols=256, v_row=8, v_col=256, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {byte = -1 : i32}
+    return
+  }
+}
+
+// CHECK: error: 'pto.thistogram' op expects byte to be in range [0, 3]


### PR DESCRIPTION
## Summary
- align `pto.thistogram` with current `PTO-ISA` `HistByte` semantics instead of the older bool-style lowering from #634
- replace `isMSB` with `byte : i32` in PTO IR and lower `byte=0..3` to `HistByte::BYTE_0..BYTE_3`
- keep verifier behavior consistent with upstream `THistogram` constraints for both `ui16` and `ui32` sources

## Why
`PTO-ISA` now exposes four `HistByte` modes, but they are not uniformly valid for all source dtypes:
- `ui16`: only `BYTE_0` / `BYTE_1`
- `ui32`: `BYTE_0` / `BYTE_1` / `BYTE_2` / `BYTE_3`

PR #634 only converted the EmitC lowering from `true/false` to `BYTE_1/BYTE_0`, which still lagged the current upstream interface.

## Changes
- IR:
  - change `pto.thistogram` attr from `isMSB: BoolAttr` to `byte: I32Attr` with default `1`
- verifier:
  - accept `src: ui16 | ui32`
  - enforce `byte in [0, 3]`
  - enforce `ui16` only allows `byte=0/1`
  - enforce `ui16` vs `ui32` specific `idx` layout / shape constraints
- lowering:
  - map `byte=0..3` to `HistByte::BYTE_0..BYTE_3`
- docs/tests:
  - refresh `PTO_IR_manual.md`
  - add `ui32` lowering coverage and invalid-byte verifier coverage

## Validation
- `cmake -G Ninja -S /Users/laoda/pto/PTOAS/_pr634_histbyte_fix -B /tmp/ptoas-pr634-build ...`
- `ninja -C /tmp/ptoas-pr634-build ptoas`
- `ptoas --pto-arch=a5 test/lit/pto/thistogram_emitc.pto | FileCheck ...`
- `ptoas --pto-arch=a5 test/lit/pto/thistogram_emitc_u32.pto | FileCheck ...`
- `not ptoas --pto-arch=a5 test/lit/pto/thistogram_verify_invalid_byte_a5.pto | FileCheck ...`
- `not ptoas --pto-arch=a5 test/lit/pto/thistogram_verify_invalid_ui16_byte_a5.pto | FileCheck ...`
