### PR TITLE
Add A5 bufid sync pass

### DIFF
--- a/docs/bufid_sync_a5_design.md
+++ b/docs/bufid_sync_a5_design.md
@@ -1,0 +1,607 @@
+# A5 BufID Sync Design
+
+Date: 2026-05-29
+Status: proposed implementation
+
+## Intent
+
+`bufid_sync` is an A5 intra-core synchronization pass for PTOAS. It inserts
+`pto.get_buf` and `pto.rls_buf` around operations that access overlapping local
+buffers on different hardware pipes. The goal is to replace event-based
+`set_flag` / `wait_flag` synchronization for this path with buffer-id based
+program-order synchronization.
+
+The pass is enabled explicitly:
+
+```bash
+ptoas input.pto --pto-arch=a5 --enable-bufid_sync -o output.cpp
+```
+
+Non-goals:
+
+- It does not change PTO dialect semantics for existing `set_flag` /
+  `wait_flag` synchronization.
+- It does not modify the existing `InsertSync` analysis implementation.
+- It does not handle global memory synchronization through bufid; GM dependency
+  handling remains outside this pass.
+- It should not emit bufid synchronization for A3.
+
+## Sync Model
+
+### Event Sync
+
+`inject_sync` / `pto-insert-sync` models hazards as explicit events:
+
+```cpp
+MTE2(tile0)
+set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0)
+wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0)
+V(tile0)
+```
+
+The event pair directly encodes a relation between source pipe, destination
+pipe, and event id. It is precise, but consumes event resources and requires
+pairing `set` and `wait` around every dependency edge.
+
+### BufID Sync
+
+`bufid_sync` uses:
+
+```cpp
+get_buf(PIPE_MTE2, id, 0)
+MTE2(tile0)
+rls_buf(PIPE_MTE2, id, 0)
+
+get_buf(PIPE_V, id, 0)
+V(tile0)
+rls_buf(PIPE_V, id, 0)
+```
+
+The hardware rule is based on program order: operations wrapped by the same
+buffer id are ordered across participating pipes. The id represents a virtual
+resource derived from local buffer aliasing. If several operations touch the
+same logical local buffer region, they should use the same id.
+
+Critical invariant:
+
+```text
+For the same physical buf id, get_buf(id) / rls_buf(id) pairs must not nest.
+```
+
+This invariant is stronger than ordinary interval coloring. Any id reuse pass
+must prove that the final emitted sequence has no same-id nesting.
+
+## Inputs And Outputs
+
+Input:
+
+- PTO MLIR after frontend lowering and memory planning where possible.
+- `PTOIRTranslator` SyncIR built in `SyncAnalysisMode::NORMALSYNC`.
+- `MemoryDependentAnalyzer` results reused from `InsertSync`.
+
+Output:
+
+- The original PTO MLIR with inserted `pto.get_buf` and `pto.rls_buf`.
+- Later `PTOToEmitC` lowers those ops to C++ intrinsic calls:
+
+```cpp
+get_buf(PIPE_MTE2, 0, 0);
+rls_buf(PIPE_MTE2, 0, 0);
+```
+
+## Pass Placement
+
+Recommended `ptoas` pipeline placement:
+
+```text
+lowering-sync-to-pipe
+infer-layout
+normalize-a5-tmov
+view-to-memref
+plan-memory, if not level3
+resolve-reserved-buffers
+bufid_sync, if --enable-bufid_sync
+materialize-tile-handles
+CSE
+PTOToEmitC
+```
+
+Rationale:
+
+- `view-to-memref` and `plan-memory` expose local memory address information.
+- Running after memory planning lets alias checks use physical local addresses.
+- Running before EmitC keeps synchronization in PTO dialect form.
+
+The pass should require effective target arch `a5`. If `--enable-bufid_sync` is
+used with `--pto-arch=a3`, the driver should reject the configuration.
+
+## High-Level Flow
+
+```text
+func.func
+  |
+  v
+Build SyncIR with PTOIRTranslator
+  |
+  v
+Collect cross-pipe local-buffer dependency pairs
+  |
+  v
+Collect dependent tiles and classify by address space and overlap
+  |
+  v
+Build intersection graph and allocate virtual buf ids
+  |
+  v
+Map dependency pairs to virtual ids
+  |
+  v
+Create per-operation get/rls sync plans
+  |
+  v
+Optimize logic ids when same-pipe ordering allows it
+  |
+  v
+Allocate physical buf ids, default capacity = 32
+  |
+  v
+Validate no same-id nesting
+  |
+  v
+Emit pto.get_buf / pto.rls_buf ops
+```
+
+## Data Model
+
+### TileInfo
+
+Represents one local tile or local memref participating in cross-pipe
+dependencies.
+
+Fields:
+
+- `memInfo`: pointer to `BaseMemInfo` from `MemoryDependentAnalyzer`.
+- `scope`: PTO address space, for example `MAT`, `LEFT`, `RIGHT`, `ACC`, `VEC`.
+- `baseAddr`: planned local address when available.
+- `size`: allocated byte range size.
+- `tileValue`: SSA value directly used by the operation.
+- `rootBuffer`: underlying allocation or alias root.
+
+Design requirement:
+
+- GM tiles must be excluded.
+- Tiles in different address spaces must never be in the same virtual id.
+- Unknown local addresses should be handled conservatively by alias analysis.
+
+### DepPair
+
+Represents one ordered pair of cross-pipe operations with at least one local
+buffer dependency.
+
+Fields:
+
+- `srcElement`: earlier SyncIR compound element.
+- `dstElement`: later SyncIR compound element.
+- `depTiles`: all local tiles participating in RAW, WAR, or WAW dependency.
+- `srcPipe`, `dstPipe`: hardware pipe classification from SyncIR.
+
+Dependency collection rules:
+
+- Only inspect two different pipes.
+- Skip GM dependencies.
+- Record RAW, WAR, and WAW dependencies.
+- Same-pipe dependencies do not need bufid sync because hardware/program order
+  already orders them on that pipe.
+
+### VirtualBufId
+
+Represents a logical synchronization id before physical id allocation.
+
+Fields:
+
+- `logicId`: unique logical id.
+- `tiles`: maximal clique of mutually-overlapping tiles.
+- `scope`: address space shared by all tiles in the clique.
+
+A tile may appear in multiple virtual ids if it belongs to multiple maximal
+cliques. When a dependency can map to several ids, choose the id whose clique
+contains the most relevant tiles.
+
+### BufSyncOperation
+
+Represents one planned synchronization operation before MLIR codegen.
+
+Fields:
+
+- `type`: `GET_BUF` or `RLS_BUF`.
+- `pipe`: concrete producer/consumer pipe.
+- `logicId`: virtual buf id.
+- `syncIRIndex`: SyncIR position of this operation.
+- `depSyncIRIndex`: SyncIR position of the paired dependency operation.
+
+Per original PTO operation, the pass builds:
+
+- `pipeBefore`: `get_buf` operations inserted before the operation.
+- `pipeAfter`: `rls_buf` operations inserted after the operation.
+
+## Dependency Collection
+
+For each ordered pair of compound SyncIR elements:
+
+```text
+for i in compounds:
+  for j in compounds after i:
+    if pipe(i) == pipe(j):
+      continue
+    deps = DepBetween(def(i), use(j))   // RAW
+         + DepBetween(use(i), def(j))   // WAR
+         + DepBetween(def(i), def(j))   // WAW
+    filter out GM and cross-space pairs
+    if deps not empty:
+      create DepPair(i, j, deps)
+```
+
+The design intent is to collect all local dependent tiles for an operation pair,
+not just the first successful dependency class. This matters for choosing the
+best virtual id and for debug explainability.
+
+## Virtual BufID Construction
+
+### Step 1: Tile Collection
+
+Collect all local tiles from all dependency pairs.
+
+Deduplication is allowed only when it preserves alias semantics:
+
+- Same SSA value can be deduped.
+- Same root, same address space, same address range can be deduped.
+- If two tiles may alias, retaining either is acceptable only if
+  `findBestVirtualBufId` can still map dependency meminfo back through alias
+  checks.
+
+### Step 2: Connected Components
+
+Partition tiles by address space first. Within each address space, construct a
+union-find over `MemAlias(tileA, tileB)`:
+
+```text
+same address space + may alias => same connected component
+```
+
+Properties:
+
+- Different components do not overlap.
+- A component contains one or more tiles connected through overlap.
+
+### Step 3: Maximal Cliques
+
+For each connected component, build an undirected intersection graph:
+
+```text
+vertex = tile
+edge(tileA, tileB) = MemAlias(tileA, tileB)
+```
+
+Run Bron-Kerbosch to enumerate maximal cliques. Each maximal clique becomes one
+`VirtualBufId`.
+
+Why maximal cliques:
+
+- A clique means every tile in the id overlaps every other tile.
+- A maximal clique groups the largest mutually-overlapping buffer set without
+  adding a non-overlapping tile.
+- One tile may be in several maximal cliques, which preserves ambiguous overlap
+  relationships.
+
+Implementation guardrails:
+
+- Clique enumeration can be exponential. Keep debug counters and abort or fall
+  back conservatively if clique count exceeds a configured threshold.
+- The traversal order should be deterministic so generated IDs are stable.
+
+## Mapping Dependencies To Sync Ops
+
+For each `DepPair`, choose a virtual id:
+
+```text
+candidate ids = ids containing or aliasing any dep tile
+score(id) = number of dep tiles covered, then clique size, then stable logic id
+best id = max score
+```
+
+Then insert planned sync operations:
+
+```text
+src pipeBefore += get_buf(srcPipe, bestId)
+src pipeAfter  += rls_buf(srcPipe, bestId)
+dst pipeBefore += get_buf(dstPipe, bestId)
+dst pipeAfter  += rls_buf(dstPipe, bestId)
+```
+
+Deduplication rule:
+
+- If an operation already has `get_buf(pipe, logicId)`, do not add another.
+- If an operation already has `rls_buf(pipe, logicId)`, do not add another.
+
+Ordering rule:
+
+- If multiple ids guard one operation, emit `get_buf` in deterministic order and
+  `rls_buf` in reverse order. This keeps the textual nesting stack-like and
+  makes later legality checks easier.
+
+## Same-Pipe Merge Optimization
+
+Motivation:
+
+```text
+MTE1_A(tileA) -> M(tileA, tileB)
+MTE1_B(tileB) -> M(tileA, tileB)
+```
+
+If `MTE1_A` and `MTE1_B` are naturally ordered on the same pipe, two logic ids
+can sometimes be reduced to one:
+
+```cpp
+get_buf(PIPE_MTE1, 1, 0)
+TMOV(tileA)
+rls_buf(PIPE_MTE1, 1, 0)
+
+get_buf(PIPE_MTE1, 1, 0)
+TMOV(tileB)
+rls_buf(PIPE_MTE1, 1, 0)
+
+get_buf(PIPE_M, 1, 0)
+TMATMUL(tileA, tileB)
+rls_buf(PIPE_M, 1, 0)
+```
+
+Eligibility:
+
+- The same operation has multiple logic ids on the same pipe.
+- For each candidate logic id, all other users are on a single identical peer
+  pipe.
+- Merging does not create same-id nesting.
+- Merging does not cross a control-flow boundary in a way that changes ordering
+  assumptions.
+
+This optimization should be run before physical id allocation because it reduces
+the number of logical intervals.
+
+## Physical BufID Allocation
+
+Default physical ID capacity is 32.
+
+### Life Interval
+
+For each logic id:
+
+- Linear sequence: interval start is first `get_buf`, interval end is last
+  `rls_buf`.
+- Inside `scf.for`: interval covers the outermost loop body, because loop back
+  edges make all iterations overlap in the hardware-visible sequence.
+
+Example:
+
+```text
+0  get_buf(id0)
+1  op
+2  rls_buf(id0)
+...
+8  get_buf(id0)
+9  op
+10 rls_buf(id0)
+
+life(id0) = [0, 10]
+```
+
+For loop:
+
+```text
+5  scf.for begin
+6    get_buf(id0)
+7    op
+8    rls_buf(id0)
+19 scf.for end
+
+life(id0) includes [5, 19]
+```
+
+### Linear Scan
+
+Sort logic intervals by start position. Maintain:
+
+- `active`: intervals currently live, sorted by end.
+- `freeIds`: reusable physical ids released from expired intervals.
+- `nextPhysicalId`: next never-used physical id.
+
+Algorithm:
+
+```text
+for interval in intervals sorted by start:
+  expire all active intervals whose end < interval.start
+  if freeIds not empty:
+    assign smallest free id
+  else:
+    assign nextPhysicalId++
+  insert interval into active sorted by end
+```
+
+If `maxPhysicalId < 32`, allocation is complete. Otherwise, enter reuse.
+
+### Reuse
+
+Reuse is a fallback when logical intervals cannot fit in 32 physical IDs.
+
+Principles:
+
+- Only reuse ids inside the same pipe signature group, for example
+  `[MTE2, MTE1]` with `[MTE2, MTE1]`.
+- Prefer reuse groups with lower performance risk. A simple score:
+
+```text
+score = pipeScore(signature) * idCount^2
+```
+
+Where MTE2-containing groups get lower reuse priority because MTE2 latency is
+usually more expensive.
+
+Reuse layout:
+
+- If producer pipe IDs are consecutive, pair adjacent IDs:
+  `(0,1), (2,3)`.
+- Otherwise pair first half with second half:
+  `(0,2), (1,3)`.
+
+Mandatory legality check after reuse and get/rls merging:
+
+```text
+for every physical id:
+  scan final get/rls sequence in program order
+  depth must never exceed 1
+  rls must match a currently-open get
+```
+
+If the final plan fails legality or still requires more than 32 physical ids,
+the pass fails with a diagnostic instead of emitting unsafe synchronization.
+
+## Get/Rls Merge Optimization
+
+Adjacent same-pipe, same-id release/acquire pairs can be removed:
+
+```cpp
+rls_buf(PIPE_MTE1, 0, 0)
+get_buf(PIPE_MTE1, 0, 0)
+```
+
+becomes an extended live region:
+
+```cpp
+// removed boundary; one longer get/rls region
+```
+
+This optimization is safe only when:
+
+- The pair has the same physical id and same pipe.
+- There is no intervening operation that requires the id to become available.
+- The final same-id nesting validator still passes.
+
+Because it can extend live regions, run the final legality validator after this
+optimization too.
+
+## MLIR Codegen
+
+`BufidSyncCodegen` lowers the planned sync model to PTO dialect ops:
+
+```mlir
+pto.get_buf[#pto.pipe_event_type<TLOAD>, 0]
+...
+pto.rls_buf[#pto.pipe_event_type<TLOAD>, 0]
+```
+
+The PTO dialect models bufid endpoints with `pipe_event_type` /
+`sync_op_type`, matching the existing `record_event` / `wait_event` style.
+`PTOToEmitC` maps the endpoint to the final C++ intrinsic pipe token.
+
+Mapping from `PipelineType` to emitted endpoint:
+
+| PipelineType | PTO endpoint | EmitC pipe |
+| --- | --- | --- |
+| `PIPE_MTE2` | `#pto.pipe_event_type<TLOAD>` | `PIPE_MTE2` |
+| `PIPE_MTE3` | `#pto.pipe_event_type<TSTORE_VEC>` | `PIPE_MTE3` |
+| `PIPE_FIX` | `#pto.pipe_event_type<TSTORE_ACC>` | `PIPE_FIX` |
+| `PIPE_MTE1` | `#pto.pipe_event_type<TMOV_M2L>` | `PIPE_MTE1` |
+| `PIPE_V` | `#pto.pipe_event_type<TVEC>` | `PIPE_V` |
+| `PIPE_M` | `#pto.pipe_event_type<TMATMUL>` | `PIPE_M` |
+
+Unknown, scalar, or virtual pipes must not silently map to `PIPE_UNASSIGNED`.
+The pass fails with a diagnostic if it cannot map a pipe to a supported A5 bufid
+endpoint.
+
+## Correctness Invariants
+
+The pass is correct only if all of these hold:
+
+- No GM dependency is converted to bufid sync.
+- Same-pipe dependency does not emit redundant bufid sync.
+- Cross-pipe RAW, WAR, and WAW local dependencies are ordered by at least one
+  common physical buf id.
+- A physical buf id never has nested `get_buf` / `rls_buf`.
+- A physical buf id never has unmatched `get_buf` or unmatched `rls_buf`.
+- Physical id is in `[0, 31]`.
+- A5-only ops are emitted only for A5.
+- ID assignment is deterministic for stable generated output.
+
+## Implementation Layout
+
+Expected files:
+
+```text
+include/PTO/Transforms/Passes.td
+include/PTO/Transforms/Passes.h
+lib/PTO/Transforms/CMakeLists.txt
+lib/PTO/Transforms/BufidSync/
+  BufidSyncPass.cpp
+  BufidSyncAnalysis.h
+  BufidSyncAnalysis.cpp
+  BufidSyncIdAlloc.h
+  BufidSyncIdAlloc.cpp
+  BufidSyncCodegen.h
+  BufidSyncCodegen.cpp
+tools/ptoas/ptoas.cpp
+```
+
+Responsibilities:
+
+| Component | Responsibility |
+| --- | --- |
+| `BufidSyncPass` | pass orchestration, SyncIR construction, phase ordering |
+| `BufidSyncAnalysis` | dep pair collection, tile grouping, virtual id allocation, logic sync planning |
+| `BufidSyncIdAlloc` | life intervals, physical id allocation, reuse policy |
+| `BufidSyncCodegen` | `PipelineType` to `pipe_event_type`, emit `pto.get_buf` / `pto.rls_buf` |
+| `Passes.td` / `Passes.h` | pass registration and options |
+| `ptoas.cpp` | CLI flag and pipeline integration |
+
+## Validation Plan
+
+Minimum build gate:
+
+```bash
+ninja -C build ptoas
+```
+
+Smoke tests:
+
+```bash
+build/tools/ptoas/ptoas test/samples/Sync/test_a5_buf_sync.pto \
+  --pto-arch=a5 --pto-level=level3 \
+  -o /tmp/manual_get_buf.cpp
+
+build/tools/ptoas/ptoas test/samples/Sync/matmul.pto \
+  --pto-arch=a5 --enable-bufid_sync \
+  -o /tmp/bufid_matmul.cpp
+```
+
+Recommended regression tests:
+
+- Basic `MTE2 -> MTE1` RAW dependency emits one id.
+- `MTE1 -> M` dependency emits shared id between pipes.
+- `M -> MTE3/FIX` store dependency emits shared id.
+- Same-pipe dependencies emit no bufid sync.
+- GM-only dependencies emit no bufid sync.
+- Overlapping local tiles share virtual ids.
+- Non-overlapping local tiles do not share virtual ids unless same-pipe merge is
+  explicitly legal.
+- More than 32 logical ids triggers reuse and final no-nesting validation.
+- `--enable-bufid_sync --pto-arch=a3` is rejected.
+
+## Implemented Guardrails
+
+- Linear scan maintains a persistent free-id pool before allocating new physical
+  ids.
+- Dependency-to-virtual-id selection scores all dependent tiles by coverage,
+  clique size, and stable logic id.
+- Reuse is followed by a final same-physical-id nesting validator.
+- `get_buf` emission is deterministic by physical id and pipe; `rls_buf`
+  emission uses the reverse order.
+- `--enable-bufid_sync` is rejected unless the effective target arch is A5.
+- Debug output is gated by `--enable-bufid-sync-debug` or LLVM debug flags.

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -44,6 +44,8 @@ std::unique_ptr<Pass> createPTOVerifyTFreePass();
 // Creates a pass for ...
 std::unique_ptr<Pass> createPTOInsertSyncPass();
 std::unique_ptr<Pass> createPTOInjectBarrierAllSyncPass();
