### PR TITLE
Fix TCI pipe modeling for insert sync

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3370,7 +3370,7 @@ def TCIOp : PTO_TOp<"tci", [
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_S; }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
   }];
 }

--- a/test/lit/pto/issue735_tci_pipe_s_sync.pto
+++ b/test/lit/pto/issue735_tci_pipe_s_sync.pto
@@ -1,0 +1,21 @@
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @tci_to_tmuls_cross_pipe_sync() {
+    %start = arith.constant 0 : i32
+    %scale = arith.constant 2 : i32
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tci ins(%start : i32)
+            outs(%tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%tile, %scale : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, i32)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: After Sync Motion
+// CHECK:      COMPOUND pto.tci [PIPE_S]
+// CHECK-NEXT:   POST: set_flag <PIPE_S -> PIPE_V>
+// CHECK-NEXT: COMPOUND pto.tmuls [PIPE_V]
+// CHECK-NEXT:   PRE : wait_flag <PIPE_S -> PIPE_V>


### PR DESCRIPTION
Summary
- Change TCIOp::getPipe() from PIPE_V to PIPE_S to match PTO-ISA opPipeList.
- Add an insert-sync regression covering TCI writing a tile before TMULS reads/writes the same tile.

Motivation
- Fixes #735.
- The insert-sync translator takes the op pipe from OpPipeInterface. Modeling TCI as PIPE_V made TCI -> TMULS look like same-pipe traffic, so the required PIPE_S -> PIPE_V set/wait handshake was dropped.

Testing
- Local: ptoas --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 test/lit/pto/issue735_tci_pipe_s_sync.pto -o - | FileCheck test/lit/pto/issue735_tci_pipe_s_sync.pto
- Local: llvm-lit -v build/test/lit --filter issue735_tci_pipe_s_sync
- Local: llvm-lit -v build/test/lit --filter 'tci_'
- Local: git diff --check

Risk / Rollback
- Risk is limited to TCIOp synchronization classification; existing TCI codegen remains unchanged.
- Rollback by reverting this PR.