### PR TITLE
Fix TPUT hidden MTE sync modeling

### DIFF
--- a/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
+++ b/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
@@ -88,6 +88,9 @@ private:
  
   // --- 核心：处理计算/搬运指令 (生成 Compound 节点) ---
   void UpdatePTOOpInfo(Operation *op);
+  void UpdateMacroOpInfo(Operation *op);
+  void MakeMacroCompound(Operation *op, PipelineType pipe, ValueRange defValues,
+                         ValueRange useValues, int macroPhaseId);
  
   // --- 辅助函数 ---
   

--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -348,6 +348,9 @@ public:
   UNIT_FLAG unitFlagModeAsWait{UNIT_FLAG::DISABLED};
   CompoundInstanceElement *linkedUnitFlagCompAsSet{nullptr};
   CompoundInstanceElement *linkedUnitFlagCompAsWait{nullptr};
+  // Macro-like operations may be represented by multiple SyncIR compounds that
+  // point at the same source operation. The phase id distinguishes those
+  // synthetic compounds without changing the source IR.
   int macroOpInstanceId{-1};
  
 public:

--- a/include/PTO/Transforms/InsertSync/SyncEventIdAllocation.h
+++ b/include/PTO/Transforms/InsertSync/SyncEventIdAllocation.h
@@ -57,6 +57,7 @@ private:
  
   SmallVector<bool> GetEventPool(const SyncOperation *sync, size_t eventIdNum);
   int ScopePair(const SyncOperation *s);
+  int ScopePair(PipelineType srcPipe, PipelineType dstPipe) const;
   void FindUseEventID(unsigned int begin, unsigned int end,
                       const SyncOperation *s, SmallVector<bool> &eventId);
  
@@ -75,6 +76,8 @@ private:
  
   void SetUseEventID(unsigned int begin, unsigned int end,
                      const SyncOperation *setFlag, unsigned int eventId);
+  void SetUseEventID(unsigned int begin, unsigned int end, int scopePair,
+                     unsigned int eventId, size_t poolSize);
  
   bool ExtendLifecycle(SmallVector<unsigned int> &syncLifeCycle,
                        unsigned int beginNew, unsigned int endNew) const;
@@ -107,6 +110,9 @@ private:
   void SetBlockSyncAllEventID(SyncOperation *sync);
   void IgnoreBackHeadAndTailSync();
   void reserveBlockAllEventIds();
+  void SeedHiddenMacroEventIds(
+      const llvm::SmallSet<int, kReallocatedPipePairInlineCapacity>
+          *scopeFilter = nullptr);
  
 private:
   SyncIRs &syncIR_;