+std::unique_ptr<Pass>
+createPTOBufidSyncPass(const PTOBufidSyncOptions &options = {});
 
 // Graph-based intra-core sync solver (coexists with PTOInsertSync).
 std::unique_ptr<Pass>

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -57,6 +57,30 @@ def PTOInjectBarrierAllSync : Pass<"pto-inject-barrier-all-sync", "func::FuncOp"
   ];
 }
 
+def PTOBufidSync : Pass<"pto-bufid-sync", "func::FuncOp"> {
+  let summary = "Insert get_buf/rls_buf synchronization for PTO dialect";
+  let description = [{
+    Analyzes cross-pipeline local buffer dependencies and wraps dependent
+    operations with A5 buffer-id synchronization. Unlike pto-insert-sync, this
+    pass emits get_buf/rls_buf pairs instead of set_flag/wait_flag events.
+  }];
+
+  let constructor = "mlir::pto::createPTOBufidSyncPass()";
+
+  let options = [
+    Option<"enableBufidSyncDebug", "enable-bufid-sync-debug",
+           "bool", "false",
+           "Enable verbose debug printing for the bufid_sync pass">
+  ];
+
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::memref::MemRefDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect"
+  ];
+}
+
 // Define PTOGraphSyncSolver Pass (graph-based intra-core sync solver).
 // Coexists with PTOInsertSync; selectable via the driver flag
 // `--enable-graph-sync-solver`. Ported from bishengir's GraphSyncSolver core:

--- a/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.cpp
@@ -1,0 +1,719 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "BufidSyncAnalysis.h"
+#include "PTO/IR/PTO.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "llvm/Support/Debug.h"
+#include <algorithm>
+#include <functional>
+#include <map>
+#include <tuple>
+
+#define DEBUG_TYPE "pto-bufid-sync"
+
+using namespace mlir;
+using namespace mlir::pto;
+
+bool BufidSyncAnalysis::isGMDependency(
+    const SmallVector<const BaseMemInfo *> &tiles) const {
+  for (auto *tile : tiles) {
+    if (tile->scope == pto::AddressSpace::GM)
+      return true;
+  }
+  return false;
+}
+
+bool BufidSyncAnalysis::isSamePipe(CompoundInstanceElement *a,
+                                   CompoundInstanceElement *b) const {
+  return a->kPipeValue == b->kPipeValue;
+}
+
+void BufidSyncAnalysis::collectDependencies() {
+  SmallVector<CompoundInstanceElement *> compounds;
+  for (auto &element : syncIR_) {
+    if (auto *comp = dyn_cast<CompoundInstanceElement>(element.get())) {
+      compounds.push_back(comp);
+    }
+  }
+  if (debugEnabled_) {
+    llvm::outs() << "[bufid_sync] collectDependencies: compounds count="
+               << compounds.size() << "\n";
+  }
+
+  for (unsigned i = 0; i < compounds.size(); ++i) {
+    for (unsigned j = i + 1; j < compounds.size(); ++j) {
+      auto *src = compounds[i];
+      auto *dst = compounds[j];
+
+      if (isSamePipe(src, dst))
+        continue;
+
+      DepBaseMemInfoPairVec depBaseMemInfosVec;
+      bool hasDep = memAnalyzer_.DepBetween(src->defVec, dst->useVec,
+                                            depBaseMemInfosVec);
+      if (!hasDep) {
+        depBaseMemInfosVec.clear();
+        hasDep = memAnalyzer_.DepBetween(src->useVec, dst->defVec,
+                                         depBaseMemInfosVec);
+      }
+      if (!hasDep) {
+        depBaseMemInfosVec.clear();
+        hasDep = memAnalyzer_.DepBetween(src->defVec, dst->defVec,
+                                         depBaseMemInfosVec);
+      }
+
+      if (!hasDep)
+        continue;
+
+      SmallVector<const BaseMemInfo *> depTiles;
+      for (auto &pair : depBaseMemInfosVec) {
+        if (pair.first->scope == pto::AddressSpace::GM ||
+            pair.second->scope == pto::AddressSpace::GM)
+          continue;
+        if (pair.first->scope != pair.second->scope)
+          continue;
+        depTiles.push_back(pair.first);
+        depTiles.push_back(pair.second);
+      }
+
+      if (depTiles.empty())
+        continue;
+
+      DepPair dp;
+      dp.srcElement = src;
+      dp.dstElement = dst;
+      dp.depTiles = depTiles;
+      dp.srcPipe = src->kPipeValue;
+      dp.dstPipe = dst->kPipeValue;
+      depPairs_.push_back(std::move(dp));
+    }
+  }
+
+  collectTilesFromDepPairs();
+
+  if (debugEnabled_) {
+    printDepPairs(llvm::outs(), depPairs_);
+  }
+}
+
+void BufidSyncAnalysis::collectTilesFromDepPairs() {
+  DenseSet<Value> seenBaseBuffers;
+  for (auto &dp : depPairs_) {
+    for (auto *memInfo : dp.depTiles) {
+      Value baseBuf = memInfo->baseBuffer;
+      if (!seenBaseBuffers.insert(baseBuf).second)
+        continue;
+      TileInfo ti;
+      ti.memInfo = memInfo;
+      ti.scope = memInfo->scope;
+      ti.baseAddr =
+          memInfo->baseAddresses.empty() ? 0 : memInfo->baseAddresses[0];
+      ti.size = memInfo->allocateSize;
+      ti.tileValue = baseBuf;
+      Value rootBuf = memInfo->rootBuffer;
+      if (rootBuf && rootBuf.getDefiningOp() &&
+          rootBuf.getDefiningOp()->hasTrait<mlir::OpTrait::ConstantLike>())
+        rootBuf = baseBuf;
+      ti.rootBuffer = rootBuf;
+      allTiles_.push_back(ti);
+    }
+  }
+
+  std::map<std::tuple<int, uint64_t, uint64_t>, SmallVector<unsigned>> keyToIndices;
+  for (unsigned i = 0; i < allTiles_.size(); ++i) {
+    auto &t = allTiles_[i];
+    auto key = std::make_tuple(static_cast<int>(t.scope), t.baseAddr, t.size);
+    keyToIndices[key].push_back(i);
+  }
+
+  SmallVector<TileInfo> deduped;
+  DenseSet<unsigned> removed;
+  for (auto &[key, indices] : keyToIndices) {
+    if (indices.size() <= 1)
+      continue;
+    DenseMap<Value, unsigned> rootToFirst;
+    for (unsigned idx : indices) {
+      Value root = allTiles_[idx].rootBuffer;
+      auto it = rootToFirst.find(root);
+      if (it != rootToFirst.end()) {
+        removed.insert(idx);
+      } else {
+        rootToFirst[root] = idx;
+      }
+    }
+  }
+
+  for (auto &[key, indices] : keyToIndices) {
+    if (indices.size() <= 1)
+      continue;
+    for (unsigned k = 1; k < indices.size(); ++k) {
+      if (removed.count(indices[k]))
+        continue;
+      auto &a = allTiles_[indices[0]];
+      auto &b = allTiles_[indices[k]];
+      if (a.scope == b.scope && a.baseAddr == b.baseAddr && a.size == b.size &&
+          memAnalyzer_.MemAlias(a.memInfo, b.memInfo))
+        removed.insert(indices[k]);
+    }
+  }
+
+  if (!removed.empty()) {
+    for (unsigned i = 0; i < allTiles_.size(); ++i) {
+      if (!removed.count(i))
+        deduped.push_back(std::move(allTiles_[i]));
+    }
+    if (debugEnabled_) {
+      llvm::outs() << "[bufid_sync] allTiles dedup: " << allTiles_.size()
+                 << " -> " << deduped.size() << "\n";
+    }
+    allTiles_ = std::move(deduped);
+  }
+
+  if (debugEnabled_) {
+    printAllTiles(llvm::outs(), allTiles_);
+  }
+}
+
+void BufidSyncAnalysis::classifyTiles() {
+  if (allTiles_.empty())
+    return;
+
+  DenseMap<pto::AddressSpace, SmallVector<unsigned>> spaceGroups;
+  for (unsigned i = 0; i < allTiles_.size(); ++i) {
+    spaceGroups[allTiles_[i].scope].push_back(i);
+  }
+
+  for (auto &[space, indices] : spaceGroups) {
+    unsigned n = indices.size();
+    SmallVector<unsigned> parent(n);
+    for (unsigned i = 0; i < n; ++i)
+      parent[i] = i;
+
+    auto find = [&](unsigned x) -> unsigned {
+      while (parent[x] != x) {
+        parent[x] = parent[parent[x]];
+        x = parent[x];
+      }
+      return x;
+    };
+
+    auto unite = [&](unsigned a, unsigned b) {
+      a = find(a);
+      b = find(b);
+      if (a != b)
+        parent[a] = b;
+    };
+
+    for (unsigned i = 0; i < n; ++i) {
+      for (unsigned j = i + 1; j < n; ++j) {
+        if (memAnalyzer_.MemAlias(allTiles_[indices[i]].memInfo,
+                                  allTiles_[indices[j]].memInfo)) {
+          unite(i, j);
+        }
+      }
+    }
+
+    DenseMap<unsigned, SmallVector<unsigned>> components;
+    for (unsigned i = 0; i < n; ++i) {
+      components[find(i)].push_back(indices[i]);
+    }
+
+    for (auto &[root, tileIndices] : components) {
+      tileGroups_.push_back(tileIndices);
+    }
+  }
+
+  if (debugEnabled_) {
+    printTileGroups(llvm::outs(), tileGroups_, allTiles_);
+  }
+}
+
+void BufidSyncAnalysis::bronKerbosch(
+    const SmallVector<unsigned> &R, SmallVector<unsigned> P,
+    SmallVector<unsigned> X,
+    const SmallVector<SmallVector<bool>> &adjMatrix,
+    SmallVector<SmallVector<unsigned>> &maximalCliques) {
+  if (P.empty() && X.empty()) {
+    if (!R.empty())
+      maximalCliques.push_back(R);
+    return;
+  }
+
+  if (maximalCliques.size() > 100000) {
+    llvm::errs() << "[bufid_sync] bronKerbosch WARNING: too many cliques ("
+                 << maximalCliques.size() << "), aborting!\n";
+    return;
+  }
+
+  unsigned pivot = P.empty() ? X[0] : P[0];
+  SmallVector<unsigned> candidates;
+  for (unsigned v : P) {
+    if (!adjMatrix[pivot][v])
+      candidates.push_back(v);
+  }
+
+  for (unsigned v : candidates) {
+    SmallVector<unsigned> newR = R;
+    newR.push_back(v);
+
+    SmallVector<unsigned> newP, newX;
+    for (unsigned u : P) {
+      if (adjMatrix[v][u])
+        newP.push_back(u);
+    }
+    for (unsigned u : X) {
+      if (adjMatrix[v][u])
+        newX.push_back(u);
+    }
+
+    bronKerbosch(newR, newP, newX, adjMatrix, maximalCliques);
+
+    auto it = std::find(P.begin(), P.end(), v);
+    if (it != P.end())
+      P.erase(it);
+    X.push_back(v);
+  }
+}
+
+void BufidSyncAnalysis::allocateVirtualBufIds() {
+  int nextLogicId = 0;
+
+  for (unsigned gi = 0; gi < tileGroups_.size(); ++gi) {
+    auto &group = tileGroups_[gi];
+    unsigned n = group.size();
+    if (n == 0)
+      continue;
+
+    SmallVector<SmallVector<bool>> adjMatrix(
+        n, SmallVector<bool>(n, false));
+    for (unsigned i = 0; i < n; ++i) {
+      for (unsigned j = i + 1; j < n; ++j) {
+        if (memAnalyzer_.MemAlias(allTiles_[group[i]].memInfo,
+                                  allTiles_[group[j]].memInfo)) {
+          adjMatrix[i][j] = true;
+          adjMatrix[j][i] = true;
+        }
+      }
+    }
+
+    SmallVector<unsigned> P;
+    for (unsigned i = 0; i < n; ++i)
+      P.push_back(i);
+
+    SmallVector<SmallVector<unsigned>> maximalCliques;
+    bronKerbosch({}, P, {}, adjMatrix, maximalCliques);
+    if (debugEnabled_) {
+      llvm::outs() << "[bufid_sync] allocateVirtualBufIds: group[" << gi
+                 << "] bronKerbosch done, maximalCliques="
+                 << maximalCliques.size() << "\n";
+    }
+
+    for (auto &clique : maximalCliques) {
+      VirtualBufId vbid;
+      vbid.logicId = nextLogicId++;
+      vbid.scope = allTiles_[group[clique[0]]].scope;
+      for (unsigned idx : clique) {
+        vbid.tiles.push_back(allTiles_[group[idx]]);
+      }
+      virtualBufIds_.push_back(std::move(vbid));
+    }
+  }
+
+  if (debugEnabled_) {
+    printVirtualBufIds(llvm::outs(), virtualBufIds_);
+  }
+}
+
+bool BufidSyncAnalysis::virtualBufIdContainsTile(const VirtualBufId &vbid,
+                                                 const BaseMemInfo *tile) const {
+  if (!tile)
+    return false;
+  if (vbid.scope != tile->scope)
+    return false;
+  for (auto &t : vbid.tiles) {
+    bool ptrMatch = (t.memInfo == tile);
+    bool valMatch = (t.tileValue == tile->baseBuffer);
+    bool aliasMatch =
+        (!ptrMatch && !valMatch && memAnalyzer_.MemAlias(t.memInfo, tile));
+    if (ptrMatch || valMatch || aliasMatch)
+      return true;
+  }
+  return false;
+}
+
+int BufidSyncAnalysis::findBestVirtualBufId(const BaseMemInfo *tile) const {
+  int bestLogicId = -1;
+  unsigned bestTileCount = 0;
+  for (auto &vbid : virtualBufIds_) {
+    if (virtualBufIdContainsTile(vbid, tile) &&
+        (vbid.tiles.size() > bestTileCount ||
+         (vbid.tiles.size() == bestTileCount &&
+          (bestLogicId < 0 || vbid.logicId < bestLogicId)))) {
+      bestLogicId = vbid.logicId;
+      bestTileCount = vbid.tiles.size();
+    }
+  }
+  return bestLogicId;
+}
+
+int BufidSyncAnalysis::findBestVirtualBufId(const DepPair &depPair) const {
+  int bestLogicId = -1;
+  unsigned bestMatchedTiles = 0;
+  unsigned bestCliqueSize = 0;
+
+  for (auto &vbid : virtualBufIds_) {
+    unsigned matchedTiles = 0;
+    for (auto *tile : depPair.depTiles) {
+      if (virtualBufIdContainsTile(vbid, tile))
+        ++matchedTiles;
+    }
+
+    if (matchedTiles == 0)
+      continue;
+
+    bool isBetter =
+        matchedTiles > bestMatchedTiles ||
+        (matchedTiles == bestMatchedTiles &&
+         vbid.tiles.size() > bestCliqueSize) ||
+        (matchedTiles == bestMatchedTiles &&
+         vbid.tiles.size() == bestCliqueSize &&
+         (bestLogicId < 0 || vbid.logicId < bestLogicId));
+    if (isBetter) {
+      bestLogicId = vbid.logicId;
+      bestMatchedTiles = matchedTiles;
+      bestCliqueSize = vbid.tiles.size();
+    }
+  }
+
+  return bestLogicId;
+}
+
+void BufidSyncAnalysis::insertSyncOperations() {
+  for (auto &dp : depPairs_) {
+    int bestLogicId = findBestVirtualBufId(dp);
+
+    if (bestLogicId < 0)
+      continue;
+
+    Operation *srcOp = dp.srcElement->elementOp;
+    Operation *dstOp = dp.dstElement->elementOp;
+
+    {
+      BufSyncOperation getOp;
+      getOp.type = BufSyncType::GET_BUF;
+      getOp.pipe = dp.srcPipe;
+      getOp.logicId = bestLogicId;
+      getOp.syncIRIndex = dp.srcElement->GetIndex();
+      getOp.depSyncIRIndex = dp.dstElement->GetIndex();
+
+      auto &pipeBefore = op2BufSync_[srcOp].pipeBefore;
+      bool exists = false;
+      for (auto &s : pipeBefore) {
+        if (s.logicId == getOp.logicId && s.pipe == getOp.pipe) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists)
+        pipeBefore.push_back(getOp);
+    }
+
+    {
+      BufSyncOperation rlsOp;
+      rlsOp.type = BufSyncType::RLS_BUF;
+      rlsOp.pipe = dp.srcPipe;
+      rlsOp.logicId = bestLogicId;
+      rlsOp.syncIRIndex = dp.srcElement->GetIndex();
+      rlsOp.depSyncIRIndex = dp.dstElement->GetIndex();
+
+      auto &pipeAfter = op2BufSync_[srcOp].pipeAfter;
+      bool exists = false;
+      for (auto &s : pipeAfter) {
+        if (s.logicId == rlsOp.logicId && s.pipe == rlsOp.pipe) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists)
+        pipeAfter.push_back(rlsOp);
+    }
+
+    {
+      BufSyncOperation getOp;
+      getOp.type = BufSyncType::GET_BUF;
+      getOp.pipe = dp.dstPipe;
+      getOp.logicId = bestLogicId;
+      getOp.syncIRIndex = dp.dstElement->GetIndex();
+      getOp.depSyncIRIndex = dp.srcElement->GetIndex();
+
+      auto &pipeBefore = op2BufSync_[dstOp].pipeBefore;
+      bool exists = false;
+      for (auto &s : pipeBefore) {
+        if (s.logicId == getOp.logicId && s.pipe == getOp.pipe) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists)
+        pipeBefore.push_back(getOp);
+    }
+
+    {
+      BufSyncOperation rlsOp;
+      rlsOp.type = BufSyncType::RLS_BUF;
+      rlsOp.pipe = dp.dstPipe;
+      rlsOp.logicId = bestLogicId;
+      rlsOp.syncIRIndex = dp.dstElement->GetIndex();
+      rlsOp.depSyncIRIndex = dp.srcElement->GetIndex();
+
+      auto &pipeAfter = op2BufSync_[dstOp].pipeAfter;
+      bool exists = false;
+      for (auto &s : pipeAfter) {
+        if (s.logicId == rlsOp.logicId && s.pipe == rlsOp.pipe) {
+          exists = true;
+          break;
+        }
+      }
+      if (!exists)
+        pipeAfter.push_back(rlsOp);
+    }
+  }
+
+  if (debugEnabled_) {
+    printOp2BufSync(llvm::outs(), op2BufSync_, func_);
+  }
+}
+
+void BufidSyncAnalysis::optimizeSamePipeMerge() {
+  DenseMap<int, DenseSet<int>> logicIdToPipeInts;
+  for (auto &[op, build] : op2BufSync_) {
+    DenseSet<std::pair<int, int>> seen;
+    for (auto &s : build.pipeBefore) {
+      auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
+      if (seen.insert(key).second)
+        logicIdToPipeInts[s.logicId].insert(static_cast<int>(s.pipe));
+    }
+    for (auto &s : build.pipeAfter) {
+      auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
+      if (seen.insert(key).second)
+        logicIdToPipeInts[s.logicId].insert(static_cast<int>(s.pipe));
+    }
+  }
+
+  DenseMap<int, int> mergeMap;
+
+  for (auto &[op, build] : op2BufSync_) {
+    DenseMap<int, SmallVector<int>> pipeIntToLogicIds;
+    DenseSet<std::pair<int, int>> seen;
+    for (auto &s : build.pipeBefore) {
+      auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
+      if (seen.insert(key).second)
+        pipeIntToLogicIds[static_cast<int>(s.pipe)].push_back(s.logicId);
+    }
+    for (auto &s : build.pipeAfter) {
+      auto key = std::make_pair(static_cast<int>(s.pipe), s.logicId);
+      if (seen.insert(key).second)
+        pipeIntToLogicIds[static_cast<int>(s.pipe)].push_back(s.logicId);
+    }
+
+    for (auto &[pipeInt, logicIds] : pipeIntToLogicIds) {
+      if (logicIds.size() <= 1)
+        continue;
+
+      DenseMap<int, SmallVector<int>> sigPipeToIds;
+      for (int lid : logicIds) {
+        auto it = logicIdToPipeInts.find(lid);
+        if (it == logicIdToPipeInts.end())
+          continue;
+        SmallVector<int> otherPipes;
+        for (int p : it->second) {
+          if (p != pipeInt)
+            otherPipes.push_back(p);
+        }
+        if (otherPipes.size() == 1)
+          sigPipeToIds[otherPipes[0]].push_back(lid);
+      }
+
+      for (auto &[sigPipe, ids] : sigPipeToIds) {
+        if (ids.size() > 1) {
+          int survivor = *std::min_element(ids.begin(), ids.end());
+          for (int id : ids) {
+            if (id != survivor && !mergeMap.count(id))
+              mergeMap[id] = survivor;
+          }
+        }
+      }
+    }
+  }
+
+  if (debugEnabled_) {
+    llvm::outs() << "[bufid_sync] optimizeSamePipeMerge: mergeMap size=" << mergeMap.size() << "\n";
+    for (auto &[id, target] : mergeMap) {
+      llvm::outs() << "[bufid_sync]   merge logicId=" << id << " -> " << target << "\n";
+    }
+  }
+
+  for (auto &[id, target] : mergeMap) {
+    while (mergeMap.count(target))
+      target = mergeMap[target];
+  }
+
+  DenseMap<Operation *, BufSyncPipeBuild> newOp2BufSync;
+  for (auto &[op, build] : op2BufSync_) {
+    BufSyncPipeBuild newBuild;
+
+    DenseSet<std::pair<int, int>> seenBefore;
+    for (auto &s : build.pipeBefore) {
+      int newLogicId = s.logicId;
+      auto it = mergeMap.find(newLogicId);
+      if (it != mergeMap.end())
+        newLogicId = it->second;
+      auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
+      if (seenBefore.insert(key).second) {
+        BufSyncOperation newS = s;
+        newS.logicId = newLogicId;
+        newBuild.pipeBefore.push_back(newS);
+      }
+    }
+
+    DenseSet<std::pair<int, int>> seenAfter;
+    for (auto &s : build.pipeAfter) {
+      int newLogicId = s.logicId;
+      auto it = mergeMap.find(newLogicId);
+      if (it != mergeMap.end())
+        newLogicId = it->second;
+      auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
+      if (seenAfter.insert(key).second) {
+        BufSyncOperation newS = s;
+        newS.logicId = newLogicId;
+        newBuild.pipeAfter.push_back(newS);
+      }
+    }
+
+    newOp2BufSync[op] = std::move(newBuild);
+  }
+
+  op2BufSync_ = std::move(newOp2BufSync);
+
+  virtualBufIds_.erase(
+      std::remove_if(virtualBufIds_.begin(), virtualBufIds_.end(),
+                     [&](const VirtualBufId &vbid) {
+                       return mergeMap.count(vbid.logicId);
+                     }),
+      virtualBufIds_.end());
+
+  if (debugEnabled_) {
+    printOp2BufSync(llvm::outs(), op2BufSync_, func_,
+                    "After optimizeSamePipeMerge");
+  }
+}
+
+void BufidSyncAnalysis::mergeGetRls() {
+  using RlsKey = std::pair<int, int>;
+  using RlsMap = DenseMap<RlsKey, Operation *>;
+
+  unsigned cancelCount = 0;
+
+  std::function<void(Block *, RlsMap &)> processBlock =
+      [&](Block *block, RlsMap &rlsMap) {
+        for (auto &op : *block) {
+          auto it = op2BufSync_.find(&op);
+          if (it != op2BufSync_.end()) {
+            auto &build = it->second;
+
+            SmallVector<BufSyncOperation> newPipeBefore;
+            for (auto &sync : build.pipeBefore) {
+              if (sync.type == BufSyncType::GET_BUF) {
+                RlsKey key(sync.logicId, static_cast<int>(sync.pipe));
+                auto mapIt = rlsMap.find(key);
+                if (mapIt != rlsMap.end()) {
+                  Operation *rlsOp = mapIt->second;
+
+                  auto rlsIt = op2BufSync_.find(rlsOp);
+                  if (rlsIt != op2BufSync_.end()) {
+                    auto &rlsPipeAfter = rlsIt->second.pipeAfter;
+                    rlsPipeAfter.erase(
+                        std::remove_if(
+                            rlsPipeAfter.begin(), rlsPipeAfter.end(),
+                            [&](const BufSyncOperation &s) {
+                              return s.type == BufSyncType::RLS_BUF &&
+                                     s.logicId == sync.logicId &&
+                                     s.pipe == sync.pipe;
+                            }),
+                        rlsPipeAfter.end());
+                  }
+                  rlsMap.erase(mapIt);
+                  ++cancelCount;
+                  continue;
+                }
+                SmallVector<RlsKey> keysToErase;
+                for (auto &[existingKey, rlsOp] : rlsMap) {
+                  if (existingKey.first == sync.logicId &&
+                      existingKey.second != static_cast<int>(sync.pipe)) {
+                    keysToErase.push_back(existingKey);
+                  }
+                }
+                for (auto &key : keysToErase)
+                  rlsMap.erase(key);
+              }
+              newPipeBefore.push_back(sync);
+            }
+            build.pipeBefore = std::move(newPipeBefore);
+
+            for (auto &sync : build.pipeAfter) {
+              if (sync.type == BufSyncType::RLS_BUF) {
+                RlsKey key(sync.logicId, static_cast<int>(sync.pipe));
+                rlsMap[key] = &op;
+                if (debugEnabled_) {
+                  llvm::outs() << "  ADD to map: RLS_BUF(pipe=" << static_cast<int>(sync.pipe)
+                               << ", lid=" << sync.logicId << ")\n";
+                }
+              }
+            }
+          }
+
+          if (auto forOp = dyn_cast<scf::ForOp>(&op)) {
+            for (auto &region : forOp->getRegions()) {
+              RlsMap freshMap;
+              for (auto &subBlock : region.getBlocks())
+                processBlock(&subBlock, freshMap);
+            }
+            rlsMap.clear();
+            continue;
+          }
+
+          if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
+            for (auto &region : ifOp->getRegions()) {
+              RlsMap freshMap;
+              for (auto &subBlock : region.getBlocks())
+                processBlock(&subBlock, freshMap);
+            }
+            rlsMap.clear();
+            continue;
+          }
+        }
+      };
+
+  RlsMap rootMap;
+  for (auto &block : func_.getBody().getBlocks())
+    processBlock(&block, rootMap);
+
+  SmallVector<Operation *> emptyOps;
+  for (auto &[op, build] : op2BufSync_) {
+    if (build.pipeBefore.empty() && build.pipeAfter.empty())
+      emptyOps.push_back(op);
+  }
+  for (auto *op : emptyOps)
+    op2BufSync_.erase(op);
+
+  if (debugEnabled_) {
+    printOp2BufSync(llvm::outs(), op2BufSync_, func_,
+                    "After mergeGetRls");
+  }
+}

