### PR TITLE
Optimize TNotify MTE drain lowering

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -125,11 +125,118 @@ static constexpr llvm::StringLiteral kForceDynamicValidShapeAttrName =
     "__pto.force_dynamic_valid_shape";
 static constexpr llvm::StringLiteral kGlobalTensorStridesAttrName =
     "__pto.globaltensor_strides";
+static constexpr llvm::StringLiteral kTNotifyDrainMte2AttrName =
+    "__pto.emitc.tnotify_drain_mte2";
+static constexpr llvm::StringLiteral kTNotifyDrainMte3AttrName =
+    "__pto.emitc.tnotify_drain_mte3";
+
+enum TNotifyMteDrainMask : unsigned {
+  kDrainMte2 = 1U << 0,
+  kDrainMte3 = 1U << 1,
+};
 
 static Value peelUnrealized(Value v) {
   if (auto castOp = v.getDefiningOp<UnrealizedConversionCastOp>())
     return castOp.getOperand(0);
   return v;
+}
+
+static unsigned getMteDrainMaskForPipe(pto::PIPE pipe) {
+  switch (pipe) {
+  case pto::PIPE::PIPE_MTE2:
+    return kDrainMte2;
+  case pto::PIPE::PIPE_MTE3:
+    return kDrainMte3;
+  case pto::PIPE::PIPE_ALL:
+    return kDrainMte2 | kDrainMte3;
+  default:
+    return 0;
+  }
+}
+
+static unsigned getDirectMteDrainMask(Operation *op) {
+  if (auto pipeOp = dyn_cast<pto::OpPipeInterface>(op))
+    return getMteDrainMaskForPipe(pipeOp.getPipe());
+  return 0;
+}
+
+static unsigned collectMteDrainMask(Operation *op) {
+  unsigned mask = getDirectMteDrainMask(op);
+  for (Region &region : op->getRegions())
+    for (Block &block : region)
+      for (Operation &nested : block)
+        mask |= collectMteDrainMask(&nested);
+  return mask;
+}
+
+static bool isLoopLikeOp(Operation *op) {
+  return isa<scf::ForOp, scf::WhileOp, scf::ParallelOp, scf::ForallOp>(op);
+}
+
+static void setTNotifyDrainAttrs(pto::TNotifyOp op, unsigned mask) {
+  op->removeAttr(kTNotifyDrainMte2AttrName);
+  op->removeAttr(kTNotifyDrainMte3AttrName);
+  if (mask & kDrainMte2)
+    op->setAttr(kTNotifyDrainMte2AttrName, UnitAttr::get(op.getContext()));
+  if (mask & kDrainMte3)
+    op->setAttr(kTNotifyDrainMte3AttrName, UnitAttr::get(op.getContext()));
+}
+
+static void markNestedTNotifyWithMask(Operation *op, unsigned mask) {
+  op->walk([&](pto::TNotifyOp notify) { setTNotifyDrainAttrs(notify, mask); });
+}
+
+static unsigned annotateTNotifyMteDrainForBlock(Block &block,
+                                                unsigned entryPendingMask,
+                                                unsigned loopCarriedMask) {
+  unsigned pendingMask = entryPendingMask;
+  for (Operation &op : block) {
+    if (auto notify = dyn_cast<pto::TNotifyOp>(op)) {
+      setTNotifyDrainAttrs(notify, pendingMask | loopCarriedMask);
+      pendingMask = 0;
+    }
+
+    pendingMask |= getDirectMteDrainMask(&op);
+
+    unsigned regionEntryMask = pendingMask;
+    unsigned combinedRegionExitMask = 0;
+    for (Region &region : op.getRegions()) {
+      unsigned nestedLoopCarriedMask = loopCarriedMask;
+      if (isLoopLikeOp(&op))
+        nestedLoopCarriedMask |= collectMteDrainMask(&op);
+
+      if (region.hasOneBlock()) {
+        combinedRegionExitMask |= annotateTNotifyMteDrainForBlock(
+            region.front(), regionEntryMask, nestedLoopCarriedMask);
+      } else {
+        unsigned regionMask = collectMteDrainMask(&op);
+        markNestedTNotifyWithMask(&op, regionEntryMask | nestedLoopCarriedMask |
+                                           regionMask);
+        combinedRegionExitMask |= regionEntryMask | regionMask;
+      }
+    }
+    pendingMask |= combinedRegionExitMask;
+
+    if (auto barrier = dyn_cast<pto::BarrierOp>(op))
+      pendingMask &= ~getMteDrainMaskForPipe(barrier.getPipe().getPipe());
+  }
+  return pendingMask;
+}
+
+static void annotateTNotifyMteDrain(ModuleOp module) {
+  for (auto func : module.getOps<func::FuncOp>()) {
+    if (func.getBody().hasOneBlock()) {
+      (void)annotateTNotifyMteDrainForBlock(func.getBody().front(),
+                                            /*entryPendingMask=*/0,
+                                            /*loopCarriedMask=*/0);
+      continue;
+    }
+
+    // Be conservative for pre-existing CFG: without a path-sensitive CFG data
+    // flow here, every TNotify may observe any MTE work in the function.
+    unsigned funcMask = collectMteDrainMask(func.getOperation());
+    markNestedTNotifyWithMask(func.getOperation(), funcMask);
+  }
 }
 
 static Value buildGlobalTensorFromMemref(ConversionPatternRewriter &rewriter,
@@ -6387,18 +6494,26 @@ static std::string notifyOpTok(pto::NotifyOp op) {
   return "pto::comm::NotifyOp::Set";
 }
 
-// Issue #711: TNOTIFY writes its signal on the scalar pipe, and
-// TNOTIFY_IMPL's trailing pipe_barrier(PIPE_ALL) runs *after* that store.
-// If any prior pto.tload / pto.tstore (local or peer) is still in flight on
-// an MTE pipe when the signal lands, the receiver's matching TWAIT can
-// return before the data is visible. The lowering of pto.comm.tnotify must
-// drain MTE-side pipes itself; callers cannot be required to insert sync.
-static void emitTNotifyMteDrain(ConversionPatternRewriter &rewriter,
-                                Location loc) {
+static void emitPipeBarrier(ConversionPatternRewriter &rewriter, Location loc,
+                            StringRef pipeTok) {
   auto *ctx = rewriter.getContext();
-  auto args = rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, "PIPE_ALL")});
+  auto args = rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, pipeTok)});
   rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "pipe_barrier", args,
                                        ArrayAttr{}, ValueRange{});