--- a/include/PTO/Transforms/InsertSync/SyncMacroModel.h
+++ b/include/PTO/Transforms/InsertSync/SyncMacroModel.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCMACROMODEL_H
+#define MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCMACROMODEL_H
+
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/SmallVector.h"
+#include <optional>
+
+namespace mlir {
+namespace pto {
+
+struct SyncMacroPhase {
+  unsigned phaseId{0};
+  PipelineType pipe{PipelineType::PIPE_UNASSIGNED};
+  SmallVector<Value> defValues;
+  SmallVector<Value> useValues;
+};
+
+struct SyncMacroHiddenEvent {
+  PipelineType srcPipe{PipelineType::PIPE_UNASSIGNED};
+  PipelineType dstPipe{PipelineType::PIPE_UNASSIGNED};
+  SmallVector<unsigned> eventIds;
+};
+
+struct SyncMacroModel {
+  SmallVector<SyncMacroPhase> phases;
+  SmallVector<SyncMacroHiddenEvent> hiddenEvents;
+
+  explicit operator bool() const { return !phases.empty(); }
+};
+
+std::optional<SyncMacroModel> getSyncMacroModel(Operation *op);
+
+} // namespace pto
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PTO_TRANSFORMS_INSERTSYNC_SYNCMACROMODEL_H

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -12965,7 +12965,17 @@ void TReduceOp::getEffects(
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
   addEffect(effects, &getAccMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getAccMutable(), MemoryEffects::Write::get());
+  addEffect(effects, &getRecvPingMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getRecvPingMutable(), MemoryEffects::Write::get());
+  if (getRecvPong()) {
+    auto recvPongRange = getRecvPongMutable();
+    if (auto it = recvPongRange.begin(); it != recvPongRange.end()) {
+      addEffect(effects, &*it, MemoryEffects::Read::get());
+      addEffect(effects, &*it, MemoryEffects::Write::get());
+    }
+  }
+  for (OpOperand &operand : getGroupMutable())
+    addEffect(effects, &operand, MemoryEffects::Read::get());
 }
 
 void WaitAsyncEventOp::getEffects(

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -12860,6 +12860,14 @@ void TPutOp::getEffects(
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPingMutable(), MemoryEffects::Read::get());
+  addEffect(effects, &getPingMutable(), MemoryEffects::Write::get());
+  if (getPong()) {
+    auto pongRange = getPongMutable();
+    if (auto it = pongRange.begin(); it != pongRange.end()) {
+      addEffect(effects, &*it, MemoryEffects::Read::get());
+      addEffect(effects, &*it, MemoryEffects::Write::get());
+    }
+  }
 }
 
 void TGetOp::getEffects(
@@ -12868,6 +12876,14 @@ void TGetOp::getEffects(
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPingMutable(), MemoryEffects::Read::get());
+  addEffect(effects, &getPingMutable(), MemoryEffects::Write::get());
+  if (getPong()) {
+    auto pongRange = getPongMutable();
+    if (auto it = pongRange.begin(); it != pongRange.end()) {
+      addEffect(effects, &*it, MemoryEffects::Read::get());
+      addEffect(effects, &*it, MemoryEffects::Write::get());
+    }
+  }
 }
 
 void TNotifyOp::getEffects(
@@ -12896,12 +12912,17 @@ void TBroadcastOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
+  addEffect(effects, &getPingMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPingMutable(), MemoryEffects::Write::get());
   if (getPong()) {
     auto pongRange = getPongMutable();
-    if (auto it = pongRange.begin(); it != pongRange.end())
+    if (auto it = pongRange.begin(); it != pongRange.end()) {
+      addEffect(effects, &*it, MemoryEffects::Read::get());
       addEffect(effects, &*it, MemoryEffects::Write::get());
+    }
   }
+  for (OpOperand &operand : getGroupMutable())
+    addEffect(effects, &operand, MemoryEffects::Write::get());
 }
 
 void CommTGatherOp::getEffects(
@@ -12909,18 +12930,33 @@ void CommTGatherOp::getEffects(
         &effects) {
   addEffect(effects, &getDstMutable(), MemoryEffects::Write::get());
   addEffect(effects, &getPingMutable(), MemoryEffects::Read::get());
+  addEffect(effects, &getPingMutable(), MemoryEffects::Write::get());
+  if (getPong()) {
+    auto pongRange = getPongMutable();
+    if (auto it = pongRange.begin(); it != pongRange.end()) {
+      addEffect(effects, &*it, MemoryEffects::Read::get());
+      addEffect(effects, &*it, MemoryEffects::Write::get());
+    }
+  }
+  for (OpOperand &operand : getGroupMutable())
+    addEffect(effects, &operand, MemoryEffects::Read::get());
 }
 
 void CommTScatterOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   addEffect(effects, &getSrcMutable(), MemoryEffects::Read::get());
+  addEffect(effects, &getPingMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPingMutable(), MemoryEffects::Write::get());
   if (getPong()) {
     auto pongRange = getPongMutable();
-    if (auto it = pongRange.begin(); it != pongRange.end())
+    if (auto it = pongRange.begin(); it != pongRange.end()) {
+      addEffect(effects, &*it, MemoryEffects::Read::get());
       addEffect(effects, &*it, MemoryEffects::Write::get());
+    }
   }
+  for (OpOperand &operand : getGroupMutable())
+    addEffect(effects, &operand, MemoryEffects::Write::get());
 }
 
 void TReduceOp::getEffects(

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -35,6 +35,7 @@ add_mlir_dialect_library(PTOTransforms
   PTOResolveReservedBuffersPass.cpp
   PTOWrapFunctionsInSectionsPass.cpp
   InsertSync/PTOIRTranslator.cpp
+  InsertSync/SyncMacroModel.cpp
   InsertSync/SyncCommon.cpp
   InsertSync/InsertSyncAnalysis.cpp
   InsertSync/MemoryDependentAnalyzer.cpp

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -13,6 +13,7 @@
 
 #include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
 #include "PTO/IR/PTOTypeUtils.h"
+#include "PTO/Transforms/InsertSync/SyncMacroModel.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -360,6 +361,8 @@ void PTOIRTranslator::RecursionIR(Region *region) {
       return WalkResult::skip();
     } else if (auto yieldOp = dyn_cast<scf::YieldOp>(op)) {
       UpdateYieldOpInfo(yieldOp);
+    } else if (getSyncMacroModel(op)) {
+      UpdateMacroOpInfo(op);
     } else if (isa<pto::OpPipeInterface>(op)) {
       // --- Case D: 带有 OpPipeInterface 的计算/搬运指令 ---
       UpdatePTOOpInfo(op);
@@ -571,6 +574,36 @@ void PTOIRTranslator::UpdatePTOOpInfo(Operation *op) {
 
   syncIR_.emplace_back(std::move(compoundElement));
   index++;
+}
+
+void PTOIRTranslator::MakeMacroCompound(Operation *op, PipelineType pipe,
+                                        ValueRange defValues,
+                                        ValueRange useValues,
+                                        int macroPhaseId) {
+  SmallVector<const BaseMemInfo *> defVec;
+  SmallVector<const BaseMemInfo *> useVec;
+  UpdateDefUseVec(defValues, defVec);
+  UpdateDefUseVec(useValues, useVec);
+
+  auto compoundElement = std::make_unique<CompoundInstanceElement>(
+      index, std::move(defVec), std::move(useVec), pipe, op->getName());
+  compoundElement->elementOp = op;
+  compoundElement->macroOpInstanceId = macroPhaseId;
+  compoundElement->compoundCoreType =
+      pipe == PipelineType::PIPE_M ? pto::TCoreType::CUBE
+                                   : pto::TCoreType::VECTOR;
+  syncIR_.emplace_back(std::move(compoundElement));
+  index++;
+}
+
+void PTOIRTranslator::UpdateMacroOpInfo(Operation *op) {
+  auto model = getSyncMacroModel(op);
+  if (!model)
+    return;
+  for (const auto &phase : model->phases) {
+    MakeMacroCompound(op, phase.pipe, ValueRange(phase.defValues),
+                      ValueRange(phase.useValues), phase.phaseId);
+  }
 }
 
 // ============================================================================

--- a/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncEventIdAllocation.cpp
@@ -13,6 +13,7 @@
 
 #include "PTO/Transforms/InsertSync/SyncEventIdAllocation.h"
 #include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "PTO/Transforms/InsertSync/SyncMacroModel.h"
 #include <algorithm>
 
 #define DEBUG_TYPE "pto-inject-sync"
@@ -30,6 +31,7 @@ static size_t getEventIdPoolSize(const SyncOperation *sync,
 }
 
 void SyncEventIdAllocation::Allocate(uint32_t runNum) {
+  SeedHiddenMacroEventIds();
   // 1. 正常分配
   for (auto &element : syncIR_) {
     AllocateEventId(element.get());
@@ -256,6 +258,11 @@ int SyncEventIdAllocation::ScopePair(const SyncOperation *s) {
       s->GetType() == SyncOperation::TYPE::SYNC_BLOCK_WAIT) {
     return 0;
   }
+  return ScopePair(s->GetActualSrcPipe(), s->GetActualDstPipe());
+}
+
+int SyncEventIdAllocation::ScopePair(PipelineType srcPipe,
+                                     PipelineType dstPipe) const {
   // Event IDs are a limited shared resource and must not be reused across
   // overlapping lifetimes within the same (src,dst) pipe pair.
   //
@@ -264,8 +271,8 @@ int SyncEventIdAllocation::ScopePair(const SyncOperation *s) {
   // pressure where a single source pipe syncs to multiple destinations (e.g.
   // PIPE_M -> PIPE_MTE1 and PIPE_M -> PIPE_FIX), which can otherwise push some
   // pairs into high event IDs and trigger device-side failures.
-  auto srcT = static_cast<unsigned int>(s->GetActualSrcPipe());
-  auto dstT = static_cast<unsigned int>(s->GetActualDstPipe());
+  auto srcT = static_cast<unsigned int>(srcPipe);
+  auto dstT = static_cast<unsigned int>(dstPipe);
   // Offset by 1 so non-block scopes never collide with block-sync scope 0.
   return static_cast<int>(((dstT << 8U) | srcT) + 1U);
 }
@@ -420,6 +427,14 @@ void SyncEventIdAllocation::SetUseEventID(unsigned int begin, unsigned int end,
   int scopePair = ScopePair(setFlag);
   const size_t poolSize =
       getEventIdPoolSize(setFlag, reservedBlockSyncEventIdNum);
+  SetUseEventID(begin, end, scopePair, eventId, poolSize);
+}
+
+void SyncEventIdAllocation::SetUseEventID(unsigned int begin, unsigned int end,
+                                          int scopePair, unsigned int eventId,
+                                          size_t poolSize) {
+  assert(begin < end);
+  assert(eventId < poolSize);
   eventCyclePool.try_emplace(scopePair, EventCyclePool(poolSize));
 
   EventCyclePool &seqPool = eventCyclePool[scopePair];
@@ -446,6 +461,47 @@ void SyncEventIdAllocation::SetUseEventID(unsigned int begin, unsigned int end,
     }
   }
   if (!isInsert) llvm_unreachable("Can't insert this sync cycle!");
+}
+
+void SyncEventIdAllocation::SeedHiddenMacroEventIds(
+    const llvm::SmallSet<int, kReallocatedPipePairInlineCapacity>
+        *scopeFilter) {
+  // Some macro-like PTO ops lower to PTO-ISA library calls that use fixed
+  // internal event ids. They are invisible to PTO IR, so seed only the local
+  // call lifetime into the allocator instead of reserving those ids globally
+  // for every kernel.
+  for (size_t i = 0; i < syncIR_.size(); ++i) {
+    auto *firstPhase = dyn_cast<CompoundInstanceElement>(syncIR_[i].get());
+    if (!firstPhase || firstPhase->macroOpInstanceId != 0) continue;
+    Operation *op = firstPhase->elementOp;
+    auto model = getSyncMacroModel(op);
+    if (!model || model->hiddenEvents.empty())
+      continue;
+
+    unsigned end = firstPhase->GetIndex() + 1;
+    for (size_t j = i + 1; j < syncIR_.size(); ++j) {
+      auto *otherPhase = dyn_cast<CompoundInstanceElement>(syncIR_[j].get());
+      if (!otherPhase || otherPhase->elementOp != op) continue;
+      end = otherPhase->GetIndex();
+    }
+    unsigned begin = firstPhase->GetIndex();
+    if (begin > 0) {
+      --begin;
+    }
+    if (end + 1 < syncIR_.size()) {
+      ++end;
+    }
+    if (begin >= end) continue;
+
+    for (const auto &hiddenEvent : model->hiddenEvents) {
+      int scopePair = ScopePair(hiddenEvent.srcPipe, hiddenEvent.dstPipe);
+      if (scopeFilter && !scopeFilter->contains(scopePair))
+        continue;
+      for (unsigned eventId : hiddenEvent.eventIds) {
+        SetUseEventID(begin, end, scopePair, eventId, kTotalEventIdNum);
+      }
+    }
+  }
 }
 
 bool SyncEventIdAllocation::ExtendLifecycle(
@@ -517,6 +573,7 @@ void SyncEventIdAllocation::ReallocatedEventId() {
   for (auto pipePair : reallocatedPipePair) {
     eventCyclePool.erase(pipePair);
   }
+  SeedHiddenMacroEventIds(&reallocatedPipePair);
   ClearReallocatedBackwardMatchSync();
   for (auto &e : syncIR_) {
     for (auto &sync : e->pipeBefore) {

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -128,6 +128,21 @@ std::optional<SyncMacroModel> getCollectiveCommSyncMacroModel(Operation *op) {
   return model;
 }
 
+std::optional<SyncMacroModel> getTScatterSyncMacroModel(pto::TScatterOp op) {
+  if (!op.hasIndexForm() || getTargetArch(op.getOperation()) == PTOArch::A5)
+    return std::nullopt;
+
+  SyncMacroModel model;
+  // A2/A3 indexed TSCATTER first initializes dst with vector_dup, then runs a
+  // scalar UB scatter loop over src/indexes.
+  addPhase(model, PipelineType::PIPE_V, ValueRange{op.getDst()}, ValueRange{});
+  addPhase(model, PipelineType::PIPE_S, ValueRange{op.getDst()},
+           ValueRange{op.getSrc(), op.getIndexes()});
+  addHiddenEvent(model, PipelineType::PIPE_V, PipelineType::PIPE_S,
+                 ArrayRef<unsigned>{0});
+  return model;
+}
+
 } // namespace
 
 std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
@@ -135,5 +150,7 @@ std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
     return model;
   if (auto model = getCollectiveCommSyncMacroModel(op))
     return model;
+  if (auto tscatter = dyn_cast<pto::TScatterOp>(op))
+    return getTScatterSyncMacroModel(tscatter);
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/InsertSync/SyncMacroModel.h"
+#include "PTO/IR/PTO.h"
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+SmallVector<unsigned> getSequentialEventIds(unsigned count) {
+  SmallVector<unsigned> eventIds;
+  eventIds.reserve(count);
+  for (unsigned eventId = 0; eventId < count; ++eventId)
+    eventIds.push_back(eventId);
+  return eventIds;
+}
+
+void addPhase(SyncMacroModel &model, PipelineType pipe, ValueRange defValues,
+              ValueRange useValues) {
+  model.phases.push_back(SyncMacroPhase{
+      static_cast<unsigned>(model.phases.size()), pipe,
+      SmallVector<Value>(defValues.begin(), defValues.end()),
+      SmallVector<Value>(useValues.begin(), useValues.end())});
+}
+
+void addHiddenEvent(SyncMacroModel &model, PipelineType srcPipe,
+                    PipelineType dstPipe, ArrayRef<unsigned> eventIds) {
+  model.hiddenEvents.push_back(
+      SyncMacroHiddenEvent{srcPipe, dstPipe,
+                           SmallVector<unsigned>(eventIds.begin(),
+                                                 eventIds.end())});
+}
+
+void addBidirectionalHiddenEvent(SyncMacroModel &model, PipelineType firstPipe,
+                                 PipelineType secondPipe,
+                                 ArrayRef<unsigned> eventIds) {
+  addHiddenEvent(model, firstPipe, secondPipe, eventIds);
+  addHiddenEvent(model, secondPipe, firstPipe, eventIds);
+}
+
+std::optional<SyncMacroModel> getP2PCommSyncMacroModel(Operation *op) {
+  Value dst;
+  Value src;
+  unsigned laneCount = 1;
+  if (auto tput = dyn_cast<pto::TPutOp>(op)) {
+    dst = tput.getDst();
+    src = tput.getSrc();
+    laneCount = tput.getPong() ? 2U : 1U;
+  } else if (auto tget = dyn_cast<pto::TGetOp>(op)) {
+    dst = tget.getDst();
+    src = tget.getSrc();
+    laneCount = tget.getPong() ? 2U : 1U;
+  } else {
+    return std::nullopt;
+  }
+
+  SyncMacroModel model;
+  // P2P comm library calls first read the source GM through MTE2, then write
+  // the destination GM through MTE3.
+  addPhase(model, PipelineType::PIPE_MTE2, ValueRange{}, ValueRange{src});
+  addPhase(model, PipelineType::PIPE_MTE3, ValueRange{dst}, ValueRange{});
+  addBidirectionalHiddenEvent(model, PipelineType::PIPE_MTE2,
+                              PipelineType::PIPE_MTE3,
+                              getSequentialEventIds(laneCount));
+  return model;
+}
+
+std::optional<SyncMacroModel> getCollectiveCommSyncMacroModel(Operation *op) {
+  SyncMacroModel model;
+  unsigned laneCount = 1;
+
+  if (auto tgather = dyn_cast<pto::CommTGatherOp>(op)) {
+    laneCount = tgather.getPong() ? 2U : 1U;
+    // TGATHER_IMPL reads each group source through MTE2 and writes the gathered
+    // result into dst through MTE3.
+    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{},
+             tgather.getGroup());
+    addPhase(model, PipelineType::PIPE_MTE3, ValueRange{tgather.getDst()},
+             ValueRange{});
+  } else if (auto tscatter = dyn_cast<pto::CommTScatterOp>(op)) {
+    laneCount = tscatter.getPong() ? 2U : 1U;
+    // TSCATTER_IMPL reads the source through MTE2 and writes every group
+    // destination through MTE3.
+    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{},
+             ValueRange{tscatter.getSrc()});
+    addPhase(model, PipelineType::PIPE_MTE3, tscatter.getGroup(),
+             ValueRange{});
+  } else if (auto tbroadcast = dyn_cast<pto::TBroadcastOp>(op)) {
+    laneCount = tbroadcast.getPong() ? 2U : 1U;
+    // TBROADCAST_IMPL reads the source through MTE2 and writes every group
+    // destination through MTE3.
+    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{},
+             ValueRange{tbroadcast.getSrc()});
+    addPhase(model, PipelineType::PIPE_MTE3, tbroadcast.getGroup(),
+             ValueRange{});
+  } else if (auto treduce = dyn_cast<pto::TReduceOp>(op)) {
+    laneCount = treduce.getRecvPong() ? 3U : 2U;
+    // TREDUCE_IMPL reads group sources through MTE2, reduces into acc on the
+    // vector pipe, and stores the final result into dst through MTE3.
+    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{}, treduce.getGroup());
+    addPhase(model, PipelineType::PIPE_V, ValueRange{treduce.getAcc()},
+             ValueRange{treduce.getAcc(), treduce.getRecvPing()});
+    addPhase(model, PipelineType::PIPE_MTE3, ValueRange{treduce.getDst()},
+             ValueRange{});
+  } else {
+    return std::nullopt;
+  }
+
+  SmallVector<unsigned> eventIds = getSequentialEventIds(laneCount);
+  addBidirectionalHiddenEvent(model, PipelineType::PIPE_MTE2,
+                              PipelineType::PIPE_MTE3, eventIds);
+  if (isa<pto::TReduceOp>(op)) {
+    addHiddenEvent(model, PipelineType::PIPE_MTE2, PipelineType::PIPE_V,
+                   eventIds);
+    addHiddenEvent(model, PipelineType::PIPE_V, PipelineType::PIPE_MTE2,
+                   eventIds);
+    addHiddenEvent(model, PipelineType::PIPE_V, PipelineType::PIPE_MTE3,
+                   eventIds);
+  }
+
+  return model;
+}
+
+} // namespace
+
+std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
+  if (auto model = getP2PCommSyncMacroModel(op))
+    return model;
+  if (auto model = getCollectiveCommSyncMacroModel(op))
+    return model;
+  return std::nullopt;
+}

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -124,12 +124,17 @@ std::optional<SyncMacroModel> getCollectiveCommSyncMacroModel(Operation *op) {
   } else if (auto treduce = dyn_cast<pto::TReduceOp>(op)) {
     laneCount = treduce.getRecvPong() ? 3U : 2U;
     // TREDUCE_IMPL reads group sources through MTE2, reduces into acc on the
-    // vector pipe, and stores the final result into dst through MTE3.
-    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{}, treduce.getGroup());
+    // vector pipe, and stores the final result into dst through MTE3, using
+    // recvPing/recvPong as receive staging tiles.
+    SmallVector<Value> recvStaging =
+        getPingPongValues(treduce.getRecvPing(), treduce.getRecvPong());
+    SmallVector<Value> reduceUses{treduce.getAcc()};
+    reduceUses.append(recvStaging.begin(), recvStaging.end());
+    addPhase(model, PipelineType::PIPE_MTE2, recvStaging, treduce.getGroup());
     addPhase(model, PipelineType::PIPE_V, ValueRange{treduce.getAcc()},
-             ValueRange{treduce.getAcc(), treduce.getRecvPing()});
+             reduceUses);
     addPhase(model, PipelineType::PIPE_MTE3, ValueRange{treduce.getDst()},
-             ValueRange{});
+             ValueRange{treduce.getAcc()});
   } else {
     return std::nullopt;
   }

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -143,6 +143,30 @@ std::optional<SyncMacroModel> getTScatterSyncMacroModel(pto::TScatterOp op) {
   return model;
 }
 
