### PR TITLE
Several cube DSL related bugfixes

### DIFF
--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -5735,6 +5735,18 @@ mlir::LogicalResult mlir::pto::TExtractOp::verify() {
     if (*srcSpace == pto::AddressSpace::MAT) {
       if (!hasMatExtractSourceLayoutA5(srcTb, *dstSpace))
         return emitOpError("expects A5 textract src to use a supported mat blayout/slayout combination");
+      if (*dstSpace == pto::AddressSpace::LEFT ||
+          *dstSpace == pto::AddressSpace::RIGHT) {
+        auto indexRowVal = getConstantIntegerValueEx(
+            getIndexRow(), /*includeIndexAndIntOpsInConstFold=*/true);
+        auto indexColVal = getConstantIntegerValueEx(
+            getIndexCol(), /*includeIndexAndIntOpsInConstFold=*/true);
+        if (!indexRowVal || !indexColVal || *indexRowVal != 0 ||
+            *indexColVal != 0)
+          return emitOpError(
+              "expects A5 mat->left/right textract to have indexRow=0 and "
+              "indexCol=0 (offset extraction not yet supported)");
+      }
       if (*dstSpace == pto::AddressSpace::LEFT) {
         if (dstTb.getBLayoutValueI32() != static_cast<int32_t>(pto::BLayout::ColMajor) ||
             dstTb.getSLayoutValueI32() != static_cast<int32_t>(pto::SLayout::RowMajor))

--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -248,8 +248,9 @@ static std::string stringifyMemorySpace(pto::AddressSpace space) {
     return "acc";
   case pto::AddressSpace::BIAS:
     return "bias";
-  case pto::AddressSpace::VEC:
   case pto::AddressSpace::SCALING:
+    return "scaling";
+  case pto::AddressSpace::VEC:
   case pto::AddressSpace::Zero:
     return "ub";
   }

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -233,6 +233,11 @@ static FailureOr<StringRef> buildMadMxCalleeName(MLIRContext *context,
   return StringAttr::get(context, "llvm.hivm.MMAD.MX." + lhs + rhs).getValue();
 }
 
+static bool isSignedOrSignlessInteger(IntegerType intType, unsigned width) {
+  return intType && intType.getWidth() == width &&
+         (intType.isSigned() || intType.isSignless());
+}
+
 static std::string getMadRhsFragment(Type type) {
   if (type.isF16())
     return "f16";
@@ -241,9 +246,9 @@ static std::string getMadRhsFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 4)
+    if (isSignedOrSignlessInteger(intType, 4))
       return "s4";
-    if (intType.isSigned() && intType.getWidth() == 8)
+    if (isSignedOrSignlessInteger(intType, 8))
       return "s8";
     if (intType.isUnsigned() && intType.getWidth() == 2)
       return "u2";
@@ -270,7 +275,7 @@ static std::string getMadDstFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 32)
+    if (isSignedOrSignlessInteger(intType, 32))
       return "s32";
   }
   return {};
@@ -291,6 +296,9 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
     return StringAttr::get(context, "llvm.hivm.MAD.bf162f32.c310").getValue();
   if (lhsElem.isF32() && rhs == "f32" && dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.f322f32.c310").getValue();
+  if (isSignedOrSignlessInteger(dyn_cast<IntegerType>(lhsElem), 8) &&
+      rhs == "s8" && dst == "s32")
+    return StringAttr::get(context, "llvm.hivm.MAD.s8.c310").getValue();
   if (isMadE4M3ElementType(lhsElem) && isMadE4M3ElementType(rhsElem) &&
       dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();

--- a/test/lit/pto/textract_verify_a5_mat_lr_nonzero_offset.pto
+++ b/test/lit/pto/textract_verify_a5_mat_lr_nonzero_offset.pto
@@ -1,0 +1,15 @@
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  func.func @textract_a5_mat_left_nonzero_offset() {
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=f32, rows=64, cols=32, v_row=64, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    pto.textract ins(%src, %c4, %c0 : !pto.tile_buf<loc=mat, dtype=f32, rows=64, cols=32, v_row=64, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>, index, index)
+                outs(%dst : !pto.tile_buf<loc=left, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.textract' op expects A5 mat->left/right textract to have indexRow=0 and indexCol=0 (offset extraction not yet supported)

--- a/test/lit/vpto/cube/mad_semantic_vpto_llvm.pto
+++ b/test/lit/vpto/cube/mad_semantic_vpto_llvm.pto
@@ -23,7 +23,19 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
       : !pto.ptr<f32, l0a>, !pto.ptr<f32, l0b>, !pto.ptr<f32, l0c>, !pto.ptr<f32, bt>, i64, i64, i64
     return
   }
+
+  func.func @mad_semantic_vpto_llvm_i8(
+      %lhs: !pto.ptr<i8, l0a>,
+      %rhs: !pto.ptr<i8, l0b>,
+      %dst: !pto.ptr<i32, l0c>) attributes {pto.aicore} {
+    %c16 = arith.constant 16 : i64
+    pto.mad %lhs, %rhs, %dst, %c16, %c16, %c16 unit_flag(check_only) disable_gemv
+      : !pto.ptr<i8, l0a>, !pto.ptr<i8, l0b>, !pto.ptr<i32, l0c>, i64, i64, i64
+    return
+  }
 }
 
 // CHECK-LABEL: llvm.func @mad_semantic_vpto_llvm_mix_aic
 // CHECK-COUNT-3: llvm.call @llvm.hivm.MAD.f322f32.c310
+// CHECK-LABEL: llvm.func @mad_semantic_vpto_llvm_i8_mix_aic
+// CHECK: llvm.call @llvm.hivm.MAD.s8.c310

--- a/tilelang-dsl/python/tilelang_dsl/daemon_core.py
+++ b/tilelang-dsl/python/tilelang_dsl/daemon_core.py
@@ -313,7 +313,10 @@ def _build_positional_context_attrs(operand_specs: list[dict]) -> dict[str, Any]
     for index, spec in enumerate(operand_specs):
         prefix = f"arg{index}"
         attrs[f"{prefix}_kind"] = spec.get("kind")
-        attrs[f"{prefix}_dtype"] = spec.get("dtype")
+        dtype = spec.get("dtype")
+        if isinstance(dtype, str):
+            dtype = _convert_dtype_str_to_scalar(dtype)
+        attrs[f"{prefix}_dtype"] = dtype
 
         if spec.get("kind") == "scalar":
             continue

--- a/tilelang-dsl/python/tilelang_dsl/daemon_core.py
+++ b/tilelang-dsl/python/tilelang_dsl/daemon_core.py
@@ -319,6 +319,8 @@ def _build_positional_context_attrs(operand_specs: list[dict]) -> dict[str, Any]
         attrs[f"{prefix}_dtype"] = dtype
 
         if spec.get("kind") == "scalar":
+            if "value" in spec:
+                attrs[f"{prefix}_value"] = spec["value"]
             continue
 
         shape = spec.get("shape")

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -2853,6 +2853,7 @@ def ckernel(
     templates: Any = _UNSET,
     dtypes: Any = None,
     name: str | None = None,
+    constraints: Any = _UNSET,
     priority: Any = _UNSET,
 ) -> VKernelDescriptor | Callable[[Callable[..., Any]], VKernelDescriptor]:
     """Create a TileLang DSL cube-kernel descriptor.
@@ -2873,7 +2874,7 @@ def ckernel(
             name=name,
             verify=True,
             advanced=False,
-            constraints=_UNSET,
+            constraints=constraints,
             priority=priority,
             kernel_family="cube",
         )

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2730,6 +2730,15 @@ class _AuthoringRenderer:
         atomic_type = self._extract_optional_static_string(expr.args[cursor + 10], context=f"pto.{expr.name} atomic type")
         atomic_op = self._extract_optional_static_string(expr.args[cursor + 11], context=f"pto.{expr.name} atomic op")
 
+        if pre_quant_mode is not None:
+            source = self._bridge_rendered_ptr_element_to_signless_integer(
+                source,
+                indent=indent,
+                into=into,
+            )
+            operands[0] = source
+            type_parts[0] = self._render_type(source.type)
+
         if unit_flag is not None:
             clause_parts.append(f"unit_flag({unit_flag})")
 
@@ -3117,6 +3126,40 @@ class _AuthoringRenderer:
             f"{self._render_type(value.type)} to {self._render_type(raw_type)}"
         )
         return _RenderedValue(name=cast_name, type=raw_type)
+
+    def _bridge_rendered_ptr_element_to_signless_integer(
+        self,
+        value: _RenderedValue,
+        *,
+        indent: int,
+        into: list[str],
+    ) -> _RenderedValue:
+        if not isinstance(value.type, SemanticPtrType) or not is_integer_dtype(value.type.element_dtype):
+            return value
+        signless_element_type = self._signless_integer_scalar_type(
+            SemanticScalarType(dtype=value.type.element_dtype)
+        )
+        if signless_element_type is None:
+            return value
+        target_type = SemanticPtrType(
+            element_dtype=signless_element_type.dtype,
+            memory_space=value.type.memory_space,
+        )
+        if value.type == target_type:
+            return value
+        rendered_target_type = self._render_type(target_type)
+        cache_key = (value.name, rendered_target_type)
+        existing = self._castptr_cache.get(cache_key)
+        if existing is not None:
+            return _RenderedValue(name=existing, type=target_type)
+        cast_name = self._new_temp()
+        into.append(
+            self._indent(indent)
+            + f"{cast_name} = pto.castptr {value.name} : "
+            f"{self._render_type(value.type)} -> {rendered_target_type}"
+        )
+        self._castptr_cache[cache_key] = cast_name
+        return _RenderedValue(name=cast_name, type=target_type)
 
     def _bridge_rendered_integer_to_target(
         self,

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4410,8 +4410,8 @@ class _SemanticAnalyzer:
                     "qf322bf16_pre_scalar", "qs322bf16_pre_vec", "qs322bf16_pre_scalar",
                 },
             )
-            if src.type.element_dtype.name not in {"f32", "i32"}:
-                raise TypeError(f"pto.{name} pre_quant requires f32 or i32 source elements in TileLang DSL v1")
+            if src.type.element_dtype.name not in {"f32", "i32", "si32"}:
+                raise TypeError(f"pto.{name} pre_quant requires f32, i32, or si32 source elements in TileLang DSL v1")
             self._validate_fixpipe_payload(
                 pre_quant_payload,
                 pre_quant_mode,
@@ -4641,6 +4641,15 @@ class _SemanticAnalyzer:
             return ("i32", "bf16")
         return (None, None)
 
+    def _fixpipe_pre_quant_src_family_matches(self, src_dtype: ScalarType, src_family: str | None) -> bool:
+        if src_family is None:
+            return True
+        if src_family == "f32":
+            return src_dtype.name == "f32"
+        if src_family == "i32":
+            return src_dtype.name in {"i32", "si32"}
+        return src_dtype.name == src_family
+
     def _fixpipe_pre_quant_dst_family_matches(self, dst_dtype: ScalarType, dst_family: str | None) -> bool:
         if dst_family is None:
             return True
@@ -4666,7 +4675,7 @@ class _SemanticAnalyzer:
     ) -> None:
         mode_value = self._require_string_expr(mode, f"{context} mode")
         expected_src_family, expected_dst_family = self._fixpipe_pre_quant_mode_families(mode_value)
-        if expected_src_family is not None and src_dtype.name != expected_src_family:
+        if not self._fixpipe_pre_quant_src_family_matches(src_dtype, expected_src_family):
             raise TypeError(
                 f"{context} mode {mode_value} requires {expected_src_family} source elements in TileLang DSL v1"
             )

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -10655,6 +10655,31 @@ class TileLangDSLDiagnosticsTests(unittest.TestCase):
             str(pre_quant_src_family_ctx.exception),
         )
 
+        @pto.ckernel(op="pto.mad", dtypes=[(pto.f16,)], name="cube_si32_pre_quant_bridge_unique")
+        def si32_pre_quant_kernel(inp: pto.TensorView):
+            acc = pto.Tile((16, 16), pto.si32, pto.MemorySpace.ACC)
+            l1 = pto.Tile((16, 16), pto.f16, pto.MemorySpace.MAT)
+            pto.mte_l0c_l1(
+                acc.as_ptr(),
+                l1.as_ptr(),
+                16,
+                16,
+                16,
+                16,
+                pre_quant=(pto.f32(1.0), "deqf16_scalar"),
+            )
+
+        text = pto.select_kernel(
+            "a5",
+            "pto.mad",
+            (pto.f16,),
+            registry=pto.KernelRegistry((si32_pre_quant_kernel,)),
+        ).specialize().mlir_text()
+
+        self.assertIn("pre_quant(", text)
+        self.assertRegex(text, r"= pto\.castptr %[^:]+ : !pto\.ptr<si32, l0c> -> !pto\.ptr<i32, l0c>")
+        self.assertRegex(text, r"pto\.mte_l0c_l1 %[^,]+, %[^,]+, .* : !pto\.ptr<i32, l0c>, !pto\.ptr<f16, l1>,")
+
         @pto.ckernel(op="pto.mad", dtypes=[(pto.f16,)], name="cube_bad_pre_quant_dst_family_unique")
         def pre_quant_dst_family_kernel(inp: pto.TensorView):
             acc = pto.Tile((16, 16), pto.f32, pto.MemorySpace.ACC)

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2160,6 +2160,97 @@ def fallback(src: pto.TensorView, dst: pto.Tile):
 
         self.assertIn("func.func @constrained", mlir_text)
 
+    def test_instance_cache_constraints_can_read_scalar_values(self) -> None:
+        source = """
+import tilelang_dsl as pto
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_scalar_value_constraints_unique",
+    dtypes=[(pto.f32, pto.i32, pto.f32)],
+    constraints=[lambda src, indexCol, dst: indexCol.value % 8 == 0],
+    priority=100,
+)
+def constrained(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+    return None
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_scalar_value_constraints_unique",
+    dtypes=[(pto.f32, pto.i32, pto.f32)],
+    constraints=[],
+    priority=10,
+)
+def fallback(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+    return None
+"""
+
+        aligned_operand_specs = [
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+            {
+                "kind": "scalar",
+                "dtype": "i32",
+                "value": 8,
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        fallback_operand_specs = [
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+            {
+                "kind": "scalar",
+                "dtype": "i32",
+                "value": 1,
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        async def instantiate_from_tmpdir(tmpdir: str, operand_specs: list[dict]) -> str:
+            cache = daemon_core.InstanceCache()
+            cache.scan_template_directory(Path(tmpdir))
+            return await cache.instantiate(
+                "a5",
+                "matcher_daemon_scalar_value_constraints_unique",
+                operand_specs,
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir) / "matcher_daemon_scalar_value_constraints_unique.py"
+            module_path.write_text(source, encoding="utf-8")
+            aligned_mlir = asyncio.run(instantiate_from_tmpdir(tmpdir, aligned_operand_specs))
+            fallback_mlir = asyncio.run(instantiate_from_tmpdir(tmpdir, fallback_operand_specs))
+
+        self.assertIn("func.func @constrained", aligned_mlir)
+        self.assertIn("func.func @fallback", fallback_mlir)
+        self.assertEqual(
+            daemon_core._build_positional_context_attrs(aligned_operand_specs)["arg1_value"],
+            8,
+        )
+
     def test_select_kernel_binds_selected_op_for_multi_op_descriptor(self) -> None:
         @pto.vkernel(
             ops=["matcher_multi_op_bind_add_unique", "matcher_multi_op_bind_sub_unique"],

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -1438,6 +1438,50 @@ class TileLangDSLMatcherEntryTests(unittest.TestCase):
         self.assertIs(selected.py_fn, high_priority_kernel.py_fn)
         self.assertEqual(selected.priority, 100)
 
+    def test_ckernel_constraints_are_forwarded_to_select_kernel(self) -> None:
+        def requires_large_batch(batch=0):
+            return batch >= 1024
+
+        @pto.ckernel(
+            op="cube_constraint_priority_unique",
+            dtypes=[(pto.f16,)],
+            constraints=[requires_large_batch],
+            priority=100,
+        )
+        def high_priority_kernel(inp: pto.TensorView):
+            return None
+
+        @pto.ckernel(
+            op="cube_constraint_priority_unique",
+            dtypes=[(pto.f16,)],
+            constraints=[],
+            priority=10,
+        )
+        def fallback_kernel(inp: pto.TensorView):
+            return None
+
+        registry = pto.KernelRegistry((high_priority_kernel, fallback_kernel))
+
+        selected = pto.select_kernel(
+            "a5",
+            "cube_constraint_priority_unique",
+            (pto.f16,),
+            context_attrs={"batch": 128},
+            registry=registry,
+        )
+        self.assertIs(selected.py_fn, fallback_kernel.py_fn)
+        self.assertEqual(selected.priority, 10)
+
+        selected = pto.select_kernel(
+            "a5",
+            "cube_constraint_priority_unique",
+            (pto.f16,),
+            context_attrs={"batch": 4096},
+            registry=registry,
+        )
+        self.assertIs(selected.py_fn, high_priority_kernel.py_fn)
+        self.assertEqual(selected.priority, 100)
+
     def test_select_kernel_raises_tie_error_for_equal_highest_priority(self) -> None:
         @pto.vkernel(
             op="matcher_priority_tie_unique",
@@ -9985,6 +10029,10 @@ class TileLangDSLDiagnosticsTests(unittest.TestCase):
         with self.assertRaises(TypeError) as constraints_ctx:
             pto.vkernel(op="x", dtypes=[(pto.f32,)], constraints=[123])(kernel)
         self.assertIn("constraints[0] must be callable", str(constraints_ctx.exception))
+
+        with self.assertRaises(TypeError) as cube_constraints_ctx:
+            pto.ckernel(op="x", dtypes=[(pto.f32,)], constraints=[123])(kernel)
+        self.assertIn("constraints[0] must be callable", str(cube_constraints_ctx.exception))
 
         with self.assertRaises(TypeError) as priority_ctx:
             pto.vkernel(op="x", dtypes=[(pto.f32,)], priority=True)(kernel)

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -1939,6 +1939,29 @@ class TileLangDSLMatcherEntryTests(unittest.TestCase):
 
         self.assertTrue(evaluation.passed, msg=evaluation.error_message)
 
+    def test_daemon_context_attrs_normalize_dtype_to_scalartype(self) -> None:
+        operand_specs = [
+            {
+                "kind": "view",
+                "dtype": "f32",
+                "shape": [1, 1, 1, 16, 64],
+                "strides": [1024, 1024, 1024, 64, 1],
+                "memory_space": "gm",
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [16, 64],
+                "valid_shape": [16, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        context_attrs = daemon_core._build_positional_context_attrs(operand_specs)
+
+        self.assertIs(context_attrs["arg0_dtype"], pto.f32)
+        self.assertIs(context_attrs["arg1_dtype"], pto.f32)
+
     def test_select_kernel_constraints_can_read_scalar_parameter_values(self) -> None:
         @pto.vkernel(
             op="matcher_scalar_value_unique",
@@ -2078,6 +2101,64 @@ def kernel(value: pto.si32):
             mlir_text = asyncio.run(instantiate_from_tmpdir(tmpdir))
 
         self.assertIn("func.func @kernel(%arg0: si32)", mlir_text)
+
+    def test_instance_cache_constraints_can_read_dtype_objects(self) -> None:
+        source = """
+import tilelang_dsl as pto
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_dtype_constraints_unique",
+    dtypes=[(pto.AnyType, pto.AnyType)],
+    constraints=[lambda src, dst: src.dtype == pto.f32 and dst.dtype == pto.f32],
+    priority=100,
+)
+def constrained(src: pto.TensorView, dst: pto.Tile):
+    return None
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_dtype_constraints_unique",
+    dtypes=[(pto.AnyType, pto.AnyType)],
+    constraints=[],
+    priority=10,
+)
+def fallback(src: pto.TensorView, dst: pto.Tile):
+    return None
+"""
+
+        operand_specs = [
+            {
+                "kind": "view",
+                "dtype": "f32",
+                "shape": [1, 1, 1, 16, 64],
+                "strides": [1024, 1024, 1024, 64, 1],
+                "memory_space": "gm",
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [16, 64],
+                "valid_shape": [16, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        async def instantiate_from_tmpdir(tmpdir: str) -> str:
+            cache = daemon_core.InstanceCache()
+            cache.scan_template_directory(Path(tmpdir))
+            return await cache.instantiate(
+                "a5",
+                "matcher_daemon_dtype_constraints_unique",
+                operand_specs,
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir) / "matcher_daemon_dtype_constraints_unique.py"
+            module_path.write_text(source, encoding="utf-8")
+            mlir_text = asyncio.run(instantiate_from_tmpdir(tmpdir))
+
+        self.assertIn("func.func @constrained", mlir_text)
 
     def test_select_kernel_binds_selected_op_for_multi_op_descriptor(self) -> None:
         @pto.vkernel(

--- a/tools/ptoas/TilelangDaemon.cpp
+++ b/tools/ptoas/TilelangDaemon.cpp
@@ -12,9 +12,12 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include <chrono>
-#include <thread>
-#include <signal.h>
 #include <cstdlib>
+#include <signal.h>
+#include <thread>
+#include <unistd.h>
+
+extern char **environ;
 
 namespace ptoas {
 


### PR DESCRIPTION
## Summary
This PR cherry-picks the 8 commits in the inclusive range [0443c37e3, 51f322407] onto the latest main.

Included fixes:
- Declare TileLang daemon POSIX symbols
- Fix ExpandTileOp memory space stringify
- Support constraints in ckernel
- Convert positional dtype strings to real dtypes in DSL lowering
- Support `si32` pre_quant type in DSL
- Support signless `i8*i8->i32` mad lowering on VPTO
- Fix daemon core scalar value passing in DSL
- Restrict `indexRow`/`indexCol` to `0` for `textract` mat -> left/right

## Validation
- `PYTHONPATH=$PWD/tilelang-dsl/python python3 -m unittest tilelang-dsl/tests/test_tilelang_dsl_v1.py`

## Notes
- I attempted to run the related `lit` tests as well, but the available generated `lit.site.cfg.py` in this environment points at a different source checkout, so I did not count that as a reliable validation result for this isolated PR branch.