### PR TITLE
feature vpto backend merge3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,6 @@ test/samples/**/npu_validation/*
 *.orig
 
 # Local workspace
+.planning/
 .work/
 .local/

--- a/docs/designs/vpto-simt-keep-resume-design.md
+++ b/docs/designs/vpto-simt-keep-resume-design.md
@@ -1,0 +1,327 @@
+# VPTO SIMT `pto.keep` / `pto.resume` 设计
+
+## 1. 背景
+
+当前 VPTO 已支持通过 `pto.store_vfsimt_info` + `func.call @simt_func(...)` + `pto.get_tid_x/y/z` 表达一次 SIMT VF 调用。
+
+硬件还存在一个额外语义：两个连续的 SIMT VF 调用之间，SIMT 寄存器状态不会被自动清零。前一个 SIMT VF 写入的部分逻辑值，可以在后一个 SIMT VF 中稳定读取。
+
+这类语义如果不显式建模，后续 pass 可能把它当成普通无依赖调用重排、复制或删除。
+
+因此需要引入一对新的 VPTO op：
+
+- `pto.keep`
+- `pto.resume`
+
+用于显式表达这段跨 SIMT VF 调用的隐式逻辑数据流。
+
+---
+
+## 2. 设计目标
+
+- 显式表达“保留哪些 SSA 值、恢复哪些 SSA 值”。
+- 不把这段语义建模成普通可长期持有的 SSA `return` 值，避免误导。
+- 不允许 `!pto.vreg` / `!pto.mask` 进入这套机制。
+- 让 verifier 能按 slot 和 payload 做强约束。
+- 让 lowering 可以先消费语义，再决定是否擦除或映射 intrinsic。
+
+非目标：
+
+- 不做任意 CFG 上的远距离传播。
+- 不支持一个 slot 对多个消费者。
+- 不支持跨 host / kernel 传播。
+
+---
+
+## 3. 核心语义
+
+`pto.keep` 和 `pto.resume` 通过一个编译期常量 `slot` 配对。
+
+- `pto.keep`
+  - 绑定当前 `simtvf` 内显式列出的 SSA 值
+  - 把这组值记录到指定 `slot`
+
+- `pto.resume`
+  - 从指定 `slot` 恢复之前 `pto.keep` 保存的那组值
+  - 重新物化成新的 SSA 值供后续使用
+
+这是一条**逻辑数据流**，不是普通 `return` 值语义。
+
+---
+
+## 4. IR 接口
+
+### 4.1 `pto.keep`
+
+语法：
+
+```mlir
+pto.keep %a {slot = 0} : i32
+```
+
+语义：
+
+- 显式保存一个 SSA 值到 `slot`
+- 支持不超过 64 bit 的整数标量，以及 `f16` / `bf16` / `f32`
+- 64-bit 整数值占用 `slot` 和 `slot + 1`，因此 `slot` 必须为偶数
+
+### 4.2 `pto.resume`
+
+语法：
+
+```mlir
+%x = pto.resume {slot = 0} : i32
+```
+
+语义：
+
+- 从 `slot` 恢复出之前保存的值
+- 恢复结果类型必须和 `keep` 的 payload 类型完全一致
+- 支持不超过 64 bit 的整数标量，以及 `f16` / `bf16` / `f32`
+- 64-bit 整数值占用 `slot` 和 `slot + 1`，因此 `slot` 必须为偶数
+
+### 4.3 示例
+
+```mlir
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%dst: !pto.ptr<i32, gm>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 32 : i32
+    %dim_x = arith.constant 32 : i32
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_stage0(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    func.call @simt_stage1(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    %tid2 = pto.resume {slot = 0} : i32
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.dma_store %ub_out, %dst, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    return
+  }
+
+  func.func @simt_stage0(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    return
+  }
+
+  func.func @simt_stage1(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    return
+  }
+}
+```
+
+---
+
+## 5. 放置约束
+
+### 5.1 `pto.keep`
+
+- 只能出现在 `pto.simt_entry` 函数内部。
+- 必须显式列出要保存的 SSA 值。
+- `slot` 必须是编译期常量。
+- payload 不得包含 `!pto.vreg` / `!pto.mask`。
+- 当前实现中必须紧邻 `func.return`。
+
+### 5.2 `pto.resume`
+
+- 只能出现在 `pto.simt_entry` 函数内部。
+- 必须显式恢复 payload。
+- `slot` 必须与对应 `pto.keep` 匹配。
+- payload 不得包含 `!pto.vreg` / `!pto.mask`。
+- 当前实现中必须是所在 block 的第一条操作。
+
+### 5.3 成对约束
+
+- 一个 `slot` 在被 `resume` 消费前不能再次被 `keep` 覆盖。
+- `keep` 和 `resume` 的 payload 类型必须完全一致。
+- 第一版只支持线性调用链，不跨分支/循环。
+
+### 5.4 中间允许的 op
+
+`keep` 和匹配的 `resume` 之间：
+
+- 禁止新的 `pto.simt_entry` 调用
+- 禁止新的 `pto.keep` / `pto.resume`
+- 禁止新的 `pto.store_vfsimt_info`
+- 允许普通标量算术、地址计算、常量、`arith.*`、以及非 `pto.simt_entry` 的纯 helper call
+
+---
+
+## 6. `store_vfsimt_info` 约束
+
+两次相关 `simtvf` 的 launch 维度必须一致：
+
+- `keep` 所在的 `simtvf`
+- `resume` 所在的 `simtvf`
+
+在 `keep` 和 `resume` 之间不得插入新的 `pto.store_vfsimt_info`。
+
+---
+
+## 7. 为什么不用 `return` 语义
+
+如果把这份状态做成普通 `return` 值，会误导成“我可以把它长期拿着，过会再用”。
+
+这不符合这里的时序敏感语义。
+
+所以本设计选择：
+
+- 用 `slot` 表达跨函数/跨调用的逻辑连接
+- 用显式 payload 表达“保存了哪些变量”
+- 不把它做成普通可长期持有的 return value
+
+---
+
+## 8. Side Effect 建模
+
+`pto.keep` / `pto.resume` 不能是 `Pure` op。
+
+建议把它们建模成访问抽象资源：
+
+- `pto.keep`：`Write<SIMT_PAYLOAD_SLOT>`
+- `pto.resume`：`Read<SIMT_PAYLOAD_SLOT>`
+
+这样可避免被 CSE / DCE / 重排误伤。
+
+---
+
+## 9. Verifier 规则
+
+至少检查：
+
+1. `pto.keep` / `pto.resume` 只能出现在 `pto.simt_entry` 内。
+2. `keep` / `resume` 的 payload 中不得出现 `!pto.vreg` / `!pto.mask`。
+3. `slot` 必须是编译期常量。
+4. `slot` 是用户显式分配的槽位；32-bit 及以下值占一个槽，64-bit
+   整数占两个槽且起始 slot 必须为偶数。
+5. 同一 keep/resume 组内的槽位覆盖范围不得重叠。
+6. `resume` 必须是所在 block 的第一条操作，`keep` 必须紧邻 `func.return`。
+7. 同一 `slot` 的 `keep` 与 `resume` payload 类型必须一致。
+8. 一个 `slot` 在被消费前不能再次被覆盖。
+9. `keep` 和 `resume` 之间不得插入新的 `pto.store_vfsimt_info`。
+10. 第一版要求线性链路，不跨分支/循环。
+
+---
+
+## 10. Lowering 方案
+
+### 10.1 LLVM 承载方式
+
+VPTO 语义层保持 `pto.keep` / `pto.resume` 不变。LLVM 层不引入可长期持有的 `simt_state` 值，也不新增 intrinsic；`keep/resume` 只是在 lowering 时映射成 `llvm.inlineasm` 形式的 sideeffect call，由后端识别其 asm 指令。
+
+当前实现把 `slot` 直接映射到固定 SIMT 物理寄存器：
+
+- `slot = 0` -> `R4`
+- `slot = 1` -> `R5`
+- ...
+- `slot = 122` -> `R126`
+
+64-bit 整数值占用一对连续槽位，且起始 slot 必须为偶数。slot 是用户
+显式分配的，不会按 keep/resume 组内出现顺序重新 packed；因此 consumer
+只恢复部分 slot 时，剩余 slot 的物理位置仍然稳定。
+
+对应 lowering：
+
+- `pto.keep %x {slot = N} : i32`
+  - `call void asm sideeffect "MOV R{4+N}, $0", "R"(i32 %x)`
+- `%y = pto.resume {slot = N} : i32`
+  - `%y = call i32 asm sideeffect "MOV $0, R{4+N}", "=R"()`
+- `pto.keep %x {slot = N} : i64`
+  - `call void asm sideeffect "IMAD.WIDE.u32 R{4+N}, RZ, RZ, $0", "R"(i64 %x)`
+- `%y = pto.resume {slot = N} : i64`
+  - `%y = call i64 asm sideeffect "IMAD.WIDE.u32 $0, RZ, RZ, R{4+N}", "=R"()`
+
+约束：
+
+- `keep` 必须带 `sideeffect`，不能被当成纯函数删除。
+- `resume` 必须产生与 `keep` payload 完全一致的结果类型。
+- 不能把它做成普通 return token，也不能让它看起来像可无限期持有的 state 值。
+- asm 指令名使用 `MOV dst, src` 这一类可被后端识别的指令名，不使用随意拼接的业务字符串。
+- `slot` 必须能映射到 `R4~R126`，超出范围直接在 verifier 中拒绝；
+  64-bit 整数值还要求偶数 slot，且第二个槽不能超出范围。
+- asm 字符串要足够稳定，后端能无歧义识别固定 `R` 寄存器名和 `MOV` 形态。
+
+### 10.2 执行顺序
+
+1. 在 authoring IR 中保留 `keep/resume`。
+2. 在 VPTO verifier 中收紧 slot、payload、边界和插入点约束。
+3. 在 `VPTOLLVMEmitter` 中 lower 成 inline asm sideeffect call。
+4. 由更底层后端识别该 asm 标记并展开为实际硬件语义。
+
+### 10.3 一个具体 case
+
+以“`simt_stage0` 保存，`simt_stage1` 恢复”为例，目标形态如下：
+
+```mlir
+module attributes {pto.target_arch = "a5"} {
+  func.func @kernel(%dst: !pto.ptr<i32, ub>, %src: !pto.ptr<i32, gm>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 32 : i32
+    %dim_x = arith.constant 32 : i32
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_stage0(%ub) : (!pto.ptr<i32, ub>) -> ()
+
+    func.call @simt_stage1(%ub) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.dma_store %ub, %dst, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    return
+  }
+
+  func.func @simt_stage0(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %tid = pto.get_tid_x : i32
+    // 这里代表 stage0 产生的状态被 keep 到 slot 0。
+    pto.keep %tid {slot = 0} : i32
+    return
+  }
+
+  func.func @simt_stage1(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    // 这里代表 stage1 从 slot 0 恢复上一个 stage 的状态。
+    %tid = pto.resume {slot = 0} : i32
+    return
+  }
+}
+```
+
+对应到 LLVM lowering 后，`keep/resume` 仍然留在各自函数内部，只是变成内联汇编承载的 sideeffect 操作：
+
+- `simt_stage0` 内的 `pto.keep %tid {slot = 0} : i32`
+  - `call void asm sideeffect "MOV R4, $0", "R"(i32 %tid)`
+- `simt_stage1` 内的 `pto.resume {slot = 0} : i32`
+  - `%tid2 = call i32 asm sideeffect "MOV $0, R4", "=R"()`
+
+这里固定的不只是数据流关系，也包括最终 asm 形态：
+
+- `keep/resume` 都必须留在对应 `simt_entry` 内。
+- `slot = 0` 只在这两个函数之间建立关联。
+- `slot` 在 lowering 时必须能映射到 `R4~R126`。
+
+---
+
+## 11. 对现有 pass 的影响
+
+- `PTOValidateVPTOIR` 需要新增 keep/resume 校验。
+- canonicalize / CSE 需要因为 side effect 而保留它们。
+- `VPTOLLVMEmitter` 需要先消费再擦除。
+
+---
+
+## 12. 结论
+
+这版方案比 `return simt_state` 更准确：
+
+- 不误导成“可长期持有的状态值”
+- 仍然能显式表达“保存了哪些变量”
+- 还能通过 slot 和 verifier 建立严格逻辑数据流

--- a/docs/designs/vpto-simt-keep-resume-design.md
+++ b/docs/designs/vpto-simt-keep-resume-design.md
@@ -96,7 +96,6 @@ module attributes {pto.target_arch = "a5"} {
     pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
     func.call @simt_stage0(%ub_out) : (!pto.ptr<i32, ub>) -> ()
     func.call @simt_stage1(%ub_out) : (!pto.ptr<i32, ub>) -> ()
-    %tid2 = pto.resume {slot = 0} : i32
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
@@ -107,10 +106,16 @@ module attributes {pto.target_arch = "a5"} {
   }
 
   func.func @simt_stage0(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %tid = pto.get_tid_x : i32
+    pto.keep %tid {slot = 0 : i64} : i32
     return
   }
 
   func.func @simt_stage1(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %tid2 = pto.resume {slot = 0 : i64} : i32
+    %tid = pto.get_tid_x : i32
+    %idx = arith.index_castui %tid : i32 to index
+    pto.store %tid2, %dst[%idx] : !pto.ptr<i32, ub>, i32
     return
   }
 }
@@ -138,6 +143,9 @@ module attributes {pto.target_arch = "a5"} {
 
 ### 5.3 成对约束
 
+这些约束描述用户必须保持的跨 SIMT entry 语义关系。实现不需要对跨
+entry 关系做 verifier 检查。
+
 - 一个 `slot` 在被 `resume` 消费前不能再次被 `keep` 覆盖。
 - `keep` 和 `resume` 的 payload 类型必须完全一致。
 - 第一版只支持线性调用链，不跨分支/循环。
@@ -146,9 +154,8 @@ module attributes {pto.target_arch = "a5"} {
 
 `keep` 和匹配的 `resume` 之间：
 
-- 禁止新的 `pto.simt_entry` 调用
+- 禁止插入无关的 `pto.simt_entry` 调用
 - 禁止新的 `pto.keep` / `pto.resume`
-- 禁止新的 `pto.store_vfsimt_info`
 - 允许普通标量算术、地址计算、常量、`arith.*`、以及非 `pto.simt_entry` 的纯 helper call
 
 ---
@@ -159,8 +166,6 @@ module attributes {pto.target_arch = "a5"} {
 
 - `keep` 所在的 `simtvf`
 - `resume` 所在的 `simtvf`
-
-在 `keep` 和 `resume` 之间不得插入新的 `pto.store_vfsimt_info`。
 
 ---
 
@@ -202,10 +207,9 @@ module attributes {pto.target_arch = "a5"} {
    整数占两个槽且起始 slot 必须为偶数。
 5. 同一 keep/resume 组内的槽位覆盖范围不得重叠。
 6. `resume` 必须是所在 block 的第一条操作，`keep` 必须紧邻 `func.return`。
-7. 同一 `slot` 的 `keep` 与 `resume` payload 类型必须一致。
-8. 一个 `slot` 在被消费前不能再次被覆盖。
-9. `keep` 和 `resume` 之间不得插入新的 `pto.store_vfsimt_info`。
-10. 第一版要求线性链路，不跨分支/循环。
+
+跨 SIMT entry 的 slot 配对、payload 类型匹配、覆盖关系和 launch 维度
+一致性属于用户必须遵守的语义约束，不作为 verifier 的跨 entry 检查项。
 
 ---
 

--- a/docs/isa/micro-isa/03-vector-load-store.md
+++ b/docs/isa/micro-isa/03-vector-load-store.md
@@ -112,12 +112,17 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
 ### `pto.vlds`
 
 - **syntax:** `%result = pto.vlds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.vreg<NxT>`
+
+  Post-update form:
+
+  `%result, %updated_base = pto.vlds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.vreg<NxT>, !pto.ptr<T, ub>`
 - **semantics:** Vector load with distribution mode.
 - **inputs:**
   `%source` is the UB base address, `%offset` is the load displacement, and
   `DIST` selects the distribution mode.
 - **outputs:**
-  `%result` is the loaded vector register value.
+  `%result` is the loaded vector register value. In the post-update form,
+  `%updated_base` is the base pointer advanced according to `%offset`.
 - **constraints and limitations:**
   The effective address MUST satisfy the alignment rule of the selected
   distribution mode. `NORM` reads one full vector footprint. Broadcast,
@@ -125,6 +130,8 @@ DMA **`TLOAD` / `TSTORE`** (global memory ↔ UB) use **MTE** pipes, not `RV_VLD
   how memory bytes are mapped into destination lanes, but they do not change the
   fact that the source is UB memory. PTO surface exposes load `dist` as family
   tokens, and each family only supports the element widths listed below.
+  The optional `%updated_base` result must have the same pointer type as the
+  base address operand.
 
 **Distribution families:**
 
@@ -367,13 +374,16 @@ for (int blk = 0; blk < VL / 32; ++blk) {
 ### `pto.vsts`
 
 - **syntax:** `pto.vsts %value, %dest[%offset], %mask {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.mask<G>`
+- **post-update syntax:** `%updated_dest = pto.vsts %value, %dest[%offset], %mask {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>, !pto.mask<G> -> !pto.ptr<T, ub>`
 - **semantics:** Vector store with distribution mode.
 - **inputs:**
   `%value` is the source vector, `%dest` is the UB base pointer, `%offset` is
   the displacement, `%mask` is the predicate operand, and
   `DIST` selects the store distribution.
 - **outputs:**
-  This op has no SSA result; it writes to UB memory.
+  The normal form has no SSA result and writes to UB memory. In the post-update
+  form, `%updated_dest` is the destination pointer advanced according to
+  `%offset`.
 - **constraints and limitations:**
   The effective destination address MUST satisfy the alignment rule of the
   selected store mode. The single-input `pto.vsts` family covers contiguous
@@ -439,13 +449,16 @@ for (int i = 0; i < 64; i++) {
 ### `pto.vsstb`
 
 - **syntax:** `pto.vsstb %value, %dest, %block_stride, %repeat_stride, %mask : !pto.vreg<NxT>, !pto.ptr<T, ub>, i16, i16, !pto.mask<G>`
+- **post-update syntax:** `%updated_dest = pto.vsstb %value, %dest, %block_stride, %repeat_stride, %mask : !pto.vreg<NxT>, !pto.ptr<T, ub>, i16, i16, !pto.mask<G> -> !pto.ptr<T, ub>`
 - **semantics:** Block-strided store for 2D tile access.
 - **inputs:**
   `%value` is the source vector, `%dest` is the UB base pointer,
   `%block_stride` and `%repeat_stride` are the two 16-bit fields of the
   hardware control word, and `%mask` controls block participation.
 - **outputs:**
-  This op writes UB memory and returns no SSA value.
+  The normal form writes UB memory and returns no SSA value. In the post-update
+  form, `%updated_dest` is the destination pointer advanced according to the
+  packed stride control word.
 - **constraints and limitations:**
   PTO surface does not expose the packed control word directly. Masked-off
   blocks MUST NOT issue memory writes.

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -1,0 +1,1093 @@
+# 17. SIMT Ops
+
+> **Category:** SIMT scalar execution, lane collectives, scalar memory, and
+> memory-reduction operations
+> **Pipeline:** Vector-side SIMT execution
+
+SIMT ops are scalar operations executed by a group of workitems. A VPTO SIMT
+program has an outer `pto.aicore` kernel that configures a VF subtask launch and
+calls a SIMT body function marked with `pto.simt_entry`. The body is executed by
+the logical workitems in the configured `dim_x * dim_y * dim_z` launch space.
+
+---
+
+## Common SIMT Execution Model
+
+- The outer non-SIMT kernel configures launch dimensions with
+  `pto.store_vfsimt_info`.
+- The SIMT body is a normal `func.func` with the `pto.simt_entry` attribute.
+- Each active workitem executes the same SIMT body with its own scalar SSA
+  values, thread coordinates, lane id, and lane-mask state.
+- SIMT scalar memory offsets are element offsets, not byte offsets.
+- Vector-register ops such as `pto.vlds`, `pto.vadd`, and `pto.vsts` belong to
+  normal vector code, not to the SIMT body.
+
+Example SIMT body:
+
+```mlir
+func.func @body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+  %tx = pto.get_tid_x : i32
+  %idx = arith.index_castui %tx : i32 to index
+  pto.store %tx, %dst[%idx] : !pto.ptr<i32, ub>, i32
+  return
+}
+```
+
+### Supported PTO SIMT Operation Surface
+
+The current PTO SIMT surface supports these operation families:
+
+| Family | Ops |
+|--------|-----|
+| Launch configuration | `pto.store_vfsimt_info` |
+| Thread and lane queries | `pto.get_tid_x`, `pto.get_tid_y`, `pto.get_tid_z`, `pto.get_block_dim_x`, `pto.get_block_dim_y`, `pto.get_block_dim_z`, `pto.get_grid_dim_x`, `pto.get_grid_dim_y`, `pto.get_grid_dim_z`, `pto.get_block_idx_x`, `pto.get_block_idx_y`, `pto.get_block_idx_z`, `pto.get_veccoreid`, `pto.get_clock32`, `pto.get_clock64`, `pto.get_laneid`, `pto.get_lanemask_eq`, `pto.get_lanemask_le`, `pto.get_lanemask_lt`, `pto.get_lanemask_ge`, `pto.get_lanemask_gt` |
+| Lane collectives | `pto.vote_all`, `pto.vote_any`, `pto.vote_uni`, `pto.vote_ballot`, `pto.shuffle_idx`, `pto.shuffle_up`, `pto.shuffle_down`, `pto.shuffle_bfly`, `pto.redux_add`, `pto.redux_max`, `pto.redux_min` |
+| Scalar memory | `pto.load`, `pto.store`, `pto.ldg`, `pto.stg` |
+| Atomic memory | `pto.atomic_exch`, `pto.atomic_add`, `pto.atomic_sub`, `pto.atomic_min`, `pto.atomic_max`, `pto.atomic_and`, `pto.atomic_or`, `pto.atomic_xor`, `pto.atomic_cas` |
+| Scalar math | `pto.prmt`, `pto.mulhi`, `pto.mul_i32toi64`, `pto.absf`, `pto.sqrt`, `pto.exp`, `pto.log`, `pto.pow`, `pto.ceil`, `pto.floor`, `pto.rint`, `pto.round`, `pto.fmin`, `pto.fmax`, `pto.fma` |
+| Conversion | `pto.convert` |
+| Entry synchronization and state | `pto.syncthreads`, `pto.threadfence`, `pto.threadfence_block`, `pto.keep`, `pto.resume` |
+
+Two optional function attributes may be attached to a `pto.simt_entry`
+function:
+
+| Function attribute | Type | Default | Meaning |
+|--------------------|------|---------|---------|
+| `pto.simt_max_threads` | signless `i32` integer attribute | `1024` | Compile-time launch envelope. It should cover the largest `dim_x * dim_y * dim_z` launch count used for this entry. |
+| `pto.simt_max_regs` | signless `i32` integer attribute | `32` | Compile-time scalar register budget per workitem. Lower values constrain scalar live state; higher values permit more scalar live values with higher resource pressure. |
+
+Both attributes are optional. If present, they must be positive `i32`
+attributes and may only appear on functions that also carry `pto.simt_entry`.
+They do not launch work by themselves; the actual workitem count comes from
+`pto.store_vfsimt_info`.
+
+```mlir
+func.func @body(%dst: !pto.ptr<i32, ub>)
+    attributes {pto.simt_entry,
+                pto.simt_max_threads = 256 : i32,
+                pto.simt_max_regs = 48 : i32} {
+  return
+}
+```
+
+---
+
+## Launch Configuration
+
+### `pto.store_vfsimt_info`
+
+- **syntax:** `pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32`
+- **semantics:** Configure the launch descriptor consumed by a subsequent SIMT
+  entry call sequence in the current outer vector-side kernel.
+
+```text
+configured_dim_z = dim_z
+configured_dim_y = dim_y
+configured_dim_x = dim_x
+logical_workitems = dim_x * dim_y * dim_z
+call one or more simt_entry_body(...) functions
+```
+
+- **inputs:** `%dim_z`, `%dim_y`, and `%dim_x` are `i32` workitem counts in
+  `z, y, x` order.
+- **outputs:** None.
+- **constraints and limitations:** This op belongs in the outer non-SIMT
+  caller and must not appear inside a function marked with `pto.simt_entry`.
+  SIMT entry calls that use the descriptor must be dominated by the matching
+  launch configuration. On the current SIMT VF model, the launch count is
+  bounded by 2048.
+  If `pto.simt_max_threads` is present on the callee, it should be at least the
+  largest launch count used for that callee.
+
+Typical outer-kernel pattern:
+
+```mlir
+%dim_z = arith.constant 1 : i32
+%dim_y = arith.constant 1 : i32
+%dim_x = arith.constant 32 : i32
+pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+func.call @body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+```
+
+---
+
+## Thread and Lane Query Ops
+
+Thread and lane query ops are nullary pure scalar ops. They return the value
+visible to the current workitem.
+
+### `pto.get_tid_x` / `pto.get_tid_y` / `pto.get_tid_z`
+
+- **syntax:** `%tx = pto.get_tid_x : i32`
+- **semantics:** Return the current workitem coordinate in the selected launch
+  dimension.
+
+```text
+0 <= tid_x < dim_x
+0 <= tid_y < dim_y
+0 <= tid_z < dim_z
+linear_tid = tid_x + dim_x * (tid_y + dim_y * tid_z)
+```
+
+- **inputs:** None.
+- **outputs:** One `i32` coordinate.
+- **constraints and limitations:** Use these coordinates for logical indexing.
+  They are launch coordinates, not necessarily the same value as the physical
+  lane id.
+
+### `pto.get_block_dim_x` / `pto.get_block_dim_y` / `pto.get_block_dim_z`
+
+- **syntax:** `%v = pto.get_block_dim_x : i32`
+- **semantics:** Return the block dimension visible to the current workitem in
+  the selected dimension.
+- **inputs:** None.
+- **outputs:** One `i32` block dimension.
+- **constraints and limitations:** For single-block VF launches, block
+  dimensions match the configured launch dimensions.
+
+### `pto.get_grid_dim_x` / `pto.get_grid_dim_y` / `pto.get_grid_dim_z`
+
+- **syntax:** `%v = pto.get_grid_dim_x : i32`
+- **semantics:** Return the grid dimension visible to the current workitem in
+  the selected dimension.
+- **inputs:** None.
+- **outputs:** One `i32` grid dimension.
+- **constraints and limitations:** Use grid dimensions with block dimensions and
+  block indices when deriving global workitem coordinates.
+
+### `pto.get_block_idx_x` / `pto.get_block_idx_y` / `pto.get_block_idx_z`
+
+- **syntax:** `%v = pto.get_block_idx_x : i32`
+- **semantics:** Return the current block index in the selected dimension.
+- **inputs:** None.
+- **outputs:** One `i32` block index.
+- **constraints and limitations:** For single-block VF launches, block indices
+  are normally zero.
+
+### `pto.get_veccoreid`
+
+- **syntax:** `%core = pto.get_veccoreid : i32`
+- **semantics:** Return the vector-core id visible to the current workitem.
+- **inputs:** None.
+- **outputs:** One `i32` vector-core id.
+- **constraints and limitations:** The value is target scoped; use it only when
+  the algorithm intentionally depends on the executing vector core.
+
+### `pto.get_clock32` / `pto.get_clock64`
+
+- **syntax:** `%c32 = pto.get_clock32 : i32`, `%c64 = pto.get_clock64 : i64`
+- **semantics:** Sample the target clock counter visible to the current
+  workitem.
+- **inputs:** None.
+- **outputs:** `pto.get_clock32` returns `i32`; `pto.get_clock64` returns `i64`.
+- **constraints and limitations:** Use `get_clock64` when 32-bit wraparound
+  could make elapsed-time comparisons ambiguous.
+
+### `pto.get_laneid`
+
+- **syntax:** `%lane = pto.get_laneid : i32`
+- **semantics:** Return the physical SIMT lane id for the current workitem.
+- **inputs:** None.
+- **outputs:** One `i32` lane id.
+- **constraints and limitations:** Use lane id for lane-mask, vote, shuffle,
+  and reduction logic. Use `get_tid_x/y/z` for logical tensor indexing.
+
+### `pto.get_lanemask_eq` / `pto.get_lanemask_le` / `pto.get_lanemask_lt` / `pto.get_lanemask_ge` / `pto.get_lanemask_gt`
+
+- **syntax:** `%mask = pto.get_lanemask_lt : i32`
+- **semantics:** Return a 32-bit mask derived from the current lane id.
+
+```text
+get_lanemask_eq = 1 << laneid
+get_lanemask_lt = bits for lanes 0 .. laneid-1
+get_lanemask_le = bits for lanes 0 .. laneid
+get_lanemask_gt = bits for lanes laneid+1 .. subgroup_width-1
+get_lanemask_ge = bits for lanes laneid .. subgroup_width-1
+```
+
+- **inputs:** None.
+- **outputs:** One `i32` mask value.
+- **constraints and limitations:** The mask is indexed by physical lane id.
+
+---
+
+## Vote Ops
+
+Vote ops consume one `i1` predicate from each participating active lane and
+return a collective result to each participating active lane.
+
+### `pto.vote_all` / `pto.vote_any` / `pto.vote_uni` / `pto.vote_ballot`
+
+- **syntax:**
+```mlir
+%all = pto.vote_all %pred : i1 -> i1
+%any = pto.vote_any %pred : i1 -> i1
+%uni = pto.vote_uni %pred : i1 -> i1
+%bits = pto.vote_ballot %pred : i1 -> i32
+```
+- **semantics:**
+```text
+active = participating active lanes
+vote_all    = forall lane in active: pred[lane]
+vote_any    = exists lane in active: pred[lane]
+vote_uni    = all pred[lane] values in active are equal
+vote_ballot = bitset of lanes in active where pred[lane] is true
+```
+- **inputs:** `%pred` is the current lane's `i1` predicate.
+- **outputs:** `vote_all`, `vote_any`, and `vote_uni` return `i1`.
+  `vote_ballot` returns an `i32` lane bit mask.
+- **constraints and limitations:** Inactive lanes do not contribute predicate
+  values to the vote.
+
+Example:
+
+```mlir
+%lane = pto.get_laneid : i32
+%one = arith.constant 1 : i32
+%low = arith.andi %lane, %one : i32
+%is_odd = arith.cmpi eq, %low, %one : i32
+%odd_mask = pto.vote_ballot %is_odd : i1 -> i32
+```
+
+---
+
+## Shuffle Ops
+
+Shuffle ops exchange values between participating lanes. The source value and
+result have the same type.
+
+### `pto.shuffle_idx`
+
+- **syntax:** `%r = pto.shuffle_idx %value, %index {width = 16 : i32} : T, i32 -> T`
+- **semantics:** Read `%value` from absolute `%index` inside the current
+  subgroup.
+- **inputs:** `%value` is the current lane's payload. `%index` is the
+  source lane index inside the subgroup.
+- **outputs:** `%r` is the selected source lane's value.
+- **constraints and limitations:** `T` is `i32`, `i64`, `f16`, `f32`, or
+  `vector<2xf16>`. `%index` is `i32`. `width` is `16` or `32` and defaults to
+  `32`.
+
+### `pto.shuffle_up` / `pto.shuffle_down` / `pto.shuffle_bfly`
+
+- **syntax:**
+```mlir
+%u = pto.shuffle_up %value, %offset : T, i32 -> T
+%d = pto.shuffle_down %value, %offset : T, i32 -> T
+%b = pto.shuffle_bfly %value, %mask : T, i32 -> T
+```
+- **semantics:**
+```text
+group_base = floor(lane / width) * width
+local_lane = lane - group_base
+shuffle_up:   source = group_base + local_lane - offset
+shuffle_down: source = group_base + local_lane + offset
+shuffle_bfly: source = group_base + (local_lane xor mask)
+result        = value[source] when source is a valid participating lane
+```
+- **inputs:** `%value` is the current lane's payload. `%offset` is the
+  relative lane distance. `%mask` is the XOR mask for butterfly selection.
+- **outputs:** The selected source lane's value.
+- **constraints and limitations:** `T` is `i32`, `i64`, `f16`, `f32`, or
+  `vector<2xf16>`. Control operands are `i32`. The optional `width` attribute is
+  `16` or `32` and defaults to `32`. Out-of-range source-lane behavior is
+  target-scoped and should not be used for portable algorithms.
+
+---
+
+## Lane Redux Ops
+
+Redux ops reduce one scalar value from each participating active lane and
+return the reduction result to each participating active lane.
+
+### `pto.redux_add` / `pto.redux_max` / `pto.redux_min`
+
+- **syntax:**
+```mlir
+%sum_i = pto.redux_add %v signed : i32 -> i32
+%max_u = pto.redux_max %v unsigned : i32 -> i32
+%sum_f = pto.redux_add %f : f32 -> f32
+```
+- **semantics:**
+```text
+redux_add = sum(value[lane] for lane in active)
+redux_max = max(value[lane] for lane in active)
+redux_min = min(value[lane] for lane in active)
+result    = the selected reduction value in every participating active lane
+```
+- **inputs:** `%value` is `i32`, `f16`, or `f32`.
+- **outputs:** The result type matches `%value`.
+- **constraints and limitations:** Floating-point forms do not accept
+  signedness. For `i32`, `pto.redux_max` and `pto.redux_min` require explicit
+  `signed` or `unsigned`. `pto.redux_add` accepts signedness for consistency
+  with integer authoring, but addition has the same two's-complement bit result
+  for signed and unsigned inputs.
+
+---
+
+## Common SIMT Memory Attributes
+
+**L1 cache.**
+
+`l1cache(cache)` and `l1cache(uncache)` are accepted on GM scalar `pto.ldg` /
+`pto.stg` forms.
+
+| Attribute | Meaning |
+|-----------|---------|
+| `l1cache(cache)` | Request cacheable GM scalar access |
+| `l1cache(uncache)` | Request uncacheable GM scalar access |
+
+The L1 cache clause selects the GM access path. It does not change the scalar value
+being loaded or stored.
+
+**L2 cache.**
+
+L2 cache clauses select the memory hierarchy behavior attached to GM `pto.ldg`,
+GM `pto.stg`, and atomic ops. They do not select the
+mathematical operation; the op mnemonic still determines the load, store,
+or atomic update.
+
+Load `l2cache(...)` uses these tokens:
+
+| Token | Meaning |
+|-------|---------|
+| `nmfv` | Normal allocation, first-victim replacement priority |
+| `nmlv` | Normal allocation, last-victim replacement priority |
+| `nmprs` | Normal allocation, persistent cache residency hint |
+| `nmpref` | Normal allocation, prefetch-oriented hint |
+| `nakeep` | Not-allocate, keep existing cache line state |
+| `naclean` | Not-allocate, clean cache line state |
+| `nadrop` | Not-allocate, drop cache line state |
+| `idsfv` | Inter-domain-share, first-victim replacement priority |
+| `idslv` | Inter-domain-share, last-victim replacement priority |
+| `idsprs` | Inter-domain-share, persistent cache residency hint |
+| `idspref` | Inter-domain-share, prefetch-oriented hint |
+| `exfv` | Exclusive, first-victim replacement priority |
+| `exlv` | Exclusive, last-victim replacement priority |
+| `exprs` | Exclusive, persistent cache residency hint |
+| `expref` | Exclusive, prefetch-oriented hint |
+
+Store and atomic `l2cache(...)` uses these tokens:
+
+| Token | Meaning |
+|-------|---------|
+| `nmfv` | Normal allocation, first-victim replacement priority |
+| `nmlv` | Normal allocation, last-victim replacement priority |
+| `nmprs` | Normal allocation, persistent cache residency hint |
+| `nmred` | Normal allocation, reduce-oriented update hint |
+| `naci` | Not-allocate, clean-invalid cache line state |
+| `napw` | Not-allocate, clean pre-writeback cache line state |
+| `napi` | Not-allocate, pre-invalid cache line state |
+| `nared` | Not-allocate, reduce-oriented update hint |
+| `wbhfv` | Write-back-home, first-victim replacement priority |
+| `wbhlv` | Write-back-home, last-victim replacement priority |
+| `wbhprs` | Write-back-home, persistent cache residency hint |
+| `wbhred` | Write-back-home, reduce-oriented update hint |
+| `wtsfv` | Write-through-share, first-victim replacement priority |
+| `wtslv` | Write-through-share, last-victim replacement priority |
+| `wtsprs` | Write-through-share, persistent cache residency hint |
+| `wtsred` | Write-through-share, reduce-oriented update hint |
+
+For scalar GM `pto.ldg` / `pto.stg` and atomic syntax, write
+`l2cache(...)`. Omitted `l2cache(...)` means `l2cache(nmfv)`. On `pto.ldg` /
+`pto.stg`, omitted `l1cache(...)` means `l1cache(cache)`.
+
+In syntax summaries, `<ld-l2cache>` means one token from the load L2 cache
+table, `<st-l2cache>` means one token from the store/atomic L2 cache table,
+`?` marks an optional clause, and `signedness?` means either
+`signed`, `unsigned`, or no signedness clause.
+
+---
+
+## SIMT Scalar Memory Ops
+
+### `pto.load`
+
+- **syntax:** `%value = pto.load %ptr[%offset] attr-dict : !pto.ptr<T, space> -> T`
+- **accepted forms:**
+
+```mlir
+// Plain scalar load. Uses the ordinary scalar memory path.
+%value = pto.load %ptr[%offset] : !pto.ptr<T, space> -> T
+```
+
+- **semantics:** Load one scalar element from `%ptr + %offset`.
+
+```text
+effective_element = ptr + offset
+result = memory[effective_element]
+```
+
+- **inputs:** `%ptr` is a `!pto.ptr<T, space>` or memref. `%offset` is an
+  `index` element offset, not a byte offset.
+- **outputs:** One scalar value of type `T`.
+- **constraints and limitations:** The result type must match the pointer
+  element type. Use `pto.ldg` for GM scalar loads that need cache controls.
+
+### `pto.store`
+
+- **syntax:** `pto.store %value, %ptr[%offset] attr-dict : !pto.ptr<T, space>, T`
+- **accepted forms:**
+
+```mlir
+// Plain scalar store. Uses the ordinary scalar memory path.
+pto.store %value, %ptr[%offset] : !pto.ptr<T, space>, T
+```
+
+- **semantics:** Store one scalar element to `%ptr + %offset`.
+
+```text
+effective_element = ptr + offset
+memory[effective_element] = value
+```
+
+- **inputs:** `%value` is the scalar element to write. `%ptr` is a
+  `!pto.ptr<T, space>` or memref. `%offset` is an `index` element offset.
+- **outputs:** None.
+- **constraints and limitations:** `%value` type must match the pointer element
+  type. Use `pto.stg` for GM scalar stores that need cache controls.
+
+### `pto.ldg`
+
+- **syntax:** `%value = pto.ldg %ptr[%offset] l1cache(...)? l2cache(...)? attr-dict : !pto.ptr<T, gm> -> T`
+- **accepted forms:**
+
+```mlir
+// GM load with default cache controls: l1cache(cache) and l2cache(nmfv).
+%value = pto.ldg %gm[%offset] : !pto.ptr<T, gm> -> T
+
+// GM load with an explicit L1 cache control.
+%value = pto.ldg %gm[%offset] l1cache(cache) : !pto.ptr<T, gm> -> T
+
+// GM load with explicit L1 and L2 cache controls.
+%value = pto.ldg %gm[%offset] l1cache(uncache) l2cache(nmpref) : !pto.ptr<T, gm> -> T
+```
+
+- **semantics:** Load one scalar element from GM at `%ptr + %offset` using the
+  selected cache controls.
+- **inputs:** `%ptr` is a `!pto.ptr<T, gm>`. `%offset` is an `index` element
+  offset, not a byte offset.
+- **attributes:** `l1cache` may be `l1cache(cache)` or `l1cache(uncache)` and
+  defaults to `cache`. `l2cache(...)` uses the load L2 cache table and defaults
+  to `nmfv`.
+- **outputs:** One scalar value of type `T`.
+- **constraints and limitations:** `pto.ldg` supports 8/16/32/64-bit integer
+  values and `f16`, `bf16`, `f32`, and `f64` floating values. The floating
+  forms use the target's same-width GM load path and reinterpret the loaded
+  bits as the requested floating type.
+
+### `pto.stg`
+
+- **syntax:** `pto.stg %value, %ptr[%offset] l1cache(...)? l2cache(...)? attr-dict : !pto.ptr<T, gm>, T`
+- **accepted forms:**
+
+```mlir
+// GM store with default cache controls: l1cache(cache) and l2cache(nmfv).
+pto.stg %value, %gm[%offset] : !pto.ptr<T, gm>, T
+
+// GM store with an explicit L1 cache control.
+pto.stg %value, %gm[%offset] l1cache(cache) : !pto.ptr<T, gm>, T
+
+// GM store with explicit L1 and L2 cache controls.
+pto.stg %value, %gm[%offset] l1cache(uncache) l2cache(wtsred) : !pto.ptr<T, gm>, T
+```
+
+- **semantics:** Store one scalar element to GM at `%ptr + %offset` using the
+  selected cache controls.
+- **inputs:** `%value` is the scalar element to write. `%ptr` is a
+  `!pto.ptr<T, gm>`. `%offset` is an `index` element offset.
+- **attributes:** `l1cache` may be `l1cache(cache)` or `l1cache(uncache)` and
+  defaults to `cache`. `l2cache(...)` uses the store/atomic L2 cache table and
+  defaults to `nmfv`.
+- **outputs:** None.
+- **constraints and limitations:** `%value` type must match the pointer element
+  type. `pto.stg` supports 8/16/32/64-bit integer values and `f16`, `bf16`,
+  `f32`, and `f64` floating values.
+
+Example:
+
+```mlir
+%tx = pto.get_tid_x : i32
+%idx = arith.index_castui %tx : i32 to index
+%loaded = pto.load %gm[%idx] : !pto.ptr<i32, gm> -> i32
+%sum = arith.addi %loaded, %tx : i32
+pto.store %sum, %gm[%idx] : !pto.ptr<i32, gm>, i32
+```
+
+---
+
+## Atomic Memory Ops
+
+Atomic ops update one scalar or supported packed memory location and return the
+old value observed by the current workitem. The read, update, and returned old
+value form one atomic read-modify-write at `%ptr`.
+
+### `pto.atomic_exch` / `pto.atomic_add` / `pto.atomic_sub`
+
+- **syntax:**
+```mlir
+%old = pto.atomic_exch %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+%old = pto.atomic_add  %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+%old = pto.atomic_sub  %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+```
+- **accepted forms:**
+
+```mlir
+// Signed integer atomic with default nmfv L2 cache.
+%old = pto.atomic_add %ptr, %value signed : !pto.ptr<i32, space>, i32 -> i32
+
+// Signed integer atomic with an explicit store/atomic L2 cache.
+%old = pto.atomic_add %ptr, %value l2cache(wtsred) signed : !pto.ptr<i32, space>, i32 -> i32
+
+// Floating-point atomic. Floating-point atomics do not take signedness.
+%old = pto.atomic_add %ptr, %value l2cache(nmfv) : !pto.ptr<f32, space>, f32 -> f32
+
+// Packed two-lane atomic. Packed atomics do not take signedness.
+%old = pto.atomic_add %ptr, %value : !pto.ptr<vector<2xf16>, space>, vector<2xf16> -> vector<2xf16>
+```
+- **semantics:**
+```text
+old = *ptr
+atomic_exch: *ptr = value
+atomic_add:  *ptr = old + value
+atomic_sub:  *ptr = old - value
+return old
+```
+- **inputs:** `%ptr` is `!pto.ptr<T, gm>` or `!pto.ptr<T, ub>`. `%value` is
+  `i32`, `i64`, `f16`, `bf16`, `f32`, `vector<2xf16>`, or
+  `vector<2xbf16>`.
+  `l2cache(...)` selects the store/atomic L2 cache control and defaults to
+  `nmfv`.
+- **outputs:** `%old` has the same type as `%value`. For packed
+  `vector<2xf16>` and `vector<2xbf16>` atomics on beta.1, `%old` must be left
+  unused; beta.1 can compile the packed atomic update but cannot compile a
+  consumed packed old-value result.
+- **constraints and limitations:** UB-space atomics do not support `i64`.
+  Floating-point and packed atomics do not accept `signed` or `unsigned`.
+  Packed atomics must be placed inside a `pto.simt_entry` function on beta.1.
+
+### `pto.atomic_min` / `pto.atomic_max`
+
+- **syntax:**
+```mlir
+%old = pto.atomic_min %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+%old = pto.atomic_max %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+```
+- **accepted forms:**
+
+```mlir
+// Signed integer comparison.
+%old = pto.atomic_min %ptr, %value signed : !pto.ptr<i32, space>, i32 -> i32
+
+// Unsigned integer comparison.
+%old = pto.atomic_min %ptr, %value unsigned : !pto.ptr<i32, space>, i32 -> i32
+
+// Floating-point comparison. Floating-point atomics do not take signedness.
+%old = pto.atomic_min %ptr, %value l2cache(nmlv) : !pto.ptr<f32, space>, f32 -> f32
+
+// Packed two-lane comparison.
+%old = pto.atomic_min %ptr, %value : !pto.ptr<vector<2xbf16>, space>, vector<2xbf16> -> vector<2xbf16>
+```
+- **semantics:**
+```text
+old = *ptr
+atomic_min: *ptr = min(old, value)
+atomic_max: *ptr = max(old, value)
+return old
+```
+- **inputs:** Same as `pto.atomic_add`. For integer values, `signed` or
+  `unsigned` selects the comparison interpretation.
+- **outputs:** `%old` has the same type as `%value`. For packed
+  `vector<2xf16>` and `vector<2xbf16>` atomics on beta.1, `%old` must be left
+  unused; beta.1 can compile the packed atomic update but cannot compile a
+  consumed packed old-value result.
+- **constraints and limitations:** Floating-point and packed atomics do not
+  accept signedness. UB-space atomics do not support `i64`. Packed atomics
+  must be placed inside a `pto.simt_entry` function on beta.1.
+
+### `pto.atomic_and` / `pto.atomic_or` / `pto.atomic_xor`
+
+- **syntax:**
+```mlir
+%old = pto.atomic_and %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+%old = pto.atomic_or  %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+%old = pto.atomic_xor %ptr, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T
+```
+- **accepted forms:**
+
+```mlir
+// Unsigned bitwise atomic with default nmfv L2 cache.
+%old = pto.atomic_and %ptr, %value unsigned : !pto.ptr<i32, space>, i32 -> i32
+
+// Signedness is accepted for integer authoring consistency; the bit operation
+// itself is bitwise and does not reinterpret arithmetic magnitude.
+%old = pto.atomic_and %ptr, %value l2cache(napw) signed : !pto.ptr<i32, space>, i32 -> i32
+```
+- **semantics:**
+```text
+old = *ptr
+atomic_and: *ptr = old & value
+atomic_or:  *ptr = old | value
+atomic_xor: *ptr = old ^ value
+return old
+```
+- **inputs:** `%ptr` points to an integer scalar element. `%value` is `i32` or
+  `i64`.
+- **outputs:** `%old` has the same type as `%value`.
+- **constraints and limitations:** Bitwise atomics require integer types.
+  UB-space bitwise atomics do not support `i64`.
+
+### `pto.atomic_cas`
+
+- **syntax:** `%old = pto.atomic_cas %ptr, %compare, %value l2cache(<st-l2cache>)? signedness? : !pto.ptr<T, space>, T -> T`
+- **accepted forms:**
+
+```mlir
+// Integer CAS with default nmfv L2 cache.
+%old = pto.atomic_cas %ptr, %compare, %value signed : !pto.ptr<i32, space>, i32 -> i32
+
+// Integer CAS with an explicit store/atomic L2 cache.
+%old = pto.atomic_cas %ptr, %compare, %value l2cache(wbhred) signed : !pto.ptr<i32, space>, i32 -> i32
+
+// Floating-point CAS. Floating-point atomics do not take signedness.
+%old = pto.atomic_cas %ptr, %compare, %value : !pto.ptr<f32, space>, f32 -> f32
+
+// Packed two-lane CAS. Packed atomics do not take signedness.
+%old = pto.atomic_cas %ptr, %compare, %value : !pto.ptr<vector<2xbf16>, space>, vector<2xbf16> -> vector<2xbf16>
+```
+
+- **semantics:**
+```text
+old = *ptr
+if old == compare:
+  *ptr = value
+return old
+```
+- **inputs:** `%ptr` is the atomic address. `%compare` is the expected old
+  value. `%value` is the replacement value.
+- **outputs:** `%old` is the value observed before the conditional update. For
+  packed `vector<2xf16>` and `vector<2xbf16>` CAS on beta.1, `%old` must be
+  left unused; beta.1 can compile the packed CAS update but cannot compile a
+  consumed packed old-value result.
+- **constraints and limitations:** `%compare`, `%value`, pointer element type,
+  and result type must match. `T` is `i32`, `i64`, `f32`,
+  `vector<2xf16>`, or `vector<2xbf16>`; UB-space `i64` is not supported.
+  Packed CAS must be placed inside a `pto.simt_entry` function on beta.1.
+
+When multiple workitems target the same address, each workitem observes one
+serialized old value from the total order chosen by the target. Algorithms must
+not rely on any particular tie order beyond atomicity.
+
+---
+
+## SIMT Scalar Math Ops
+
+### `pto.prmt`
+
+- **syntax:** `%r = pto.prmt %lhs, %rhs, %selector : i32, i32, i32 -> i32`
+- **semantics:** Build the `i32` result byte-by-byte from the eight source bytes
+  in `%lhs:%rhs` according to `%selector`.
+- **inputs:** `%lhs` and `%rhs` provide the source bytes. `%selector` selects
+  which source byte is copied into each destination byte.
+- **outputs:** One `i32` result.
+- **constraints and limitations:** All operands and the result are `i32`.
+
+### `pto.mulhi`
+
+- **syntax:**
+```mlir
+%s32 = pto.mulhi %lhs, %rhs signed : i32, i32 -> i32
+%u32 = pto.mulhi %lhs, %rhs unsigned : i32, i32 -> i32
+%s64 = pto.mulhi %lhs64, %rhs64 signed : i64, i64 -> i64
+%u64 = pto.mulhi %lhs64, %rhs64 unsigned : i64, i64 -> i64
+```
+- **semantics:**
+```text
+N = bitwidth(lhs)
+if signed:
+  product = signed_N(lhs) * signed_N(rhs)
+else:
+  product = unsigned_N(lhs) * unsigned_N(rhs)
+result = high_N_bits(product)
+```
+- **inputs:** `%lhs` and `%rhs` are scalar integer operands with the same type.
+- **outputs:** One scalar integer result with the same type as the inputs.
+- **attributes:** The required `signed` or `unsigned` clause selects whether
+  the operands are interpreted as signed two's-complement values or unsigned
+  values before forming the double-width product.
+- **constraints and limitations:** The operands and result must all be `i32` or
+  all be `i64`.
+
+### `pto.mul_i32toi64`
+
+- **syntax:**
+```mlir
+%s = pto.mul_i32toi64 %lhs, %rhs signed : i32, i32 -> i64
+%u = pto.mul_i32toi64 %lhs, %rhs unsigned : i32, i32 -> i64
+```
+- **semantics:**
+```text
+if signed:
+  result = sign_extend_i64(lhs) * sign_extend_i64(rhs)
+else:
+  result = zero_extend_i64(lhs) * zero_extend_i64(rhs)
+```
+- **inputs:** `%lhs` and `%rhs` are `i32` scalar operands.
+- **outputs:** One `i64` widened-product result.
+- **attributes:** The required `signed` or `unsigned` clause selects the
+  extension rule before multiplication.
+- **constraints and limitations:** The operand types are fixed to `i32`, and
+  the result type is fixed to `i64`.
+
+### `pto.absf`
+
+- **syntax:** `%r = pto.absf %x : T -> T`
+- **semantics:** Return `abs(x)`. For `vector<2xT>`, absolute value is applied
+  independently to each element.
+- **inputs:** `%x` is an `f32` scalar, `vector<2xf16>`, or `vector<2xbf16>`.
+- **outputs:** One value with the same type as `%x`.
+- **constraints and limitations:** Scalar `f16` and scalar `bf16` are not
+  accepted by this op; use the packed form only for `vector<2xT>`.
+
+### `pto.sqrt`
+
+- **syntax:** `%r = pto.sqrt %x : T -> T`
+- **semantics:** Return `sqrt(x)`. For `vector<2xT>`, square root is applied
+  independently to each element.
+- **inputs:** `%x` is `f16`, `f32`, or `vector<2xf16>`.
+- **outputs:** One value with the same type as `%x`.
+- **constraints and limitations:** `T` is `f16`, `f32`, or `vector<2xf16>`.
+
+### `pto.exp`
+
+- **syntax:** `%r = pto.exp %x : T -> T`
+- **semantics:** Return the natural exponential `e ** x`. For `vector<2xT>`,
+  exponentiation is applied independently to each element.
+- **inputs:** `%x` is an `f16` scalar, `f32` scalar, or `vector<2xf16>`.
+- **outputs:** One value with the same type as `%x`.
+- **constraints and limitations:** `T` is `f16`, `f32`, or `vector<2xf16>`.
+  Overflow, underflow, infinities, and NaNs follow the target floating-point
+  rules.
+
+### `pto.log`
+
+- **syntax:** `%r = pto.log %x : T -> T`
+- **semantics:** Return the natural logarithm `ln(x)`. For `vector<2xT>`,
+  logarithm is applied independently to each element.
+- **inputs:** `%x` is an `f16` scalar, `f32` scalar, or `vector<2xf16>`.
+- **outputs:** One value with the same type as `%x`.
+- **constraints and limitations:** `T` is `f16`, `f32`, or `vector<2xf16>`.
+  For real-number semantics, each element should be positive; non-positive
+  inputs follow the target floating-point rules.
+
+### `pto.pow`
+
+- **syntax:** `%r = pto.pow %a, %b : T, T -> T`
+- **semantics:** Return `%a ** %b`. For `vector<2xT>`, power is applied
+  independently to each element pair.
+- **inputs:** `%a` is the base and `%b` is the exponent. Both operands have the
+  same type.
+- **outputs:** One value with the same type as the inputs.
+- **constraints and limitations:** `T` is `f16`, `f32`, or `vector<2xf16>`.
+  Exceptional inputs follow the target floating-point rules.
+
+### `pto.ceil`
+
+- **syntax:** `%r = pto.ceil %x : T -> T`
+- **semantics:** Return the smallest integral floating value not less than
+  `%x`.
+- **inputs:** `%x` is an `f16`, `bf16`, or `f32` scalar.
+- **outputs:** One scalar with the same type as `%x`.
+- **constraints and limitations:** `T` is `f16`, `bf16`, or `f32`.
+
+### `pto.floor`
+
+- **syntax:** `%r = pto.floor %x : T -> T`
+- **semantics:** Return the largest integral floating value not greater than
+  `%x`.
+- **inputs:** `%x` is an `f16`, `bf16`, or `f32` scalar.
+- **outputs:** One scalar with the same type as `%x`.
+- **constraints and limitations:** `T` is `f16`, `bf16`, or `f32`.
+
+### `pto.rint`
+
+- **syntax:** `%r = pto.rint %x : T -> T`
+- **semantics:** Return the integral floating value selected by the target's
+  current floating rounding rule.
+- **inputs:** `%x` is an `f16`, `bf16`, or `f32` scalar.
+- **outputs:** One scalar with the same type as `%x`.
+- **constraints and limitations:** `T` is `f16`, `bf16`, or `f32`.
+
+### `pto.round`
+
+- **syntax:** `%r = pto.round %x : T -> T`
+- **semantics:** Return the nearest integral floating value using the target
+  round operation's tie rule.
+- **inputs:** `%x` is an `f16`, `bf16`, or `f32` scalar.
+- **outputs:** One scalar with the same type as `%x`.
+- **constraints and limitations:** `T` is `f16`, `bf16`, or `f32`.
+
+### `pto.fmin`
+
+- **syntax:** `%r = pto.fmin %a, %b : T, T -> T`
+- **semantics:** Return the floating minimum of `%a` and `%b`.
+- **inputs:** `%a` and `%b` have the same type.
+- **outputs:** One value with the same type as the inputs.
+- **constraints and limitations:** `T` is `f32`, `bf16`, `vector<2xf16>`, or
+  `vector<2xbf16>`. For vector types, the minimum is computed element-wise. NaN
+  handling follows the target floating-point minimum rule.
+
+### `pto.fmax`
+
+- **syntax:** `%r = pto.fmax %a, %b : T, T -> T`
+- **semantics:** Return the floating maximum of `%a` and `%b`.
+- **inputs:** `%a` and `%b` have the same type.
+- **outputs:** One value with the same type as the inputs.
+- **constraints and limitations:** `T` is `f32`, `bf16`, `vector<2xf16>`, or
+  `vector<2xbf16>`. For vector types, the maximum is computed element-wise. NaN
+  handling follows the target floating-point maximum rule.
+
+### `pto.fma`
+
+- **syntax:** `%r = pto.fma %a, %b, %acc : T, T, T -> T`
+- **semantics:** Return fused `a * b + acc` with one final rounding.
+- **inputs:** `%a`, `%b`, and `%acc` have the same type.
+- **outputs:** One value with the same type as the inputs.
+- **constraints and limitations:** `T` is `f16`, `bf16`, `f32`,
+  `vector<2xf16>`, or `vector<2xbf16>`. For vector types, fused multiply-add is
+  computed element-wise.
+
+---
+
+## SIMT Conversion Op
+
+### `pto.convert`
+
+- **syntax:** `%dst = pto.convert %src round(R) sat|nosat [signed|unsigned] : SrcType -> DstType`
+- **semantics:** Convert one scalar or packed two-element value from `SrcType` to
+  `DstType` using the specified rounding, saturation, and signedness controls.
+
+```mlir
+%as_f32 = pto.convert %i round(r) nosat signed : i32 -> f32
+%as_i32 = pto.convert %f round(z) sat signed : f32 -> i32
+%as_h2 = pto.convert %f2 round(r) nosat : vector<2xf32> -> vector<2xf16>
+```
+
+- **inputs:** `%src` is `i32`, `i64`, `f16`, `bf16`, `f32`,
+  `vector<2xf16>`, `vector<2xbf16>`, or `vector<2xf32>`.
+  `round(R)` selects the rounding rule. `sat` or `nosat` selects whether
+  finite overflow is clamped to the destination range. `signed` or `unsigned`
+  is required when converting to or from an integer type and is omitted for
+  floating-to-floating and packed vector conversion.
+- **outputs:** `%dst` is `i32`, `i64`, `f16`, `bf16`, `f32`,
+  `vector<2xf16>`, `vector<2xbf16>`, or `vector<2xf32>`.
+- **constraints and limitations:** Integer-to-integer conversion is not
+  supported by `pto.convert`. Scalar floating-to-floating conversion supports
+  `f32`, `f16`, and `bf16` source/destination pairs. `i64` source conversion is
+  supported only to `f32`; conversion to `i64` is supported only from `f32`.
+  `i32` can convert to `f32`, `f16`, or `bf16`, with `signed` or `unsigned`
+  selecting the source interpretation. Floating-to-integer conversion supports
+  `i32` destinations, plus `f32 -> i64`, and requires `sat`. Packed conversion
+  supports only
+  `vector<2xf32> -> vector<2xf16>`, `vector<2xf16> -> vector<2xf32>`,
+  `vector<2xf32> -> vector<2xbf16>`, and
+  `vector<2xbf16> -> vector<2xf32>`.
+
+Rounding selectors:
+
+| Selector | Meaning |
+|----------|---------|
+| `round(r)` | Round to nearest, ties to even |
+| `round(a)` | Round away from zero |
+| `round(f)` | Round toward minus infinity |
+| `round(c)` | Round toward plus infinity |
+| `round(z)` | Round toward zero |
+| `round(o)` | Round to odd |
+| `round(h)` | Cast-ceil mode for the target conversion slice that supports it |
+
+Saturation selectors:
+
+| Selector | Meaning |
+|----------|---------|
+| `nosat` | Do not clamp finite overflow to the destination range |
+| `sat` | Clamp finite overflow to the destination range |
+
+---
+
+## SIMT Entry Synchronization and State Ops
+
+### `pto.syncthreads`
+
+- **syntax:** `pto.syncthreads attr-dict`
+- **semantics:** Synchronize all active workitems in the current SIMT entry.
+  Memory effects issued before the barrier by participating workitems are
+  ordered before memory effects issued after the barrier by those workitems.
+- **inputs:** None.
+- **outputs:** None.
+- **constraints and limitations:** `pto.syncthreads` must appear inside a
+  function marked with `pto.simt_entry`. It synchronizes workitems in the
+  active SIMT entry; it is not a substitute for outer pipeline synchronization
+  between vector, MTE, cube, and scalar host-visible effects.
+
+Example:
+
+```mlir
+func.func @body(%ub: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+  %tx = pto.get_tid_x : i32
+  %idx = arith.index_castui %tx : i32 to index
+  pto.store %tx, %ub[%idx] : !pto.ptr<i32, ub>, i32
+  pto.syncthreads
+  %v = pto.load %ub[%idx] : !pto.ptr<i32, ub> -> i32
+  pto.store %v, %ub[%idx] : !pto.ptr<i32, ub>, i32
+  return
+}
+```
+
+### `pto.threadfence` / `pto.threadfence_block`
+
+- **syntax:** `pto.threadfence attr-dict` or `pto.threadfence_block attr-dict`
+- **semantics:** Issue a memory fence for memory effects from the current SIMT
+  workitem. `pto.threadfence` uses the target workitem fence operation;
+  `pto.threadfence_block` uses the target block-scoped workitem fence
+  operation.
+- **inputs:** None.
+- **outputs:** None.
+- **constraints and limitations:** These ops must appear inside a function
+  marked with `pto.simt_entry`. They order memory effects but do not by
+  themselves make other workitems wait; use `pto.syncthreads` when a workitem
+  barrier is required.
+
+### `pto.keep` / `pto.resume`
+
+- **syntax:**
+
+```mlir
+pto.keep %value {slot = N : i64} : T
+%value = pto.resume {slot = N : i64} : T
+```
+
+- **semantics:** Preserve and restore one per-workitem scalar payload across
+  adjacent SIMT entry calls in the same outer launch sequence. `pto.keep`
+  records the current workitem's `%value` in logical slot `N`; `pto.resume`
+  restores the value for the same logical workitem from logical slot `N`.
+
+```text
+for each active workitem:
+  keep(slot, value) stores value in that workitem's slot
+  resume(slot) returns the value stored in the same workitem's slot
+```
+
+- **inputs:** `pto.keep` takes one scalar `%value` of type `T`.
+- **outputs:** `pto.resume` returns one scalar value of type `T`.
+- **attributes:** `slot` is a non-negative `i64` logical slot identifier in
+  the range `[0, 122]`.
+- **supported types:** `T` may be any signless integer scalar with bit width up
+  to 64 bits, `f16`, `bf16`, or `f32`.
+- **constraints and limitations:** Both ops must appear inside functions marked
+  with `pto.simt_entry`. A `pto.resume` group must be the first non-constant
+  operation group in its SIMT entry. A `pto.keep` group must be the final
+  operation group before optional `pto.syncthreads` and `func.return`. Slot
+  storage words must not overlap within one `pto.resume` group or one
+  `pto.keep` group. A value resumed from a slot should use the same type as the
+  value kept into that slot.
+- **slot allocation rule:** Users allocate slots explicitly. Values up to 32
+  bits and supported floating-point values consume only `slot`. A 64-bit
+  integer value consumes `slot` and `slot + 1`; therefore its slot must be even
+  and must leave room for the second word. Because slot mapping is explicit, a
+  later SIMT entry may resume only the subset of preserved slots that it needs
+  without changing the location of those slots.
+
+Example:
+
+```mlir
+func.func @stage0(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+  %tx = pto.get_tid_x : i32
+  %idx = arith.index_castui %tx : i32 to index
+  pto.store %tx, %dst[%idx] : !pto.ptr<i32, ub>, i32
+  pto.keep %tx {slot = 0 : i64} : i32
+  pto.syncthreads
+  return
+}
+
+func.func @stage1(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+  %tx0 = pto.resume {slot = 0 : i64} : i32
+  %tx = pto.get_tid_x : i32
+  %idx = arith.index_castui %tx : i32 to index
+  %sum = arith.addi %tx0, %tx : i32
+  pto.store %sum, %dst[%idx] : !pto.ptr<i32, ub>, i32
+  return
+}
+```
+
+---
+
+## Outer Pipeline Synchronization and Ordering
+
+SIMT body execution is sequenced as a function call from the outer kernel. Use
+the existing PTO pipeline synchronization ops around the SIMT call when data is
+produced or consumed by other pipelines.
+
+```mlir
+pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+func.call @body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+pto.mte_ub_gm %ub_out, %gm_out, %len
+  nburst(%n, %src_stride, %dst_stride)
+  : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+```
+
+For pipeline synchronization semantics, see
+[`01-pipeline-sync.md`](01-pipeline-sync.md). Do not use pipeline barriers as a
+substitute for lane collectives: vote, shuffle, redux, and atomic ops are the
+SIMT-specific mechanisms documented in this chapter.
+
+---
+
+## Complete Minimal Example
+
+```mlir
+module attributes {pto.target_arch = "a5",
+                   pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_store_tid_kernel(%out: !pto.ptr<i32, gm>)
+      attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_write(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %out, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_write(%dst: !pto.ptr<i32, ub>)
+      attributes {pto.simt_entry} {
+    %tx = pto.get_tid_x : i32
+    %ty = pto.get_tid_y : i32
+    %tz = pto.get_tid_z : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %ty_shift = arith.shli %ty, %c8_i32 : i32
+    %tz_shift = arith.shli %tz, %c16_i32 : i32
+    %xy = arith.ori %tx, %ty_shift : i32
+    %xyz = arith.ori %xy, %tz_shift : i32
+    %lane_base = arith.muli %ty, %c32_i32 : i32
+    %idx_i32 = arith.addi %lane_base, %tx : i32
+    %idx = arith.index_castui %idx_i32 : i32 to index
+    pto.store %xyz, %dst[%idx] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}
+```

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -39,7 +39,7 @@ The current PTO SIMT surface supports these operation families:
 
 | Family | Ops |
 |--------|-----|
-| Launch configuration | `pto.store_vfsimt_info` |
+| Launch configuration | `pto.store_vfsimt_info`, `pto.simt_launch` |
 | Thread and lane queries | `pto.get_tid_x`, `pto.get_tid_y`, `pto.get_tid_z`, `pto.get_block_dim_x`, `pto.get_block_dim_y`, `pto.get_block_dim_z`, `pto.get_grid_dim_x`, `pto.get_grid_dim_y`, `pto.get_grid_dim_z`, `pto.get_block_idx_x`, `pto.get_block_idx_y`, `pto.get_block_idx_z`, `pto.get_veccoreid`, `pto.get_clock32`, `pto.get_clock64`, `pto.get_laneid`, `pto.get_lanemask_eq`, `pto.get_lanemask_le`, `pto.get_lanemask_lt`, `pto.get_lanemask_ge`, `pto.get_lanemask_gt` |
 | Lane collectives | `pto.vote_all`, `pto.vote_any`, `pto.vote_uni`, `pto.vote_ballot`, `pto.shuffle_idx`, `pto.shuffle_up`, `pto.shuffle_down`, `pto.shuffle_bfly`, `pto.redux_add`, `pto.redux_max`, `pto.redux_min` |
 | Scalar memory | `pto.load`, `pto.store`, `pto.ldg`, `pto.stg` |
@@ -59,7 +59,7 @@ function:
 Both attributes are optional. If present, they must be positive `i32`
 attributes and may only appear on functions that also carry `pto.simt_entry`.
 They do not launch work by themselves; the actual workitem count comes from
-`pto.store_vfsimt_info`.
+`pto.store_vfsimt_info` or `pto.simt_launch`.
 
 ```mlir
 func.func @body(%dst: !pto.ptr<i32, ub>)
@@ -107,6 +107,34 @@ Typical outer-kernel pattern:
 %dim_x = arith.constant 32 : i32
 pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
 func.call @body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+```
+
+### `pto.simt_launch`
+
+- **syntax:** `pto.simt_launch @body<<<%dim_x, %dim_y, %dim_z>>>(%arg0, ...) : (arg_types...) -> ()`
+- **semantics:** Launch the SIMT body `@body` using the workitem dimensions
+  `%dim_x`, `%dim_y`, and `%dim_z`. The dimension order follows the launch-site
+  order `x, y, z`; each active workitem in the body observes coordinates in the
+  ranges `tid_x in [0, dim_x)`, `tid_y in [0, dim_y)`, and
+  `tid_z in [0, dim_z)`.
+- **inputs:** `%dim_x`, `%dim_y`, and `%dim_z` are `i32` workitem counts. The
+  remaining operands are passed to the SIMT body and must match the callee
+  function signature.
+- **outputs:** None. The SIMT body must return no values.
+- **constraints and limitations:** The callee must be a `func.func` marked with
+  `pto.simt_entry`. The launch op belongs in the outer non-SIMT caller and must
+  not appear inside a function marked with `pto.simt_entry`. The launch count is
+  `dim_x * dim_y * dim_z` and is bounded by the same limits as
+  `pto.store_vfsimt_info`.
+
+Example launch-site pattern:
+
+```mlir
+%dim_x = arith.constant 32 : i32
+%dim_y = arith.constant 1 : i32
+%dim_z = arith.constant 1 : i32
+pto.simt_launch @body<<<%dim_x, %dim_y, %dim_z>>>(%ub_out)
+  : (!pto.ptr<i32, ub>) -> ()
 ```
 
 ---

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -431,7 +431,7 @@ table, `<st-l2cache>` means one token from the store/atomic L2 cache table,
 
 ### `pto.load`
 
-- **syntax:** `%value = pto.load %ptr[%offset] attr-dict : !pto.ptr<T, space> -> T`
+- **syntax:** `%value = pto.load %ptr[%offset] : !pto.ptr<T, space> -> T`
 - **accepted forms:**
 
 ```mlir
@@ -450,11 +450,12 @@ result = memory[effective_element]
   `index` element offset, not a byte offset.
 - **outputs:** One scalar value of type `T`.
 - **constraints and limitations:** The result type must match the pointer
-  element type. Use `pto.ldg` for GM scalar loads that need cache controls.
+  element type. This op does not accept cache-control clauses; use `pto.ldg`
+  for GM scalar loads that need `l1cache(...)` or `l2cache(...)`.
 
 ### `pto.store`
 
-- **syntax:** `pto.store %value, %ptr[%offset] attr-dict : !pto.ptr<T, space>, T`
+- **syntax:** `pto.store %value, %ptr[%offset] : !pto.ptr<T, space>, T`
 - **accepted forms:**
 
 ```mlir
@@ -473,7 +474,8 @@ memory[effective_element] = value
   `!pto.ptr<T, space>` or memref. `%offset` is an `index` element offset.
 - **outputs:** None.
 - **constraints and limitations:** `%value` type must match the pointer element
-  type. Use `pto.stg` for GM scalar stores that need cache controls.
+  type. This op does not accept cache-control clauses; use `pto.stg` for GM
+  scalar stores that need `l1cache(...)` or `l2cache(...)`.
 
 ### `pto.ldg`
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -775,7 +775,7 @@ subblock_num = subblock_num();
 
 - **syntax:** `pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32`
 - **operands:** `i32, i32, i32`
-- **semantics:** Configure the SIMT VF launch descriptor consumed by a subsequent SIMT entry invocation. The three operands are the launch dimensions in `z, y, x` order. Lowering packs them into the `llvm.hivm.store.vfsimt.info` intrinsic payload.
+- **semantics:** Configure the SIMT VF launch descriptor consumed by a subsequent SIMT entry invocation. The three operands are the launch dimensions in `z, y, x` order.
 - **placement:** This op must appear in the outer non-SIMT caller. It must not appear inside a function marked with `pto.simt_entry`.
 
 ```c
@@ -1386,6 +1386,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 | 16 | [Cube Matrix Multiply](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`l1`/cbuf) staging, L1 (`l1`)↔UB/BT/FB side moves, L1→L0A/L0B loads, L0C (`l0c`) matmul, and FIXPIPE MTE writeback | 19 | `pto.mte_gm_l1`, `pto.mte_l1_ub`, `pto.mte_gm_l1_frac`, `pto.mte_l1_bt`, `pto.mte_l1_fb`, `pto.mte_l1_l0a`, `pto.mte_l1_l0b`, `pto.mte_l1_l0a_mx`, `pto.mte_l1_l0b_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.mte_l0c_l1`, `pto.mte_l0c_gm`, `pto.mte_l0c_ub` |
+| 17 | [SIMT Ops](isa/micro-isa/17-simt.md) | SIMT launch, thread/lane queries, vote/shuffle/redux, scalar memory, atomics, scalar math, conversion, entry synchronization, and state preservation | ~65 | `pto.store_vfsimt_info`, `pto.get_tid_x`, `pto.get_laneid`, `pto.vote_*`, `pto.shuffle_*`, `pto.redux_*`, `pto.load`, `pto.store`, `pto.atomic_*`, `pto.convert`, `pto.syncthreads`, `pto.keep`, `pto.resume`, etc. |
 
 ---
 

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -1181,12 +1181,14 @@ All PTO micro Instruction operations follow standard MLIR syntax. The common pat
 
 ```mlir
 %result = pto.vlds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.vreg<NxT>
+%result, %updated_base = pto.vlds %source[%offset] {dist = "DIST"} : !pto.ptr<T, ub> -> !pto.vreg<NxT>, !pto.ptr<T, ub>
 ```
 
 **Store (register to memory):**
 
 ```mlir
 pto.vsts %value, %destination[%offset] {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub>
+%updated_base = pto.vsts %value, %destination[%offset] {dist = "DIST"} : !pto.vreg<NxT>, !pto.ptr<T, ub> -> !pto.ptr<T, ub>
 ```
 
 **Dual Load (one load, two results — deinterleave):**

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -782,6 +782,18 @@ subblock_num = subblock_num();
 store_vfsimt_info(dim_z, dim_y, dim_x);
 ```
 
+#### `pto.simt_launch`
+
+- **syntax:** `pto.simt_launch @body<<<%dim_x, %dim_y, %dim_z>>>(%arg0, ...) : (arg_types...) -> ()`
+- **operands:** `%dim_x`, `%dim_y`, and `%dim_z` are `i32` workitem counts in `x, y, z` launch order. The remaining operands are passed to `@body`.
+- **semantics:** Invoke the SIMT entry `@body` for the workitem space described by `%dim_x * %dim_y * %dim_z`. Workitems in `@body` observe thread coordinates through the SIMT query ops.
+- **placement:** This op must appear in the outer non-SIMT caller. The callee must be marked with `pto.simt_entry` and must return no values.
+
+```mlir
+pto.simt_launch @simt_write<<<%dim_x, %dim_y, %dim_z>>>(%ub_out)
+  : (!pto.ptr<i32, ub>) -> ()
+```
+
 #### `pto.get_tid_x`
 
 - **syntax:** `%tx = pto.get_tid_x : i32`
@@ -1386,7 +1398,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 | 14 | [Arith (Shared MLIR Dialect)](isa/micro-isa/14-shared-arith.md) | Full scalar `arith` surface used around PTO ops; the companion page lists categories and representative examples | all scalar ops | `arith.constant`, `arith.addi`, `arith.addf`, `arith.cmpi`, `arith.cmpf`, `arith.select`, `arith.index_cast`, `arith.extsi`, `arith.trunci`, `arith.andi`, `arith.shli`, etc. |
 | 15 | [SCF (Shared MLIR Dialect)](isa/micro-isa/15-shared-scf.md) | Structured loops, branches, and loop-carried state around PTO regions | 5 | `scf.for`, `scf.if`, `scf.while`, `scf.condition`, `scf.yield` |
 | 16 | [Cube Matrix Multiply](isa/micro-isa/16-cube-matmul.md) | GM↔L1 (`l1`/cbuf) staging, L1 (`l1`)↔UB/BT/FB side moves, L1→L0A/L0B loads, L0C (`l0c`) matmul, and FIXPIPE MTE writeback | 19 | `pto.mte_gm_l1`, `pto.mte_l1_ub`, `pto.mte_gm_l1_frac`, `pto.mte_l1_bt`, `pto.mte_l1_fb`, `pto.mte_l1_l0a`, `pto.mte_l1_l0b`, `pto.mte_l1_l0a_mx`, `pto.mte_l1_l0b_mx`, `pto.mad`, `pto.mad_acc`, `pto.mad_bias`, `pto.mad_mx`, `pto.mad_mx_acc`, `pto.mad_mx_bias`, `pto.mte_l0c_l1`, `pto.mte_l0c_gm`, `pto.mte_l0c_ub` |
-| 17 | [SIMT Ops](isa/micro-isa/17-simt.md) | SIMT launch, thread/lane queries, vote/shuffle/redux, scalar memory, atomics, scalar math, conversion, entry synchronization, and state preservation | ~65 | `pto.store_vfsimt_info`, `pto.get_tid_x`, `pto.get_laneid`, `pto.vote_*`, `pto.shuffle_*`, `pto.redux_*`, `pto.load`, `pto.store`, `pto.atomic_*`, `pto.convert`, `pto.syncthreads`, `pto.keep`, `pto.resume`, etc. |
+| 17 | [SIMT Ops](isa/micro-isa/17-simt.md) | SIMT launch, thread/lane queries, vote/shuffle/redux, scalar memory, atomics, scalar math, conversion, entry synchronization, and state preservation | ~65 | `pto.store_vfsimt_info`, `pto.simt_launch`, `pto.get_tid_x`, `pto.get_laneid`, `pto.vote_*`, `pto.shuffle_*`, `pto.redux_*`, `pto.load`, `pto.store`, `pto.atomic_*`, `pto.convert`, `pto.syncthreads`, `pto.keep`, `pto.resume`, etc. |
 
 ---
 

--- a/include/PTO/IR/PTO.h
+++ b/include/PTO/IR/PTO.h
@@ -181,6 +181,10 @@ private:
 inline constexpr llvm::StringLiteral kPTOEntryAttrName = "pto.entry";
 inline constexpr llvm::StringLiteral kLegacyHACCEntryAttrName = "hacc.entry";
 inline constexpr llvm::StringLiteral kPTOSimtEntryAttrName = "pto.simt_entry";
+inline constexpr llvm::StringLiteral kPTOSimtMaxThreadsAttrName =
+    "pto.simt_max_threads";
+inline constexpr llvm::StringLiteral kPTOSimtMaxRegistersAttrName =
+    "pto.simt_max_regs";
 
 /// Return true if the function carries an explicit entry marker.
 bool hasExplicitPTOEntryAttr(func::FuncOp func);

--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -74,6 +74,139 @@ def PTO_AddressSpaceAttr : PTO_Attr<"AddressSpace", "address_space"> {
 }
 
 //===----------------------------------------------------------------------===//
+// Signedness
+//===----------------------------------------------------------------------===//
+
+def PTO_Signedness_Signed : I32EnumAttrCase<"Signed", 0, "signed">;
+def PTO_Signedness_Unsigned : I32EnumAttrCase<"Unsigned", 1, "unsigned">;
+
+def PTO_SignednessEnum : PTO_I32Enum<
+  "Signedness", "PTO integer signedness", [
+    PTO_Signedness_Signed,
+    PTO_Signedness_Unsigned
+  ]>;
+
+def PTO_SignednessAttr : PTO_Attr<"Signedness", "signedness"> {
+  let parameters = (ins EnumParameter<PTO_SignednessEnum>:$value);
+  let assemblyFormat = "`<` params `>`";
+  let summary = "Integer signedness control for semantic ops";
+}
+
+//===----------------------------------------------------------------------===//
+// SIMT GM load/store L1 and L2 cache controls
+//===----------------------------------------------------------------------===//
+
+def PTO_LdL2CacheEnum : PTO_I32Enum<
+  "LdL2Cache", "PTO load L2 cache control", [
+    I32EnumAttrCase<"NMFV", 0, "nmfv">,
+    I32EnumAttrCase<"NMLV", 1, "nmlv">,
+    I32EnumAttrCase<"NMPRS", 2, "nmprs">,
+    I32EnumAttrCase<"NMPREF", 3, "nmpref">,
+    I32EnumAttrCase<"NAKEEP", 4, "nakeep">,
+    I32EnumAttrCase<"NACLEAN", 5, "naclean">,
+    I32EnumAttrCase<"NADROP", 6, "nadrop">,
+    I32EnumAttrCase<"IDSFV", 8, "idsfv">,
+    I32EnumAttrCase<"IDSLV", 9, "idslv">,
+    I32EnumAttrCase<"IDSPRS", 10, "idsprs">,
+    I32EnumAttrCase<"IDSPREF", 11, "idspref">,
+    I32EnumAttrCase<"EXFV", 12, "exfv">,
+    I32EnumAttrCase<"EXLV", 13, "exlv">,
+    I32EnumAttrCase<"EXPRS", 14, "exprs">,
+    I32EnumAttrCase<"EXPREF", 15, "expref">
+  ]>;
+
+def PTO_LdL2CacheAttr
+    : EnumAttr<PTO_Dialect, PTO_LdL2CacheEnum, "ld_l2cache"> {
+  let assemblyFormat = "`<` params `>`";
+  let summary = "load L2 cache control";
+}
+
+def PTO_StL2CacheEnum : PTO_I32Enum<
+  "StL2Cache", "PTO store/atomic L2 cache control", [
+    I32EnumAttrCase<"NMFV", 0, "nmfv">,
+    I32EnumAttrCase<"NMLV", 1, "nmlv">,
+    I32EnumAttrCase<"NMPRS", 2, "nmprs">,
+    I32EnumAttrCase<"NMRED", 3, "nmred">,
+    I32EnumAttrCase<"NACI", 4, "naci">,
+    I32EnumAttrCase<"NAPW", 5, "napw">,
+    I32EnumAttrCase<"NAPI", 6, "napi">,
+    I32EnumAttrCase<"NARED", 7, "nared">,
+    I32EnumAttrCase<"WBHFV", 8, "wbhfv">,
+    I32EnumAttrCase<"WBHLV", 9, "wbhlv">,
+    I32EnumAttrCase<"WBHPRS", 10, "wbhprs">,
+    I32EnumAttrCase<"WBHRED", 11, "wbhred">,
+    I32EnumAttrCase<"WTSFV", 12, "wtsfv">,
+    I32EnumAttrCase<"WTSLV", 13, "wtslv">,
+    I32EnumAttrCase<"WTSPRS", 14, "wtsprs">,
+    I32EnumAttrCase<"WTSRED", 15, "wtsred">
+  ]>;
+
+def PTO_StL2CacheAttr
+    : EnumAttr<PTO_Dialect, PTO_StL2CacheEnum, "st_l2cache"> {
+  let assemblyFormat = "`<` params `>`";
+  let summary = "store and atomic L2 cache control";
+}
+
+def PTO_L1CacheEnum : PTO_I32Enum<
+  "L1Cache", "PTO L1 cache control", [
+    I32EnumAttrCase<"Uncache", 0, "uncache">,
+    I32EnumAttrCase<"Cache", 1, "cache">
+  ]>;
+
+def PTO_L1CacheAttr
+    : EnumAttr<PTO_Dialect, PTO_L1CacheEnum, "l1cache"> {
+  let assemblyFormat = "`<` params `>`";
+  let summary = "L1 cache control";
+}
+
+//===----------------------------------------------------------------------===//
+// SIMT conversion controls
+//===----------------------------------------------------------------------===//
+
+// CANN ROUND semantics confirmed from installed beta.1 headers:
+//   R = round to nearest, ties to even
+//   A = round away from zero
+//   F = round toward minus infinity
+//   C = round toward plus infinity
+//   Z = round toward zero
+//   O = round to odd
+//   H = CAST_CEIL (special cast mode observed on H8/HiF8 conversion paths)
+def PTO_RoundingEnum : PTO_I32Enum<
+  "Rounding", "PTO SIMT conversion rounding selector", [
+    // nearest-even
+    I32EnumAttrCase<"R", 0, "r">,
+    // away-zero
+    I32EnumAttrCase<"A", 1, "a">,
+    // floor / toward minus infinity
+    I32EnumAttrCase<"F", 2, "f">,
+    // ceil / toward plus infinity
+    I32EnumAttrCase<"C", 3, "c">,
+    // trunc / toward zero
+    I32EnumAttrCase<"Z", 4, "z">,
+    // round to odd
+    I32EnumAttrCase<"O", 5, "o">,
+    // CAST_CEIL on the confirmed H8/HiF8 conversion slice
+    I32EnumAttrCase<"H", 6, "h">
+  ]>;
+
+def PTO_RoundingAttr : EnumAttr<PTO_Dialect, PTO_RoundingEnum, "rounding"> {
+  let assemblyFormat = "`<` params `>`";
+  let summary = "SIMT conversion rounding selector";
+}
+
+def PTO_SaturationEnum : PTO_I32Enum<
+  "Saturation", "PTO SIMT conversion saturation selector", [
+    I32EnumAttrCase<"Disable", 0, "nosat">,
+    I32EnumAttrCase<"Enable", 1, "sat">
+  ]>;
+
+def PTO_SaturationAttr
+    : EnumAttr<PTO_Dialect, PTO_SaturationEnum, "saturation"> {
+  let assemblyFormat = "`<` params `>`";
+  let summary = "SIMT conversion saturation selector";
+}
+
+//===----------------------------------------------------------------------===//
 // Pipe
 //===----------------------------------------------------------------------===//
 

--- a/include/PTO/IR/PTOTypeDefs.td
+++ b/include/PTO/IR/PTOTypeDefs.td
@@ -295,6 +295,15 @@ def HiF8Type : TypeDef<PTO_Dialect, "HiF8", [
   let summary = "Ascend A5 HiFloat8 (8-bit, 1 byte per element).";
 }
 
+// ---- !pto.hif8x2 ---- Corresponding type name: hifloat8x2_t (2 bytes)
+def HiF8x2Type : TypeDef<PTO_Dialect, "HiF8x2", [
+    DeclareTypeInterfaceMethods<DataLayoutTypeInterface,
+      ["getTypeSizeInBits", "getABIAlignment", "getPreferredAlignment"]>
+]> {
+  let mnemonic = "hif8x2";
+  let summary = "Packed pair of Ascend A5 HiFloat8 values (2 bytes).";
+}
+
 // ---- !pto.f4E1M2x2 ---- Corresponding type name: float4_e1m2x2_t (1 byte = 2 FP4 packed)
 def F4E1M2x2Type : TypeDef<PTO_Dialect, "F4E1M2x2", [
     MemRefElementTypeInterface,

--- a/include/PTO/IR/PTOTypeUtils.h
+++ b/include/PTO/IR/PTOTypeUtils.h
@@ -16,6 +16,7 @@ namespace mlir::pto {
 
 bool isPTOFloat8Type(Type t);
 bool isPTOHiFloat8Type(Type t);
+bool isPTOHiFloat8x2Type(Type t);
 bool isPTOFloat4PackedType(Type t);
 bool isPTOLowPrecisionType(Type t);
 

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -794,31 +794,14 @@ def PTO_VldsOp : PTO_Op<"vlds", [
     OptionalAttr<StrAttr>:$dist
   );
 
-  let results = (outs PTO_VectorType:$result);
+  let results = (outs PTO_VectorType:$result,
+                      Optional<PTO_BufferLikeType>:$updated_base);
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
     $source `[` $offset `]` attr-dict `:` type($source) `->` type($result)
-  }];
-}
-
-def PTO_VldsPostOp : PTO_Op<"vlds_post", [
-    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
-  ]> {
-  let arguments = (ins
-    PTO_BufferLikeType:$source,
-    Index:$offset,
-    OptionalAttr<StrAttr>:$dist
-  );
-
-  let results = (outs PTO_VectorType:$result,
-                      PTO_BufferLikeType:$updated_source);
-
-  let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $source `[` $offset `]` attr-dict `:` type($source) `->` type($result) `,` type($updated_source)
+    (`,` type($updated_base)^)?
   }];
 }
 
@@ -1860,32 +1843,13 @@ def PTO_VstsOp : PTO_Op<"vsts", [
     PTO_MaskTypeConstraint:$mask
   );
 
-  let results = (outs);
+  let results = (outs Optional<PTO_BufferLikeType>:$updated_base);
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
     $value `,` $destination `[` $offset `]` `,` $mask attr-dict `:` type($value) `,` type($destination) `,` type($mask)
-  }];
-}
-
-def PTO_VstsPostOp : PTO_Op<"vsts_post", [
-    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
-  ]> {
-  let arguments = (ins
-    PTO_VectorType:$value,
-    PTO_BufferLikeType:$destination,
-    Index:$offset,
-    OptionalAttr<StrAttr>:$dist,
-    PTO_MaskTypeConstraint:$mask
-  );
-
-  let results = (outs PTO_BufferLikeType:$updated_destination);
-
-  let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $value `,` $destination `[` $offset `]` `,` $mask attr-dict `:` type($value) `,` type($destination) `,` type($mask) `->` type($updated_destination)
+    (`->` type($updated_base)^)?
   }];
 }
 
@@ -2668,12 +2632,13 @@ def PTO_VsstbOp : PTO_Op<"vsstb", [
     I16:$repeat_stride,
     PTO_MaskTypeConstraint:$mask
   );
-  let results = (outs);
+  let results = (outs Optional<PTO_BufferLikeType>:$updated_base);
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
     $value `,` $destination `,` $block_stride `,` $repeat_stride `,` $mask attr-dict `:` type($value) `,` type($destination) `,` type($block_stride) `,` type($repeat_stride) `,` type($mask)
+    (`->` type($updated_base)^)?
   }];
 }
 

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -50,6 +50,62 @@ def PTO_AccStorePayloadType : AnyTypeOf<[AnySignlessInteger, AnyFloat, PTO_Scali
                                         "signless integer, float scalar, or scaling pointer">;
 def PTO_AccStoreClipPayloadType : AnyTypeOf<[AnyInteger, AnyFloat],
                                             "integer or float clip scalar">;
+def PTO_V2F16Type : Type<
+  CPred<"::llvm::isa<::mlir::VectorType>($_self) && "
+        "::llvm::cast<::mlir::VectorType>($_self).getRank() == 1 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getDimSize(0) == 2 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getElementType().isF16()">,
+  "vector<2xf16>">;
+def PTO_V2BF16Type : Type<
+  CPred<"::llvm::isa<::mlir::VectorType>($_self) && "
+        "::llvm::cast<::mlir::VectorType>($_self).getRank() == 1 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getDimSize(0) == 2 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getElementType().isBF16()">,
+  "vector<2xbf16>">;
+def PTO_V2F32Type : Type<
+  CPred<"::llvm::isa<::mlir::VectorType>($_self) && "
+        "::llvm::cast<::mlir::VectorType>($_self).getRank() == 1 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getDimSize(0) == 2 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getElementType().isF32()">,
+  "vector<2xf32>">;
+def PTO_V2F8E4M3FNType : Type<
+  CPred<"::llvm::isa<::mlir::VectorType>($_self) && "
+        "::llvm::cast<::mlir::VectorType>($_self).getRank() == 1 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getDimSize(0) == 2 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getElementType().isFloat8E4M3FN()">,
+  "vector<2xf8E4M3FN>">;
+def PTO_V2F8E5M2Type : Type<
+  CPred<"::llvm::isa<::mlir::VectorType>($_self) && "
+        "::llvm::cast<::mlir::VectorType>($_self).getRank() == 1 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getDimSize(0) == 2 && "
+        "::llvm::cast<::mlir::VectorType>($_self).getElementType().isFloat8E5M2()">,
+  "vector<2xf8E5M2>">;
+def PTO_V2HiF8Type : Type<
+  CPred<"::llvm::isa<::mlir::pto::HiF8x2Type>($_self)">,
+  "!pto.hif8x2">;
+def PTO_LowPrecisionPackedType : AnyTypeOf<[PTO_V2F8E4M3FNType, PTO_V2F8E5M2Type,
+                                            PTO_V2HiF8Type],
+                                           "supported vector<2xFP8/HiF8> packed type">;
+def PTO_SimtF4ValueType : Type<
+  CPred<"::llvm::isa<::mlir::pto::F4E1M2x2Type, ::mlir::pto::F4E2M1x2Type>($_self)">,
+  "!pto.f4E1M2x2 or !pto.f4E2M1x2">;
+def PTO_SimtShuffleValueType : AnyTypeOf<[I32, I64, F16, F32, PTO_V2F16Type],
+                                         "i32, i64, f16, f32 or vector<2xf16>">;
+def PTO_SimtUnaryFloatValueType : AnyTypeOf<[F16, F32, BF16, PTO_V2F16Type, PTO_V2BF16Type],
+                                           "f16, f32, bf16, vector<2xf16> or vector<2xbf16>">;
+def PTO_SimtUnaryF16F32ValueType : AnyTypeOf<[F16, F32, PTO_V2F16Type],
+                                            "f16, f32 or vector<2xf16>">;
+def PTO_SimtBinaryF32BF16ValueType : AnyTypeOf<[F32, BF16, PTO_V2F16Type, PTO_V2BF16Type],
+                                              "f32, bf16, vector<2xf16> or vector<2xbf16>">;
+def PTO_SimtBinaryF16F32ValueType : AnyTypeOf<[F16, F32, PTO_V2F16Type],
+                                             "f16, f32 or vector<2xf16>">;
+def PTO_SimtConvertValueType : AnyTypeOf<[I32, I64, F16, BF16, F32,
+                                          PTO_V2F16Type, PTO_V2BF16Type,
+                                          PTO_V2F32Type, PTO_LowPrecisionPackedType,
+                                          PTO_SimtF4ValueType],
+                                         "standard scalar, low-precision scalar payload, or supported vector<2xT> conversion type">;
+def PTO_AtomicValueType : AnyTypeOf<[I32, I64, F16, BF16, F32, PTO_V2F16Type, PTO_V2BF16Type],
+                                    "i32, i64, f16, bf16, f32, vector<2xf16> or vector<2xbf16>">;
 
 def PTOLoadOp : PTO_Op<"load", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
@@ -87,6 +143,51 @@ def PTOStoreOp : PTO_Op<"store", [
 
   let assemblyFormat = [{
     $value `,` $ptr `[` $offset `]` attr-dict `:` type($ptr) `,` type($value)
+  }];
+}
+
+def PTOLdgOp : PTO_Op<"ldg", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Load one scalar element from GM with cache controls.";
+
+  let arguments = (ins
+    PTO_BufferType:$ptr,
+    Index:$offset,
+    OptionalAttr<PTO_L1CacheAttr>:$l1cache,
+    OptionalAttr<PTO_LdL2CacheAttr>:$l2cache
+  );
+
+  let results = (outs AnyType:$value);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $ptr `[` $offset `]` custom<L1Cache>($l1cache)
+    custom<LdL2Cache>($l2cache) attr-dict `:` type($ptr) `->` type($value)
+  }];
+}
+
+def PTOStgOp : PTO_Op<"stg", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Store one scalar element to GM with cache controls.";
+
+  let arguments = (ins
+    PTO_BufferType:$ptr,
+    Index:$offset,
+    AnyType:$value,
+    OptionalAttr<PTO_L1CacheAttr>:$l1cache,
+    OptionalAttr<PTO_StL2CacheAttr>:$l2cache
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $value `,` $ptr `[` $offset `]` custom<L1Cache>($l1cache)
+    custom<StL2Cache>($l2cache) attr-dict `:` type($ptr) `,` type($value)
   }];
 }
 
@@ -299,6 +400,418 @@ def PTO_SetAtomicS8Op : PTO_NullaryConfigOp<"set_atomic_s8">;
 def PTO_GetTidXOp : PTO_NullaryI32PureOp<"get_tid_x">;
 def PTO_GetTidYOp : PTO_NullaryI32PureOp<"get_tid_y">;
 def PTO_GetTidZOp : PTO_NullaryI32PureOp<"get_tid_z">;
+def PTO_GetBlockDimXOp : PTO_NullaryI32PureOp<"get_block_dim_x">;
+def PTO_GetBlockDimYOp : PTO_NullaryI32PureOp<"get_block_dim_y">;
+def PTO_GetBlockDimZOp : PTO_NullaryI32PureOp<"get_block_dim_z">;
+def PTO_GetGridDimXOp : PTO_NullaryI32PureOp<"get_grid_dim_x">;
+def PTO_GetGridDimYOp : PTO_NullaryI32PureOp<"get_grid_dim_y">;
+def PTO_GetGridDimZOp : PTO_NullaryI32PureOp<"get_grid_dim_z">;
+def PTO_GetBlockIdxXOp : PTO_NullaryI32PureOp<"get_block_idx_x">;
+def PTO_GetBlockIdxYOp : PTO_NullaryI32PureOp<"get_block_idx_y">;
+def PTO_GetBlockIdxZOp : PTO_NullaryI32PureOp<"get_block_idx_z">;
+def PTO_GetVecCoreIdOp : PTO_NullaryI32PureOp<"get_veccoreid">;
+def PTO_GetLaneIdOp : PTO_NullaryI32PureOp<"get_laneid">;
+def PTO_GetClock32Op : PTO_NullaryI32PureOp<"get_clock32">;
+def PTO_GetClock64Op : PTO_NullaryI64PureOp<"get_clock64">;
+def PTO_GetLaneMaskEqOp : PTO_NullaryI32PureOp<"get_lanemask_eq">;
+def PTO_GetLaneMaskLeOp : PTO_NullaryI32PureOp<"get_lanemask_le">;
+def PTO_GetLaneMaskLtOp : PTO_NullaryI32PureOp<"get_lanemask_lt">;
+def PTO_GetLaneMaskGeOp : PTO_NullaryI32PureOp<"get_lanemask_ge">;
+def PTO_GetLaneMaskGtOp : PTO_NullaryI32PureOp<"get_lanemask_gt">;
+
+def PTO_VoteAllOp : PTO_Op<"vote_all", [Pure]> {
+  let arguments = (ins I1:$pred);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    $pred attr-dict `:` type($pred) `->` type($result)
+  }];
+}
+
+def PTO_VoteAnyOp : PTO_Op<"vote_any", [Pure]> {
+  let arguments = (ins I1:$pred);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    $pred attr-dict `:` type($pred) `->` type($result)
+  }];
+}
+
+def PTO_VoteUniOp : PTO_Op<"vote_uni", [Pure]> {
+  let arguments = (ins I1:$pred);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = [{
+    $pred attr-dict `:` type($pred) `->` type($result)
+  }];
+}
+
+def PTO_VoteBallotOp : PTO_Op<"vote_ballot", [Pure]> {
+  let arguments = (ins I1:$pred);
+  let results = (outs I32:$result);
+
+  let assemblyFormat = [{
+    $pred attr-dict `:` type($pred) `->` type($result)
+  }];
+}
+
+def PTO_ShuffleIdxOp : PTO_Op<"shuffle_idx", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins
+    PTO_SimtShuffleValueType:$value,
+    I32:$index,
+    DefaultValuedAttr<I32Attr, "32">:$width
+  );
+  let results = (outs PTO_SimtShuffleValueType:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $value `,` $index attr-dict `:` type($value) `,` type($index) `->` type($result)
+  }];
+}
+
+def PTO_ShuffleUpOp : PTO_Op<"shuffle_up", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins
+    PTO_SimtShuffleValueType:$value,
+    I32:$offset,
+    DefaultValuedAttr<I32Attr, "32">:$width
+  );
+  let results = (outs PTO_SimtShuffleValueType:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $value `,` $offset attr-dict `:` type($value) `,` type($offset) `->` type($result)
+  }];
+}
+
+def PTO_ShuffleDownOp : PTO_Op<"shuffle_down", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins
+    PTO_SimtShuffleValueType:$value,
+    I32:$offset,
+    DefaultValuedAttr<I32Attr, "32">:$width
+  );
+  let results = (outs PTO_SimtShuffleValueType:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $value `,` $offset attr-dict `:` type($value) `,` type($offset) `->` type($result)
+  }];
+}
+
+def PTO_ShuffleBflyOp : PTO_Op<"shuffle_bfly", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins
+    PTO_SimtShuffleValueType:$value,
+    I32:$mask,
+    DefaultValuedAttr<I32Attr, "32">:$width
+  );
+  let results = (outs PTO_SimtShuffleValueType:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $value `,` $mask attr-dict `:` type($value) `,` type($mask) `->` type($result)
+  }];
+}
+
+def PTO_ReduxAddOp : PTO_Op<"redux_add", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins
+    AnyTypeOf<[I32, F16, F32], "integer/float scalar">:$value,
+    OptionalAttr<PTO_SignednessAttr>:$signedness
+  );
+  let results = (outs AnyTypeOf<[I32, F16, F32], "integer/float scalar">:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $value (custom<OptionalSignedness>($signedness)^)? attr-dict
+    `:` type($value) `->` type($result)
+  }];
+}
+
+def PTO_ReduxMaxOp : PTO_Op<"redux_max", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins
+    AnyTypeOf<[I32, F16, F32], "integer/float scalar">:$value,
+    OptionalAttr<PTO_SignednessAttr>:$signedness
+  );
+  let results = (outs AnyTypeOf<[I32, F16, F32], "integer/float scalar">:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $value (custom<OptionalSignedness>($signedness)^)? attr-dict
+    `:` type($value) `->` type($result)
+  }];
+}
+
+def PTO_ReduxMinOp : PTO_Op<"redux_min", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins
+    AnyTypeOf<[I32, F16, F32], "integer/float scalar">:$value,
+    OptionalAttr<PTO_SignednessAttr>:$signedness
+  );
+  let results = (outs AnyTypeOf<[I32, F16, F32], "integer/float scalar">:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $value (custom<OptionalSignedness>($signedness)^)? attr-dict
+    `:` type($value) `->` type($result)
+  }];
+}
+
+class PTO_AtomicBinaryOp<string mnemonic>
+    : PTO_Op<mnemonic, [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let arguments = (ins
+    PTO_BufferType:$ptr,
+    PTO_AtomicValueType:$value,
+    OptionalAttr<PTO_StL2CacheAttr>:$l2cache,
+    OptionalAttr<PTO_SignednessAttr>:$signedness
+  );
+  let results = (outs PTO_AtomicValueType:$old);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $ptr `,` $value custom<StL2Cache>($l2cache)
+    (custom<OptionalSignedness>($signedness)^)? attr-dict
+    `:` type($ptr) `,` type($value) `->` type($old)
+  }];
+}
+
+class PTO_AtomicCasLikeOp<string mnemonic>
+    : PTO_Op<mnemonic, [
+        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+        AllTypesMatch<["compare", "value", "old"]>
+      ]> {
+  let arguments = (ins
+    PTO_BufferType:$ptr,
+    PTO_AtomicValueType:$compare,
+    PTO_AtomicValueType:$value,
+    OptionalAttr<PTO_StL2CacheAttr>:$l2cache,
+    OptionalAttr<PTO_SignednessAttr>:$signedness
+  );
+  let results = (outs PTO_AtomicValueType:$old);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $ptr `,` $compare `,` $value custom<StL2Cache>($l2cache)
+    (custom<OptionalSignedness>($signedness)^)? attr-dict
+    `:` type($ptr) `,` type($value) `->` type($old)
+  }];
+}
+
+def PTO_AtomicCasOp : PTO_AtomicCasLikeOp<"atomic_cas">;
+def PTO_AtomicExchOp : PTO_AtomicBinaryOp<"atomic_exch">;
+def PTO_AtomicAddOp : PTO_AtomicBinaryOp<"atomic_add">;
+def PTO_AtomicSubOp : PTO_AtomicBinaryOp<"atomic_sub">;
+def PTO_AtomicMinOp : PTO_AtomicBinaryOp<"atomic_min">;
+def PTO_AtomicMaxOp : PTO_AtomicBinaryOp<"atomic_max">;
+def PTO_AtomicAndOp : PTO_AtomicBinaryOp<"atomic_and">;
+def PTO_AtomicOrOp : PTO_AtomicBinaryOp<"atomic_or">;
+def PTO_AtomicXorOp : PTO_AtomicBinaryOp<"atomic_xor">;
+
+def PTO_PrmtOp : PTO_Op<"prmt", [Pure]> {
+  let arguments = (ins I32:$lhs, I32:$rhs, I32:$selector);
+  let results = (outs I32:$result);
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs `,` $selector attr-dict `:` type($lhs) `,` type($rhs) `,` type($selector) `->` type($result)
+  }];
+}
+
+def PTO_MulhiOp : PTO_Op<"mulhi", [
+    Pure,
+    AllTypesMatch<["lhs", "rhs", "result"]>
+  ]> {
+  let arguments = (ins
+    AnyTypeOf<[I32, I64], "i32 or i64">:$lhs,
+    AnyTypeOf<[I32, I64], "i32 or i64">:$rhs,
+    PTO_SignednessAttr:$signedness
+  );
+  let results = (outs AnyTypeOf<[I32, I64], "i32 or i64">:$result);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs custom<Signedness>($signedness) attr-dict
+    `:` type($lhs) `,` type($rhs) `->` type($result)
+  }];
+}
+
+def PTO_MulI32ToI64Op : PTO_Op<"mul_i32toi64", [Pure]> {
+  let arguments = (ins
+    I32:$lhs,
+    I32:$rhs,
+    PTO_SignednessAttr:$signedness
+  );
+  let results = (outs I64:$result);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs custom<Signedness>($signedness) attr-dict
+    `:` type($lhs) `,` type($rhs) `->` type($result)
+  }];
+}
+
+def PTO_SqrtOp : PTO_Op<"sqrt", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins PTO_SimtUnaryF16F32ValueType:$value);
+  let results = (outs PTO_SimtUnaryF16F32ValueType:$result);
+
+  let assemblyFormat = [{
+    $value attr-dict `:` type($value) `->` type($result)
+  }];
+}
+
+class PTO_UnaryFloatScalarOp<string mnemonic>
+    : PTO_Op<mnemonic, [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins AnyTypeOf<[F16, F32, BF16], "floating scalar">:$value);
+  let results = (outs AnyTypeOf<[F16, F32, BF16], "floating scalar">:$result);
+
+  let assemblyFormat = [{
+    $value attr-dict `:` type($value) `->` type($result)
+  }];
+}
+
+class PTO_BinaryFloatScalarOp<string mnemonic>
+    : PTO_Op<mnemonic, [Pure, AllTypesMatch<["lhs", "rhs", "result"]>]> {
+  let arguments = (ins
+    AnyTypeOf<[F16, F32, BF16], "floating scalar">:$lhs,
+    AnyTypeOf<[F16, F32, BF16], "floating scalar">:$rhs
+  );
+  let results = (outs AnyTypeOf<[F16, F32, BF16], "floating scalar">:$result);
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)
+  }];
+}
+
+def PTO_AbsFOp : PTO_Op<"absf", [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins AnyTypeOf<[F32, PTO_V2F16Type, PTO_V2BF16Type],
+                                 "f32, vector<2xf16> or vector<2xbf16>">:$value);
+  let results = (outs AnyTypeOf<[F32, PTO_V2F16Type, PTO_V2BF16Type],
+                                "f32, vector<2xf16> or vector<2xbf16>">:$result);
+
+  let assemblyFormat = [{
+    $value attr-dict `:` type($value) `->` type($result)
+  }];
+}
+
+class PTO_UnaryF16F32ScalarOp<string mnemonic>
+    : PTO_Op<mnemonic, [Pure, AllTypesMatch<["value", "result"]>]> {
+  let arguments = (ins PTO_SimtUnaryF16F32ValueType:$value);
+  let results = (outs PTO_SimtUnaryF16F32ValueType:$result);
+
+  let assemblyFormat = [{
+    $value attr-dict `:` type($value) `->` type($result)
+  }];
+}
+
+def PTO_ExpOp : PTO_UnaryF16F32ScalarOp<"exp">;
+def PTO_LogOp : PTO_UnaryF16F32ScalarOp<"log">;
+def PTO_CeilOp : PTO_UnaryFloatScalarOp<"ceil">;
+def PTO_FloorOp : PTO_UnaryFloatScalarOp<"floor">;
+def PTO_RintOp : PTO_UnaryFloatScalarOp<"rint">;
+def PTO_RoundOp : PTO_UnaryFloatScalarOp<"round">;
+
+class PTO_BinaryF32BF16ScalarOp<string mnemonic>
+    : PTO_Op<mnemonic, [Pure, AllTypesMatch<["lhs", "rhs", "result"]>]> {
+  let arguments = (ins
+    PTO_SimtBinaryF32BF16ValueType:$lhs,
+    PTO_SimtBinaryF32BF16ValueType:$rhs
+  );
+  let results = (outs PTO_SimtBinaryF32BF16ValueType:$result);
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)
+  }];
+}
+
+class PTO_BinaryF16F32ScalarOp<string mnemonic>
+    : PTO_Op<mnemonic, [Pure, AllTypesMatch<["lhs", "rhs", "result"]>]> {
+  let arguments = (ins
+    PTO_SimtBinaryF16F32ValueType:$lhs,
+    PTO_SimtBinaryF16F32ValueType:$rhs
+  );
+  let results = (outs PTO_SimtBinaryF16F32ValueType:$result);
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)
+  }];
+}
+
+def PTO_FMinOp : PTO_BinaryF32BF16ScalarOp<"fmin">;
+def PTO_FMaxOp : PTO_BinaryF32BF16ScalarOp<"fmax">;
+def PTO_PowOp : PTO_BinaryF16F32ScalarOp<"pow">;
+
+def PTO_FmaOp : PTO_Op<"fma", [Pure, AllTypesMatch<["lhs", "rhs", "acc", "result"]>]> {
+  let arguments = (ins
+    PTO_SimtUnaryFloatValueType:$lhs,
+    PTO_SimtUnaryFloatValueType:$rhs,
+    PTO_SimtUnaryFloatValueType:$acc
+  );
+  let results = (outs PTO_SimtUnaryFloatValueType:$result);
+
+  let assemblyFormat = [{
+    $lhs `,` $rhs `,` $acc attr-dict `:` type($lhs) `,` type($rhs) `,` type($acc) `->` type($result)
+  }];
+}
+
+def PTO_ConvertOp : PTO_Op<"convert", [Pure]> {
+  let arguments = (ins
+    PTO_SimtConvertValueType:$src,
+    PTO_RoundingAttr:$rounding,
+    PTO_SaturationAttr:$saturation,
+    OptionalAttr<PTO_SignednessAttr>:$signedness
+  );
+  let results = (outs PTO_SimtConvertValueType:$dst);
+  let hasVerifier = 1;
+  let assemblyFormat = [{
+    $src custom<ConvertRounding>($rounding)
+    custom<ConvertSaturation>($saturation)
+    (custom<OptionalSignedness>($signedness)^)? attr-dict
+    `:` type($src) `->` type($dst)
+  }];
+}
+
+def PTO_SyncthreadsOp : PTO_Op<"syncthreads", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Synchronize all workitems in a SIMT VF entry";
+  let arguments = (ins);
+  let results = (outs);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{ attr-dict }];
+}
+
+def PTO_ThreadfenceOp : PTO_Op<"threadfence", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Issue a SIMT workitem memory fence";
+  let arguments = (ins);
+  let results = (outs);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{ attr-dict }];
+}
+
+def PTO_ThreadfenceBlockOp : PTO_Op<"threadfence_block", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+  ]> {
+  let summary = "Issue a SIMT block-scoped workitem memory fence";
+  let arguments = (ins);
+  let results = (outs);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{ attr-dict }];
+}
+
+def PTO_KeepOp : PTO_Op<"keep"> {
+  let summary = "Preserve one scalar payload across adjacent SIMT VF entries";
+  let arguments = (ins AnyType:$payload, I64Attr:$slot);
+  let results = (outs);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $payload attr-dict `:` type($payload)
+  }];
+}
+
+def PTO_ResumeOp : PTO_Op<"resume"> {
+  let summary = "Restore one scalar payload preserved by a previous SIMT VF entry";
+  let arguments = (ins I64Attr:$slot);
+  let results = (outs AnyType:$result);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    attr-dict `:` type($result)
+  }];
+}
 
 def PTO_CopyGmToUbufOp : PTO_Op<"copy_gm_to_ubuf", [
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -389,6 +389,28 @@ def PTO_StoreVfSimtInfoOp : PTO_Op<"store_vfsimt_info"> {
     $dimZ `,` $dimY `,` $dimX attr-dict `:` type($dimZ) `,` type($dimY) `,` type($dimX)
   }];
 }
+def PTO_SimtLaunchOp : PTO_Op<"simt_launch"> {
+  let summary = "Launch a SIMT entry with VF launch dimensions";
+  let description = [{
+    `pto.simt_launch` is source-level sugar for configuring SIMT VF launch
+    dimensions and calling a function marked with `pto.simt_entry`.
+
+    The textual dimension order follows the familiar launch order
+    `<<<x, y, z>>>`; the canonical `pto.store_vfsimt_info` operation stores
+    the same values in `z, y, x` order for the backend.
+  }];
+  let arguments = (ins FlatSymbolRefAttr:$callee,
+                       I32:$dimX,
+                       I32:$dimY,
+                       I32:$dimZ,
+                       Variadic<AnyType>:$args);
+  let results = (outs);
+  let assemblyFormat = [{
+    $callee `<` `<` `<` $dimX `,` $dimY `,` $dimZ `>` `>` `>`
+    `` `(` $args `)` attr-dict `:` functional-type($args, results)
+  }];
+  let hasVerifier = 1;
+}
 def PTO_Sbitset0Op : PTO_BinaryI64PureOp<"sbitset0">;
 def PTO_Sbitset1Op : PTO_BinaryI64PureOp<"sbitset1">;
 def PTO_SetQuantPreOp : PTO_UnaryI64ConfigOp<"set_quant_pre">;

--- a/include/pto-c/Dialect/PTO.h
+++ b/include/pto-c/Dialect/PTO.h
@@ -39,9 +39,11 @@ MlirType mlirPTOAsyncEventTypeGet(MlirContext ctx);
 bool mlirPTOTypeIsAPrefetchAsyncContextType(MlirType type);
 MlirType mlirPTOPrefetchAsyncContextTypeGet(MlirContext ctx);
 
-// ---- !pto.hif8 / !pto.f4E1M2x2 / !pto.f4E2M1x2 ----
+// ---- !pto.hif8 / !pto.hif8x2 / !pto.f4E1M2x2 / !pto.f4E2M1x2 ----
 bool mlirPTOTypeIsAHiF8Type(MlirType type);
 MlirType mlirPTOHiF8TypeGet(MlirContext ctx);
+bool mlirPTOTypeIsAHiF8x2Type(MlirType type);
+MlirType mlirPTOHiF8x2TypeGet(MlirContext ctx);
 bool mlirPTOTypeIsAF4E1M2x2Type(MlirType type);
 MlirType mlirPTOF4E1M2x2TypeGet(MlirContext ctx);
 bool mlirPTOTypeIsAF4E2M1x2Type(MlirType type);

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -886,6 +886,17 @@ static void bindPTOModule(pybind11::module &m) {
             py::arg("cls"), py::arg("context") = py::none());
 
     mlir_type_subclass(
+        m, "HiF8x2Type",
+        [](MlirType type) -> bool { return mlirPTOTypeIsAHiF8x2Type(type); })
+        .def_classmethod(
+            "get",
+            [](py::object cls, MlirContext context) -> py::object {
+                MlirType t = mlirPTOHiF8x2TypeGet(context);
+                return cls.attr("__call__")(t);
+            },
+            py::arg("cls"), py::arg("context") = py::none());
+
+    mlir_type_subclass(
         m, "F4E1M2x2Type",
         [](MlirType type) -> bool { return mlirPTOTypeIsAF4E1M2x2Type(type); })
         .def_classmethod(

--- a/lib/CAPI/Dialect/PTO.cpp
+++ b/lib/CAPI/Dialect/PTO.cpp
@@ -121,6 +121,14 @@ MlirType mlirPTOHiF8TypeGet(MlirContext ctx) {
   return wrap(mlir::pto::HiF8Type::get(unwrap(ctx)));
 }
 
+bool mlirPTOTypeIsAHiF8x2Type(MlirType type) {
+  return isa<mlir::pto::HiF8x2Type>(unwrap(type));
+}
+
+MlirType mlirPTOHiF8x2TypeGet(MlirContext ctx) {
+  return wrap(mlir::pto::HiF8x2Type::get(unwrap(ctx)));
+}
+
 bool mlirPTOTypeIsAF4E1M2x2Type(MlirType type) {
   return isa<mlir::pto::F4E1M2x2Type>(unwrap(type));
 }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -14201,6 +14201,8 @@ static ParseResult parseL1Cache(OpAsmParser &parser, L1CacheAttr &l1cache) {
 
 static void printL1Cache(OpAsmPrinter &printer, Operation *op,
                          L1CacheAttr l1cache) {
+  if (!l1cache)
+    return;
   printer << "l1cache(" << stringifyL1Cache(l1cache.getValue()) << ")";
 }
 
@@ -14226,6 +14228,8 @@ static ParseResult parseLdL2Cache(OpAsmParser &parser,
 
 static void printLdL2Cache(OpAsmPrinter &printer, Operation *op,
                            LdL2CacheAttr l2cache) {
+  if (!l2cache)
+    return;
   printer << "l2cache(" << stringifyLdL2Cache(l2cache.getValue()) << ")";
 }
 
@@ -14251,6 +14255,8 @@ static ParseResult parseStL2Cache(OpAsmParser &parser,
 
 static void printStL2Cache(OpAsmPrinter &printer, Operation *op,
                            StL2CacheAttr l2cache) {
+  if (!l2cache)
+    return;
   printer << "l2cache(" << stringifyStL2Cache(l2cache.getValue()) << ")";
 }
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -304,6 +304,25 @@ uint64_t mlir::pto::HiF8Type::getPreferredAlignment(
   return 1;
 }
 
+static llvm::TypeSize getTwoByteTypeSize() {
+  return llvm::TypeSize::getFixed(16);
+}
+
+llvm::TypeSize mlir::pto::HiF8x2Type::getTypeSizeInBits(
+    const DataLayout &, DataLayoutEntryListRef) const {
+  return getTwoByteTypeSize();
+}
+
+uint64_t mlir::pto::HiF8x2Type::getABIAlignment(
+    const DataLayout &, DataLayoutEntryListRef) const {
+  return 2;
+}
+
+uint64_t mlir::pto::HiF8x2Type::getPreferredAlignment(
+    const DataLayout &, DataLayoutEntryListRef) const {
+  return 2;
+}
+
 llvm::TypeSize mlir::pto::F4E1M2x2Type::getTypeSizeInBits(
     const DataLayout &, DataLayoutEntryListRef) const {
   return getOneByteTypeSize();
@@ -13588,6 +13607,274 @@ void TFreeOp::print(OpAsmPrinter &p) {
                           /*elidedAttrs=*/{"split"});
 }
 
+static func::FuncOp getParentFunc(Operation *op) {
+  return op ? op->getParentOfType<func::FuncOp>() : func::FuncOp();
+}
+
+static constexpr int64_t kSimtKeepResumeSlotLimit = 123;
+
+static Operation *getFirstNonConstantLikeOp(Block *block) {
+  if (!block)
+    return nullptr;
+  for (Operation &op : *block) {
+    if (!op.hasTrait<OpTrait::ConstantLike>())
+      return &op;
+  }
+  return nullptr;
+}
+
+static bool isOpInRange(Operation *op, Operation *first, Operation *last) {
+  for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+    if (cur == op)
+      return true;
+    if (cur == last)
+      return false;
+  }
+  return false;
+}
+
+static std::optional<unsigned> getSimtKeepResumeRegisterCount(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    if (intType.getWidth() <= 32)
+      return 1;
+    if (intType.getWidth() == 64)
+      return 2;
+    return std::nullopt;
+  }
+  if (type.isF16() || type.isBF16() || type.isF32())
+    return 1;
+  return std::nullopt;
+}
+
+template <typename OpT>
+static Type getSimtKeepResumeValueType(OpT op);
+
+template <>
+Type getSimtKeepResumeValueType(KeepOp op) {
+  return op.getPayload().getType();
+}
+
+template <>
+Type getSimtKeepResumeValueType(ResumeOp op) {
+  return op.getResult().getType();
+}
+
+template <typename OpT>
+static LogicalResult verifySimtKeepResumeSlotRange(OpT op) {
+  std::optional<unsigned> registerCount =
+      getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
+  if (!registerCount)
+    return success();
+  int64_t slot = op.getSlot();
+  if (slot < 0 || slot >= kSimtKeepResumeSlotLimit)
+    return op.emitOpError()
+           << "requires slot in range [0, "
+           << (kSimtKeepResumeSlotLimit - 1) << "]";
+  if (*registerCount == 2) {
+    if ((slot % 2) != 0)
+      return op.emitOpError()
+             << "requires an even slot for 64-bit keep/resume values";
+    if (slot + 1 >= kSimtKeepResumeSlotLimit)
+      return op.emitOpError()
+             << "requires slot in range [0, "
+             << (kSimtKeepResumeSlotLimit - 2)
+             << "] for 64-bit keep/resume values";
+  }
+  return success();
+}
+
+template <typename OpT>
+static bool overlapsEarlierSimtKeepResumeSlotUse(OpT op,
+                                                 SmallVectorImpl<int64_t> &used) {
+  std::optional<unsigned> registerCount =
+      getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
+  if (!registerCount)
+    return false;
+  int64_t slot = op.getSlot();
+  for (int64_t word = slot; word < slot + *registerCount; ++word) {
+    if (llvm::is_contained(used, word))
+      return true;
+  }
+  for (int64_t word = slot; word < slot + *registerCount; ++word)
+    used.push_back(word);
+  return false;
+}
+
+static LogicalResult verifyUniqueResumeGroupSlots(ResumeOp current,
+                                                  Operation *first) {
+  SmallVector<int64_t, 4> slots;
+  for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+    auto resume = dyn_cast<ResumeOp>(cur);
+    if (!resume)
+      break;
+    if (overlapsEarlierSimtKeepResumeSlotUse(resume, slots) &&
+        resume.getOperation() == current.getOperation())
+      return current.emitOpError()
+             << "duplicates an earlier slot " << resume.getSlot()
+             << " in the SIMT resume prologue group";
+  }
+  return success();
+}
+
+static LogicalResult verifyUniqueKeepGroupSlots(KeepOp current,
+                                                Operation *first,
+                                                Operation *last) {
+  SmallVector<int64_t, 4> slots;
+  for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+    auto keep = dyn_cast<KeepOp>(cur);
+    if (!keep)
+      break;
+    if (overlapsEarlierSimtKeepResumeSlotUse(keep, slots) &&
+        keep.getOperation() == current.getOperation())
+      return current.emitOpError()
+             << "duplicates an earlier slot " << keep.getSlot()
+             << " in the SIMT keep epilogue group";
+    if (cur == last)
+      break;
+  }
+  return success();
+}
+
+static LogicalResult verifySimtKeepResumeCommon(Operation *op, int64_t slot) {
+  func::FuncOp func = getParentFunc(op);
+  if (!func || !func->hasAttr(pto::kPTOSimtEntryAttrName))
+    return op->emitOpError("must appear inside a function marked with '")
+           << pto::kPTOSimtEntryAttrName << "'";
+  if (slot < 0 || slot >= kSimtKeepResumeSlotLimit) {
+    return op->emitOpError("requires slot in range [0, ")
+           << (kSimtKeepResumeSlotLimit - 1) << "]";
+  }
+  return success();
+}
+
+static bool isSupportedSimtKeepResumeType(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type))
+    return intType.getWidth() <= 64;
+  return type.isF16() || type.isBF16() || type.isF32();
+}
+
+static LogicalResult verifyInsideSimtEntry(Operation *op) {
+  func::FuncOp func = getParentFunc(op);
+  if (!func || !func->hasAttr(pto::kPTOSimtEntryAttrName))
+    return op->emitOpError("must appear inside a function marked with '")
+           << pto::kPTOSimtEntryAttrName << "'";
+  return success();
+}
+
+LogicalResult SyncthreadsOp::verify() {
+  return verifyInsideSimtEntry(getOperation());
+}
+
+LogicalResult ThreadfenceOp::verify() {
+  return verifyInsideSimtEntry(getOperation());
+}
+
+LogicalResult ThreadfenceBlockOp::verify() {
+  return verifyInsideSimtEntry(getOperation());
+}
+
+void SyncthreadsOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(),
+                       SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+void ThreadfenceOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(),
+                       SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+void ThreadfenceBlockOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(),
+                       SideEffects::DefaultResource::get());
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+LogicalResult KeepOp::verify() {
+  if (failed(verifySimtKeepResumeCommon(getOperation(), getSlot())))
+    return failure();
+  if (!isSupportedSimtKeepResumeType(getPayload().getType()))
+    return emitOpError()
+           << "supports integer scalar payloads up to 64 bits and "
+              "f16/bf16/f32 payloads";
+  if (failed(verifySimtKeepResumeSlotRange(*this)))
+    return failure();
+
+  Block *block = getOperation()->getBlock();
+  Operation *terminator = block ? block->getTerminator() : nullptr;
+  if (!terminator || !isa<func::ReturnOp>(terminator))
+    return emitOpError(
+        "must be placed in the SIMT epilogue before func.return");
+
+  Operation *cur = terminator->getPrevNode();
+  while (cur && isa<SyncthreadsOp>(cur))
+    cur = cur->getPrevNode();
+  Operation *lastKeep = cur;
+  if (!lastKeep || !isa<KeepOp>(lastKeep))
+    return emitOpError()
+           << "must be placed in the SIMT epilogue before func.return; only "
+              "'pto.syncthreads' may appear between the final 'pto.keep' group "
+              "and func.return";
+
+  Operation *firstKeep = lastKeep;
+  while (Operation *prev = firstKeep->getPrevNode()) {
+    if (!isa<KeepOp>(prev))
+      break;
+    firstKeep = prev;
+  }
+  if (!isOpInRange(getOperation(), firstKeep, lastKeep))
+    return emitOpError()
+           << "must be in the contiguous SIMT keep epilogue group immediately "
+              "before optional 'pto.syncthreads' and func.return";
+  if (failed(verifyUniqueKeepGroupSlots(*this, firstKeep, lastKeep)))
+    return failure();
+  return success();
+}
+
+LogicalResult ResumeOp::verify() {
+  if (failed(verifySimtKeepResumeCommon(getOperation(), getSlot())))
+    return failure();
+  if (!isSupportedSimtKeepResumeType(getResult().getType()))
+    return emitOpError()
+           << "supports integer scalar results up to 64 bits and "
+              "f16/bf16/f32 results";
+  if (failed(verifySimtKeepResumeSlotRange(*this)))
+    return failure();
+  Block *block = getOperation()->getBlock();
+  Operation *first = getFirstNonConstantLikeOp(block);
+  if (!first || !isa<ResumeOp>(first))
+    return emitOpError()
+           << "must be in the contiguous SIMT resume prologue group after "
+              "constant-like operations";
+
+  bool found = false;
+  for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+    if (!isa<ResumeOp>(cur))
+      break;
+    if (cur == getOperation()) {
+      found = true;
+      break;
+    }
+  }
+  if (!found)
+    return emitOpError()
+           << "must be in the contiguous SIMT resume prologue group after "
+              "constant-like operations";
+  if (failed(verifyUniqueResumeGroupSlots(*this, first)))
+    return failure();
+  return success();
+}
+
 void BuildAsyncSessionOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
@@ -13806,6 +14093,165 @@ void TFreeOp::getEffects(
     addEffect(effects, &*entry.begin(), MemoryEffects::Read::get());
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Read::get());
   addEffect(effects, &getPipeHandleMutable(), MemoryEffects::Write::get());
+}
+
+static constexpr const char kConvertRoundingKeywords[] = "r/a/f/c/z/o/h";
+
+static ParseResult parseConvertRounding(OpAsmParser &parser,
+                                        RoundingAttr &roundingAttr) {
+  StringRef roundingKeyword;
+  if (parser.parseKeyword("round") || parser.parseLParen() ||
+      parser.parseKeyword(&roundingKeyword) || parser.parseRParen())
+    return failure();
+  std::optional<Rounding> rounding = symbolizeRounding(roundingKeyword);
+  if (!rounding)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected convert rounding to be one of "
+           << kConvertRoundingKeywords;
+  roundingAttr = RoundingAttr::get(parser.getContext(), *rounding);
+  return success();
+}
+
+static void printConvertRounding(OpAsmPrinter &printer, Operation *op,
+                                 RoundingAttr rounding) {
+  printer << "round(" << stringifyRounding(rounding.getValue()) << ")";
+}
+
+static ParseResult parseConvertSaturation(OpAsmParser &parser,
+                                          SaturationAttr &saturationAttr) {
+  StringRef saturationKeyword;
+  if (parser.parseKeyword(&saturationKeyword))
+    return failure();
+  std::optional<Saturation> saturation =
+      symbolizeSaturation(saturationKeyword);
+  if (!saturation)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected convert saturation to be sat or nosat";
+  saturationAttr = SaturationAttr::get(parser.getContext(), *saturation);
+  return success();
+}
+
+static void printConvertSaturation(OpAsmPrinter &printer, Operation *op,
+                                   SaturationAttr saturation) {
+  printer << stringifySaturation(saturation.getValue());
+}
+
+static ParseResult parseSignedness(OpAsmParser &parser,
+                                   SignednessAttr &signedness) {
+  StringRef signednessKeyword;
+  if (parser.parseKeyword(&signednessKeyword))
+    return failure();
+  std::optional<Signedness> parsed = symbolizeSignedness(signednessKeyword);
+  if (!parsed)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected signedness to be signed or unsigned";
+  signedness = SignednessAttr::get(parser.getContext(), *parsed);
+  return success();
+}
+
+static void printSignedness(OpAsmPrinter &printer, Operation *op,
+                            SignednessAttr signedness) {
+  printer << stringifySignedness(signedness.getValue());
+}
+
+static OptionalParseResult parseOptionalSignedness(OpAsmParser &parser,
+                                                   SignednessAttr &signedness) {
+  if (succeeded(parser.parseOptionalKeyword("signed"))) {
+    signedness = SignednessAttr::get(parser.getContext(), Signedness::Signed);
+    return success();
+  }
+  if (succeeded(parser.parseOptionalKeyword("unsigned"))) {
+    signedness =
+        SignednessAttr::get(parser.getContext(), Signedness::Unsigned);
+    return success();
+  }
+  return std::nullopt;
+}
+
+static void printOptionalSignedness(OpAsmPrinter &printer, Operation *op,
+                                    SignednessAttr signedness) {
+  printer << stringifySignedness(signedness.getValue());
+}
+
+static constexpr const char kLdL2CacheKeywords[] =
+    "nmfv/nmlv/nmprs/nmpref/nakeep/naclean/nadrop/idsfv/idslv/idsprs/"
+    "idspref/exfv/exlv/exprs/expref";
+
+static constexpr const char kStL2CacheKeywords[] =
+    "nmfv/nmlv/nmprs/nmred/naci/napw/napi/nared/wbhfv/wbhlv/wbhprs/"
+    "wbhred/wtsfv/wtslv/wtsprs/wtsred";
+
+static ParseResult parseL1Cache(OpAsmParser &parser, L1CacheAttr &l1cache) {
+  if (failed(parser.parseOptionalKeyword("l1cache"))) {
+    l1cache = L1CacheAttr::get(parser.getContext(), L1Cache::Cache);
+    return success();
+  }
+
+  StringRef keyword;
+  if (parser.parseLParen() || parser.parseKeyword(&keyword) ||
+      parser.parseRParen())
+    return failure();
+  std::optional<L1Cache> parsed = symbolizeL1Cache(keyword);
+  if (!parsed)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected memory l1cache to be cache or uncache";
+  l1cache = L1CacheAttr::get(parser.getContext(), *parsed);
+  return success();
+}
+
+static void printL1Cache(OpAsmPrinter &printer, Operation *op,
+                         L1CacheAttr l1cache) {
+  printer << "l1cache(" << stringifyL1Cache(l1cache.getValue()) << ")";
+}
+
+static ParseResult parseLdL2Cache(OpAsmParser &parser,
+                                  LdL2CacheAttr &l2cache) {
+  if (failed(parser.parseOptionalKeyword("l2cache"))) {
+    l2cache = LdL2CacheAttr::get(parser.getContext(), LdL2Cache::NMFV);
+    return success();
+  }
+
+  StringRef keyword;
+  if (parser.parseLParen() || parser.parseKeyword(&keyword) ||
+      parser.parseRParen())
+    return failure();
+  std::optional<LdL2Cache> parsed = symbolizeLdL2Cache(keyword);
+  if (!parsed)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected load L2 cache control to be one of "
+           << kLdL2CacheKeywords;
+  l2cache = LdL2CacheAttr::get(parser.getContext(), *parsed);
+  return success();
+}
+
+static void printLdL2Cache(OpAsmPrinter &printer, Operation *op,
+                           LdL2CacheAttr l2cache) {
+  printer << "l2cache(" << stringifyLdL2Cache(l2cache.getValue()) << ")";
+}
+
+static ParseResult parseStL2Cache(OpAsmParser &parser,
+                                  StL2CacheAttr &l2cache) {
+  if (failed(parser.parseOptionalKeyword("l2cache"))) {
+    l2cache = StL2CacheAttr::get(parser.getContext(), StL2Cache::NMFV);
+    return success();
+  }
+
+  StringRef keyword;
+  if (parser.parseLParen() || parser.parseKeyword(&keyword) ||
+      parser.parseRParen())
+    return failure();
+  std::optional<StL2Cache> parsed = symbolizeStL2Cache(keyword);
+  if (!parsed)
+    return parser.emitError(parser.getCurrentLocation())
+           << "expected store L2 cache control to be one of "
+           << kStL2CacheKeywords;
+  l2cache = StL2CacheAttr::get(parser.getContext(), *parsed);
+  return success();
+}
+
+static void printStL2Cache(OpAsmPrinter &printer, Operation *op,
+                           StL2CacheAttr l2cache) {
+  printer << "l2cache(" << stringifyStL2Cache(l2cache.getValue()) << ")";
 }
 
 // [Include 必须放在最后]

--- a/lib/PTO/IR/PTOTypeUtils.cpp
+++ b/lib/PTO/IR/PTOTypeUtils.cpp
@@ -24,15 +24,20 @@ bool mlir::pto::isPTOFloat8Type(Type t) {
 
 bool mlir::pto::isPTOHiFloat8Type(Type t) { return isa<HiF8Type>(t); }
 
+bool mlir::pto::isPTOHiFloat8x2Type(Type t) { return isa<HiF8x2Type>(t); }
+
 bool mlir::pto::isPTOFloat4PackedType(Type t) {
   return isa<F4E1M2x2Type, F4E2M1x2Type>(t);
 }
 
 bool mlir::pto::isPTOLowPrecisionType(Type t) {
-  return isPTOFloat8Type(t) || isPTOHiFloat8Type(t) || isPTOFloat4PackedType(t);
+  return isPTOFloat8Type(t) || isPTOHiFloat8Type(t) ||
+         isPTOHiFloat8x2Type(t) || isPTOFloat4PackedType(t);
 }
 
 unsigned mlir::pto::getPTOStorageElemBitWidth(Type t) {
+  if (isPTOHiFloat8x2Type(t))
+    return 16;
   if (isPTOLowPrecisionType(t))
     return kBitsPerByte;
   if (auto floatTy = dyn_cast<FloatType>(t))

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -17,6 +17,7 @@
 #include "PTO/IR/PTO.h"
 #include "PTO/IR/PTOTypeUtils.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/Builders.h"
@@ -28,6 +29,7 @@
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -121,14 +123,501 @@ static bool isMaskGranularityAdjacentNarrowing(StringRef inputGranularity,
          (inputGranularity == "b32" && resultGranularity == "b16");
 }
 
+static bool isSupportedShuffleValueType(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type))
+    return intType.getWidth() == 32 || intType.getWidth() == 64;
+  if (auto vecType = dyn_cast<VectorType>(type))
+    return vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
+           vecType.getElementType().isF16();
+  return type.isF16() || type.isF32();
+}
+
+static bool isSupportedReduxValueType(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type))
+    return intType.getWidth() == 32;
+  return type.isF16() || type.isF32();
+}
+
+static LogicalResult verifyShuffleSemanticControl(Operation *op,
+                                                  Type controlType,
+                                                  IntegerAttr widthAttr,
+                                                  StringRef ctrlName) {
+  if (!isSupportedShuffleValueType(op->getResultTypes().front()))
+    return op->emitOpError()
+           << "requires i32, i64, f16, f32 or vector<2xf16> value/result type";
+  if (!controlType.isInteger(32))
+    return op->emitOpError() << "requires " << ctrlName
+                             << " operand to be i32";
+
+  int64_t width = widthAttr.getInt();
+  if (width != 16 && width != 32)
+    return op->emitOpError() << "requires width to be 16 or 32";
+  return success();
+}
+
+static LogicalResult verifyReduxSemanticType(Operation *op, Type valueType,
+                                             Attribute signednessAttr,
+                                             bool requireSignedness) {
+  if (!isSupportedReduxValueType(valueType))
+    return op->emitOpError()
+           << "requires i32, f16 or f32 value/result type";
+
+  auto intType = dyn_cast<IntegerType>(valueType);
+  if (!intType) {
+    if (signednessAttr)
+      return op->emitOpError()
+             << "does not accept signedness for floating-point redux";
+    return success();
+  }
+
+  if (!signednessAttr && requireSignedness)
+    return op->emitOpError()
+           << "requires explicit signedness for integer redux";
+
+  if (!signednessAttr)
+    return success();
+
+  auto signedness = cast<pto::SignednessAttr>(signednessAttr).getValue();
+  (void)signedness;
+  return success();
+}
+
+static bool isStandardScalarConvertType(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type))
+    return intType.getWidth() == 32 || intType.getWidth() == 64;
+  return type.isF16() || type.isBF16() || type.isF32();
+}
+
+static bool isIntegerLikeConvertType(Type type) {
+  return isa<IntegerType>(type);
+}
+
+static bool isVector2Of(Type type, llvm::function_ref<bool(Type)> elementPred) {
+  auto vecType = dyn_cast<VectorType>(type);
+  return vecType && vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
+         elementPred(vecType.getElementType());
+}
+
+static bool isSupportedPackedConvertType(Type type) {
+  if (pto::isPTOHiFloat8x2Type(type))
+    return true;
+  return isVector2Of(type, [](Type elem) {
+    return elem.isF16() || elem.isBF16() || elem.isF32() ||
+           pto::isPTOFloat8Type(elem) || pto::isPTOHiFloat8Type(elem);
+  });
+}
+
+static bool isSupportedLowPrecisionConvertType(Type type) {
+  return pto::isPTOFloat4PackedType(type);
+}
+
+static bool isVector2F16OrBF16Type(Type type) {
+  return isVector2Of(type, [](Type elem) {
+    return elem.isF16() || elem.isBF16();
+  });
+}
+
+static bool isInsideSimtEntry(Operation *op) {
+  auto funcOp = op->getParentOfType<func::FuncOp>();
+  return funcOp && funcOp->hasAttr(pto::kPTOSimtEntryAttrName);
+}
+
+static bool isSupportedConvertType(Type type) {
+  return isStandardScalarConvertType(type) || isSupportedPackedConvertType(type) ||
+         isSupportedLowPrecisionConvertType(type);
+}
+
+static LogicalResult verifyPackedConvertControls(Operation *op, Type srcType,
+                                                 Type dstType,
+                                                 pto::Rounding rounding) {
+  auto isV2F16 = [](Type type) {
+    return isVector2Of(type, [](Type elem) { return elem.isF16(); });
+  };
+  auto isV2BF16 = [](Type type) {
+    return isVector2Of(type, [](Type elem) { return elem.isBF16(); });
+  };
+  auto isV2F32 = [](Type type) {
+    return isVector2Of(type, [](Type elem) { return elem.isF32(); });
+  };
+  auto isV2F8 = [](Type type) {
+    return isVector2Of(type, [](Type elem) { return pto::isPTOFloat8Type(elem); });
+  };
+  auto isV2HiF8 = [](Type type) {
+    return pto::isPTOHiFloat8x2Type(type);
+  };
+  auto isF4 = [](Type type) { return pto::isPTOFloat4PackedType(type); };
+  auto isRoundRAFZC = [](pto::Rounding rounding) {
+    return rounding == pto::Rounding::R || rounding == pto::Rounding::A ||
+           rounding == pto::Rounding::F || rounding == pto::Rounding::C ||
+           rounding == pto::Rounding::Z;
+  };
+
+  if (isV2F32(srcType) && isV2F16(dstType)) {
+    if (rounding == pto::Rounding::H)
+      return op->emitOpError()
+             << "f32x2-to-f16x2 conversion supports rounding r/a/f/c/z/o";
+    return success();
+  }
+  if (isV2F32(srcType) && isV2BF16(dstType)) {
+    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+      return op->emitOpError()
+             << "f32x2-to-bf16x2 conversion supports rounding r/a/f/c/z";
+    return success();
+  }
+  if ((isV2F16(srcType) || isV2BF16(srcType)) && isV2F32(dstType)) {
+    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+      return op->emitOpError()
+             << "packed-to-f32x2 conversion supports rounding r/a/f/c/z";
+    return success();
+  }
+  if (isV2F32(srcType) && isV2F8(dstType)) {
+    if (rounding != pto::Rounding::R)
+      return op->emitOpError()
+             << "f32x2-to-f8x2 conversion supports rounding r";
+    return success();
+  }
+  if ((isV2F32(srcType) || isV2F16(srcType)) && isV2HiF8(dstType)) {
+    if (rounding != pto::Rounding::A && rounding != pto::Rounding::H)
+      return op->emitOpError()
+             << "f32x2/f16x2-to-hif8x2 conversion supports rounding a/h";
+    return success();
+  }
+  if ((isV2F8(srcType) || isV2HiF8(srcType)) &&
+      (isV2F32(dstType) || isV2F16(dstType))) {
+    if (!isRoundRAFZC(rounding))
+      return op->emitOpError()
+             << "f8x2/hif8x2-to-f32x2/f16x2 conversion supports rounding r/a/f/c/z";
+    return success();
+  }
+  if ((isV2BF16(srcType) && isF4(dstType)) ||
+      (isF4(srcType) && isV2BF16(dstType))) {
+    if (!isRoundRAFZC(rounding))
+      return op->emitOpError()
+             << "bf16x2-to-f4 and f4-to-bf16x2 conversion supports rounding r/a/f/c/z";
+    return success();
+  }
+
+  return op->emitOpError()
+         << "unsupported packed conversion type pair; supported packed pairs are "
+            "f32x2-to-f16x2, f16x2-to-f32x2, f32x2-to-bf16x2, and "
+            "bf16x2-to-f32x2, f32x2-to-f8x2, f32x2/f16x2-to-hif8x2, "
+            "f8x2/hif8x2-to-f32x2/f16x2, and bf16x2-to/from-f4";
+}
+
+static LogicalResult verifyConvertControls(Operation *op, Type srcType,
+                                           Type dstType,
+                                           pto::Rounding rounding,
+                                           pto::Saturation saturation,
+                                           Attribute signednessAttr) {
+  if (!isSupportedConvertType(srcType) || !isSupportedConvertType(dstType))
+    return op->emitOpError()
+           << "requires i32, i64, f16, bf16, f32 or supported vector<2xT> "
+              "conversion types";
+
+  bool srcInt = isIntegerLikeConvertType(srcType);
+  bool dstInt = isIntegerLikeConvertType(dstType);
+  bool srcPacked = isSupportedPackedConvertType(srcType);
+  bool dstPacked = isSupportedPackedConvertType(dstType);
+  bool srcLowPrecision = isSupportedLowPrecisionConvertType(srcType);
+  bool dstLowPrecision = isSupportedLowPrecisionConvertType(dstType);
+  if (srcPacked || dstPacked || srcLowPrecision || dstLowPrecision) {
+    if (srcInt || dstInt)
+      return op->emitOpError()
+             << "does not support mixed integer and packed conversion";
+    if (signednessAttr)
+      return op->emitOpError()
+             << "does not accept signedness for packed floating conversion";
+    if (!((srcPacked || srcLowPrecision) && (dstPacked || dstLowPrecision)))
+      return op->emitOpError()
+             << "does not support mixed scalar and packed conversion";
+    return verifyPackedConvertControls(op, srcType, dstType, rounding);
+  }
+
+  if (srcInt && dstInt)
+    return op->emitOpError()
+           << "does not support integer-to-integer conversion";
+
+  if ((srcInt || dstInt) && !signednessAttr)
+    return op->emitOpError()
+           << "requires signedness when converting to or from integer type";
+  if (!srcInt && !dstInt && signednessAttr)
+    return op->emitOpError()
+           << "does not accept signedness for floating-to-floating conversion";
+
+  if (srcInt) {
+    if (srcType.isInteger(64) && !dstType.isF32())
+      return op->emitOpError()
+             << "supports i64 conversion only to f32 in the confirmed slice";
+    if (srcType.isInteger(32) &&
+        !(dstType.isF32() || dstType.isF16() || dstType.isBF16()))
+      return op->emitOpError()
+             << "unsupported integer-to-floating conversion type pair";
+    if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+      return op->emitOpError()
+             << "integer-to-floating conversion supports rounding r/a/f/c/z";
+    (void)saturation;
+    return success();
+  }
+
+  if (dstType.isInteger(64) && !srcType.isF32())
+    return op->emitOpError()
+           << "supports conversion to i64 only from f32 in the confirmed slice";
+  if (srcType.isF32()) {
+    if (dstType.isInteger(32) || dstType.isInteger(64)) {
+      if (saturation != pto::Saturation::Enable)
+        return op->emitOpError()
+               << "fp32-to-integer conversion requires saturation enable";
+      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+        return op->emitOpError()
+               << "fp32-to-integer conversion supports rounding r/a/f/c/z";
+      return success();
+    }
+    if (dstType.isF16() || dstType.isBF16() || dstType.isF32()) {
+      if (dstType.isF16()) {
+        if (rounding == pto::Rounding::H)
+          return op->emitOpError()
+                 << "fp32-to-fp16 conversion supports rounding r/a/f/c/z/o";
+      } else if (rounding == pto::Rounding::O ||
+                 rounding == pto::Rounding::H) {
+        return op->emitOpError()
+               << "fp32-to-floating conversion supports rounding r/a/f/c/z";
+      }
+      return success();
+    }
+  }
+
+  if (srcType.isF16() || srcType.isBF16()) {
+    if (dstType.isInteger(32)) {
+      if (saturation != pto::Saturation::Enable)
+        return op->emitOpError()
+               << "fp16/bf16-to-integer conversion requires saturation enable";
+      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+        return op->emitOpError()
+               << "fp16/bf16-to-integer conversion supports rounding r/a/f/c/z";
+      return success();
+    }
+    if (dstType.isF32() || dstType.isF16() || dstType.isBF16()) {
+      if (rounding == pto::Rounding::O || rounding == pto::Rounding::H)
+        return op->emitOpError()
+               << "fp16/bf16-to-floating conversion supports rounding r/a/f/c/z";
+      return success();
+    }
+  }
+
+  return op->emitOpError() << "unsupported conversion type pair";
+}
+
+static bool isSupportedAtomicScalarType(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type))
+    return intType.getWidth() == 32 || intType.getWidth() == 64;
+  return type.isF16() || type.isBF16() || type.isF32() ||
+         isVector2F16OrBF16Type(type);
+}
+
+static LogicalResult verifyAtomicCommon(Operation *op, Value ptr, Type valueType,
+                                        Type resultType, bool bitwise,
+                                        Attribute signednessAttr) {
+  if (!isSupportedAtomicScalarType(valueType))
+    return op->emitOpError()
+           << "requires i32, i64, f16, bf16, f32, vector<2xf16> or "
+              "vector<2xbf16> atomic value type";
+  if (resultType != valueType)
+    return op->emitOpError()
+           << "requires atomic result type to match value type";
+
+  auto ptrTy = dyn_cast<PtrType>(ptr.getType());
+  if (!ptrTy)
+    return op->emitOpError() << "requires !pto.ptr pointer operand";
+  if (ptrTy.getElementType() != valueType)
+    return op->emitOpError()
+           << "requires atomic value type to match pointer element type";
+
+  AddressSpace addressSpace = ptrTy.getMemorySpace().getAddressSpace();
+  if (addressSpace != AddressSpace::GM && addressSpace != AddressSpace::VEC)
+    return op->emitOpError() << "requires GM or UB pointer";
+  if (addressSpace == AddressSpace::VEC && valueType.isInteger(64))
+    return op->emitOpError() << "does not support i64 UB-space atomics";
+
+  auto intType = dyn_cast<IntegerType>(valueType);
+  if (bitwise) {
+    if (!intType)
+      return op->emitOpError() << "requires integer type for bitwise atomics";
+    if (addressSpace == AddressSpace::VEC && intType.getWidth() == 64)
+      return op->emitOpError() << "does not support i64 UB-space bitwise atomics";
+  }
+
+  if (signednessAttr && !intType)
+    return op->emitOpError()
+           << "does not accept signedness for floating-point atomics";
+  if (isVector2F16OrBF16Type(valueType)) {
+    if (!isInsideSimtEntry(op))
+      return op->emitOpError()
+             << "requires packed atomics to be inside a pto.simt_entry "
+                "function on beta.1";
+    if (!op->getResult(0).use_empty())
+      return op->emitOpError()
+             << "does not support using the old value result for packed "
+                "atomics on beta.1; leave the result unused";
+  }
+  return success();
+}
+
+static LogicalResult verifyLdgStgAccess(Operation *op, Type ptrType,
+                                        Type valueType) {
+  auto ptrTy = dyn_cast<PtrType>(ptrType);
+  if (!ptrTy)
+    return op->emitOpError() << "requires !pto.ptr operand";
+  if (ptrTy.getMemorySpace().getAddressSpace() != AddressSpace::GM)
+    return op->emitOpError() << "requires GM pointer";
+
+  if (auto intType = dyn_cast<IntegerType>(valueType)) {
+    unsigned width = intType.getWidth();
+    if (width == 8 || width == 16 || width == 32 || width == 64)
+      return success();
+  }
+  if (valueType.isF16() || valueType.isBF16() || valueType.isF32() ||
+      valueType.isF64())
+    return success();
+
+  return op->emitOpError()
+         << "currently supports 8/16/32/64-bit integer and "
+            "f16/bf16/f32/f64 value type";
+}
+
 LogicalResult PTOLoadOp::verify() {
-  return verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                     getValue().getType(), "load");
+  if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
+                                         getValue().getType(), "load")))
+    return failure();
+  return success();
 }
 
 LogicalResult PTOStoreOp::verify() {
-  return verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
-                                     getValue().getType(), "store");
+  if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
+                                         getValue().getType(), "store")))
+    return failure();
+  return success();
+}
+
+LogicalResult PTOLdgOp::verify() {
+  if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
+                                         getValue().getType(), "ldg")))
+    return failure();
+  return verifyLdgStgAccess(getOperation(), getPtr().getType(),
+                            getValue().getType());
+}
+
+LogicalResult PTOStgOp::verify() {
+  if (failed(verifyVPTOScalarAccessTypes(getOperation(), getPtr().getType(),
+                                         getValue().getType(), "stg")))
+    return failure();
+  return verifyLdgStgAccess(getOperation(), getPtr().getType(),
+                            getValue().getType());
+}
+
+LogicalResult ShuffleIdxOp::verify() {
+  return verifyShuffleSemanticControl(getOperation(), getIndex().getType(),
+                                      getWidthAttr(), "index");
+}
+
+LogicalResult ShuffleUpOp::verify() {
+  return verifyShuffleSemanticControl(getOperation(), getOffset().getType(),
+                                      getWidthAttr(), "offset");
+}
+
+LogicalResult ShuffleDownOp::verify() {
+  return verifyShuffleSemanticControl(getOperation(), getOffset().getType(),
+                                      getWidthAttr(), "offset");
+}
+
+LogicalResult ShuffleBflyOp::verify() {
+  return verifyShuffleSemanticControl(getOperation(), getMask().getType(),
+                                      getWidthAttr(), "mask");
+}
+
+LogicalResult ReduxAddOp::verify() {
+  return verifyReduxSemanticType(getOperation(), getValue().getType(),
+                                  getSignednessAttr(), /*requireSignedness=*/false);
+}
+
+LogicalResult ReduxMaxOp::verify() {
+  return verifyReduxSemanticType(getOperation(), getValue().getType(),
+                                  getSignednessAttr(), /*requireSignedness=*/true);
+}
+
+LogicalResult ReduxMinOp::verify() {
+  return verifyReduxSemanticType(getOperation(), getValue().getType(),
+                                  getSignednessAttr(), /*requireSignedness=*/true);
+}
+
+LogicalResult MulhiOp::verify() {
+  if (!getResult().getType().isInteger(32) &&
+      !getResult().getType().isInteger(64))
+    return emitOpError() << "requires i32 or i64 result type";
+  return success();
+}
+
+LogicalResult MulI32ToI64Op::verify() { return success(); }
+
+LogicalResult AtomicCasOp::verify() {
+  if (getCompare().getType() != getValue().getType())
+    return emitOpError() << "requires compare and value types to match";
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/false,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicExchOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/false,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicAddOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/false,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicSubOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/false,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicMinOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/false,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicMaxOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/false,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicAndOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/true,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicOrOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/true,
+                            getSignednessAttr());
+}
+
+LogicalResult AtomicXorOp::verify() {
+  return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
+                            getOld().getType(), /*bitwise=*/true,
+                            getSignednessAttr());
+}
+
+LogicalResult ConvertOp::verify() {
+  return verifyConvertControls(getOperation(), getSrc().getType(),
+                               getDst().getType(), getRounding(),
+                               getSaturation(), getSignednessAttr());
 }
 
 void PTOLoadOp::getEffects(
@@ -141,6 +630,73 @@ void PTOStoreOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   effects.emplace_back(MemoryEffects::Write::get(), &getPtrMutable());
+}
+
+void PTOLdgOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getPtrMutable());
+}
+
+void PTOStgOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), &getPtrMutable());
+}
+
+template <typename OpTy>
+static void getAtomicEffects(
+    OpTy op,
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &op.getPtrMutable());
+  effects.emplace_back(MemoryEffects::Write::get(), &op.getPtrMutable());
+}
+
+void AtomicCasOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicExchOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicAddOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicSubOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicMinOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicMaxOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicAndOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicOrOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
+}
+void AtomicXorOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  getAtomicEffects(*this, effects);
 }
 
 static LogicalResult verifyNotNestedInVecScope(Operation *op,

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -1058,12 +1058,6 @@ static bool isSupportedPostMode(StringRef mode) {
   return mode == "NO_POST_UPDATE" || mode == "POST_UPDATE";
 }
 
-static std::optional<StringRef> getOptionalPostModeAttr(Operation *op) {
-  if (auto mode = op->getAttrOfType<StringAttr>("mode"))
-    return mode.getValue();
-  return std::nullopt;
-}
-
 static unsigned getIntOrFloatBitWidth(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type))
     return intType.getWidth();
@@ -3947,25 +3941,12 @@ static LogicalResult verifyVldsCommon(LoadOp op) {
 LogicalResult VldsOp::verify() {
   if (failed(verifyVldsCommon(*this)))
     return failure();
-  if (std::optional<StringRef> mode = getOptionalPostModeAttr(getOperation());
-      mode && !isSupportedPostMode(*mode))
-    return emitOpError("requires mode to be POST_UPDATE or NO_POST_UPDATE");
+  if (Value updatedBase = getUpdatedBase()) {
+    if (updatedBase.getType() != getSource().getType())
+      return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
-void VldsPostOp::getEffects(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects) {
-  effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable());
-}
-
-LogicalResult VldsPostOp::verify() {
-  if (failed(verifyVldsCommon(*this)))
-    return failure();
-  if (getUpdatedSource().getType() != getSource().getType())
-    return emitOpError("requires updated source result to match source type");
-  return success();
-}
-
 void VldasOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
@@ -5323,27 +5304,11 @@ static LogicalResult verifyVstsCommon(StoreOp op) {
 LogicalResult VstsOp::verify() {
   if (failed(verifyVstsCommon(*this)))
     return failure();
-  if (std::optional<StringRef> mode = getOptionalPostModeAttr(getOperation());
-      mode && !isSupportedPostMode(*mode))
-    return emitOpError("requires mode to be POST_UPDATE or NO_POST_UPDATE");
+  if (getUpdatedBase() &&
+      getUpdatedBase().getType() != getDestination().getType())
+    return emitOpError("requires updated base result to match base type");
   return success();
 }
-void VstsPostOp::getEffects(
-    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
-        &effects) {
-  effects.emplace_back(MemoryEffects::Read::get(), &getValueMutable());
-  effects.emplace_back(MemoryEffects::Write::get(), &getDestinationMutable());
-}
-
-LogicalResult VstsPostOp::verify() {
-  if (failed(verifyVstsCommon(*this)))
-    return failure();
-  if (getUpdatedDestination().getType() != getDestination().getType())
-    return emitOpError(
-        "requires updated destination result to match destination type");
-  return success();
-}
-
 void Vstsx2Op::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
@@ -5484,6 +5449,9 @@ LogicalResult VsstbOp::verify() {
     return emitOpError("requires block_stride to be i16");
   if (!getRepeatStride().getType().isSignlessInteger(16))
     return emitOpError("requires repeat_stride to be i16");
+  if (getUpdatedBase() &&
+      getUpdatedBase().getType() != getDestination().getType())
+    return emitOpError("requires updated base result to match base type");
   return success();
 }
 

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -24,6 +24,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -136,6 +137,46 @@ static bool isSupportedReduxValueType(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type))
     return intType.getWidth() == 32;
   return type.isF16() || type.isF32();
+}
+
+LogicalResult SimtLaunchOp::verify() {
+  if (auto parentFunc = (*this)->getParentOfType<func::FuncOp>()) {
+    if (parentFunc->hasAttr(pto::kPTOSimtEntryAttrName)) {
+      return emitOpError()
+             << "must not appear inside a function marked with '"
+             << pto::kPTOSimtEntryAttrName
+             << "'; launch the SIMT entry from an outer non-simt function";
+    }
+  }
+
+  func::FuncOp callee =
+      SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this, getCalleeAttr());
+  if (!callee)
+    return emitOpError() << "'" << getCalleeAttr().getValue()
+                         << "' does not reference a valid function";
+
+  if (!callee->hasAttr(pto::kPTOSimtEntryAttrName)) {
+    return emitOpError() << "callee '" << getCalleeAttr().getValue()
+                         << "' must be marked with '"
+                         << pto::kPTOSimtEntryAttrName << "'";
+  }
+
+  FunctionType calleeType = callee.getFunctionType();
+  if (!calleeType.getResults().empty())
+    return emitOpError("requires a callee with no results");
+
+  if (calleeType.getNumInputs() != getArgs().size())
+    return emitOpError("incorrect number of operands for callee");
+
+  for (auto [index, argType, operand] :
+       llvm::enumerate(calleeType.getInputs(), getArgs())) {
+    if (argType != operand.getType()) {
+      return emitOpError("operand type mismatch: expected operand type ")
+             << argType << ", but provided " << operand.getType()
+             << " for operand number " << index;
+    }
+  }
+  return success();
 }
 
 static LogicalResult verifyShuffleSemanticControl(Operation *op,

--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -248,8 +248,9 @@ static std::string stringifyMemorySpace(pto::AddressSpace space) {
     return "acc";
   case pto::AddressSpace::BIAS:
     return "bias";
-  case pto::AddressSpace::VEC:
   case pto::AddressSpace::SCALING:
+    return "scaling";
+  case pto::AddressSpace::VEC:
   case pto::AddressSpace::Zero:
     return "ub";
   }

--- a/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
@@ -199,8 +199,8 @@ public:
             CopyCbufToUbufOp, CopyUbufToCbufOp>(op))
       return VPTOBufferAddressFamily::Copy;
 
-    if (isa<VldsPostOp, VstsPostOp, VldasOp, VldusOp, PstuOp, VstusOp, VsturOp,
-            MadOp, MadMxOp, CopyGmToCbufOp, LoadCbufToCaOp,
+    if (isa<VldasOp, VldusOp, PstuOp, VstusOp, VsturOp, MadOp, MadMxOp,
+            CopyGmToCbufOp, LoadCbufToCaOp,
             LoadCbufToCbOp, CopyMatrixCcToGmOp>(op))
       return VPTOBufferAddressFamily::PtrOnly;
 
@@ -323,8 +323,6 @@ private:
     Value value;
     if (auto vsts = dyn_cast<VstsOp>(op))
       value = vsts.getValue();
-    else if (auto vstsPost = dyn_cast<VstsPostOp>(op))
-      value = vstsPost.getValue();
     else
       return std::nullopt;
 
@@ -450,8 +448,7 @@ private:
 
   template <typename OpTy>
   static LogicalResult validateValueMaskVectorConsumer(OpTy op) {
-    if constexpr (std::is_same_v<OpTy, VstsOp> ||
-                  std::is_same_v<OpTy, VstsPostOp>) {
+    if constexpr (std::is_same_v<OpTy, VstsOp>) {
       if (std::optional<VPTOMaskGranularity> expected =
               inferVstsMaskGranularityOverride(op.getOperation())) {
         auto actual =
@@ -487,10 +484,6 @@ private:
 
     if (auto vsts = dyn_cast<VstsOp>(op)) {
       emitForStore(vsts);
-      return;
-    }
-    if (auto vstsPost = dyn_cast<VstsPostOp>(op)) {
-      emitForStore(vstsPost);
       return;
     }
   }
@@ -711,7 +704,7 @@ private:
         .Case<Vgather2BcOp, VsldbOp>([](auto concreteOp) {
           return validateResultMaskVectorConsumer(concreteOp);
         })
-        .Case<VstsOp, VstsPostOp, VsstbOp>([](auto concreteOp) {
+        .Case<VstsOp, VsstbOp>([](auto concreteOp) {
           return validateValueMaskVectorConsumer(concreteOp);
         })
         .Case<Vstsx2Op>([](Vstsx2Op concreteOp) {

--- a/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
@@ -48,6 +48,130 @@ LogicalResult validateVPTOEmissionIR(ModuleOp module,
 
 namespace detail {
 
+static Operation *getFirstNonConstantLikeOp(Block *block) {
+  if (!block)
+    return nullptr;
+  for (Operation &op : *block) {
+    if (!op.hasTrait<OpTrait::ConstantLike>())
+      return &op;
+  }
+  return nullptr;
+}
+
+static bool isOpInRange(Operation *op, Operation *first, Operation *last) {
+  for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+    if (cur == op)
+      return true;
+    if (cur == last)
+      return false;
+  }
+  return false;
+}
+
+static constexpr int64_t kSimtKeepResumeSlotLimit = 123;
+
+static std::optional<unsigned> getSimtKeepResumeRegisterCount(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    if (intType.getWidth() <= 32)
+      return 1;
+    if (intType.getWidth() == 64)
+      return 2;
+    return std::nullopt;
+  }
+  if (type.isF16() || type.isBF16() || type.isF32())
+    return 1;
+  return std::nullopt;
+}
+
+template <typename OpT>
+static Type getSimtKeepResumeValueType(OpT op);
+
+template <>
+Type getSimtKeepResumeValueType(KeepOp op) {
+  return op.getPayload().getType();
+}
+
+template <>
+Type getSimtKeepResumeValueType(ResumeOp op) {
+  return op.getResult().getType();
+}
+
+template <typename OpT>
+static LogicalResult verifySimtKeepResumeSlotRange(OpT op) {
+  std::optional<unsigned> registerCount =
+      getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
+  if (!registerCount)
+    return success();
+  int64_t slot = op.getSlot();
+  if (slot < 0 || slot >= kSimtKeepResumeSlotLimit)
+    return op.emitOpError()
+           << "requires slot in range [0, "
+           << (kSimtKeepResumeSlotLimit - 1) << "]";
+  if (*registerCount == 2) {
+    if ((slot % 2) != 0)
+      return op.emitOpError()
+             << "requires an even slot for 64-bit keep/resume values";
+    if (slot + 1 >= kSimtKeepResumeSlotLimit)
+      return op.emitOpError()
+             << "requires slot in range [0, "
+             << (kSimtKeepResumeSlotLimit - 2)
+             << "] for 64-bit keep/resume values";
+  }
+  return success();
+}
+
+template <typename OpT>
+static bool overlapsEarlierSimtKeepResumeSlotUse(OpT op,
+                                                 SmallVectorImpl<int64_t> &used) {
+  std::optional<unsigned> registerCount =
+      getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
+  if (!registerCount)
+    return false;
+  int64_t slot = op.getSlot();
+  for (int64_t word = slot; word < slot + *registerCount; ++word) {
+    if (llvm::is_contained(used, word))
+      return true;
+  }
+  for (int64_t word = slot; word < slot + *registerCount; ++word)
+    used.push_back(word);
+  return false;
+}
+
+static LogicalResult verifyUniqueResumeGroupSlots(ResumeOp current,
+                                                  Operation *first) {
+  SmallVector<int64_t, 4> slots;
+  for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+    auto resume = dyn_cast<ResumeOp>(cur);
+    if (!resume)
+      break;
+    if (overlapsEarlierSimtKeepResumeSlotUse(resume, slots) &&
+        resume.getOperation() == current.getOperation())
+      return current.emitOpError()
+             << "duplicates an earlier slot " << resume.getSlot()
+             << " in the SIMT resume prologue group";
+  }
+  return success();
+}
+
+static LogicalResult verifyUniqueKeepGroupSlots(KeepOp current,
+                                                Operation *first,
+                                                Operation *last) {
+  SmallVector<int64_t, 4> slots;
+  for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+    auto keep = dyn_cast<KeepOp>(cur);
+    if (!keep)
+      break;
+    if (overlapsEarlierSimtKeepResumeSlotUse(keep, slots) &&
+        keep.getOperation() == current.getOperation())
+      return current.emitOpError()
+             << "duplicates an earlier slot " << keep.getSlot()
+             << " in the SIMT keep epilogue group";
+    if (cur == last)
+      break;
+  }
+  return success();
+}
+
 constexpr llvm::StringLiteral kAIVectorScopeAttrName =
     "llvm.loop.aivector_scope";
 
@@ -726,6 +850,43 @@ private:
 
   LogicalResult validateAuthoringFunctionSurface() {
     for (func::FuncOp func : helper.getFunctions()) {
+      auto validatePositiveI32FuncAttr =
+          [&](StringRef attrName, int64_t upperBound,
+              StringRef description) -> LogicalResult {
+        Attribute attr = func->getAttr(attrName);
+        if (!attr)
+          return success();
+
+        auto intAttr = dyn_cast<IntegerAttr>(attr);
+        if (!intAttr || !intAttr.getType().isSignlessInteger(32))
+          return func.emitError()
+                 << "'" << attrName
+                 << "' must be a signless i32 integer attribute";
+
+        if (intAttr.getInt() <= 0)
+          return func.emitError()
+                 << "'" << attrName << "' must be a positive integer, got "
+                 << intAttr.getInt();
+
+        if (intAttr.getInt() > upperBound)
+          return func.emitError()
+                 << "'" << attrName << "' must be in range [1, "
+                 << upperBound << "] for " << description;
+
+        if (!func->hasAttr(pto::kPTOSimtEntryAttrName))
+          return func.emitError()
+                 << "'" << attrName << "' is only allowed on functions marked '"
+                 << pto::kPTOSimtEntryAttrName << "'";
+
+        return success();
+      };
+
+      if (failed(validatePositiveI32FuncAttr(pto::kPTOSimtMaxThreadsAttrName,
+                                             2048, "SIMT max threads")) ||
+          failed(validatePositiveI32FuncAttr(pto::kPTOSimtMaxRegistersAttrName,
+                                             128, "SIMT max registers")))
+        return failure();
+
       if (!func->hasAttr(pto::kPTOSimtEntryAttrName))
         continue;
 
@@ -740,6 +901,89 @@ private:
       if (walkResult.wasInterrupted())
         return failure();
     }
+
+    WalkResult keepResumeWalk = helper.getModule().walk([&](Operation *op) {
+      if (!isa<KeepOp, ResumeOp, SyncthreadsOp>(op))
+        return WalkResult::advance();
+      func::FuncOp func = op->getParentOfType<func::FuncOp>();
+      if (!func || !func->hasAttr(pto::kPTOSimtEntryAttrName)) {
+        op->emitOpError()
+            << "must appear inside a function marked with '"
+            << pto::kPTOSimtEntryAttrName << "'";
+        return WalkResult::interrupt();
+      }
+      Block *block = op->getBlock();
+      if (auto resume = dyn_cast<ResumeOp>(op)) {
+        if (failed(verifySimtKeepResumeSlotRange(resume)))
+          return WalkResult::interrupt();
+        Operation *first = getFirstNonConstantLikeOp(block);
+        if (!first || !isa<ResumeOp>(first)) {
+          op->emitOpError()
+              << "must be in the contiguous SIMT resume prologue group after "
+                 "constant-like operations";
+          return WalkResult::interrupt();
+        }
+        bool found = false;
+        for (Operation *cur = first; cur; cur = cur->getNextNode()) {
+          if (!isa<ResumeOp>(cur))
+            break;
+          if (cur == op) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          op->emitOpError()
+              << "must be in the contiguous SIMT resume prologue group after "
+                 "constant-like operations";
+          return WalkResult::interrupt();
+        }
+        if (failed(verifyUniqueResumeGroupSlots(resume, first)))
+          return WalkResult::interrupt();
+      }
+      if (auto keep = dyn_cast<KeepOp>(op)) {
+        if (failed(verifySimtKeepResumeSlotRange(keep)))
+          return WalkResult::interrupt();
+        Operation *terminator = block ? block->getTerminator() : nullptr;
+        if (!terminator || !isa<func::ReturnOp>(terminator)) {
+          op->emitOpError()
+              << "must be placed in the SIMT epilogue before func.return";
+          return WalkResult::interrupt();
+        }
+
+        Operation *cur = terminator->getPrevNode();
+        while (cur && isa<SyncthreadsOp>(cur))
+          cur = cur->getPrevNode();
+        Operation *lastKeep = cur;
+        if (!lastKeep || !isa<KeepOp>(lastKeep)) {
+          op->emitOpError()
+              << "must be placed in the SIMT epilogue before func.return; "
+                 "only 'pto.syncthreads' may appear between the final "
+                 "'pto.keep' group and func.return";
+          return WalkResult::interrupt();
+        }
+
+        Operation *firstKeep = lastKeep;
+        while (Operation *prev = firstKeep->getPrevNode()) {
+          if (!isa<KeepOp>(prev))
+            break;
+          firstKeep = prev;
+        }
+        if (!isOpInRange(op, firstKeep, lastKeep)) {
+          op->emitOpError()
+              << "must be in the contiguous SIMT keep epilogue group "
+                 "immediately before optional 'pto.syncthreads' and "
+                 "func.return";
+          return WalkResult::interrupt();
+        }
+        if (failed(verifyUniqueKeepGroupSlots(keep, firstKeep, lastKeep))) {
+          return WalkResult::interrupt();
+        }
+      }
+      return WalkResult::advance();
+    });
+    if (keepResumeWalk.wasInterrupted())
+      return failure();
     return success();
   }
 

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -1631,6 +1631,21 @@ struct ExpandAccStoreUbPattern : public OpRewritePattern<pto::MteL0cUbOp> {
   }
 };
 
+struct ExpandSimtLaunchPattern : public OpRewritePattern<pto::SimtLaunchOp> {
+  using OpRewritePattern<pto::SimtLaunchOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(pto::SimtLaunchOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    rewriter.create<pto::StoreVfSimtInfoOp>(loc, op.getDimZ(), op.getDimY(),
+                                            op.getDimX());
+    rewriter.create<func::CallOp>(loc, op.getCalleeAttr(), TypeRange{},
+                                  op.getArgs());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct VPTOExpandWrapperOpsPass
     : public pto::impl::VPTOExpandWrapperOpsBase<VPTOExpandWrapperOpsPass> {
   using pto::impl::VPTOExpandWrapperOpsBase<
@@ -1656,6 +1671,7 @@ struct VPTOExpandWrapperOpsPass
                  ExpandRightLoadMxPattern, ExpandAccStorePattern,
                  ExpandAccStoreGmPattern,
                  ExpandAccStoreUbPattern,
+                 ExpandSimtLaunchPattern,
                  ExpandMadSemanticPattern<pto::MadOp>,
                  ExpandMadSemanticPattern<pto::MadAccOp>,
                  ExpandMadSemanticPattern<pto::MadBiasOp>,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -2561,6 +2561,10 @@ static StringRef buildVsstbCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.vsstb").getValue();
 }
 
+static StringRef buildVsstbPostCallee(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.vsstb.post").getValue();
+}
+
 static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
                                                 Type resultType) {
   std::string vec =
@@ -5160,7 +5164,8 @@ public:
   LogicalResult
   matchAndRewrite(pto::VldsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type elementType = getElementTypeFromVectorLike(op.getResult().getType());
+    Type ptoResultType = op.getResult().getType();
+    Type elementType = getElementTypeFromVectorLike(ptoResultType);
     if (!elementType)
       return rewriter.notifyMatchFailure(op, "unsupported vlds element type");
     auto offsetBytes = convertElementOffsetToBytes(op, adaptor.getOffset(), elementType);
@@ -5174,77 +5179,30 @@ public:
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
       return rewriter.notifyMatchFailure(op, "failed to convert vlds result types");
 
-    FailureOr<StringRef> calleeName = buildVldsCallee(op.getContext(),
-                                                      op.getResult().getType());
-    if (failed(calleeName))
-      return rewriter.notifyMatchFailure(op, "unsupported vlds signature");
-
-    Value distValue = rewriter.create<arith::ConstantOp>(
-        op.getLoc(), rewriter.getI32IntegerAttr(*dist));
-    Value zero = rewriter.create<arith::ConstantOp>(op.getLoc(),
-                                                    rewriter.getI32IntegerAttr(0));
-    SmallVector<Value> args{adaptor.getSource(), *offsetBytes, distValue, zero};
-    auto funcType = rewriter.getFunctionType(
-        TypeRange{adaptor.getSource().getType(), rewriter.getI32Type(),
-                  rewriter.getI32Type(), rewriter.getI32Type()},
-        resultTypes);
-    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
-                                              resultTypes, args);
-    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
-    rewriter.replaceOp(op, call.getResults());
-    return success();
-  }
-
-private:
-  LoweringState &state;
-};
-
-class LowerVldsPostOpPattern final
-    : public OpConversionPattern<pto::VldsPostOp> {
-public:
-  explicit LowerVldsPostOpPattern(TypeConverter &typeConverter,
-                                  MLIRContext *context, LoweringState &state)
-      : OpConversionPattern<pto::VldsPostOp>(typeConverter, context),
-        state(state) {}
-
-  LogicalResult
-  matchAndRewrite(pto::VldsPostOp op, pto::VldsPostOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    Type elementType = getElementTypeFromVectorLike(op.getResult().getType());
-    if (!elementType)
-      return rewriter.notifyMatchFailure(op, "unsupported vlds_post element type");
-
-    auto offsetBytes = convertElementOffsetToBytes(op, adaptor.getOffset(), elementType);
-    auto basePtr = dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource().getType());
-    auto dist =
-        parseLoadDistImmediate(op.getDist().value_or("NORM"), elementType);
-    if (failed(offsetBytes) || !basePtr || !dist) {
-      return rewriter.notifyMatchFailure(op,
-                                         "failed to materialize vlds_post operands");
-    }
-
-    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
-    Type updatedSourceType =
-        this->getTypeConverter()->convertType(op.getUpdatedSource().getType());
-    if (!resultType || !updatedSourceType || updatedSourceType != adaptor.getSource().getType()) {
-      return rewriter.notifyMatchFailure(op,
-                                         "failed to convert vlds_post result types");
+    bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
+    if (usePostIntrinsic) {
+      if (resultTypes.size() != 2 || resultTypes[1] != adaptor.getSource().getType())
+        return rewriter.notifyMatchFailure(op,
+                                           "unsupported vlds post-update results");
+    } else if (resultTypes.size() != 1) {
+      return rewriter.notifyMatchFailure(op, "unsupported vlds result count");
     }
 
     FailureOr<StringRef> calleeName =
-        buildVldsPostCallee(op.getContext(), op.getResult().getType());
+        usePostIntrinsic ? buildVldsPostCallee(op.getContext(), ptoResultType)
+                         : buildVldsCallee(op.getContext(), ptoResultType);
     if (failed(calleeName))
-      return rewriter.notifyMatchFailure(op, "unsupported vlds_post signature");
+      return rewriter.notifyMatchFailure(op, "unsupported vlds signature");
 
     Value distValue = getI32Constant(rewriter, op.getLoc(), *dist);
-    Value postValue = getI32Constant(rewriter, op.getLoc(), 1);
+    Value postValue = getI32Constant(rewriter, op.getLoc(), usePostIntrinsic ? 1 : 0);
     SmallVector<Value> args{adaptor.getSource(), *offsetBytes, distValue, postValue};
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getSource().getType(), (*offsetBytes).getType(),
                   distValue.getType(), postValue.getType()},
-        TypeRange{resultType, updatedSourceType});
-    auto call = rewriter.create<func::CallOp>(
-        op.getLoc(), *calleeName, TypeRange{resultType, updatedSourceType}, args);
+        resultTypes);
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
+                                              resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     rewriter.replaceOp(op, call.getResults());
     return success();
@@ -5498,24 +5456,45 @@ public:
       return rewriter.notifyMatchFailure(op, "failed to materialize vsts operands");
 
     FailureOr<StringRef> calleeName =
-        buildVstsCallee(op.getContext(), op.getValue().getType());
+        op.getUpdatedBase()
+            ? buildVstsPostCallee(op.getContext(), op.getValue().getType())
+            : buildVstsCallee(op.getContext(), op.getValue().getType());
     if (failed(calleeName))
       return rewriter.notifyMatchFailure(op, "unsupported vsts signature");
+
+    SmallVector<Type> resultTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes)))
+      return rewriter.notifyMatchFailure(op, "failed to convert vsts result types");
+    bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
+    if (usePostIntrinsic) {
+      if (resultTypes.size() != 1 ||
+          resultTypes[0] != adaptor.getDestination().getType())
+        return rewriter.notifyMatchFailure(op,
+                                           "unsupported vsts post-update result");
+    } else if (!resultTypes.empty()) {
+      return rewriter.notifyMatchFailure(op, "unsupported vsts result count");
+    }
 
     Value distValue = rewriter.create<arith::ConstantOp>(
         op.getLoc(), rewriter.getI32IntegerAttr(*dist));
     Value zero = rewriter.create<arith::ConstantOp>(op.getLoc(),
-                                                    rewriter.getI32IntegerAttr(0));
+                                                    rewriter.getI32IntegerAttr(
+                                                        usePostIntrinsic ? 1 : 0));
     SmallVector<Value> args{adaptor.getValue(), adaptor.getDestination(),
                             *offsetBytes, distValue, zero, adaptor.getMask()};
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getValue().getType(), adaptor.getDestination().getType(),
                   rewriter.getI32Type(), rewriter.getI32Type(),
                   rewriter.getI32Type(), adaptor.getMask().getType()},
-        TypeRange{});
-    rewriter.create<func::CallOp>(op.getLoc(), *calleeName, TypeRange{}, args);
+        resultTypes);
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
+                                              resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
-    rewriter.eraseOp(op);
+    if (usePostIntrinsic)
+      rewriter.replaceOp(op, call.getResults());
+    else
+      rewriter.eraseOp(op);
     return success();
   }
 
@@ -5539,75 +5518,39 @@ public:
     if (!basePtr || !packedStride)
       return rewriter.notifyMatchFailure(op, "failed to materialize vsstb operands");
 
-    StringRef calleeName = buildVsstbCallee(op.getContext());
-    Value zeroValue = getI32Constant(rewriter, op.getLoc(), 0);
+    SmallVector<Type> resultTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes)))
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to convert vsstb result types");
+    bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
+    if (usePostIntrinsic) {
+      if (resultTypes.size() != 1 ||
+          resultTypes[0] != adaptor.getDestination().getType())
+        return rewriter.notifyMatchFailure(
+            op, "unsupported vsstb post-update result");
+    } else if (!resultTypes.empty()) {
+      return rewriter.notifyMatchFailure(op, "unsupported vsstb result count");
+    }
+
+    StringRef calleeName = usePostIntrinsic
+                               ? buildVsstbPostCallee(op.getContext())
+                               : buildVsstbCallee(op.getContext());
+    Value zeroValue = getI32Constant(rewriter, op.getLoc(), usePostIntrinsic ? 1 : 0);
     SmallVector<Value> args{adaptor.getValue(), adaptor.getDestination(),
                             packedStride, zeroValue, adaptor.getMask()};
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getValue().getType(), adaptor.getDestination().getType(),
                   packedStride.getType(), zeroValue.getType(),
                   adaptor.getMask().getType()},
-        TypeRange{});
-    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{}, args);
+        resultTypes);
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), calleeName,
+                                              resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
-    rewriter.eraseOp(op);
-    return success();
-  }
-
-private:
-  LoweringState &state;
-};
-
-class LowerVstsPostOpPattern final
-    : public OpConversionPattern<pto::VstsPostOp> {
-public:
-  explicit LowerVstsPostOpPattern(TypeConverter &typeConverter,
-                                  MLIRContext *context, LoweringState &state)
-      : OpConversionPattern<pto::VstsPostOp>(typeConverter, context),
-        state(state) {}
-
-  LogicalResult
-  matchAndRewrite(pto::VstsPostOp op, pto::VstsPostOp::Adaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    Type elementType = getElementTypeFromVectorLike(op.getValue().getType());
-    if (!elementType)
-      return rewriter.notifyMatchFailure(op, "unsupported vsts_post element type");
-
-    auto offsetBytes = convertElementOffsetToBytes(op, adaptor.getOffset(), elementType);
-    auto basePtr =
-        dyn_cast<LLVM::LLVMPointerType>(adaptor.getDestination().getType());
-    auto dist =
-        parseStoreDistImmediate(op.getDist().value_or(""), elementType);
-    if (failed(offsetBytes) || !basePtr || !dist) {
-      return rewriter.notifyMatchFailure(op,
-                                         "failed to materialize vsts_post operands");
-    }
-
-    Type updatedDestinationType =
-        this->getTypeConverter()->convertType(op.getUpdatedDestination().getType());
-    if (!updatedDestinationType || updatedDestinationType != adaptor.getDestination().getType()) {
-      return rewriter.notifyMatchFailure(op,
-                                         "failed to convert vsts_post result type");
-    }
-
-    FailureOr<StringRef> calleeName =
-        buildVstsPostCallee(op.getContext(), op.getValue().getType());
-    if (failed(calleeName))
-      return rewriter.notifyMatchFailure(op, "unsupported vsts_post signature");
-
-    Value distValue = getI32Constant(rewriter, op.getLoc(), *dist);
-    Value postValue = getI32Constant(rewriter, op.getLoc(), 1);
-    SmallVector<Value> args{adaptor.getValue(), adaptor.getDestination(), *offsetBytes,
-                            distValue, postValue, adaptor.getMask()};
-    auto funcType = rewriter.getFunctionType(
-        TypeRange{adaptor.getValue().getType(), adaptor.getDestination().getType(),
-                  (*offsetBytes).getType(), distValue.getType(), postValue.getType(),
-                  adaptor.getMask().getType()},
-        TypeRange{updatedDestinationType});
-    auto call = rewriter.create<func::CallOp>(
-        op.getLoc(), *calleeName, TypeRange{updatedDestinationType}, args);
-    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
-    rewriter.replaceOp(op, call.getResults());
+    if (usePostIntrinsic)
+      rewriter.replaceOp(op, call.getResults());
+    else
+      rewriter.eraseOp(op);
     return success();
   }
 
@@ -7485,12 +7428,11 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockIdxOp>,
                LowerRuntimeQueryOpPattern<pto::GetBlockNumOp>,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockNumOp>,
-               LowerVldsOpPattern, LowerVldsPostOpPattern,
-               LowerVldsx2OpPattern, LowerVsldbOpPattern,
+               LowerVldsOpPattern, LowerVldsx2OpPattern, LowerVsldbOpPattern,
                LowerVldasOpPattern, LowerInitAlignOpPattern,
                LowerVldusOpPattern, LowerSprclrOpPattern,
                LowerVstsOpPattern, LowerVsstbOpPattern,
-               LowerVstsPostOpPattern, LowerVstsx2OpPattern,
+               LowerVstsx2OpPattern,
                LowerVstarOpPattern, LowerVstasOpPattern,
                LowerVgather2OpPattern, LowerVgather2BcOpPattern,
                LowerVgatherbOpPattern, LowerVscatterOpPattern,
@@ -7555,10 +7497,9 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::StoreVfSimtInfoOp,
                       pto::SetMovPadValOp, pto::SetQuantPreOp>();
   target.addIllegalOp<pto::Sbitset0Op, pto::Sbitset1Op>();
-  target.addIllegalOp<pto::VldsOp, pto::VldsPostOp, pto::Vldsx2Op,
-                      pto::VsldbOp, pto::VldasOp, pto::InitAlignOp,
-                      pto::VldusOp, pto::SprclrOp, pto::VstsOp,
-                      pto::VsstbOp, pto::VstsPostOp, pto::Vstsx2Op,
+  target.addIllegalOp<pto::VldsOp, pto::Vldsx2Op, pto::VsldbOp,
+                      pto::VldasOp, pto::InitAlignOp, pto::VldusOp,
+                      pto::SprclrOp, pto::VstsOp, pto::VsstbOp, pto::Vstsx2Op,
                       pto::VstarOp, pto::VstasOp, pto::Vgather2Op,
                       pto::Vgather2BcOp, pto::VgatherbOp, pto::VscatterOp,
                       pto::PldiOp, pto::PldsOp, pto::PstiOp, pto::PstsOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -38,10 +38,13 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/GlobalVariable.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 namespace mlir::pto {
 
@@ -51,7 +54,8 @@ LogicalResult applyQueriedTargetAttrs(ModuleOp module,
                                       llvm::raw_ostream &diagOS);
 LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
                                           llvm::raw_ostream &diagOS);
-void attachHIVMKernelAnnotations(llvm::Module &llvmModule);
+void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
+                                 ModuleOp sourceModule);
 
 namespace {
 
@@ -69,7 +73,36 @@ static std::string getElementTypeFragment(Type type);
 static Type getElementTypeFromVectorLike(Type type);
 static std::optional<int64_t> getElementCountFromVectorLike(Type type);
 
-static Type normalizeIntegerTypeForLLVMLowering(Type type, Builder &builder) {
+static Type getLowPrecisionLLVMType(Type type, MLIRContext *context) {
+  if (pto::isPTOHiFloat8Type(type))
+    return LLVM::LLVMHiFloat8Type::get(context);
+  if (isa<pto::F4E1M2x2Type>(type))
+    return LLVM::LLVMFloat4E1M2x2Type::get(context);
+  if (isa<pto::F4E2M1x2Type>(type))
+    return LLVM::LLVMFloat4E2M1x2Type::get(context);
+  if (type.isFloat8E4M3() || type.isFloat8E4M3FN() ||
+      type.isFloat8E4M3FNUZ() || type.isFloat8E4M3B11FNUZ())
+    return LLVM::LLVMFloat8E4M3Type::get(context);
+  if (type.isFloat8E5M2() || type.isFloat8E5M2FNUZ())
+    return LLVM::LLVMFloat8E5M2Type::get(context);
+  return {};
+}
+
+static Type getLLVMCompatibleVectorType(ArrayRef<int64_t> shape,
+                                        Type elementType,
+                                        ArrayRef<bool> scalableDims = {}) {
+  if (shape.size() == 1 && !elementType.isIntOrIndexOrFloat())
+    return LLVM::LLVMFixedVectorType::get(elementType, shape.front());
+  return VectorType::get(shape, elementType, scalableDims);
+}
+
+static Type normalizePayloadTypeForLLVMLowering(Type type, Builder &builder) {
+  if (pto::isPTOHiFloat8x2Type(type))
+    return LLVM::LLVMFixedVectorType::get(
+        LLVM::LLVMHiFloat8Type::get(builder.getContext()), 2);
+  if (Type lowpType = getLowPrecisionLLVMType(type, builder.getContext()))
+    return lowpType;
+
   if (auto intType = dyn_cast<IntegerType>(type)) {
     if (!intType.isSignless())
       return builder.getIntegerType(intType.getWidth());
@@ -78,11 +111,11 @@ static Type normalizeIntegerTypeForLLVMLowering(Type type, Builder &builder) {
 
   if (auto vecType = dyn_cast<VectorType>(type)) {
     Type normalizedElement =
-        normalizeIntegerTypeForLLVMLowering(vecType.getElementType(), builder);
+        normalizePayloadTypeForLLVMLowering(vecType.getElementType(), builder);
     if (normalizedElement == vecType.getElementType())
       return type;
-    return VectorType::get(vecType.getShape(), normalizedElement,
-                           vecType.getScalableDims());
+    return getLLVMCompatibleVectorType(vecType.getShape(), normalizedElement,
+                                       vecType.getScalableDims());
   }
 
   return type;
@@ -91,8 +124,9 @@ static Type normalizeIntegerTypeForLLVMLowering(Type type, Builder &builder) {
 static Type convertVPTOType(Type type, Builder &builder) {
   if (auto vecType = dyn_cast<pto::VRegType>(type)) {
     Type elementType =
-        normalizeIntegerTypeForLLVMLowering(vecType.getElementType(), builder);
-    return VectorType::get({vecType.getElementCount()}, elementType);
+        normalizePayloadTypeForLLVMLowering(vecType.getElementType(), builder);
+    return getLLVMCompatibleVectorType({vecType.getElementCount()},
+                                       elementType);
   }
   if (isa<pto::MaskType>(type))
     return VectorType::get({256}, builder.getI1Type());
@@ -103,7 +137,38 @@ static Type convertVPTOType(Type type, Builder &builder) {
         builder.getContext(),
         static_cast<unsigned>(ptrType.getMemorySpace().getAddressSpace()));
   }
-  return normalizeIntegerTypeForLLVMLowering(type, builder);
+  return normalizePayloadTypeForLLVMLowering(type, builder);
+}
+
+static unsigned getNaturalByteAlignment(Type type) {
+  if (auto vecType = dyn_cast<VectorType>(type)) {
+    unsigned elemAlign = getNaturalByteAlignment(vecType.getElementType());
+    if (!elemAlign)
+      return 0;
+    int64_t elems = 1;
+    for (int64_t dim : vecType.getShape())
+      elems *= dim;
+    return elemAlign * static_cast<unsigned>(elems);
+  }
+  if (auto vecType = dyn_cast<LLVM::LLVMFixedVectorType>(type)) {
+    unsigned elemAlign = getNaturalByteAlignment(vecType.getElementType());
+    if (!elemAlign)
+      return 0;
+    return elemAlign * vecType.getNumElements();
+  }
+  if (auto intType = dyn_cast<IntegerType>(type))
+    return llvm::divideCeil(unsigned(intType.getWidth()), 8u);
+  if (pto::isPTOHiFloat8x2Type(type))
+    return 2;
+  if (pto::isPTOLowPrecisionType(type))
+    return 1;
+  if (type.isF16() || type.isBF16())
+    return 2;
+  if (type.isF32())
+    return 4;
+  if (type.isF64())
+    return 8;
+  return 0;
 }
 
 static bool hasVPTOConvertibleType(Type type) {
@@ -360,6 +425,54 @@ static std::string getElementTypeFragment(Type type) {
   return {};
 }
 
+static std::string getLowPrecisionElementFragment(Type type) {
+  if (pto::isPTOHiFloat8x2Type(type))
+    return "hif8x2";
+  if (pto::isPTOHiFloat8Type(type))
+    return "hif8";
+  if (isa<pto::F4E1M2x2Type>(type))
+    return "f4e1m2x2";
+  if (isa<pto::F4E2M1x2Type>(type))
+    return "f4e2m1x2";
+  if (type.isFloat8E4M3() || type.isFloat8E4M3FN() ||
+      type.isFloat8E4M3FNUZ() || type.isFloat8E4M3B11FNUZ())
+    return "f8e4m3";
+  if (type.isFloat8E5M2() || type.isFloat8E5M2FNUZ())
+    return "f8e5m2";
+  return {};
+}
+
+static std::string getAtomicElementTypeFragment(Type type,
+                                                Attribute signednessAttr) {
+  if (auto vecType = dyn_cast<VectorType>(type)) {
+    if (vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+      return {};
+    if (vecType.getElementType().isF16())
+      return "f16x2";
+    if (vecType.getElementType().isBF16())
+      return "bf16x2";
+    return {};
+  }
+  if (type.isF16())
+    return "fp16";
+  if (type.isBF16())
+    return "bf16";
+  if (type.isF32())
+    return "fp32";
+  auto intType = dyn_cast<IntegerType>(type);
+  if (!intType)
+    return {};
+  if (intType.getWidth() != 32 && intType.getWidth() != 64)
+    return {};
+  if (signednessAttr) {
+    auto signedness = cast<pto::SignednessAttr>(signednessAttr).getValue();
+    return std::string(signedness == pto::Signedness::Unsigned ? "u" : "s") +
+           std::to_string(intType.getWidth());
+  }
+  return std::string(intType.isUnsigned() ? "u" : "s") +
+         std::to_string(intType.getWidth());
+}
+
 static std::string getL0LoadElementFragment(Type type) {
   std::string elem = getElementTypeFragment(type);
   if (!elem.empty())
@@ -390,10 +503,54 @@ static std::string getVbrScalarFragment(Type type) {
   return {};
 }
 
+static std::string getShuffleIntrinsicTypeFragment(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    switch (intType.getWidth()) {
+    case 32:
+      return "i32";
+    case 64:
+      return "i64";
+    default:
+      return {};
+    }
+  }
+  if (type.isF16())
+    return "f16";
+  if (type.isF32())
+    return "f32";
+  if (auto vecType = dyn_cast<VectorType>(type)) {
+    if (vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
+        vecType.getElementType().isF16())
+      return "v2f16";
+  }
+  return {};
+}
+
+static std::string getReduxIntrinsicTypeFragment(Type type,
+                                                 Attribute signednessAttr) {
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    if (intType.getWidth() != 32)
+      return {};
+    bool isUnsigned = false;
+    if (signednessAttr) {
+      isUnsigned = cast<pto::SignednessAttr>(signednessAttr).getValue() ==
+                   pto::Signedness::Unsigned;
+    }
+    return isUnsigned ? "u32" : "s32";
+  }
+  if (type.isF16())
+    return "f16";
+  if (type.isF32())
+    return "f32";
+  return {};
+}
+
 static Type getElementTypeFromVectorLike(Type type) {
   if (auto vecType = dyn_cast<pto::VRegType>(type))
     return vecType.getElementType();
   if (auto vecType = dyn_cast<VectorType>(type))
+    return vecType.getElementType();
+  if (auto vecType = dyn_cast<LLVM::LLVMFixedVectorType>(type))
     return vecType.getElementType();
   return {};
 }
@@ -406,6 +563,8 @@ static std::optional<int64_t> getElementCountFromVectorLike(Type type) {
       return std::nullopt;
     return vecType.getShape().front();
   }
+  if (auto vecType = dyn_cast<LLVM::LLVMFixedVectorType>(type))
+    return vecType.getNumElements();
   return std::nullopt;
 }
 
@@ -1914,6 +2073,96 @@ StringRef buildRuntimeQueryCallee<pto::GetTidZOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.get.TID.Z").getValue();
 }
 
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetBlockDimXOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.BLOCK.DIM.X").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetBlockDimYOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.BLOCK.DIM.Y").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetBlockDimZOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.BLOCK.DIM.Z").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetGridDimXOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.GRID.DIM.X").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetGridDimYOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.GRID.DIM.Y").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetGridDimZOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.GRID.DIM.Z").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetBlockIdxXOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.BLOCK.IDX.X").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetBlockIdxYOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.BLOCK.IDX.Y").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetBlockIdxZOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.BLOCK.IDX.Z").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetVecCoreIdOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.tpe.get.VECCOREID").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetLaneIdOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.laneID").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetClock32Op>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.CLOCK32").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetClock64Op>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.CLOCK64").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetLaneMaskEqOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.LANEMASK.EQ").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetLaneMaskLeOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.LANEMASK.LE").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetLaneMaskLtOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.LANEMASK.LT").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetLaneMaskGeOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.LANEMASK.GE").getValue();
+}
+
+template <>
+StringRef buildRuntimeQueryCallee<pto::GetLaneMaskGtOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.get.LANEMASK.GT").getValue();
+}
+
 static StringRef buildSprclrCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.sprclr").getValue();
 }
@@ -1930,12 +2179,47 @@ static StringRef buildStoreVfSimtInfoCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.store.vfsimt.info").getValue();
 }
 
+static StringRef buildSyncthreadsCallee(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.sync.workitems").getValue();
+}
+
+static StringRef buildThreadfenceCallee(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.fence.workitems").getValue();
+}
+
+static StringRef buildThreadfenceBlockCallee(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.fenceblock.workitems").getValue();
+}
+
 static StringRef buildVstarCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.vstar").getValue();
 }
 
 static StringRef buildVstasCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.vstas").getValue();
+}
+
+template <typename VoteOp>
+static StringRef buildVoteCallee(MLIRContext *context);
+
+template <>
+StringRef buildVoteCallee<pto::VoteAllOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.vote.all").getValue();
+}
+
+template <>
+StringRef buildVoteCallee<pto::VoteAnyOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.vote.any").getValue();
+}
+
+template <>
+StringRef buildVoteCallee<pto::VoteUniOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.vote.uni").getValue();
+}
+
+template <>
+StringRef buildVoteCallee<pto::VoteBallotOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.vote.ballot").getValue();
 }
 
 template <typename BinaryOp>
@@ -1949,6 +2233,458 @@ StringRef buildBinaryI64PureCallee<pto::Sbitset0Op>(MLIRContext *context) {
 template <>
 StringRef buildBinaryI64PureCallee<pto::Sbitset1Op>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.SBITSET1").getValue();
+}
+
+template <typename ShuffleOp>
+static FailureOr<StringRef> buildShuffleCallee(MLIRContext *context,
+                                               Type valueType);
+
+template <>
+FailureOr<StringRef> buildShuffleCallee<pto::ShuffleIdxOp>(MLIRContext *context,
+                                                           Type valueType) {
+  std::string elem = getShuffleIntrinsicTypeFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.shfl.idx." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildShuffleCallee<pto::ShuffleUpOp>(MLIRContext *context,
+                                                          Type valueType) {
+  std::string elem = getShuffleIntrinsicTypeFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.shfl.up." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildShuffleCallee<pto::ShuffleDownOp>(MLIRContext *context,
+                                                            Type valueType) {
+  std::string elem = getShuffleIntrinsicTypeFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.shfl.down." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildShuffleCallee<pto::ShuffleBflyOp>(MLIRContext *context,
+                                                            Type valueType) {
+  std::string elem = getShuffleIntrinsicTypeFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.shfl.bfly." + elem).getValue();
+}
+
+static Value buildShuffleControlValue(OpBuilder &builder, Location loc,
+                                      Value controlValue, int64_t widthValue,
+                                      unsigned controlMask) {
+  Value lowBits = builder.create<arith::AndIOp>(
+      loc, controlValue, getI32Constant(builder, loc, 0x1f));
+  Value encodedWidth =
+      getI32Constant(builder, loc, static_cast<uint32_t>(32 - widthValue) << 16);
+  Value encodedMask =
+      getI32Constant(builder, loc, static_cast<uint32_t>(controlMask) << 8);
+  Value highBits = builder.create<arith::OrIOp>(loc, encodedWidth, encodedMask);
+  return builder.create<arith::OrIOp>(loc, highBits, lowBits);
+}
+
+template <typename ReduxOp>
+static FailureOr<StringRef> buildReduxCallee(MLIRContext *context,
+                                             Type valueType,
+                                             Attribute signednessAttr);
+
+template <>
+FailureOr<StringRef> buildReduxCallee<pto::ReduxAddOp>(MLIRContext *context,
+                                                      Type valueType,
+                                                      Attribute signednessAttr) {
+  std::string elem = getReduxIntrinsicTypeFragment(valueType, signednessAttr);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.redux.add." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildReduxCallee<pto::ReduxMaxOp>(MLIRContext *context,
+                                                      Type valueType,
+                                                      Attribute signednessAttr) {
+  std::string elem = getReduxIntrinsicTypeFragment(valueType, signednessAttr);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.redux.max." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildReduxCallee<pto::ReduxMinOp>(MLIRContext *context,
+                                                      Type valueType,
+                                                      Attribute signednessAttr) {
+  std::string elem = getReduxIntrinsicTypeFragment(valueType, signednessAttr);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.redux.min." + elem).getValue();
+}
+
+template <typename AtomicOp>
+static FailureOr<StringRef> buildAtomicCallee(MLIRContext *context,
+                                              Type ptrType, Type valueType,
+                                              Attribute signednessAttr);
+
+static FailureOr<StringRef> buildAtomicCalleeName(MLIRContext *context,
+                                                  Type ptrType, Type valueType,
+                                                  Attribute signednessAttr,
+                                                  StringRef opName) {
+  std::string elem = getAtomicElementTypeFragment(valueType, signednessAttr);
+  if (elem.empty())
+    return failure();
+  auto ptrTy = dyn_cast<pto::PtrType>(ptrType);
+  if (!ptrTy)
+    return failure();
+
+  StringRef space;
+  switch (ptrTy.getMemorySpace().getAddressSpace()) {
+  case pto::AddressSpace::GM:
+    space = "G";
+    break;
+  case pto::AddressSpace::VEC:
+    if (valueType.isInteger(64))
+      return failure();
+    space = "S";
+    break;
+  default:
+    return failure();
+  }
+
+  return StringAttr::get(context, "llvm.hivm.atom." + opName.str() + "." +
+                                      space.str() + "." + elem)
+      .getValue();
+}
+
+#define PTO_BUILD_ATOMIC_CALLEE(OP, NAME)                                      \
+  template <>                                                                  \
+  [[maybe_unused]] FailureOr<StringRef> buildAtomicCallee<pto::OP>(            \
+      MLIRContext *context, Type ptrType, Type valueType,                      \
+      Attribute signednessAttr) {                                              \
+    return buildAtomicCalleeName(context, ptrType, valueType, signednessAttr,  \
+                                 NAME);                                        \
+  }
+
+PTO_BUILD_ATOMIC_CALLEE(AtomicCasOp, "CAS")
+PTO_BUILD_ATOMIC_CALLEE(AtomicExchOp, "EXCH")
+PTO_BUILD_ATOMIC_CALLEE(AtomicAddOp, "ADD")
+PTO_BUILD_ATOMIC_CALLEE(AtomicSubOp, "SUB")
+PTO_BUILD_ATOMIC_CALLEE(AtomicMinOp, "MIN")
+PTO_BUILD_ATOMIC_CALLEE(AtomicMaxOp, "MAX")
+PTO_BUILD_ATOMIC_CALLEE(AtomicAndOp, "AND")
+PTO_BUILD_ATOMIC_CALLEE(AtomicOrOp, "OR")
+PTO_BUILD_ATOMIC_CALLEE(AtomicXorOp, "XOR")
+
+#undef PTO_BUILD_ATOMIC_CALLEE
+
+static FailureOr<StringRef> buildL1CacheLoadCallee(MLIRContext *context,
+                                                   Type resultType,
+                                                   pto::L1Cache l1cache) {
+  std::string elem;
+  if (auto intType = dyn_cast<IntegerType>(resultType)) {
+    if (intType.getWidth() == 8)
+      elem = "s8";
+    else if (intType.getWidth() == 16)
+      elem = "s16";
+    else if (intType.getWidth() == 32)
+      elem = "s32";
+    else if (intType.getWidth() == 64)
+      elem = "s64";
+  } else if (resultType.isF16() || resultType.isBF16()) {
+    elem = "s16";
+  } else if (resultType.isF32()) {
+    elem = "s32";
+  } else if (resultType.isF64()) {
+    elem = "s64";
+  } else if (pto::isPTOFloat8Type(resultType) ||
+             pto::isPTOHiFloat8Type(resultType)) {
+    elem = "s8";
+  }
+  if (elem.empty())
+    return failure();
+  StringRef l1cacheName =
+      l1cache == pto::L1Cache::Cache ? "cache" : "uncache";
+  return StringAttr::get(context,
+                         "llvm.hivm.ldg." + l1cacheName.str() + "." + elem)
+      .getValue();
+}
+
+static FailureOr<StringRef> buildL1CacheStoreCallee(MLIRContext *context,
+                                                    Type valueType,
+                                                    pto::L1Cache l1cache) {
+  std::string elem;
+  if (auto intType = dyn_cast<IntegerType>(valueType)) {
+    if (intType.getWidth() == 8)
+      elem = "b8";
+    else if (intType.getWidth() == 16)
+      elem = "b16";
+    else if (intType.getWidth() == 32)
+      elem = "b32";
+    else if (intType.getWidth() == 64)
+      elem = "b64";
+  } else if (valueType.isF16() || valueType.isBF16()) {
+    elem = "b16";
+  } else if (valueType.isF32()) {
+    elem = "b32";
+  } else if (valueType.isF64()) {
+    elem = "b64";
+  } else if (pto::isPTOFloat8Type(valueType) ||
+             pto::isPTOHiFloat8Type(valueType)) {
+    elem = "b8";
+  }
+  if (elem.empty())
+    return failure();
+  StringRef l1cacheName =
+      l1cache == pto::L1Cache::Cache ? "cache" : "uncache";
+  return StringAttr::get(context,
+                         "llvm.hivm.stg." + l1cacheName.str() + "." + elem)
+      .getValue();
+}
+
+template <typename ScalarOp>
+static StringRef buildScalarIntrinsicCallee(MLIRContext *context);
+
+template <>
+StringRef buildScalarIntrinsicCallee<pto::PrmtOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.prmt").getValue();
+}
+
+static FailureOr<StringRef>
+buildMulhiCallee(MLIRContext *context, Type resultType,
+                 pto::Signedness signedness) {
+  if (resultType.isInteger(32)) {
+    return StringAttr::get(
+               context, signedness == pto::Signedness::Unsigned
+                            ? "llvm.hivm.mulhi.ui"
+                            : "llvm.hivm.mulhi.i")
+        .getValue();
+  }
+  if (resultType.isInteger(64) && signedness == pto::Signedness::Unsigned)
+    return StringAttr::get(context, "llvm.hivm.mul64hi.ui").getValue();
+  return failure();
+}
+
+static FailureOr<StringRef>
+buildMulI32ToI64Callee(MLIRContext *context, pto::Signedness signedness) {
+  return StringAttr::get(
+             context, signedness == pto::Signedness::Unsigned
+                          ? "llvm.hivm.mul.i32toi64.ui"
+                          : "llvm.hivm.mul.i32toi64.i")
+      .getValue();
+}
+
+static std::string getScalarFloatBuiltinFragment(Type type) {
+  if (type.isF32())
+    return "f32";
+  if (type.isF16())
+    return "f16";
+  if (type.isBF16())
+    return "bf16";
+  return {};
+}
+
+static std::string getLLVMFloatBuiltinFragment(Type type) {
+  std::string scalar = getScalarFloatBuiltinFragment(type);
+  if (!scalar.empty())
+    return scalar;
+
+  auto vecType = dyn_cast<VectorType>(type);
+  if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+    return {};
+  Type elementType = vecType.getElementType();
+  if (elementType.isF16())
+    return "v2f16";
+  if (elementType.isBF16())
+    return "v2bf16";
+  return {};
+}
+
+static std::string getHIVMFloatBuiltinFragment(Type type) {
+  std::string scalar = getScalarFloatBuiltinFragment(type);
+  if (!scalar.empty())
+    return scalar;
+
+  auto vecType = dyn_cast<VectorType>(type);
+  if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+    return {};
+  Type elementType = vecType.getElementType();
+  if (elementType.isF16())
+    return "f16x2";
+  if (elementType.isBF16())
+    return "bf16x2";
+  return {};
+}
+
+static FailureOr<StringRef> buildSqrtCallee(MLIRContext *context, Type valueType) {
+  std::string elem = getLLVMFloatBuiltinFragment(valueType);
+  if (elem != "f32" && elem != "f16" && elem != "v2f16")
+    return failure();
+  return StringAttr::get(context, "llvm.sqrt." + elem).getValue();
+}
+
+static std::string getScalarHIVMFloatShortFragment(Type type) {
+  if (type.isF32())
+    return "f";
+  if (type.isF16())
+    return "h";
+  if (type.isBF16())
+    return "y";
+  return {};
+}
+
+template <typename UnaryOp>
+static FailureOr<StringRef> buildUnaryScalarMathCallee(MLIRContext *context,
+                                                       Type valueType);
+
+template <>
+FailureOr<StringRef> buildUnaryScalarMathCallee<pto::AbsFOp>(MLIRContext *context,
+                                                             Type valueType) {
+  std::string elem = getLLVMFloatBuiltinFragment(valueType);
+  if (elem != "f32" && elem != "v2f16" && elem != "v2bf16")
+    return failure();
+  return StringAttr::get(context, "llvm.fabs." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildUnaryScalarMathCallee<pto::ExpOp>(MLIRContext *context,
+                                                            Type valueType) {
+  std::string elem = getLLVMFloatBuiltinFragment(valueType);
+  if (elem != "f32" && elem != "f16" && elem != "v2f16")
+    return failure();
+  return StringAttr::get(context, "llvm.exp." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildUnaryScalarMathCallee<pto::LogOp>(MLIRContext *context,
+                                                            Type valueType) {
+  std::string elem = getLLVMFloatBuiltinFragment(valueType);
+  if (elem != "f32" && elem != "f16" && elem != "v2f16")
+    return failure();
+  return StringAttr::get(context, "llvm.log." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildUnaryScalarMathCallee<pto::CeilOp>(MLIRContext *context,
+                                                             Type valueType) {
+  std::string elem = getScalarHIVMFloatShortFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.ceil." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildUnaryScalarMathCallee<pto::FloorOp>(MLIRContext *context,
+                                                              Type valueType) {
+  std::string elem = getScalarHIVMFloatShortFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.floor." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildUnaryScalarMathCallee<pto::RintOp>(MLIRContext *context,
+                                                             Type valueType) {
+  std::string elem = getScalarHIVMFloatShortFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.rint." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildUnaryScalarMathCallee<pto::RoundOp>(MLIRContext *context,
+                                                              Type valueType) {
+  std::string elem = getScalarHIVMFloatShortFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.round." + elem).getValue();
+}
+
+template <typename BinaryOp>
+static FailureOr<StringRef> buildBinaryScalarMathCallee(MLIRContext *context,
+                                                        Type valueType);
+
+template <>
+FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMinOp>(MLIRContext *context,
+                                                              Type valueType) {
+  std::string elem = getLLVMFloatBuiltinFragment(valueType);
+  if (elem != "f32" && elem != "bf16" && elem != "v2f16" &&
+      elem != "v2bf16")
+    return failure();
+  return StringAttr::get(context, "llvm.minnum." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMaxOp>(MLIRContext *context,
+                                                              Type valueType) {
+  std::string elem = getLLVMFloatBuiltinFragment(valueType);
+  if (elem != "f32" && elem != "bf16" && elem != "v2f16" &&
+      elem != "v2bf16")
+    return failure();
+  return StringAttr::get(context, "llvm.maxnum." + elem).getValue();
+}
+
+template <>
+FailureOr<StringRef> buildBinaryScalarMathCallee<pto::PowOp>(MLIRContext *context,
+                                                             Type valueType) {
+  std::string elem = getLLVMFloatBuiltinFragment(valueType);
+  if (elem != "f32" && elem != "f16" && elem != "v2f16")
+    return failure();
+  return StringAttr::get(context, "llvm.pow." + elem).getValue();
+}
+
+static FailureOr<StringRef> buildFmaCallee(MLIRContext *context, Type valueType) {
+  std::string elem = getHIVMFloatBuiltinFragment(valueType);
+  if (elem.empty())
+    return failure();
+  return StringAttr::get(context, "llvm.hivm.ffma." + elem + ".rrr").getValue();
+}
+
+static std::string getConvertScalarFragment(Type type,
+                                            Attribute signednessAttr) {
+  if (auto vecType = dyn_cast<VectorType>(type)) {
+    if (vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
+      return {};
+    Type elementType = vecType.getElementType();
+    if (std::string elem = getLowPrecisionElementFragment(elementType);
+        !elem.empty() && !pto::isPTOFloat4PackedType(elementType))
+      return elem + "x2";
+    if (elementType.isF32())
+      return "f32x2";
+    if (elementType.isF16())
+      return "f16x2";
+    if (elementType.isBF16())
+      return "bf16x2";
+    return {};
+  }
+  if (type.isF32())
+    return "fp32";
+  if (type.isF16())
+    return "fp16";
+  if (type.isBF16())
+    return "bf16";
+  if (std::string elem = getLowPrecisionElementFragment(type); !elem.empty())
+    return elem;
+  auto intType = dyn_cast<IntegerType>(type);
+  if (!intType || (intType.getWidth() != 32 && intType.getWidth() != 64) ||
+      !signednessAttr)
+    return {};
+  auto signedness = cast<pto::SignednessAttr>(signednessAttr).getValue();
+  return std::string(signedness == pto::Signedness::Unsigned ? "u" : "s") +
+         std::to_string(intType.getWidth());
+}
+
+static FailureOr<StringRef> buildConvertCallee(MLIRContext *context,
+                                               Type srcType, Type dstType,
+                                               Attribute signednessAttr) {
+  std::string src = getConvertScalarFragment(srcType, signednessAttr);
+  std::string dst = getConvertScalarFragment(dstType, signednessAttr);
+  if (src.empty() || dst.empty())
+    return failure();
+  return StringAttr::get(context,
+                         "llvm.hivm." + src + ".to." + dst)
+      .getValue();
 }
 
 static FailureOr<StringRef> buildVldsPostCallee(MLIRContext *context,
@@ -4676,7 +5412,7 @@ public:
     Value result = call.getResult(0);
     if (intrinsicResultType != resultType)
       result = rewriter.create<LLVM::BitcastOp>(op.getLoc(), resultType, result);
-    rewriter.replaceOp(op, result);
+    rewriter.replaceOp(op, ValueRange{result});
     return success();
   }
 
@@ -6621,6 +7357,354 @@ private:
   LoweringState &state;
 };
 
+template <typename FenceOp>
+static StringRef buildSimtFenceCallee(MLIRContext *context);
+
+template <>
+StringRef buildSimtFenceCallee<pto::SyncthreadsOp>(MLIRContext *context) {
+  return buildSyncthreadsCallee(context);
+}
+
+template <>
+StringRef buildSimtFenceCallee<pto::ThreadfenceOp>(MLIRContext *context) {
+  return buildThreadfenceCallee(context);
+}
+
+template <>
+StringRef buildSimtFenceCallee<pto::ThreadfenceBlockOp>(MLIRContext *context) {
+  return buildThreadfenceBlockCallee(context);
+}
+
+template <typename FenceOp>
+class LowerSimtFenceOpPattern final : public OpConversionPattern<FenceOp> {
+public:
+  explicit LowerSimtFenceOpPattern(TypeConverter &typeConverter,
+                                   MLIRContext *context,
+                                   LoweringState &state)
+      : OpConversionPattern<FenceOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(FenceOp op, typename FenceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    FunctionType funcType = rewriter.getFunctionType({}, {});
+    StringRef calleeName = buildSimtFenceCallee<FenceOp>(op.getContext());
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
+                                  ValueRange{});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+static std::string buildRepeatedInlineAsmConstraints(StringRef constraint,
+                                                     size_t count) {
+  std::string result;
+  llvm::raw_string_ostream os(result);
+  for (size_t i = 0; i < count; ++i) {
+    if (i != 0)
+      os << ",";
+    os << constraint;
+  }
+  return os.str();
+}
+
+static std::string appendSimtKeepResumeClobbers(std::string constraints,
+                                                ArrayRef<std::pair<int64_t, unsigned>> physicalRegs) {
+  llvm::raw_string_ostream os(constraints);
+  // The asm body names fixed SIMT R registers directly. Model those registers
+  // as clobbers so LLVM does not allocate a different operand/result into a
+  // slot that another keep/resume line reads or overwrites in the same asm.
+  for (auto [reg, registerCount] : physicalRegs) {
+    for (unsigned offset = 0; offset < registerCount; ++offset)
+      os << ",~{R" << (reg + offset) << "}";
+  }
+  return os.str();
+}
+
+template <typename OpT>
+static SmallVector<OpT, 4> collectConsecutiveOps(OpT first) {
+  SmallVector<OpT, 4> ops;
+  for (Operation *cur = first.getOperation(); cur; cur = cur->getNextNode()) {
+    auto typed = dyn_cast<OpT>(cur);
+    if (!typed)
+      break;
+    ops.push_back(typed);
+  }
+  return ops;
+}
+
+static bool hasPreviousSameOp(Operation *op) {
+  Operation *prev = op->getPrevNode();
+  return prev && prev->getName() == op->getName();
+}
+
+static std::optional<unsigned> getSimtKeepResumeBitWidth(Type type) {
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    if (intType.getWidth() <= 64)
+      return intType.getWidth();
+    return std::nullopt;
+  }
+  if (type.isF16() || type.isBF16())
+    return 16;
+  if (type.isF32())
+    return 32;
+  return std::nullopt;
+}
+
+static Value packSimtKeepResumePayload(Location loc, Value value,
+                                       ConversionPatternRewriter &rewriter) {
+  Type type = value.getType();
+  std::optional<unsigned> width = getSimtKeepResumeBitWidth(type);
+  if (!width)
+    return {};
+
+  Type intType = rewriter.getIntegerType(*width);
+  Value bits = value;
+  if (!isa<IntegerType>(type))
+    bits = rewriter.create<LLVM::BitcastOp>(loc, intType, value);
+  else if (bits.getType() != intType)
+    bits = rewriter.create<LLVM::BitcastOp>(loc, intType, bits);
+  if (*width < 32)
+    return rewriter.create<LLVM::ZExtOp>(loc, rewriter.getI32Type(), bits);
+  if (*width == 32 && bits.getType() != rewriter.getI32Type())
+    return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI32Type(), bits);
+  return bits;
+}
+
+static Value unpackSimtKeepResumePayload(Location loc, Value value,
+                                         Type resultType,
+                                         ConversionPatternRewriter &rewriter) {
+  std::optional<unsigned> width = getSimtKeepResumeBitWidth(resultType);
+  if (!width)
+    return {};
+
+  Type intType = rewriter.getIntegerType(*width);
+  Value bits = value;
+  if (*width < 32)
+    bits = rewriter.create<LLVM::TruncOp>(loc, intType, bits);
+  else if (bits.getType() != intType)
+    bits = rewriter.create<LLVM::BitcastOp>(loc, intType, bits);
+
+  if (isa<IntegerType>(resultType)) {
+    if (bits.getType() == resultType)
+      return bits;
+    return rewriter.create<LLVM::BitcastOp>(loc, resultType, bits);
+  }
+  return rewriter.create<LLVM::BitcastOp>(loc, resultType, bits);
+}
+
+static unsigned getSimtKeepResumeRegisterCount(Type type) {
+  std::optional<unsigned> width = getSimtKeepResumeBitWidth(type);
+  return width && *width > 32 ? 2 : 1;
+}
+
+static FailureOr<SmallVector<int64_t, 4>> computeSimtKeepResumePhysicalRegs(
+    ArrayRef<std::pair<int64_t, unsigned>> logicalSlots) {
+  SmallVector<int64_t, 4> physicalRegs(logicalSlots.size(), -1);
+  for (auto [index, logicalSlot] : llvm::enumerate(logicalSlots)) {
+    auto [slot, registerCount] = logicalSlot;
+    if (slot < 0 || slot >= 123)
+      return failure();
+    if (registerCount == 2 && ((slot % 2) != 0 || slot + 1 >= 123))
+      return failure();
+    // Slots are user-assigned storage words, not dense ordinals in the current
+    // keep/resume group. This keeps a consumer that resumes only a subset of
+    // slots from changing where the remaining slots are read from.
+    int64_t reg = 4 + slot;
+    if (reg + static_cast<int64_t>(registerCount) - 1 > 126)
+      return failure();
+    physicalRegs[index] = reg;
+  }
+  return physicalRegs;
+}
+
+static bool isValidSimtKeepResumeSlot(int64_t slot, unsigned registerCount) {
+  if (slot < 0 || slot >= 123)
+    return false;
+  if (registerCount == 2 && ((slot % 2) != 0 || slot + 1 >= 123))
+    return false;
+  return true;
+}
+
+class LowerKeepOpPattern final : public OpConversionPattern<pto::KeepOp> {
+public:
+  explicit LowerKeepOpPattern(TypeConverter &typeConverter, MLIRContext *context,
+                              LoweringState &state)
+      : OpConversionPattern<pto::KeepOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::KeepOp op, pto::KeepOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    if (hasPreviousSameOp(op.getOperation()))
+      return rewriter.notifyMatchFailure(
+          op, "only the first keep in a contiguous group is lowered");
+
+    SmallVector<pto::KeepOp, 4> keepOps = collectConsecutiveOps(op);
+    SmallVector<Value, 4> payloads;
+    SmallVector<std::pair<int64_t, unsigned>, 4> logicalSlots;
+    std::string asmString;
+    llvm::raw_string_ostream asmOS(asmString);
+    for (pto::KeepOp keep : keepOps) {
+      Value payload = rewriter.getRemappedValue(keep.getPayload());
+      if (!payload)
+        return rewriter.notifyMatchFailure(keep, "payload is not remapped");
+      payload = packSimtKeepResumePayload(keep.getLoc(), payload, rewriter);
+      if (!payload)
+        return rewriter.notifyMatchFailure(
+            keep, "expected integer scalar up to 64 bits or f16/bf16/f32");
+      int64_t slot = keep.getSlot();
+      unsigned registerCount = getSimtKeepResumeRegisterCount(payload.getType());
+      if (!isValidSimtKeepResumeSlot(slot, registerCount))
+        return rewriter.notifyMatchFailure(keep,
+                                           "slot must be in range [0, 122] and 64-bit slots must be even");
+      logicalSlots.push_back({slot, registerCount});
+      payloads.push_back(payload);
+    }
+    FailureOr<SmallVector<int64_t, 4>> physicalRegs =
+        computeSimtKeepResumePhysicalRegs(logicalSlots);
+    if (failed(physicalRegs))
+      return rewriter.notifyMatchFailure(
+          op, "keep slots must map to valid non-overlapping SIMT registers");
+
+    SmallVector<std::pair<int64_t, unsigned>, 4> clobbers;
+    for (auto [index, keep] : llvm::enumerate(keepOps)) {
+      (void)keep;
+      if (index != 0)
+        asmOS << "\n";
+      if (logicalSlots[index].second == 2)
+        asmOS << "IMAD.WIDE.u32 R" << (*physicalRegs)[index]
+              << ", RZ, RZ, $" << index << " wait:0b0000000 stall:1";
+      else
+        asmOS << "MOV R" << (*physicalRegs)[index] << ", $" << index
+              << " wait:0b0000000 stall:1";
+      clobbers.push_back({(*physicalRegs)[index], logicalSlots[index].second});
+    }
+    asmOS.flush();
+
+    rewriter.setInsertionPoint(op);
+    rewriter.create<LLVM::InlineAsmOp>(
+        op.getLoc(), TypeRange{}, payloads, asmString,
+        appendSimtKeepResumeClobbers(
+            buildRepeatedInlineAsmConstraints("R", payloads.size()), clobbers),
+        true, false,
+        LLVM::AsmDialectAttr::get(op.getContext(), LLVM::AsmDialect::AD_ATT),
+        ArrayAttr{});
+    for (pto::KeepOp keep : llvm::reverse(keepOps))
+      rewriter.eraseOp(keep);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerResumeOpPattern final : public OpConversionPattern<pto::ResumeOp> {
+public:
+  explicit LowerResumeOpPattern(TypeConverter &typeConverter,
+                                MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::ResumeOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::ResumeOp op, pto::ResumeOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    if (hasPreviousSameOp(op.getOperation()))
+      return rewriter.notifyMatchFailure(
+          op, "only the first resume in a contiguous group is lowered");
+
+    SmallVector<pto::ResumeOp, 4> resumeOps = collectConsecutiveOps(op);
+    SmallVector<std::pair<int64_t, unsigned>, 4> logicalSlots;
+    SmallVector<Type, 4> asmResultTypes;
+    std::string asmString;
+    llvm::raw_string_ostream asmOS(asmString);
+    for (pto::ResumeOp resume : resumeOps) {
+      Type resultType = getTypeConverter()->convertType(resume.getType());
+      if (!resultType || !getSimtKeepResumeBitWidth(resultType))
+        return rewriter.notifyMatchFailure(
+            resume, "expected integer scalar up to 64 bits or f16/bf16/f32");
+      int64_t slot = resume.getSlot();
+      unsigned registerCount = getSimtKeepResumeRegisterCount(resultType);
+      if (!isValidSimtKeepResumeSlot(slot, registerCount))
+        return rewriter.notifyMatchFailure(resume,
+                                           "slot must be in range [0, 122] and 64-bit slots must be even");
+      logicalSlots.push_back({slot, registerCount});
+      asmResultTypes.push_back(rewriter.getIntegerType(
+          *getSimtKeepResumeBitWidth(resultType) > 32 ? 64 : 32));
+    }
+    FailureOr<SmallVector<int64_t, 4>> physicalRegs =
+        computeSimtKeepResumePhysicalRegs(logicalSlots);
+    if (failed(physicalRegs))
+      return rewriter.notifyMatchFailure(
+          op, "resume slots must map to valid non-overlapping SIMT registers");
+
+    SmallVector<std::pair<int64_t, unsigned>, 4> clobbers;
+    for (auto [index, resume] : llvm::enumerate(resumeOps)) {
+      (void)resume;
+      if (index != 0)
+        asmOS << "\n";
+      if (logicalSlots[index].second == 2)
+        asmOS << "IMAD.WIDE.u32 $" << index << ", RZ, RZ, R"
+              << (*physicalRegs)[index] << " wait:0b0000000 stall:1";
+      else
+        asmOS << "MOV $" << index << ", R" << (*physicalRegs)[index]
+              << " wait:0b0000000 stall:1";
+      clobbers.push_back({(*physicalRegs)[index], logicalSlots[index].second});
+    }
+    asmOS.flush();
+
+    Type asmResultType = asmResultTypes.front();
+    if (asmResultTypes.size() > 1) {
+      asmResultType =
+          LLVM::LLVMStructType::getLiteral(op.getContext(), asmResultTypes);
+    }
+    rewriter.setInsertionPoint(op);
+    auto asmOp = rewriter.create<LLVM::InlineAsmOp>(
+        op.getLoc(), TypeRange{asmResultType}, ValueRange{}, asmString,
+        appendSimtKeepResumeClobbers(
+            buildRepeatedInlineAsmConstraints("=R", resumeOps.size()), clobbers),
+        true, false,
+        LLVM::AsmDialectAttr::get(op.getContext(), LLVM::AsmDialect::AD_ATT),
+        ArrayAttr{});
+
+    if (resumeOps.size() == 1) {
+      Type resultType = getTypeConverter()->convertType(op.getType());
+      Value result = unpackSimtKeepResumePayload(op.getLoc(), asmOp.getRes(),
+                                                 resultType, rewriter);
+      if (!result)
+        return rewriter.notifyMatchFailure(op, "failed to unpack result");
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    rewriter.setInsertionPointAfter(asmOp);
+    SmallVector<Value, 4> results;
+    for (auto [index, resume] : llvm::enumerate(resumeOps)) {
+      auto extract = rewriter.create<LLVM::ExtractValueOp>(
+          resume.getLoc(), asmOp.getRes(),
+          ArrayRef<int64_t>{static_cast<int64_t>(index)});
+      Type resultType = getTypeConverter()->convertType(resume.getType());
+      Value result = unpackSimtKeepResumePayload(resume.getLoc(),
+                                                 extract.getRes(), resultType,
+                                                 rewriter);
+      if (!result)
+        return rewriter.notifyMatchFailure(resume, "failed to unpack result");
+      results.push_back(result);
+    }
+    for (auto [resume, result] : llvm::zip(resumeOps, results))
+      rewriter.replaceOp(resume, result);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 template <typename ConfigOp>
 class LowerNullaryConfigOpPattern final : public OpConversionPattern<ConfigOp> {
 public:
@@ -6924,6 +8008,558 @@ private:
   LoweringState &state;
 };
 
+template <typename VoteOp>
+class LowerVoteOpPattern final : public OpConversionPattern<VoteOp> {
+public:
+  explicit LowerVoteOpPattern(TypeConverter &typeConverter,
+                              MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<VoteOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(VoteOp op, typename VoteOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op, "failed to convert vote result type");
+
+    Type predType = this->getTypeConverter()->convertType(op.getPred().getType());
+    if (!predType || predType != rewriter.getI1Type())
+      return rewriter.notifyMatchFailure(op, "failed to convert vote predicate type");
+
+    StringRef calleeName = buildVoteCallee<VoteOp>(op.getContext());
+    auto funcType = rewriter.getFunctionType(TypeRange{predType}, TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), calleeName,
+                                              TypeRange{resultType},
+                                              ValueRange{adaptor.getPred()});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename ShuffleOp>
+class LowerShuffleOpPattern final : public OpConversionPattern<ShuffleOp> {
+public:
+  explicit LowerShuffleOpPattern(TypeConverter &typeConverter,
+                                 MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<ShuffleOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(ShuffleOp op, typename ShuffleOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op, "failed to convert shuffle result type");
+
+    Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
+    if (!valueType || valueType != resultType)
+      return rewriter.notifyMatchFailure(op, "unexpected converted shuffle operand type");
+
+    FailureOr<StringRef> calleeName =
+        buildShuffleCallee<ShuffleOp>(op.getContext(), op.getValue().getType());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported shuffle VPTO signature");
+
+    IntegerAttr widthAttr = op.getWidthAttr();
+    Value controlValue;
+    unsigned controlMask = 0;
+    if constexpr (std::is_same_v<ShuffleOp, pto::ShuffleIdxOp>) {
+      controlValue = adaptor.getIndex();
+      controlMask = 0x1f;
+    } else if constexpr (std::is_same_v<ShuffleOp, pto::ShuffleUpOp>) {
+      controlValue = adaptor.getOffset();
+      controlMask = 0;
+    } else if constexpr (std::is_same_v<ShuffleOp, pto::ShuffleDownOp>) {
+      controlValue = adaptor.getOffset();
+      controlMask = 0x1f;
+    } else if constexpr (std::is_same_v<ShuffleOp, pto::ShuffleBflyOp>) {
+      controlValue = adaptor.getMask();
+      controlMask = 0x1f;
+    }
+    if (!controlValue)
+      return rewriter.notifyMatchFailure(op, "missing shuffle control operand");
+
+    Value control = buildShuffleControlValue(
+        rewriter, op.getLoc(), controlValue, widthAttr.getInt(), controlMask);
+
+    Type i32Type = rewriter.getI32Type();
+    auto funcType = rewriter.getFunctionType(TypeRange{resultType, i32Type},
+                                             TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{resultType},
+        ValueRange{adaptor.getValue(), control});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename ReduxOp>
+class LowerReduxOpPattern final : public OpConversionPattern<ReduxOp> {
+public:
+  explicit LowerReduxOpPattern(TypeConverter &typeConverter,
+                               MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<ReduxOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(ReduxOp op, typename ReduxOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op, "failed to convert redux result type");
+
+    Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
+    if (!valueType || valueType != resultType)
+      return rewriter.notifyMatchFailure(op, "unexpected converted redux operand type");
+
+    FailureOr<StringRef> calleeName = buildReduxCallee<ReduxOp>(
+        op.getContext(), op.getValue().getType(), op.getSignednessAttr());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported redux VPTO signature");
+
+    auto funcType = rewriter.getFunctionType(TypeRange{resultType},
+                                             TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
+                                              TypeRange{resultType},
+                                              ValueRange{adaptor.getValue()});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename AtomicOp>
+class LowerAtomicBinaryOpPattern final : public OpConversionPattern<AtomicOp> {
+public:
+  explicit LowerAtomicBinaryOpPattern(TypeConverter &typeConverter,
+                                      MLIRContext *context,
+                                      LoweringState &state)
+      : OpConversionPattern<AtomicOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(AtomicOp op, typename AtomicOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getOld().getType());
+    Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
+    if (!resultType || !valueType || resultType != valueType)
+      return rewriter.notifyMatchFailure(op,
+                                         "unexpected atomic operand/result type");
+
+    Type ptrType = this->getTypeConverter()->convertType(op.getPtr().getType());
+    if (!ptrType)
+      return rewriter.notifyMatchFailure(op, "failed to convert atomic pointer type");
+
+    FailureOr<StringRef> calleeName = buildAtomicCallee<AtomicOp>(
+        op.getContext(), op.getPtr().getType(), op.getValue().getType(),
+        op.getSignednessAttr());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported atomic VPTO signature");
+
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{ptrType, valueType, rewriter.getI32Type()},
+        TypeRange{resultType});
+    Value modeValue = getI32Constant(
+        rewriter, op.getLoc(),
+        static_cast<uint64_t>(op.getL2cacheAttr()
+                                  ? op.getL2cacheAttr().getValue()
+                                  : pto::StL2Cache::NMFV));
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{resultType},
+        ValueRange{adaptor.getPtr(), adaptor.getValue(), modeValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerAtomicCasOpPattern final
+    : public OpConversionPattern<pto::AtomicCasOp> {
+public:
+  explicit LowerAtomicCasOpPattern(TypeConverter &typeConverter,
+                                   MLIRContext *context,
+                                   LoweringState &state)
+      : OpConversionPattern<pto::AtomicCasOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::AtomicCasOp op, pto::AtomicCasOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getOld().getType());
+    Type compareType =
+        this->getTypeConverter()->convertType(op.getCompare().getType());
+    Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
+    if (!resultType || !compareType || !valueType || resultType != compareType ||
+        resultType != valueType)
+      return rewriter.notifyMatchFailure(op, "unexpected atomic CAS type");
+
+    Type ptrType = this->getTypeConverter()->convertType(op.getPtr().getType());
+    if (!ptrType)
+      return rewriter.notifyMatchFailure(op, "failed to convert atomic pointer type");
+
+    FailureOr<StringRef> calleeName = buildAtomicCallee<pto::AtomicCasOp>(
+        op.getContext(), op.getPtr().getType(), op.getValue().getType(),
+        op.getSignednessAttr());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported atomic CAS signature");
+
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{ptrType, compareType, valueType, rewriter.getI32Type()},
+        TypeRange{resultType});
+    Value modeValue = getI32Constant(
+        rewriter, op.getLoc(),
+        static_cast<uint64_t>(op.getL2cacheAttr()
+                                  ? op.getL2cacheAttr().getValue()
+                                  : pto::StL2Cache::NMFV));
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{resultType},
+        ValueRange{adaptor.getPtr(), adaptor.getCompare(), adaptor.getValue(),
+                   modeValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename ScalarOp>
+class LowerScalarIntrinsicOpPattern final : public OpConversionPattern<ScalarOp> {
+public:
+  explicit LowerScalarIntrinsicOpPattern(TypeConverter &typeConverter,
+                                         MLIRContext *context,
+                                         LoweringState &state)
+      : OpConversionPattern<ScalarOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(ScalarOp op, typename ScalarOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
+                                                      resultTypes)))
+      return rewriter.notifyMatchFailure(op, "failed to convert scalar result types");
+
+    SmallVector<Type> operandTypes;
+    if (failed(this->getTypeConverter()->convertTypes(op->getOperandTypes(),
+                                                      operandTypes)))
+      return rewriter.notifyMatchFailure(op, "failed to convert scalar operand types");
+
+    StringRef calleeName = buildScalarIntrinsicCallee<ScalarOp>(op.getContext());
+    auto funcType = rewriter.getFunctionType(operandTypes, resultTypes);
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), calleeName,
+                                              resultTypes, adaptor.getOperands());
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerMulhiOpPattern final : public OpConversionPattern<pto::MulhiOp> {
+public:
+  explicit LowerMulhiOpPattern(TypeConverter &typeConverter,
+                               MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::MulhiOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::MulhiOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    Type lhsType = getTypeConverter()->convertType(op.getLhs().getType());
+    Type rhsType = getTypeConverter()->convertType(op.getRhs().getType());
+    if (!resultType || !lhsType || !rhsType || lhsType != resultType ||
+        rhsType != resultType)
+      return rewriter.notifyMatchFailure(op, "unexpected mulhi type");
+
+    pto::Signedness signedness = op.getSignednessAttr().getValue();
+    FailureOr<StringRef> calleeName =
+        buildMulhiCallee(op.getContext(), op.getResult().getType(), signedness);
+    if (succeeded(calleeName)) {
+      auto funcType =
+          rewriter.getFunctionType(TypeRange{lhsType, rhsType}, TypeRange{resultType});
+      auto call = rewriter.create<func::CallOp>(
+          op.getLoc(), *calleeName, TypeRange{resultType},
+          ValueRange{adaptor.getLhs(), adaptor.getRhs()});
+      state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+      rewriter.replaceOp(op, call.getResults());
+      return success();
+    }
+
+    if (!op.getResult().getType().isInteger(64) ||
+        signedness != pto::Signedness::Signed)
+      return rewriter.notifyMatchFailure(op, "unsupported mulhi signature");
+
+    FailureOr<StringRef> unsignedCalleeName =
+        buildMulhiCallee(op.getContext(), op.getResult().getType(),
+                         pto::Signedness::Unsigned);
+    if (failed(unsignedCalleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported mul64hi signature");
+
+    auto funcType =
+        rewriter.getFunctionType(TypeRange{lhsType, rhsType}, TypeRange{resultType});
+    auto unsignedCall = rewriter.create<func::CallOp>(
+        op.getLoc(), *unsignedCalleeName, TypeRange{resultType},
+        ValueRange{adaptor.getLhs(), adaptor.getRhs()});
+    state.plannedDecls.push_back(PlannedDecl{unsignedCalleeName->str(), funcType});
+
+    Value zero = getI64Constant(rewriter, op.getLoc(), 0);
+    Value lhsNeg = rewriter.create<LLVM::ICmpOp>(
+        op.getLoc(), LLVM::ICmpPredicate::slt, adaptor.getLhs(), zero);
+    Value rhsNeg = rewriter.create<LLVM::ICmpOp>(
+        op.getLoc(), LLVM::ICmpPredicate::slt, adaptor.getRhs(), zero);
+    Value subRhs = rewriter.create<LLVM::SubOp>(
+        op.getLoc(), unsignedCall.getResult(0), adaptor.getRhs());
+    Value correctedLhs = rewriter.create<LLVM::SelectOp>(
+        op.getLoc(), resultType, lhsNeg, subRhs, unsignedCall.getResult(0));
+    Value subLhs = rewriter.create<LLVM::SubOp>(
+        op.getLoc(), correctedLhs, adaptor.getLhs());
+    Value corrected = rewriter.create<LLVM::SelectOp>(
+        op.getLoc(), resultType, rhsNeg, subLhs, correctedLhs);
+    rewriter.replaceOp(op, corrected);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerMulI32ToI64OpPattern final
+    : public OpConversionPattern<pto::MulI32ToI64Op> {
+public:
+  explicit LowerMulI32ToI64OpPattern(TypeConverter &typeConverter,
+                                     MLIRContext *context,
+                                     LoweringState &state)
+      : OpConversionPattern<pto::MulI32ToI64Op>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::MulI32ToI64Op op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getResult().getType());
+    Type lhsType = getTypeConverter()->convertType(op.getLhs().getType());
+    Type rhsType = getTypeConverter()->convertType(op.getRhs().getType());
+    if (!resultType || !lhsType || !rhsType)
+      return rewriter.notifyMatchFailure(op, "unexpected mul_i32toi64 type");
+
+    FailureOr<StringRef> calleeName =
+        buildMulI32ToI64Callee(op.getContext(),
+                               op.getSignednessAttr().getValue());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op,
+                                         "unsupported mul_i32toi64 signature");
+
+    auto funcType =
+        rewriter.getFunctionType(TypeRange{lhsType, rhsType}, TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{resultType},
+        ValueRange{adaptor.getLhs(), adaptor.getRhs()});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerSqrtOpPattern final : public OpConversionPattern<pto::SqrtOp> {
+public:
+  explicit LowerSqrtOpPattern(TypeConverter &typeConverter,
+                              MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::SqrtOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::SqrtOp op, pto::SqrtOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
+    Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
+    if (!resultType || !valueType || valueType != resultType)
+      return rewriter.notifyMatchFailure(op, "unexpected sqrt operand/result type");
+
+    FailureOr<StringRef> calleeName =
+        buildSqrtCallee(op.getContext(), op.getValue().getType());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported sqrt VPTO signature");
+
+    auto funcType = rewriter.getFunctionType(TypeRange{valueType},
+                                             TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
+                                              TypeRange{resultType},
+                                              ValueRange{adaptor.getValue()});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename UnaryOp>
+class LowerUnaryScalarMathOpPattern final : public OpConversionPattern<UnaryOp> {
+public:
+  explicit LowerUnaryScalarMathOpPattern(TypeConverter &typeConverter,
+                                         MLIRContext *context,
+                                         LoweringState &state)
+      : OpConversionPattern<UnaryOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(UnaryOp op, typename UnaryOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
+    Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
+    if (!resultType || !valueType || valueType != resultType)
+      return rewriter.notifyMatchFailure(op, "unexpected unary scalar math type");
+
+    FailureOr<StringRef> calleeName =
+        buildUnaryScalarMathCallee<UnaryOp>(op.getContext(), op.getValue().getType());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported unary scalar math signature");
+
+    auto funcType = rewriter.getFunctionType(TypeRange{valueType},
+                                             TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
+                                              TypeRange{resultType},
+                                              ValueRange{adaptor.getValue()});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename BinaryOp>
+class LowerBinaryScalarMathOpPattern final : public OpConversionPattern<BinaryOp> {
+public:
+  explicit LowerBinaryScalarMathOpPattern(TypeConverter &typeConverter,
+                                          MLIRContext *context,
+                                          LoweringState &state)
+      : OpConversionPattern<BinaryOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(BinaryOp op, typename BinaryOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
+    Type lhsType = this->getTypeConverter()->convertType(op.getLhs().getType());
+    Type rhsType = this->getTypeConverter()->convertType(op.getRhs().getType());
+    if (!resultType || !lhsType || !rhsType ||
+        lhsType != rhsType || lhsType != resultType)
+      return rewriter.notifyMatchFailure(op, "unexpected binary scalar math type");
+
+    FailureOr<StringRef> calleeName =
+        buildBinaryScalarMathCallee<BinaryOp>(op.getContext(), op.getLhs().getType());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported binary scalar math signature");
+
+    auto funcType = rewriter.getFunctionType(TypeRange{lhsType, rhsType},
+                                             TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{resultType},
+        ValueRange{adaptor.getLhs(), adaptor.getRhs()});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerFmaOpPattern final : public OpConversionPattern<pto::FmaOp> {
+public:
+  explicit LowerFmaOpPattern(TypeConverter &typeConverter, MLIRContext *context,
+                             LoweringState &state)
+      : OpConversionPattern<pto::FmaOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::FmaOp op, pto::FmaOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
+    Type lhsType = this->getTypeConverter()->convertType(op.getLhs().getType());
+    Type rhsType = this->getTypeConverter()->convertType(op.getRhs().getType());
+    Type accType = this->getTypeConverter()->convertType(op.getAcc().getType());
+    if (!resultType || !lhsType || !rhsType || !accType ||
+        lhsType != rhsType || lhsType != accType || lhsType != resultType)
+      return rewriter.notifyMatchFailure(op, "unexpected fma scalar math type");
+
+    FailureOr<StringRef> calleeName = buildFmaCallee(op.getContext(),
+                                                     op.getLhs().getType());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported fma scalar signature");
+
+    auto funcType = rewriter.getFunctionType(TypeRange{lhsType, rhsType, accType},
+                                             TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{resultType},
+        ValueRange{adaptor.getLhs(), adaptor.getRhs(), adaptor.getAcc()});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerConvertOpPattern final : public OpConversionPattern<pto::ConvertOp> {
+public:
+  explicit LowerConvertOpPattern(TypeConverter &typeConverter,
+                                 MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::ConvertOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::ConvertOp op, pto::ConvertOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type resultType = getTypeConverter()->convertType(op.getDst().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(op,
+                                         "failed to convert result type");
+
+    FailureOr<StringRef> calleeName =
+        buildConvertCallee(op.getContext(), op.getSrc().getType(),
+                           op.getDst().getType(), op.getSignednessAttr());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported convert signature");
+
+    Value rounding = getI32Constant(
+        rewriter, op.getLoc(), static_cast<uint64_t>(op.getRounding()));
+    Value saturation = getI32Constant(
+        rewriter, op.getLoc(), static_cast<uint64_t>(op.getSaturation()));
+
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{adaptor.getSrc().getType(), rewriter.getI32Type(),
+                  rewriter.getI32Type()},
+        TypeRange{resultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{resultType},
+        ValueRange{adaptor.getSrc(), rounding, saturation});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.replaceOp(op, call.getResults());
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 class LowerGetVms4SrOpPattern final
     : public OpConversionPattern<pto::GetVms4SrOp> {
 public:
@@ -7135,22 +8771,9 @@ public:
                                              ValueRange{offset});
     }
 
-    auto getNaturalAlignment = [&](Type type) -> unsigned {
-      unsigned alignBytes = 0;
-      if (auto intType = dyn_cast<IntegerType>(type))
-        alignBytes = llvm::divideCeil(unsigned(intType.getWidth()), 8u);
-      else if (type.isF16() || type.isBF16())
-        alignBytes = 2;
-      else if (type.isF32())
-        alignBytes = 4;
-      else if (type.isF64())
-        alignBytes = 8;
-      return alignBytes;
-    };
-
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(
         op, convertedValueType, elemPtr,
-        getNaturalAlignment(convertedValueType));
+        getNaturalByteAlignment(convertedValueType));
     return success();
   }
 };
@@ -7179,21 +8802,8 @@ public:
                                              adaptor.getPtr(), ValueRange{offset});
     }
 
-    auto getNaturalAlignment = [&](Type type) -> unsigned {
-      unsigned alignBytes = 0;
-      if (auto intType = dyn_cast<IntegerType>(type))
-        alignBytes = llvm::divideCeil(unsigned(intType.getWidth()), 8u);
-      else if (type.isF16() || type.isBF16())
-        alignBytes = 2;
-      else if (type.isF32())
-        alignBytes = 4;
-      else if (type.isF64())
-        alignBytes = 8;
-      return alignBytes;
-    };
-
     rewriter.create<LLVM::StoreOp>(op.getLoc(), adaptor.getValue(), elemPtr,
-                                   getNaturalAlignment(adaptor.getValue().getType()));
+                                   getNaturalByteAlignment(adaptor.getValue().getType()));
     rewriter.eraseOp(op);
     return success();
   }
@@ -7201,7 +8811,10 @@ public:
 
 class ConvertPtoLoadOp final : public OpConversionPattern<pto::PTOLoadOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  ConvertPtoLoadOp(TypeConverter &typeConverter, MLIRContext *context,
+                   LoweringState &state)
+      : OpConversionPattern<pto::PTOLoadOp>(typeConverter, context),
+        state(state) {}
 
   LogicalResult
   matchAndRewrite(pto::PTOLoadOp op, OpAdaptor adaptor,
@@ -7227,29 +8840,135 @@ public:
                                              ValueRange{offset});
     }
 
-    auto getNaturalAlignment = [&](Type type) -> unsigned {
-      unsigned alignBytes = 0;
-      if (auto intType = dyn_cast<IntegerType>(type))
-        alignBytes = llvm::divideCeil(unsigned(intType.getWidth()), 8u);
-      else if (type.isF16() || type.isBF16())
-        alignBytes = 2;
-      else if (type.isF32())
-        alignBytes = 4;
-      else if (type.isF64())
-        alignBytes = 8;
-      return alignBytes;
-    };
-
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(
         op, convertedValueType, elemPtr,
-        getNaturalAlignment(convertedValueType));
+        getNaturalByteAlignment(convertedValueType));
     return success();
   }
+
+private:
+  LoweringState &state;
+};
+
+static Type getLdgCallResultType(Type valueType, Type convertedValueType,
+                                 ConversionPatternRewriter &rewriter) {
+  if (auto intType = dyn_cast<IntegerType>(valueType)) {
+    unsigned width = intType.getWidth();
+    if (width == 8 || width == 16)
+      return rewriter.getI32Type();
+    return convertedValueType;
+  }
+  if (valueType.isF16() || valueType.isBF16() || valueType.isF32())
+    return rewriter.getI32Type();
+  if (valueType.isF64())
+    return rewriter.getI64Type();
+  if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType))
+    return rewriter.getI32Type();
+  return convertedValueType;
+}
+
+static Value convertLdgCallResult(Location loc, Type valueType,
+                                  Type convertedValueType, Value callResult,
+                                  ConversionPatternRewriter &rewriter) {
+  if (auto intType = dyn_cast<IntegerType>(valueType)) {
+    unsigned width = intType.getWidth();
+    if (width == 8 || width == 16)
+      return rewriter.create<arith::TruncIOp>(
+          loc, rewriter.getIntegerType(width), callResult);
+    return callResult;
+  }
+
+  if (valueType.isF16() || valueType.isBF16()) {
+    Value payload =
+        rewriter.create<arith::TruncIOp>(loc, rewriter.getI16Type(), callResult);
+    return rewriter.create<LLVM::BitcastOp>(loc, convertedValueType, payload);
+  }
+  if (valueType.isF32() || valueType.isF64())
+    return rewriter.create<LLVM::BitcastOp>(loc, convertedValueType,
+                                            callResult);
+  if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType))
+    return rewriter.create<arith::TruncIOp>(loc, rewriter.getI8Type(),
+                                            callResult);
+  return callResult;
+}
+
+class ConvertPtoLdgOp final : public OpConversionPattern<pto::PTOLdgOp> {
+public:
+  ConvertPtoLdgOp(TypeConverter &typeConverter, MLIRContext *context,
+                  LoweringState &state)
+      : OpConversionPattern<pto::PTOLdgOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::PTOLdgOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
+    if (!llvmPtrType)
+      return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+
+    Type convertedValueType =
+        getTypeConverter()->convertType(op.getValue().getType());
+    if (!convertedValueType)
+      return rewriter.notifyMatchFailure(op, "could not convert ldg result type");
+
+    Value offset = adaptor.getOffset();
+    if (offset.getType().isIndex())
+      offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
+                                                     rewriter.getI64Type(), offset);
+
+    Value elemPtr = adaptor.getPtr();
+    if (!matchPattern(offset, m_Zero())) {
+      elemPtr = rewriter.create<LLVM::GEPOp>(op.getLoc(), llvmPtrType,
+                                             convertedValueType, adaptor.getPtr(),
+                                             ValueRange{offset});
+    }
+
+    auto ptrTy = cast<pto::PtrType>(op.getPtr().getType());
+    FailureOr<Value> ptr = reinterpretPointerToAddrSpace(
+        op, elemPtr,
+        static_cast<unsigned>(ptrTy.getMemorySpace().getAddressSpace()));
+    if (failed(ptr))
+      return rewriter.notifyMatchFailure(op, "failed to map ldg pointer");
+
+    pto::L1Cache l1cache = op.getL1cacheAttr()
+                               ? op.getL1cacheAttr().getValue()
+                               : pto::L1Cache::Cache;
+    FailureOr<StringRef> calleeName = buildL1CacheLoadCallee(
+        op.getContext(), op.getValue().getType(), l1cache);
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported ldg signature");
+
+    pto::LdL2Cache mode = op.getL2cacheAttr()
+                               ? op.getL2cacheAttr().getValue()
+                               : pto::LdL2Cache::NMFV;
+    Value modeValue =
+        getI32Constant(rewriter, op.getLoc(), static_cast<uint64_t>(mode));
+    Type callResultType = getLdgCallResultType(op.getValue().getType(),
+                                               convertedValueType, rewriter);
+    auto funcType =
+        rewriter.getFunctionType(TypeRange{ptr->getType(), rewriter.getI32Type()},
+                                 TypeRange{callResultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{callResultType},
+        ValueRange{*ptr, modeValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    Value result = convertLdgCallResult(op.getLoc(), op.getValue().getType(),
+                                        convertedValueType, call.getResult(0),
+                                        rewriter);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  LoweringState &state;
 };
 
 class ConvertPtoStoreOp final : public OpConversionPattern<pto::PTOStoreOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  ConvertPtoStoreOp(TypeConverter &typeConverter, MLIRContext *context,
+                    LoweringState &state)
+      : OpConversionPattern<pto::PTOStoreOp>(typeConverter, context),
+        state(state) {}
 
   LogicalResult
   matchAndRewrite(pto::PTOStoreOp op, OpAdaptor adaptor,
@@ -7270,24 +8989,100 @@ public:
                                              adaptor.getPtr(), ValueRange{offset});
     }
 
-    auto getNaturalAlignment = [&](Type type) -> unsigned {
-      unsigned alignBytes = 0;
-      if (auto intType = dyn_cast<IntegerType>(type))
-        alignBytes = llvm::divideCeil(unsigned(intType.getWidth()), 8u);
-      else if (type.isF16() || type.isBF16())
-        alignBytes = 2;
-      else if (type.isF32())
-        alignBytes = 4;
-      else if (type.isF64())
-        alignBytes = 8;
-      return alignBytes;
-    };
-
     rewriter.replaceOpWithNewOp<LLVM::StoreOp>(
         op, adaptor.getValue(), elemPtr,
-        getNaturalAlignment(adaptor.getValue().getType()));
+        getNaturalByteAlignment(adaptor.getValue().getType()));
     return success();
   }
+
+private:
+  LoweringState &state;
+};
+
+static Value convertStgValue(Location loc, Type valueType, Value value,
+                             ConversionPatternRewriter &rewriter) {
+  if (auto intType = dyn_cast<IntegerType>(valueType)) {
+    unsigned width = intType.getWidth();
+    if (width == 8)
+      return rewriter.create<arith::ExtUIOp>(loc, rewriter.getI32Type(), value);
+    if (width == 16)
+      return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getF16Type(), value);
+    return value;
+  }
+
+  if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType))
+    return rewriter.create<arith::ExtUIOp>(loc, rewriter.getI32Type(), value);
+  if (valueType.isBF16())
+    return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getF16Type(), value);
+  if (valueType.isF32())
+    return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI32Type(), value);
+  if (valueType.isF64())
+    return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI64Type(), value);
+  return value;
+}
+
+class ConvertPtoStgOp final : public OpConversionPattern<pto::PTOStgOp> {
+public:
+  ConvertPtoStgOp(TypeConverter &typeConverter, MLIRContext *context,
+                  LoweringState &state)
+      : OpConversionPattern<pto::PTOStgOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::PTOStgOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
+    if (!llvmPtrType)
+      return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+
+    Value offset = adaptor.getOffset();
+    if (offset.getType().isIndex())
+      offset = rewriter.create<arith::IndexCastUIOp>(op.getLoc(),
+                                                     rewriter.getI64Type(), offset);
+
+    Value elemPtr = adaptor.getPtr();
+    if (!matchPattern(offset, m_Zero())) {
+      elemPtr = rewriter.create<LLVM::GEPOp>(op.getLoc(), llvmPtrType,
+                                             adaptor.getValue().getType(),
+                                             adaptor.getPtr(), ValueRange{offset});
+    }
+
+    auto ptrTy = cast<pto::PtrType>(op.getPtr().getType());
+    FailureOr<Value> ptr = reinterpretPointerToAddrSpace(
+        op, elemPtr,
+        static_cast<unsigned>(ptrTy.getMemorySpace().getAddressSpace()));
+    if (failed(ptr))
+      return rewriter.notifyMatchFailure(op, "failed to map stg pointer");
+
+    pto::L1Cache l1cache = op.getL1cacheAttr()
+                               ? op.getL1cacheAttr().getValue()
+                               : pto::L1Cache::Cache;
+    FailureOr<StringRef> calleeName = buildL1CacheStoreCallee(
+        op.getContext(), op.getValue().getType(), l1cache);
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported stg signature");
+
+    pto::StL2Cache mode = op.getL2cacheAttr()
+                               ? op.getL2cacheAttr().getValue()
+                               : pto::StL2Cache::NMFV;
+    Value modeValue =
+        getI32Constant(rewriter, op.getLoc(), static_cast<uint64_t>(mode));
+    Value storedValue = convertStgValue(op.getLoc(), op.getValue().getType(),
+                                        adaptor.getValue(), rewriter);
+    auto funcType =
+        rewriter.getFunctionType(TypeRange{ptr->getType(), storedValue.getType(),
+                                           rewriter.getI32Type()},
+                                 TypeRange{});
+    rewriter.create<func::CallOp>(
+        op.getLoc(), *calleeName, TypeRange{},
+        ValueRange{*ptr, storedValue, modeValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
 };
 
 class ConvertVPTOTypedCarrierOp final : public ConversionPattern {
@@ -7393,6 +9188,65 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerRuntimeQueryOpPattern<pto::GetTidXOp>,
                LowerRuntimeQueryOpPattern<pto::GetTidYOp>,
                LowerRuntimeQueryOpPattern<pto::GetTidZOp>,
+               LowerRuntimeQueryOpPattern<pto::GetBlockDimXOp>,
+               LowerRuntimeQueryOpPattern<pto::GetBlockDimYOp>,
+               LowerRuntimeQueryOpPattern<pto::GetBlockDimZOp>,
+               LowerRuntimeQueryOpPattern<pto::GetGridDimXOp>,
+               LowerRuntimeQueryOpPattern<pto::GetGridDimYOp>,
+               LowerRuntimeQueryOpPattern<pto::GetGridDimZOp>,
+               LowerRuntimeQueryOpPattern<pto::GetBlockIdxXOp>,
+               LowerRuntimeQueryOpPattern<pto::GetBlockIdxYOp>,
+               LowerRuntimeQueryOpPattern<pto::GetBlockIdxZOp>,
+               LowerRuntimeQueryOpPattern<pto::GetVecCoreIdOp>,
+               LowerRuntimeQueryOpPattern<pto::GetLaneIdOp>,
+               LowerRuntimeQueryOpPattern<pto::GetClock32Op>,
+               LowerRuntimeQueryOpPattern<pto::GetClock64Op>,
+               LowerRuntimeQueryOpPattern<pto::GetLaneMaskEqOp>,
+               LowerRuntimeQueryOpPattern<pto::GetLaneMaskLeOp>,
+               LowerRuntimeQueryOpPattern<pto::GetLaneMaskLtOp>,
+               LowerRuntimeQueryOpPattern<pto::GetLaneMaskGeOp>,
+               LowerRuntimeQueryOpPattern<pto::GetLaneMaskGtOp>,
+               LowerVoteOpPattern<pto::VoteAllOp>,
+               LowerVoteOpPattern<pto::VoteAnyOp>,
+               LowerVoteOpPattern<pto::VoteUniOp>,
+               LowerVoteOpPattern<pto::VoteBallotOp>,
+               LowerShuffleOpPattern<pto::ShuffleIdxOp>,
+               LowerShuffleOpPattern<pto::ShuffleUpOp>,
+               LowerShuffleOpPattern<pto::ShuffleDownOp>,
+               LowerShuffleOpPattern<pto::ShuffleBflyOp>,
+               LowerReduxOpPattern<pto::ReduxAddOp>,
+               LowerReduxOpPattern<pto::ReduxMaxOp>,
+               LowerReduxOpPattern<pto::ReduxMinOp>,
+               LowerAtomicCasOpPattern,
+               LowerAtomicBinaryOpPattern<pto::AtomicExchOp>,
+               LowerAtomicBinaryOpPattern<pto::AtomicAddOp>,
+               LowerAtomicBinaryOpPattern<pto::AtomicSubOp>,
+               LowerAtomicBinaryOpPattern<pto::AtomicMinOp>,
+               LowerAtomicBinaryOpPattern<pto::AtomicMaxOp>,
+               LowerAtomicBinaryOpPattern<pto::AtomicAndOp>,
+               LowerAtomicBinaryOpPattern<pto::AtomicOrOp>,
+               LowerAtomicBinaryOpPattern<pto::AtomicXorOp>,
+               LowerScalarIntrinsicOpPattern<pto::PrmtOp>,
+               LowerMulhiOpPattern,
+               LowerMulI32ToI64OpPattern,
+               LowerSqrtOpPattern,
+               LowerUnaryScalarMathOpPattern<pto::AbsFOp>,
+               LowerUnaryScalarMathOpPattern<pto::ExpOp>,
+               LowerUnaryScalarMathOpPattern<pto::LogOp>,
+               LowerUnaryScalarMathOpPattern<pto::CeilOp>,
+               LowerUnaryScalarMathOpPattern<pto::FloorOp>,
+               LowerUnaryScalarMathOpPattern<pto::RintOp>,
+               LowerUnaryScalarMathOpPattern<pto::RoundOp>,
+               LowerBinaryScalarMathOpPattern<pto::FMinOp>,
+               LowerBinaryScalarMathOpPattern<pto::FMaxOp>,
+               LowerBinaryScalarMathOpPattern<pto::PowOp>,
+               LowerFmaOpPattern,
+               LowerConvertOpPattern,
+               LowerSimtFenceOpPattern<pto::SyncthreadsOp>,
+               LowerSimtFenceOpPattern<pto::ThreadfenceOp>,
+               LowerSimtFenceOpPattern<pto::ThreadfenceBlockOp>,
+               LowerKeepOpPattern,
+               LowerResumeOpPattern,
                LowerBinaryI64PureOpPattern<pto::Sbitset0Op>,
                LowerBinaryI64PureOpPattern<pto::Sbitset1Op>,
                LowerSetLoopConfigOpPattern<pto::SetLoop2StrideOutToUbOp>,
@@ -7476,6 +9330,7 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
   (void)typeConverter;
   target.addLegalOp<ModuleOp>();
   target.addLegalDialect<arith::ArithDialect, cf::ControlFlowDialect,
+                         LLVM::LLVMDialect,
                          func::FuncDialect, scf::SCFDialect>();
   target.addLegalOp<UnrealizedConversionCastOp>();
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
@@ -7484,7 +9339,30 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
   target.addIllegalOp<pto::GetBlockIdxOp, pto::GetSubBlockIdxOp,
                       pto::GetBlockNumOp, pto::GetSubBlockNumOp,
                       pto::GetCtrlOp, pto::GetVms4SrOp, pto::GetTidXOp,
-                      pto::GetTidYOp, pto::GetTidZOp>();
+                      pto::GetTidYOp, pto::GetTidZOp,
+                      pto::GetBlockDimXOp, pto::GetBlockDimYOp,
+                      pto::GetBlockDimZOp, pto::GetGridDimXOp,
+                      pto::GetGridDimYOp, pto::GetGridDimZOp,
+                      pto::GetBlockIdxXOp, pto::GetBlockIdxYOp,
+                      pto::GetBlockIdxZOp, pto::GetVecCoreIdOp,
+                      pto::GetLaneIdOp, pto::GetClock32Op, pto::GetClock64Op,
+                      pto::GetLaneMaskEqOp, pto::GetLaneMaskLeOp,
+                      pto::GetLaneMaskLtOp, pto::GetLaneMaskGeOp,
+                      pto::GetLaneMaskGtOp, pto::VoteAllOp, pto::VoteAnyOp,
+                      pto::VoteUniOp, pto::VoteBallotOp, pto::ShuffleIdxOp,
+                      pto::ShuffleUpOp, pto::ShuffleDownOp,
+                      pto::ShuffleBflyOp, pto::ReduxAddOp, pto::ReduxMaxOp,
+                      pto::ReduxMinOp, pto::AtomicCasOp, pto::AtomicExchOp,
+                      pto::AtomicAddOp, pto::AtomicSubOp,
+                      pto::AtomicMinOp, pto::AtomicMaxOp,
+                      pto::AtomicAndOp, pto::AtomicOrOp,
+                      pto::AtomicXorOp, pto::PrmtOp,
+                      pto::MulhiOp, pto::MulI32ToI64Op, pto::SqrtOp,
+                      pto::AbsFOp, pto::ExpOp, pto::LogOp, pto::CeilOp,
+                      pto::FloorOp, pto::RintOp, pto::RoundOp, pto::FMinOp,
+                      pto::FMaxOp, pto::PowOp, pto::FmaOp, pto::ConvertOp,
+                      pto::SyncthreadsOp, pto::ThreadfenceOp,
+                      pto::ThreadfenceBlockOp, pto::KeepOp, pto::ResumeOp>();
   target.addIllegalOp<pto::SetLoop2StrideOutToUbOp, pto::SetLoop1StrideOutToUbOp,
                       pto::SetLoopSizeOutToUbOp, pto::SetLoop2StrideUbToOutOp,
                       pto::SetLoop1StrideUbToOutOp, pto::SetLoopSizeUbToOutOp,
@@ -7605,6 +9483,7 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
   VPTOTypeConverter typeConverter(context);
   ConversionTarget target(*context);
   RewritePatternSet patterns(context);
+  LoweringState state;
 
   target.addLegalOp<ModuleOp>();
   target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
@@ -7621,7 +9500,8 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
                                                                 typeConverter);
       });
   target.addIllegalOp<pto::AddPtrOp, pto::CastPtrOp, pto::LoadScalarOp,
-                      pto::StoreScalarOp, pto::PTOLoadOp, pto::PTOStoreOp>();
+                      pto::StoreScalarOp, pto::PTOLoadOp, pto::PTOStoreOp,
+                      pto::PTOLdgOp, pto::PTOStgOp>();
   target.addDynamicallyLegalOp<UnrealizedConversionCastOp>(
       [&](UnrealizedConversionCastOp op) {
         return !hasVPTOConvertibleType(op->getOperandTypes()) &&
@@ -7634,8 +9514,10 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
 
   populateVPTOStructuralTypePatterns(typeConverter, patterns, target);
   patterns.add<ConvertPtoAddPtrOp, ConvertPtoCastPtrOp, ConvertPtoLoadScalarOp,
-               ConvertPtoStoreScalarOp, ConvertPtoLoadOp, ConvertPtoStoreOp>(
-      typeConverter, context);
+               ConvertPtoStoreScalarOp>(typeConverter, context);
+  patterns.add<ConvertPtoLoadOp, ConvertPtoStoreOp, ConvertPtoLdgOp,
+               ConvertPtoStgOp>(
+      typeConverter, context, state);
   patterns.add<ConvertVPTOUnrealizedCastOp>(typeConverter, context);
   patterns.add<ConvertVPTOTypedCarrierOp>(typeConverter, context);
 
@@ -7643,6 +9525,8 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
     diagOS << "VPTO LLVM emission failed: VPTO type lowering failed\n";
     return failure();
   }
+  if (failed(materializeDecls(module, state.plannedDecls, diagOS)))
+    return failure();
   foldVPTOTypeCasts(module, typeConverter);
   return success();
 }
@@ -7842,12 +9726,18 @@ collectSimtEntryFunctionNames(ModuleOp module) {
 static void applySimtEntryCallingConvention(
     llvm::Module &llvmModule,
     const llvm::StringSet<llvm::BumpPtrAllocator> &simtEntryNames) {
-  constexpr unsigned kSimtEntryCallingConv = 109;
-
   for (llvm::Function &function : llvmModule) {
     if (simtEntryNames.contains(function.getName())) {
-      function.setCallingConv(kSimtEntryCallingConv);
+      function.setCallingConv(llvm::CallingConv::SimtEntry);
       function.addFnAttr(llvm::Attribute::NoInline);
+      // Match Bisheng's C++ frontend shape for SIMT outlined bodies. The
+      // exported wrapper owns the real kernel metadata, while the SIMT body is
+      // an ODR helper called with the SIMT calling convention. In CANN beta.1,
+      // leaving the SIMT body as a strong GLOBAL FUNC makes the runtime count it
+      // as an extra kernel without matching .ascend.meta, which can corrupt the
+      // selected kernel metadata. linkonce_odr lowers to a weak helper symbol
+      // and avoids that beta.1 metadata mismatch.
+      function.setLinkage(llvm::GlobalValue::LinkOnceODRLinkage);
     }
   }
 
@@ -7860,7 +9750,7 @@ static void applySimtEntryCallingConvention(
         auto *callee = call->getCalledFunction();
         if (!callee || !simtEntryNames.contains(callee->getName()))
           continue;
-        call->setCallingConv(kSimtEntryCallingConv);
+        call->setCallingConv(llvm::CallingConv::SimtEntry);
       }
     }
   }
@@ -7890,7 +9780,7 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   applySimtEntryCallingConvention(*llvmModule, simtEntryNames);
   if (failed(attachAIVectorScopeMetadata(*llvmModule, diagOS)))
     return failure();
-  attachHIVMKernelAnnotations(*llvmModule);
+  attachHIVMKernelAnnotations(*llvmModule, deviceModule);
   llvmModule->setModuleIdentifier(("ptoas.hivm.official." + kernelKind).str());
   llvmModule->setSourceFileName(("ptoas.hivm.official." + kernelKind).str());
   return EmittedLLVMModule{std::move(llvmContext), std::move(llvmModule)};
@@ -7898,7 +9788,6 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
 
 template <typename EmitFn>
 static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
-                                 const llvm::StringSet<llvm::BumpPtrAllocator> &simtEntryNames,
                                  EmitFn &&emit) {
   OwningOpRef<Operation *> clonedOp(module->clone());
   ModuleOp clonedModule = cast<ModuleOp>(*clonedOp);
@@ -7949,7 +9838,7 @@ LogicalResult lowerVPTOModuleToLLVMModules(
   cubeModule.module.reset();
   vectorModule.context.reset();
   vectorModule.module.reset();
-  return runPipeline(module, diagOS, simtEntryNames,
+  return runPipeline(module, diagOS,
                      [&](ModuleOp loweredModule) {
     auto vectorDeviceModule =
         getUniqueDeviceModuleByKernelKind(

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -233,6 +233,11 @@ static FailureOr<StringRef> buildMadMxCalleeName(MLIRContext *context,
   return StringAttr::get(context, "llvm.hivm.MMAD.MX." + lhs + rhs).getValue();
 }
 
+static bool isSignedOrSignlessInteger(IntegerType intType, unsigned width) {
+  return intType && intType.getWidth() == width &&
+         (intType.isSigned() || intType.isSignless());
+}
+
 static std::string getMadRhsFragment(Type type) {
   if (type.isF16())
     return "f16";
@@ -241,9 +246,9 @@ static std::string getMadRhsFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 4)
+    if (isSignedOrSignlessInteger(intType, 4))
       return "s4";
-    if (intType.isSigned() && intType.getWidth() == 8)
+    if (isSignedOrSignlessInteger(intType, 8))
       return "s8";
     if (intType.isUnsigned() && intType.getWidth() == 2)
       return "u2";
@@ -270,7 +275,7 @@ static std::string getMadDstFragment(Type type) {
   if (type.isF32())
     return "f32";
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.isSigned() && intType.getWidth() == 32)
+    if (isSignedOrSignlessInteger(intType, 32))
       return "s32";
   }
   return {};
@@ -291,6 +296,9 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
     return StringAttr::get(context, "llvm.hivm.MAD.bf162f32.c310").getValue();
   if (lhsElem.isF32() && rhs == "f32" && dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.f322f32.c310").getValue();
+  if (isSignedOrSignlessInteger(dyn_cast<IntegerType>(lhsElem), 8) &&
+      rhs == "s8" && dst == "s32")
+    return StringAttr::get(context, "llvm.hivm.MAD.s8.c310").getValue();
   if (isMadE4M3ElementType(lhsElem) && isMadE4M3ElementType(rhsElem) &&
       dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();

--- a/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
@@ -533,12 +533,33 @@ LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
   return success();
 }
 
-void attachHIVMKernelAnnotations(llvm::Module &llvmModule) {
+void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
+                                 ModuleOp sourceModule) {
+  constexpr uint32_t kDefaultSimtMaxThreads = 1024;
+  constexpr uint32_t kDefaultSimtMaxRegisters = 32;
+
   llvm::NamedMDNode *annotations =
       llvmModule.getOrInsertNamedMetadata("hivm.annotations");
   llvm::LLVMContext &ctx = llvmModule.getContext();
   llvm::Type *i32Ty = llvm::Type::getInt32Ty(ctx);
   llvm::Constant *one = llvm::ConstantInt::get(i32Ty, 1);
+
+  llvm::StringMap<std::pair<uint32_t, uint32_t>> simtConfigByName;
+  sourceModule.walk([&](func::FuncOp funcOp) {
+    if (!funcOp->hasAttr(pto::kPTOSimtEntryAttrName))
+      return;
+
+    uint32_t maxThreads = kDefaultSimtMaxThreads;
+    uint32_t maxRegisters = kDefaultSimtMaxRegisters;
+    if (auto attr =
+            funcOp->getAttrOfType<IntegerAttr>(pto::kPTOSimtMaxThreadsAttrName))
+      maxThreads = static_cast<uint32_t>(attr.getInt());
+    if (auto attr = funcOp->getAttrOfType<IntegerAttr>(
+            pto::kPTOSimtMaxRegistersAttrName))
+      maxRegisters = static_cast<uint32_t>(attr.getInt());
+
+    simtConfigByName[funcOp.getSymName()] = {maxThreads, maxRegisters};
+  });
 
   auto hasInModuleCaller = [](llvm::Function &function) {
     for (llvm::User *user : function.users()) {
@@ -552,6 +573,19 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule) {
     return false;
   };
 
+  auto callsSimtEntry = [](llvm::Function &function) {
+    for (llvm::BasicBlock &block : function) {
+      for (llvm::Instruction &inst : block) {
+        auto *call = llvm::dyn_cast<llvm::CallBase>(&inst);
+        if (!call)
+          continue;
+        if (call->getCallingConv() == llvm::CallingConv::SimtEntry)
+          return true;
+      }
+    }
+    return false;
+  };
+
   auto addAnnotation = [&](llvm::Function &function, llvm::StringRef kind) {
     llvm::Metadata *ops[] = {
         llvm::ValueAsMetadata::get(&function),
@@ -560,9 +594,41 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule) {
     annotations->addOperand(llvm::MDNode::get(ctx, ops));
   };
 
+  auto addHIVMModuleI32Annotation = [&](llvm::StringRef kind, uint32_t value) {
+    llvm::Metadata *ops[] = {
+        nullptr, llvm::MDString::get(ctx, kind),
+        llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(i32Ty, value))};
+    annotations->addOperand(llvm::MDNode::getDistinct(ctx, ops));
+  };
+
+  auto addLLVMFunctionI32Annotation = [&](llvm::Function &function,
+                                          llvm::StringRef kind,
+                                          uint32_t value) {
+    llvm::Metadata *ops[] = {
+        llvm::MDString::get(ctx, kind),
+        llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(i32Ty, value))};
+    function.addMetadata("annotation", *llvm::MDNode::get(ctx, ops));
+  };
+
   for (llvm::Function &function : llvmModule) {
     if (function.isDeclaration())
       continue;
+    if (function.getCallingConv() == llvm::CallingConv::SimtEntry) {
+      uint32_t maxThreads = kDefaultSimtMaxThreads;
+      uint32_t maxRegisters = kDefaultSimtMaxRegisters;
+      if (auto it = simtConfigByName.find(function.getName());
+          it != simtConfigByName.end()) {
+        maxThreads = it->second.first;
+        maxRegisters = it->second.second;
+      }
+
+      addLLVMFunctionI32Annotation(function, "simt-max-threads", maxThreads);
+      addLLVMFunctionI32Annotation(function, "simt-max-registers",
+                                   maxRegisters);
+      addHIVMModuleI32Annotation("simt-max-threads", maxThreads);
+      addHIVMModuleI32Annotation("simt-max-registers", maxRegisters);
+      continue;
+    }
     if (function.getLinkage() != llvm::GlobalValue::ExternalLinkage)
       continue;
 
@@ -574,7 +640,10 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule) {
 
     addAnnotation(function, "kernel");
     addAnnotation(function, "kernel_with_simd");
+    if (callsSimtEntry(function))
+      addAnnotation(function, "kernel_with_simt");
   }
+
 }
 
 LogicalResult

--- a/lib/PTO/Transforms/VPTOPtrNormalize.cpp
+++ b/lib/PTO/Transforms/VPTOPtrNormalize.cpp
@@ -694,8 +694,8 @@ struct ConvertLoadOperandToPtrPattern : public OpConversionPattern<pto::PTOLoadO
     if (!isa<pto::PtrType>(ptr.getType()))
       return rewriter.notifyMatchFailure(op, "expected ptr-form load input");
 
-    rewriter.replaceOpWithNewOp<pto::PTOLoadOp>(op, op.getValue().getType(),
-                                                ptr, adaptor.getOffset());
+    rewriter.replaceOpWithNewOp<pto::PTOLoadOp>(
+        op, op.getValue().getType(), ptr, adaptor.getOffset());
     return success();
   }
 };
@@ -713,8 +713,8 @@ struct ConvertStoreOperandToPtrPattern
     if (!isa<pto::PtrType>(ptr.getType()))
       return rewriter.notifyMatchFailure(op, "expected ptr-form store input");
 
-    rewriter.replaceOpWithNewOp<pto::PTOStoreOp>(op, ptr, adaptor.getOffset(),
-                                                 adaptor.getValue());
+    rewriter.replaceOpWithNewOp<pto::PTOStoreOp>(
+        op, ptr, adaptor.getOffset(), adaptor.getValue());
     return success();
   }
 };

--- a/lib/PTO/Transforms/VPTOPtrNormalize.cpp
+++ b/lib/PTO/Transforms/VPTOPtrNormalize.cpp
@@ -89,6 +89,14 @@ static bool hasPtrNormalizeConvertibleType(TypeRange types) {
       types, [](Type type) { return hasPtrNormalizeConvertibleType(type); });
 }
 
+static FailureOr<SmallVector<Type>>
+convertTypes(const TypeConverter &typeConverter, TypeRange types) {
+  SmallVector<Type> convertedTypes;
+  if (failed(typeConverter.convertTypes(types, convertedTypes)))
+    return failure();
+  return convertedTypes;
+}
+
 static bool isMemRefType(Type type) { return isa<BaseMemRefType>(type); }
 
 static Value materializeUnrealizedCast(OpBuilder &builder, Type resultType,
@@ -408,7 +416,11 @@ struct ConvertVldsSubviewOperandPattern : public OpConversionPattern<pto::VldsOp
 
     OperationState state(op.getLoc(), op->getName().getStringRef());
     state.addOperands({adaptor.getSource(), adaptor.getOffset()});
-    state.addTypes(op->getResultTypes());
+    FailureOr<SmallVector<Type>> resultTypes =
+        convertTypes(*getTypeConverter(), op->getResultTypes());
+    if (failed(resultTypes))
+      return failure();
+    state.addTypes(*resultTypes);
     state.addAttributes(op->getAttrs());
     Operation *newOp = rewriter.create(state);
     rewriter.replaceOp(op, newOp->getResults());
@@ -429,7 +441,37 @@ struct ConvertVstsSubviewOperandPattern : public OpConversionPattern<pto::VstsOp
     state.addOperands(
         {adaptor.getValue(), adaptor.getDestination(), adaptor.getOffset(),
          adaptor.getMask()});
-    state.addTypes(op->getResultTypes());
+    FailureOr<SmallVector<Type>> resultTypes =
+        convertTypes(*getTypeConverter(), op->getResultTypes());
+    if (failed(resultTypes))
+      return failure();
+    state.addTypes(*resultTypes);
+    state.addAttributes(op->getAttrs());
+    Operation *newOp = rewriter.create(state);
+    rewriter.replaceOp(op, newOp->getResults());
+    return success();
+  }
+};
+
+struct ConvertVsstbSubviewOperandPattern
+    : public OpConversionPattern<pto::VsstbOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(pto::VsstbOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!isa<pto::PtrType>(adaptor.getDestination().getType()))
+      return failure();
+
+    OperationState state(op.getLoc(), op->getName().getStringRef());
+    state.addOperands({adaptor.getValue(), adaptor.getDestination(),
+                       adaptor.getBlockStride(), adaptor.getRepeatStride(),
+                       adaptor.getMask()});
+    FailureOr<SmallVector<Type>> resultTypes =
+        convertTypes(*getTypeConverter(), op->getResultTypes());
+    if (failed(resultTypes))
+      return failure();
+    state.addTypes(*resultTypes);
     state.addAttributes(op->getAttrs());
     Operation *newOp = rewriter.create(state);
     rewriter.replaceOp(op, newOp->getResults());
@@ -726,7 +768,7 @@ struct VPTOPtrNormalizePass
                            scf::SCFDialect>();
     target.addDynamicallyLegalDialect<pto::PTODialect>([](Operation *op) {
       return !isa<pto::TileBufAddrOp, pto::PointerCastOp, pto::CastPtrOp,
-                  pto::BindTileOp, pto::VldsOp, pto::VstsOp>(op);
+                  pto::BindTileOp, pto::VldsOp, pto::VstsOp, pto::VsstbOp>(op);
     });
     target.addLegalOp<ModuleOp>();
     target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
@@ -760,10 +802,20 @@ struct VPTOPtrNormalizePass
              typeConverter.convertType(op.getResult().getType());
     });
     target.addDynamicallyLegalOp<pto::VldsOp>(
-        [](pto::VldsOp op) { return isa<pto::PtrType>(op.getSource().getType()); });
-    target.addDynamicallyLegalOp<pto::VstsOp>([](pto::VstsOp op) {
-      return isa<pto::PtrType>(op.getDestination().getType());
-    });
+        [&](pto::VldsOp op) {
+          return isa<pto::PtrType>(op.getSource().getType()) &&
+                 typeConverter.isLegal(op->getResultTypes());
+        });
+    target.addDynamicallyLegalOp<pto::VstsOp>(
+        [&](pto::VstsOp op) {
+          return isa<pto::PtrType>(op.getDestination().getType()) &&
+                 typeConverter.isLegal(op->getResultTypes());
+        });
+    target.addDynamicallyLegalOp<pto::VsstbOp>(
+        [&](pto::VsstbOp op) {
+          return isa<pto::PtrType>(op.getDestination().getType()) &&
+                 typeConverter.isLegal(op->getResultTypes());
+        });
     target.addDynamicallyLegalOp<pto::LoadScalarOp>(
         [](pto::LoadScalarOp op) { return isa<pto::PtrType>(op.getPtr().getType()); });
     target.addDynamicallyLegalOp<pto::StoreScalarOp>(
@@ -839,6 +891,7 @@ struct VPTOPtrNormalizePass
                  ConvertBindTileToPtrPattern,
                  ConvertSubviewToAddPtrPattern, ConvertVldsSubviewOperandPattern,
                  ConvertVstsSubviewOperandPattern,
+                 ConvertVsstbSubviewOperandPattern,
                  ConvertLoadScalarOperandToPtrPattern,
                  ConvertStoreScalarOperandToPtrPattern,
                  ConvertMteUbUbOperandPattern,

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -300,9 +300,9 @@ The compiler automatically computes the byte offset from the tile's shape, eleme
 
 ---
 
-#### `pto.vlds(tile[row, col:], dist: VLoadDist | None = None) -> VRegType`
-#### `pto.vlds(tile[start:], dist: VLoadDist | None = None) -> VRegType`
-#### `pto.vlds(buf: PtrType, offset: Index, dist: VLoadDist | None = None) -> VRegType`
+#### `pto.vlds(tile[row, col:], dist: VLoadDist | None = None, return_updated_base: bool = False) -> VRegType | (VRegType, PtrType)`
+#### `pto.vlds(tile[start:], dist: VLoadDist | None = None, return_updated_base: bool = False) -> VRegType | (VRegType, PtrType)`
+#### `pto.vlds(buf: PtrType, offset: Index, dist: VLoadDist | None = None, return_updated_base: bool = False) -> VRegType | (VRegType, PtrType)`
 
 **Description**: Stateless vector load from UB. Reads one vector-width slice.
 
@@ -315,12 +315,14 @@ The compiler automatically computes the byte offset from the tile's shape, eleme
 | `buf` | `PtrType` (UB) | Pointer to buffer in UB (pointer form) |
 | `offset` | `Index` | Element offset (pointer form) |
 | `dist` | `VLoadDist` or `None` | Optional load distribution: `NORM` (default), `UNPK_B8`/`UNPK_B16`/`UNPK_B32`, `BRC_B8`/`BRC_B16`/`BRC_B32` |
+| `return_updated_base` | `bool` | When `True`, also returns the post-update base address |
 
 **Returns**:
 
 | Return Value | Type | Description |
 |--------------|------|-------------|
 | `vec` | `VRegType` | Loaded vector register |
+| `updated_base` | `PtrType` | Returned with `vec` when `return_updated_base=True` |
 
 ---
 
@@ -528,9 +530,9 @@ blocks are zero-filled.
 
 Vector stores write `vreg` contents back to UB tiles. Like loads, they support tile-index syntax.
 
-#### `pto.vsts(vec: VRegType, tile[row, col:], mask: MaskType, dist: VStoreDist | None = None) -> None`
-#### `pto.vsts(vec: VRegType, tile[start:], mask: MaskType, dist: VStoreDist | None = None) -> None`
-#### `pto.vsts(vec: VRegType, buf: PtrType, offset: Index, mask: MaskType, dist: VStoreDist | None = None) -> None`
+#### `pto.vsts(vec: VRegType, tile[row, col:], mask: MaskType, dist: VStoreDist | None = None, return_updated_base: bool = False) -> PtrType | None`
+#### `pto.vsts(vec: VRegType, tile[start:], mask: MaskType, dist: VStoreDist | None = None, return_updated_base: bool = False) -> PtrType | None`
+#### `pto.vsts(vec: VRegType, buf: PtrType, offset: Index, mask: MaskType, dist: VStoreDist | None = None, return_updated_base: bool = False) -> PtrType | None`
 
 **Description**: Stateless vector store to UB. The mask gates writes for the
 distributions that use predicate masking.
@@ -544,6 +546,7 @@ distributions that use predicate masking.
 | `tile[start:]` | Tile index | 1D destination (vector-width range) |
 | `buf` | `PtrType` (UB) | Destination buffer (pointer form) |
 | `offset` | `Index` | Element offset (pointer form) |
+| `return_updated_base` | `bool` | When `True`, returns the post-update base address |
 | `mask` | `MaskType` | Predicate mask gating writes |
 | `dist` | `VStoreDist` or `None` | Store distribution token. When omitted, PTODSL defaults to `NORM_B32` on the current surface. |
 
@@ -604,12 +607,13 @@ into one destination.
 
 ---
 
-#### `pto.vsstb(tile[row, col], block_stride: Index, repeat_stride: Index, mask: MaskType) -> None`
-#### `pto.vsstb(tile[pos], block_stride: Index, repeat_stride: Index, mask: MaskType) -> None`
-#### `pto.vsstb(buf: PtrType, block_stride: Index, repeat_stride: Index, mask: MaskType) -> None`
+#### `pto.vsstb(tile[row, col], block_stride: Index, repeat_stride: Index, mask: MaskType, return_updated_base: bool = False) -> PtrType | None`
+#### `pto.vsstb(tile[pos], block_stride: Index, repeat_stride: Index, mask: MaskType, return_updated_base: bool = False) -> PtrType | None`
+#### `pto.vsstb(buf: PtrType, block_stride: Index, repeat_stride: Index, mask: MaskType, return_updated_base: bool = False) -> PtrType | None`
 
 **Description**: Block-strided store. Stores 32-byte source blocks to a
 block-strided UB destination. Masked-off blocks do not write memory.
+When `return_updated_base=True`, returns the post-update base address.
 
 **Parameters**:
 

--- a/ptodsl/ptodsl/_bootstrap.py
+++ b/ptodsl/ptodsl/_bootstrap.py
@@ -21,7 +21,8 @@ from pathlib import Path
 def _candidate_python_roots() -> list[Path]:
     here = Path(__file__).resolve()
     repo_root = here.parents[2]
-    workspace_root = repo_root.parent
+    owner_root = repo_root.parent
+    github_root = owner_root.parent
     env_roots = []
     for env_name in ("MLIR_PYTHON_ROOT", "PTO_PYTHON_ROOT"):
         raw = os.environ.get(env_name)
@@ -32,7 +33,9 @@ def _candidate_python_roots() -> list[Path]:
         *env_roots,
         repo_root / "build" / "python",
         repo_root / "install",
-        workspace_root / "llvm-project" / "build-shared" / "tools" / "mlir" / "python_packages" / "mlir_core",
+        github_root / "llvm" / "llvm-project" / "build" / "tools" / "mlir" / "python_packages" / "mlir_core",
+        github_root / "llvm" / "llvm-project" / "install" / "python_packages" / "mlir_core",
+        github_root / "llvm" / "llvm-project" / "build-shared" / "tools" / "mlir" / "python_packages" / "mlir_core",
     ]
 
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -208,7 +208,7 @@ _VLOAD_DIST_TOKENS = {
 }
 
 
-def vlds(src_ptr, offset=None, result_vreg_type=None, *, dist=None):
+def vlds(src_ptr, offset=None, result_vreg_type=None, *, dist=None, return_updated_base=False):
     """``pto.vlds`` – vector load from a tile slice or from *src_ptr* at *offset*."""
     if isinstance(src_ptr, TileSliceValue):
         if offset is not None or result_vreg_type is not None:
@@ -220,12 +220,18 @@ def vlds(src_ptr, offset=None, result_vreg_type=None, *, dist=None):
                 allowed=_VLOAD_DIST_TOKENS,
                 context="vlds(..., dist)",
             )
-        return wrap_surface_value(_pto.VldsOp(
+        raw_source = unwrap_surface_value(src_ptr)
+        op = _pto.VldsOp(
             _infer_vreg_type_from_tile_slice(src_ptr),
-            unwrap_surface_value(src_ptr),
+            raw_source.type if return_updated_base else None,
+            raw_source,
             _index_zero(),
             **kwargs,
-        ).result)
+        )
+        result = wrap_surface_value(op.result)
+        if return_updated_base:
+            return result, wrap_surface_value(op.updated_base)
+        return result
 
     if offset is None:
         raise TypeError("vlds(ptr, offset, result_vreg_type=None) requires an explicit offset")
@@ -238,12 +244,18 @@ def vlds(src_ptr, offset=None, result_vreg_type=None, *, dist=None):
             allowed=_VLOAD_DIST_TOKENS,
             context="vlds(..., dist)",
         )
-    return wrap_surface_value(_pto.VldsOp(
+    raw_source = unwrap_surface_value(src_ptr)
+    op = _pto.VldsOp(
         _resolve(result_vreg_type),
-        unwrap_surface_value(src_ptr),
+        raw_source.type if return_updated_base else None,
+        raw_source,
         unwrap_surface_value(offset),
         **kwargs,
-    ).result)
+    )
+    result = wrap_surface_value(op.result)
+    if return_updated_base:
+        return result, wrap_surface_value(op.updated_base)
+    return result
 
 
 def vldas(source):
@@ -359,7 +371,7 @@ def pbitcast(mask_value, to_type):
     )
 
 
-def vsts(val, dst_ptr, offset, mask=None, *, dist=None):
+def vsts(val, dst_ptr, offset, mask=None, *, dist=None, return_updated_base=False):
     """``pto.vsts`` – vector store to a tile slice or to *dst_ptr* at *offset*."""
     if isinstance(dst_ptr, TileSliceValue):
         if mask is not None:
@@ -371,13 +383,17 @@ def vsts(val, dst_ptr, offset, mask=None, *, dist=None):
                 allowed=_VSTORE_DIST_TOKENS,
                 context="vsts(..., dist)",
             )
-        _pto.VstsOp(
+        raw_destination = unwrap_surface_value(dst_ptr)
+        op = _pto.VstsOp(
+            raw_destination.type if return_updated_base else None,
             unwrap_surface_value(val),
-            unwrap_surface_value(dst_ptr),
+            raw_destination,
             _index_zero(),
             unwrap_surface_value(offset),
             **kwargs,
         )
+        if return_updated_base:
+            return wrap_surface_value(op.updated_base)
         return
 
     if mask is None:
@@ -389,13 +405,17 @@ def vsts(val, dst_ptr, offset, mask=None, *, dist=None):
             allowed=_VSTORE_DIST_TOKENS,
             context="vsts(..., dist)",
         )
-    _pto.VstsOp(
+    raw_destination = unwrap_surface_value(dst_ptr)
+    op = _pto.VstsOp(
+        raw_destination.type if return_updated_base else None,
         unwrap_surface_value(val),
-        unwrap_surface_value(dst_ptr),
+        raw_destination,
         unwrap_surface_value(offset),
         unwrap_surface_value(mask),
         **kwargs,
     )
+    if return_updated_base:
+        return wrap_surface_value(op.updated_base)
 
 
 def vstsx2(low, high, dst_ptr, offset_or_dist, dist_or_mask=None, mask=None):
@@ -525,15 +545,19 @@ def vsldb(source, block_stride, repeat_stride, mask):
     )
 
 
-def vsstb(value, destination, block_stride, repeat_stride, mask):
+def vsstb(value, destination, block_stride, repeat_stride, mask, *, return_updated_base=False):
     """``pto.vsstb`` – block-strided store."""
-    _pto.VsstbOp(
+    raw_destination = unwrap_surface_value(destination)
+    op = _pto.VsstbOp(
+        raw_destination.type if return_updated_base else None,
         unwrap_surface_value(value),
-        unwrap_surface_value(destination),
+        raw_destination,
         _coerce_i16(block_stride, context="vsstb(..., block_stride, repeat_stride, mask)"),
         _coerce_i16(repeat_stride, context="vsstb(..., block_stride, repeat_stride, mask)"),
         unwrap_surface_value(mask),
     )
+    if return_updated_base:
+        return wrap_surface_value(op.updated_base)
 
 
 # ── Mask / predicate ops ──────────────────────────────────────────────────────

--- a/ptodsl/ptodsl/_tile_template_tracing.py
+++ b/ptodsl/ptodsl/_tile_template_tracing.py
@@ -620,7 +620,7 @@ def vlds(tile_slice: _TileSlice) -> _VectorValue:
     ptr_value = trace.ensure_tile_ptr(tile_slice.tile)
     offset = trace.materialize_linear_offset(tile_slice)
     vector_ty = _resolve(_vreg_type(tile_slice.tile.element_type.lanes, _scalar_descriptor(tile_slice.tile.element_type)))
-    result = _pto.VldsOp(vector_ty, ptr_value.value, offset.value).result
+    result = _pto.VldsOp(vector_ty, None, ptr_value.value, offset.value).result
     return _VectorValue(result, tile_slice.tile.element_type)
 
 
@@ -641,7 +641,7 @@ def vsts(vec: _VectorValue, tile_slice: _TileSlice, mask: _MaskValue) -> None:
         raise TypeError("tile-template tracing expects vsts destination dtype to match vector dtype")
     ptr_value = trace.ensure_tile_ptr(tile_slice.tile)
     offset = trace.materialize_linear_offset(tile_slice)
-    _pto.VstsOp(vec.value, ptr_value.value, offset.value, mask.value)
+    _pto.VstsOp(None, vec.value, ptr_value.value, offset.value, mask.value)
 
 
 def _is_tile_annotation(annotation) -> bool:

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -900,6 +900,29 @@ def public_data_movement_surface_probe():
     _ = blocked
 
 
+@pto.jit(target="a5", mode="explicit")
+def vector_post_update_surface_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    ub_src = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
+    ub_dst = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
+    mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
+
+    vec, load_base = pto.vlds(ub_src, pto.const(0), return_updated_base=True)
+    store_base = pto.vsts(vec, ub_dst, pto.const(0), mask32_full, return_updated_base=True)
+    block_base = pto.vsstb(
+        vec,
+        ub_dst,
+        pto.i16(32),
+        pto.i16(0),
+        mask32_full,
+        return_updated_base=True,
+    )
+
+    _ = load_base
+    _ = store_base
+    _ = block_base
+
+
 @pto.jit(target="a5")
 def auto_mode_explicit_surface_violation_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
@@ -1767,6 +1790,8 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(sync_surface_text, "public sync surface specialization")
     data_movement_surface_text = public_data_movement_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(data_movement_surface_text, "public data movement surface specialization")
+    vector_post_update_surface_text = vector_post_update_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(vector_post_update_surface_text, "vector post-update surface specialization")
     expect("pto.mte_gm_ub" in public_surface_text, "mte_load(...) should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in public_surface_text, "mte_store(...) should lower to pto.mte_ub_gm")
     expect(public_surface_text.count("pto.mem_bar") >= 1, "mem_bar(...) should still lower explicit memory barriers")
@@ -1802,6 +1827,14 @@ def main() -> None:
     expect("pto.vscatter" in data_movement_surface_text, "vscatter(...) should lower to pto.vscatter")
     expect("pto.vsldb" in data_movement_surface_text, "vsldb(...) should lower to pto.vsldb")
     expect("pto.vsstb" in data_movement_surface_text, "vsstb(...) should lower to pto.vsstb")
+    expect(
+        "-> !pto.vreg<64xf32>, !pto.ptr<f32, ub>" in vector_post_update_surface_text,
+        "vlds(..., return_updated_base=True) should request the updated base result",
+    )
+    expect(
+        vector_post_update_surface_text.count("-> !pto.ptr<f32, ub>") >= 2,
+        "vsts/vsstb(..., return_updated_base=True) should request updated base results",
+    )
     expect("pto.vstar" in data_movement_surface_text, "vstar(...) should lower to pto.vstar")
     expect("pto.vstas" in data_movement_surface_text, "vstas(...) should lower to pto.vstas")
     expect("pto.mte_l1_l0b" in public_surface_text, "mte_l1_l0b(...) should lower to pto.mte_l1_l0b")

--- a/python/pto/dialects/pto.py
+++ b/python/pto/dialects/pto.py
@@ -18,8 +18,15 @@ from . import _pto_ops_gen as _pto_ops_gen
 
 def _load_local_pto_ext():
     lib_dir = Path(__file__).resolve().parent.parent / "_mlir_libs"
+    candidates = []
     for suffix in ("*.so", "*.pyd", "*.dll", "*.dylib"):
-        for so_path in lib_dir.glob(f"_pto{suffix}"):
+        candidates.extend(lib_dir.glob(f"_pto{suffix}"))
+    if not candidates:
+        raise FileNotFoundError("cannot locate local _pto extension in _mlir_libs")
+
+    first_error = None
+    for so_path in candidates:
+        try:
             spec = importlib.util.spec_from_file_location(
                 "mlir._mlir_libs._pto", so_path
             )
@@ -27,12 +34,15 @@ def _load_local_pto_ext():
                 mod = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(mod)
                 return mod
-    raise ImportError("cannot locate local _pto extension in _mlir_libs")
+        except ImportError as exc:
+            if first_error is None:
+                first_error = exc
+    raise ImportError(f"failed to load local _pto extension from {lib_dir}") from first_error
 
 
 try:
     _pto_mod = _load_local_pto_ext()
-except Exception:
+except FileNotFoundError:
     _pto_mod = importlib.import_module(".._mlir_libs._pto", __package__)
 
 

--- a/test/lit/pto/low_precision_type_roundtrip.pto
+++ b/test/lit/pto/low_precision_type_roundtrip.pto
@@ -11,13 +11,15 @@
 module {
   func.func @low_precision_type_roundtrip(
       %arg0: !pto.hif8,
-      %arg1: !pto.f4E1M2x2,
-      %arg2: !pto.f4E2M1x2) {
+      %arg1: !pto.hif8x2,
+      %arg2: !pto.f4E1M2x2,
+      %arg3: !pto.f4E2M1x2) {
     return
   }
 }
 
 // CHECK-LABEL: func.func @low_precision_type_roundtrip(
 // CHECK-SAME: %arg0: !pto.hif8
-// CHECK-SAME: %arg1: !pto.f4E1M2x2
-// CHECK-SAME: %arg2: !pto.f4E2M1x2
+// CHECK-SAME: %arg1: !pto.hif8x2
+// CHECK-SAME: %arg2: !pto.f4E1M2x2
+// CHECK-SAME: %arg3: !pto.f4E2M1x2

--- a/test/lit/vpto/cube/mad_semantic_vpto_llvm.pto
+++ b/test/lit/vpto/cube/mad_semantic_vpto_llvm.pto
@@ -23,7 +23,19 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
       : !pto.ptr<f32, l0a>, !pto.ptr<f32, l0b>, !pto.ptr<f32, l0c>, !pto.ptr<f32, bt>, i64, i64, i64
     return
   }
+
+  func.func @mad_semantic_vpto_llvm_i8(
+      %lhs: !pto.ptr<i8, l0a>,
+      %rhs: !pto.ptr<i8, l0b>,
+      %dst: !pto.ptr<i32, l0c>) attributes {pto.aicore} {
+    %c16 = arith.constant 16 : i64
+    pto.mad %lhs, %rhs, %dst, %c16, %c16, %c16 unit_flag(check_only) disable_gemv
+      : !pto.ptr<i8, l0a>, !pto.ptr<i8, l0b>, !pto.ptr<i32, l0c>, i64, i64, i64
+    return
+  }
 }
 
 // CHECK-LABEL: llvm.func @mad_semantic_vpto_llvm_mix_aic
 // CHECK-COUNT-3: llvm.call @llvm.hivm.MAD.f322f32.c310
+// CHECK-LABEL: llvm.func @mad_semantic_vpto_llvm_i8_mix_aic
+// CHECK: llvm.call @llvm.hivm.MAD.s8.c310

--- a/test/lit/vpto/simt_keep_resume_direct_slots_vpto_llvm.pto
+++ b/test/lit/vpto/simt_keep_resume_direct_slots_vpto_llvm.pto
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @kernel(%dst: !pto.ptr<i32, ub>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @stage0(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @stage1(%dst) : (!pto.ptr<i32, ub>) -> ()
+    return
+  }
+
+  func.func @stage0(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %tid = pto.get_tid_x : i32
+    %wide = arith.extui %tid : i32 to i64
+    pto.keep %tid {slot = 0 : i64} : i32
+    pto.keep %wide {slot = 8 : i64} : i64
+    return
+  }
+
+  func.func @stage1(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %wide = pto.resume {slot = 8 : i64} : i64
+    %tid = pto.get_tid_x : i32
+    %idx = arith.index_castui %tid : i32 to index
+    %value = arith.trunci %wide : i64 to i32
+    pto.store %value, %dst[%idx] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}
+
+// CHECK: llvm.func @stage0
+// CHECK: MOV R4, $0
+// CHECK-SAME: IMAD.WIDE.u32 R12, RZ, RZ, $1
+// CHECK: llvm.func @stage1
+// CHECK: IMAD.WIDE.u32 $0, RZ, RZ, R12
+// CHECK-NOT: IMAD.WIDE.u32 $0, RZ, RZ, R4

--- a/test/lit/vpto/simt_keep_resume_i64_odd_slot_invalid.pto
+++ b/test/lit/vpto/simt_keep_resume_i64_odd_slot_invalid.pto
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @kernel(%dst: !pto.ptr<i32, ub>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @stage0(%dst) : (!pto.ptr<i32, ub>) -> ()
+    return
+  }
+
+  func.func @stage0(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %tid = pto.get_tid_x : i32
+    %wide = arith.extui %tid : i32 to i64
+    pto.keep %wide {slot = 7 : i64} : i64
+    return
+  }
+}
+
+// CHECK: requires an even slot for 64-bit keep/resume values

--- a/test/lit/vpto/simt_launch_sugar.pto
+++ b/test/lit/vpto/simt_launch_sugar.pto
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=EXPAND
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_launch_kernel(%dst: !pto.ptr<i32, ub>) attributes {pto.aicore} {
+    %dim_x = arith.constant 32 : i32
+    %dim_y = arith.constant 2 : i32
+    %dim_z = arith.constant 1 : i32
+    pto.simt_launch @simt_body<<<%dim_x, %dim_y, %dim_z>>>(%dst) : (!pto.ptr<i32, ub>) -> ()
+    return
+  }
+
+  func.func @simt_body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %tid = pto.get_tid_x : i32
+    pto.store %tid, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}
+
+// ROUNDTRIP: pto.simt_launch @simt_body<<<{{.*}}, {{.*}}, {{.*}}>>>({{.*}}) : (!pto.ptr<i32, ub>) -> ()
+
+// EXPAND: pto.store_vfsimt_info {{.*}}, {{.*}}, {{.*}} : i32, i32, i32
+// EXPAND-NEXT: call @simt_body{{.*}} : (!pto.ptr<i32, ub>) -> ()
+// EXPAND-NOT: pto.simt_launch

--- a/test/lit/vpto/simt_lowlevel_atomic_packed_verify_invalid.pto
+++ b/test/lit/vpto/simt_lowlevel_atomic_packed_verify_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @atomic_packed_invalid(%gm_h2: !pto.ptr<vector<2xf16>, gm>, %gm_b2: !pto.ptr<vector<2xbf16>, gm>) attributes {pto.simt_entry} {
+    %b2 = arith.constant dense<1.000000e+00> : vector<2xbf16>
+    %old = pto.atomic_add %gm_b2, %b2 : !pto.ptr<vector<2xbf16>, gm>, vector<2xbf16> -> vector<2xbf16>
+    func.call @use_old(%old) : (vector<2xbf16>) -> ()
+    return
+  }
+
+  func.func private @use_old(vector<2xbf16>)
+}
+
+// CHECK: does not support using the old value result for packed atomics on beta.1

--- a/test/lit/vpto/simt_lowlevel_atomic_verify_invalid.pto
+++ b/test/lit/vpto/simt_lowlevel_atomic_verify_invalid.pto
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @atomic_invalid(%ub_i64: !pto.ptr<i64, ub>) attributes {pto.aicore} {
+    %i64 = arith.constant 9 : i64
+    // CHECK: does not support i64 UB-space atomics
+    %old = pto.atomic_add %ub_i64, %i64 l2cache(nmfv) signed : !pto.ptr<i64, ub>, i64 -> i64
+    return
+  }
+}

--- a/test/lit/vpto/simt_lowlevel_atomic_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_atomic_vpto_llvm.pto
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @atomic_kernel(%gm_i32: !pto.ptr<i32, gm>, %gm_i64: !pto.ptr<i64, gm>, %gm_f16: !pto.ptr<f16, gm>, %gm_bf16: !pto.ptr<bf16, gm>, %gm_f32: !pto.ptr<f32, gm>, %gm_h2: !pto.ptr<vector<2xf16>, gm>, %gm_b2: !pto.ptr<vector<2xbf16>, gm>, %ub_i32: !pto.ptr<i32, ub>, %ub_f16: !pto.ptr<f16, ub>, %ub_bf16: !pto.ptr<bf16, ub>, %ub_f32: !pto.ptr<f32, ub>, %dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>, %dst_f32: !pto.ptr<f32, ub>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %i32 = arith.constant 7 : i32
+    %cmp = arith.constant 13 : i32
+    %i64 = arith.constant 9 : i64
+    %f16 = arith.constant 1.500000e+00 : f16
+    %bf16 = arith.constant 1.500000e+00 : bf16
+    %f32 = arith.constant 1.500000e+00 : f32
+
+    %cas = pto.atomic_cas %gm_i32, %cmp, %i32 signed : !pto.ptr<i32, gm>, i32 -> i32
+    %exch = pto.atomic_exch %gm_i32, %i32 l2cache(nmlv) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %add = pto.atomic_add %gm_i32, %i32 l2cache(wtsred) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %sub64 = pto.atomic_sub %gm_i64, %i64 l2cache(nmfv) signed : !pto.ptr<i64, gm>, i64 -> i64
+    %add_h = pto.atomic_add %gm_f16, %f16 l2cache(nmfv) : !pto.ptr<f16, gm>, f16 -> f16
+    %min_s_h = pto.atomic_min %ub_f16, %f16 l2cache(nmfv) : !pto.ptr<f16, ub>, f16 -> f16
+    %cas_b = pto.atomic_cas %gm_bf16, %bf16, %bf16 l2cache(nmfv) : !pto.ptr<bf16, gm>, bf16 -> bf16
+    %max_s_b = pto.atomic_max %ub_bf16, %bf16 l2cache(nmfv) : !pto.ptr<bf16, ub>, bf16 -> bf16
+    %minf = pto.atomic_min %gm_f32, %f32 l2cache(nmfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %maxs = pto.atomic_max %ub_i32, %i32 l2cache(nmfv) signed : !pto.ptr<i32, ub>, i32 -> i32
+    %ands = pto.atomic_and %ub_i32, %i32 l2cache(nmfv) unsigned : !pto.ptr<i32, ub>, i32 -> i32
+    %exch_s_f32 = pto.atomic_exch %ub_f32, %f32 l2cache(nmfv) : !pto.ptr<f32, ub>, f32 -> f32
+    pto.store %cas, %dst_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %exch, %dst_i32[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %add, %dst_i32[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %maxs, %dst_i32[%c3] : !pto.ptr<i32, ub>, i32
+    pto.store %ands, %dst_i32[%c4] : !pto.ptr<i32, ub>, i32
+    pto.store %sub64, %dst_i64[%c0] : !pto.ptr<i64, ub>, i64
+    pto.store %minf, %dst_f32[%c0] : !pto.ptr<f32, ub>, f32
+    pto.store %exch_s_f32, %dst_f32[%c1] : !pto.ptr<f32, ub>, f32
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    %gm_h2_addr = pto.castptr %gm_h2 : !pto.ptr<vector<2xf16>, gm> -> i64
+    %gm_b2_addr = pto.castptr %gm_b2 : !pto.ptr<vector<2xbf16>, gm> -> i64
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @packed_atomic_body(%gm_h2_addr, %gm_b2_addr) : (i64, i64) -> ()
+    return
+  }
+
+  func.func @packed_atomic_body(%gm_h2_addr: i64, %gm_b2_addr: i64) attributes {pto.simt_entry} {
+    %c0_i64 = arith.constant 0 : i64
+    %gm_h2 = pto.castptr %gm_h2_addr : i64 -> !pto.ptr<vector<2xf16>, gm>
+    %gm_b2 = pto.castptr %gm_b2_addr : i64 -> !pto.ptr<vector<2xbf16>, gm>
+    %ub_h2 = pto.castptr %c0_i64 : i64 -> !pto.ptr<vector<2xf16>, ub>
+    %ub_b2 = pto.castptr %c0_i64 : i64 -> !pto.ptr<vector<2xbf16>, ub>
+    %h2a = arith.constant dense<1.000000e+00> : vector<2xf16>
+    %h2b = arith.constant dense<2.000000e+00> : vector<2xf16>
+    %b2a = arith.constant dense<1.000000e+00> : vector<2xbf16>
+    %b2b = arith.constant dense<2.000000e+00> : vector<2xbf16>
+    %cas_h2 = pto.atomic_cas %gm_h2, %h2a, %h2b l2cache(nmfv) : !pto.ptr<vector<2xf16>, gm>, vector<2xf16> -> vector<2xf16>
+    %cas_s_b2 = pto.atomic_cas %ub_b2, %b2a, %b2b l2cache(nmfv) : !pto.ptr<vector<2xbf16>, ub>, vector<2xbf16> -> vector<2xbf16>
+    %exch_b2 = pto.atomic_exch %gm_b2, %b2a l2cache(nmfv) : !pto.ptr<vector<2xbf16>, gm>, vector<2xbf16> -> vector<2xbf16>
+    %add_h2 = pto.atomic_add %gm_h2, %h2a l2cache(nmfv) : !pto.ptr<vector<2xf16>, gm>, vector<2xf16> -> vector<2xf16>
+    %sub_s_b2 = pto.atomic_sub %ub_b2, %b2a l2cache(nmfv) : !pto.ptr<vector<2xbf16>, ub>, vector<2xbf16> -> vector<2xbf16>
+    %min_b2 = pto.atomic_min %gm_b2, %b2a l2cache(nmfv) : !pto.ptr<vector<2xbf16>, gm>, vector<2xbf16> -> vector<2xbf16>
+    %max_s_h2 = pto.atomic_max %ub_h2, %h2a l2cache(nmfv) : !pto.ptr<vector<2xf16>, ub>, vector<2xf16> -> vector<2xf16>
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @atomic_kernel_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.atom.CAS.G.s32
+// CHECK-DAG: llvm.call @llvm.hivm.atom.EXCH.G.s32
+// CHECK-DAG: llvm.call @llvm.hivm.atom.ADD.G.s32
+// CHECK-DAG: llvm.call @llvm.hivm.atom.SUB.G.s64
+// CHECK-DAG: llvm.call @llvm.hivm.atom.ADD.G.fp16
+// CHECK-DAG: llvm.call @llvm.hivm.atom.MIN.S.fp16
+// CHECK-DAG: llvm.call @llvm.hivm.atom.CAS.G.bf16
+// CHECK-DAG: llvm.call @llvm.hivm.atom.MAX.S.bf16
+// CHECK-DAG: llvm.call @llvm.hivm.atom.MIN.G.fp32
+// CHECK-DAG: llvm.call @llvm.hivm.atom.MAX.S.s32
+// CHECK-DAG: llvm.call @llvm.hivm.atom.AND.S.u32
+// CHECK-DAG: llvm.call @llvm.hivm.atom.EXCH.S.fp32
+// CHECK-LABEL: llvm.func @packed_atomic_body
+// CHECK-DAG: llvm.call @llvm.hivm.atom.CAS.G.f16x2
+// CHECK-DAG: llvm.call @llvm.hivm.atom.CAS.S.bf16x2
+// CHECK-DAG: llvm.call @llvm.hivm.atom.EXCH.G.bf16x2
+// CHECK-DAG: llvm.call @llvm.hivm.atom.ADD.G.f16x2
+// CHECK-DAG: llvm.call @llvm.hivm.atom.SUB.S.bf16x2
+// CHECK-DAG: llvm.call @llvm.hivm.atom.MIN.G.bf16x2
+// CHECK-DAG: llvm.call @llvm.hivm.atom.MAX.S.f16x2
+// CHECK-DAG: llvm.mlir.constant(0 : i32)

--- a/test/lit/vpto/simt_lowlevel_convert_negative.pto
+++ b/test/lit/vpto/simt_lowlevel_convert_negative.pto
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @convert_negative() attributes {pto.aicore} {
+    %f32 = arith.constant 2.000000e+00 : f32
+    %bad = pto.convert %f32 round(z) nosat signed : f32 -> i32
+    return
+  }
+}
+
+// CHECK: fp32-to-integer conversion requires saturation enable

--- a/test/lit/vpto/simt_lowlevel_convert_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_convert_vpto_llvm.pto
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @convert_kernel(%dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>, %dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>, %dst_bf16: !pto.ptr<bf16, ub>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @convert_body(%dst_i32, %dst_i64, %dst_f32, %dst_f16, %dst_bf16) : (!pto.ptr<i32, ub>, !pto.ptr<i64, ub>, !pto.ptr<f32, ub>, !pto.ptr<f16, ub>, !pto.ptr<bf16, ub>) -> ()
+    return
+  }
+
+  func.func @convert_body(%dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>, %dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>, %dst_bf16: !pto.ptr<bf16, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+
+    %f32 = arith.constant 4.000000e+00 : f32
+    %f16 = arith.constant 4.000000e+00 : f16
+    %bf16 = arith.constant 4.000000e+00 : bf16
+    %s32 = arith.constant -4 : i32
+    %u32 = arith.constant 4 : i32
+    %s64 = arith.constant -8 : i64
+    %u64 = arith.constant 8 : i64
+
+    %f32_to_s32 = pto.convert %f32 round(z) sat signed : f32 -> i32
+    %f32_to_u64 = pto.convert %f32 round(z) sat unsigned : f32 -> i64
+    %f32_to_f16 = pto.convert %f32 round(r) nosat : f32 -> f16
+    %f32_to_bf16 = pto.convert %f32 round(r) nosat : f32 -> bf16
+    %f16_to_f32 = pto.convert %f16 round(r) nosat : f16 -> f32
+    %f16_to_s32 = pto.convert %f16 round(z) sat signed : f16 -> i32
+    %f16_to_u32 = pto.convert %f16 round(z) sat unsigned : f16 -> i32
+    %f16_to_f16 = pto.convert %f16 round(r) nosat : f16 -> f16
+    %f16_to_bf16 = pto.convert %f16 round(r) nosat : f16 -> bf16
+    %bf16_to_f32 = pto.convert %bf16 round(r) nosat : bf16 -> f32
+    %bf16_to_s32 = pto.convert %bf16 round(z) sat signed : bf16 -> i32
+    %bf16_to_u32 = pto.convert %bf16 round(z) sat unsigned : bf16 -> i32
+    %bf16_to_f16 = pto.convert %bf16 round(r) nosat : bf16 -> f16
+    %bf16_to_bf16 = pto.convert %bf16 round(r) nosat : bf16 -> bf16
+    %s32_to_f32 = pto.convert %s32 round(r) nosat signed : i32 -> f32
+    %s32_to_f16 = pto.convert %s32 round(r) nosat signed : i32 -> f16
+    %s32_to_bf16 = pto.convert %s32 round(r) nosat signed : i32 -> bf16
+    %u32_to_f16 = pto.convert %u32 round(r) nosat unsigned : i32 -> f16
+    %u32_to_bf16 = pto.convert %u32 round(r) nosat unsigned : i32 -> bf16
+    %s64_to_f32 = pto.convert %s64 round(r) nosat signed : i64 -> f32
+    %u64_to_f32 = pto.convert %u64 round(r) nosat unsigned : i64 -> f32
+
+    pto.store %f32_to_s32, %dst_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %f16_to_s32, %dst_i32[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %f16_to_u32, %dst_i32[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %bf16_to_s32, %dst_i32[%c3] : !pto.ptr<i32, ub>, i32
+    pto.store %bf16_to_u32, %dst_i32[%c4] : !pto.ptr<i32, ub>, i32
+    pto.store %f32_to_u64, %dst_i64[%c0] : !pto.ptr<i64, ub>, i64
+    pto.store %f16_to_f32, %dst_f32[%c0] : !pto.ptr<f32, ub>, f32
+    pto.store %bf16_to_f32, %dst_f32[%c1] : !pto.ptr<f32, ub>, f32
+    pto.store %s32_to_f32, %dst_f32[%c2] : !pto.ptr<f32, ub>, f32
+    pto.store %s64_to_f32, %dst_f32[%c3] : !pto.ptr<f32, ub>, f32
+    pto.store %u64_to_f32, %dst_f32[%c4] : !pto.ptr<f32, ub>, f32
+    pto.store %f32_to_f16, %dst_f16[%c0] : !pto.ptr<f16, ub>, f16
+    pto.store %u32_to_f16, %dst_f16[%c1] : !pto.ptr<f16, ub>, f16
+    pto.store %f16_to_f16, %dst_f16[%c2] : !pto.ptr<f16, ub>, f16
+    pto.store %bf16_to_f16, %dst_f16[%c3] : !pto.ptr<f16, ub>, f16
+    pto.store %s32_to_f16, %dst_f16[%c4] : !pto.ptr<f16, ub>, f16
+    pto.store %f32_to_bf16, %dst_bf16[%c0] : !pto.ptr<bf16, ub>, bf16
+    pto.store %f16_to_bf16, %dst_bf16[%c1] : !pto.ptr<bf16, ub>, bf16
+    pto.store %bf16_to_bf16, %dst_bf16[%c2] : !pto.ptr<bf16, ub>, bf16
+    pto.store %s32_to_bf16, %dst_bf16[%c3] : !pto.ptr<bf16, ub>, bf16
+    pto.store %u32_to_bf16, %dst_bf16[%c4] : !pto.ptr<bf16, ub>, bf16
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @convert_kernel_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.store.vfsimt.info
+// CHECK-LABEL: llvm.func @convert_body
+// CHECK-DAG: llvm.call @llvm.hivm.fp32.to.s32
+// CHECK-DAG: llvm.call @llvm.hivm.fp32.to.u64
+// CHECK-DAG: llvm.call @llvm.hivm.fp32.to.fp16
+// CHECK-DAG: llvm.call @llvm.hivm.fp32.to.bf16
+// CHECK-DAG: llvm.call @llvm.hivm.fp16.to.fp32
+// CHECK-DAG: llvm.call @llvm.hivm.fp16.to.s32
+// CHECK-DAG: llvm.call @llvm.hivm.fp16.to.u32
+// CHECK-DAG: llvm.call @llvm.hivm.fp16.to.fp16
+// CHECK-DAG: llvm.call @llvm.hivm.fp16.to.bf16
+// CHECK-DAG: llvm.call @llvm.hivm.bf16.to.fp32
+// CHECK-DAG: llvm.call @llvm.hivm.bf16.to.s32
+// CHECK-DAG: llvm.call @llvm.hivm.bf16.to.u32
+// CHECK-DAG: llvm.call @llvm.hivm.bf16.to.fp16
+// CHECK-DAG: llvm.call @llvm.hivm.bf16.to.bf16
+// CHECK-DAG: llvm.call @llvm.hivm.s32.to.fp32
+// CHECK-DAG: llvm.call @llvm.hivm.s32.to.fp16
+// CHECK-DAG: llvm.call @llvm.hivm.s32.to.bf16
+// CHECK-DAG: llvm.call @llvm.hivm.u32.to.fp16
+// CHECK-DAG: llvm.call @llvm.hivm.u32.to.bf16
+// CHECK-DAG: llvm.call @llvm.hivm.s64.to.fp32
+// CHECK-DAG: llvm.call @llvm.hivm.u64.to.fp32

--- a/test/lit/vpto/simt_lowlevel_float_math_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_float_math_vpto_llvm.pto
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_float_math_kernel(%dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>, %dst_bf16: !pto.ptr<bf16, ub>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_float_math(%dst_f32, %dst_f16, %dst_bf16) : (!pto.ptr<f32, ub>, !pto.ptr<f16, ub>, !pto.ptr<bf16, ub>) -> ()
+    return
+  }
+
+  func.func @simt_float_math(%dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>, %dst_bf16: !pto.ptr<bf16, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %f32_a = arith.constant 1.500000e+00 : f32
+    %f32_b = arith.constant 2.000000e+00 : f32
+    %f32_c = arith.constant 4.000000e+00 : f32
+    %f16_a = arith.constant 1.500000e+00 : f16
+    %f16_b = arith.constant 2.000000e+00 : f16
+    %f16_c = arith.constant 4.000000e+00 : f16
+    %bf16_a = arith.constant 1.500000e+00 : bf16
+    %bf16_b = arith.constant 2.000000e+00 : bf16
+    %bf16_c = arith.constant 4.000000e+00 : bf16
+
+    %abs = pto.absf %f32_a : f32 -> f32
+    %fmin = pto.fmin %f32_a, %f32_b : f32, f32 -> f32
+    %fmax = pto.fmax %bf16_a, %bf16_b : bf16, bf16 -> bf16
+    %exp = pto.exp %f32_a : f32 -> f32
+    %exp16 = pto.exp %f16_a : f16 -> f16
+    %log = pto.log %f32_c : f32 -> f32
+    %log16 = pto.log %f16_c : f16 -> f16
+    %pow = pto.pow %f32_b, %f32_c : f32, f32 -> f32
+    %pow16 = pto.pow %f16_b, %f16_c : f16, f16 -> f16
+    %ceil = pto.ceil %bf16_a : bf16 -> bf16
+    %floor = pto.floor %f32_a : f32 -> f32
+    %rint = pto.rint %f16_a : f16 -> f16
+    %round = pto.round %bf16_a : bf16 -> bf16
+    %fma = pto.fma %f32_a, %f32_b, %f32_c : f32, f32, f32 -> f32
+    %fma16 = pto.fma %f16_a, %f16_b, %f16_c : f16, f16, f16 -> f16
+    %fmabf16 = pto.fma %bf16_a, %bf16_b, %bf16_c : bf16, bf16, bf16 -> bf16
+
+    pto.store %abs, %dst_f32[%c0] : !pto.ptr<f32, ub>, f32
+    pto.store %fmin, %dst_f32[%c1] : !pto.ptr<f32, ub>, f32
+    pto.store %exp, %dst_f32[%c2] : !pto.ptr<f32, ub>, f32
+    pto.store %log, %dst_f32[%c3] : !pto.ptr<f32, ub>, f32
+    pto.store %pow, %dst_f32[%c4] : !pto.ptr<f32, ub>, f32
+    pto.store %floor, %dst_f32[%c5] : !pto.ptr<f32, ub>, f32
+    pto.store %fma, %dst_f32[%c6] : !pto.ptr<f32, ub>, f32
+    pto.store %exp16, %dst_f16[%c0] : !pto.ptr<f16, ub>, f16
+    pto.store %log16, %dst_f16[%c1] : !pto.ptr<f16, ub>, f16
+    pto.store %pow16, %dst_f16[%c2] : !pto.ptr<f16, ub>, f16
+    pto.store %rint, %dst_f16[%c3] : !pto.ptr<f16, ub>, f16
+    pto.store %fma16, %dst_f16[%c4] : !pto.ptr<f16, ub>, f16
+    pto.store %fmax, %dst_bf16[%c0] : !pto.ptr<bf16, ub>, bf16
+    pto.store %ceil, %dst_bf16[%c1] : !pto.ptr<bf16, ub>, bf16
+    pto.store %round, %dst_bf16[%c2] : !pto.ptr<bf16, ub>, bf16
+    pto.store %fmabf16, %dst_bf16[%c3] : !pto.ptr<bf16, ub>, bf16
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @simt_float_math_kernel_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.store.vfsimt.info
+// CHECK-LABEL: llvm.func @simt_float_math
+// CHECK-DAG: llvm.call @llvm.fabs.f32
+// CHECK-DAG: llvm.call @llvm.minnum.f32
+// CHECK-DAG: llvm.call @llvm.maxnum.bf16
+// CHECK-DAG: llvm.call @llvm.exp.f32
+// CHECK-DAG: llvm.call @llvm.exp.f16
+// CHECK-DAG: llvm.call @llvm.log.f32
+// CHECK-DAG: llvm.call @llvm.log.f16
+// CHECK-DAG: llvm.call @llvm.pow.f32
+// CHECK-DAG: llvm.call @llvm.pow.f16
+// CHECK-DAG: llvm.call @llvm.hivm.ceil.y
+// CHECK-DAG: llvm.call @llvm.hivm.floor.f
+// CHECK-DAG: llvm.call @llvm.hivm.rint.h
+// CHECK-DAG: llvm.call @llvm.hivm.round.y
+// CHECK-DAG: llvm.call @llvm.hivm.ffma.f32.rrr
+// CHECK-DAG: llvm.call @llvm.hivm.ffma.f16.rrr
+// CHECK-DAG: llvm.call @llvm.hivm.ffma.bf16.rrr

--- a/test/lit/vpto/simt_lowlevel_intrinsics_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_intrinsics_vpto_llvm.pto
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_intrinsics_kernel(%dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>, %dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 32 : i32
+    %dim_x = arith.constant 32 : i32
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_intrinsics(%dst_i32, %dst_i64, %dst_f32, %dst_f16) : (!pto.ptr<i32, ub>, !pto.ptr<i64, ub>, !pto.ptr<f32, ub>, !pto.ptr<f16, ub>) -> ()
+    return
+  }
+
+  func.func @simt_intrinsics(%dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>, %dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    %c18 = arith.constant 18 : index
+    %c19 = arith.constant 19 : index
+    %c20 = arith.constant 20 : index
+    %c21 = arith.constant 21 : index
+    %c22 = arith.constant 22 : index
+    %c23 = arith.constant 23 : index
+    %c24 = arith.constant 24 : index
+    %c25 = arith.constant 25 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c_i64 = arith.constant 42 : i64
+    %c_f32 = arith.constant 1.500000e+00 : f32
+    %c_f16 = arith.constant 1.500000e+00 : f16
+    %tid_x = pto.get_tid_x : i32
+    %block_dim_y = pto.get_block_dim_y : i32
+    %block_dim_z = pto.get_block_dim_z : i32
+    %block_dim_x = pto.get_block_dim_x : i32
+    %grid_dim_x = pto.get_grid_dim_x : i32
+    %grid_dim_y = pto.get_grid_dim_y : i32
+    %grid_dim_z = pto.get_grid_dim_z : i32
+    %block_idx_x = pto.get_block_idx_x : i32
+    %block_idx_y = pto.get_block_idx_y : i32
+    %block_idx_z = pto.get_block_idx_z : i32
+    %veccoreid = pto.get_veccoreid : i32
+    %laneid = pto.get_laneid : i32
+    %clock32 = pto.get_clock32 : i32
+    %clock64 = pto.get_clock64 : i64
+    %lanemask_eq = pto.get_lanemask_eq : i32
+    %lanemask_le = pto.get_lanemask_le : i32
+    %lanemask_lt = pto.get_lanemask_lt : i32
+    %lanemask_ge = pto.get_lanemask_ge : i32
+    %lanemask_gt = pto.get_lanemask_gt : i32
+    %pred = arith.cmpi eq, %laneid, %c0_i32 : i32
+    %vote_all = pto.vote_all %pred : i1 -> i1
+    %vote_any = pto.vote_any %pred : i1 -> i1
+    %vote_uni = pto.vote_uni %pred : i1 -> i1
+    %vote_all_i32 = arith.extui %vote_all : i1 to i32
+    %vote_any_i32 = arith.extui %vote_any : i1 to i32
+    %vote_uni_i32 = arith.extui %vote_uni : i1 to i32
+    %vote = pto.vote_ballot %pred : i1 -> i32
+    %shfl = pto.shuffle_idx %block_dim_x, %laneid : i32, i32 -> i32
+    %shfl_up = pto.shuffle_up %block_dim_y, %c1_i32 {width = 16 : i32} : i32, i32 -> i32
+    %shfl_down = pto.shuffle_down %block_dim_z, %c1_i32 : i32, i32 -> i32
+    %shfl_bfly = pto.shuffle_bfly %grid_dim_x, %c1_i32 : i32, i32 -> i32
+    %shfl_i64 = pto.shuffle_idx %c_i64, %c2_i32 : i64, i32 -> i64
+    %shfl_f32 = pto.shuffle_idx %c_f32, %c2_i32 : f32, i32 -> f32
+    %shfl_f16 = pto.shuffle_idx %c_f16, %c2_i32 : f16, i32 -> f16
+    %redux_add = pto.redux_add %grid_dim_y unsigned : i32 -> i32
+    %redux = pto.redux_max %grid_dim_z signed : i32 -> i32
+    %redux_min = pto.redux_min %block_idx_y unsigned : i32 -> i32
+    %redux_f32 = pto.redux_add %c_f32 : f32 -> f32
+    %redux_f16 = pto.redux_min %c_f16 : f16 -> f16
+    pto.threadfence
+    pto.threadfence_block
+    pto.store %tid_x, %dst_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %block_dim_x, %dst_i32[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %block_dim_y, %dst_i32[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %block_dim_z, %dst_i32[%c3] : !pto.ptr<i32, ub>, i32
+    pto.store %grid_dim_x, %dst_i32[%c4] : !pto.ptr<i32, ub>, i32
+    pto.store %grid_dim_y, %dst_i32[%c5] : !pto.ptr<i32, ub>, i32
+    pto.store %grid_dim_z, %dst_i32[%c6] : !pto.ptr<i32, ub>, i32
+    pto.store %block_idx_x, %dst_i32[%c7] : !pto.ptr<i32, ub>, i32
+    pto.store %block_idx_y, %dst_i32[%c8] : !pto.ptr<i32, ub>, i32
+    pto.store %block_idx_z, %dst_i32[%c9] : !pto.ptr<i32, ub>, i32
+    pto.store %veccoreid, %dst_i32[%c10] : !pto.ptr<i32, ub>, i32
+    pto.store %laneid, %dst_i32[%c11] : !pto.ptr<i32, ub>, i32
+    pto.store %clock32, %dst_i32[%c12] : !pto.ptr<i32, ub>, i32
+    pto.store %lanemask_eq, %dst_i32[%c13] : !pto.ptr<i32, ub>, i32
+    pto.store %lanemask_le, %dst_i32[%c14] : !pto.ptr<i32, ub>, i32
+    pto.store %lanemask_lt, %dst_i32[%c15] : !pto.ptr<i32, ub>, i32
+    pto.store %lanemask_ge, %dst_i32[%c16] : !pto.ptr<i32, ub>, i32
+    pto.store %lanemask_gt, %dst_i32[%c17] : !pto.ptr<i32, ub>, i32
+    pto.store %vote_all_i32, %dst_i32[%c18] : !pto.ptr<i32, ub>, i32
+    pto.store %vote_any_i32, %dst_i32[%c19] : !pto.ptr<i32, ub>, i32
+    pto.store %vote_uni_i32, %dst_i32[%c20] : !pto.ptr<i32, ub>, i32
+    pto.store %vote, %dst_i32[%c21] : !pto.ptr<i32, ub>, i32
+    pto.store %shfl, %dst_i32[%c22] : !pto.ptr<i32, ub>, i32
+    pto.store %shfl_up, %dst_i32[%c23] : !pto.ptr<i32, ub>, i32
+    pto.store %shfl_down, %dst_i32[%c24] : !pto.ptr<i32, ub>, i32
+    pto.store %shfl_bfly, %dst_i32[%c25] : !pto.ptr<i32, ub>, i32
+    pto.store %redux_add, %dst_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %redux, %dst_i32[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %redux_min, %dst_i32[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %redux_f32, %dst_f32[%c0] : !pto.ptr<f32, ub>, f32
+    pto.store %redux_f16, %dst_f16[%c0] : !pto.ptr<f16, ub>, f16
+    pto.store %shfl_f32, %dst_f32[%c1] : !pto.ptr<f32, ub>, f32
+    pto.store %shfl_f16, %dst_f16[%c1] : !pto.ptr<f16, ub>, f16
+    pto.store %clock64, %dst_i64[%c0] : !pto.ptr<i64, ub>, i64
+    pto.store %shfl_i64, %dst_i64[%c1] : !pto.ptr<i64, ub>, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @simt_intrinsics_kernel_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.store.vfsimt.info
+// CHECK-LABEL: llvm.func @simt_intrinsics
+// CHECK-DAG: llvm.call @llvm.hivm.get.TID.X
+// CHECK-DAG: llvm.call @llvm.hivm.get.BLOCK.DIM.X
+// CHECK-DAG: llvm.call @llvm.hivm.get.BLOCK.DIM.Y
+// CHECK-DAG: llvm.call @llvm.hivm.get.BLOCK.DIM.Z
+// CHECK-DAG: llvm.call @llvm.hivm.get.GRID.DIM.X
+// CHECK-DAG: llvm.call @llvm.hivm.get.GRID.DIM.Y
+// CHECK-DAG: llvm.call @llvm.hivm.get.GRID.DIM.Z
+// CHECK-DAG: llvm.call @llvm.hivm.get.BLOCK.IDX.X
+// CHECK-DAG: llvm.call @llvm.hivm.get.BLOCK.IDX.Y
+// CHECK-DAG: llvm.call @llvm.hivm.get.BLOCK.IDX.Z
+// CHECK-DAG: llvm.call @llvm.hivm.tpe.get.VECCOREID
+// CHECK-DAG: llvm.call @llvm.hivm.get.laneID
+// CHECK-DAG: llvm.call @llvm.hivm.get.CLOCK32
+// CHECK-DAG: llvm.call @llvm.hivm.get.CLOCK64
+// CHECK-DAG: llvm.call @llvm.hivm.get.LANEMASK.EQ
+// CHECK-DAG: llvm.call @llvm.hivm.get.LANEMASK.LE
+// CHECK-DAG: llvm.call @llvm.hivm.get.LANEMASK.LT
+// CHECK-DAG: llvm.call @llvm.hivm.get.LANEMASK.GE
+// CHECK-DAG: llvm.call @llvm.hivm.get.LANEMASK.GT
+// CHECK-DAG: llvm.call @llvm.hivm.vote.all
+// CHECK-DAG: llvm.call @llvm.hivm.vote.any
+// CHECK-DAG: llvm.call @llvm.hivm.vote.uni
+// CHECK-DAG: llvm.call @llvm.hivm.vote.ballot
+// CHECK-DAG: llvm.and
+// CHECK-DAG: llvm.or
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.idx.i32
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.up.i32
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.down.i32
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.bfly.i32
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.idx.i64
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.idx.f32
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.idx.f16
+// CHECK-DAG: llvm.call @llvm.hivm.redux.add.u32
+// CHECK-DAG: llvm.call @llvm.hivm.redux.max.s32
+// CHECK-DAG: llvm.call @llvm.hivm.redux.min.u32
+// CHECK-DAG: llvm.call @llvm.hivm.redux.add.f32
+// CHECK-DAG: llvm.call @llvm.hivm.redux.min.f16
+// CHECK-DAG: llvm.call @llvm.hivm.fence.workitems
+// CHECK-DAG: llvm.call @llvm.hivm.fenceblock.workitems

--- a/test/lit/vpto/simt_lowlevel_launch_config_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_launch_config_vpto_llvm.pto
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @launch_config_kernel(%dst: !pto.ptr<i32, ub>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @launch_config_body(%dst) : (!pto.ptr<i32, ub>) -> ()
+    return
+  }
+
+  func.func @launch_config_body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 256 : i32, pto.simt_max_regs = 48 : i32} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %tid_x = pto.get_tid_x : i32
+    %laneid = pto.get_laneid : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %laneid, %dst[%c1] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @launch_config_body
+// CHECK-SAME: pto.simt_max_regs = 48 : i32
+// CHECK-SAME: pto.simt_max_threads = 256 : i32

--- a/test/lit/vpto/simt_lowlevel_ldst_policy_negative.pto
+++ b/test/lit/vpto/simt_lowlevel_ldst_policy_negative.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @ldst_policy_negative(%ub_i32: !pto.ptr<i32, ub>, %gm_v2f32: !pto.ptr<vector<2xf32>, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %bad_space = pto.ldg %ub_i32[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<i32, ub> -> i32
+    %bad_type = pto.ldg %gm_v2f32[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<vector<2xf32>, gm> -> vector<2xf32>
+    pto.store %bad_space, %ub_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %bad_type, %gm_v2f32[%c0] : !pto.ptr<vector<2xf32>, gm>, vector<2xf32>
+    return
+  }
+}
+
+// CHECK: requires GM pointer

--- a/test/lit/vpto/simt_lowlevel_ldst_policy_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_ldst_policy_vpto_llvm.pto
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @ldst_policy_kernel(%gm_i8: !pto.ptr<i8, gm>, %gm_i16: !pto.ptr<i16, gm>, %gm_i32: !pto.ptr<i32, gm>, %gm_i64: !pto.ptr<i64, gm>, %gm_f16: !pto.ptr<f16, gm>, %gm_bf16: !pto.ptr<bf16, gm>, %gm_f32: !pto.ptr<f32, gm>, %gm_f64: !pto.ptr<f64, gm>, %dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %i8 = arith.constant 7 : i8
+    %i16 = arith.constant 17 : i16
+    %f16 = arith.constant 1.500000e+00 : f16
+    %bf16 = arith.constant 1.500000e+00 : bf16
+    %f32 = arith.constant 2.500000e+00 : f32
+    %f64 = arith.constant 3.500000e+00 : f64
+
+    %load_i8 = pto.ldg %gm_i8[%c0] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i8, gm> -> i8
+    %load_i16 = pto.ldg %gm_i16[%c0] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i16, gm> -> i16
+    %load_cache = pto.ldg %gm_i32[%c0] : !pto.ptr<i32, gm> -> i32
+    %load_uncache = pto.ldg %gm_i64[%c1] l1cache(uncache) l2cache(nmpref) : !pto.ptr<i64, gm> -> i64
+    %load_f16 = pto.ldg %gm_f16[%c0] : !pto.ptr<f16, gm> -> f16
+    %load_bf16 = pto.ldg %gm_bf16[%c0] l1cache(uncache) l2cache(nmfv) : !pto.ptr<bf16, gm> -> bf16
+    %load_f32 = pto.ldg %gm_f32[%c0] : !pto.ptr<f32, gm> -> f32
+    %load_f64 = pto.ldg %gm_f64[%c0] : !pto.ptr<f64, gm> -> f64
+    pto.stg %i8, %gm_i8[%c1] l1cache(cache) l2cache(nmfv) : !pto.ptr<i8, gm>, i8
+    pto.stg %i16, %gm_i16[%c1] l1cache(cache) l2cache(nmfv) : !pto.ptr<i16, gm>, i16
+    pto.stg %load_i8, %gm_i8[%c2] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i8, gm>, i8
+    pto.stg %load_i16, %gm_i16[%c2] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i16, gm>, i16
+    pto.stg %load_cache, %gm_i32[%c1] l1cache(cache) l2cache(nmlv) : !pto.ptr<i32, gm>, i32
+    pto.stg %load_uncache, %gm_i64[%c2] l1cache(uncache) l2cache(wtsred) : !pto.ptr<i64, gm>, i64
+    pto.stg %f16, %gm_f16[%c0] : !pto.ptr<f16, gm>, f16
+    pto.stg %bf16, %gm_bf16[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<bf16, gm>, bf16
+    pto.stg %f32, %gm_f32[%c1] l1cache(cache) l2cache(nmfv) : !pto.ptr<f32, gm>, f32
+    pto.stg %f64, %gm_f64[%c1] l1cache(cache) l2cache(nmfv) : !pto.ptr<f64, gm>, f64
+    pto.stg %load_f32, %gm_f32[%c2] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f32, gm>, f32
+    pto.stg %load_f64, %gm_f64[%c2] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f64, gm>, f64
+    pto.stg %load_f16, %gm_f16[%c1] : !pto.ptr<f16, gm>, f16
+    pto.stg %load_bf16, %gm_bf16[%c2] : !pto.ptr<bf16, gm>, bf16
+
+    pto.store %load_cache, %dst_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %load_uncache, %dst_i64[%c0] : !pto.ptr<i64, ub>, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @ldst_policy_kernel_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.uncache.s8
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.uncache.s16
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.cache.s32
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.uncache.s64
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.cache.s16
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.uncache.s16
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.cache.s32
+// CHECK-DAG: llvm.call @llvm.hivm.ldg.cache.s64
+// CHECK-DAG: llvm.call @llvm.hivm.stg.cache.b8
+// CHECK-DAG: llvm.call @llvm.hivm.stg.cache.b16
+// CHECK-DAG: llvm.call @llvm.hivm.stg.cache.b32
+// CHECK-DAG: llvm.call @llvm.hivm.stg.uncache.b64
+// CHECK-DAG: llvm.call @llvm.hivm.stg.cache.b16
+// CHECK-DAG: llvm.call @llvm.hivm.stg.uncache.b16
+// CHECK-DAG: llvm.call @llvm.hivm.stg.cache.b32
+// CHECK-DAG: llvm.call @llvm.hivm.stg.cache.b64
+// CHECK-DAG: llvm.mlir.constant(0 : i32)
+// CHECK-DAG: llvm.mlir.constant(1 : i32)
+// CHECK-DAG: llvm.mlir.constant(3 : i32)
+// CHECK-DAG: llvm.mlir.constant(15 : i32)

--- a/test/lit/vpto/simt_lowlevel_packed_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_packed_vpto_llvm.pto
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @packed_kernel(%gm: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    %ub_i32 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    %ub_i64 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i64, ub>
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @packed_body(%ub_i32, %ub_i64) : (!pto.ptr<i32, ub>, !pto.ptr<i64, ub>) -> ()
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_i32, %gm, %c128_i64
+      nburst(%c1_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    return
+  }
+
+  func.func @packed_body(%ub_i32: !pto.ptr<i32, ub>, %ub_i64: !pto.ptr<i64, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %f2_off0 = arith.constant 8 : index
+    %f2_off1 = arith.constant 9 : index
+    %idx = arith.constant 1 : i32
+    %h2a = arith.constant dense<1.000000e+00> : vector<2xf16>
+    %h2b = arith.constant dense<2.000000e+00> : vector<2xf16>
+    %b2a = arith.constant dense<1.000000e+00> : vector<2xbf16>
+    %b2b = arith.constant dense<2.000000e+00> : vector<2xbf16>
+    %f2a = arith.constant dense<1.000000e+00> : vector<2xf32>
+
+    %shfl = pto.shuffle_idx %h2a, %idx {width = 16 : i32} : vector<2xf16>, i32 -> vector<2xf16>
+    %sqrt_h2 = pto.sqrt %h2a : vector<2xf16> -> vector<2xf16>
+    %abs_h2 = pto.absf %h2a : vector<2xf16> -> vector<2xf16>
+    %abs_b2 = pto.absf %b2a : vector<2xbf16> -> vector<2xbf16>
+    %exp_h2 = pto.exp %h2a : vector<2xf16> -> vector<2xf16>
+    %log_h2 = pto.log %h2b : vector<2xf16> -> vector<2xf16>
+    %min_h2 = pto.fmin %h2a, %h2b : vector<2xf16>, vector<2xf16> -> vector<2xf16>
+    %max_b2 = pto.fmax %b2a, %b2b : vector<2xbf16>, vector<2xbf16> -> vector<2xbf16>
+    %pow_h2 = pto.pow %h2a, %h2b : vector<2xf16>, vector<2xf16> -> vector<2xf16>
+    %fma_h2 = pto.fma %h2a, %h2b, %h2a : vector<2xf16>, vector<2xf16>, vector<2xf16> -> vector<2xf16>
+    %fma_b2 = pto.fma %b2a, %b2b, %b2a : vector<2xbf16>, vector<2xbf16>, vector<2xbf16> -> vector<2xbf16>
+    %f32_to_h2 = pto.convert %f2a round(r) nosat : vector<2xf32> -> vector<2xf16>
+    %h2_to_f32 = pto.convert %h2a round(r) nosat : vector<2xf16> -> vector<2xf32>
+    %f32_to_b2 = pto.convert %f2a round(r) nosat : vector<2xf32> -> vector<2xbf16>
+    %b2_to_f32 = pto.convert %b2a round(r) nosat : vector<2xbf16> -> vector<2xf32>
+
+    %shfl_bits = llvm.bitcast %shfl : vector<2xf16> to i32
+    %sqrt_h2_bits = llvm.bitcast %sqrt_h2 : vector<2xf16> to i32
+    %abs_h2_bits = llvm.bitcast %abs_h2 : vector<2xf16> to i32
+    %exp_h2_bits = llvm.bitcast %exp_h2 : vector<2xf16> to i32
+    %log_h2_bits = llvm.bitcast %log_h2 : vector<2xf16> to i32
+    %min_h2_bits = llvm.bitcast %min_h2 : vector<2xf16> to i32
+    %pow_h2_bits = llvm.bitcast %pow_h2 : vector<2xf16> to i32
+    %fma_h2_bits = llvm.bitcast %fma_h2 : vector<2xf16> to i32
+    %f32_to_h2_bits = llvm.bitcast %f32_to_h2 : vector<2xf16> to i32
+    %abs_b2_bits = llvm.bitcast %abs_b2 : vector<2xbf16> to i32
+    %max_b2_bits = llvm.bitcast %max_b2 : vector<2xbf16> to i32
+    %fma_b2_bits = llvm.bitcast %fma_b2 : vector<2xbf16> to i32
+    %f32_to_b2_bits = llvm.bitcast %f32_to_b2 : vector<2xbf16> to i32
+    %h2_to_f32_bits = llvm.bitcast %h2_to_f32 : vector<2xf32> to i64
+    %b2_to_f32_bits = llvm.bitcast %b2_to_f32 : vector<2xf32> to i64
+
+    pto.store %shfl_bits, %ub_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %sqrt_h2_bits, %ub_i32[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %abs_h2_bits, %ub_i32[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %exp_h2_bits, %ub_i32[%c3] : !pto.ptr<i32, ub>, i32
+    pto.store %log_h2_bits, %ub_i32[%c4] : !pto.ptr<i32, ub>, i32
+    pto.store %min_h2_bits, %ub_i32[%c5] : !pto.ptr<i32, ub>, i32
+    pto.store %pow_h2_bits, %ub_i32[%c6] : !pto.ptr<i32, ub>, i32
+    pto.store %fma_h2_bits, %ub_i32[%c7] : !pto.ptr<i32, ub>, i32
+    pto.store %f32_to_h2_bits, %ub_i32[%c8] : !pto.ptr<i32, ub>, i32
+    pto.store %abs_b2_bits, %ub_i32[%c9] : !pto.ptr<i32, ub>, i32
+    pto.store %max_b2_bits, %ub_i32[%c10] : !pto.ptr<i32, ub>, i32
+    pto.store %fma_b2_bits, %ub_i32[%c11] : !pto.ptr<i32, ub>, i32
+    pto.store %f32_to_b2_bits, %ub_i32[%c12] : !pto.ptr<i32, ub>, i32
+    pto.store %h2_to_f32_bits, %ub_i64[%f2_off0] : !pto.ptr<i64, ub>, i64
+    pto.store %b2_to_f32_bits, %ub_i64[%f2_off1] : !pto.ptr<i64, ub>, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @packed_kernel_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.store.vfsimt.info
+// CHECK-LABEL: llvm.func @packed_body
+// CHECK-DAG: llvm.call @llvm.hivm.shfl.idx.v2f16
+// CHECK-DAG: llvm.call @llvm.sqrt.v2f16
+// CHECK-DAG: llvm.call @llvm.fabs.v2f16
+// CHECK-DAG: llvm.call @llvm.fabs.v2bf16
+// CHECK-DAG: llvm.call @llvm.exp.v2f16
+// CHECK-DAG: llvm.call @llvm.log.v2f16
+// CHECK-DAG: llvm.call @llvm.minnum.v2f16
+// CHECK-DAG: llvm.call @llvm.maxnum.v2bf16
+// CHECK-DAG: llvm.call @llvm.pow.v2f16
+// CHECK-DAG: llvm.call @llvm.hivm.ffma.f16x2.rrr
+// CHECK-DAG: llvm.call @llvm.hivm.ffma.bf16x2.rrr
+// CHECK-DAG: llvm.call @llvm.hivm.f32x2.to.f16x2
+// CHECK-DAG: llvm.call @llvm.hivm.f16x2.to.f32x2
+// CHECK-DAG: llvm.call @llvm.hivm.f32x2.to.bf16x2
+// CHECK-DAG: llvm.call @llvm.hivm.bf16x2.to.f32x2
+// CHECK-DAG: llvm.bitcast {{.*}} : vector<2xf16> to i32
+// CHECK-DAG: llvm.bitcast {{.*}} : vector<2xbf16> to i32
+// CHECK-DAG: llvm.bitcast {{.*}} : vector<2xf32> to i64
+// CHECK-DAG: llvm.store {{.*}} : i32, !llvm.ptr<6>
+// CHECK-DAG: llvm.store {{.*}} : i64, !llvm.ptr<6>

--- a/test/lit/vpto/simt_lowlevel_redux_verify_invalid.pto
+++ b/test/lit/vpto/simt_lowlevel_redux_verify_invalid.pto
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @kernel() attributes {pto.aicore, pto.simt_entry} {
+    %value = arith.constant 7 : i32
+    %bad = pto.redux_max %value : i32 -> i32
+    return
+  }
+}
+
+// CHECK: requires explicit signedness for integer redux

--- a/test/lit/vpto/simt_lowlevel_scalar_intrinsics_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_scalar_intrinsics_vpto_llvm.pto
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_scalar_kernel(%dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>, %dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_scalar(%dst_i32, %dst_i64, %dst_f32, %dst_f16) : (!pto.ptr<i32, ub>, !pto.ptr<i64, ub>, !pto.ptr<f32, ub>, !pto.ptr<f16, ub>) -> ()
+    return
+  }
+
+  func.func @simt_scalar(%dst_i32: !pto.ptr<i32, ub>, %dst_i64: !pto.ptr<i64, ub>, %dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %a = arith.constant -2000000000 : i32
+    %b = arith.constant 3 : i32
+    %ua = arith.constant -268435456 : i32
+    %ub = arith.constant 16 : i32
+    %selector = arith.constant 12816 : i32
+    %x64 = arith.constant -1 : i64
+    %y64 = arith.constant 2 : i64
+    %f32 = arith.constant 4.000000e+00 : f32
+    %f16 = arith.constant 4.000000e+00 : f16
+
+    %prmt = pto.prmt %a, %ua, %selector : i32, i32, i32 -> i32
+    %mulhi_s = pto.mulhi %a, %b signed : i32, i32 -> i32
+    %mulhi_u = pto.mulhi %ua, %ub unsigned : i32, i32 -> i32
+    %wide_s = pto.mul_i32toi64 %a, %b signed : i32, i32 -> i64
+    %wide_u = pto.mul_i32toi64 %ua, %ub unsigned : i32, i32 -> i64
+    %hi64_u = pto.mulhi %x64, %y64 unsigned : i64, i64 -> i64
+    %hi64_s = pto.mulhi %x64, %y64 signed : i64, i64 -> i64
+    %sqrt_f32 = pto.sqrt %f32 : f32 -> f32
+    %sqrt_f16 = pto.sqrt %f16 : f16 -> f16
+
+    pto.store %prmt, %dst_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %mulhi_s, %dst_i32[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %mulhi_u, %dst_i32[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %wide_s, %dst_i64[%c0] : !pto.ptr<i64, ub>, i64
+    pto.store %wide_u, %dst_i64[%c1] : !pto.ptr<i64, ub>, i64
+    pto.store %hi64_u, %dst_i64[%c2] : !pto.ptr<i64, ub>, i64
+    pto.store %hi64_s, %dst_i64[%c3] : !pto.ptr<i64, ub>, i64
+    pto.store %sqrt_f32, %dst_f32[%c0] : !pto.ptr<f32, ub>, f32
+    pto.store %sqrt_f16, %dst_f16[%c0] : !pto.ptr<f16, ub>, f16
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @simt_scalar_kernel_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.store.vfsimt.info
+// CHECK-LABEL: llvm.func @simt_scalar
+// CHECK-DAG: llvm.call @llvm.hivm.prmt
+// CHECK-DAG: llvm.call @llvm.hivm.mulhi.i
+// CHECK-DAG: llvm.call @llvm.hivm.mulhi.ui
+// CHECK-DAG: llvm.call @llvm.hivm.mul.i32toi64.i
+// CHECK-DAG: llvm.call @llvm.hivm.mul.i32toi64.ui
+// CHECK-DAG: llvm.call @llvm.hivm.mul64hi.ui
+// CHECK-DAG: llvm.icmp "slt"
+// CHECK-DAG: llvm.sub
+// CHECK-DAG: llvm.select
+// CHECK-DAG: llvm.call @llvm.sqrt.f32
+// CHECK-DAG: llvm.call @llvm.sqrt.f16

--- a/test/lit/vpto/simt_lowlevel_shuffle_verify_invalid.pto
+++ b/test/lit/vpto/simt_lowlevel_shuffle_verify_invalid.pto
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @kernel() attributes {pto.aicore, pto.simt_entry} {
+    %value = arith.constant 7 : i32
+    %index = arith.constant 3 : i32
+    %bad = pto.shuffle_idx %value, %index {width = 24 : i32} : i32, i32 -> i32
+    return
+  }
+}
+
+// CHECK: requires width to be 16 or 32

--- a/test/lit/vpto/vlds_post_update_result_vpto_llvm.pto
+++ b/test/lit/vpto/vlds_post_update_result_vpto_llvm.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vlds_with_updated_base(%src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %vec, %next = pto.vlds %src[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+      pto.vsts %vec, %next[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @vlds_with_updated_base_mix_aiv
+// CHECK: llvm.call @llvm.hivm.vldsx1.post.v64f32
+// CHECK: llvm.call @llvm.hivm.vstsx1.v64f32

--- a/test/lit/vpto/vlds_post_update_verify_invalid.pto
+++ b/test/lit/vpto/vlds_post_update_verify_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vlds_post_update_requires_matching_source_type(%src: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %vec, %next = pto.vlds %src[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>, !pto.ptr<i32, ub>
+    }
+    return
+  }
+}
+
+// CHECK: requires updated base result to match base type

--- a/test/lit/vpto/vsstb_post_update_result_vpto_llvm.pto
+++ b/test/lit/vpto/vsstb_post_update_result_vpto_llvm.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsstb_with_updated_base(%value: !pto.vreg<64xf32>, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c2_i16 = arith.constant 2 : i16
+    %c4_i16 = arith.constant 4 : i16
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %next = pto.vsstb %value, %dst, %c2_i16, %c4_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32> -> !pto.ptr<f32, ub>
+      pto.vsstb %value, %next, %c2_i16, %c4_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @vsstb_with_updated_base_mix_aiv
+// CHECK: llvm.call @llvm.hivm.vsstb.post
+// CHECK: llvm.call @llvm.hivm.vsstb

--- a/test/lit/vpto/vsstb_post_update_verify_invalid.pto
+++ b/test/lit/vpto/vsstb_post_update_verify_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsstb_post_update_requires_matching_destination_type(%value: !pto.vreg<64xf32>, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c2_i16 = arith.constant 2 : i16
+    %c4_i16 = arith.constant 4 : i16
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %next = pto.vsstb %value, %dst, %c2_i16, %c4_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32> -> !pto.ptr<i32, ub>
+    }
+    return
+  }
+}
+
+// CHECK: requires updated base result to match base type

--- a/test/lit/vpto/vsts_post_update_result_vpto_llvm.pto
+++ b/test/lit/vpto/vsts_post_update_result_vpto_llvm.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsts_with_updated_base(%value: !pto.vreg<64xf32>, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %next = pto.vsts %value, %dst[%c0], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32> -> !pto.ptr<f32, ub>
+      pto.vsts %value, %next[%c0], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @vsts_with_updated_base_mix_aiv
+// CHECK: llvm.call @llvm.hivm.vstsx1.post.v64f32
+// CHECK: llvm.call @llvm.hivm.vstsx1.v64f32

--- a/test/lit/vpto/vsts_post_update_verify_invalid.pto
+++ b/test/lit/vpto/vsts_post_update_verify_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsts_post_update_requires_matching_destination_type(%value: !pto.vreg<64xf32>, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %next = pto.vsts %value, %dst[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32> -> !pto.ptr<i32, ub>
+    }
+    return
+  }
+}
+
+// CHECK: requires updated base result to match base type

--- a/test/vpto/cases/micro-op/cube-matmul/mad_acc/kernel.pto
+++ b/test/vpto/cases/micro-op/cube-matmul/mad_acc/kernel.pto
@@ -21,6 +21,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1536_i64 = arith.constant 1536 : i64
     %false = arith.constant false
 
+    // L1 is split into four 16x16 f16 tiles: the first pair computes the
+    // initial C = A * B, and the second pair is accumulated with mad_acc.
     %l1_a = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, l1>
     %l1_b = pto.castptr %c512_i64 : i64 -> !pto.ptr<f16, l1>
     %l1_a_acc = pto.castptr %c1024_i64 : i64 -> !pto.ptr<f16, l1>
@@ -29,6 +31,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %l0b = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, l0b>
     %l0c = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, l0c>
 
+    // Step 1: load all four source matrices from GM to L1. nd2nz converts
+    // normal row-major GM tiles into the cube-friendly NZ layout.
     pto.mte_gm_l1_frac %a_gm, %l1_a, nd2nz,
         shape(%c16_i64, %c16_i64),
         src_layout(%c32_i64),
@@ -65,29 +69,41 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     pto.set_flag["PIPE_MTE2", "PIPE_MTE1", "EVENT_ID0"]
     pto.wait_flag["PIPE_MTE2", "PIPE_MTE1", "EVENT_ID0"]
 
+    // Step 2: feed the first A/B pair into L0A/L0B. B is transposed because
+    // the MAD instruction consumes the right-hand operand from L0B in that form.
     pto.mte_l1_l0a %l1_a, %l0a, %c16_i64, %c16_i64
       : !pto.ptr<f16, l1>, !pto.ptr<f16, l0a>, i64, i64
     pto.mte_l1_l0b %l1_b, %l0b, %c16_i64, %c16_i64 {transpose = true}
       : !pto.ptr<f16, l1>, !pto.ptr<f16, l0b>, i64, i64
     pto.set_flag["PIPE_MTE1", "PIPE_M", "EVENT_ID0"]
     pto.wait_flag["PIPE_MTE1", "PIPE_M", "EVENT_ID0"]
+    // Step 3: compute the base product in L0C:
+    //   L0C = f32(A * B)
+    // check_only leaves the accumulation buffer available for the next MAD.
     pto.mad %l0a, %l0b, %l0c, %c16_i64, %c16_i64, %c16_i64 unit_flag(check_only) disable_gemv n_dir
       : !pto.ptr<f16, l0a>, !pto.ptr<f16, l0b>, !pto.ptr<f32, l0c>, i64, i64, i64
 
     pto.set_flag["PIPE_M", "PIPE_MTE1", "EVENT_ID1"]
     pto.wait_flag["PIPE_M", "PIPE_MTE1", "EVENT_ID1"]
+    // Step 4: load the second A/B pair into L0A/L0B after the first MAD has
+    // produced L0C, so the next instruction can accumulate into the same L0C.
     pto.mte_l1_l0a %l1_a_acc, %l0a, %c16_i64, %c16_i64
       : !pto.ptr<f16, l1>, !pto.ptr<f16, l0a>, i64, i64
     pto.mte_l1_l0b %l1_b_acc, %l0b, %c16_i64, %c16_i64 {transpose = true}
       : !pto.ptr<f16, l1>, !pto.ptr<f16, l0b>, i64, i64
     pto.set_flag["PIPE_MTE1", "PIPE_M", "EVENT_ID1"]
     pto.wait_flag["PIPE_MTE1", "PIPE_M", "EVENT_ID1"]
+    // Step 5: accumulate the second product:
+    //   L0C += f32(A_acc * B_acc)
+    // check_and_set marks the accumulated result ready for FIX/writeback.
     pto.mad_acc %l0a, %l0b, %l0c, %c16_i64, %c16_i64, %c16_i64 unit_flag(check_and_set) disable_gemv n_dir
       : !pto.ptr<f16, l0a>, !pto.ptr<f16, l0b>, !pto.ptr<f32, l0c>, i64, i64, i64
 
     pto.set_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
     pto.wait_flag["PIPE_M", "PIPE_FIX", "EVENT_ID1"]
 
+    // Step 6: convert L0C back from NZ to normal layout and store the final
+    // f32 matrix C to GM.
     pto.mte_l0c_gm %l0c, %c_gm, %c16_i64, %c16_i64, %c16_i64, %c16_i64,
       %c0_i64, %c0_i64,
       nz2nd

--- a/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/compare.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/compare.py
@@ -45,11 +45,13 @@ def main() -> None:
     output_values, output_indices = read_pairs("v2.bin")
     golden_counts = read_counts("golden_v3.bin")
     output_counts = read_counts("v3.bin")
+    produced = int(golden_counts.sum())
     ok = (
         golden_values.shape == output_values.shape
         and golden_indices.shape == output_indices.shape
-        and np.allclose(golden_values, output_values)
-        and np.array_equal(golden_indices, output_indices)
+        and 0 <= produced <= PAIR_COUNT
+        and np.allclose(golden_values[:produced], output_values[:produced])
+        and np.array_equal(golden_indices[:produced], output_indices[:produced])
         and np.array_equal(golden_counts, output_counts)
     )
     if not ok:

--- a/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/golden.py
+++ b/test/vpto/cases/micro-op/dsa-sfu/vmrgsort4/golden.py
@@ -30,6 +30,9 @@ def main() -> None:
     out.mkdir(parents=True, exist_ok=True)
 
     src = [(9.0, 90), (7.0, 70), (8.0, 80), (6.0, 60)]
+    # Exhausted mode stops after emitting the only valid proposal. The
+    # remaining output slots are not architecturally produced and are ignored by
+    # compare.py.
     golden = [(9.0, 90), (0.0, 0), (0.0, 0), (0.0, 0)]
 
     write_pairs(out / "v1.bin", src)

--- a/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.float32)
+    out = np.fromfile("v1.bin", dtype=np.float32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={float(golden[idx])}, out={float(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/golden.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    golden_v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    v1[:8] = np.full(8, 10.0, dtype=np.float32)
+    v1[8:16] = np.full(8, 11.0, dtype=np.float32)
+    golden_v1[:8] = np.full(8, 15.0, dtype=np.float32)
+    golden_v1[8:16] = np.full(8, 11.0, dtype=np.float32)
+    golden_v1[16:24] = np.full(8, 10.0, dtype=np.float32)
+    golden_v1[24:32] = np.full(8, 11.0, dtype=np.float32)
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/kernel.pto
@@ -1,0 +1,90 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_cas_f32_core_kernel(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    %c18 = arith.constant 18 : index
+    %c19 = arith.constant 19 : index
+    %c20 = arith.constant 20 : index
+    %c21 = arith.constant 21 : index
+    %c22 = arith.constant 22 : index
+    %c23 = arith.constant 23 : index
+    %c24 = arith.constant 24 : index
+    %c25 = arith.constant 25 : index
+    %c26 = arith.constant 26 : index
+    %c27 = arith.constant 27 : index
+    %c28 = arith.constant 28 : index
+    %c29 = arith.constant 29 : index
+    %c30 = arith.constant 30 : index
+    %c31 = arith.constant 31 : index
+    %v10 = arith.constant 1.000000e+01 : f32
+    %v15 = arith.constant 1.500000e+01 : f32
+
+    %ptr0 = pto.addptr %arg0, %c0 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old0 = pto.atomic_cas %ptr0, %v10, %v15 l2cache(nmfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr1 = pto.addptr %arg0, %c1 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old1 = pto.atomic_cas %ptr1, %v10, %v15 l2cache(nmlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr2 = pto.addptr %arg0, %c2 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old2 = pto.atomic_cas %ptr2, %v10, %v15 l2cache(nmprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr3 = pto.addptr %arg0, %c3 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old3 = pto.atomic_cas %ptr3, %v10, %v15 l2cache(nmred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr4 = pto.addptr %arg0, %c4 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old4 = pto.atomic_cas %ptr4, %v10, %v15 l2cache(naci) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr5 = pto.addptr %arg0, %c5 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old5 = pto.atomic_cas %ptr5, %v10, %v15 l2cache(napw) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr6 = pto.addptr %arg0, %c6 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old6 = pto.atomic_cas %ptr6, %v10, %v15 l2cache(napi) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr7 = pto.addptr %arg0, %c7 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old7 = pto.atomic_cas %ptr7, %v10, %v15 l2cache(nared) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr8 = pto.addptr %arg0, %c8 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old8 = pto.atomic_cas %ptr8, %v10, %v15 l2cache(wbhfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr9 = pto.addptr %arg0, %c9 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old9 = pto.atomic_cas %ptr9, %v10, %v15 l2cache(wbhlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr10 = pto.addptr %arg0, %c10 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old10 = pto.atomic_cas %ptr10, %v10, %v15 l2cache(wbhprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr11 = pto.addptr %arg0, %c11 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old11 = pto.atomic_cas %ptr11, %v10, %v15 l2cache(wbhred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr12 = pto.addptr %arg0, %c12 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old12 = pto.atomic_cas %ptr12, %v10, %v15 l2cache(wtsfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr13 = pto.addptr %arg0, %c13 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old13 = pto.atomic_cas %ptr13, %v10, %v15 l2cache(wtslv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr14 = pto.addptr %arg0, %c14 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old14 = pto.atomic_cas %ptr14, %v10, %v15 l2cache(wtsprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr15 = pto.addptr %arg0, %c15 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old15 = pto.atomic_cas %ptr15, %v10, %v15 l2cache(wtsred) : !pto.ptr<f32, gm>, f32 -> f32
+
+    pto.store %old0, %arg0[%c16] : !pto.ptr<f32, gm>, f32
+    pto.store %old1, %arg0[%c17] : !pto.ptr<f32, gm>, f32
+    pto.store %old2, %arg0[%c18] : !pto.ptr<f32, gm>, f32
+    pto.store %old3, %arg0[%c19] : !pto.ptr<f32, gm>, f32
+    pto.store %old4, %arg0[%c20] : !pto.ptr<f32, gm>, f32
+    pto.store %old5, %arg0[%c21] : !pto.ptr<f32, gm>, f32
+    pto.store %old6, %arg0[%c22] : !pto.ptr<f32, gm>, f32
+    pto.store %old7, %arg0[%c23] : !pto.ptr<f32, gm>, f32
+    pto.store %old8, %arg0[%c24] : !pto.ptr<f32, gm>, f32
+    pto.store %old9, %arg0[%c25] : !pto.ptr<f32, gm>, f32
+    pto.store %old10, %arg0[%c26] : !pto.ptr<f32, gm>, f32
+    pto.store %old11, %arg0[%c27] : !pto.ptr<f32, gm>, f32
+    pto.store %old12, %arg0[%c28] : !pto.ptr<f32, gm>, f32
+    pto.store %old13, %arg0[%c29] : !pto.ptr<f32, gm>, f32
+    pto.store %old14, %arg0[%c30] : !pto.ptr<f32, gm>, f32
+    pto.store %old15, %arg0[%c31] : !pto.ptr<f32, gm>, f32
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/launch.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_cas_f32_core_kernel(__gm__ float *v1);
+void LaunchSimt_atomic_cas_f32_core_kernel(float *v1, void *stream) {
+  simt_atomic_cas_f32_core_kernel<<<1, nullptr, stream>>>((__gm__ float *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-cas-f32-core/main.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_cas_f32_core_kernel(float *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(float);
+  float *v1Host = nullptr;
+  float *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_cas_f32_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.float32)
+    out = np.fromfile("v1.bin", dtype=np.float32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={float(golden[idx])}, out={float(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/golden.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    golden_v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    v1[:16] = np.full(16, 10.0, dtype=np.float32)
+    golden_v1[:16] = np.full(16, 15.0, dtype=np.float32)
+    golden_v1[16:32] = np.full(16, 10.0, dtype=np.float32)
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/kernel.pto
@@ -1,0 +1,89 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_exch_f32_core_kernel(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    %c18 = arith.constant 18 : index
+    %c19 = arith.constant 19 : index
+    %c20 = arith.constant 20 : index
+    %c21 = arith.constant 21 : index
+    %c22 = arith.constant 22 : index
+    %c23 = arith.constant 23 : index
+    %c24 = arith.constant 24 : index
+    %c25 = arith.constant 25 : index
+    %c26 = arith.constant 26 : index
+    %c27 = arith.constant 27 : index
+    %c28 = arith.constant 28 : index
+    %c29 = arith.constant 29 : index
+    %c30 = arith.constant 30 : index
+    %c31 = arith.constant 31 : index
+    %v15 = arith.constant 1.500000e+01 : f32
+
+    %ptr0 = pto.addptr %arg0, %c0 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old0 = pto.atomic_exch %ptr0, %v15 l2cache(nmfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr1 = pto.addptr %arg0, %c1 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old1 = pto.atomic_exch %ptr1, %v15 l2cache(nmlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr2 = pto.addptr %arg0, %c2 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old2 = pto.atomic_exch %ptr2, %v15 l2cache(nmprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr3 = pto.addptr %arg0, %c3 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old3 = pto.atomic_exch %ptr3, %v15 l2cache(nmred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr4 = pto.addptr %arg0, %c4 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old4 = pto.atomic_exch %ptr4, %v15 l2cache(naci) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr5 = pto.addptr %arg0, %c5 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old5 = pto.atomic_exch %ptr5, %v15 l2cache(napw) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr6 = pto.addptr %arg0, %c6 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old6 = pto.atomic_exch %ptr6, %v15 l2cache(napi) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr7 = pto.addptr %arg0, %c7 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old7 = pto.atomic_exch %ptr7, %v15 l2cache(nared) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr8 = pto.addptr %arg0, %c8 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old8 = pto.atomic_exch %ptr8, %v15 l2cache(wbhfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr9 = pto.addptr %arg0, %c9 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old9 = pto.atomic_exch %ptr9, %v15 l2cache(wbhlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr10 = pto.addptr %arg0, %c10 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old10 = pto.atomic_exch %ptr10, %v15 l2cache(wbhprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr11 = pto.addptr %arg0, %c11 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old11 = pto.atomic_exch %ptr11, %v15 l2cache(wbhred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr12 = pto.addptr %arg0, %c12 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old12 = pto.atomic_exch %ptr12, %v15 l2cache(wtsfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr13 = pto.addptr %arg0, %c13 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old13 = pto.atomic_exch %ptr13, %v15 l2cache(wtslv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr14 = pto.addptr %arg0, %c14 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old14 = pto.atomic_exch %ptr14, %v15 l2cache(wtsprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr15 = pto.addptr %arg0, %c15 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old15 = pto.atomic_exch %ptr15, %v15 l2cache(wtsred) : !pto.ptr<f32, gm>, f32 -> f32
+
+    pto.store %old0, %arg0[%c16] : !pto.ptr<f32, gm>, f32
+    pto.store %old1, %arg0[%c17] : !pto.ptr<f32, gm>, f32
+    pto.store %old2, %arg0[%c18] : !pto.ptr<f32, gm>, f32
+    pto.store %old3, %arg0[%c19] : !pto.ptr<f32, gm>, f32
+    pto.store %old4, %arg0[%c20] : !pto.ptr<f32, gm>, f32
+    pto.store %old5, %arg0[%c21] : !pto.ptr<f32, gm>, f32
+    pto.store %old6, %arg0[%c22] : !pto.ptr<f32, gm>, f32
+    pto.store %old7, %arg0[%c23] : !pto.ptr<f32, gm>, f32
+    pto.store %old8, %arg0[%c24] : !pto.ptr<f32, gm>, f32
+    pto.store %old9, %arg0[%c25] : !pto.ptr<f32, gm>, f32
+    pto.store %old10, %arg0[%c26] : !pto.ptr<f32, gm>, f32
+    pto.store %old11, %arg0[%c27] : !pto.ptr<f32, gm>, f32
+    pto.store %old12, %arg0[%c28] : !pto.ptr<f32, gm>, f32
+    pto.store %old13, %arg0[%c29] : !pto.ptr<f32, gm>, f32
+    pto.store %old14, %arg0[%c30] : !pto.ptr<f32, gm>, f32
+    pto.store %old15, %arg0[%c31] : !pto.ptr<f32, gm>, f32
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_exch_f32_core_kernel(__gm__ float *v1);
+void LaunchSimt_atomic_exch_f32_core_kernel(float *v1, void *stream) {
+  simt_atomic_exch_f32_core_kernel<<<1, nullptr, stream>>>((__gm__ float *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-exch-f32-core/main.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_exch_f32_core_kernel(float *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(float);
+  float *v1Host = nullptr;
+  float *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_exch_f32_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/compare.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def compare_one(name: str, dtype) -> bool:
+    golden = np.fromfile(f"golden_{name}.bin", dtype=dtype)
+    out = np.fromfile(f"{name}.bin", dtype=dtype)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        if dtype == np.float32:
+            print(
+                f"[ERROR] {name} mismatch at idx={idx}, "
+                f"golden={float(golden[idx])}, out={float(out[idx])}"
+            )
+        else:
+            print(
+                f"[ERROR] {name} mismatch at idx={idx}, "
+                f"golden=0x{int(golden[idx]):04x}, out=0x{int(out[idx]):04x}"
+            )
+    return ok
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    ok = (
+        compare_one("v1", np.float32)
+        and compare_one("v2", np.uint16)
+        and compare_one("v3", np.uint16)
+    )
+    if not ok and strict:
+        sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/golden.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    golden_v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    v2 = np.full(ELEMS, 0xBC00, dtype=np.uint16)
+    v3 = np.full(ELEMS, 0xBF80, dtype=np.uint16)
+    golden_v2 = v2.copy()
+    golden_v3 = v3.copy()
+    v1[:16] = np.full(16, 10.0, dtype=np.float32)
+    golden_v1[:16] = np.full(16, 15.0, dtype=np.float32)
+    golden_v1[16:32] = np.full(16, 10.0, dtype=np.float32)
+    v2[:2] = np.array([0x3C00, 0x4000], dtype=np.uint16)  # f16: 1.0, 2.0
+    v3[:2] = np.array([0x3F80, 0x4040], dtype=np.uint16)  # bf16: 1.0, 3.0
+    golden_v2[:2] = np.array([0x4000, 0x4200], dtype=np.uint16)  # 2.0, 3.0
+    golden_v3[:2] = np.array([0x4000, 0x4000], dtype=np.uint16)  # 2.0, 2.0
+    v1.tofile(output_dir / "v1.bin")
+    v2.tofile(output_dir / "v2.bin")
+    v3.tofile(output_dir / "v3.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+    golden_v2.tofile(output_dir / "golden_v2.bin")
+    golden_v3.tofile(output_dir / "golden_v3.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/kernel.pto
@@ -1,0 +1,104 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_f32_mode_core_kernel(%arg0: !pto.ptr<f32, gm>,
+                                              %arg1: !pto.ptr<f16, gm>,
+                                              %arg2: !pto.ptr<bf16, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    %c18 = arith.constant 18 : index
+    %c19 = arith.constant 19 : index
+    %c20 = arith.constant 20 : index
+    %c21 = arith.constant 21 : index
+    %c22 = arith.constant 22 : index
+    %c23 = arith.constant 23 : index
+    %c24 = arith.constant 24 : index
+    %c25 = arith.constant 25 : index
+    %c26 = arith.constant 26 : index
+    %c27 = arith.constant 27 : index
+    %c28 = arith.constant 28 : index
+    %c29 = arith.constant 29 : index
+    %c30 = arith.constant 30 : index
+    %c31 = arith.constant 31 : index
+    %v5 = arith.constant 5.000000e+00 : f32
+    %h1 = arith.constant 1.000000e+00 : f16
+    %h3 = arith.constant 3.000000e+00 : f16
+    %b1 = arith.constant 1.000000e+00 : bf16
+    %b2 = arith.constant 2.000000e+00 : bf16
+
+    %ptr0 = pto.addptr %arg0, %c0 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old0 = pto.atomic_add %ptr0, %v5 l2cache(nmfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr1 = pto.addptr %arg0, %c1 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old1 = pto.atomic_add %ptr1, %v5 l2cache(nmlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr2 = pto.addptr %arg0, %c2 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old2 = pto.atomic_add %ptr2, %v5 l2cache(nmprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr3 = pto.addptr %arg0, %c3 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old3 = pto.atomic_add %ptr3, %v5 l2cache(nmred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr4 = pto.addptr %arg0, %c4 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old4 = pto.atomic_add %ptr4, %v5 l2cache(naci) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr5 = pto.addptr %arg0, %c5 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old5 = pto.atomic_add %ptr5, %v5 l2cache(napw) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr6 = pto.addptr %arg0, %c6 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old6 = pto.atomic_add %ptr6, %v5 l2cache(napi) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr7 = pto.addptr %arg0, %c7 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old7 = pto.atomic_add %ptr7, %v5 l2cache(nared) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr8 = pto.addptr %arg0, %c8 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old8 = pto.atomic_add %ptr8, %v5 l2cache(wbhfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr9 = pto.addptr %arg0, %c9 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old9 = pto.atomic_add %ptr9, %v5 l2cache(wbhlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr10 = pto.addptr %arg0, %c10 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old10 = pto.atomic_add %ptr10, %v5 l2cache(wbhprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr11 = pto.addptr %arg0, %c11 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old11 = pto.atomic_add %ptr11, %v5 l2cache(wbhred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr12 = pto.addptr %arg0, %c12 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old12 = pto.atomic_add %ptr12, %v5 l2cache(wtsfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr13 = pto.addptr %arg0, %c13 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old13 = pto.atomic_add %ptr13, %v5 l2cache(wtslv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr14 = pto.addptr %arg0, %c14 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old14 = pto.atomic_add %ptr14, %v5 l2cache(wtsprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr15 = pto.addptr %arg0, %c15 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old15 = pto.atomic_add %ptr15, %v5 l2cache(wtsred) : !pto.ptr<f32, gm>, f32 -> f32
+
+    pto.store %old0, %arg0[%c16] : !pto.ptr<f32, gm>, f32
+    pto.store %old1, %arg0[%c17] : !pto.ptr<f32, gm>, f32
+    pto.store %old2, %arg0[%c18] : !pto.ptr<f32, gm>, f32
+    pto.store %old3, %arg0[%c19] : !pto.ptr<f32, gm>, f32
+    pto.store %old4, %arg0[%c20] : !pto.ptr<f32, gm>, f32
+    pto.store %old5, %arg0[%c21] : !pto.ptr<f32, gm>, f32
+    pto.store %old6, %arg0[%c22] : !pto.ptr<f32, gm>, f32
+    pto.store %old7, %arg0[%c23] : !pto.ptr<f32, gm>, f32
+    pto.store %old8, %arg0[%c24] : !pto.ptr<f32, gm>, f32
+    pto.store %old9, %arg0[%c25] : !pto.ptr<f32, gm>, f32
+    pto.store %old10, %arg0[%c26] : !pto.ptr<f32, gm>, f32
+    pto.store %old11, %arg0[%c27] : !pto.ptr<f32, gm>, f32
+    pto.store %old12, %arg0[%c28] : !pto.ptr<f32, gm>, f32
+    pto.store %old13, %arg0[%c29] : !pto.ptr<f32, gm>, f32
+    pto.store %old14, %arg0[%c30] : !pto.ptr<f32, gm>, f32
+    pto.store %old15, %arg0[%c31] : !pto.ptr<f32, gm>, f32
+
+    %h_ptr0 = pto.addptr %arg1, %c0 : !pto.ptr<f16, gm> -> !pto.ptr<f16, gm>
+    %h_ptr1 = pto.addptr %arg1, %c1 : !pto.ptr<f16, gm> -> !pto.ptr<f16, gm>
+    %b_ptr0 = pto.addptr %arg2, %c0 : !pto.ptr<bf16, gm> -> !pto.ptr<bf16, gm>
+    %b_ptr1 = pto.addptr %arg2, %c1 : !pto.ptr<bf16, gm> -> !pto.ptr<bf16, gm>
+    %old_h0 = pto.atomic_add %h_ptr0, %h1 l2cache(nmfv) : !pto.ptr<f16, gm>, f16 -> f16
+    %old_h1 = pto.atomic_max %h_ptr1, %h3 l2cache(nmfv) : !pto.ptr<f16, gm>, f16 -> f16
+    %old_b0 = pto.atomic_add %b_ptr0, %b1 l2cache(nmfv) : !pto.ptr<bf16, gm>, bf16 -> bf16
+    %old_b1 = pto.atomic_min %b_ptr1, %b2 l2cache(nmfv) : !pto.ptr<bf16, gm>, bf16 -> bf16
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/launch.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <stdint.h>
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_f32_mode_core_kernel(
+    __gm__ float *v1, __gm__ half *v2, __gm__ bfloat16_t *v3);
+void LaunchSimt_atomic_f32_mode_core_kernel(float *v1, uint16_t *v2,
+                                            uint16_t *v3, void *stream) {
+  simt_atomic_f32_mode_core_kernel<<<1, nullptr, stream>>>(
+      (__gm__ float *)v1, (__gm__ half *)v2, (__gm__ bfloat16_t *)v3);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-f32-mode-core/main.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+#include <stdint.h>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_f32_mode_core_kernel(float *v1, uint16_t *v2,
+                                            uint16_t *v3, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(float);
+  size_t elemCount_v2 = 1024;
+  size_t fileSize_v2 = elemCount_v2 * sizeof(uint16_t);
+  float *v1Host = nullptr;
+  uint16_t *v2Host = nullptr;
+  uint16_t *v3Host = nullptr;
+  float *v1Device = nullptr;
+  uint16_t *v2Device = nullptr;
+  uint16_t *v3Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMallocHost((void **)(&v2Host), fileSize_v2));
+  ACL_CHECK(aclrtMallocHost((void **)(&v3Host), fileSize_v2));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v2Device, fileSize_v2, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v3Device, fileSize_v2, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ReadFile("./v2.bin", fileSize_v2, v2Host, fileSize_v2);
+  ReadFile("./v3.bin", fileSize_v2, v3Host, fileSize_v2);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v2Device, fileSize_v2, v2Host, fileSize_v2, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v3Device, fileSize_v2, v3Host, fileSize_v2, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_f32_mode_core_kernel(v1Device, v2Device, v3Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v2Host, fileSize_v2, v2Device, fileSize_v2, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v3Host, fileSize_v2, v3Device, fileSize_v2, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+  WriteFile("./v2.bin", v2Host, fileSize_v2);
+  WriteFile("./v3.bin", v3Host, fileSize_v2);
+
+cleanup:
+  aclrtFree(v3Device);
+  aclrtFree(v2Device);
+  aclrtFree(v1Device);
+  aclrtFreeHost(v3Host);
+  aclrtFreeHost(v2Host);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.float32)
+    out = np.fromfile("v1.bin", dtype=np.float32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={float(golden[idx])}, out={float(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/golden.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    golden_v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    v1[:16] = np.full(16, 10.0, dtype=np.float32)
+    golden_v1[:16] = np.full(16, 15.0, dtype=np.float32)
+    golden_v1[16:32] = np.full(16, 10.0, dtype=np.float32)
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/kernel.pto
@@ -1,0 +1,89 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_max_f32_core_kernel(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    %c18 = arith.constant 18 : index
+    %c19 = arith.constant 19 : index
+    %c20 = arith.constant 20 : index
+    %c21 = arith.constant 21 : index
+    %c22 = arith.constant 22 : index
+    %c23 = arith.constant 23 : index
+    %c24 = arith.constant 24 : index
+    %c25 = arith.constant 25 : index
+    %c26 = arith.constant 26 : index
+    %c27 = arith.constant 27 : index
+    %c28 = arith.constant 28 : index
+    %c29 = arith.constant 29 : index
+    %c30 = arith.constant 30 : index
+    %c31 = arith.constant 31 : index
+    %v15 = arith.constant 1.500000e+01 : f32
+
+    %ptr0 = pto.addptr %arg0, %c0 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old0 = pto.atomic_max %ptr0, %v15 l2cache(nmfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr1 = pto.addptr %arg0, %c1 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old1 = pto.atomic_max %ptr1, %v15 l2cache(nmlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr2 = pto.addptr %arg0, %c2 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old2 = pto.atomic_max %ptr2, %v15 l2cache(nmprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr3 = pto.addptr %arg0, %c3 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old3 = pto.atomic_max %ptr3, %v15 l2cache(nmred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr4 = pto.addptr %arg0, %c4 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old4 = pto.atomic_max %ptr4, %v15 l2cache(naci) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr5 = pto.addptr %arg0, %c5 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old5 = pto.atomic_max %ptr5, %v15 l2cache(napw) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr6 = pto.addptr %arg0, %c6 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old6 = pto.atomic_max %ptr6, %v15 l2cache(napi) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr7 = pto.addptr %arg0, %c7 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old7 = pto.atomic_max %ptr7, %v15 l2cache(nared) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr8 = pto.addptr %arg0, %c8 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old8 = pto.atomic_max %ptr8, %v15 l2cache(wbhfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr9 = pto.addptr %arg0, %c9 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old9 = pto.atomic_max %ptr9, %v15 l2cache(wbhlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr10 = pto.addptr %arg0, %c10 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old10 = pto.atomic_max %ptr10, %v15 l2cache(wbhprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr11 = pto.addptr %arg0, %c11 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old11 = pto.atomic_max %ptr11, %v15 l2cache(wbhred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr12 = pto.addptr %arg0, %c12 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old12 = pto.atomic_max %ptr12, %v15 l2cache(wtsfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr13 = pto.addptr %arg0, %c13 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old13 = pto.atomic_max %ptr13, %v15 l2cache(wtslv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr14 = pto.addptr %arg0, %c14 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old14 = pto.atomic_max %ptr14, %v15 l2cache(wtsprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr15 = pto.addptr %arg0, %c15 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old15 = pto.atomic_max %ptr15, %v15 l2cache(wtsred) : !pto.ptr<f32, gm>, f32 -> f32
+
+    pto.store %old0, %arg0[%c16] : !pto.ptr<f32, gm>, f32
+    pto.store %old1, %arg0[%c17] : !pto.ptr<f32, gm>, f32
+    pto.store %old2, %arg0[%c18] : !pto.ptr<f32, gm>, f32
+    pto.store %old3, %arg0[%c19] : !pto.ptr<f32, gm>, f32
+    pto.store %old4, %arg0[%c20] : !pto.ptr<f32, gm>, f32
+    pto.store %old5, %arg0[%c21] : !pto.ptr<f32, gm>, f32
+    pto.store %old6, %arg0[%c22] : !pto.ptr<f32, gm>, f32
+    pto.store %old7, %arg0[%c23] : !pto.ptr<f32, gm>, f32
+    pto.store %old8, %arg0[%c24] : !pto.ptr<f32, gm>, f32
+    pto.store %old9, %arg0[%c25] : !pto.ptr<f32, gm>, f32
+    pto.store %old10, %arg0[%c26] : !pto.ptr<f32, gm>, f32
+    pto.store %old11, %arg0[%c27] : !pto.ptr<f32, gm>, f32
+    pto.store %old12, %arg0[%c28] : !pto.ptr<f32, gm>, f32
+    pto.store %old13, %arg0[%c29] : !pto.ptr<f32, gm>, f32
+    pto.store %old14, %arg0[%c30] : !pto.ptr<f32, gm>, f32
+    pto.store %old15, %arg0[%c31] : !pto.ptr<f32, gm>, f32
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_max_f32_core_kernel(__gm__ float *v1);
+void LaunchSimt_atomic_max_f32_core_kernel(float *v1, void *stream) {
+  simt_atomic_max_f32_core_kernel<<<1, nullptr, stream>>>((__gm__ float *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-max-f32-core/main.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_max_f32_core_kernel(float *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(float);
+  float *v1Host = nullptr;
+  float *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_max_f32_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.float32)
+    out = np.fromfile("v1.bin", dtype=np.float32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={float(golden[idx])}, out={float(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/golden.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    golden_v1 = np.full(ELEMS, -1.0, dtype=np.float32)
+    v1[:16] = np.full(16, 10.0, dtype=np.float32)
+    golden_v1[:16] = np.full(16, 5.0, dtype=np.float32)
+    golden_v1[16:32] = np.full(16, 10.0, dtype=np.float32)
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/kernel.pto
@@ -1,0 +1,89 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_min_f32_core_kernel(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    %c18 = arith.constant 18 : index
+    %c19 = arith.constant 19 : index
+    %c20 = arith.constant 20 : index
+    %c21 = arith.constant 21 : index
+    %c22 = arith.constant 22 : index
+    %c23 = arith.constant 23 : index
+    %c24 = arith.constant 24 : index
+    %c25 = arith.constant 25 : index
+    %c26 = arith.constant 26 : index
+    %c27 = arith.constant 27 : index
+    %c28 = arith.constant 28 : index
+    %c29 = arith.constant 29 : index
+    %c30 = arith.constant 30 : index
+    %c31 = arith.constant 31 : index
+    %v5 = arith.constant 5.000000e+00 : f32
+
+    %ptr0 = pto.addptr %arg0, %c0 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old0 = pto.atomic_min %ptr0, %v5 l2cache(nmfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr1 = pto.addptr %arg0, %c1 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old1 = pto.atomic_min %ptr1, %v5 l2cache(nmlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr2 = pto.addptr %arg0, %c2 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old2 = pto.atomic_min %ptr2, %v5 l2cache(nmprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr3 = pto.addptr %arg0, %c3 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old3 = pto.atomic_min %ptr3, %v5 l2cache(nmred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr4 = pto.addptr %arg0, %c4 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old4 = pto.atomic_min %ptr4, %v5 l2cache(naci) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr5 = pto.addptr %arg0, %c5 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old5 = pto.atomic_min %ptr5, %v5 l2cache(napw) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr6 = pto.addptr %arg0, %c6 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old6 = pto.atomic_min %ptr6, %v5 l2cache(napi) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr7 = pto.addptr %arg0, %c7 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old7 = pto.atomic_min %ptr7, %v5 l2cache(nared) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr8 = pto.addptr %arg0, %c8 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old8 = pto.atomic_min %ptr8, %v5 l2cache(wbhfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr9 = pto.addptr %arg0, %c9 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old9 = pto.atomic_min %ptr9, %v5 l2cache(wbhlv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr10 = pto.addptr %arg0, %c10 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old10 = pto.atomic_min %ptr10, %v5 l2cache(wbhprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr11 = pto.addptr %arg0, %c11 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old11 = pto.atomic_min %ptr11, %v5 l2cache(wbhred) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr12 = pto.addptr %arg0, %c12 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old12 = pto.atomic_min %ptr12, %v5 l2cache(wtsfv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr13 = pto.addptr %arg0, %c13 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old13 = pto.atomic_min %ptr13, %v5 l2cache(wtslv) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr14 = pto.addptr %arg0, %c14 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old14 = pto.atomic_min %ptr14, %v5 l2cache(wtsprs) : !pto.ptr<f32, gm>, f32 -> f32
+    %ptr15 = pto.addptr %arg0, %c15 : !pto.ptr<f32, gm> -> !pto.ptr<f32, gm>
+    %old15 = pto.atomic_min %ptr15, %v5 l2cache(wtsred) : !pto.ptr<f32, gm>, f32 -> f32
+
+    pto.store %old0, %arg0[%c16] : !pto.ptr<f32, gm>, f32
+    pto.store %old1, %arg0[%c17] : !pto.ptr<f32, gm>, f32
+    pto.store %old2, %arg0[%c18] : !pto.ptr<f32, gm>, f32
+    pto.store %old3, %arg0[%c19] : !pto.ptr<f32, gm>, f32
+    pto.store %old4, %arg0[%c20] : !pto.ptr<f32, gm>, f32
+    pto.store %old5, %arg0[%c21] : !pto.ptr<f32, gm>, f32
+    pto.store %old6, %arg0[%c22] : !pto.ptr<f32, gm>, f32
+    pto.store %old7, %arg0[%c23] : !pto.ptr<f32, gm>, f32
+    pto.store %old8, %arg0[%c24] : !pto.ptr<f32, gm>, f32
+    pto.store %old9, %arg0[%c25] : !pto.ptr<f32, gm>, f32
+    pto.store %old10, %arg0[%c26] : !pto.ptr<f32, gm>, f32
+    pto.store %old11, %arg0[%c27] : !pto.ptr<f32, gm>, f32
+    pto.store %old12, %arg0[%c28] : !pto.ptr<f32, gm>, f32
+    pto.store %old13, %arg0[%c29] : !pto.ptr<f32, gm>, f32
+    pto.store %old14, %arg0[%c30] : !pto.ptr<f32, gm>, f32
+    pto.store %old15, %arg0[%c31] : !pto.ptr<f32, gm>, f32
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/launch.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_min_f32_core_kernel(__gm__ float *v1);
+void LaunchSimt_atomic_min_f32_core_kernel(float *v1, void *stream) {
+  simt_atomic_min_f32_core_kernel<<<1, nullptr, stream>>>((__gm__ float *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-min-f32-core/main.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_min_f32_core_kernel(float *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(float);
+  float *v1Host = nullptr;
+  float *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_min_f32_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/golden.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    golden_v1 = np.full(ELEMS, -1, dtype=np.int32)
+    v1[:16] = np.full(16, 10, dtype=np.int32)
+    golden_v1[:16] = np.full(16, 15, dtype=np.int32)
+    golden_v1[16:32] = np.full(16, 10, dtype=np.int32)
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/kernel.pto
@@ -1,0 +1,89 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_mode_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    %c18 = arith.constant 18 : index
+    %c19 = arith.constant 19 : index
+    %c20 = arith.constant 20 : index
+    %c21 = arith.constant 21 : index
+    %c22 = arith.constant 22 : index
+    %c23 = arith.constant 23 : index
+    %c24 = arith.constant 24 : index
+    %c25 = arith.constant 25 : index
+    %c26 = arith.constant 26 : index
+    %c27 = arith.constant 27 : index
+    %c28 = arith.constant 28 : index
+    %c29 = arith.constant 29 : index
+    %c30 = arith.constant 30 : index
+    %c31 = arith.constant 31 : index
+    %v5 = arith.constant 5 : i32
+
+    %ptr0 = pto.addptr %arg0, %c0 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old0 = pto.atomic_add %ptr0, %v5 l2cache(nmfv) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr1 = pto.addptr %arg0, %c1 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old1 = pto.atomic_add %ptr1, %v5 l2cache(nmlv) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr2 = pto.addptr %arg0, %c2 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old2 = pto.atomic_add %ptr2, %v5 l2cache(nmprs) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr3 = pto.addptr %arg0, %c3 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old3 = pto.atomic_add %ptr3, %v5 l2cache(nmred) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr4 = pto.addptr %arg0, %c4 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old4 = pto.atomic_add %ptr4, %v5 l2cache(naci) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr5 = pto.addptr %arg0, %c5 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old5 = pto.atomic_add %ptr5, %v5 l2cache(napw) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr6 = pto.addptr %arg0, %c6 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old6 = pto.atomic_add %ptr6, %v5 l2cache(napi) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr7 = pto.addptr %arg0, %c7 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old7 = pto.atomic_add %ptr7, %v5 l2cache(nared) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr8 = pto.addptr %arg0, %c8 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old8 = pto.atomic_add %ptr8, %v5 l2cache(wbhfv) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr9 = pto.addptr %arg0, %c9 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old9 = pto.atomic_add %ptr9, %v5 l2cache(wbhlv) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr10 = pto.addptr %arg0, %c10 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old10 = pto.atomic_add %ptr10, %v5 l2cache(wbhprs) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr11 = pto.addptr %arg0, %c11 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old11 = pto.atomic_add %ptr11, %v5 l2cache(wbhred) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr12 = pto.addptr %arg0, %c12 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old12 = pto.atomic_add %ptr12, %v5 l2cache(wtsfv) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr13 = pto.addptr %arg0, %c13 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old13 = pto.atomic_add %ptr13, %v5 l2cache(wtslv) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr14 = pto.addptr %arg0, %c14 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old14 = pto.atomic_add %ptr14, %v5 l2cache(wtsprs) signed : !pto.ptr<i32, gm>, i32 -> i32
+    %ptr15 = pto.addptr %arg0, %c15 : !pto.ptr<i32, gm> -> !pto.ptr<i32, gm>
+    %old15 = pto.atomic_add %ptr15, %v5 l2cache(wtsred) signed : !pto.ptr<i32, gm>, i32 -> i32
+
+    pto.store %old0, %arg0[%c16] : !pto.ptr<i32, gm>, i32
+    pto.store %old1, %arg0[%c17] : !pto.ptr<i32, gm>, i32
+    pto.store %old2, %arg0[%c18] : !pto.ptr<i32, gm>, i32
+    pto.store %old3, %arg0[%c19] : !pto.ptr<i32, gm>, i32
+    pto.store %old4, %arg0[%c20] : !pto.ptr<i32, gm>, i32
+    pto.store %old5, %arg0[%c21] : !pto.ptr<i32, gm>, i32
+    pto.store %old6, %arg0[%c22] : !pto.ptr<i32, gm>, i32
+    pto.store %old7, %arg0[%c23] : !pto.ptr<i32, gm>, i32
+    pto.store %old8, %arg0[%c24] : !pto.ptr<i32, gm>, i32
+    pto.store %old9, %arg0[%c25] : !pto.ptr<i32, gm>, i32
+    pto.store %old10, %arg0[%c26] : !pto.ptr<i32, gm>, i32
+    pto.store %old11, %arg0[%c27] : !pto.ptr<i32, gm>, i32
+    pto.store %old12, %arg0[%c28] : !pto.ptr<i32, gm>, i32
+    pto.store %old13, %arg0[%c29] : !pto.ptr<i32, gm>, i32
+    pto.store %old14, %arg0[%c30] : !pto.ptr<i32, gm>, i32
+    pto.store %old15, %arg0[%c31] : !pto.ptr<i32, gm>, i32
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_mode_core_kernel(__gm__ int *v1);
+void LaunchSimt_atomic_mode_core_kernel(int *v1, void *stream) {
+  simt_atomic_mode_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-mode-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_mode_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_mode_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/compare.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def compare_one(name: str) -> bool:
+    golden = np.fromfile(f"golden_{name}.bin", dtype=np.uint32)
+    out = np.fromfile(f"{name}.bin", dtype=np.uint32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] {name} mismatch at idx={idx}, "
+            f"golden=0x{int(golden[idx]):08x}, out=0x{int(out[idx]):08x}"
+        )
+    return ok
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    ok = compare_one("v1") and compare_one("v2")
+    if not ok and strict:
+        sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/golden.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 16
+
+
+def pack_u16_pair(lo: int, hi: int) -> np.uint32:
+    return np.uint32((hi << 16) | lo)
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    h2 = np.zeros(ELEMS, dtype=np.uint32)
+    b2 = np.zeros(ELEMS, dtype=np.uint32)
+    h2[0] = pack_u16_pair(0x3C00, 0x3C00)  # f16x2: (1.0, 1.0)
+    h2[1] = pack_u16_pair(0x3C00, 0x4000)  # f16x2: (1.0, 2.0)
+    b2[0] = pack_u16_pair(0x3F80, 0x4040)  # bf16x2: (1.0, 3.0)
+    b2[1] = pack_u16_pair(0x4040, 0x4040)  # bf16x2: (3.0, 3.0)
+
+    golden_h2 = h2.copy()
+    golden_b2 = b2.copy()
+    golden_h2[0] = pack_u16_pair(0x4000, 0x4000)  # CAS -> (2.0, 2.0)
+    golden_h2[1] = pack_u16_pair(0x4000, 0x4200)  # ADD -> (2.0, 3.0)
+    golden_b2[0] = pack_u16_pair(0x4000, 0x4000)  # EXCH -> (2.0, 2.0)
+    golden_b2[1] = pack_u16_pair(0x3F80, 0x3F80)  # MIN -> (1.0, 1.0)
+
+    h2.tofile(output_dir / "v1.bin")
+    b2.tofile(output_dir / "v2.bin")
+    golden_h2.tofile(output_dir / "golden_v1.bin")
+    golden_b2.tofile(output_dir / "golden_v2.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/kernel.pto
@@ -1,0 +1,39 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_packed_core_kernel(%h2_gm: !pto.ptr<vector<2xf16>, gm>,
+                                            %b2_gm: !pto.ptr<vector<2xbf16>, gm>)
+      attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 1 : i32
+    %h2_addr = pto.castptr %h2_gm : !pto.ptr<vector<2xf16>, gm> -> i64
+    %b2_addr = pto.castptr %b2_gm : !pto.ptr<vector<2xbf16>, gm> -> i64
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_atomic_packed_core_body(%h2_addr, %b2_addr) : (i64, i64) -> ()
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_atomic_packed_core_body(%h2_addr: i64, %b2_addr: i64)
+      attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %h2_gm = pto.castptr %h2_addr : i64 -> !pto.ptr<vector<2xf16>, gm>
+    %b2_gm = pto.castptr %b2_addr : i64 -> !pto.ptr<vector<2xbf16>, gm>
+    %h2_one = arith.constant dense<1.000000e+00> : vector<2xf16>
+    %h2_two = arith.constant dense<2.000000e+00> : vector<2xf16>
+    %b2_one = arith.constant dense<1.000000e+00> : vector<2xbf16>
+    %b2_two = arith.constant dense<2.000000e+00> : vector<2xbf16>
+
+    %h2_cas = pto.addptr %h2_gm, %c0 : !pto.ptr<vector<2xf16>, gm> -> !pto.ptr<vector<2xf16>, gm>
+    %h2_add = pto.addptr %h2_gm, %c1 : !pto.ptr<vector<2xf16>, gm> -> !pto.ptr<vector<2xf16>, gm>
+    %b2_exch = pto.addptr %b2_gm, %c0 : !pto.ptr<vector<2xbf16>, gm> -> !pto.ptr<vector<2xbf16>, gm>
+    %b2_min = pto.addptr %b2_gm, %c1 : !pto.ptr<vector<2xbf16>, gm> -> !pto.ptr<vector<2xbf16>, gm>
+
+    %old_h2_cas = pto.atomic_cas %h2_cas, %h2_one, %h2_two l2cache(nmfv) : !pto.ptr<vector<2xf16>, gm>, vector<2xf16> -> vector<2xf16>
+    %old_h2_add = pto.atomic_add %h2_add, %h2_one l2cache(nmfv) : !pto.ptr<vector<2xf16>, gm>, vector<2xf16> -> vector<2xf16>
+    %old_b2_exch = pto.atomic_exch %b2_exch, %b2_two l2cache(nmfv) : !pto.ptr<vector<2xbf16>, gm>, vector<2xbf16> -> vector<2xbf16>
+    %old_b2_min = pto.atomic_min %b2_min, %b2_one l2cache(nmfv) : !pto.ptr<vector<2xbf16>, gm>, vector<2xbf16> -> vector<2xbf16>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/kernel.pto
@@ -8,8 +8,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %h2_addr = pto.castptr %h2_gm : !pto.ptr<vector<2xf16>, gm> -> i64
     %b2_addr = pto.castptr %b2_gm : !pto.ptr<vector<2xbf16>, gm> -> i64
 
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_atomic_packed_core_body(%h2_addr, %b2_addr) : (i64, i64) -> ()
+    pto.simt_launch @simt_atomic_packed_core_body<<<%dim_x, %dim_y, %dim_z>>>(%h2_addr, %b2_addr) : (i64, i64) -> ()
     pto.barrier #pto.pipe<PIPE_ALL>
     return
   }

--- a/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/launch.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_packed_core_kernel(
+    __gm__ uint32_t *h2, __gm__ uint32_t *b2);
+void LaunchSimt_atomic_packed_core_kernel(uint32_t *h2, uint32_t *b2,
+                                          void *stream) {
+  simt_atomic_packed_core_kernel<<<1, nullptr, stream>>>(
+      (__gm__ uint32_t *)h2, (__gm__ uint32_t *)b2);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-packed-core/main.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+#include <stdint.h>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_packed_core_kernel(uint32_t *h2, uint32_t *b2,
+                                          void *stream);
+
+int main() {
+  size_t elemCount = 16;
+  size_t fileSize = elemCount * sizeof(uint32_t);
+  uint32_t *h2Host = nullptr;
+  uint32_t *b2Host = nullptr;
+  uint32_t *h2Device = nullptr;
+  uint32_t *b2Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&h2Host), fileSize));
+  ACL_CHECK(aclrtMallocHost((void **)(&b2Host), fileSize));
+  ACL_CHECK(aclrtMalloc((void **)&h2Device, fileSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&b2Device, fileSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize, h2Host, fileSize);
+  ReadFile("./v2.bin", fileSize, b2Host, fileSize);
+  ACL_CHECK(aclrtMemcpy(h2Device, fileSize, h2Host, fileSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(b2Device, fileSize, b2Host, fileSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_packed_core_kernel(h2Device, b2Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(h2Host, fileSize, h2Device, fileSize, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(b2Host, fileSize, b2Device, fileSize, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", h2Host, fileSize);
+  WriteFile("./v2.bin", b2Host, fileSize);
+
+cleanup:
+  aclrtFree(b2Device);
+  aclrtFree(h2Device);
+  aclrtFreeHost(b2Host);
+  aclrtFreeHost(h2Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-s-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-s-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-s-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-s-core/golden.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+LANES = 32
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    golden_v1 = np.full(ELEMS, -1, dtype=np.int32)
+    v1[0:LANES] = 10
+    v1[32 : 32 + LANES] = 20
+    v1[64 : 64 + LANES] = 10
+    v1[96 : 96 + LANES] = 10
+    golden_v1[0:LANES] = 15
+    golden_v1[32 : 32 + LANES] = 20
+    golden_v1[64 : 64 + LANES] = 42
+    golden_v1[96 : 96 + LANES] = 2
+    golden_v1[128 : 128 + LANES] = 10
+    golden_v1[160 : 160 + LANES] = 20
+    golden_v1[192 : 192 + LANES] = 10
+    golden_v1[224 : 224 + LANES] = 10
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-atomic-s-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-s-core/kernel.pto
@@ -1,0 +1,77 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_atomic_s_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    %s = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    pto.mte_gm_ub %arg0, %ub, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, gm>, !pto.ptr<i32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_atomic_s_core_body(%s, %ub) : (!pto.ptr<i32, ub>, !pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub, %arg0, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_atomic_s_core_body(%s: !pto.ptr<i32, ub>, %out: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %laneid = pto.get_laneid : i32
+    %c32 = arith.constant 32 : i32
+    %c64 = arith.constant 64 : i32
+    %c96 = arith.constant 96 : i32
+    %c128 = arith.constant 128 : i32
+    %c160 = arith.constant 160 : i32
+    %c192 = arith.constant 192 : i32
+    %c224 = arith.constant 224 : i32
+    %v5 = arith.constant 5 : i32
+    %v7 = arith.constant 7 : i32
+    %v10 = arith.constant 10 : i32
+    %v15 = arith.constant 15 : i32
+    %v42 = arith.constant 42 : i32
+
+    %idx_add = arith.index_castui %laneid : i32 to index
+    %off_max = arith.addi %laneid, %c32 : i32
+    %idx_max = arith.index_castui %off_max : i32 to index
+    %off_cas = arith.addi %laneid, %c64 : i32
+    %idx_cas = arith.index_castui %off_cas : i32 to index
+    %off_and = arith.addi %laneid, %c96 : i32
+    %idx_and = arith.index_castui %off_and : i32 to index
+    %out_add = arith.addi %laneid, %c128 : i32
+    %out_add_idx = arith.index_castui %out_add : i32 to index
+    %out_max = arith.addi %laneid, %c160 : i32
+    %out_max_idx = arith.index_castui %out_max : i32 to index
+    %out_cas = arith.addi %laneid, %c192 : i32
+    %out_cas_idx = arith.index_castui %out_cas : i32 to index
+    %out_and = arith.addi %laneid, %c224 : i32
+    %out_and_idx = arith.index_castui %out_and : i32 to index
+
+    %ptr0 = pto.addptr %s, %idx_add : !pto.ptr<i32, ub> -> !pto.ptr<i32, ub>
+    %old_add = pto.atomic_add %ptr0, %v5 l2cache(nmfv) signed : !pto.ptr<i32, ub>, i32 -> i32
+    %ptr1 = pto.addptr %s, %idx_max : !pto.ptr<i32, ub> -> !pto.ptr<i32, ub>
+    %old_max = pto.atomic_max %ptr1, %v7 l2cache(nmfv) signed : !pto.ptr<i32, ub>, i32 -> i32
+    %ptr2 = pto.addptr %s, %idx_cas : !pto.ptr<i32, ub> -> !pto.ptr<i32, ub>
+    %old_cas = pto.atomic_cas %ptr2, %v10, %v42 l2cache(nmfv) signed : !pto.ptr<i32, ub>, i32 -> i32
+    %ptr3 = pto.addptr %s, %idx_and : !pto.ptr<i32, ub> -> !pto.ptr<i32, ub>
+    %old_and = pto.atomic_and %ptr3, %v7 l2cache(nmfv) unsigned : !pto.ptr<i32, ub>, i32 -> i32
+
+    pto.store %old_add, %out[%out_add_idx] : !pto.ptr<i32, ub>, i32
+    pto.store %old_max, %out[%out_max_idx] : !pto.ptr<i32, ub>, i32
+    pto.store %old_cas, %out[%out_cas_idx] : !pto.ptr<i32, ub>, i32
+    pto.store %old_and, %out[%out_and_idx] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-s-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-s-core/kernel.pto
@@ -16,8 +16,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
     pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_atomic_s_core_body(%s, %ub) : (!pto.ptr<i32, ub>, !pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_atomic_s_core_body<<<%dim_x, %dim_y, %dim_z>>>(%s, %ub) : (!pto.ptr<i32, ub>, !pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/simt/simt-atomic-s-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-s-core/launch.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_atomic_s_core_kernel(__gm__ int *v1);
+void LaunchSimt_atomic_s_core_kernel(int *v1, void *stream) {
+  simt_atomic_s_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-atomic-s-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-atomic-s-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_atomic_s_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_atomic_s_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-control-typed-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-control-typed-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-control-typed-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-control-typed-core/golden.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+LANES = 32
+FIELDS = 20
+ELEMS = 1024
+
+
+def i32_bits(value: int) -> np.int32:
+    value &= 0xFFFFFFFF
+    if value >= 0x80000000:
+        value -= 0x100000000
+    return np.int32(value)
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.zeros(ELEMS, dtype=np.int32)
+    golden_v1 = np.zeros(ELEMS, dtype=np.int32)
+    for lane in range(LANES):
+        base = lane * FIELDS
+        group = 0 if lane < 16 else 16
+        local = lane - group
+        golden_v1[base + 0] = 528
+        golden_v1[base + 1] = np.int32(-1)
+        golden_v1[base + 2] = 0
+        golden_v1[base + 3] = 528
+        golden_v1[base + 4] = 32
+        golden_v1[base + 5] = 1
+        golden_v1[base + 6] = 528
+        golden_v1[base + 7] = 32
+        golden_v1[base + 8] = 1
+        golden_v1[base + 9] = 100 + group + 3
+        golden_v1[base + 10] = 100 + (lane - 2 if local >= 2 else lane)
+        golden_v1[base + 11] = 100 + (lane + 2 if local <= 13 else lane)
+        golden_v1[base + 12] = (lane ^ 1) + 1
+        golden_v1[base + 13] = group + 4
+        golden_v1[base + 14] = 1
+        golden_v1[base + 15] = 2
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-control-typed-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-control-typed-core/kernel.pto
@@ -1,0 +1,152 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_control_typed_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_control_typed_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %arg0, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_control_typed_core_body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %c5_i32 = arith.constant 5 : i32
+    %c6_i32 = arith.constant 6 : i32
+    %c7_i32 = arith.constant 7 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c9_i32 = arith.constant 9 : i32
+    %c10_i32 = arith.constant 10 : i32
+    %c11_i32 = arith.constant 11 : i32
+    %c12_i32 = arith.constant 12 : i32
+    %c13_i32 = arith.constant 13 : i32
+    %c14_i32 = arith.constant 14 : i32
+    %c15_i32 = arith.constant 15 : i32
+    %c31_i32 = arith.constant 31 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c_fields_i32 = arith.constant 20 : i32
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+
+    %laneid = pto.get_laneid : i32
+    %lane_plus_one = arith.addi %laneid, %c1_i32 : i32
+    %is_last = arith.cmpi eq, %laneid, %c31_i32 : i32
+    %minus_one = arith.constant -1 : i32
+    %u32_edge = arith.select %is_last, %minus_one, %laneid : i1, i32
+    %value_i32 = arith.addi %laneid, %c100_i32 : i32
+    %value_i64 = arith.extui %value_i32 : i32 to i64
+    %value_f32 = pto.convert %lane_plus_one round(r) nosat unsigned : i32 -> f32
+    %value_f16 = pto.convert %lane_plus_one round(r) nosat unsigned : i32 -> f16
+
+    %redux_u32_add = pto.redux_add %lane_plus_one unsigned : i32 -> i32
+    %redux_u32_max = pto.redux_max %u32_edge unsigned : i32 -> i32
+    %redux_u32_min = pto.redux_min %u32_edge unsigned : i32 -> i32
+    %redux_f32_add = pto.redux_add %value_f32 : f32 -> f32
+    %redux_f32_max = pto.redux_max %value_f32 : f32 -> f32
+    %redux_f32_min = pto.redux_min %value_f32 : f32 -> f32
+    %redux_f16_add = pto.redux_add %value_f16 : f16 -> f16
+    %redux_f16_max = pto.redux_max %value_f16 : f16 -> f16
+    %redux_f16_min = pto.redux_min %value_f16 : f16 -> f16
+    %redux_f32_add_i = pto.convert %redux_f32_add round(z) sat signed : f32 -> i32
+    %redux_f32_max_i = pto.convert %redux_f32_max round(z) sat signed : f32 -> i32
+    %redux_f32_min_i = pto.convert %redux_f32_min round(z) sat signed : f32 -> i32
+    %redux_f16_add_i = pto.convert %redux_f16_add round(z) sat signed : f16 -> i32
+    %redux_f16_max_i = pto.convert %redux_f16_max round(z) sat signed : f16 -> i32
+    %redux_f16_min_i = pto.convert %redux_f16_min round(z) sat signed : f16 -> i32
+
+    %shfl_idx_w16 = pto.shuffle_idx %value_i32, %c3_i32 {width = 16 : i32} : i32, i32 -> i32
+    %shfl_up_w16 = pto.shuffle_up %value_i32, %c2_i32 {width = 16 : i32} : i32, i32 -> i32
+    %shfl_down_i64_w16 = pto.shuffle_down %value_i64, %c2_i32 {width = 16 : i32} : i64, i32 -> i64
+    %shfl_down_i64_i32 = arith.trunci %shfl_down_i64_w16 : i64 to i32
+    %shfl_bfly_f32_w16 = pto.shuffle_bfly %value_f32, %c1_i32 {width = 16 : i32} : f32, i32 -> f32
+    %shfl_bfly_f32_i = pto.convert %shfl_bfly_f32_w16 round(z) sat signed : f32 -> i32
+    %shfl_idx_f16_w16 = pto.shuffle_idx %value_f16, %c3_i32 {width = 16 : i32} : f16, i32 -> f16
+    %shfl_idx_f16_i = pto.convert %shfl_idx_f16_w16 round(z) sat signed : f16 -> i32
+
+    %one_point_75 = arith.constant 1.750000e+00 : f32
+    %round_z = pto.convert %one_point_75 round(z) sat signed : f32 -> i32
+    %round_r = pto.convert %one_point_75 round(r) sat signed : f32 -> i32
+
+    %base_i32 = arith.muli %laneid, %c_fields_i32 : i32
+    %base = arith.index_castui %base_i32 : i32 to index
+    pto.store %redux_u32_add, %dst[%base] : !pto.ptr<i32, ub>, i32
+    %idx1_i32 = arith.addi %base_i32, %c1_i32 : i32
+    %idx1 = arith.index_castui %idx1_i32 : i32 to index
+    pto.store %redux_u32_max, %dst[%idx1] : !pto.ptr<i32, ub>, i32
+    %idx2_i32 = arith.addi %base_i32, %c2_i32 : i32
+    %idx2 = arith.index_castui %idx2_i32 : i32 to index
+    pto.store %redux_u32_min, %dst[%idx2] : !pto.ptr<i32, ub>, i32
+    %idx3_i32 = arith.addi %base_i32, %c3_i32 : i32
+    %idx3 = arith.index_castui %idx3_i32 : i32 to index
+    pto.store %redux_f32_add_i, %dst[%idx3] : !pto.ptr<i32, ub>, i32
+    %idx4_i32 = arith.addi %base_i32, %c4_i32 : i32
+    %idx4 = arith.index_castui %idx4_i32 : i32 to index
+    pto.store %redux_f32_max_i, %dst[%idx4] : !pto.ptr<i32, ub>, i32
+    %idx5_i32 = arith.addi %base_i32, %c5_i32 : i32
+    %idx5 = arith.index_castui %idx5_i32 : i32 to index
+    pto.store %redux_f32_min_i, %dst[%idx5] : !pto.ptr<i32, ub>, i32
+    %idx6_i32 = arith.addi %base_i32, %c6_i32 : i32
+    %idx6 = arith.index_castui %idx6_i32 : i32 to index
+    pto.store %redux_f16_add_i, %dst[%idx6] : !pto.ptr<i32, ub>, i32
+    %idx7_i32 = arith.addi %base_i32, %c7_i32 : i32
+    %idx7 = arith.index_castui %idx7_i32 : i32 to index
+    pto.store %redux_f16_max_i, %dst[%idx7] : !pto.ptr<i32, ub>, i32
+    %idx8_i32 = arith.addi %base_i32, %c8_i32 : i32
+    %idx8 = arith.index_castui %idx8_i32 : i32 to index
+    pto.store %redux_f16_min_i, %dst[%idx8] : !pto.ptr<i32, ub>, i32
+    %idx9_i32 = arith.addi %base_i32, %c9_i32 : i32
+    %idx9 = arith.index_castui %idx9_i32 : i32 to index
+    pto.store %shfl_idx_w16, %dst[%idx9] : !pto.ptr<i32, ub>, i32
+    %idx10_i32 = arith.addi %base_i32, %c10_i32 : i32
+    %idx10 = arith.index_castui %idx10_i32 : i32 to index
+    pto.store %shfl_up_w16, %dst[%idx10] : !pto.ptr<i32, ub>, i32
+    %idx11_i32 = arith.addi %base_i32, %c11_i32 : i32
+    %idx11 = arith.index_castui %idx11_i32 : i32 to index
+    pto.store %shfl_down_i64_i32, %dst[%idx11] : !pto.ptr<i32, ub>, i32
+    %idx12_i32 = arith.addi %base_i32, %c12_i32 : i32
+    %idx12 = arith.index_castui %idx12_i32 : i32 to index
+    pto.store %shfl_bfly_f32_i, %dst[%idx12] : !pto.ptr<i32, ub>, i32
+    %idx13_i32 = arith.addi %base_i32, %c13_i32 : i32
+    %idx13 = arith.index_castui %idx13_i32 : i32 to index
+    pto.store %shfl_idx_f16_i, %dst[%idx13] : !pto.ptr<i32, ub>, i32
+    %idx14_i32 = arith.addi %base_i32, %c14_i32 : i32
+    %idx14 = arith.index_castui %idx14_i32 : i32 to index
+    pto.store %round_z, %dst[%idx14] : !pto.ptr<i32, ub>, i32
+    %idx15_i32 = arith.addi %base_i32, %c15_i32 : i32
+    %idx15 = arith.index_castui %idx15_i32 : i32 to index
+    pto.store %round_r, %dst[%idx15] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-control-typed-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-control-typed-core/kernel.pto
@@ -8,8 +8,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %dim_x = arith.constant 32 : i32
 
     %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_control_typed_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_control_typed_core_body<<<%dim_x, %dim_y, %dim_z>>>(%ub_out) : (!pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/simt/simt-control-typed-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-control-typed-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_control_typed_core_kernel(__gm__ int *v1);
+void LaunchSimt_control_typed_core_kernel(int *v1, void *stream) {
+  simt_control_typed_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-control-typed-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-control-typed-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_control_typed_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_control_typed_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/golden.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    golden_v1 = np.zeros(ELEMS, dtype=np.int32)
+    golden_v1[:18] = np.array(
+        [3, 2, 2, 1, 2, 2, 0, 16, 16, 1, 2, 2, 2, 6, 6, 6, -4, 4],
+        dtype=np.int32,
+    )
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
@@ -1,0 +1,114 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_float_convert_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_float_convert_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %arg0, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_float_convert_core_body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+
+    %f32_neg = arith.constant -3.000000e+00 : f32
+    %f32_one = arith.constant 1.000000e+00 : f32
+    %f32_two = arith.constant 2.000000e+00 : f32
+    %f32_four = arith.constant 4.000000e+00 : f32
+    %f16_one = arith.constant 1.000000e+00 : f16
+    %f16_two = arith.constant 2.000000e+00 : f16
+    %f16_four = arith.constant 4.000000e+00 : f16
+    %bf16_one = arith.constant 1.000000e+00 : bf16
+    %bf16_two = arith.constant 2.000000e+00 : bf16
+    %bf16_four = arith.constant 4.000000e+00 : bf16
+    %i32_neg = arith.constant -4 : i32
+    %u32_four = arith.constant 4 : i32
+
+    %abs = pto.absf %f32_neg : f32 -> f32
+    %sqrt_f32 = pto.sqrt %f32_four : f32 -> f32
+    %sqrt_f16 = pto.sqrt %f16_four : f16 -> f16
+    %fmin = pto.fmin %f32_one, %f32_two : f32, f32 -> f32
+    %fmax = pto.fmax %bf16_one, %bf16_two : bf16, bf16 -> bf16
+    %exp = pto.exp %f32_one : f32 -> f32
+    %log = pto.log %f32_one : f32 -> f32
+    %pow = pto.pow %f32_two, %f32_four : f32, f32 -> f32
+    %pow16 = pto.pow %f16_two, %f16_four : f16, f16 -> f16
+    %ceil = pto.ceil %bf16_one : bf16 -> bf16
+    %floor = pto.floor %f32_two : f32 -> f32
+    %rint = pto.rint %f16_two : f16 -> f16
+    %round = pto.round %bf16_two : bf16 -> bf16
+    %fma = pto.fma %f32_one, %f32_two, %f32_four : f32, f32, f32 -> f32
+    %fma16 = pto.fma %f16_one, %f16_two, %f16_four : f16, f16, f16 -> f16
+    %fmabf16 = pto.fma %bf16_one, %bf16_two, %bf16_four : bf16, bf16, bf16 -> bf16
+    %s32_f32 = pto.convert %i32_neg round(r) nosat signed : i32 -> f32
+    %u32_f16 = pto.convert %u32_four round(r) nosat unsigned : i32 -> f16
+
+    %abs_i = pto.convert %abs round(z) sat signed : f32 -> i32
+    %sqrt_f32_i = pto.convert %sqrt_f32 round(z) sat signed : f32 -> i32
+    %sqrt_f16_i = pto.convert %sqrt_f16 round(z) sat signed : f16 -> i32
+    %fmin_i = pto.convert %fmin round(z) sat signed : f32 -> i32
+    %fmax_i = pto.convert %fmax round(z) sat signed : bf16 -> i32
+    %exp_i = pto.convert %exp round(z) sat signed : f32 -> i32
+    %log_i = pto.convert %log round(z) sat signed : f32 -> i32
+    %pow_i = pto.convert %pow round(z) sat signed : f32 -> i32
+    %pow16_i = pto.convert %pow16 round(z) sat signed : f16 -> i32
+    %ceil_i = pto.convert %ceil round(z) sat signed : bf16 -> i32
+    %floor_i = pto.convert %floor round(z) sat signed : f32 -> i32
+    %rint_i = pto.convert %rint round(z) sat signed : f16 -> i32
+    %round_i = pto.convert %round round(z) sat signed : bf16 -> i32
+    %fma_i = pto.convert %fma round(z) sat signed : f32 -> i32
+    %fma16_i = pto.convert %fma16 round(z) sat signed : f16 -> i32
+    %fmabf16_i = pto.convert %fmabf16 round(z) sat signed : bf16 -> i32
+    %s32_f32_i = pto.convert %s32_f32 round(z) sat signed : f32 -> i32
+    %u32_f16_i = pto.convert %u32_f16 round(z) sat unsigned : f16 -> i32
+
+    pto.store %abs_i, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %sqrt_f32_i, %dst[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %sqrt_f16_i, %dst[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %fmin_i, %dst[%c3] : !pto.ptr<i32, ub>, i32
+    pto.store %fmax_i, %dst[%c4] : !pto.ptr<i32, ub>, i32
+    pto.store %exp_i, %dst[%c5] : !pto.ptr<i32, ub>, i32
+    pto.store %log_i, %dst[%c6] : !pto.ptr<i32, ub>, i32
+    pto.store %pow_i, %dst[%c7] : !pto.ptr<i32, ub>, i32
+    pto.store %pow16_i, %dst[%c8] : !pto.ptr<i32, ub>, i32
+    pto.store %ceil_i, %dst[%c9] : !pto.ptr<i32, ub>, i32
+    pto.store %floor_i, %dst[%c10] : !pto.ptr<i32, ub>, i32
+    pto.store %rint_i, %dst[%c11] : !pto.ptr<i32, ub>, i32
+    pto.store %round_i, %dst[%c12] : !pto.ptr<i32, ub>, i32
+    pto.store %fma_i, %dst[%c13] : !pto.ptr<i32, ub>, i32
+    pto.store %fma16_i, %dst[%c14] : !pto.ptr<i32, ub>, i32
+    pto.store %fmabf16_i, %dst[%c15] : !pto.ptr<i32, ub>, i32
+    %c16 = arith.constant 16 : index
+    %c17 = arith.constant 17 : index
+    pto.store %s32_f32_i, %dst[%c16] : !pto.ptr<i32, ub>, i32
+    pto.store %u32_f16_i, %dst[%c17] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
@@ -8,8 +8,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %dim_x = arith.constant 32 : i32
 
     %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_float_convert_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_float_convert_core_body<<<%dim_x, %dim_y, %dim_z>>>(%ub_out) : (!pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_float_convert_core_kernel(__gm__ int *v1);
+void LaunchSimt_float_convert_core_kernel(int *v1, void *stream) {
+  simt_float_convert_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_float_convert_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_float_convert_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-gm-memory-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-gm-memory-core/compare.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main():
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    if golden.shape != out.shape or not np.array_equal(golden, out):
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-gm-memory-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-gm-memory-core/golden.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 128
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lanes = np.arange(32, dtype=np.int32)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    v1[:32] = 100 + lanes
+    golden_v1 = v1.copy()
+    golden_v1[32:64] = v1[:32] + lanes + 1000
+    golden_v1[64:96] = lanes
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-gm-memory-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-gm-memory-core/kernel.pto
@@ -1,0 +1,39 @@
+module attributes {pto.target_arch = "a5"} {
+  func.func @simt_gm_memory_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    pto.section.vector {
+      pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+      func.call @simt_gm_memory_core_body(%arg0) : (!pto.ptr<i32, gm>) -> ()
+
+      pto.barrier #pto.pipe<PIPE_ALL>
+    }
+    pto.section.cube {
+      pto.barrier #pto.pipe<PIPE_ALL>
+    }
+    return
+  }
+
+  func.func @simt_gm_memory_core_body(%gm: !pto.ptr<i32, gm>) attributes {pto.simt_entry} {
+    %tx = pto.get_tid_x : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1000_i32 = arith.constant 1000 : i32
+
+    %src_idx = arith.index_castui %tx : i32 to index
+    %loaded = pto.load %gm[%src_idx] : !pto.ptr<i32, gm> -> i32
+    %sum = arith.addi %loaded, %tx : i32
+    %with_bias = arith.addi %sum, %c1000_i32 : i32
+
+    %dst_i32 = arith.addi %tx, %c32_i32 : i32
+    %dst_idx = arith.index_castui %dst_i32 : i32 to index
+    pto.store %with_bias, %gm[%dst_idx] : !pto.ptr<i32, gm>, i32
+
+    %lane_dst_i32 = arith.addi %tx, %c64_i32 : i32
+    %lane_dst_idx = arith.index_castui %lane_dst_i32 : i32 to index
+    pto.store %tx, %gm[%lane_dst_idx] : !pto.ptr<i32, gm>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-gm-memory-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-gm-memory-core/kernel.pto
@@ -5,8 +5,7 @@ module attributes {pto.target_arch = "a5"} {
     %dim_x = arith.constant 32 : i32
 
     pto.section.vector {
-      pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-      func.call @simt_gm_memory_core_body(%arg0) : (!pto.ptr<i32, gm>) -> ()
+      pto.simt_launch @simt_gm_memory_core_body<<<%dim_x, %dim_y, %dim_z>>>(%arg0) : (!pto.ptr<i32, gm>) -> ()
 
       pto.barrier #pto.pipe<PIPE_ALL>
     }

--- a/test/vpto/cases/micro-op/simt/simt-gm-memory-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-gm-memory-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_gm_memory_core_kernel(__gm__ int *v1);
+void LaunchSimt_gm_memory_core_kernel(int *v1, void *stream) {
+  simt_gm_memory_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-gm-memory-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-gm-memory-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_gm_memory_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 128;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_gm_memory_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/compare.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def compare_one(name: str, dtype) -> bool:
+    golden = np.fromfile(f"golden_{name}.bin", dtype=dtype)
+    out = np.fromfile(f"{name}.bin", dtype=dtype)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        if dtype in (np.int8, np.int16, np.int32, np.int64):
+            print(
+                f"[ERROR] {name} mismatch at idx={idx}, "
+                f"golden={int(golden[idx])}, out={int(out[idx])}"
+            )
+        elif dtype == np.uint16:
+            print(
+                f"[ERROR] {name} mismatch at idx={idx}, "
+                f"golden=0x{int(golden[idx]):04x}, out=0x{int(out[idx]):04x}"
+            )
+        else:
+            print(
+                f"[ERROR] {name} mismatch at idx={idx}, "
+                f"golden={golden[idx]}, out={out[idx]}"
+            )
+    return ok
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    ok = (
+        compare_one("v1", np.int32)
+        and compare_one("v2", np.uint16)
+        and compare_one("v3", np.uint16)
+        and compare_one("v4", np.int8)
+        and compare_one("v5", np.int16)
+        and compare_one("v6", np.int64)
+        and compare_one("v7", np.float32)
+        and compare_one("v8", np.float64)
+    )
+    if not ok and strict:
+        sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/golden.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    golden_v1 = np.full(ELEMS, -1, dtype=np.int32)
+    v2 = np.full(ELEMS, 0xBC00, dtype=np.uint16)
+    v3 = np.full(ELEMS, 0xBF80, dtype=np.uint16)
+    v4 = np.full(ELEMS, -1, dtype=np.int8)
+    v5 = np.full(ELEMS, -1, dtype=np.int16)
+    v6 = np.full(ELEMS, -1, dtype=np.int64)
+    v7 = np.full(ELEMS, -1.0, dtype=np.float32)
+    v8 = np.full(ELEMS, -1.0, dtype=np.float64)
+    golden_v2 = v2.copy()
+    golden_v3 = v3.copy()
+    golden_v4 = v4.copy()
+    golden_v5 = v5.copy()
+    golden_v6 = v6.copy()
+    golden_v7 = v7.copy()
+    golden_v8 = v8.copy()
+    inputs = np.array([0x10203040, -1234567], dtype=np.int32)
+    v1[:2] = inputs
+    golden_v1[:2] = inputs
+    golden_v1[2] = inputs[0]
+    golden_v1[3] = inputs[1]
+    golden_v1[4] = np.int32(inputs[0] + inputs[1])
+    v2[:2] = np.array([0x3E00, 0xC000], dtype=np.uint16)  # f16: 1.5, -2.0
+    v3[:2] = np.array([0x3FC0, 0xC000], dtype=np.uint16)  # bf16: 1.5, -2.0
+    golden_v2[:2] = v2[:2]
+    golden_v2[2:4] = v2[:2]
+    golden_v3[:2] = v3[:2]
+    golden_v3[2:4] = v3[:2]
+    v4[:2] = np.array([0x12, -0x34], dtype=np.int8)
+    v5[:2] = np.array([0x1234, -0x3456], dtype=np.int16)
+    v6[:2] = np.array([0x1020304050607080, -0x102030405060708], dtype=np.int64)
+    v7[:2] = np.array([2.5, -3.5], dtype=np.float32)
+    v8[:2] = np.array([4.5, -5.5], dtype=np.float64)
+    golden_v4[:2] = v4[:2]
+    golden_v4[2:4] = v4[:2]
+    golden_v5[:2] = v5[:2]
+    golden_v5[2:4] = v5[:2]
+    golden_v6[:2] = v6[:2]
+    golden_v6[2:4] = v6[:2]
+    golden_v7[:2] = v7[:2]
+    golden_v7[2:4] = v7[:2]
+    golden_v8[:2] = v8[:2]
+    golden_v8[2:4] = v8[:2]
+    v1.tofile(output_dir / "v1.bin")
+    v2.tofile(output_dir / "v2.bin")
+    v3.tofile(output_dir / "v3.bin")
+    v4.tofile(output_dir / "v4.bin")
+    v5.tofile(output_dir / "v5.bin")
+    v6.tofile(output_dir / "v6.bin")
+    v7.tofile(output_dir / "v7.bin")
+    v8.tofile(output_dir / "v8.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+    golden_v2.tofile(output_dir / "golden_v2.bin")
+    golden_v3.tofile(output_dir / "golden_v3.bin")
+    golden_v4.tofile(output_dir / "golden_v4.bin")
+    golden_v5.tofile(output_dir / "golden_v5.bin")
+    golden_v6.tofile(output_dir / "golden_v6.bin")
+    golden_v7.tofile(output_dir / "golden_v7.bin")
+    golden_v8.tofile(output_dir / "golden_v8.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/kernel.pto
@@ -1,0 +1,74 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_ldst_policy_core_kernel(%arg0: !pto.ptr<i32, gm>,
+                                          %arg1: !pto.ptr<f16, gm>,
+                                          %arg2: !pto.ptr<bf16, gm>,
+                                          %arg3: !pto.ptr<i8, gm>,
+                                          %arg4: !pto.ptr<i16, gm>,
+                                          %arg5: !pto.ptr<i64, gm>,
+                                          %arg6: !pto.ptr<f32, gm>,
+                                          %arg7: !pto.ptr<f64, gm>) attributes {pto.aicore} {
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_ldst_policy_core_body(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7)
+      : (!pto.ptr<i32, gm>, !pto.ptr<f16, gm>, !pto.ptr<bf16, gm>, !pto.ptr<i8, gm>, !pto.ptr<i16, gm>, !pto.ptr<i64, gm>, !pto.ptr<f32, gm>, !pto.ptr<f64, gm>) -> ()
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_ldst_policy_core_body(%arg0: !pto.ptr<i32, gm>,
+                                        %arg1: !pto.ptr<f16, gm>,
+                                        %arg2: !pto.ptr<bf16, gm>,
+                                        %arg3: !pto.ptr<i8, gm>,
+                                        %arg4: !pto.ptr<i16, gm>,
+                                        %arg5: !pto.ptr<i64, gm>,
+                                        %arg6: !pto.ptr<f32, gm>,
+                                        %arg7: !pto.ptr<f64, gm>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+
+    %v_cache = pto.ldg %arg0[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<i32, gm> -> i32
+    %v_uncache = pto.ldg %arg0[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i32, gm> -> i32
+
+    %sum = arith.addi %v_cache, %v_uncache : i32
+    pto.stg %v_cache, %arg0[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<i32, gm>, i32
+    pto.stg %v_uncache, %arg0[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i32, gm>, i32
+    pto.stg %sum, %arg0[%c4] l1cache(cache) l2cache(nmfv) : !pto.ptr<i32, gm>, i32
+
+    %h_cache = pto.ldg %arg1[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<f16, gm> -> f16
+    %h_uncache = pto.ldg %arg1[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f16, gm> -> f16
+    %b_cache = pto.ldg %arg2[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<bf16, gm> -> bf16
+    %b_uncache = pto.ldg %arg2[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<bf16, gm> -> bf16
+    pto.stg %h_cache, %arg1[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<f16, gm>, f16
+    pto.stg %h_uncache, %arg1[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f16, gm>, f16
+    pto.stg %b_cache, %arg2[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<bf16, gm>, bf16
+    pto.stg %b_uncache, %arg2[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<bf16, gm>, bf16
+
+    %i8_cache = pto.ldg %arg3[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<i8, gm> -> i8
+    %i8_uncache = pto.ldg %arg3[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i8, gm> -> i8
+    %i16_cache = pto.ldg %arg4[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<i16, gm> -> i16
+    %i16_uncache = pto.ldg %arg4[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i16, gm> -> i16
+    %i64_cache = pto.ldg %arg5[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<i64, gm> -> i64
+    %i64_uncache = pto.ldg %arg5[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i64, gm> -> i64
+    %f32_cache = pto.ldg %arg6[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<f32, gm> -> f32
+    %f32_uncache = pto.ldg %arg6[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f32, gm> -> f32
+    %f64_cache = pto.ldg %arg7[%c0] l1cache(cache) l2cache(nmfv) : !pto.ptr<f64, gm> -> f64
+    %f64_uncache = pto.ldg %arg7[%c1] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f64, gm> -> f64
+    pto.stg %i8_cache, %arg3[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<i8, gm>, i8
+    pto.stg %i8_uncache, %arg3[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i8, gm>, i8
+    pto.stg %i16_cache, %arg4[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<i16, gm>, i16
+    pto.stg %i16_uncache, %arg4[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i16, gm>, i16
+    pto.stg %i64_cache, %arg5[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<i64, gm>, i64
+    pto.stg %i64_uncache, %arg5[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<i64, gm>, i64
+    pto.stg %f32_cache, %arg6[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<f32, gm>, f32
+    pto.stg %f32_uncache, %arg6[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f32, gm>, f32
+    pto.stg %f64_cache, %arg7[%c2] l1cache(cache) l2cache(nmfv) : !pto.ptr<f64, gm>, f64
+    pto.stg %f64_uncache, %arg7[%c3] l1cache(uncache) l2cache(nmfv) : !pto.ptr<f64, gm>, f64
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/kernel.pto
@@ -11,8 +11,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %dim_y = arith.constant 1 : i32
     %dim_x = arith.constant 32 : i32
 
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_ldst_policy_core_body(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7)
+    pto.simt_launch @simt_ldst_policy_core_body<<<%dim_x, %dim_y, %dim_z>>>(%arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7)
       : (!pto.ptr<i32, gm>, !pto.ptr<f16, gm>, !pto.ptr<bf16, gm>, !pto.ptr<i8, gm>, !pto.ptr<i16, gm>, !pto.ptr<i64, gm>, !pto.ptr<f32, gm>, !pto.ptr<f64, gm>) -> ()
     pto.barrier #pto.pipe<PIPE_ALL>
     return

--- a/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/launch.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <stdint.h>
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_ldst_policy_core_kernel(
+    __gm__ int *v1, __gm__ half *v2, __gm__ bfloat16_t *v3,
+    __gm__ int8_t *v4, __gm__ int16_t *v5, __gm__ int64_t *v6,
+    __gm__ float *v7, __gm__ double *v8);
+void LaunchSimt_ldst_policy_core_kernel(int *v1, uint16_t *v2, uint16_t *v3,
+                                        int8_t *v4, int16_t *v5, int64_t *v6,
+                                        float *v7, double *v8,
+                                        void *stream) {
+  simt_ldst_policy_core_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int *)v1, (__gm__ half *)v2, (__gm__ bfloat16_t *)v3,
+      (__gm__ int8_t *)v4, (__gm__ int16_t *)v5, (__gm__ int64_t *)v6,
+      (__gm__ float *)v7, (__gm__ double *)v8);
+}

--- a/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-ldst-policy-core/main.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+#include <stdint.h>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_ldst_policy_core_kernel(int *v1, uint16_t *v2, uint16_t *v3,
+                                        int8_t *v4, int16_t *v5, int64_t *v6,
+                                        float *v7, double *v8,
+                                        void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  size_t elemCount_v2 = 1024;
+  size_t fileSize_v2 = elemCount_v2 * sizeof(uint16_t);
+  size_t fileSize_v4 = elemCount_v2 * sizeof(int8_t);
+  size_t fileSize_v5 = elemCount_v2 * sizeof(int16_t);
+  size_t fileSize_v6 = elemCount_v2 * sizeof(int64_t);
+  size_t fileSize_v7 = elemCount_v2 * sizeof(float);
+  size_t fileSize_v8 = elemCount_v2 * sizeof(double);
+  int *v1Host = nullptr;
+  uint16_t *v2Host = nullptr;
+  uint16_t *v3Host = nullptr;
+  int8_t *v4Host = nullptr;
+  int16_t *v5Host = nullptr;
+  int64_t *v6Host = nullptr;
+  float *v7Host = nullptr;
+  double *v8Host = nullptr;
+  int *v1Device = nullptr;
+  uint16_t *v2Device = nullptr;
+  uint16_t *v3Device = nullptr;
+  int8_t *v4Device = nullptr;
+  int16_t *v5Device = nullptr;
+  int64_t *v6Device = nullptr;
+  float *v7Device = nullptr;
+  double *v8Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMallocHost((void **)(&v2Host), fileSize_v2));
+  ACL_CHECK(aclrtMallocHost((void **)(&v3Host), fileSize_v2));
+  ACL_CHECK(aclrtMallocHost((void **)(&v4Host), fileSize_v4));
+  ACL_CHECK(aclrtMallocHost((void **)(&v5Host), fileSize_v5));
+  ACL_CHECK(aclrtMallocHost((void **)(&v6Host), fileSize_v6));
+  ACL_CHECK(aclrtMallocHost((void **)(&v7Host), fileSize_v7));
+  ACL_CHECK(aclrtMallocHost((void **)(&v8Host), fileSize_v8));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v2Device, fileSize_v2, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v3Device, fileSize_v2, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v4Device, fileSize_v4, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v5Device, fileSize_v5, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v6Device, fileSize_v6, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v7Device, fileSize_v7, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v8Device, fileSize_v8, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ReadFile("./v2.bin", fileSize_v2, v2Host, fileSize_v2);
+  ReadFile("./v3.bin", fileSize_v2, v3Host, fileSize_v2);
+  ReadFile("./v4.bin", fileSize_v4, v4Host, fileSize_v4);
+  ReadFile("./v5.bin", fileSize_v5, v5Host, fileSize_v5);
+  ReadFile("./v6.bin", fileSize_v6, v6Host, fileSize_v6);
+  ReadFile("./v7.bin", fileSize_v7, v7Host, fileSize_v7);
+  ReadFile("./v8.bin", fileSize_v8, v8Host, fileSize_v8);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v2Device, fileSize_v2, v2Host, fileSize_v2, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v3Device, fileSize_v2, v3Host, fileSize_v2, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v4Device, fileSize_v4, v4Host, fileSize_v4, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v5Device, fileSize_v5, v5Host, fileSize_v5, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v6Device, fileSize_v6, v6Host, fileSize_v6, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v7Device, fileSize_v7, v7Host, fileSize_v7, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v8Device, fileSize_v8, v8Host, fileSize_v8, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_ldst_policy_core_kernel(v1Device, v2Device, v3Device, v4Device,
+                                     v5Device, v6Device, v7Device, v8Device,
+                                     stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v2Host, fileSize_v2, v2Device, fileSize_v2, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v3Host, fileSize_v2, v3Device, fileSize_v2, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v4Host, fileSize_v4, v4Device, fileSize_v4, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v5Host, fileSize_v5, v5Device, fileSize_v5, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v6Host, fileSize_v6, v6Device, fileSize_v6, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v7Host, fileSize_v7, v7Device, fileSize_v7, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v8Host, fileSize_v8, v8Device, fileSize_v8, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+  WriteFile("./v2.bin", v2Host, fileSize_v2);
+  WriteFile("./v3.bin", v3Host, fileSize_v2);
+  WriteFile("./v4.bin", v4Host, fileSize_v4);
+  WriteFile("./v5.bin", v5Host, fileSize_v5);
+  WriteFile("./v6.bin", v6Host, fileSize_v6);
+  WriteFile("./v7.bin", v7Host, fileSize_v7);
+  WriteFile("./v8.bin", v8Host, fileSize_v8);
+
+cleanup:
+  aclrtFree(v8Device);
+  aclrtFree(v7Device);
+  aclrtFree(v6Device);
+  aclrtFree(v5Device);
+  aclrtFree(v4Device);
+  aclrtFree(v3Device);
+  aclrtFree(v2Device);
+  aclrtFree(v1Device);
+  aclrtFreeHost(v8Host);
+  aclrtFreeHost(v7Host);
+  aclrtFreeHost(v6Host);
+  aclrtFreeHost(v5Host);
+  aclrtFreeHost(v4Host);
+  aclrtFreeHost(v3Host);
+  aclrtFreeHost(v2Host);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-memory-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-memory-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-memory-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-memory-core/golden.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+LANES = 32
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    golden_v1 = np.full(ELEMS, -1, dtype=np.int32)
+
+    for y in range(LANES):
+        for x in range(LANES):
+            dst = y * LANES + x
+            golden_v1[dst] = dst + 1000 + y * 10
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-memory-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-memory-core/kernel.pto
@@ -1,0 +1,46 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_memory_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 32 : i32
+    %dim_x = arith.constant 32 : i32
+
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    pto.mte_gm_ub %arg0, %ub, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, gm>, !pto.ptr<i32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_memory_core_body(%ub) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub, %arg0, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_memory_core_body(%buf: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %tx = pto.get_tid_x : i32
+    %ty = pto.get_tid_y : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1000_i32 = arith.constant 1000 : i32
+    %c10_i32 = arith.constant 10 : i32
+    %row = arith.muli %ty, %c32_i32 : i32
+    %dst_i32 = arith.addi %row, %tx : i32
+    %dst_idx = arith.index_castui %dst_i32 : i32 to index
+
+    %scaled_y = arith.muli %ty, %c10_i32 : i32
+    %value = arith.addi %dst_i32, %scaled_y : i32
+    %final = arith.addi %value, %c1000_i32 : i32
+    pto.store %final, %buf[%dst_idx] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-memory-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-memory-core/kernel.pto
@@ -15,8 +15,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
     pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_memory_core_body(%ub) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_memory_core_body<<<%dim_x, %dim_y, %dim_z>>>(%ub) : (!pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/simt/simt-memory-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-memory-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_memory_core_kernel(__gm__ int *v1);
+void LaunchSimt_memory_core_kernel(int *v1, void *stream) {
+  simt_memory_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-memory-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-memory-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_memory_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_memory_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-packed-math-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-packed-math-core/compare.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main():
+    golden = np.fromfile("golden_v1.bin", dtype=np.uint32)
+    out = np.fromfile("v1.bin", dtype=np.uint32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, "
+            f"golden=0x{int(golden[idx]):08x}, out=0x{int(out[idx]):08x}"
+        )
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-packed-math-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-packed-math-core/golden.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 32
+
+
+def pack_u16_pair(lo: int, hi: int) -> np.uint32:
+    return np.uint32((hi << 16) | lo)
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    initial = np.zeros(ELEMS, dtype=np.uint32)
+    golden = np.zeros(ELEMS, dtype=np.uint32)
+
+    golden[0] = pack_u16_pair(0x3C00, 0x3C00)   # shuffle: f16x2 (1, 1)
+    golden[1] = pack_u16_pair(0x4000, 0x4000)   # sqrt: f16x2 (2, 2)
+    golden[2] = pack_u16_pair(0x3C00, 0x4000)   # abs: f16x2 (1, 2)
+    golden[3] = pack_u16_pair(0x3C00, 0x3C00)   # exp(0): f16x2 (1, 1)
+    golden[4] = pack_u16_pair(0x0000, 0x0000)   # log(1): f16x2 (0, 0)
+    golden[5] = pack_u16_pair(0x3C00, 0x3C00)   # fmin: f16x2 (1, 1)
+    golden[6] = pack_u16_pair(0x4400, 0x4400)   # pow(2, 2): f16x2 (4, 4)
+    golden[7] = pack_u16_pair(0x4200, 0x4200)   # fma: f16x2 (3, 3)
+    golden[8] = pack_u16_pair(0x3C00, 0x4000)   # f32x2 -> f16x2 (1, 2)
+    golden[9] = pack_u16_pair(0x3F80, 0x4000)   # abs: bf16x2 (1, 2)
+    golden[10] = pack_u16_pair(0x4000, 0x4000)  # fmax: bf16x2 (2, 2)
+    golden[11] = pack_u16_pair(0x4040, 0x4040)  # fma: bf16x2 (3, 3)
+    golden[12] = pack_u16_pair(0x3F80, 0x4000)  # f32x2 -> bf16x2 (1, 2)
+    golden[13] = np.uint32(0x4038)              # f32x2 -> f8e4m3x2 (1, 2)
+    golden[14] = np.uint32(0x403C)              # f32x2 -> f8e5m2x2 (1, 2)
+    golden[15] = np.uint32(0x1008)              # f32x2 -> hif8x2 (1, 2)
+    golden[16] = np.uint32(0x3F800000)          # f16x2 -> f32x2 lane 0
+    golden[17] = np.uint32(0x40000000)          # f16x2 -> f32x2 lane 1
+    golden[18] = np.uint32(0x3F800000)          # bf16x2 -> f32x2 lane 0
+    golden[19] = np.uint32(0x40000000)          # bf16x2 -> f32x2 lane 1
+    golden[20] = np.uint32(0x3F800000)          # f8e4m3x2 -> f32x2 lane 0
+    golden[21] = np.uint32(0x40000000)          # f8e4m3x2 -> f32x2 lane 1
+    golden[22] = np.uint32(0x3F800000)          # f8e5m2x2 -> f32x2 lane 0
+    golden[23] = np.uint32(0x40000000)          # f8e5m2x2 -> f32x2 lane 1
+    golden[24] = np.uint32(0x3F800000)          # hif8x2 -> f32x2 lane 0
+    golden[25] = np.uint32(0x40000000)          # hif8x2 -> f32x2 lane 1
+
+    initial.tofile(output_dir / "v1.bin")
+    golden.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-packed-math-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-packed-math-core/kernel.pto
@@ -1,0 +1,141 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_packed_math_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 1 : i32
+
+    %ub_i32 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    %ub_i64 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i64, ub>
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_packed_math_core_body(%ub_i32, %ub_i64) : (!pto.ptr<i32, ub>, !pto.ptr<i64, ub>) -> ()
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_i32, %arg0, %c128_i64
+      nburst(%c1_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_packed_math_core_body(%ub_i32: !pto.ptr<i32, ub>, %ub_i64: !pto.ptr<i64, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %c14 = arith.constant 14 : index
+    %c15 = arith.constant 15 : index
+    %c26 = arith.constant 26 : index
+    %c27 = arith.constant 27 : index
+    %f2_off0 = arith.constant 8 : index
+    %f2_off1 = arith.constant 9 : index
+    %f2_off2 = arith.constant 10 : index
+    %f2_off3 = arith.constant 11 : index
+    %f2_off4 = arith.constant 12 : index
+    %c0_i64 = arith.constant 0 : i64
+    %shfl_idx = arith.constant 0 : i32
+
+    %h2_zero = arith.constant dense<0.000000e+00> : vector<2xf16>
+    %h2_one = arith.constant dense<1.000000e+00> : vector<2xf16>
+    %h2_two = arith.constant dense<2.000000e+00> : vector<2xf16>
+    %h2_four = arith.constant dense<4.000000e+00> : vector<2xf16>
+    %h2_neg = arith.constant dense<[-1.000000e+00, -2.000000e+00]> : vector<2xf16>
+    %h2_12 = arith.constant dense<[1.000000e+00, 2.000000e+00]> : vector<2xf16>
+    %h2_21 = arith.constant dense<[2.000000e+00, 1.000000e+00]> : vector<2xf16>
+    %b2_one = arith.constant dense<1.000000e+00> : vector<2xbf16>
+    %b2_two = arith.constant dense<2.000000e+00> : vector<2xbf16>
+    %b2_neg = arith.constant dense<[-1.000000e+00, -2.000000e+00]> : vector<2xbf16>
+    %b2_12 = arith.constant dense<[1.000000e+00, 2.000000e+00]> : vector<2xbf16>
+    %b2_21 = arith.constant dense<[2.000000e+00, 1.000000e+00]> : vector<2xbf16>
+    %f2_12 = arith.constant dense<[1.000000e+00, 2.000000e+00]> : vector<2xf32>
+
+    %shfl = pto.shuffle_idx %h2_one, %shfl_idx {width = 16 : i32} : vector<2xf16>, i32 -> vector<2xf16>
+    %sqrt_h2 = pto.sqrt %h2_four : vector<2xf16> -> vector<2xf16>
+    %abs_h2 = pto.absf %h2_neg : vector<2xf16> -> vector<2xf16>
+    %exp_h2 = pto.exp %h2_zero : vector<2xf16> -> vector<2xf16>
+    %log_h2 = pto.log %h2_one : vector<2xf16> -> vector<2xf16>
+    %min_h2 = pto.fmin %h2_12, %h2_21 : vector<2xf16>, vector<2xf16> -> vector<2xf16>
+    %pow_h2 = pto.pow %h2_two, %h2_two : vector<2xf16>, vector<2xf16> -> vector<2xf16>
+    %fma_h2 = pto.fma %h2_one, %h2_two, %h2_one : vector<2xf16>, vector<2xf16>, vector<2xf16> -> vector<2xf16>
+    %f32_to_h2 = pto.convert %f2_12 round(r) nosat : vector<2xf32> -> vector<2xf16>
+    %abs_b2 = pto.absf %b2_neg : vector<2xbf16> -> vector<2xbf16>
+    %max_b2 = pto.fmax %b2_12, %b2_21 : vector<2xbf16>, vector<2xbf16> -> vector<2xbf16>
+    %fma_b2 = pto.fma %b2_one, %b2_two, %b2_one : vector<2xbf16>, vector<2xbf16>, vector<2xbf16> -> vector<2xbf16>
+    %f32_to_b2 = pto.convert %f2_12 round(r) nosat : vector<2xf32> -> vector<2xbf16>
+    %h2_to_f32 = pto.convert %h2_12 round(r) nosat : vector<2xf16> -> vector<2xf32>
+    %b2_to_f32 = pto.convert %b2_12 round(r) nosat : vector<2xbf16> -> vector<2xf32>
+    %f32_to_f8e4 = pto.convert %f2_12 round(r) nosat : vector<2xf32> -> vector<2xf8E4M3FN>
+    %f32_to_f8e5 = pto.convert %f2_12 round(r) nosat : vector<2xf32> -> vector<2xf8E5M2>
+    %f32_to_hif8 = pto.convert %f2_12 round(a) nosat : vector<2xf32> -> !pto.hif8x2
+    %f8e4_to_f32 = pto.convert %f32_to_f8e4 round(r) nosat : vector<2xf8E4M3FN> -> vector<2xf32>
+    %f8e5_to_f32 = pto.convert %f32_to_f8e5 round(r) nosat : vector<2xf8E5M2> -> vector<2xf32>
+    %hif8_to_f32 = pto.convert %f32_to_hif8 round(a) nosat : !pto.hif8x2 -> vector<2xf32>
+
+    %shfl_bits = llvm.bitcast %shfl : vector<2xf16> to i32
+    %sqrt_h2_bits = llvm.bitcast %sqrt_h2 : vector<2xf16> to i32
+    %abs_h2_bits = llvm.bitcast %abs_h2 : vector<2xf16> to i32
+    %exp_h2_bits = llvm.bitcast %exp_h2 : vector<2xf16> to i32
+    %log_h2_bits = llvm.bitcast %log_h2 : vector<2xf16> to i32
+    %min_h2_bits = llvm.bitcast %min_h2 : vector<2xf16> to i32
+    %pow_h2_bits = llvm.bitcast %pow_h2 : vector<2xf16> to i32
+    %fma_h2_bits = llvm.bitcast %fma_h2 : vector<2xf16> to i32
+    %f32_to_h2_bits = llvm.bitcast %f32_to_h2 : vector<2xf16> to i32
+    %abs_b2_bits = llvm.bitcast %abs_b2 : vector<2xbf16> to i32
+    %max_b2_bits = llvm.bitcast %max_b2 : vector<2xbf16> to i32
+    %fma_b2_bits = llvm.bitcast %fma_b2 : vector<2xbf16> to i32
+    %f32_to_b2_bits = llvm.bitcast %f32_to_b2 : vector<2xbf16> to i32
+    %h2_to_f32_bits = llvm.bitcast %h2_to_f32 : vector<2xf32> to i64
+    %b2_to_f32_bits = llvm.bitcast %b2_to_f32 : vector<2xf32> to i64
+    %ub_f8e4 = pto.castptr %c0_i64 : i64 -> !pto.ptr<vector<2xf8E4M3FN>, ub>
+    %ub_f8e5 = pto.castptr %c0_i64 : i64 -> !pto.ptr<vector<2xf8E5M2>, ub>
+    %ub_hif8 = pto.castptr %c0_i64 : i64 -> !pto.ptr<!pto.hif8x2, ub>
+    %ub_i16 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i16, ub>
+    pto.store %f32_to_f8e4, %ub_f8e4[%c26] : !pto.ptr<vector<2xf8E4M3FN>, ub>, vector<2xf8E4M3FN>
+    pto.store %f32_to_f8e5, %ub_f8e5[%c27] : !pto.ptr<vector<2xf8E5M2>, ub>, vector<2xf8E5M2>
+    pto.store %f32_to_hif8, %ub_hif8[%c15] : !pto.ptr<!pto.hif8x2, ub>, !pto.hif8x2
+    %f8e4_bits16 = pto.load %ub_i16[%c26] : !pto.ptr<i16, ub> -> i16
+    %f8e5_bits16 = pto.load %ub_i16[%c27] : !pto.ptr<i16, ub> -> i16
+    %hif8_bits16 = pto.load %ub_i16[%c15] : !pto.ptr<i16, ub> -> i16
+    %f8e4_bits = arith.extui %f8e4_bits16 : i16 to i32
+    %f8e5_bits = arith.extui %f8e5_bits16 : i16 to i32
+    %hif8_bits = arith.extui %hif8_bits16 : i16 to i32
+    %f8e4_to_f32_bits = llvm.bitcast %f8e4_to_f32 : vector<2xf32> to i64
+    %f8e5_to_f32_bits = llvm.bitcast %f8e5_to_f32 : vector<2xf32> to i64
+    %hif8_to_f32_bits = llvm.bitcast %hif8_to_f32 : vector<2xf32> to i64
+
+    pto.store %shfl_bits, %ub_i32[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %sqrt_h2_bits, %ub_i32[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %abs_h2_bits, %ub_i32[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %exp_h2_bits, %ub_i32[%c3] : !pto.ptr<i32, ub>, i32
+    pto.store %log_h2_bits, %ub_i32[%c4] : !pto.ptr<i32, ub>, i32
+    pto.store %min_h2_bits, %ub_i32[%c5] : !pto.ptr<i32, ub>, i32
+    pto.store %pow_h2_bits, %ub_i32[%c6] : !pto.ptr<i32, ub>, i32
+    pto.store %fma_h2_bits, %ub_i32[%c7] : !pto.ptr<i32, ub>, i32
+    pto.store %f32_to_h2_bits, %ub_i32[%c8] : !pto.ptr<i32, ub>, i32
+    pto.store %abs_b2_bits, %ub_i32[%c9] : !pto.ptr<i32, ub>, i32
+    pto.store %max_b2_bits, %ub_i32[%c10] : !pto.ptr<i32, ub>, i32
+    pto.store %fma_b2_bits, %ub_i32[%c11] : !pto.ptr<i32, ub>, i32
+    pto.store %f32_to_b2_bits, %ub_i32[%c12] : !pto.ptr<i32, ub>, i32
+    pto.store %f8e4_bits, %ub_i32[%c13] : !pto.ptr<i32, ub>, i32
+    pto.store %f8e5_bits, %ub_i32[%c14] : !pto.ptr<i32, ub>, i32
+    pto.store %hif8_bits, %ub_i32[%c15] : !pto.ptr<i32, ub>, i32
+    pto.store %h2_to_f32_bits, %ub_i64[%f2_off0] : !pto.ptr<i64, ub>, i64
+    pto.store %b2_to_f32_bits, %ub_i64[%f2_off1] : !pto.ptr<i64, ub>, i64
+    pto.store %f8e4_to_f32_bits, %ub_i64[%f2_off2] : !pto.ptr<i64, ub>, i64
+    pto.store %f8e5_to_f32_bits, %ub_i64[%f2_off3] : !pto.ptr<i64, ub>, i64
+    pto.store %hif8_to_f32_bits, %ub_i64[%f2_off4] : !pto.ptr<i64, ub>, i64
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-packed-math-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-packed-math-core/kernel.pto
@@ -9,8 +9,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %ub_i32 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
     %ub_i64 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i64, ub>
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_packed_math_core_body(%ub_i32, %ub_i64) : (!pto.ptr<i32, ub>, !pto.ptr<i64, ub>) -> ()
+    pto.simt_launch @simt_packed_math_core_body<<<%dim_x, %dim_y, %dim_z>>>(%ub_i32, %ub_i64) : (!pto.ptr<i32, ub>, !pto.ptr<i64, ub>) -> ()
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.mte_ub_gm %ub_i32, %arg0, %c128_i64

--- a/test/vpto/cases/micro-op/simt/simt-packed-math-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-packed-math-core/launch.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void simt_packed_math_core_kernel(__gm__ uint32_t *out);
+
+void LaunchSimt_packed_math_core_kernel(uint32_t *out, void *stream) {
+  simt_packed_math_core_kernel<<<1, nullptr, stream>>>((__gm__ uint32_t *)out);
+}

--- a/test/vpto/cases/micro-op/simt/simt-packed-math-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-packed-math-core/main.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+#include <stdint.h>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_packed_math_core_kernel(uint32_t *out, void *stream);
+
+int main() {
+  size_t elemCount = 32;
+  size_t fileSize = elemCount * sizeof(uint32_t);
+  uint32_t *host = nullptr;
+  uint32_t *device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&host), fileSize));
+  ACL_CHECK(aclrtMalloc((void **)&device, fileSize, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize, host, fileSize);
+  ACL_CHECK(aclrtMemcpy(device, fileSize, host, fileSize, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_packed_math_core_kernel(device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(host, fileSize, device, fileSize, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", host, fileSize);
+
+cleanup:
+  aclrtFree(device);
+  aclrtFreeHost(host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-scalar-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-scalar-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-core/golden.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+LANES = 32
+FIELDS = 32
+ELEMS = LANES * FIELDS
+
+
+def i32_bits(value: int) -> np.int32:
+    value &= 0xFFFFFFFF
+    if value >= 0x80000000:
+        value -= 0x100000000
+    return np.int32(value)
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    golden_v1 = np.zeros(ELEMS, dtype=np.int32)
+    for lane in range(LANES):
+        base = lane * FIELDS
+        golden_v1[base + 0] = lane
+        golden_v1[base + 1] = lane
+        golden_v1[base + 2] = 32
+        golden_v1[base + 3] = 1
+        golden_v1[base + 4] = 1
+        golden_v1[base + 5] = 0
+        golden_v1[base + 6] = 0
+        golden_v1[base + 7] = 0
+        golden_v1[base + 8] = 0
+        golden_v1[base + 9] = i32_bits(1 << lane)
+        golden_v1[base + 10] = i32_bits((1 << (lane + 1)) - 1) if lane < 31 else np.int32(-1)
+        golden_v1[base + 11] = i32_bits((1 << lane) - 1)
+        golden_v1[base + 12] = i32_bits(0xFFFFFFFF << lane)
+        golden_v1[base + 13] = i32_bits(0xFFFFFFFF << (lane + 1)) if lane < 31 else np.int32(0)
+        golden_v1[base + 14] = 0
+        golden_v1[base + 15] = 1
+        golden_v1[base + 16] = 0
+        golden_v1[base + 17] = i32_bits(0x55555555)
+        golden_v1[base + 18] = 103
+        golden_v1[base + 19] = 100 + (lane - 2 if lane >= 2 else lane)
+        golden_v1[base + 20] = 100 + (lane + 2 if lane <= 29 else lane)
+        golden_v1[base + 21] = 100 + (lane ^ 1)
+        golden_v1[base + 22] = 528
+        golden_v1[base + 23] = 32
+        golden_v1[base + 24] = 1
+        golden_v1[base + 25] = 32
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-scalar-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-core/kernel.pto
@@ -1,0 +1,176 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_scalar_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_scalar_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %arg0, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_scalar_core_body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c2_i32 = arith.constant 2 : i32
+    %c3_i32 = arith.constant 3 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c_fields_i32 = arith.constant 32 : i32
+
+    %tid_x = pto.get_tid_x : i32
+    %laneid = pto.get_laneid : i32
+    %block_dim_x = pto.get_block_dim_x : i32
+    %block_dim_y = pto.get_block_dim_y : i32
+    %block_dim_z = pto.get_block_dim_z : i32
+    %grid_dim_x = pto.get_grid_dim_x : i32
+    %grid_dim_y = pto.get_grid_dim_y : i32
+    %grid_dim_z = pto.get_grid_dim_z : i32
+    %block_idx_x = pto.get_block_idx_x : i32
+
+    %lanemask_eq = pto.get_lanemask_eq : i32
+    %lanemask_le = pto.get_lanemask_le : i32
+    %lanemask_lt = pto.get_lanemask_lt : i32
+    %lanemask_ge = pto.get_lanemask_ge : i32
+    %lanemask_gt = pto.get_lanemask_gt : i32
+
+    %lane_low_bit = arith.andi %laneid, %c1_i32 : i32
+    %is_even = arith.cmpi eq, %lane_low_bit, %c0_i32 : i32
+    %vote_all = pto.vote_all %is_even : i1 -> i1
+    %vote_any = pto.vote_any %is_even : i1 -> i1
+    %vote_uni = pto.vote_uni %is_even : i1 -> i1
+    %vote_all_i32 = arith.extui %vote_all : i1 to i32
+    %vote_any_i32 = arith.extui %vote_any : i1 to i32
+    %vote_uni_i32 = arith.extui %vote_uni : i1 to i32
+    %ballot = pto.vote_ballot %is_even : i1 -> i32
+
+    %value = arith.addi %laneid, %c100_i32 : i32
+    %shfl_idx = pto.shuffle_idx %value, %c3_i32 : i32, i32 -> i32
+    %shfl_up = pto.shuffle_up %value, %c2_i32 : i32, i32 -> i32
+    %shfl_down = pto.shuffle_down %value, %c2_i32 : i32, i32 -> i32
+    %shfl_bfly = pto.shuffle_bfly %value, %c1_i32 : i32, i32 -> i32
+
+    %lane_plus_one = arith.addi %laneid, %c1_i32 : i32
+    %redux_add = pto.redux_add %lane_plus_one signed : i32 -> i32
+    %redux_max = pto.redux_max %lane_plus_one signed : i32 -> i32
+    %redux_min = pto.redux_min %lane_plus_one signed : i32 -> i32
+    %one_f32 = arith.constant 1.000000e+00 : f32
+    %redux_f32 = pto.redux_add %one_f32 : f32 -> f32
+    %redux_f32_i32 = pto.convert %redux_f32 round(r) sat signed : f32 -> i32
+
+    %base_i32 = arith.muli %laneid, %c_fields_i32 : i32
+    %base = arith.index_castui %base_i32 : i32 to index
+
+    pto.store %tid_x, %dst[%base] : !pto.ptr<i32, ub>, i32
+    %idx1_i32 = arith.addi %base_i32, %c1_i32 : i32
+    %idx1 = arith.index_castui %idx1_i32 : i32 to index
+    pto.store %laneid, %dst[%idx1] : !pto.ptr<i32, ub>, i32
+    %idx2_i32 = arith.addi %base_i32, %c2_i32 : i32
+    %idx2 = arith.index_castui %idx2_i32 : i32 to index
+    pto.store %block_dim_x, %dst[%idx2] : !pto.ptr<i32, ub>, i32
+    %idx3_i32 = arith.addi %base_i32, %c3_i32 : i32
+    %idx3 = arith.index_castui %idx3_i32 : i32 to index
+    pto.store %block_dim_y, %dst[%idx3] : !pto.ptr<i32, ub>, i32
+    %c4_i32 = arith.constant 4 : i32
+    %idx4_i32 = arith.addi %base_i32, %c4_i32 : i32
+    %idx4 = arith.index_castui %idx4_i32 : i32 to index
+    pto.store %block_dim_z, %dst[%idx4] : !pto.ptr<i32, ub>, i32
+    %c5_i32 = arith.constant 5 : i32
+    %idx5_i32 = arith.addi %base_i32, %c5_i32 : i32
+    %idx5 = arith.index_castui %idx5_i32 : i32 to index
+    pto.store %grid_dim_x, %dst[%idx5] : !pto.ptr<i32, ub>, i32
+    %c6_i32 = arith.constant 6 : i32
+    %idx6_i32 = arith.addi %base_i32, %c6_i32 : i32
+    %idx6 = arith.index_castui %idx6_i32 : i32 to index
+    pto.store %grid_dim_y, %dst[%idx6] : !pto.ptr<i32, ub>, i32
+    %c7_i32 = arith.constant 7 : i32
+    %idx7_i32 = arith.addi %base_i32, %c7_i32 : i32
+    %idx7 = arith.index_castui %idx7_i32 : i32 to index
+    pto.store %grid_dim_z, %dst[%idx7] : !pto.ptr<i32, ub>, i32
+    %c8_i32 = arith.constant 8 : i32
+    %idx8_i32 = arith.addi %base_i32, %c8_i32 : i32
+    %idx8 = arith.index_castui %idx8_i32 : i32 to index
+    pto.store %block_idx_x, %dst[%idx8] : !pto.ptr<i32, ub>, i32
+    %c9_i32 = arith.constant 9 : i32
+    %idx9_i32 = arith.addi %base_i32, %c9_i32 : i32
+    %idx9 = arith.index_castui %idx9_i32 : i32 to index
+    pto.store %lanemask_eq, %dst[%idx9] : !pto.ptr<i32, ub>, i32
+    %c10_i32 = arith.constant 10 : i32
+    %idx10_i32 = arith.addi %base_i32, %c10_i32 : i32
+    %idx10 = arith.index_castui %idx10_i32 : i32 to index
+    pto.store %lanemask_le, %dst[%idx10] : !pto.ptr<i32, ub>, i32
+    %c11_i32 = arith.constant 11 : i32
+    %idx11_i32 = arith.addi %base_i32, %c11_i32 : i32
+    %idx11 = arith.index_castui %idx11_i32 : i32 to index
+    pto.store %lanemask_lt, %dst[%idx11] : !pto.ptr<i32, ub>, i32
+    %c12_i32 = arith.constant 12 : i32
+    %idx12_i32 = arith.addi %base_i32, %c12_i32 : i32
+    %idx12 = arith.index_castui %idx12_i32 : i32 to index
+    pto.store %lanemask_ge, %dst[%idx12] : !pto.ptr<i32, ub>, i32
+    %c13_i32 = arith.constant 13 : i32
+    %idx13_i32 = arith.addi %base_i32, %c13_i32 : i32
+    %idx13 = arith.index_castui %idx13_i32 : i32 to index
+    pto.store %lanemask_gt, %dst[%idx13] : !pto.ptr<i32, ub>, i32
+    %c14_i32 = arith.constant 14 : i32
+    %idx14_i32 = arith.addi %base_i32, %c14_i32 : i32
+    %idx14 = arith.index_castui %idx14_i32 : i32 to index
+    pto.store %vote_all_i32, %dst[%idx14] : !pto.ptr<i32, ub>, i32
+    %c15_i32 = arith.constant 15 : i32
+    %idx15_i32 = arith.addi %base_i32, %c15_i32 : i32
+    %idx15 = arith.index_castui %idx15_i32 : i32 to index
+    pto.store %vote_any_i32, %dst[%idx15] : !pto.ptr<i32, ub>, i32
+    %c16_i32 = arith.constant 16 : i32
+    %idx16_i32 = arith.addi %base_i32, %c16_i32 : i32
+    %idx16 = arith.index_castui %idx16_i32 : i32 to index
+    pto.store %vote_uni_i32, %dst[%idx16] : !pto.ptr<i32, ub>, i32
+    %c17_i32 = arith.constant 17 : i32
+    %idx17_i32 = arith.addi %base_i32, %c17_i32 : i32
+    %idx17 = arith.index_castui %idx17_i32 : i32 to index
+    pto.store %ballot, %dst[%idx17] : !pto.ptr<i32, ub>, i32
+    %c18_i32 = arith.constant 18 : i32
+    %idx18_i32 = arith.addi %base_i32, %c18_i32 : i32
+    %idx18 = arith.index_castui %idx18_i32 : i32 to index
+    pto.store %shfl_idx, %dst[%idx18] : !pto.ptr<i32, ub>, i32
+    %c19_i32 = arith.constant 19 : i32
+    %idx19_i32 = arith.addi %base_i32, %c19_i32 : i32
+    %idx19 = arith.index_castui %idx19_i32 : i32 to index
+    pto.store %shfl_up, %dst[%idx19] : !pto.ptr<i32, ub>, i32
+    %c20_i32 = arith.constant 20 : i32
+    %idx20_i32 = arith.addi %base_i32, %c20_i32 : i32
+    %idx20 = arith.index_castui %idx20_i32 : i32 to index
+    pto.store %shfl_down, %dst[%idx20] : !pto.ptr<i32, ub>, i32
+    %c21_i32 = arith.constant 21 : i32
+    %idx21_i32 = arith.addi %base_i32, %c21_i32 : i32
+    %idx21 = arith.index_castui %idx21_i32 : i32 to index
+    pto.store %shfl_bfly, %dst[%idx21] : !pto.ptr<i32, ub>, i32
+    %c22_i32 = arith.constant 22 : i32
+    %idx22_i32 = arith.addi %base_i32, %c22_i32 : i32
+    %idx22 = arith.index_castui %idx22_i32 : i32 to index
+    pto.store %redux_add, %dst[%idx22] : !pto.ptr<i32, ub>, i32
+    %c23_i32 = arith.constant 23 : i32
+    %idx23_i32 = arith.addi %base_i32, %c23_i32 : i32
+    %idx23 = arith.index_castui %idx23_i32 : i32 to index
+    pto.store %redux_max, %dst[%idx23] : !pto.ptr<i32, ub>, i32
+    %c24_i32 = arith.constant 24 : i32
+    %idx24_i32 = arith.addi %base_i32, %c24_i32 : i32
+    %idx24 = arith.index_castui %idx24_i32 : i32 to index
+    pto.store %redux_min, %dst[%idx24] : !pto.ptr<i32, ub>, i32
+    %c25_i32 = arith.constant 25 : i32
+    %idx25_i32 = arith.addi %base_i32, %c25_i32 : i32
+    %idx25 = arith.index_castui %idx25_i32 : i32 to index
+    pto.store %redux_f32_i32, %dst[%idx25] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-scalar-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-core/kernel.pto
@@ -9,8 +9,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
 
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_scalar_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_scalar_core_body<<<%dim_x, %dim_y, %dim_z>>>(%ub_out) : (!pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/simt/simt-scalar-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_scalar_core_kernel(__gm__ int *v1);
+void LaunchSimt_scalar_core_kernel(int *v1, void *stream) {
+  simt_scalar_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-scalar-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_scalar_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_scalar_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-scalar-math-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-math-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-scalar-math-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-math-core/golden.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def i32(value: int) -> np.int32:
+    value &= 0xFFFFFFFF
+    if value >= 0x80000000:
+        value -= 0x100000000
+    return np.int32(value)
+
+
+def split_i64(value: int) -> tuple[np.int32, np.int32]:
+    value &= 0xFFFFFFFFFFFFFFFF
+    return i32(value), i32(value >> 32)
+
+
+def prmt(a: int, b: int, selector: int) -> np.int32:
+    a &= 0xFFFFFFFF
+    b &= 0xFFFFFFFF
+    src = [(b >> (8 * i)) & 0xFF for i in range(4)]
+    src += [(a >> (8 * i)) & 0xFF for i in range(4)]
+    out = 0
+    for pos in range(4):
+        nibble = (selector >> (4 * pos)) & 0xF
+        out |= src[nibble & 0x7] << (8 * pos)
+    return i32(out)
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    golden_v1 = np.zeros(ELEMS, dtype=np.int32)
+
+    a = -2_000_000_000
+    b = 3
+    ua = 0xF0000000
+    ub = 16
+    x64 = 0xFFFFFFFFFFFFFFFF
+    y64 = 2
+    signed_prod = a * b
+    unsigned_prod = ua * ub
+    hi64_u = (x64 * y64) >> 64
+    sx64 = -1
+    sy64 = 2
+    hi64_s = (sx64 * sy64) >> 64
+
+    wide_s_lo, wide_s_hi = split_i64(signed_prod)
+    wide_u_lo, wide_u_hi = split_i64(unsigned_prod)
+    hi64_u_lo, hi64_u_hi = split_i64(hi64_u)
+    hi64_s_lo, hi64_s_hi = split_i64(hi64_s)
+    prmt_a = 0x11223344
+    prmt_b = 0xAABBCCDD
+
+    golden_v1[:14] = np.array(
+        [
+            i32(signed_prod >> 32),
+            i32(unsigned_prod >> 32),
+            wide_s_lo,
+            wide_s_hi,
+            wide_u_lo,
+            wide_u_hi,
+            hi64_u_lo,
+            hi64_u_hi,
+            prmt(prmt_a, prmt_b, 0x3210),
+            prmt(prmt_a, prmt_b, 0x7654),
+            prmt(prmt_a, prmt_b, 0x89AB),
+            prmt(prmt_a, prmt_b, 0xFFFF),
+            hi64_s_lo,
+            hi64_s_hi,
+        ],
+        dtype=np.int32,
+    )
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-scalar-math-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-math-core/kernel.pto
@@ -1,0 +1,92 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_scalar_math_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_scalar_math_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %arg0, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_scalar_math_core_body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c4 = arith.constant 4 : index
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c7 = arith.constant 7 : index
+    %c8 = arith.constant 8 : index
+    %c9 = arith.constant 9 : index
+    %c10 = arith.constant 10 : index
+    %c11 = arith.constant 11 : index
+    %c12 = arith.constant 12 : index
+    %c13 = arith.constant 13 : index
+    %shift32 = arith.constant 32 : i64
+
+    %a = arith.constant -2000000000 : i32
+    %b = arith.constant 3 : i32
+    %ua = arith.constant -268435456 : i32
+    %ub = arith.constant 16 : i32
+    %x64 = arith.constant -1 : i64
+    %y64 = arith.constant 2 : i64
+    %prmt_a = arith.constant 287454020 : i32
+    %prmt_b = arith.constant -1430532899 : i32
+    %sel_3210 = arith.constant 12816 : i32
+    %sel_7654 = arith.constant 30292 : i32
+    %sel_89ab = arith.constant 35243 : i32
+    %sel_ffff = arith.constant 65535 : i32
+
+    %mulhi_s = pto.mulhi %a, %b signed : i32, i32 -> i32
+    %mulhi_u = pto.mulhi %ua, %ub unsigned : i32, i32 -> i32
+    %wide_s = pto.mul_i32toi64 %a, %b signed : i32, i32 -> i64
+    %wide_u = pto.mul_i32toi64 %ua, %ub unsigned : i32, i32 -> i64
+    %hi64_u = pto.mulhi %x64, %y64 unsigned : i64, i64 -> i64
+    %hi64_s = pto.mulhi %x64, %y64 signed : i64, i64 -> i64
+    %wide_s_lo = arith.trunci %wide_s : i64 to i32
+    %wide_s_shr = arith.shrsi %wide_s, %shift32 : i64
+    %wide_s_hi = arith.trunci %wide_s_shr : i64 to i32
+    %wide_u_lo = arith.trunci %wide_u : i64 to i32
+    %wide_u_shr = arith.shrui %wide_u, %shift32 : i64
+    %wide_u_hi = arith.trunci %wide_u_shr : i64 to i32
+    %hi64_u_lo = arith.trunci %hi64_u : i64 to i32
+    %hi64_u_shr = arith.shrui %hi64_u, %shift32 : i64
+    %hi64_u_hi = arith.trunci %hi64_u_shr : i64 to i32
+    %hi64_s_lo = arith.trunci %hi64_s : i64 to i32
+    %hi64_s_shr = arith.shrui %hi64_s, %shift32 : i64
+    %hi64_s_hi = arith.trunci %hi64_s_shr : i64 to i32
+    %prmt_3210 = pto.prmt %prmt_a, %prmt_b, %sel_3210 : i32, i32, i32 -> i32
+    %prmt_7654 = pto.prmt %prmt_a, %prmt_b, %sel_7654 : i32, i32, i32 -> i32
+    %prmt_89ab = pto.prmt %prmt_a, %prmt_b, %sel_89ab : i32, i32, i32 -> i32
+    %prmt_ffff = pto.prmt %prmt_a, %prmt_b, %sel_ffff : i32, i32, i32 -> i32
+
+    pto.store %mulhi_s, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    pto.store %mulhi_u, %dst[%c1] : !pto.ptr<i32, ub>, i32
+    pto.store %wide_s_lo, %dst[%c2] : !pto.ptr<i32, ub>, i32
+    pto.store %wide_s_hi, %dst[%c3] : !pto.ptr<i32, ub>, i32
+    pto.store %wide_u_lo, %dst[%c4] : !pto.ptr<i32, ub>, i32
+    pto.store %wide_u_hi, %dst[%c5] : !pto.ptr<i32, ub>, i32
+    pto.store %hi64_u_lo, %dst[%c6] : !pto.ptr<i32, ub>, i32
+    pto.store %hi64_u_hi, %dst[%c7] : !pto.ptr<i32, ub>, i32
+    pto.store %prmt_3210, %dst[%c8] : !pto.ptr<i32, ub>, i32
+    pto.store %prmt_7654, %dst[%c9] : !pto.ptr<i32, ub>, i32
+    pto.store %prmt_89ab, %dst[%c10] : !pto.ptr<i32, ub>, i32
+    pto.store %prmt_ffff, %dst[%c11] : !pto.ptr<i32, ub>, i32
+    pto.store %hi64_s_lo, %dst[%c12] : !pto.ptr<i32, ub>, i32
+    pto.store %hi64_s_hi, %dst[%c13] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-scalar-math-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-math-core/kernel.pto
@@ -8,8 +8,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %dim_x = arith.constant 32 : i32
 
     %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_scalar_math_core_body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_scalar_math_core_body<<<%dim_x, %dim_y, %dim_z>>>(%ub_out) : (!pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/simt/simt-scalar-math-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-math-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_scalar_math_core_kernel(__gm__ int *v1);
+void LaunchSimt_scalar_math_core_kernel(int *v1, void *stream) {
+  simt_scalar_math_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-scalar-math-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-scalar-math-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_scalar_math_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_scalar_math_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/micro-op/simt/simt-store-tid/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-store-tid/kernel.pto
@@ -9,8 +9,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
 
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_write(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_write<<<%dim_x, %dim_y, %dim_z>>>(%ub_out) : (!pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/micro-op/vector-load-store/cbuf-ubuf-roundtrip-mixed/kernel.pto
+++ b/test/vpto/cases/micro-op/vector-load-store/cbuf-ubuf-roundtrip-mixed/kernel.pto
@@ -38,9 +38,14 @@ module attributes {pto.target_arch = "a5"} {
 
       pto.sync.wait <PIPE_MTE3>, 1
 
-      pto.mte_ub_gm %ub1, %dst_gm, %c32_i64
-        nburst(%c16_i64, %c32_i64, %c32_i64)
-        : !pto.ptr<i16, ub>, !pto.ptr<i16, gm>, i64, i64, i64, i64
+      %subblock = pto.get_subblock_idx
+      %is_subblock0 = arith.cmpi eq, %subblock, %c0_i64 : i64
+      %is_subblock1 = arith.cmpi eq, %subblock, %c1_i64 : i64
+      scf.if %is_subblock0 {
+        pto.mte_ub_gm %ub1, %dst_gm, %c32_i64
+          nburst(%c16_i64, %c32_i64, %c32_i64)
+          : !pto.ptr<i16, ub>, !pto.ptr<i16, gm>, i64, i64, i64, i64
+      }
       pto.barrier #pto.pipe<PIPE_ALL>
     }
 

--- a/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/compare.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/compare.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden_path = "golden_output.bin"
+    output_path = "output.bin"
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+
+    if not os.path.exists(golden_path) or not os.path.exists(output_path):
+        print("[ERROR] missing golden_output.bin or output.bin")
+        sys.exit(2 if strict else 0)
+
+    golden = np.fromfile(golden_path, dtype=np.float32)
+    output = np.fromfile(output_path, dtype=np.float32)
+    ok = golden.shape == output.shape and np.allclose(
+        golden, output, atol=0.0001, rtol=0.0001, equal_nan=True
+    )
+    if not ok:
+        if golden.shape != output.shape:
+            print(f"[ERROR] shape mismatch: {golden.shape} vs {output.shape}")
+        elif golden.size:
+            diff = np.abs(golden.astype(np.float64) - output.astype(np.float64))
+            idx = int(np.argmax(diff))
+            print(
+                f"[ERROR] mismatch at idx={idx}: golden={golden[idx]} "
+                f"output={output[idx]} diff={diff[idx]}"
+            )
+        if strict:
+            sys.exit(2)
+        return
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/golden.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/golden.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+ELEMENTS = 1024
+SEED = 19
+
+
+def generate(output_dir: Path, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    data = rng.uniform(-8.0, 8.0, size=(ELEMENTS,)).astype(np.float32)
+    output = np.zeros((ELEMENTS,), dtype=np.float32)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    data.tofile(output_dir / "input.bin")
+    output.tofile(output_dir / "output.bin")
+    data.tofile(output_dir / "golden_output.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate inputs/golden for VPTO vlds post-update validation."
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+    generate(args.output_dir, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/kernel.pto
+++ b/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/kernel.pto
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// case: micro-op/vector-load-store/vlds-post-update
+// family: vector-load-store
+// target_ops: pto.vlds
+// scenarios: core-f32, contiguous, full-mask, post-update-result, dist-norm
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vlds_post_update_kernel(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %_:2 = scf.for %offset = %c0 to %c1024 step %c64
+          iter_args(%remaining = %c1024_i32, %src = %ub_in)
+          -> (i32, !pto.ptr<f32, ub>) {
+        %mask, %next_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec, %updated = pto.vlds %src[%c64] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>, !pto.ptr<f32, ub>
+        pto.vsts %vec, %ub_out[%offset], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        scf.yield %next_remaining, %updated : i32, !pto.ptr<f32, ub>
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/launch.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/launch.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+
+#include <stdint.h>
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vlds_post_update_kernel(__gm__ float *input, __gm__ float *output);
+
+void LaunchVldsPostUpdate(float *input, float *output, void *stream) {
+  vlds_post_update_kernel<<<1, nullptr, stream>>>((__gm__ float *)input,
+                                                  (__gm__ float *)output);
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/main.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vlds-post-update/main.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+void LaunchVldsPostUpdate(float *input, float *output, void *stream);
+
+namespace {
+constexpr size_t kElementCount = 1024;
+constexpr size_t kBufferSize = kElementCount * sizeof(float);
+}
+
+#define ACL_CHECK(expr)                                                        \
+  do {                                                                         \
+    const aclError ret = (expr);                                               \
+    if (ret != ACL_SUCCESS) {                                                  \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,          \
+                   static_cast<int>(ret), __FILE__, __LINE__);                \
+      const char *recent = aclGetRecentErrMsg();                               \
+      if (recent != nullptr && recent[0] != '\0')                              \
+        std::fprintf(stderr, "[ERROR] RecentErrMsg: %s\n", recent);           \
+      rc = 1;                                                                  \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  float *inputHost = nullptr;
+  float *outputHost = nullptr;
+  float *inputDevice = nullptr;
+  float *outputDevice = nullptr;
+  aclrtStream stream = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  size_t inputSize = kBufferSize;
+  size_t outputSize = kBufferSize;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+
+  ACL_CHECK(aclrtMallocHost(reinterpret_cast<void **>(&inputHost), kBufferSize));
+  ACL_CHECK(aclrtMallocHost(reinterpret_cast<void **>(&outputHost), kBufferSize));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&inputDevice), kBufferSize,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&outputDevice), kBufferSize,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./input.bin", inputSize, inputHost, kBufferSize);
+  ReadFile("./output.bin", outputSize, outputHost, kBufferSize);
+  ACL_CHECK(aclrtMemcpy(inputDevice, kBufferSize, inputHost, kBufferSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(outputDevice, kBufferSize, outputHost, kBufferSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+
+  LaunchVldsPostUpdate(inputDevice, outputDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(outputHost, kBufferSize, outputDevice, kBufferSize,
+                        ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./output.bin", outputHost, kBufferSize);
+
+cleanup:
+  aclrtFree(inputDevice);
+  aclrtFree(outputDevice);
+  aclrtFreeHost(inputHost);
+  aclrtFreeHost(outputHost);
+  if (stream != nullptr) {
+    const aclError ret = aclrtDestroyStream(stream);
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclrtDestroyStream failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  if (deviceSet) {
+    const aclError ret = aclrtResetDevice(deviceId);
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclrtResetDevice failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  if (aclInited) {
+    const aclError ret = aclFinalize();
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclFinalize failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  return rc;
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/compare.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/compare.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden_path = "golden_output.bin"
+    output_path = "output.bin"
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+
+    if not os.path.exists(golden_path) or not os.path.exists(output_path):
+        print("[ERROR] missing golden_output.bin or output.bin")
+        sys.exit(2 if strict else 0)
+
+    golden = np.fromfile(golden_path, dtype=np.float32)
+    output = np.fromfile(output_path, dtype=np.float32)
+    ok = golden.shape == output.shape and np.allclose(
+        golden, output, atol=0.0001, rtol=0.0001, equal_nan=True
+    )
+    if not ok:
+        if golden.shape != output.shape:
+            print(f"[ERROR] shape mismatch: {golden.shape} vs {output.shape}")
+        elif golden.size:
+            diff = np.abs(golden.astype(np.float64) - output.astype(np.float64))
+            idx = int(np.argmax(diff))
+            print(
+                f"[ERROR] mismatch at idx={idx}: golden={golden[idx]} "
+                f"output={output[idx]} diff={diff[idx]}"
+            )
+        if strict:
+            sys.exit(2)
+        return
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/golden.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/golden.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+ELEMENTS = 1024
+SEED = 19
+
+
+def generate(output_dir: Path, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    data = rng.uniform(-8.0, 8.0, size=(ELEMENTS,)).astype(np.float32)
+    output = np.zeros((ELEMENTS,), dtype=np.float32)
+    golden = np.array(data, copy=True)
+    golden[:32] = data[32:64]
+    golden[32:64] = 0.0
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    data.tofile(output_dir / "input.bin")
+    output.tofile(output_dir / "output.bin")
+    golden.tofile(output_dir / "golden_output.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate inputs/golden for VPTO vsstb post-update validation."
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+    generate(args.output_dir, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/kernel.pto
+++ b/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/kernel.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// case: micro-op/vector-load-store/vsstb-post-update
+// family: vector-load-store
+// target_ops: pto.vsstb
+// scenarios: core-f32, full-mask, block-strided-store, post-update-result
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsstb_post_update_kernel(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c2_i16 = arith.constant 2 : i16
+    %c4_i16 = arith.constant 4 : i16
+    %c32_i64 = arith.constant 32 : i64
+    %c64_i32 = arith.constant 64 : i32
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %mask, %next_remaining = pto.plt_b32 %c64_i32 : i32 -> !pto.mask<b32>, i32
+      %value = pto.vlds %ub_in[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+      %updated = pto.vsstb %value, %ub_out, %c2_i16, %c4_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32> -> !pto.ptr<f32, ub>
+      pto.mem_bar "VST_VLD"
+      %roundtrip = pto.vsldb %updated, %c2_i16, %c4_i16, %mask : !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32> -> !pto.vreg<64xf32>
+      pto.vsts %roundtrip, %ub_in[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_in, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/launch.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/launch.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+
+#include <stdint.h>
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vsstb_post_update_kernel(__gm__ float *input, __gm__ float *output);
+
+void LaunchVsstbPostUpdate(float *input, float *output, void *stream) {
+  vsstb_post_update_kernel<<<1, nullptr, stream>>>((__gm__ float *)input,
+                                                   (__gm__ float *)output);
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/main.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vsstb-post-update/main.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+void LaunchVsstbPostUpdate(float *input, float *output, void *stream);
+
+namespace {
+constexpr size_t kElementCount = 1024;
+constexpr size_t kBufferSize = kElementCount * sizeof(float);
+}
+
+#define ACL_CHECK(expr)                                                        \
+  do {                                                                         \
+    const aclError ret = (expr);                                               \
+    if (ret != ACL_SUCCESS) {                                                  \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,          \
+                   static_cast<int>(ret), __FILE__, __LINE__);                \
+      const char *recent = aclGetRecentErrMsg();                               \
+      if (recent != nullptr && recent[0] != '\0')                              \
+        std::fprintf(stderr, "[ERROR] RecentErrMsg: %s\n", recent);           \
+      rc = 1;                                                                  \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  float *inputHost = nullptr;
+  float *outputHost = nullptr;
+  float *inputDevice = nullptr;
+  float *outputDevice = nullptr;
+  aclrtStream stream = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  size_t inputSize = kBufferSize;
+  size_t outputSize = kBufferSize;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+
+  ACL_CHECK(aclrtMallocHost(reinterpret_cast<void **>(&inputHost), kBufferSize));
+  ACL_CHECK(aclrtMallocHost(reinterpret_cast<void **>(&outputHost), kBufferSize));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&inputDevice), kBufferSize,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&outputDevice), kBufferSize,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./input.bin", inputSize, inputHost, kBufferSize);
+  ReadFile("./output.bin", outputSize, outputHost, kBufferSize);
+  ACL_CHECK(aclrtMemcpy(inputDevice, kBufferSize, inputHost, kBufferSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(outputDevice, kBufferSize, outputHost, kBufferSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+
+  LaunchVsstbPostUpdate(inputDevice, outputDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(outputHost, kBufferSize, outputDevice, kBufferSize,
+                        ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./output.bin", outputHost, kBufferSize);
+
+cleanup:
+  aclrtFree(inputDevice);
+  aclrtFree(outputDevice);
+  aclrtFreeHost(inputHost);
+  aclrtFreeHost(outputHost);
+  if (stream != nullptr) {
+    const aclError ret = aclrtDestroyStream(stream);
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclrtDestroyStream failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  if (deviceSet) {
+    const aclError ret = aclrtResetDevice(deviceId);
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclrtResetDevice failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  if (aclInited) {
+    const aclError ret = aclFinalize();
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclFinalize failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  return rc;
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/compare.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/compare.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden_path = "golden_output.bin"
+    output_path = "output.bin"
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+
+    if not os.path.exists(golden_path) or not os.path.exists(output_path):
+        print("[ERROR] missing golden_output.bin or output.bin")
+        sys.exit(2 if strict else 0)
+
+    golden = np.fromfile(golden_path, dtype=np.float32)
+    output = np.fromfile(output_path, dtype=np.float32)
+    ok = golden.shape == output.shape and np.allclose(
+        golden, output, atol=0.0001, rtol=0.0001, equal_nan=True
+    )
+    if not ok:
+        if golden.shape != output.shape:
+            print(f"[ERROR] shape mismatch: {golden.shape} vs {output.shape}")
+        elif golden.size:
+            diff = np.abs(golden.astype(np.float64) - output.astype(np.float64))
+            idx = int(np.argmax(diff))
+            print(
+                f"[ERROR] mismatch at idx={idx}: golden={golden[idx]} "
+                f"output={output[idx]} diff={diff[idx]}"
+            )
+        if strict:
+            sys.exit(2)
+        return
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/golden.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/golden.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+ELEMENTS = 1024
+SEED = 19
+
+
+def generate(output_dir: Path, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    data = rng.uniform(-8.0, 8.0, size=(ELEMENTS,)).astype(np.float32)
+    output = np.zeros((ELEMENTS,), dtype=np.float32)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    data.tofile(output_dir / "input.bin")
+    output.tofile(output_dir / "output.bin")
+    data.tofile(output_dir / "golden_output.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate inputs/golden for VPTO vsts post-update validation."
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+    generate(args.output_dir, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/kernel.pto
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/kernel.pto
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// case: micro-op/vector-load-store/vsts-post-update
+// family: vector-load-store
+// target_ops: pto.vsts
+// scenarios: core-f32, contiguous, full-mask, post-update-result, dist-norm
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsts_post_update_kernel(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %_:2 = scf.for %offset = %c0 to %c1024 step %c64
+          iter_args(%remaining = %c1024_i32, %dst = %ub_out)
+          -> (i32, !pto.ptr<f32, ub>) {
+        %mask, %next_remaining = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%offset] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        %updated = pto.vsts %vec, %dst[%c64], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32> -> !pto.ptr<f32, ub>
+        scf.yield %next_remaining, %updated : i32, !pto.ptr<f32, ub>
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/launch.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/launch.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+
+#include <stdint.h>
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vsts_post_update_kernel(__gm__ float *input, __gm__ float *output);
+
+void LaunchVstsPostUpdate(float *input, float *output, void *stream) {
+  vsts_post_update_kernel<<<1, nullptr, stream>>>((__gm__ float *)input,
+                                                  (__gm__ float *)output);
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/main.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-post-update/main.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+void LaunchVstsPostUpdate(float *input, float *output, void *stream);
+
+namespace {
+constexpr size_t kElementCount = 1024;
+constexpr size_t kBufferSize = kElementCount * sizeof(float);
+}
+
+#define ACL_CHECK(expr)                                                        \
+  do {                                                                         \
+    const aclError ret = (expr);                                               \
+    if (ret != ACL_SUCCESS) {                                                  \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,          \
+                   static_cast<int>(ret), __FILE__, __LINE__);                \
+      const char *recent = aclGetRecentErrMsg();                               \
+      if (recent != nullptr && recent[0] != '\0')                              \
+        std::fprintf(stderr, "[ERROR] RecentErrMsg: %s\n", recent);           \
+      rc = 1;                                                                  \
+      goto cleanup;                                                            \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  float *inputHost = nullptr;
+  float *outputHost = nullptr;
+  float *inputDevice = nullptr;
+  float *outputDevice = nullptr;
+  aclrtStream stream = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  size_t inputSize = kBufferSize;
+  size_t outputSize = kBufferSize;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+
+  ACL_CHECK(aclrtMallocHost(reinterpret_cast<void **>(&inputHost), kBufferSize));
+  ACL_CHECK(aclrtMallocHost(reinterpret_cast<void **>(&outputHost), kBufferSize));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&inputDevice), kBufferSize,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc(reinterpret_cast<void **>(&outputDevice), kBufferSize,
+                        ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./input.bin", inputSize, inputHost, kBufferSize);
+  ReadFile("./output.bin", outputSize, outputHost, kBufferSize);
+  ACL_CHECK(aclrtMemcpy(inputDevice, kBufferSize, inputHost, kBufferSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(outputDevice, kBufferSize, outputHost, kBufferSize,
+                        ACL_MEMCPY_HOST_TO_DEVICE));
+
+  LaunchVstsPostUpdate(inputDevice, outputDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(outputHost, kBufferSize, outputDevice, kBufferSize,
+                        ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./output.bin", outputHost, kBufferSize);
+
+cleanup:
+  aclrtFree(inputDevice);
+  aclrtFree(outputDevice);
+  aclrtFreeHost(inputHost);
+  aclrtFreeHost(outputHost);
+  if (stream != nullptr) {
+    const aclError ret = aclrtDestroyStream(stream);
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclrtDestroyStream failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  if (deviceSet) {
+    const aclError ret = aclrtResetDevice(deviceId);
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclrtResetDevice failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  if (aclInited) {
+    const aclError ret = aclFinalize();
+    if (ret != ACL_SUCCESS)
+      std::fprintf(stderr, "[ERROR] aclFinalize failed: %d\n",
+                   static_cast<int>(ret));
+  }
+  return rc;
+}

--- a/test/vpto/cases/onboard-only/simt-keep-resume/compare.py
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/onboard-only/simt-keep-resume/compare.py
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/compare.py
@@ -12,21 +12,41 @@ import sys
 
 import numpy as np
 
+CHECK_ELEMS = 128
+
 
 def main():
     strict = os.getenv("COMPARE_STRICT", "1") != "0"
     golden = np.fromfile("golden_v1.bin", dtype=np.int32)
     out = np.fromfile("v1.bin", dtype=np.int32)
-    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    golden_prefix = golden[:CHECK_ELEMS]
+    out_prefix = out[:CHECK_ELEMS]
+    shape_ok = golden_prefix.shape == (CHECK_ELEMS,) and out_prefix.shape == (
+        CHECK_ELEMS,
+    )
+    ok = shape_ok and np.array_equal(golden_prefix, out_prefix)
     if not ok:
-        idxs = np.nonzero(golden != out)[0]
+        if not shape_ok:
+            print(
+                f"[ERROR] expected at least {CHECK_ELEMS} elements, "
+                f"golden={golden.size}, out={out.size}"
+            )
+            if strict:
+                sys.exit(2)
+            print(f"[WARN] compare failed for first {CHECK_ELEMS} elements (non-gating)")
+            return
+        idxs = np.nonzero(golden_prefix != out_prefix)[0]
         idx = int(idxs[0]) if idxs.size else 0
         print(
-            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden_prefix[idx])}, out={int(out_prefix[idx])}"
         )
         if strict:
             sys.exit(2)
-    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+    print(
+        f"[INFO] compare passed for first {CHECK_ELEMS} elements"
+        if ok
+        else f"[WARN] compare failed for first {CHECK_ELEMS} elements (non-gating)"
+    )
 
 
 if __name__ == "__main__":

--- a/test/vpto/cases/onboard-only/simt-keep-resume/golden.py
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/golden.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 1024
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    xs = np.arange(32, dtype=np.int32)
+    ys = np.arange(32, dtype=np.int32)[:, None]
+    tid = ys * 32 + xs[None, :]
+    tid_i16 = tid & 0xFFFF
+    tid_i8 = tid & 0xFF
+    golden_v1 = (
+        (xs[None, :] | (ys << 8))
+        + tid
+        + tid_i16
+        + tid_i8
+        + tid
+        + 100
+        + 1000
+        + 100000
+    ).reshape(ELEMS)
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/onboard-only/simt-keep-resume/golden.py
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/golden.py
@@ -18,21 +18,9 @@ ELEMS = 1024
 def generate(output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     v1 = np.full(ELEMS, -1, dtype=np.int32)
-    xs = np.arange(32, dtype=np.int32)
-    ys = np.arange(32, dtype=np.int32)[:, None]
-    tid = ys * 32 + xs[None, :]
-    tid_i16 = tid & 0xFFFF
-    tid_i8 = tid & 0xFF
-    golden_v1 = (
-        (xs[None, :] | (ys << 8))
-        + tid
-        + tid_i16
-        + tid_i8
-        + tid
-        + 100
-        + 1000
-        + 100000
-    ).reshape(ELEMS)
+    golden_v1 = np.zeros(ELEMS, dtype=np.int32)
+    tx = np.arange(128, dtype=np.int32)
+    golden_v1[:128] = 101100 + 5 * tx
     v1.tofile(output_dir / "v1.bin")
     golden_v1.tofile(output_dir / "golden_v1.bin")
 

--- a/test/vpto/cases/onboard-only/simt-keep-resume/kernel.pto
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/kernel.pto
@@ -1,0 +1,101 @@
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_keep_resume_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 128 : i32
+
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
+
+    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
+    func.call @simt_stage0(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    func.call @simt_stage1(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %arg0, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+
+  func.func @simt_stage0(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %tx = pto.get_tid_x : i32
+    %ty = pto.get_tid_y : i32
+    %tz = pto.get_tid_z : i32
+    %c8_i32 = arith.constant 8 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %f16_1 = arith.constant 1.000000e+00 : f16
+    %bf16_1 = arith.constant 1.000000e+00 : bf16
+    %f1 = arith.constant 1.000000e+00 : f32
+    %ty_shift = arith.shli %ty, %c8_i32 : i32
+    %tz_shift = arith.shli %tz, %c16_i32 : i32
+    %xy = arith.ori %tx, %ty_shift : i32
+    %xyz = arith.ori %xy, %tz_shift : i32
+    %lane_base = arith.muli %ty, %c32_i32 : i32
+    %tid = arith.addi %lane_base, %tx : i32
+    %tid_i64 = arith.extui %tid : i32 to i64
+    %tid_i8 = arith.trunci %tid : i32 to i8
+    %tid_i16 = arith.trunci %tid : i32 to i16
+    %tid_idx = arith.index_castui %tid : i32 to index
+    pto.store %xyz, %dst[%tid_idx] : !pto.ptr<i32, ub>, i32
+    pto.keep %xyz {slot = 0 : i64} : i32
+    pto.keep %tid {slot = 1 : i64} : i32
+    pto.keep %tid_i16 {slot = 2 : i64} : i16
+    pto.keep %f1 {slot = 3 : i64} : f32
+    pto.keep %tid_i8 {slot = 4 : i64} : i8
+    pto.keep %f16_1 {slot = 5 : i64} : f16
+    pto.keep %bf16_1 {slot = 6 : i64} : bf16
+    pto.keep %tid_i64 {slot = 8 : i64} : i64
+    pto.syncthreads
+    return
+  }
+
+  func.func @simt_stage1(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %xyz = pto.resume {slot = 0 : i64} : i32
+    %kept_tid = pto.resume {slot = 1 : i64} : i32
+    %kept_tid_i16 = pto.resume {slot = 2 : i64} : i16
+    %kept_f1 = pto.resume {slot = 3 : i64} : f32
+    %kept_tid_i8 = pto.resume {slot = 4 : i64} : i8
+    %kept_f16_1 = pto.resume {slot = 5 : i64} : f16
+    %kept_bf16_1 = pto.resume {slot = 6 : i64} : bf16
+    %kept_tid_i64 = pto.resume {slot = 8 : i64} : i64
+    %tx = pto.get_tid_x : i32
+    %ty = pto.get_tid_y : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c1000_i32 = arith.constant 1000 : i32
+    %c100_i32 = arith.constant 100 : i32
+    %c100000_i32 = arith.constant 100000 : i32
+    %f16_1 = arith.constant 1.000000e+00 : f16
+    %bf16_1 = arith.constant 1.000000e+00 : bf16
+    %f1 = arith.constant 1.000000e+00 : f32
+    %lane_base = arith.muli %ty, %c32_i32 : i32
+    %tid = arith.addi %lane_base, %tx : i32
+    %tid_idx = arith.index_castui %tid : i32 to index
+    %kept_tid_i64_i32 = arith.trunci %kept_tid_i64 : i64 to i32
+    %kept_tid_i8_i32 = arith.extui %kept_tid_i8 : i8 to i32
+    %kept_tid_i32 = arith.extui %kept_tid_i16 : i16 to i32
+    %f16_ok = arith.cmpf oeq, %kept_f16_1, %f16_1 : f16
+    %f16_ok_i32 = arith.extui %f16_ok : i1 to i32
+    %f16_score = arith.muli %f16_ok_i32, %c1000_i32 : i32
+    %bf16_ok = arith.cmpf oeq, %kept_bf16_1, %bf16_1 : bf16
+    %bf16_ok_i32 = arith.extui %bf16_ok : i1 to i32
+    %bf16_score = arith.muli %bf16_ok_i32, %c100_i32 : i32
+    %f_ok = arith.cmpf oeq, %kept_f1, %f1 : f32
+    %f_ok_i32 = arith.extui %f_ok : i1 to i32
+    %f_score = arith.muli %f_ok_i32, %c100000_i32 : i32
+    %out0 = arith.addi %xyz, %kept_tid : i32
+    %out1 = arith.addi %out0, %kept_tid_i32 : i32
+    %out2 = arith.addi %out1, %kept_tid_i8_i32 : i32
+    %out3 = arith.addi %out2, %f16_score : i32
+    %out4 = arith.addi %out3, %bf16_score : i32
+    %out5 = arith.addi %out4, %kept_tid_i64_i32 : i32
+    %out = arith.addi %out5, %f_score : i32
+    pto.store %out, %dst[%tid_idx] : !pto.ptr<i32, ub>, i32
+    return
+  }
+}

--- a/test/vpto/cases/onboard-only/simt-keep-resume/kernel.pto
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/kernel.pto
@@ -9,9 +9,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<i32, ub>
 
-    pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @simt_stage0(%ub_out) : (!pto.ptr<i32, ub>) -> ()
-    func.call @simt_stage1(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_stage0<<<%dim_x, %dim_y, %dim_z>>>(%ub_out) : (!pto.ptr<i32, ub>) -> ()
+    pto.simt_launch @simt_stage1<<<%dim_x, %dim_y, %dim_z>>>(%ub_out) : (!pto.ptr<i32, ub>) -> ()
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]

--- a/test/vpto/cases/onboard-only/simt-keep-resume/launch.cpp
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_keep_resume_kernel(__gm__ int *v1);
+void LaunchSimt_keep_resume_kernel(int *v1, void *stream) {
+  simt_keep_resume_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/onboard-only/simt-keep-resume/main.cpp
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_keep_resume_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 1024;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_keep_resume_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/onboard-only/simt-keep-resume/stub.cpp
+++ b/test/vpto/cases/onboard-only/simt-keep-resume/stub.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __global__
+#define __global__
+#endif
+#ifndef __gm__
+#define __gm__
+#endif
+extern "C" __global__ [aicore] void simt_keep_resume_kernel(__gm__ int *v1) {
+  (void)v1;
+}

--- a/test/vpto/scripts/run_host_vpto_validation.sh
+++ b/test/vpto/scripts/run_host_vpto_validation.sh
@@ -111,9 +111,14 @@ discover_cases() {
     golden.py
     compare.py
   )
+  local onboard_only_prefix="onboard-only/"
 
   if [[ -n "${CASE_NAME}" ]]; then
     [[ "${CASE_NAME}" != /* ]] || die "CASE_NAME must be relative to CASES_ROOT: ${CASE_NAME}"
+    if [[ "${DEVICE}" == "SIM" && "${COMPILE_ONLY}" != "1" &&
+          "${CASE_NAME}" == "${onboard_only_prefix}"* ]]; then
+      die "case ${CASE_NAME} is onboard-only and cannot run with DEVICE=SIM"
+    fi
     local requested_dir="${CASES_ROOT}/${CASE_NAME}"
     [[ -d "${requested_dir}" ]] || die "unknown case: ${CASE_NAME}"
     for f in "${required_files[@]}"; do
@@ -136,9 +141,18 @@ discover_cases() {
     [[ "${ok}" -eq 1 ]] || continue
     [[ -f "${dir}/kernel.pto" ]] || continue
     local rel="${dir#${CASES_ROOT}/}"
+    if [[ "${DEVICE}" == "SIM" && "${COMPILE_ONLY}" != "1" &&
+          "${rel}" == "${onboard_only_prefix}"* ]]; then
+      continue
+    fi
     printf "%s\n" "${rel}"
   done
 }
+
+if [[ "${DEVICE}" == "SIM" && "${COMPILE_ONLY}" != "1" &&
+      "${CASE_NAME}" == onboard-only/* ]]; then
+  die "case ${CASE_NAME} is onboard-only and cannot run with DEVICE=SIM"
+fi
 
 readarray -t CASES < <(discover_cases)
 [[ "${#CASES[@]}" -gt 0 ]] || die "no cases found under ${CASES_ROOT}"

--- a/test/vpto/scripts/run_host_vpto_validation_parallel.sh
+++ b/test/vpto/scripts/run_host_vpto_validation_parallel.sh
@@ -81,8 +81,13 @@ discover_cases() {
     golden.py
     compare.py
   )
+  local onboard_only_prefix="onboard-only/"
 
   if [[ -n "${CASE_NAME}" ]]; then
+    if [[ "${DEVICE:-SIM}" == "SIM" && "${COMPILE_ONLY:-0}" != "1" &&
+          "${CASE_NAME}" == "${onboard_only_prefix}"* ]]; then
+      die "case ${CASE_NAME} is onboard-only and cannot run with DEVICE=SIM"
+    fi
     local requested_dir="${CASES_ROOT}/${CASE_NAME}"
     [[ -d "${requested_dir}" ]] || die "unknown case: ${CASE_NAME}"
     for f in "${required_files[@]}"; do
@@ -105,12 +110,21 @@ discover_cases() {
     [[ "${ok}" -eq 1 ]] || continue
     [[ -f "${dir}/kernel.pto" ]] || continue
     local rel="${dir#${CASES_ROOT}/}"
+    if [[ "${DEVICE:-SIM}" == "SIM" && "${COMPILE_ONLY:-0}" != "1" &&
+          "${rel}" == "${onboard_only_prefix}"* ]]; then
+      continue
+    fi
     if [[ -n "${CASE_PREFIX}" && "${rel}" != "${CASE_PREFIX}"* ]]; then
       continue
     fi
     printf "%s\n" "${rel}"
   done
 }
+
+if [[ "${DEVICE:-SIM}" == "SIM" && "${COMPILE_ONLY:-0}" != "1" &&
+      "${CASE_NAME}" == onboard-only/* ]]; then
+  die "case ${CASE_NAME} is onboard-only and cannot run with DEVICE=SIM"
+fi
 
 readarray -t CASES < <(discover_cases)
 [[ "${#CASES[@]}" -gt 0 ]] || die "no cases found under ${CASES_ROOT}"

--- a/tilelang-dsl/python/tilelang_dsl/daemon_core.py
+++ b/tilelang-dsl/python/tilelang_dsl/daemon_core.py
@@ -313,7 +313,10 @@ def _build_positional_context_attrs(operand_specs: list[dict]) -> dict[str, Any]
     for index, spec in enumerate(operand_specs):
         prefix = f"arg{index}"
         attrs[f"{prefix}_kind"] = spec.get("kind")
-        attrs[f"{prefix}_dtype"] = spec.get("dtype")
+        dtype = spec.get("dtype")
+        if isinstance(dtype, str):
+            dtype = _convert_dtype_str_to_scalar(dtype)
+        attrs[f"{prefix}_dtype"] = dtype
 
         if spec.get("kind") == "scalar":
             continue

--- a/tilelang-dsl/python/tilelang_dsl/daemon_core.py
+++ b/tilelang-dsl/python/tilelang_dsl/daemon_core.py
@@ -319,6 +319,8 @@ def _build_positional_context_attrs(operand_specs: list[dict]) -> dict[str, Any]
         attrs[f"{prefix}_dtype"] = dtype
 
         if spec.get("kind") == "scalar":
+            if "value" in spec:
+                attrs[f"{prefix}_value"] = spec["value"]
             continue
 
         shape = spec.get("shape")

--- a/tilelang-dsl/python/tilelang_dsl/kernel.py
+++ b/tilelang-dsl/python/tilelang_dsl/kernel.py
@@ -2853,6 +2853,7 @@ def ckernel(
     templates: Any = _UNSET,
     dtypes: Any = None,
     name: str | None = None,
+    constraints: Any = _UNSET,
     priority: Any = _UNSET,
 ) -> VKernelDescriptor | Callable[[Callable[..., Any]], VKernelDescriptor]:
     """Create a TileLang DSL cube-kernel descriptor.
@@ -2873,7 +2874,7 @@ def ckernel(
             name=name,
             verify=True,
             advanced=False,
-            constraints=_UNSET,
+            constraints=constraints,
             priority=priority,
             kernel_family="cube",
         )

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2730,6 +2730,15 @@ class _AuthoringRenderer:
         atomic_type = self._extract_optional_static_string(expr.args[cursor + 10], context=f"pto.{expr.name} atomic type")
         atomic_op = self._extract_optional_static_string(expr.args[cursor + 11], context=f"pto.{expr.name} atomic op")
 
+        if pre_quant_mode is not None:
+            source = self._bridge_rendered_ptr_element_to_signless_integer(
+                source,
+                indent=indent,
+                into=into,
+            )
+            operands[0] = source
+            type_parts[0] = self._render_type(source.type)
+
         if unit_flag is not None:
             clause_parts.append(f"unit_flag({unit_flag})")
 
@@ -3117,6 +3126,40 @@ class _AuthoringRenderer:
             f"{self._render_type(value.type)} to {self._render_type(raw_type)}"
         )
         return _RenderedValue(name=cast_name, type=raw_type)
+
+    def _bridge_rendered_ptr_element_to_signless_integer(
+        self,
+        value: _RenderedValue,
+        *,
+        indent: int,
+        into: list[str],
+    ) -> _RenderedValue:
+        if not isinstance(value.type, SemanticPtrType) or not is_integer_dtype(value.type.element_dtype):
+            return value
+        signless_element_type = self._signless_integer_scalar_type(
+            SemanticScalarType(dtype=value.type.element_dtype)
+        )
+        if signless_element_type is None:
+            return value
+        target_type = SemanticPtrType(
+            element_dtype=signless_element_type.dtype,
+            memory_space=value.type.memory_space,
+        )
+        if value.type == target_type:
+            return value
+        rendered_target_type = self._render_type(target_type)
+        cache_key = (value.name, rendered_target_type)
+        existing = self._castptr_cache.get(cache_key)
+        if existing is not None:
+            return _RenderedValue(name=existing, type=target_type)
+        cast_name = self._new_temp()
+        into.append(
+            self._indent(indent)
+            + f"{cast_name} = pto.castptr {value.name} : "
+            f"{self._render_type(value.type)} -> {rendered_target_type}"
+        )
+        self._castptr_cache[cache_key] = cast_name
+        return _RenderedValue(name=cast_name, type=target_type)
 
     def _bridge_rendered_integer_to_target(
         self,

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4410,8 +4410,8 @@ class _SemanticAnalyzer:
                     "qf322bf16_pre_scalar", "qs322bf16_pre_vec", "qs322bf16_pre_scalar",
                 },
             )
-            if src.type.element_dtype.name not in {"f32", "i32"}:
-                raise TypeError(f"pto.{name} pre_quant requires f32 or i32 source elements in TileLang DSL v1")
+            if src.type.element_dtype.name not in {"f32", "i32", "si32"}:
+                raise TypeError(f"pto.{name} pre_quant requires f32, i32, or si32 source elements in TileLang DSL v1")
             self._validate_fixpipe_payload(
                 pre_quant_payload,
                 pre_quant_mode,
@@ -4641,6 +4641,15 @@ class _SemanticAnalyzer:
             return ("i32", "bf16")
         return (None, None)
 
+    def _fixpipe_pre_quant_src_family_matches(self, src_dtype: ScalarType, src_family: str | None) -> bool:
+        if src_family is None:
+            return True
+        if src_family == "f32":
+            return src_dtype.name == "f32"
+        if src_family == "i32":
+            return src_dtype.name in {"i32", "si32"}
+        return src_dtype.name == src_family
+
     def _fixpipe_pre_quant_dst_family_matches(self, dst_dtype: ScalarType, dst_family: str | None) -> bool:
         if dst_family is None:
             return True
@@ -4666,7 +4675,7 @@ class _SemanticAnalyzer:
     ) -> None:
         mode_value = self._require_string_expr(mode, f"{context} mode")
         expected_src_family, expected_dst_family = self._fixpipe_pre_quant_mode_families(mode_value)
-        if expected_src_family is not None and src_dtype.name != expected_src_family:
+        if not self._fixpipe_pre_quant_src_family_matches(src_dtype, expected_src_family):
             raise TypeError(
                 f"{context} mode {mode_value} requires {expected_src_family} source elements in TileLang DSL v1"
             )

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -10655,6 +10655,31 @@ class TileLangDSLDiagnosticsTests(unittest.TestCase):
             str(pre_quant_src_family_ctx.exception),
         )
 
+        @pto.ckernel(op="pto.mad", dtypes=[(pto.f16,)], name="cube_si32_pre_quant_bridge_unique")
+        def si32_pre_quant_kernel(inp: pto.TensorView):
+            acc = pto.Tile((16, 16), pto.si32, pto.MemorySpace.ACC)
+            l1 = pto.Tile((16, 16), pto.f16, pto.MemorySpace.MAT)
+            pto.mte_l0c_l1(
+                acc.as_ptr(),
+                l1.as_ptr(),
+                16,
+                16,
+                16,
+                16,
+                pre_quant=(pto.f32(1.0), "deqf16_scalar"),
+            )
+
+        text = pto.select_kernel(
+            "a5",
+            "pto.mad",
+            (pto.f16,),
+            registry=pto.KernelRegistry((si32_pre_quant_kernel,)),
+        ).specialize().mlir_text()
+
+        self.assertIn("pre_quant(", text)
+        self.assertRegex(text, r"= pto\.castptr %[^:]+ : !pto\.ptr<si32, l0c> -> !pto\.ptr<i32, l0c>")
+        self.assertRegex(text, r"pto\.mte_l0c_l1 %[^,]+, %[^,]+, .* : !pto\.ptr<i32, l0c>, !pto\.ptr<f16, l1>,")
+
         @pto.ckernel(op="pto.mad", dtypes=[(pto.f16,)], name="cube_bad_pre_quant_dst_family_unique")
         def pre_quant_dst_family_kernel(inp: pto.TensorView):
             acc = pto.Tile((16, 16), pto.f32, pto.MemorySpace.ACC)

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2160,6 +2160,97 @@ def fallback(src: pto.TensorView, dst: pto.Tile):
 
         self.assertIn("func.func @constrained", mlir_text)
 
+    def test_instance_cache_constraints_can_read_scalar_values(self) -> None:
+        source = """
+import tilelang_dsl as pto
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_scalar_value_constraints_unique",
+    dtypes=[(pto.f32, pto.i32, pto.f32)],
+    constraints=[lambda src, indexCol, dst: indexCol.value % 8 == 0],
+    priority=100,
+)
+def constrained(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+    return None
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_scalar_value_constraints_unique",
+    dtypes=[(pto.f32, pto.i32, pto.f32)],
+    constraints=[],
+    priority=10,
+)
+def fallback(src: pto.Tile, indexCol: pto.i32, dst: pto.Tile):
+    return None
+"""
+
+        aligned_operand_specs = [
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+            {
+                "kind": "scalar",
+                "dtype": "i32",
+                "value": 8,
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        fallback_operand_specs = [
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+            {
+                "kind": "scalar",
+                "dtype": "i32",
+                "value": 1,
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [1, 64],
+                "valid_shape": [1, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        async def instantiate_from_tmpdir(tmpdir: str, operand_specs: list[dict]) -> str:
+            cache = daemon_core.InstanceCache()
+            cache.scan_template_directory(Path(tmpdir))
+            return await cache.instantiate(
+                "a5",
+                "matcher_daemon_scalar_value_constraints_unique",
+                operand_specs,
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir) / "matcher_daemon_scalar_value_constraints_unique.py"
+            module_path.write_text(source, encoding="utf-8")
+            aligned_mlir = asyncio.run(instantiate_from_tmpdir(tmpdir, aligned_operand_specs))
+            fallback_mlir = asyncio.run(instantiate_from_tmpdir(tmpdir, fallback_operand_specs))
+
+        self.assertIn("func.func @constrained", aligned_mlir)
+        self.assertIn("func.func @fallback", fallback_mlir)
+        self.assertEqual(
+            daemon_core._build_positional_context_attrs(aligned_operand_specs)["arg1_value"],
+            8,
+        )
+
     def test_select_kernel_binds_selected_op_for_multi_op_descriptor(self) -> None:
         @pto.vkernel(
             ops=["matcher_multi_op_bind_add_unique", "matcher_multi_op_bind_sub_unique"],

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -1438,6 +1438,50 @@ class TileLangDSLMatcherEntryTests(unittest.TestCase):
         self.assertIs(selected.py_fn, high_priority_kernel.py_fn)
         self.assertEqual(selected.priority, 100)
 
+    def test_ckernel_constraints_are_forwarded_to_select_kernel(self) -> None:
+        def requires_large_batch(batch=0):
+            return batch >= 1024
+
+        @pto.ckernel(
+            op="cube_constraint_priority_unique",
+            dtypes=[(pto.f16,)],
+            constraints=[requires_large_batch],
+            priority=100,
+        )
+        def high_priority_kernel(inp: pto.TensorView):
+            return None
+
+        @pto.ckernel(
+            op="cube_constraint_priority_unique",
+            dtypes=[(pto.f16,)],
+            constraints=[],
+            priority=10,
+        )
+        def fallback_kernel(inp: pto.TensorView):
+            return None
+
+        registry = pto.KernelRegistry((high_priority_kernel, fallback_kernel))
+
+        selected = pto.select_kernel(
+            "a5",
+            "cube_constraint_priority_unique",
+            (pto.f16,),
+            context_attrs={"batch": 128},
+            registry=registry,
+        )
+        self.assertIs(selected.py_fn, fallback_kernel.py_fn)
+        self.assertEqual(selected.priority, 10)
+
+        selected = pto.select_kernel(
+            "a5",
+            "cube_constraint_priority_unique",
+            (pto.f16,),
+            context_attrs={"batch": 4096},
+            registry=registry,
+        )
+        self.assertIs(selected.py_fn, high_priority_kernel.py_fn)
+        self.assertEqual(selected.priority, 100)
+
     def test_select_kernel_raises_tie_error_for_equal_highest_priority(self) -> None:
         @pto.vkernel(
             op="matcher_priority_tie_unique",
@@ -9985,6 +10029,10 @@ class TileLangDSLDiagnosticsTests(unittest.TestCase):
         with self.assertRaises(TypeError) as constraints_ctx:
             pto.vkernel(op="x", dtypes=[(pto.f32,)], constraints=[123])(kernel)
         self.assertIn("constraints[0] must be callable", str(constraints_ctx.exception))
+
+        with self.assertRaises(TypeError) as cube_constraints_ctx:
+            pto.ckernel(op="x", dtypes=[(pto.f32,)], constraints=[123])(kernel)
+        self.assertIn("constraints[0] must be callable", str(cube_constraints_ctx.exception))
 
         with self.assertRaises(TypeError) as priority_ctx:
             pto.vkernel(op="x", dtypes=[(pto.f32,)], priority=True)(kernel)

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -1939,6 +1939,29 @@ class TileLangDSLMatcherEntryTests(unittest.TestCase):
 
         self.assertTrue(evaluation.passed, msg=evaluation.error_message)
 
+    def test_daemon_context_attrs_normalize_dtype_to_scalartype(self) -> None:
+        operand_specs = [
+            {
+                "kind": "view",
+                "dtype": "f32",
+                "shape": [1, 1, 1, 16, 64],
+                "strides": [1024, 1024, 1024, 64, 1],
+                "memory_space": "gm",
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [16, 64],
+                "valid_shape": [16, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        context_attrs = daemon_core._build_positional_context_attrs(operand_specs)
+
+        self.assertIs(context_attrs["arg0_dtype"], pto.f32)
+        self.assertIs(context_attrs["arg1_dtype"], pto.f32)
+
     def test_select_kernel_constraints_can_read_scalar_parameter_values(self) -> None:
         @pto.vkernel(
             op="matcher_scalar_value_unique",
@@ -2078,6 +2101,64 @@ def kernel(value: pto.si32):
             mlir_text = asyncio.run(instantiate_from_tmpdir(tmpdir))
 
         self.assertIn("func.func @kernel(%arg0: si32)", mlir_text)
+
+    def test_instance_cache_constraints_can_read_dtype_objects(self) -> None:
+        source = """
+import tilelang_dsl as pto
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_dtype_constraints_unique",
+    dtypes=[(pto.AnyType, pto.AnyType)],
+    constraints=[lambda src, dst: src.dtype == pto.f32 and dst.dtype == pto.f32],
+    priority=100,
+)
+def constrained(src: pto.TensorView, dst: pto.Tile):
+    return None
+
+@pto.vkernel(
+    target="a5",
+    op="matcher_daemon_dtype_constraints_unique",
+    dtypes=[(pto.AnyType, pto.AnyType)],
+    constraints=[],
+    priority=10,
+)
+def fallback(src: pto.TensorView, dst: pto.Tile):
+    return None
+"""
+
+        operand_specs = [
+            {
+                "kind": "view",
+                "dtype": "f32",
+                "shape": [1, 1, 1, 16, 64],
+                "strides": [1024, 1024, 1024, 64, 1],
+                "memory_space": "gm",
+            },
+            {
+                "kind": "tile",
+                "dtype": "f32",
+                "shape": [16, 64],
+                "valid_shape": [16, 64],
+                "memory_space": "ub",
+            },
+        ]
+
+        async def instantiate_from_tmpdir(tmpdir: str) -> str:
+            cache = daemon_core.InstanceCache()
+            cache.scan_template_directory(Path(tmpdir))
+            return await cache.instantiate(
+                "a5",
+                "matcher_daemon_dtype_constraints_unique",
+                operand_specs,
+            )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            module_path = Path(tmpdir) / "matcher_daemon_dtype_constraints_unique.py"
+            module_path.write_text(source, encoding="utf-8")
+            mlir_text = asyncio.run(instantiate_from_tmpdir(tmpdir))
+
+        self.assertIn("func.func @constrained", mlir_text)
 
     def test_select_kernel_binds_selected_op_for_multi_op_descriptor(self) -> None:
         @pto.vkernel(

--- a/tools/ptoas/TilelangDaemon.cpp
+++ b/tools/ptoas/TilelangDaemon.cpp
@@ -12,9 +12,12 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include <chrono>
-#include <thread>
-#include <signal.h>
 #include <cstdlib>
+#include <signal.h>
+#include <thread>
+#include <unistd.h>
+
+extern char **environ;
 
 namespace ptoas {
 

--- a/tools/ptoas/VPTOFatobjEmission.cpp
+++ b/tools/ptoas/VPTOFatobjEmission.cpp
@@ -85,6 +85,17 @@ static bool writeTextFile(StringRef path, StringRef content,
   return true;
 }
 
+static void stripUnsupportedBishengAttrs(llvm::Module &module) {
+  for (llvm::Function &function : module) {
+    // LLVM 19 prints memory effect attributes in textual form like
+    // `memory(none)`. beta.1 Bisheng cannot parse that syntax, so remove only
+    // the unsupported memory-effect attribute before serializing the module.
+    function.setAttributes(
+        function.getAttributes().removeFnAttribute(module.getContext(),
+                                                   llvm::Attribute::Memory));
+  }
+}
+
 static bool writeLLVMModuleFile(llvm::Module &module, StringRef path,
                                 llvm::raw_ostream &diagOS) {
   std::error_code ec;
@@ -94,6 +105,7 @@ static bool writeLLVMModuleFile(llvm::Module &module, StringRef path,
            << ec.message() << "\n";
     return false;
   }
+  stripUnsupportedBishengAttrs(module);
   module.print(os, nullptr);
   os.flush();
   return true;
@@ -398,6 +410,8 @@ static bool compileDeviceLLVMToObject(llvm::StringRef llPath,
       std::string("--cce-aicore-arch=") + targetCPU.str(),
       "--cce-aicore-only",
       "-O2",
+      "-mllvm",
+      "-cce-dyn-kernel-stack-size=true",
       "-c",
       "-x",
       "ir",

--- a/tools/ptoas/VPTOHostStubEmission.cpp
+++ b/tools/ptoas/VPTOHostStubEmission.cpp
@@ -121,10 +121,9 @@ LogicalResult mlir::pto::emitVPTOHostStubSource(ModuleOp module,
 
   stubSource.clear();
   llvm::raw_string_ostream os(stubSource);
-  os << "#ifndef __global__\n#define __global__\n#endif\n\n";
-  os << "#ifndef __gm__\n#define __gm__\n#endif\n\n";
+  os << "#ifndef AICORE\n#define AICORE [aicore]\n#endif\n\n";
   for (const VPTOKernelStubDecl &decl : stubDecls) {
-    os << "extern \"C\" __global__ [aicore] void " << decl.logicalName << "(";
+    os << "extern \"C\" __global__ AICORE void " << decl.logicalName << "(";
     for (size_t i = 0; i < decl.argTypes.size(); ++i) {
       if (i)
         os << ", ";


### PR DESCRIPTION
## 主要修改

本 PR 合入 VPTO backend 第三批功能与修复，重点包括 SIMT 支持、VPTO load/store post-update 接口、DSL/TileLang 修复，以及配套测试和文档更新。

### VPTO / SIMT

- 新增并完善 SIMT 相关 PTO/VPTO op、类型、C API、Python binding、verifier 和 LLVM lowering。
- 支持 `pto.simt_launch` 语法糖，以及 SIMT body、launch config、thread id、scalar memory、atomic、shuffle/redux、convert、float/scalar math、packed ops 等能力。
- 增加 keep/resume 相关约束、lowering、测试和设计文档。
- 新增多组 `test/lit/vpto/simt_*` 编译回归测试和 `test/vpto/cases/micro-op/simt/*` runtime case。

### VPTO load/store post-update

- 支持 `vlds`、`vsts`、`vsstb` post-update 接口。
- 增加 post-update 正向 lowering 检查和非法用法 verifier 测试。
- 新增对应 runtime case：`vlds-post-update`、`vsts-post-update`、`vsstb-post-update`。

### DSL / TileLang 修复

- 修复 TileLang daemon POSIX symbol 声明问题。
- 修复 daemon core scalar value passing。
- 支持 ckernel constraints。
- 修复 positional dtype string 到真实 dtype 的转换。
- 支持 `si32` pre_quant type。

### VPTO lowering / verifier 修复

- 修复 ExpandTileOp memory space stringify。
- 支持 signless `i8 * i8 -> i32` MAD lowering。
- 限制 `textract mat -> left/right` 时 `indexRow/indexCol` 必须为 0。
- 更新 VPTO ptr normalize、wrapper expansion、LLVM emitter、VPTO IR validation 等核心路径。

### 测试和文档

- 更新 VPTO spec、SIMT ISA 文档、vector load/store 文档和 keep/resume 设计文档。
- 增加低精度类型 roundtrip、textract verifier、MAD lowering、SIMT、post-update 等 lit 测试。
- 从 PTO-Gym 同步并保留部分已验证的 runtime fixup，例如 `vmrgsort4` compare、`cbuf-ubuf-roundtrip-mixed` subblock 写回限制，以及 `mad_acc` 语义注释。

## 验证

- 已覆盖新增/修改的 lit 测试用例。
- 已补充多组 `test/vpto` runtime case，用于 SIMT 和 post-update 行为验证。