+std::optional<SyncMacroModel> getTGatherSyncMacroModel(pto::TGatherOp op) {
+  if (!op.hasCompareForm() || getTargetArch(op.getOperation()) == PTOArch::A5)
+    return std::nullopt;
+
+  Value tmp = op.getTmp();
+  Value cdst = op.getCdst();
+  if (!tmp || !cdst)
+    return std::nullopt;
+
+  SyncMacroModel model;
+  // A2/A3 compare TGATHER lowers to TCMPS on PIPE_V, an index generation loop
+  // on PIPE_S, a V reduce over the generated indexes, and a scalar writeback of
+  // the reserved count into cdst.
+  addPhase(model, PipelineType::PIPE_V, ValueRange{tmp},
+           ValueRange{op.getSrc()});
+  addPhase(model, PipelineType::PIPE_S, ValueRange{tmp}, ValueRange{});
+  addPhase(model, PipelineType::PIPE_V, ValueRange{op.getDst()},
+           ValueRange{tmp});
+  addPhase(model, PipelineType::PIPE_S, ValueRange{cdst}, ValueRange{});
+  addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_V,
+                 ArrayRef<unsigned>{0});
+  return model;
+}
+
 } // namespace
 
 std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
@@ -152,5 +176,7 @@ std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
     return model;
   if (auto tscatter = dyn_cast<pto::TScatterOp>(op))
     return getTScatterSyncMacroModel(tscatter);