--- a/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.h
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCANALYSIS_H
+#define MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCANALYSIS_H
+
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
+#include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/raw_ostream.h"
+#include <algorithm>
+#include <optional>
+
+namespace mlir {
+namespace pto {
+
+struct TileInfo {
+  const BaseMemInfo *memInfo;
+  pto::AddressSpace scope;
+  uint64_t baseAddr;
+  uint64_t size;
+  Value tileValue;
+  Value rootBuffer;
+};
+
+struct DepPair {
+  CompoundInstanceElement *srcElement;
+  CompoundInstanceElement *dstElement;
+  SmallVector<const BaseMemInfo *> depTiles;
+  PipelineType srcPipe;
+  PipelineType dstPipe;
+};
+
+struct VirtualBufId {
+  int logicId;
+  SmallVector<TileInfo> tiles;
+  pto::AddressSpace scope;
+};
+
+enum class BufSyncType {
+  GET_BUF,
+  RLS_BUF
+};
+
+struct BufSyncOperation {
+  BufSyncType type;
+  PipelineType pipe;
+  int logicId;
+  unsigned syncIRIndex;
+  unsigned depSyncIRIndex;
+};
+
+struct BufSyncPipeBuild {
+  SmallVector<BufSyncOperation> pipeBefore;
+  SmallVector<BufSyncOperation> pipeAfter;
+};
+
+struct BufIdInterval {
+  int logicId;
+  unsigned startPos;
+  unsigned endPos;
+  SmallVector<PipelineType> pipes;
+};
+
+inline void printTileValue(llvm::raw_ostream &os, Value val) {
+  val.printAsOperand(os, OpPrintingFlags());
+}
+
+inline llvm::StringRef stringifyAddressSpace(pto::AddressSpace as) {
+  switch (as) {
+  case pto::AddressSpace::GM:      return "gm";
+  case pto::AddressSpace::MAT:    return "mat";
+  case pto::AddressSpace::LEFT:   return "left";
+  case pto::AddressSpace::RIGHT:  return "right";
+  case pto::AddressSpace::ACC:    return "acc";
+  case pto::AddressSpace::VEC:    return "vec";
+  case pto::AddressSpace::BIAS:   return "bias";
+  case pto::AddressSpace::SCALING:return "scaling";
+  default: return "unknown";
+  }
+}
+
+inline std::optional<pto::AddressSpace> getTileLocFromType(Value tileValue) {
+  if (!tileValue) return std::nullopt;
+  auto tileType = dyn_cast<pto::TileBufType>(tileValue.getType());
+  if (tileType) {
+    auto asAttr = dyn_cast_or_null<pto::AddressSpaceAttr>(tileType.getMemorySpace());
+    if (asAttr) return asAttr.getAddressSpace();
+  }
+  auto memrefType = dyn_cast<mlir::MemRefType>(tileValue.getType());
+  if (memrefType) {
+    auto asAttr = dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace());
+    if (asAttr) return asAttr.getAddressSpace();
+  }
+  return std::nullopt;
+}
+
+inline void printTileLoc(llvm::raw_ostream &os, Value tileValue) {
+  if (!tileValue) return;
+  auto *defOp = tileValue.getDefiningOp();
+  if (!defOp) {
+    os << " BlockArg";
+    return;
+  }
+  os << " defBy=" << defOp->getName().getStringRef();
+  auto locAs = getTileLocFromType(tileValue);
+  if (locAs)
+    os << " typeLoc=" << stringifyAddressSpace(*locAs);
+}
+
+inline void printTileInfo(llvm::raw_ostream &os, const TileInfo &t) {
+  printTileValue(os, t.tileValue);
+  os << " scope=" << static_cast<int>(t.scope)
+     << "(" << stringifyAddressSpace(t.scope) << ")";
+  auto typeLoc = getTileLocFromType(t.tileValue);
+  if (typeLoc && *typeLoc != t.scope)
+    os << " MISMATCH! typeLoc=" << stringifyAddressSpace(*typeLoc);
+  os << " baseAddr=" << t.baseAddr << " size=" << t.size;
+  printTileLoc(os, t.tileValue);
+  os << " root=";
+  printTileValue(os, t.rootBuffer);
+  if (t.rootBuffer) {
+    if (auto *defOp = t.rootBuffer.getDefiningOp())
+      os << " rootDefBy=" << defOp->getName().getStringRef();
+    else
+      os << " rootDefBy=BlockArg";
+    os << " rootPtr=" << (const void *)t.rootBuffer.getAsOpaquePointer();
+  }
+}
+
+inline void printDepPairs(llvm::raw_ostream &os,
+                          const SmallVector<DepPair> &depPairs) {
+  os << "[bufid_sync] depPairs count: " << depPairs.size() << "\n";
+  for (unsigned i = 0; i < depPairs.size(); ++i) {
+    auto &dp = depPairs[i];
+    os << "  depPair[" << i << "] src[syncIR=" << dp.srcElement->GetIndex()
+       << "] dst[syncIR=" << dp.dstElement->GetIndex()
+       << "] srcPipe=" << static_cast<int>(dp.srcPipe)
+       << " dstPipe=" << static_cast<int>(dp.dstPipe) << "\n";
+    for (unsigned j = 0; j < dp.depTiles.size(); ++j) {
+      os << "    depTile[" << j << "] ";
+      printTileValue(os, dp.depTiles[j]->baseBuffer);
+      os << " scope=" << static_cast<int>(dp.depTiles[j]->scope)
+         << " rootBuffer=";
+      printTileValue(os, dp.depTiles[j]->rootBuffer);
+      printTileLoc(os, dp.depTiles[j]->baseBuffer);
+      os << "\n";
+    }
+  }
+}
+
+inline void printAllTiles(llvm::raw_ostream &os,
+                          const SmallVector<TileInfo> &allTiles) {
+  os << "[bufid_sync] allTiles count: " << allTiles.size() << "\n";
+  for (unsigned i = 0; i < allTiles.size(); ++i) {
+    os << "  tile[" << i << "] ";
+    printTileInfo(os, allTiles[i]);
+    os << "\n";
+  }
+}
+
+inline void printTileGroups(llvm::raw_ostream &os,
+                            const SmallVector<SmallVector<unsigned>> &tileGroups,
+                            const SmallVector<TileInfo> &allTiles) {
+  os << "[bufid_sync] tileGroups count: " << tileGroups.size() << "\n";
+  for (unsigned i = 0; i < tileGroups.size(); ++i) {
+    os << "  group[" << i << "] size=" << tileGroups[i].size() << " tiles=[";
+    for (unsigned j = 0; j < tileGroups[i].size(); ++j) {
+      if (j > 0) os << " ; ";
+      printTileValue(os, allTiles[tileGroups[i][j]].tileValue);
+      //printTileInfo(os, allTiles[tileGroups[i][j]]);
+    }
+    os << "]\n";
+  }
+}
+
+inline void printVirtualBufIds(llvm::raw_ostream &os,
+                               const SmallVector<VirtualBufId> &virtualBufIds) {
+  os << "[bufid_sync] VirtualBufId count: " << virtualBufIds.size() << "\n";
+  for (auto &vbid : virtualBufIds) {
+    os << "  logicId=" << vbid.logicId
+       << " scope=" << static_cast<int>(vbid.scope)
+       << " tileCount=" << vbid.tiles.size() << " tiles=[";
+    for (unsigned i = 0; i < vbid.tiles.size(); ++i) {
+      if (i > 0) os << " ; ";
+      printTileValue(os, vbid.tiles[i].tileValue);
+      //printTileInfo(os, vbid.tiles[i]);
+    }
+    os << "]\n";
+  }
+}
+
+inline void printOp2BufSync(llvm::raw_ostream &os,
+                            const DenseMap<Operation *, BufSyncPipeBuild> &op2BufSync,
+                            func::FuncOp func, const char *title = nullptr) {
+  if (title)
+    os << "[bufid_sync] " << title << ":\n";
+
+  SmallVector<Operation *> sortedOps;
+  sortedOps.reserve(op2BufSync.size());
+  for (auto &[op, build] : op2BufSync)
+    sortedOps.push_back(op);
+
+  DenseMap<Operation *, unsigned> opOrder;
+  unsigned orderIdx = 0;
+  func.walk([&](Operation *op) { opOrder[op] = orderIdx++; });
+
+  std::sort(sortedOps.begin(), sortedOps.end(),
+            [&](Operation *a, Operation *b) {
+              return opOrder[a] < opOrder[b];
+            });
+
+  os << "[bufid_sync] op2BufSync count: " << op2BufSync.size() << "\n";
+  unsigned printIdx = 0;
+  for (auto *op : sortedOps) {
+    auto &build = op2BufSync.find(op)->second;
+    auto firstSyncIdx = build.pipeBefore.empty()
+                            ? (build.pipeAfter.empty() ? 0
+                                                       : build.pipeAfter[0].syncIRIndex)
+                            : build.pipeBefore[0].syncIRIndex;
+    os << "  [" << printIdx << "][syncIR=" << firstSyncIdx << "] op: ";
+    op->getName().print(os);
+    if (op->getNumResults() > 0) {
+      os << " ";
+      op->getResult(0).printAsOperand(os, OpPrintingFlags());
+    }
+    os << " <- ";
+    for (unsigned i = 0; i < op->getNumOperands(); ++i) {
+      if (i > 0) os << ", ";
+      op->getOperand(i).printAsOperand(os, OpPrintingFlags());
+    }
+    os << "\n    pipeBefore:";
+    for (auto &s : build.pipeBefore) {
+      os << " [GET_BUF pipe=" << static_cast<int>(s.pipe)
+         << " logicId=" << s.logicId
+         << " syncIR=" << s.syncIRIndex << "]";
+    }
+    os << "\n    pipeAfter:";
+    for (auto &s : build.pipeAfter) {
+      os << " [RLS_BUF pipe=" << static_cast<int>(s.pipe)
+         << " logicId=" << s.logicId
+         << " syncIR=" << s.syncIRIndex << "]";
+    }
+    os << "\n";
+    ++printIdx;
+  }
+}
+
+inline void printLifeIntervals(llvm::raw_ostream &os,
+                               const SmallVector<BufIdInterval> &intervals) {
+  os << "[bufid_sync] LifeIntervals count: " << intervals.size() << "\n";
+  for (auto &iv : intervals) {
+    os << "  logicId=" << iv.logicId
+       << " [" << iv.startPos << "," << iv.endPos << "] pipes=";
+    for (auto p : iv.pipes)
+      os << static_cast<int>(p) << ",";
+    os << "\n";
+  }
+}
+
+inline void printLogicToPhysical(llvm::raw_ostream &os,
+                                 const DenseMap<int, int> &logicToPhysical,
+                                 const char *label = "") {
+  os << "[bufid_sync] " << label << ":\n";
+  for (auto &[lid, pid] : logicToPhysical) {
+    os << "  logicId=" << lid << " -> physicalId=" << pid << "\n";
+  }
+}
+
+class BufidSyncAnalysis {
+public:
+  BufidSyncAnalysis(SyncIRs &syncIR, MemoryDependentAnalyzer &memAnalyzer,
+                    func::FuncOp func, bool debugEnabled = false)
+      : syncIR_(syncIR), memAnalyzer_(memAnalyzer), func_(func),
+        debugEnabled_(debugEnabled) {}
+
+  void collectDependencies();
+  void classifyTiles();
+  void allocateVirtualBufIds();
+  void insertSyncOperations();
+  void optimizeSamePipeMerge();
+  void mergeGetRls();
+
+  const SmallVector<DepPair> &getDepPairs() const { return depPairs_; }
+  const SmallVector<VirtualBufId> &getVirtualBufIds() const { return virtualBufIds_; }
+  SmallVector<VirtualBufId> &getVirtualBufIds() { return virtualBufIds_; }
+  const DenseMap<Operation *, BufSyncPipeBuild> &getOp2BufSync() const { return op2BufSync_; }
+  DenseMap<Operation *, BufSyncPipeBuild> &getOp2BufSync() { return op2BufSync_; }
+  const DenseMap<int, int> &getLogicToPhysicalId() const { return logicToPhysicalId_; }
+  void setLogicToPhysicalId(const DenseMap<int, int> &mapping) { logicToPhysicalId_ = mapping; }
+
+private:
+  bool isGMDependency(const SmallVector<const BaseMemInfo *> &tiles) const;
+  bool isSamePipe(CompoundInstanceElement *a, CompoundInstanceElement *b) const;
+  void collectTilesFromDepPairs();
+  int findBestVirtualBufId(const BaseMemInfo *tile) const;
+  int findBestVirtualBufId(const DepPair &depPair) const;
+  bool virtualBufIdContainsTile(const VirtualBufId &vbid,
+                                const BaseMemInfo *tile) const;
+
+  void bronKerbosch(const SmallVector<unsigned> &R, SmallVector<unsigned> P,
+                    SmallVector<unsigned> X,
+                    const SmallVector<SmallVector<bool>> &adjMatrix,
+                    SmallVector<SmallVector<unsigned>> &maximalCliques);
+
+  SyncIRs &syncIR_;
+  MemoryDependentAnalyzer &memAnalyzer_;
+  func::FuncOp func_;
+  bool debugEnabled_;
+
+  SmallVector<DepPair> depPairs_;
+  SmallVector<TileInfo> allTiles_;
+  SmallVector<SmallVector<unsigned>> tileGroups_;
+  SmallVector<VirtualBufId> virtualBufIds_;
+  DenseMap<Operation *, BufSyncPipeBuild> op2BufSync_;
+  DenseMap<int, int> logicToPhysicalId_;
+};
+
+} // namespace pto
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCANALYSIS_H