+}
+
+// Issue #711: TNOTIFY writes its signal on the scalar pipe, and
+// TNOTIFY_IMPL's trailing pipe_barrier(PIPE_ALL) runs *after* that store.
+// If prior pto.tload / pto.tstore work is still in flight on an MTE pipe when
+// the signal lands, the receiver's matching TWAIT can return before the data
+// is visible. Emit only the MTE pipe drains that the pre-lowering analysis
+// proved may be needed before this TNotify.
+static void emitTNotifyMteDrain(ConversionPatternRewriter &rewriter,
+                                Location loc, unsigned mask) {
+  if (mask & kDrainMte2)
+    emitPipeBarrier(rewriter, loc, "PIPE_MTE2");
+  if (mask & kDrainMte3)
+    emitPipeBarrier(rewriter, loc, "PIPE_MTE3");
 }
 
 static std::string waitCmpTok(pto::WaitCmp cmp) {
@@ -6657,7 +6772,12 @@ struct PTOSignalCommToEmitC : public OpConversionPattern<SignalOp> {
                                   notifyOp};
       // See emitTNotifyMteDrain comment: drain in-flight MTE work before the
       // scalar-pipe signal store so the notify/wait handshake is honored.
-      emitTNotifyMteDrain(rewriter, op.getLoc());
+      unsigned drainMask = 0;
+      if (op->hasAttr(kTNotifyDrainMte2AttrName))
+        drainMask |= kDrainMte2;
+      if (op->hasAttr(kTNotifyDrainMte3AttrName))
+        drainMask |= kDrainMte3;
+      emitTNotifyMteDrain(rewriter, op.getLoc(), drainMask);
       rewriter.create<emitc::CallOpaqueOp>(op.getLoc(), TypeRange{}, callee,
                                            ArrayAttr{}, ArrayAttr{}, operands);
       rewriter.eraseOp(op);
@@ -12726,6 +12846,8 @@ static AICORE inline void ptoas_auto_sync_tail(
         return signalPassFailure();
       }
     }
+
+    annotateTNotifyMteDrain(mop);
 
     // 3. 配置转换目标
     ConversionTarget target(*ctx);

--- a/test/lit/pto/issue711_tnotify_mte_drain.pto
+++ b/test/lit/pto/issue711_tnotify_mte_drain.pto
@@ -11,7 +11,8 @@
 // signal on the scalar pipe and only does pipe_barrier(PIPE_ALL) *after* the
 // store, so without an MTE drain the signal can overtake an in-flight
 // pto.tload / pto.tstore (local or peer) and the receiver's matching TWAIT
-// returns before the data is visible.
+// returns before the data is visible. The drain should be precise: only MTE
+// pipes that may have prior in-flight work are drained before TNOTIFY.
 
 // RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s
 
@@ -90,6 +91,58 @@ module {
     return
   }
 