+  if (auto tgather = dyn_cast<pto::TGatherOp>(op))
+    return getTGatherSyncMacroModel(tgather);
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -45,27 +45,42 @@ void addBidirectionalHiddenEvent(SyncMacroModel &model, PipelineType firstPipe,
   addHiddenEvent(model, secondPipe, firstPipe, eventIds);
 }
 
+SmallVector<Value> getPingPongValues(Value ping, Value pong = {}) {
+  SmallVector<Value> values;
+  values.push_back(ping);
+  if (pong)
+    values.push_back(pong);
+  return values;
+}
+
 std::optional<SyncMacroModel> getP2PCommSyncMacroModel(Operation *op) {
   Value dst;
   Value src;
+  Value ping;
+  Value pong;
   unsigned laneCount = 1;
   if (auto tput = dyn_cast<pto::TPutOp>(op)) {
     dst = tput.getDst();
     src = tput.getSrc();
+    ping = tput.getPing();
+    pong = tput.getPong();
     laneCount = tput.getPong() ? 2U : 1U;
   } else if (auto tget = dyn_cast<pto::TGetOp>(op)) {
     dst = tget.getDst();
     src = tget.getSrc();
+    ping = tget.getPing();
+    pong = tget.getPong();
     laneCount = tget.getPong() ? 2U : 1U;
   } else {
     return std::nullopt;
   }
 
   SyncMacroModel model;
+  SmallVector<Value> staging = getPingPongValues(ping, pong);
   // P2P comm library calls first read the source GM through MTE2, then write
-  // the destination GM through MTE3.
-  addPhase(model, PipelineType::PIPE_MTE2, ValueRange{}, ValueRange{src});
-  addPhase(model, PipelineType::PIPE_MTE3, ValueRange{dst}, ValueRange{});
+  // the destination GM through MTE3, using ping/pong as staging tiles.
+  addPhase(model, PipelineType::PIPE_MTE2, staging, ValueRange{src});
+  addPhase(model, PipelineType::PIPE_MTE3, ValueRange{dst}, staging);
   addBidirectionalHiddenEvent(model, PipelineType::PIPE_MTE2,
                               PipelineType::PIPE_MTE3,
                               getSequentialEventIds(laneCount));
@@ -79,27 +94,33 @@ std::optional<SyncMacroModel> getCollectiveCommSyncMacroModel(Operation *op) {
   if (auto tgather = dyn_cast<pto::CommTGatherOp>(op)) {
     laneCount = tgather.getPong() ? 2U : 1U;
     // TGATHER_IMPL reads each group source through MTE2 and writes the gathered
-    // result into dst through MTE3.
-    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{},
+    // result into dst through MTE3, using ping/pong as staging tiles.
+    SmallVector<Value> staging =
+        getPingPongValues(tgather.getPing(), tgather.getPong());
+    addPhase(model, PipelineType::PIPE_MTE2, staging,
              tgather.getGroup());
     addPhase(model, PipelineType::PIPE_MTE3, ValueRange{tgather.getDst()},
-             ValueRange{});
+             staging);
   } else if (auto tscatter = dyn_cast<pto::CommTScatterOp>(op)) {
     laneCount = tscatter.getPong() ? 2U : 1U;
     // TSCATTER_IMPL reads the source through MTE2 and writes every group
-    // destination through MTE3.
-    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{},
+    // destination through MTE3, using ping/pong as staging tiles.
+    SmallVector<Value> staging =
+        getPingPongValues(tscatter.getPing(), tscatter.getPong());
+    addPhase(model, PipelineType::PIPE_MTE2, staging,
              ValueRange{tscatter.getSrc()});
     addPhase(model, PipelineType::PIPE_MTE3, tscatter.getGroup(),
-             ValueRange{});
+             staging);
   } else if (auto tbroadcast = dyn_cast<pto::TBroadcastOp>(op)) {
     laneCount = tbroadcast.getPong() ? 2U : 1U;
     // TBROADCAST_IMPL reads the source through MTE2 and writes every group
-    // destination through MTE3.
-    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{},
+    // destination through MTE3, using ping/pong as staging tiles.
+    SmallVector<Value> staging =
+        getPingPongValues(tbroadcast.getPing(), tbroadcast.getPong());
+    addPhase(model, PipelineType::PIPE_MTE2, staging,
              ValueRange{tbroadcast.getSrc()});
     addPhase(model, PipelineType::PIPE_MTE3, tbroadcast.getGroup(),
-             ValueRange{});
+             staging);
   } else if (auto treduce = dyn_cast<pto::TReduceOp>(op)) {
     laneCount = treduce.getRecvPong() ? 3U : 2U;
     // TREDUCE_IMPL reads group sources through MTE2, reduces into acc on the

--- a/test/lit/pto/issue706_comm_staging_buffer_sync.pto
+++ b/test/lit/pto/issue706_comm_staging_buffer_sync.pto
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Macro comm ops use ping/pong as internal staging tiles. InsertSync must model
+// those tile side effects so later tile users cannot race with the hidden MTE2
+// staging write inside the library call.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tput_reuses_pong_after_call(
+      %dst_ptr: !pto.ptr<f32>,
+      %src_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reuse = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.comm.tput(%dst, %src, buf(%ping, %pong) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+        {atomicType = #pto<atomic_type atomic_none>}
+    pto.tmov ins(%pong : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%reuse : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @tbroadcast_reuses_pong_after_call(
+      %src_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reuse = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.comm.tbroadcast(%src, recv(%ping, %pong), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {root = 0 : i32}
+    pto.tmov ins(%pong : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%reuse : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tput_reuses_pong_after_call(
+// CHECK:      pto::comm::TPUT(
+// CHECK:      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[TPUT:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[TPUT]]);
+// CHECK-NEXT: TMOV(
+
+// CHECK-LABEL: AICORE void tbroadcast_reuses_pong_after_call(
+// CHECK:      pto::comm::TBROADCAST(
+// CHECK:      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[BCAST:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[BCAST]]);
+// CHECK-NEXT: TMOV(

--- a/test/lit/pto/issue706_tbroadcast_hidden_mte_sync.pto
+++ b/test/lit/pto/issue706_tbroadcast_hidden_mte_sync.pto
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// pto.comm.tbroadcast is a macro-like library call: TBROADCAST_IMPL reads src
+// through MTE2 and writes group destinations through MTE3. If a preceding
+// TSTORE writes src, insert-sync must see the hidden MTE2 read and emit an
+// MTE3->MTE2 sync before TBROADCAST. The library also uses fixed EVENT_ID0/1
+// internally, so compiler-generated sync around the call must avoid them.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tbroadcast_waits_for_tstore_src(
+      %src_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%src : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tbroadcast(%src, recv(%ping), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {root = 0 : i32}
+    return
+  }
+
+  func.func @tbroadcast_pingpong_keeps_internal_events_hidden(
+      %src_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%src : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tbroadcast(%src, recv(%ping, %pong), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {root = 0 : i32}
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tbroadcast_waits_for_tstore_src(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK:      pto::comm::TBROADCAST(
+
+// CHECK-LABEL: AICORE void tbroadcast_pingpong_keeps_internal_events_hidden(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK:      pto::comm::TBROADCAST(

--- a/test/lit/pto/issue706_tgather_hidden_mte_sync.pto
+++ b/test/lit/pto/issue706_tgather_hidden_mte_sync.pto
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// pto.comm.tgather is a macro-like library call: TGATHER_IMPL reads each group
+// source through MTE2 and writes dst through MTE3. If a preceding TSTORE writes
+// a group source, insert-sync must see the hidden MTE2 read and emit an
+// MTE3->MTE2 sync before TGATHER. The library also uses fixed EVENT_ID0/1
+// internally, so compiler-generated sync around the call must avoid them.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tgather_waits_for_tstore_group(
+      %dst_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%peer : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tgather(%dst, recv(%ping), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {root = 0 : i32}
+    return
+  }
+
+  func.func @tgather_pingpong_keeps_internal_events_hidden(
+      %dst_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%peer : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tgather(%dst, recv(%ping, %pong), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {root = 0 : i32}
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tgather_waits_for_tstore_group(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK:      pto::comm::TGATHER(
+
+// CHECK-LABEL: AICORE void tgather_pingpong_keeps_internal_events_hidden(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK:      pto::comm::TGATHER(

--- a/test/lit/pto/issue706_tput_hidden_mte2_sync.pto
+++ b/test/lit/pto/issue706_tput_hidden_mte2_sync.pto
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression for issue #706: pto.comm.tput is an opaque library call, but its
+// implementation reads src through MTE2. If a preceding TSTORE writes the same
+// GM buffer through MTE3, insert-sync must emit an MTE3->MTE2 sync before TPUT.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tput_waits_for_tstore_src(
+      %dst_ptr: !pto.ptr<f32>,
+      %src_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%src : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tput(%dst, %src, buf(%ping) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+        {atomicType = #pto<atomic_type atomic_none>}
+    return
+  }
+
+  func.func @tput_pingpong_keeps_internal_events_hidden(
+      %dst_ptr: !pto.ptr<f32>,
+      %src_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%src : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tput(%dst, %src, buf(%ping, %pong) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+        {atomicType = #pto<atomic_type atomic_none>}
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tput_waits_for_tstore_src(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK-NEXT: pto::comm::TPUT(
+
+// CHECK-LABEL: AICORE void tput_pingpong_keeps_internal_events_hidden(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK-NEXT: pto::comm::TPUT(

--- a/test/lit/pto/issue706_treduce_hidden_mte_sync.pto
+++ b/test/lit/pto/issue706_treduce_hidden_mte_sync.pto
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// pto.comm.treduce is a macro-like library call: TREDUCE_IMPL reads group
+// sources through MTE2, reduces on PIPE_V, then writes dst through MTE3. If a
+// preceding TSTORE writes a group source, insert-sync must see the hidden MTE2
+// read and emit an MTE3->MTE2 sync before TREDUCE. The library also uses fixed
+// EVENT_ID0/1 in the single-buffer path and EVENT_ID0/1/2 in the ping-pong
+// path, so compiler-generated sync around the call must avoid them.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @treduce_waits_for_tstore_group(
+      %dst_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %acc = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%peer : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.treduce(%dst, %acc, recv(%ping), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {reduceOp = #pto<reduce_op sum>, root = 0 : i32}
+    return
+  }
+
+  func.func @treduce_pingpong_keeps_internal_events_hidden(
+      %dst_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %acc = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%peer : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.treduce(%dst, %acc, recv(%ping, %pong), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {reduceOp = #pto<reduce_op sum>, root = 0 : i32}
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void treduce_waits_for_tstore_group(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK:      pto::comm::TREDUCE(
+
+// CHECK-LABEL: AICORE void treduce_pingpong_keeps_internal_events_hidden(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID3);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID3);
+// CHECK:      pto::comm::TREDUCE(

--- a/test/lit/pto/issue706_treduce_recv_pong_staging_sync.pto
+++ b/test/lit/pto/issue706_treduce_recv_pong_staging_sync.pto
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// TREDUCE ping-pong mode uses recvPong as an internal receive staging tile.
+// InsertSync must model that hidden write so later tile users cannot race with
+// the MTE2 receive inside the library call.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @treduce_reuses_recv_pong_after_call(
+      %dst_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %acc = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reuse = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.comm.treduce(%dst, %acc, recv(%ping, %pong), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {reduceOp = #pto<reduce_op sum>, root = 0 : i32}
+    pto.tmov ins(%pong : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%reuse : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void treduce_reuses_recv_pong_after_call(
+// CHECK:      pto::comm::TREDUCE(
+// CHECK:      set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[PONG:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[PONG]]);
+// CHECK-NEXT: TMOV(

--- a/test/lit/pto/issue706_tscatter_hidden_mte_sync.pto
+++ b/test/lit/pto/issue706_tscatter_hidden_mte_sync.pto
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// pto.comm.tscatter is a macro-like library call: TSCATTER_IMPL reads src
+// through MTE2 and writes group destinations through MTE3. If a preceding
+// TSTORE writes src, insert-sync must see the hidden MTE2 read and emit an
+// MTE3->MTE2 sync before TSCATTER. The library also uses fixed EVENT_ID0/1
+// internally, so compiler-generated sync around the call must avoid them.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tscatter_waits_for_tstore_src(
+      %src_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%src : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tscatter(%src, recv(%ping), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {root = 0 : i32}
+    return
+  }
+
+  func.func @tscatter_pingpong_keeps_internal_events_hidden(
+      %src_ptr: !pto.ptr<f32>,
+      %peer_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %ping = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %pong = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    %peer_view = pto.make_tensor_view %peer_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %peer = pto.partition_view %peer_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%src : !pto.partition_tensor_view<1x32xf32>)
+    pto.comm.tscatter(%src, recv(%ping, %pong), group(%peer) :
+        !pto.partition_tensor_view<1x32xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+        !pto.partition_tensor_view<1x32xf32>) {root = 0 : i32}
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void tscatter_waits_for_tstore_src(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID1);
+// CHECK:      pto::comm::TSCATTER(
+
+// CHECK-LABEL: AICORE void tscatter_pingpong_keeps_internal_events_hidden(
+// CHECK:      TSTORE(
+// CHECK:      set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID2);
+// CHECK:      pto::comm::TSCATTER(

--- a/test/lit/pto/tgather_compare_macro_sync_model.pto
+++ b/test/lit/pto/tgather_compare_macro_sync_model.pto
@@ -1,0 +1,19 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tgather_compare_macro_model() {
+    %c0_f16 = arith.constant 0.0 : f16
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %cdst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tgather ins(%src, %c0_f16, %tmp : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f16, !pto.tile_buf<loc=vec, dtype=ui8, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst, %cdst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: After Sync Motion
+// CHECK:      COMPOUND pto.tgather [PIPE_V]
+// CHECK-NEXT: COMPOUND pto.tgather [PIPE_S]
+// CHECK-NEXT: COMPOUND pto.tgather [PIPE_V]
+// CHECK-NEXT: COMPOUND pto.tgather [PIPE_S]

--- a/test/lit/pto/tscatter_indexed_macro_sync_model.pto
+++ b/test/lit/pto/tscatter_indexed_macro_sync_model.pto
@@ -1,0 +1,32 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tscatter_indexed_macro_model(%src_gm: memref<1x32xf16, #pto.address_space<gm>>,
+                                          %idx_gm: memref<1x32xi16, #pto.address_space<gm>>) {
+    %src = memref.alloc() : memref<1x32xf16, #pto.address_space<vec>>
+    %idx = memref.alloc() : memref<1x32xi16, #pto.address_space<vec>>
+    %dst = memref.alloc() : memref<1x32xf16, #pto.address_space<vec>>
+    %out = memref.alloc() : memref<1x32xf16, #pto.address_space<vec>>
+
+    pto.tload ins(%src_gm : memref<1x32xf16, #pto.address_space<gm>>)
+              outs(%src : memref<1x32xf16, #pto.address_space<vec>>) {layout = #pto.layout<nd>}
+    pto.tload ins(%idx_gm : memref<1x32xi16, #pto.address_space<gm>>)
+              outs(%idx : memref<1x32xi16, #pto.address_space<vec>>) {layout = #pto.layout<nd>}
+    pto.tscatter ins(%src, %idx : memref<1x32xf16, #pto.address_space<vec>>, memref<1x32xi16, #pto.address_space<vec>>)
+                 outs(%dst : memref<1x32xf16, #pto.address_space<vec>>)
+    pto.tmov ins(%dst : memref<1x32xf16, #pto.address_space<vec>>)
+             outs(%out : memref<1x32xf16, #pto.address_space<vec>>)
+    return
+  }
+}
+
+// CHECK-LABEL: After Sync Motion
+// CHECK:      COMPOUND pto.tload [PIPE_MTE2]
+// CHECK:      COMPOUND pto.tload [PIPE_MTE2]
+// CHECK:      COMPOUND pto.tscatter [PIPE_V]
+// CHECK-NEXT: COMPOUND pto.tscatter [PIPE_S]
+// CHECK:      COMPOUND pto.tmov [PIPE_V]
+// CHECK:      set_flag <PIPE_MTE2 -> PIPE_S>
+// CHECK:      wait_flag <PIPE_MTE2 -> PIPE_S>
+// CHECK:      set_flag <PIPE_S -> PIPE_V>
+// CHECK:      wait_flag <PIPE_S -> PIPE_V>


### PR DESCRIPTION
Summary
- Model pto.comm.tput / pto.comm.tget as macro-like P2P comm operations in InsertSync: an MTE2 source-read phase followed by an MTE3 destination-write phase.
- Seed the local hidden EVENT_ID0/1 lifetimes used by current PTO-ISA TPUT/TGET library calls, so auto-inserted sync around the call does not reuse those internal event ids.
- Add a #706 regression test covering both single-buffer and ping-pong TPUT paths.

Motivation
- Fixes #706.
- A preceding TSTORE writes the TPUT source through MTE3, while TPUT internally reads that source through MTE2. Without modeling the hidden MTE2 read, insert-sync can miss the required MTE3->MTE2 ordering before TPUT.

Design
- Scope is intentionally limited to P2P comm macro modeling for #706.
- This PR does not implement the TNotify release-fence/MTE-drain design for #711.
- The hidden event-id handling is local to each TPUT/TGET call lifetime instead of globally reserving EVENT_ID0/1, avoiding event-id capacity loss in kernels that do not call these libraries.

Testing
- Local: ninja -C build_issue706 ptoas
- Local: ptoas --pto-arch=a3 --enable-insert-sync test/lit/pto/issue706_tput_hidden_mte2_sync.pto -o - | FileCheck test/lit/pto/issue706_tput_hidden_mte2_sync.pto
- Local: ptoas --pto-arch=a3 test/lit/pto/comm_p2p_emitc.pto -o - | FileCheck test/lit/pto/comm_p2p_emitc.pto --check-prefix=A3
- Local: ptoas --pto-arch=a3 test/lit/pto/issue711_tnotify_mte_drain.pto -o - | FileCheck test/lit/pto/issue711_tnotify_mte_drain.pto
- Local: ninja -C build_issue706 check-pto (265/265 passed)

Risk / Rollback
- Risk: affects legacy InsertSync modeling of TPUT/TGET only. It may add required sync before/after P2P comm ops where the opaque library call previously hid memory hazards.
- Rollback: revert this PR.