--- a/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "BufidSyncCodegen.h"
+#include "PTO/IR/PTO.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "llvm/Support/Debug.h"
+#include <algorithm>
+#include <tuple>
+
+#define DEBUG_TYPE "pto-bufid-sync"
+
+using namespace mlir;
+using namespace mlir::pto;
+
+std::optional<pto::SyncOpType>
+BufidSyncCodegen::mapPipelineToSyncOpType(PipelineType pipe) const {
+  switch (pipe) {
+  case PipelineType::PIPE_MTE2:
+    return pto::SyncOpType::TLOAD;
+  case PipelineType::PIPE_MTE3:
+    return pto::SyncOpType::TSTORE_VEC;
+  case PipelineType::PIPE_FIX:
+    return pto::SyncOpType::TSTORE_ACC;
+  case PipelineType::PIPE_MTE1:
+    return pto::SyncOpType::TMOV_M2L;
+  case PipelineType::PIPE_V:
+    return pto::SyncOpType::TVEC;
+  case PipelineType::PIPE_M:
+    return pto::SyncOpType::TMATMUL;
+  default:
+    return std::nullopt;
+  }
+}
+
+pto::PipeEventTypeAttr
+BufidSyncCodegen::getOpTypeAttr(Builder &builder,
+                                pto::SyncOpType opType) const {
+  return pto::PipeEventTypeAttr::get(builder.getContext(), opType);
+}
+
+LogicalResult BufidSyncCodegen::run() {
+  MLIRContext *ctx = func_->getContext();
+  IRRewriter rewriter(ctx);
+
+  WalkResult walkResult = func_->walk<WalkOrder::PreOrder>([&](Operation *op) {
+    auto it = op2BufSync_.find(op);
+    if (it == op2BufSync_.end())
+      return WalkResult::advance();
+
+    auto &build = it->second;
+    SmallVector<BufSyncOperation> pipeBefore(build.pipeBefore.begin(),
+                                             build.pipeBefore.end());
+    SmallVector<BufSyncOperation> pipeAfter(build.pipeAfter.begin(),
+                                            build.pipeAfter.end());
+    auto physicalIdFor = [&](const BufSyncOperation &sync) {
+      return idAlloc_.getLogicToPhysical().lookup(sync.logicId);
+    };
+    std::sort(pipeBefore.begin(), pipeBefore.end(),
+              [&](const BufSyncOperation &a, const BufSyncOperation &b) {
+                return std::make_tuple(physicalIdFor(a),
+                                       static_cast<int>(a.pipe), a.logicId) <
+                       std::make_tuple(physicalIdFor(b),
+                                       static_cast<int>(b.pipe), b.logicId);
+              });
+    std::sort(pipeAfter.begin(), pipeAfter.end(),
+              [&](const BufSyncOperation &a, const BufSyncOperation &b) {
+                return std::make_tuple(physicalIdFor(a),
+                                       static_cast<int>(a.pipe), a.logicId) >
+                       std::make_tuple(physicalIdFor(b),
+                                       static_cast<int>(b.pipe), b.logicId);
+              });
+
+    for (auto &syncBefore : pipeBefore) {
+      int physicalId = idAlloc_.getLogicToPhysical().lookup(syncBefore.logicId);
+      auto syncOpType = mapPipelineToSyncOpType(syncBefore.pipe);
+      if (!syncOpType) {
+        op->emitError("bufid_sync cannot encode get_buf for unsupported pipe ")
+            << static_cast<int>(syncBefore.pipe);
+        return WalkResult::interrupt();
+      }
+
+      rewriter.setInsertionPoint(op);
+      auto opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
+      rewriter.create<pto::GetBufOp>(op->getLoc(), opTypeAttr,
+                                     static_cast<uint32_t>(physicalId), 0);
+    }
+
+    for (auto &syncAfter : pipeAfter) {
+      int physicalId = idAlloc_.getLogicToPhysical().lookup(syncAfter.logicId);
+      auto syncOpType = mapPipelineToSyncOpType(syncAfter.pipe);
+      if (!syncOpType) {
+        op->emitError("bufid_sync cannot encode rls_buf for unsupported pipe ")
+            << static_cast<int>(syncAfter.pipe);
+        return WalkResult::interrupt();
+      }
+
+      if (op->hasTrait<OpTrait::IsTerminator>()) {
+        rewriter.setInsertionPoint(op);
+      } else {
+        rewriter.setInsertionPointAfter(op);
+      }
+      auto opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
+      rewriter.create<pto::RlsBufOp>(op->getLoc(), opTypeAttr,
+                                     static_cast<uint32_t>(physicalId), 0);
+    }
+
+    return WalkResult::advance();
+  });
+  return failure(walkResult.wasInterrupted());
+}