+  // A user/pass-provided MTE barrier already drains the pending load, so
+  // tnotify lowering should not duplicate the same MTE2 drain.
+  func.func @tnotify_after_existing_mte2_barrier(
+      %src_ptr: !pto.ptr<f32>,
+      %signal_ptr: !pto.ptr<i32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %v_i32 = arith.constant 1 : i32
+
+    %tile = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c32]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<1x32xf32>
+
+    pto.tload ins(%src : !pto.partition_tensor_view<1x32xf32>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.barrier <PIPE_MTE2>
+
+    %sig_view = pto.make_tensor_view %signal_ptr,
+      shape = [%c1], strides = [%c1] : !pto.tensor_view<1xi32>
+    %sig = pto.partition_view %sig_view,
+      offsets = [%c0], sizes = [%c1]
+      : !pto.tensor_view<1xi32> -> !pto.partition_tensor_view<1xi32>
+    pto.comm.tnotify(%sig, %v_i32 : !pto.partition_tensor_view<1xi32>, i32)
+        {notifyOp = #pto<notify_op set>}
+    return
+  }
+
+  // tnotify without prior MTE-side work does not need a release drain.
+  func.func @tnotify_no_mte_drain(
+      %signal_ptr: !pto.ptr<i32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %v_i32 = arith.constant 1 : i32
+
+    %sig_view = pto.make_tensor_view %signal_ptr,
+      shape = [%c1], strides = [%c1] : !pto.tensor_view<1xi32>
+    %sig = pto.partition_view %sig_view,
+      offsets = [%c0], sizes = [%c1]
+      : !pto.tensor_view<1xi32> -> !pto.partition_tensor_view<1xi32>
+    pto.comm.tnotify(%sig, %v_i32 : !pto.partition_tensor_view<1xi32>, i32)
+        {notifyOp = #pto<notify_op set>}
+    return
+  }
+
   // twait must NOT receive the new MTE drain -- the receiver-side wait does
   // not write any peer-visible data, so adding a barrier there would only be
   // a needless stall. Pair this with --implicit-check-not to lock that in.
@@ -115,15 +168,26 @@ module {
 // CHECK:      pto::comm::NotifyOp{{.*}}= pto::comm::NotifyOp::Set;
 // CHECK:      TLOAD(
 // CHECK:      TSTORE(
-// CHECK:      pipe_barrier(PIPE_ALL);
+// CHECK:      pipe_barrier(PIPE_MTE2);
+// CHECK-NEXT: pipe_barrier(PIPE_MTE3);
 // CHECK-NEXT: pto::comm::TNOTIFY(
 
 // CHECK-LABEL: AICORE void tnotify_drain_after_tload(
 // CHECK:      pto::comm::NotifyOp{{.*}}= pto::comm::NotifyOp::AtomicAdd;
 // CHECK:      TLOAD(
-// CHECK:      pipe_barrier(PIPE_ALL);
+// CHECK:      pipe_barrier(PIPE_MTE2);
 // CHECK-NEXT: pto::comm::TNOTIFY(
 
+// CHECK-LABEL: AICORE void tnotify_after_existing_mte2_barrier(
+// CHECK:      TLOAD(
+// CHECK:      pipe_barrier(PIPE_MTE2);
+// CHECK-NOT:  pipe_barrier(
+// CHECK:      pto::comm::TNOTIFY(
+
+// CHECK-LABEL: AICORE void tnotify_no_mte_drain(
+// CHECK-NOT:  pipe_barrier(
+// CHECK:      pto::comm::TNOTIFY(
+
 // CHECK-LABEL: AICORE void twait_no_extra_drain(
-// CHECK-NOT:  pipe_barrier(PIPE_ALL);
+// CHECK-NOT:  pipe_barrier(
 // CHECK:      pto::comm::TWAIT(


### PR DESCRIPTION
Summary
- Optimize the #711 TNotify release drain by annotating each `pto.comm.tnotify` with the MTE pipes that may still have prior in-flight work.
- Lower the drain as precise `pipe_barrier(PIPE_MTE2)` / `pipe_barrier(PIPE_MTE3)` calls instead of unconditional `pipe_barrier(PIPE_ALL)`.
- Avoid inserting a drain when there is no prior MTE-side work, and avoid duplicating a drain when an existing MTE barrier already cleared the pending pipe.

Motivation
- #711 requires TNotify to release prior MTE-side data movement before the scalar-pipe signal store, otherwise a peer TWait may observe the signal before data visibility.
- The current correctness fix is safe but conservative because every TNotify emits a global `PIPE_ALL` barrier.

Design
- Adds a pre-lowering analysis in PTOToEmitC that tracks pending MTE2/MTE3 work through structured blocks.
- Treats loop bodies conservatively by accounting for loop-carried pending MTE work from previous iterations.
- Falls back conservatively for pre-existing multi-block CFG.
- Keeps the implementation barrier-based, so it does not add event-id pressure or interact with the #706 TPUT/TGET event-id fix.

Testing
- `build_issue711/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/issue711_tnotify_mte_drain.pto -o - 2>&1 | /Users/lishengtao/Documents/PTO/llvm-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/issue711_tnotify_mte_drain.pto`
- `ninja -C build_issue711 check-pto` (264/264 passed)

Risk / Rollback
- Risk is limited to TNotify EmitC lowering. The analysis is intentionally conservative across loops and CFG, so it should preserve #711 correctness while removing unnecessary barriers.
- Rollback by reverting this PR, which restores the existing unconditional `PIPE_ALL` drain behavior.