--- a/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCCODEGEN_H
+#define MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCCODEGEN_H
+
+#include "BufidSyncAnalysis.h"
+#include "BufidSyncIdAlloc.h"
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/PatternMatch.h"
+#include <optional>
+
+namespace mlir {
+namespace pto {
+
+class BufidSyncCodegen {
+public:
+  BufidSyncCodegen(func::FuncOp func,
+                   const DenseMap<Operation *, BufSyncPipeBuild> &op2BufSync,
+                   const BufidSyncIdAlloc &idAlloc)
+      : func_(func), op2BufSync_(op2BufSync), idAlloc_(idAlloc) {}
+
+  LogicalResult run();
+
+private:
+  std::optional<pto::SyncOpType>
+  mapPipelineToSyncOpType(PipelineType pipe) const;
+  pto::PipeEventTypeAttr getOpTypeAttr(Builder &builder,
+                                       pto::SyncOpType opType) const;
+
+  func::FuncOp func_;
+  const DenseMap<Operation *, BufSyncPipeBuild> &op2BufSync_;
+  const BufidSyncIdAlloc &idAlloc_;
+};
+
+} // namespace pto
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCCODEGEN_H

--- a/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.cpp
@@ -1,0 +1,604 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "BufidSyncIdAlloc.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "llvm/Support/Debug.h"
+#include <algorithm>
+#include <climits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <tuple>
+
+#define DEBUG_TYPE "pto-bufid-sync"
+
+using namespace mlir;
+using namespace mlir::pto;
+
+void BufidSyncIdAlloc::collectPipeSignature(
+    int logicId, SmallVector<PipelineType> &pipes) const {
+  DenseSet<PipelineType> seen;
+  for (auto &[op, build] : op2BufSync_) {
+    for (auto &s : build.pipeBefore) {
+      if (s.logicId == logicId && seen.insert(s.pipe).second)
+        pipes.push_back(s.pipe);
+    }
+    for (auto &s : build.pipeAfter) {
+      if (s.logicId == logicId && seen.insert(s.pipe).second)
+        pipes.push_back(s.pipe);
+    }
+  }
+}
+
+unsigned BufidSyncIdAlloc::getOutermostLoopBegin(Operation *op) const {
+  unsigned begin = UINT_MAX;
+  Operation *current = op;
+  while (auto forOp = current->getParentOfType<scf::ForOp>()) {
+    Operation *forOpOp = forOp.getOperation();
+    for (auto &e : syncIR_) {
+      auto *loop = dyn_cast<LoopInstanceElement>(e.get());
+      if (loop && loop->getLoopKind() == KindOfLoop::LOOP_BEGIN &&
+          loop->elementOp == forOpOp) {
+        begin = std::min(begin, loop->beginId);
+        break;
+      }
+    }
+    current = forOpOp;
+  }
+  return begin;
+}
+
+unsigned BufidSyncIdAlloc::getOutermostLoopEnd(Operation *op) const {
+  unsigned end = 0;
+  Operation *current = op;
+  while (auto forOp = current->getParentOfType<scf::ForOp>()) {
+    Operation *forOpOp = forOp.getOperation();
+    for (auto &e : syncIR_) {
+      auto *loop = dyn_cast<LoopInstanceElement>(e.get());
+      if (loop && loop->getLoopKind() == KindOfLoop::LOOP_END &&
+          loop->elementOp == forOpOp) {
+        end = std::max(end, loop->endId);
+        break;
+      }
+    }
+    current = forOpOp;
+  }
+  return end;
+}
+
+void BufidSyncIdAlloc::computeLifeIntervals() {
+  DenseMap<int, unsigned> logicIdStartPos;
+  DenseMap<int, unsigned> logicIdEndPos;
+
+  for (auto &[op, build] : op2BufSync_) {
+    unsigned loopBegin = getOutermostLoopBegin(op);
+    unsigned loopEnd = getOutermostLoopEnd(op);
+    bool inLoop = (loopBegin != UINT_MAX && loopEnd > 0);
+
+    for (auto &s : build.pipeBefore) {
+      unsigned pos = inLoop ? loopBegin : s.syncIRIndex;
+      if (!logicIdStartPos.count(s.logicId))
+        logicIdStartPos[s.logicId] = pos;
+      else
+        logicIdStartPos[s.logicId] = std::min(logicIdStartPos[s.logicId], pos);
+    }
+    for (auto &s : build.pipeAfter) {
+      unsigned pos = inLoop ? loopEnd : s.syncIRIndex;
+      if (!logicIdEndPos.count(s.logicId))
+        logicIdEndPos[s.logicId] = pos;
+      else
+        logicIdEndPos[s.logicId] = std::max(logicIdEndPos[s.logicId], pos);
+    }
+  }
+
+  for (auto &vbid : virtualBufIds_) {
+    BufIdInterval interval;
+    interval.logicId = vbid.logicId;
+
+    auto itStart = logicIdStartPos.find(vbid.logicId);
+    auto itEnd = logicIdEndPos.find(vbid.logicId);
+    if (itStart != logicIdStartPos.end() && itEnd != logicIdEndPos.end()) {
+      interval.startPos = itStart->second;
+      interval.endPos = itEnd->second;
+    } else {
+      interval.startPos = 0;
+      interval.endPos = 0;
+    }
+
+    collectPipeSignature(vbid.logicId, interval.pipes);
+    intervals_.push_back(std::move(interval));
+  }
+
+  std::sort(intervals_.begin(), intervals_.end(),
+            [](const BufIdInterval &a, const BufIdInterval &b) {
+              return a.startPos < b.startPos;
+            });
+
+  if (debugEnabled_) {
+    printLifeIntervals(llvm::outs(), intervals_);
+  }
+}
+
+void BufidSyncIdAlloc::linearScanAllocate() {
+  SmallVector<unsigned> active;
+  std::set<int> freeIds;
+
+  int nextPhysicalId = 0;
+  maxPhysicalIdUsed_ = -1;
+
+  for (unsigned intervalIdx = 0; intervalIdx < intervals_.size(); ++intervalIdx) {
+    auto &interval = intervals_[intervalIdx];
+    SmallVector<unsigned> newActive;
+
+    for (unsigned idx : active) {
+      if (intervals_[idx].endPos < interval.startPos) {
+        auto it = logicToPhysical_.find(intervals_[idx].logicId);
+        if (it != logicToPhysical_.end())
+          freeIds.insert(it->second);
+      } else {
+        newActive.push_back(idx);
+      }
+    }
+    active = newActive;
+
+    int physicalId;
+    if (!freeIds.empty()) {
+      auto freeIt = freeIds.begin();
+      physicalId = *freeIt;
+      freeIds.erase(freeIt);
+    } else {
+      physicalId = nextPhysicalId++;
+    }
+
+    logicToPhysical_[interval.logicId] = physicalId;
+    maxPhysicalIdUsed_ = std::max(maxPhysicalIdUsed_, physicalId);
+    active.push_back(intervalIdx);
+  }
+
+  if (debugEnabled_) {
+    llvm::outs() << "[bufid_sync] LinearScan result: maxPhysicalIdUsed="
+                 << maxPhysicalIdUsed_ << "\n";
+    printLogicToPhysical(llvm::outs(), logicToPhysical_, "LinearScan logicId->physicalId");
+  }
+}
+
+void BufidSyncIdAlloc::compactPhysicalIds() {
+  DenseMap<int, unsigned> logicIdFirstPos;
+  DenseSet<int> activeLogicIds;
+  for (auto &[op, build] : op2BufSync_) {
+    for (auto &s : build.pipeBefore) {
+      activeLogicIds.insert(s.logicId);
+      if (!logicIdFirstPos.count(s.logicId))
+        logicIdFirstPos[s.logicId] = s.syncIRIndex;
+      else
+        logicIdFirstPos[s.logicId] = std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+    }
+    for (auto &s : build.pipeAfter) {
+      activeLogicIds.insert(s.logicId);
+      if (!logicIdFirstPos.count(s.logicId))
+        logicIdFirstPos[s.logicId] = s.syncIRIndex;
+      else
+        logicIdFirstPos[s.logicId] = std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+    }
+  }
+
+  SmallVector<int> logicIdsByPos;
+  for (auto &[lid, pid] : logicToPhysical_) {
+    if (activeLogicIds.count(lid))
+      logicIdsByPos.push_back(lid);
+  }
+  std::sort(logicIdsByPos.begin(), logicIdsByPos.end(), [&](int a, int b) {
+    return logicIdFirstPos[a] < logicIdFirstPos[b];
+  });
+
+  DenseMap<int, int> oldPidToNew;
+  for (unsigned i = 0; i < logicIdsByPos.size(); ++i) {
+    int lid = logicIdsByPos[i];
+    int oldPid = logicToPhysical_[lid];
+    if (!oldPidToNew.count(oldPid))
+      oldPidToNew[oldPid] = static_cast<int>(oldPidToNew.size());
+  }
+
+  for (auto &[lid, pid] : logicToPhysical_) {
+    if (oldPidToNew.count(pid))
+      pid = oldPidToNew[pid];
+  }
+
+  maxPhysicalIdUsed_ = static_cast<int>(oldPidToNew.size()) - 1;
+
+  if (debugEnabled_) {
+    llvm::outs() << "[bufid_sync] After compactPhysicalIds: maxPhysicalIdUsed="
+                 << maxPhysicalIdUsed_ << "\n";
+    printLogicToPhysical(llvm::outs(), logicToPhysical_, "compactPhysicalIds logicId->physicalId");
+  }
+}
+
+void BufidSyncIdAlloc::reuseIds() {
+  auto encodeSig = [](const SmallVector<PipelineType> &sig) -> std::string {
+    SmallVector<PipelineType> s = sig;
+    std::sort(s.begin(), s.end());
+    std::string key;
+    for (auto p : s) {
+      if (!key.empty())
+        key += ",";
+      key += std::to_string(static_cast<int>(p));
+    }
+    return key;
+  };
+
+  auto decodeSig = [](const std::string &key) -> SmallVector<PipelineType> {
+    SmallVector<PipelineType> pipes;
+    std::string token;
+    std::istringstream iss(key);
+    while (std::getline(iss, token, ',')) {
+      if (!token.empty())
+        pipes.push_back(static_cast<PipelineType>(std::stoi(token)));
+    }
+    return pipes;
+  };
+
+  auto getPipeScore = [](PipelineType p) -> int {
+    switch (p) {
+    case PipelineType::PIPE_MTE2:
+      return 1;
+    case PipelineType::PIPE_MTE3:
+    case PipelineType::PIPE_FIX:
+      return 2;
+    default:
+      return 3;
+    }
+  };
+
+  auto getMinPipeScore = [&](const SmallVector<PipelineType> &pipes) -> int {
+    int minScore = 99;
+    for (auto p : pipes)
+      minScore = std::min(minScore, getPipeScore(p));
+    return minScore;
+  };
+
+  auto isConsecutiveOnPipe = [&](const SmallVector<int> &ids,
+                                 PipelineType pipe) -> bool {
+    SmallVector<std::pair<unsigned, unsigned>> idRanges;
+    for (int lid : ids) {
+      unsigned minIdx = UINT_MAX, maxIdx = 0;
+      for (auto &[op, build] : op2BufSync_) {
+        for (auto &s : build.pipeBefore) {
+          if (s.logicId == lid && s.pipe == pipe) {
+            minIdx = std::min(minIdx, s.syncIRIndex);
+            maxIdx = std::max(maxIdx, s.syncIRIndex);
+          }
+        }
+        for (auto &s : build.pipeAfter) {
+          if (s.logicId == lid && s.pipe == pipe) {
+            minIdx = std::min(minIdx, s.syncIRIndex);
+            maxIdx = std::max(maxIdx, s.syncIRIndex);
+          }
+        }
+      }
+      if (minIdx != UINT_MAX)
+        idRanges.push_back({minIdx, maxIdx});
+    }
+    std::sort(idRanges.begin(), idRanges.end());
+    for (unsigned i = 1; i < idRanges.size(); ++i) {
+      if (idRanges[i].first <= idRanges[i - 1].second)
+        return false;
+    }
+    for (unsigned i = 1; i < idRanges.size(); ++i) {
+      unsigned gapStart = idRanges[i - 1].second;
+      unsigned gapEnd = idRanges[i].first;
+      for (auto &[op, build] : op2BufSync_) {
+        for (auto &s : build.pipeBefore) {
+          if (s.syncIRIndex > gapStart && s.syncIRIndex < gapEnd)
+            return false;
+        }
+        for (auto &s : build.pipeAfter) {
+          if (s.syncIRIndex > gapStart && s.syncIRIndex < gapEnd)
+            return false;
+        }
+      }
+    }
+    return true;
+  };
+
+  int iteration = 0;
+  while (maxPhysicalIdUsed_ >= (int)physicalBufIdCount_) {
+    ++iteration;
+
+    DenseMap<int, SmallVector<PipelineType>> logicIdPipes;
+    DenseMap<int, unsigned> logicIdFirstPos;
+    DenseMap<int, DenseSet<PipelineType>> logicIdSeenPipes;
+    for (auto &[op, build] : op2BufSync_) {
+      for (auto &s : build.pipeBefore) {
+        if (logicIdSeenPipes[s.logicId].insert(s.pipe).second)
+          logicIdPipes[s.logicId].push_back(s.pipe);
+        if (!logicIdFirstPos.count(s.logicId))
+          logicIdFirstPos[s.logicId] = s.syncIRIndex;
+        else
+          logicIdFirstPos[s.logicId] =
+              std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+      }
+      for (auto &s : build.pipeAfter) {
+        if (logicIdSeenPipes[s.logicId].insert(s.pipe).second)
+          logicIdPipes[s.logicId].push_back(s.pipe);
+        if (!logicIdFirstPos.count(s.logicId))
+          logicIdFirstPos[s.logicId] = s.syncIRIndex;
+        else
+          logicIdFirstPos[s.logicId] =
+              std::min(logicIdFirstPos[s.logicId], s.syncIRIndex);
+      }
+    }
+
+    std::map<std::string, SmallVector<int>> sigGroups;
+    for (auto &[lid, pipes] : logicIdPipes) {
+      std::string sigKey = encodeSig(pipes);
+      sigGroups[sigKey].push_back(lid);
+    }
+
+    if (debugEnabled_) {
+      llvm::outs() << "[bufid_sync] reuseIds iteration=" << iteration
+                   << " sigGroups=" << sigGroups.size() << "\n";
+      for (auto &[sigKey, ids] : sigGroups) {
+        llvm::outs() << "  sig=" << sigKey << " count=" << ids.size() << "\n";
+      }
+    }
+
+    int bestScore = -1;
+    std::string bestSigKey;
+    for (auto &[sigKey, ids] : sigGroups) {
+      if (ids.size() < 2)
+        continue;
+      SmallVector<PipelineType> sigPipes = decodeSig(sigKey);
+      int pipeScore = getMinPipeScore(sigPipes);
+      int idNum = static_cast<int>(ids.size());
+      int score = pipeScore * idNum * idNum;
+      if (score > bestScore) {
+        bestScore = score;
+        bestSigKey = sigKey;
+      }
+    }
+
+    if (bestSigKey.empty()) {
+      if (debugEnabled_) {
+        llvm::outs() << "[bufid_sync] reuseIds: no group with >=2 IDs to reuse, breaking\n";
+      }
+      break;
+    }
+
+    auto &groupIds = sigGroups[bestSigKey];
+
+    std::sort(groupIds.begin(), groupIds.end(), [&](int a, int b) {
+      auto itA = logicIdFirstPos.find(a);
+      auto itB = logicIdFirstPos.find(b);
+      if (itA == logicIdFirstPos.end() || itB == logicIdFirstPos.end())
+        return a < b;
+      return itA->second < itB->second;
+    });
+
+    SmallVector<PipelineType> bestSigPipes = decodeSig(bestSigKey);
+
+    PipelineType checkPipe = bestSigPipes[0];
+    int minPipeScore = getPipeScore(bestSigPipes[0]);
+    for (auto p : bestSigPipes) {
+      if (getPipeScore(p) < minPipeScore) {
+        minPipeScore = getPipeScore(p);
+        checkPipe = p;
+      }
+    }
+
+    bool consecutive = isConsecutiveOnPipe(groupIds, checkPipe);
+
+    if (debugEnabled_) {
+      llvm::outs() << "[bufid_sync] reuseIds: bestSig=" << bestSigKey
+                   << " groupSize=" << groupIds.size()
+                   << " checkPipe=" << static_cast<int>(checkPipe)
+                   << " consecutive=" << consecutive << "\n";
+    }
+
+    unsigned halfSize = groupIds.size() / 2;
+    if (halfSize == 0) {
+      if (debugEnabled_) {
+        llvm::outs() << "[bufid_sync] reuseIds: halfSize=0, breaking\n";
+      }
+      break;
+    }
+
+    DenseMap<int, int> mergeMap;
+    if (consecutive) {
+      for (unsigned i = 0; i < halfSize; ++i) {
+        int donorLid = groupIds[2 * i];
+        int targetLid = groupIds[2 * i + 1];
+        mergeMap[targetLid] = donorLid;
+      }
+    } else {
+      for (unsigned i = 0; i < halfSize; ++i) {
+        int donorLid = groupIds[i];
+        int targetLid = groupIds[i + halfSize];
+        mergeMap[targetLid] = donorLid;
+      }
+    }
+
+    for (auto &[lid, donorLid] : mergeMap) {
+      while (mergeMap.count(donorLid))
+        donorLid = mergeMap[donorLid];
+    }
+
+    DenseMap<Operation *, BufSyncPipeBuild> newOp2BufSync;
+    for (auto &[op, build] : op2BufSync_) {
+      BufSyncPipeBuild newBuild;
+
+      DenseSet<std::pair<int, int>> seenBefore;
+      for (auto &s : build.pipeBefore) {
+        int newLogicId = s.logicId;
+        auto it = mergeMap.find(newLogicId);
+        if (it != mergeMap.end())
+          newLogicId = it->second;
+        auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
+        if (seenBefore.insert(key).second) {
+          BufSyncOperation newS = s;
+          newS.logicId = newLogicId;
+          newBuild.pipeBefore.push_back(newS);
+        }
+      }
+
+      DenseSet<std::pair<int, int>> seenAfter;
+      for (auto &s : build.pipeAfter) {
+        int newLogicId = s.logicId;
+        auto it = mergeMap.find(newLogicId);
+        if (it != mergeMap.end())
+          newLogicId = it->second;
+        auto key = std::make_pair(static_cast<int>(s.pipe), newLogicId);
+        if (seenAfter.insert(key).second) {
+          BufSyncOperation newS = s;
+          newS.logicId = newLogicId;
+          newBuild.pipeAfter.push_back(newS);
+        }
+      }
+
+      newOp2BufSync[op] = std::move(newBuild);
+    }
+
+    op2BufSync_ = std::move(newOp2BufSync);
+
+    for (auto &[lid, donorLid] : mergeMap) {
+      int donorPid = logicToPhysical_[donorLid];
+      logicToPhysical_[lid] = donorPid;
+    }
+
+    virtualBufIds_.erase(
+        std::remove_if(virtualBufIds_.begin(), virtualBufIds_.end(),
+                       [&](const VirtualBufId &vbid) {
+                         return mergeMap.count(vbid.logicId);
+                       }),
+        virtualBufIds_.end());
+
+    for (auto &[lid, pid] : logicToPhysical_) {
+      auto it = mergeMap.find(lid);
+      if (it != mergeMap.end())
+        pid = logicToPhysical_[it->second];
+    }
+
+    compactPhysicalIds();
+
+    if (debugEnabled_) {
+      llvm::outs() << "[bufid_sync] reuseIds: iteration=" << iteration
+                   << " maxPhysicalIdUsed=" << maxPhysicalIdUsed_ << "\n";
+      for (auto &[lid, donorLid] : mergeMap) {
+        llvm::outs() << "  merge logicId=" << lid << " -> donor logicId="
+                     << donorLid << " physicalId=" << logicToPhysical_[lid] << "\n";
+      }
+    }
+
+    if (mergeMap.empty()) {
+      if (debugEnabled_) {
+        llvm::outs() << "[bufid_sync] reuseIds: no merges in this iteration, breaking\n";
+      }
+      break;
+    }
+  }
+
+  for (auto &vbid : virtualBufIds_) {
+    if (!logicToPhysical_.count(vbid.logicId)) {
+      logicToPhysical_[vbid.logicId] = 0;
+    }
+  }
+}
+
+bool BufidSyncIdAlloc::validateNoSamePhysicalIdNesting(
+    std::string *error) const {
+  struct Event {
+    unsigned syncIRIndex;
+    unsigned phase;
+    BufSyncType type;
+    int logicId;
+    int physicalId;
+    PipelineType pipe;
+  };
+
+  SmallVector<Event> events;
+  for (auto &[op, build] : op2BufSync_) {
+    (void)op;
+    for (auto &sync : build.pipeBefore) {
+      auto it = logicToPhysical_.find(sync.logicId);
+      if (it == logicToPhysical_.end()) {
+        if (error)
+          *error = "missing physical bufid for logic id " +
+                   std::to_string(sync.logicId);
+        return false;
+      }
+      events.push_back({sync.syncIRIndex, 0, sync.type, sync.logicId,
+                        it->second, sync.pipe});
+    }
+    for (auto &sync : build.pipeAfter) {
+      auto it = logicToPhysical_.find(sync.logicId);
+      if (it == logicToPhysical_.end()) {
+        if (error)
+          *error = "missing physical bufid for logic id " +
+                   std::to_string(sync.logicId);
+        return false;
+      }
+      events.push_back({sync.syncIRIndex, 1, sync.type, sync.logicId,
+                        it->second, sync.pipe});
+    }
+  }
+
+  std::sort(events.begin(), events.end(), [](const Event &a, const Event &b) {
+    return std::make_tuple(a.syncIRIndex, a.phase,
+                           static_cast<int>(a.type), a.physicalId,
+                           a.logicId, static_cast<int>(a.pipe)) <
+           std::make_tuple(b.syncIRIndex, b.phase,
+                           static_cast<int>(b.type), b.physicalId,
+                           b.logicId, static_cast<int>(b.pipe));
+  });
+
+  DenseMap<int, Event> activeByPhysicalId;
+  for (const Event &event : events) {
+    if (event.type == BufSyncType::GET_BUF) {
+      auto activeIt = activeByPhysicalId.find(event.physicalId);
+      if (activeIt != activeByPhysicalId.end()) {
+        if (error) {
+          const Event &active = activeIt->second;
+          *error = "nested get_buf for physical bufid " +
+                   std::to_string(event.physicalId) + " at SyncIR " +
+                   std::to_string(event.syncIRIndex) +
+                   " while logic id " + std::to_string(active.logicId) +
+                   " from SyncIR " + std::to_string(active.syncIRIndex) +
+                   " is still active";
+        }
+        return false;
+      }
+      activeByPhysicalId[event.physicalId] = event;
+      continue;
+    }
+
+    auto activeIt = activeByPhysicalId.find(event.physicalId);
+    if (activeIt == activeByPhysicalId.end()) {
+      if (error) {
+        *error = "rls_buf without active get_buf for physical bufid " +
+                 std::to_string(event.physicalId) + " at SyncIR " +
+                 std::to_string(event.syncIRIndex);
+      }
+      return false;
+    }
+    activeByPhysicalId.erase(activeIt);
+  }
+
+  if (!activeByPhysicalId.empty()) {
+    if (error) {
+      auto activeIt = activeByPhysicalId.begin();
+      const Event &active = activeIt->second;
+      *error = "unclosed get_buf for physical bufid " +
+               std::to_string(active.physicalId) + " from SyncIR " +
+               std::to_string(active.syncIRIndex);
+    }
+    return false;
+  }
+
+  return true;
+}

--- a/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCIDALLOC_H
+#define MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCIDALLOC_H
+
+#include "BufidSyncAnalysis.h"
+#include <string>
+
+namespace mlir {
+namespace pto {
+
+class BufidSyncIdAlloc {
+public:
+  BufidSyncIdAlloc(SmallVector<VirtualBufId> &virtualBufIds,
+                   DenseMap<Operation *, BufSyncPipeBuild> &op2BufSync,
+                   const SyncIRs &syncIR, unsigned physicalBufIdCount,
+                   bool debugEnabled = false)
+      : virtualBufIds_(virtualBufIds), op2BufSync_(op2BufSync),
+        syncIR_(syncIR), physicalBufIdCount_(physicalBufIdCount),
+        debugEnabled_(debugEnabled) {}
+
+  void computeLifeIntervals();
+  void linearScanAllocate();
+  bool needsReuse() const { return maxPhysicalIdUsed_ >= (int)physicalBufIdCount_; }
+  void reuseIds();
+  void compactPhysicalIds();
+  bool validateNoSamePhysicalIdNesting(std::string *error = nullptr) const;
+
+  const DenseMap<int, int> &getLogicToPhysical() const { return logicToPhysical_; }
+
+private:
+  void collectPipeSignature(int logicId, SmallVector<PipelineType> &pipes) const;
+  unsigned getOutermostLoopBegin(Operation *op) const;
+  unsigned getOutermostLoopEnd(Operation *op) const;
+
+  SmallVector<VirtualBufId> &virtualBufIds_;
+  DenseMap<Operation *, BufSyncPipeBuild> &op2BufSync_;
+  const SyncIRs &syncIR_;
+  unsigned physicalBufIdCount_;
+  bool debugEnabled_;
+
+  SmallVector<BufIdInterval> intervals_;
+  DenseMap<int, int> logicToPhysical_;
+  int maxPhysicalIdUsed_ = -1;
+};
+
+} // namespace pto
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PTO_TRANSFORMS_BUFIDSYNC_BUFIDSYNCIDALLOC_H

--- a/lib/PTO/Transforms/BufidSync/BufidSyncPass.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncPass.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "BufidSyncAnalysis.h"
+#include "BufidSyncCodegen.h"
+#include "BufidSyncIdAlloc.h"
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
+#include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/Support/Debug.h"
+#include <string>
+
+#define DEBUG_TYPE "pto-bufid-sync"
+
+namespace mlir {
+namespace pto {
+
+#define GEN_PASS_DECL_PTOBUFIDSYNC
+#define GEN_PASS_DEF_PTOBUFIDSYNC
+#include "PTO/Transforms/Passes.h.inc"
+
+namespace {
+struct PTOBufidSyncPass
+    : public impl::PTOBufidSyncBase<PTOBufidSyncPass> {
+  PTOBufidSyncPass() = default;
+  PTOBufidSyncPass(const PTOBufidSyncOptions &options) {
+    enableBufidSyncDebug = options.enableBufidSyncDebug;
+  }
+  void runOnOperation() override;
+};
+} // namespace
+
+void PTOBufidSyncPass::runOnOperation() {
+  func::FuncOp func = getOperation();
+
+  bool hasExistingBufSync = false;
+  func.walk([&](pto::GetBufOp) { hasExistingBufSync = true; });
+  func.walk([&](pto::RlsBufOp) { hasExistingBufSync = true; });
+  if (hasExistingBufSync) {
+    LLVM_DEBUG(llvm::dbgs() << "bufid_sync: existing get_buf ops found, "
+                               "skipping pass.\n");
+    return;
+  }
+  if (enableBufidSyncDebug) {
+    llvm::outs() << "[bufid_sync] STEP 0: Build SyncIR...\n";
+  }
+  SyncIRs syncIR;
+  Buffer2MemInfoMap buffer2MemInfoMap;
+  MemoryDependentAnalyzer memAnalyzer;
+
+  PTOIRTranslator translator(syncIR, memAnalyzer, buffer2MemInfoMap, func,
+                             SyncAnalysisMode::NORMALSYNC);
+  translator.Build();
+  if (enableBufidSyncDebug) {
+    llvm::outs() << "[bufid_sync] STEP 0 done: syncIR size=" << syncIR.size() << "\n";
+  }
+
+  if (syncIR.empty()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "bufid_sync: SyncIR is empty, nothing to do.\n");
+    return;
+  }
+
+  BufidSyncAnalysis analysis(syncIR, memAnalyzer, func, enableBufidSyncDebug);
+
+  analysis.collectDependencies();
+  analysis.classifyTiles();
+  analysis.allocateVirtualBufIds();
+  analysis.insertSyncOperations();
+  analysis.optimizeSamePipeMerge();
+
+  if (analysis.getOp2BufSync().empty()) {
+    if (enableBufidSyncDebug) {
+      llvm::outs() << "[bufid_sync] No sync operations to insert, done.\n";
+    }
+    return;
+  }
+
+  BufidSyncIdAlloc idAlloc(analysis.getVirtualBufIds(),
+                           analysis.getOp2BufSync(), syncIR, 32,
+                           enableBufidSyncDebug);
+
+  idAlloc.computeLifeIntervals();
+  idAlloc.linearScanAllocate();
+  idAlloc.compactPhysicalIds();
+
+  if (idAlloc.needsReuse()) {
+    idAlloc.reuseIds();
+    idAlloc.compactPhysicalIds();
+  }
+  if (idAlloc.needsReuse()) {
+    func.emitError("bufid_sync requires more than 32 physical buf ids after "
+                   "reuse");
+    signalPassFailure();
+    return;
+  }
+
+  analysis.setLogicToPhysicalId(idAlloc.getLogicToPhysical());
+
+  analysis.mergeGetRls();
+
+  std::string validationError;
+  if (!idAlloc.validateNoSamePhysicalIdNesting(&validationError)) {
+    func.emitError("bufid_sync produced invalid physical bufid nesting: ")
+        << validationError;
+    signalPassFailure();
+    return;
+  }
+
+  BufidSyncCodegen codegen(func, analysis.getOp2BufSync(), idAlloc);
+  if (failed(codegen.run())) {
+    signalPassFailure();
+    return;
+  }
+}
+
+std::unique_ptr<Pass>
+createPTOBufidSyncPass(const PTOBufidSyncOptions &options) {
+  return std::make_unique<PTOBufidSyncPass>(options);
+}
+
+} // namespace pto
+} // namespace mlir

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -42,6 +42,10 @@ add_mlir_dialect_library(PTOTransforms
   InsertSync/RemoveRedundantSync.cpp
   InsertSync/SyncEventIdAllocation.cpp
   InsertSync/SyncCodegen.cpp
+  BufidSync/BufidSyncPass.cpp
+  BufidSync/BufidSyncAnalysis.cpp
+  BufidSync/BufidSyncIdAlloc.cpp
+  BufidSync/BufidSyncCodegen.cpp
   GraphSyncSolver/PTOGraphSyncSolver.cpp
   GraphSyncSolver/SyncSolverIR.cpp
   GraphSyncSolver/SyncSolverIRTranslator.cpp

--- a/test/lit/pto/bufid_sync_a5_auto.pto
+++ b/test/lit/pto/bufid_sync_a5_auto.pto
@@ -1,0 +1,34 @@
+// RUN: ptoas --pto-arch=a5 --enable-bufid_sync %s -o - 2>&1 | FileCheck %s
+// RUN: not ptoas --pto-arch=a3 --enable-bufid_sync %s -o - 2>&1 | FileCheck %s --check-prefix=A3ERR
+//
+// CHECK: get_buf(PIPE_MTE2, [[ID:[0-9]+]], 0);
+// CHECK-NEXT: TLOAD
+// CHECK-NEXT: rls_buf(PIPE_MTE2, [[ID]], 0);
+// CHECK-NEXT: get_buf(PIPE_V, [[ID]], 0);
+// CHECK-NEXT: TRELU
+// CHECK-NEXT: rls_buf(PIPE_V, [[ID]], 0);
+// CHECK-NOT: set_flag
+// CHECK-NOT: wait_flag
+//
+// A3ERR: Error: --enable-bufid_sync requires --pto-arch=a5.
+
+module {
+  func.func @bufid_sync_a5_auto(%arg0: !pto.ptr<f32>, %argN: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %n = arith.index_cast %argN : i32 to index
+
+    pto.section.vector {
+      %tv0 = pto.make_tensor_view %arg0, shape = [%n], strides = [%c1] : !pto.tensor_view<?xf32>
+      %ptv0 = pto.partition_view %tv0, offsets = [%c0], sizes = [%c32] : !pto.tensor_view<?xf32> -> !pto.partition_tensor_view<32xf32>
+
+      %tb0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+      %tb1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+      pto.tload ins(%ptv0 : !pto.partition_tensor_view<32xf32>) outs(%tb0 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      pto.trelu ins(%tb0 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%tb1 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    }
+    return
+  }
+}

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -201,6 +201,16 @@ static llvm::cl::opt<bool> enableInsertSync("enable-insert-sync",
                                             llvm::cl::desc("Enable automatic synchronization insertion pass"),
                                             llvm::cl::init(false));
 
+static llvm::cl::opt<bool> enableBufidSync(
+    "enable-bufid_sync",
+    llvm::cl::desc("Enable A5 buffer-id synchronization insertion pass"),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> enableBufidSyncDebug(
+    "enable-bufid-sync-debug",
+    llvm::cl::desc("Enable verbose debug printing for --enable-bufid_sync"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> enableInjectBarrierAllSync(
     "enable-inject-barrier-all-sync",
     llvm::cl::desc("Enable conservative synchronization by inserting "
@@ -211,7 +221,7 @@ static llvm::cl::opt<bool> enableGraphSyncSolver(
     "enable-graph-sync-solver",
     llvm::cl::desc("Enable the graph-based intra-core sync solver "
                    "(experimental). Mutually exclusive with "
-                   "--enable-insert-sync and "
+                   "--enable-insert-sync, --enable-bufid_sync, and "
                    "--enable-inject-barrier-all-sync."),
     llvm::cl::init(false));
 
@@ -1308,6 +1318,10 @@ int main(int argc, char **argv) {
                  << "'. Expected 'level1', 'level2', or 'level3'.\n";
     return 1;
   }
+  if (enableBufidSync && arch != "a5") {
+    llvm::errs() << "Error: --enable-bufid_sync requires --pto-arch=a5.\n";
+    return 1;
+  }
 
   bool invalidAutoSyncTailHint = false;
   module->walk([&](mlir::func::FuncOp func) {
@@ -1347,10 +1361,10 @@ int main(int argc, char **argv) {
   }
 
   int enabledAutoSyncModes =
-      (enableInsertSync ? 1 : 0) + (enableInjectBarrierAllSync ? 1 : 0) +
-      (enableGraphSyncSolver ? 1 : 0);
+      (enableInsertSync ? 1 : 0) + (enableBufidSync ? 1 : 0) +
+      (enableInjectBarrierAllSync ? 1 : 0) + (enableGraphSyncSolver ? 1 : 0);
   if (enabledAutoSyncModes > 1) {
-    llvm::errs() << "Error: --enable-insert-sync, "
+    llvm::errs() << "Error: --enable-insert-sync, --enable-bufid_sync, "
                     "--enable-inject-barrier-all-sync, and "
                     "--enable-graph-sync-solver are mutually exclusive.\n";
     return 1;
@@ -1363,6 +1377,11 @@ int main(int argc, char **argv) {
   if (hasTAssign && enableGraphSyncSolver) {
     llvm::errs() << "Error: pto.tassign requires --enable-graph-sync-solver "
                     "to be disabled.\n";
+    return 1;
+  }
+  if (hasTAssign && enableBufidSync) {
+    llvm::errs() << "Error: pto.tassign requires --enable-bufid_sync to be "
+                    "disabled.\n";
     return 1;
   }
 
@@ -1420,10 +1439,15 @@ int main(int argc, char **argv) {
 
   // Conditionally add one automatic synchronization mode. Barrier-all is a
   // conservative standalone pass; InsertSync and GraphSyncSolver are set/wait
-  // solvers.
+  // solvers, while BufidSync is A5-only get_buf/rls_buf synchronization.
   if (enableInsertSync)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOInsertSyncPass());
-  else if (enableInjectBarrierAllSync)
+  else if (enableBufidSync) {
+    PTOBufidSyncOptions bufidOptions;
+    bufidOptions.enableBufidSyncDebug = enableBufidSyncDebug;
+    pm.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOBufidSyncPass(bufidOptions));
+  } else if (enableInjectBarrierAllSync)
     pm.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOInjectBarrierAllSyncPass());
   else if (enableGraphSyncSolver) {


### PR DESCRIPTION
## Summary
- Add an A5-only bufid synchronization pass that inserts `pto.get_buf` / `pto.rls_buf` around cross-pipe local-buffer dependencies.
- Keep the pass opt-in behind `--enable-bufid_sync` and reject it for non-A5 targets.
- Add a design note and a lit regression for automatic A5 bufid insertion.

## Design
- `BufidSyncAnalysis` reuses SyncIR and `MemoryDependentAnalyzer` to collect local RAW/WAR/WAW dependencies across pipes.
- Virtual buf ids are built from overlapping local-buffer cliques; dependency-to-id mapping scores all dependent tiles instead of stopping at the first match.
- `BufidSyncIdAlloc` uses linear scan with a persistent free-id pool, optional reuse, and final same-physical-id nesting validation.
- Codegen emits existing PTO dialect `pto.get_buf` / `pto.rls_buf` ops using `pipe_event_type`; EmitC lowering maps those endpoints to `PIPE_*` intrinsics.

## Testing
- `ninja -C build ptoas`
- `ninja -C build check-pto` (284/284 passed)
- `build/tools/ptoas/ptoas test/samples/Sync/matmul.pto --pto-arch=a5 --enable-bufid_sync -o /tmp/bufid_sync_smoke/matmul.cpp`
- `build/tools/ptoas/ptoas test/samples/Sync/test_dynamic_valid_shape.pto --pto-arch=a5 --enable-bufid_sync -o /tmp/bufid_sync_smoke/dynamic.cpp`
- `build/tools/ptoas/ptoas test/samples/Sync/matmul.pto --pto-arch=a3 --enable-bufid_sync -o /tmp/bufid_sync_smoke/a3.cpp` fails as expected with the A5-only diagnostic
- `PTOAS_DIR=/Users/lishengtao/Documents/PTO/PTOAS-bufid-sync PTOAS_BIN=/Users/lishengtao/Documents/PTO/PTOAS-bufid-sync/build/tools/ptoas/ptoas /Users/lishengtao/Workspace/PTO/verify.sh` (`OK=263`, `FAIL=0`, `SKIP=16`)

## Risk / Rollback
- Unsupported pipes fail with a diagnostic rather than emitting unsafe bufid sync.
- Final same-id nesting validation blocks unsafe physical-id reuse.
- Rollback: revert this PR or avoid passing `--enable-bufid_sync`.
