### PR TITLE
Add PTODSL load_tile and store_tile helpers

### DIFF
--- a/ptodsl/README.md
+++ b/ptodsl/README.md
@@ -389,8 +389,8 @@ pto.partition_view(tv, offsets=…, sizes=…)        # type inferred
 pto.alloc_tile(shape=…, dtype=…, memory_space=…, valid_shape=…, addr=…)  # authored surface
 pto.tile.load(part, tile)
 pto.tile.store(tile, part)
-pto.tile.load(tv, tile, offset=…)                 # partition + tile.load, sizes inferred from tile
-pto.tile.store(tile, tv, offset=…)                # partition + tile.store, sizes inferred from tile
+pto.tile.load(tv, tile)                           # partition + tile.load, zero offsets, sizes inferred from tile
+pto.tile.store(tile, tv)                          # partition + tile.store, zero offsets, sizes inferred from tile
 tile.as_ptr() / view.as_ptr()
 pto.get_block_idx()           # → i64
 pto.set_flag("MTE2", "V", event_id=0)

--- a/ptodsl/README.md
+++ b/ptodsl/README.md
@@ -386,11 +386,11 @@ pto.vadd(a, b, mask)   # infers result type from a.type
 pto.vmul / vmax / vdiv / vcmax / vcadd / vdup / vexpdif  # similarly
 pto.make_tensor_view(ptr, shape=…, strides=…)    # type inferred
 pto.partition_view(tv, offsets=…, sizes=…)        # type inferred
-pto.load_tile(tv, tile, offset=…)                 # partition + tile.load, sizes inferred from tile
-pto.store_tile(tile, tv, offset=…)                # partition + tile.store, sizes inferred from tile
 pto.alloc_tile(shape=…, dtype=…, memory_space=…, valid_shape=…, addr=…)  # authored surface
 pto.tile.load(part, tile)
 pto.tile.store(tile, part)
+pto.tile.load(tv, tile, offset=…)                 # partition + tile.load, sizes inferred from tile
+pto.tile.store(tile, tv, offset=…)                # partition + tile.store, sizes inferred from tile
 tile.as_ptr() / view.as_ptr()
 pto.get_block_idx()           # → i64
 pto.set_flag("MTE2", "V", event_id=0)

--- a/ptodsl/README.md
+++ b/ptodsl/README.md
@@ -386,6 +386,8 @@ pto.vadd(a, b, mask)   # infers result type from a.type
 pto.vmul / vmax / vdiv / vcmax / vcadd / vdup / vexpdif  # similarly
 pto.make_tensor_view(ptr, shape=…, strides=…)    # type inferred
 pto.partition_view(tv, offsets=…, sizes=…)        # type inferred
+pto.load_tile(tv, tile, offset=…)                 # partition + tile.load, sizes inferred from tile
+pto.store_tile(tile, tv, offset=…)                # partition + tile.store, sizes inferred from tile
 pto.alloc_tile(shape=…, dtype=…, memory_space=…, valid_shape=…, addr=…)  # authored surface
 pto.tile.load(part, tile)
 pto.tile.store(tile, part)

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -6,12 +6,12 @@ This chapter covers every operation that moves data between memory spaces in PTO
 
 Tile ops move entire blocks between Global Memory and the Unified Buffer in a single call. They are the primary data movement interface inside `@pto.jit`.
 
-Use `pto.load_tile(view, tile, offset=[...])` and `pto.store_tile(tile, view, offset=[...])` when the GM partition is only needed for that transfer. These helpers build the `partition_view` internally and infer `sizes` from `tile.valid_shape` when the tensor-view rank matches the tile rank:
+Use `pto.tile.load(view, tile, offset=[...])` and `pto.tile.store(tile, view, offset=[...])` when the GM partition is only needed for that transfer. These overloads build the `partition_view` internally and infer `sizes` from `tile.valid_shape` when the tensor-view rank matches the tile rank:
 
 ```python
 a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[1, cols])
-pto.load_tile(a_view, a_tile, offset=[row, 0])
-pto.store_tile(a_tile, o_view, offset=[row, 0])
+pto.tile.load(a_view, a_tile, offset=[row, 0])
+pto.tile.store(a_tile, o_view, offset=[row, 0])
 ```
 
 For rank-changing layouts, pass `sizes=` explicitly or keep using `partition_view(...)` plus `pto.tile.load/store`.

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -6,26 +6,23 @@ This chapter covers every operation that moves data between memory spaces in PTO
 
 Tile ops move entire blocks between Global Memory and the Unified Buffer in a single call. They are the primary data movement interface inside `@pto.jit`.
 
-Use `pto.tile.load(view, tile, offset=[...])` and `pto.tile.store(tile, view, offset=[...])` when the GM partition is only needed for that transfer. These overloads build the `partition_view` internally and infer `sizes` from `tile.valid_shape` when the tensor-view rank matches the tile rank:
-
-```python
-a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[1, cols])
-pto.tile.load(a_view, a_tile, offset=[row, 0])
-pto.tile.store(a_tile, o_view, offset=[row, 0])
-```
-
-For rank-changing layouts, pass `sizes=` explicitly or keep using `partition_view(...)` plus `pto.tile.load/store`.
-
 #### `pto.tile.load(partition: PartitionTensorView, tile: Tile) -> None`
 
+#### `pto.tile.load(tensor: TensorView, tile: Tile, *, offsets: tuple[IndexLike, ...] | None = None, sizes: tuple[IndexLike, ...] | None = None) -> None`
+
 **Description**: Copies data from a GM partition into a UB tile. The transfer size is determined by the partition's `sizes` and the tile's shape — they must be compatible.
+
+The `TensorView` overload builds the `partition_view` internally. When `offsets` is omitted, it defaults to zero offsets for every tensor dimension. When `sizes` is omitted, it is inferred from `tile.valid_shape`; for rank-changing layouts, pass `sizes=` explicitly or build a `PartitionTensorView` yourself.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `partition` | `PartitionTensorView` | Source region in GM |
+| `tensor` | `TensorView` | Source GM tensor view; used by the overload that builds a partition internally |
 | `tile` | `Tile` | Destination buffer in UB |
+| `offsets` | `tuple[IndexLike, ...]` or `None` | Optional tensor offsets for the internal partition; defaults to all zeros |
+| `sizes` | `tuple[IndexLike, ...]` or `None` | Optional partition sizes; defaults to `tile.valid_shape` when ranks match |
 
 **Returns**: None (side-effect operation).
 
@@ -36,13 +33,18 @@ For rank-changing layouts, pass `sizes=` explicitly or keep using `partition_vie
 a_part = pto.partition_view(a_view, offsets=[offset, 0], sizes=[1, cols])
 a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
 pto.tile.load(a_part, a_tile)
+pto.tile.load(a_view, a_tile, offsets=[offset, 0], sizes=[1, cols])
 ```
 
 ---
 
 #### `pto.tile.store(tile: Tile, partition: PartitionTensorView) -> None`
 
+#### `pto.tile.store(tile: Tile, tensor: TensorView, *, offsets: tuple[IndexLike, ...] | None = None, sizes: tuple[IndexLike, ...] | None = None) -> None`
+
 **Description**: Copies data from a UB tile back to a GM partition. The tile's `valid_shape` determines how many elements are written; elements outside `valid_shape` are not stored.
+
+The `TensorView` overload builds the `partition_view` internally. When `offsets` is omitted, it defaults to zero offsets for every tensor dimension. When `sizes` is omitted, it is inferred from `tile.valid_shape`; for rank-changing layouts, pass `sizes=` explicitly or build a `PartitionTensorView` yourself.
 
 **Parameters**:
 
@@ -50,6 +52,9 @@ pto.tile.load(a_part, a_tile)
 |-----------|------|-------------|
 | `tile` | `Tile` | Source buffer in UB |
 | `partition` | `PartitionTensorView` | Destination region in GM |
+| `tensor` | `TensorView` | Destination GM tensor view; used by the overload that builds a partition internally |
+| `offsets` | `tuple[IndexLike, ...]` or `None` | Optional tensor offsets for the internal partition; defaults to all zeros |
+| `sizes` | `tuple[IndexLike, ...]` or `None` | Optional partition sizes; defaults to `tile.valid_shape` when ranks match |
 
 **Returns**: None (side-effect operation).
 
@@ -58,6 +63,7 @@ pto.tile.load(a_part, a_tile)
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"quick_start.tile_io","symbol":"quick_start_tile_io_probe","compile":{"BLOCK":128}} -->
 ```python
 pto.tile.store(o_tile, o_part)
+pto.tile.store(o_tile, o_view, offsets=[0, 0], sizes=[rows, cols])
 ```
 
 ---

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -6,6 +6,16 @@ This chapter covers every operation that moves data between memory spaces in PTO
 
 Tile ops move entire blocks between Global Memory and the Unified Buffer in a single call. They are the primary data movement interface inside `@pto.jit`.
 
+Use `pto.load_tile(view, tile, offset=[...])` and `pto.store_tile(tile, view, offset=[...])` when the GM partition is only needed for that transfer. These helpers build the `partition_view` internally and infer `sizes` from `tile.valid_shape` when the tensor-view rank matches the tile rank:
+
+```python
+a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[1, cols])
+pto.load_tile(a_view, a_tile, offset=[row, 0])
+pto.store_tile(a_tile, o_view, offset=[row, 0])
+```
+
+For rank-changing layouts, pass `sizes=` explicitly or keep using `partition_view(...)` plus `pto.tile.load/store`.
+
 #### `pto.tile.load(partition: PartitionTensorView, tile: Tile) -> None`
 
 **Description**: Copies data from a GM partition into a UB tile. The transfer size is determined by the partition's `sizes` and the tile's shape — they must be compatible.

--- a/ptodsl/examples/softmax_dsl.py
+++ b/ptodsl/examples/softmax_dsl.py
@@ -81,7 +81,7 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                     valid_shape=[runtime_seq, runtime_rows],
                 )
 
-                pto.tile.load(scores_view, scores_tile, offset=[0, 0])
+                pto.tile.load(scores_view, scores_tile)
 
                 pto.set_flag("MTE2", "V", event_id=0)
                 pto.wait_flag("MTE2", "V", event_id=0)
@@ -128,7 +128,7 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                 pto.set_flag("V", "MTE3", event_id=0)
                 pto.wait_flag("V", "MTE3", event_id=0)
 
-                pto.tile.store(out_tile, out_view, offset=[0, 0])
+                pto.tile.store(out_tile, out_view)
                 pto.pipe_barrier(pto.Pipe.ALL)
 
     return kernel

--- a/ptodsl/examples/softmax_dsl.py
+++ b/ptodsl/examples/softmax_dsl.py
@@ -81,7 +81,7 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                     valid_shape=[runtime_seq, runtime_rows],
                 )
 
-                pto.load_tile(scores_view, scores_tile, offset=[0, 0])
+                pto.tile.load(scores_view, scores_tile, offset=[0, 0])
 
                 pto.set_flag("MTE2", "V", event_id=0)
                 pto.wait_flag("MTE2", "V", event_id=0)
@@ -128,7 +128,7 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                 pto.set_flag("V", "MTE3", event_id=0)
                 pto.wait_flag("V", "MTE3", event_id=0)
 
-                pto.store_tile(out_tile, out_view, offset=[0, 0])
+                pto.tile.store(out_tile, out_view, offset=[0, 0])
                 pto.pipe_barrier(pto.Pipe.ALL)
 
     return kernel

--- a/ptodsl/examples/softmax_dsl.py
+++ b/ptodsl/examples/softmax_dsl.py
@@ -68,17 +68,6 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                     shape=[seq, rows],
                     strides=[1, seq],
                 )
-                scores_part = pto.partition_view(
-                    scores_view,
-                    offsets=[0, 0],
-                    sizes=[runtime_seq, runtime_rows],
-                )
-                out_part = pto.partition_view(
-                    out_view,
-                    offsets=[0, 0],
-                    sizes=[runtime_seq, runtime_rows],
-                )
-
                 scores_tile = pto.alloc_tile(
                     shape=[seq, physical_rows],
                     dtype=pto.float32,
@@ -92,7 +81,7 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                     valid_shape=[runtime_seq, runtime_rows],
                 )
 
-                pto.tile.load(scores_part, scores_tile)
+                pto.load_tile(scores_view, scores_tile, offset=[0, 0])
 
                 pto.set_flag("MTE2", "V", event_id=0)
                 pto.wait_flag("MTE2", "V", event_id=0)
@@ -139,7 +128,7 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                 pto.set_flag("V", "MTE3", event_id=0)
                 pto.wait_flag("V", "MTE3", event_id=0)
 
-                pto.tile.store(out_tile, out_part)
+                pto.store_tile(out_tile, out_view, offset=[0, 0])
                 pto.pipe_barrier(pto.Pipe.ALL)
 
     return kernel

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -1656,17 +1656,22 @@ def _source_view_rank(tv, *, context: str) -> int:
             raise TypeError(f"{context} expects a tensor view or partition tensor view, got {raw_type}") from exc
 
 
-def _normalize_transfer_offsets(tv, *, offset, offsets, context: str):
-    if offset is not None and offsets is not None:
-        raise TypeError(f"{context} accepts only one of offset= or offsets=")
-    authored_offsets = offsets if offsets is not None else offset
-    if authored_offsets is None:
+def _is_partition_tensor_view(value) -> bool:
+    try:
+        _pto.PartitionTensorViewType(unwrap_surface_value(value).type)
+        return True
+    except Exception:
+        return False
+
+
+def _normalize_transfer_offsets(tv, *, offsets, context: str):
+    if offsets is None:
         return [0] * _source_view_rank(tv, context=context)
-    if isinstance(authored_offsets, tuple):
-        return list(authored_offsets)
-    if isinstance(authored_offsets, list):
-        return authored_offsets
-    return [authored_offsets]
+    if isinstance(offsets, tuple):
+        return list(offsets)
+    if isinstance(offsets, list):
+        return offsets
+    return [offsets]
 
 
 def _normalize_transfer_sizes(sizes):
@@ -1699,10 +1704,9 @@ def _infer_tile_transfer_sizes(tile, *, context: str):
     return sizes
 
 
-def _tile_transfer_partition(tv, tile, *, offset=None, offsets=None, sizes=None, context: str):
+def _tile_transfer_partition(tv, tile, *, offsets=None, sizes=None, context: str):
     normalized_offsets = _normalize_transfer_offsets(
         tv,
-        offset=offset,
         offsets=offsets,
         context=context,
     )

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -1724,40 +1724,6 @@ def _tile_transfer_partition(tv, tile, *, offset=None, offsets=None, sizes=None,
     return partition_view(tv, offsets=normalized_offsets, sizes=normalized_sizes)
 
 
-def load_tile(src, dst_tile, *, offset=None, offsets=None, sizes=None):
-    """
-    Load a tensor-view partition into ``dst_tile``.
-
-    ``sizes`` defaults to ``dst_tile.valid_shape`` when the view and tile ranks match.
-    """
-    part = _tile_transfer_partition(
-        src,
-        dst_tile,
-        offset=offset,
-        offsets=offsets,
-        sizes=sizes,
-        context="load_tile(...)",
-    )
-    tload(part, dst_tile)
-
-
-def store_tile(src_tile, dst, *, offset=None, offsets=None, sizes=None):
-    """
-    Store ``src_tile`` into a tensor-view partition.
-
-    ``sizes`` defaults to ``src_tile.valid_shape`` when the view and tile ranks match.
-    """
-    part = _tile_transfer_partition(
-        dst,
-        src_tile,
-        offset=offset,
-        offsets=offsets,
-        sizes=sizes,
-        context="store_tile(...)",
-    )
-    tstore(src_tile, part)
-
-
 def alloc_tile(
     tile_type=None,
     *,
@@ -4043,7 +4009,6 @@ __all__ = [
     "vaxpy", "vaddrelu", "vsubrelu",
     "vsel",
     "make_tensor_view", "partition_view",
-    "load_tile", "store_tile",
     "alloc_tile",
     "tload", "tstore", "tmov",
     "tadd", "tsub", "tmul", "tdiv", "tmax", "tmin",

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -1678,9 +1678,25 @@ def _normalize_transfer_sizes(sizes):
 
 
 def _infer_tile_transfer_sizes(tile, *, context: str):
-    if not hasattr(tile, "valid_shape"):
+    valid_shape = getattr(tile, "valid_shape", None)
+    if valid_shape is None:
         raise TypeError(f"{context} requires tile valid_shape metadata to infer sizes")
-    return [tile.valid_shape[index] for index in range(_tile_logical_rank(tile, context=context))]
+    sizes = []
+    for index in range(_tile_logical_rank(tile, context=context)):
+        try:
+            dim = valid_shape[index]
+        except Exception as exc:
+            raise TypeError(
+                f"{context} could not read tile.valid_shape[{index}] to infer sizes; "
+                "pass sizes= explicitly"
+            ) from exc
+        if dim is None:
+            raise ValueError(
+                f"{context} cannot infer partition sizes because tile.valid_shape[{index}] is None; "
+                "pass sizes= explicitly"
+            )
+        sizes.append(dim)
+    return sizes
 
 
 def _tile_transfer_partition(tv, tile, *, offset=None, offsets=None, sizes=None, context: str):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -1632,6 +1632,116 @@ def partition_view(tv, *, offsets, sizes):
     )
 
 
+def _tile_logical_rank(tile, *, context: str) -> int:
+    shape = getattr(tile, "shape", None)
+    if shape is not None:
+        return len(shape)
+    parsed = parse_tile_type_metadata(unwrap_surface_value(tile).type)
+    if parsed is not None:
+        return len(parsed["shape_dims"])
+    raise TypeError(f"{context} requires tile shape metadata to infer sizes")
+
+
+def _source_view_rank(tv, *, context: str) -> int:
+    shape = getattr(tv, "shape", None)
+    if shape is not None:
+        return len(shape)
+    raw_type = unwrap_surface_value(tv).type
+    try:
+        return _pto.TensorViewType(raw_type).rank
+    except Exception:
+        try:
+            return _pto.PartitionTensorViewType(raw_type).rank
+        except Exception as exc:
+            raise TypeError(f"{context} expects a tensor view or partition tensor view, got {raw_type}") from exc
+
+
+def _normalize_transfer_offsets(tv, *, offset, offsets, context: str):
+    if offset is not None and offsets is not None:
+        raise TypeError(f"{context} accepts only one of offset= or offsets=")
+    authored_offsets = offsets if offsets is not None else offset
+    if authored_offsets is None:
+        return [0] * _source_view_rank(tv, context=context)
+    if isinstance(authored_offsets, tuple):
+        return list(authored_offsets)
+    if isinstance(authored_offsets, list):
+        return authored_offsets
+    return [authored_offsets]
+
+
+def _normalize_transfer_sizes(sizes):
+    if isinstance(sizes, tuple):
+        return list(sizes)
+    if isinstance(sizes, list):
+        return sizes
+    return [sizes]
+
+
+def _infer_tile_transfer_sizes(tile, *, context: str):
+    if not hasattr(tile, "valid_shape"):
+        raise TypeError(f"{context} requires tile valid_shape metadata to infer sizes")
+    return [tile.valid_shape[index] for index in range(_tile_logical_rank(tile, context=context))]
+
+
+def _tile_transfer_partition(tv, tile, *, offset=None, offsets=None, sizes=None, context: str):
+    normalized_offsets = _normalize_transfer_offsets(
+        tv,
+        offset=offset,
+        offsets=offsets,
+        context=context,
+    )
+    normalized_sizes = (
+        _infer_tile_transfer_sizes(tile, context=context)
+        if sizes is None
+        else _normalize_transfer_sizes(sizes)
+    )
+    if len(normalized_offsets) != len(normalized_sizes):
+        if sizes is None:
+            raise ValueError(
+                f"{context} cannot infer partition sizes for rank-{len(normalized_offsets)} view "
+                f"from rank-{len(normalized_sizes)} tile; pass sizes= explicitly"
+            )
+        raise ValueError(
+            f"{context} expects offset rank and sizes rank to match, got "
+            f"{len(normalized_offsets)} and {len(normalized_sizes)}"
+        )
+    return partition_view(tv, offsets=normalized_offsets, sizes=normalized_sizes)
+
+
+def load_tile(src, dst_tile, *, offset=None, offsets=None, sizes=None):
+    """
+    Load a tensor-view partition into ``dst_tile``.
+
+    ``sizes`` defaults to ``dst_tile.valid_shape`` when the view and tile ranks match.
+    """
+    part = _tile_transfer_partition(
+        src,
+        dst_tile,
+        offset=offset,
+        offsets=offsets,
+        sizes=sizes,
+        context="load_tile(...)",
+    )
+    tload(part, dst_tile)
+
+
+def store_tile(src_tile, dst, *, offset=None, offsets=None, sizes=None):
+    """
+    Store ``src_tile`` into a tensor-view partition.
+
+    ``sizes`` defaults to ``src_tile.valid_shape`` when the view and tile ranks match.
+    """
+    part = _tile_transfer_partition(
+        dst,
+        src_tile,
+        offset=offset,
+        offsets=offsets,
+        sizes=sizes,
+        context="store_tile(...)",
+    )
+    tstore(src_tile, part)
+
+
 def alloc_tile(
     tile_type=None,
     *,
@@ -3917,6 +4027,7 @@ __all__ = [
     "vaxpy", "vaddrelu", "vsubrelu",
     "vsel",
     "make_tensor_view", "partition_view",
+    "load_tile", "store_tile",
     "alloc_tile",
     "tload", "tstore", "tmov",
     "tadd", "tsub", "tmul", "tdiv", "tmax", "tmin",

--- a/ptodsl/ptodsl/_tile_namespace.py
+++ b/ptodsl/ptodsl/_tile_namespace.py
@@ -16,9 +16,35 @@ def _resolve_row_reduction_tmp(src, tmp):
 
 
 class _TileNamespace:
-    load = staticmethod(_ops.tload)
-    store = staticmethod(_ops.tstore)
     mov = staticmethod(_ops.tmov)
+
+    @staticmethod
+    def load(src, tile, *, offset=None, offsets=None, sizes=None):
+        if offset is None and offsets is None and sizes is None:
+            return _ops.tload(src, tile)
+        part = _ops._tile_transfer_partition(
+            src,
+            tile,
+            offset=offset,
+            offsets=offsets,
+            sizes=sizes,
+            context="tile.load(...)",
+        )
+        return _ops.tload(part, tile)
+
+    @staticmethod
+    def store(tile, dst, *, offset=None, offsets=None, sizes=None):
+        if offset is None and offsets is None and sizes is None:
+            return _ops.tstore(tile, dst)
+        part = _ops._tile_transfer_partition(
+            dst,
+            tile,
+            offset=offset,
+            offsets=offsets,
+            sizes=sizes,
+            context="tile.store(...)",
+        )
+        return _ops.tstore(tile, part)
 
     add = staticmethod(_ops.tadd)
     sub = staticmethod(_ops.tsub)

--- a/ptodsl/ptodsl/_tile_namespace.py
+++ b/ptodsl/ptodsl/_tile_namespace.py
@@ -19,13 +19,12 @@ class _TileNamespace:
     mov = staticmethod(_ops.tmov)
 
     @staticmethod
-    def load(src, tile, *, offset=None, offsets=None, sizes=None):
-        if offset is None and offsets is None and sizes is None:
+    def load(src, tile, *, offsets=None, sizes=None):
+        if offsets is None and sizes is None and _ops._is_partition_tensor_view(src):
             return _ops.tload(src, tile)
         part = _ops._tile_transfer_partition(
             src,
             tile,
-            offset=offset,
             offsets=offsets,
             sizes=sizes,
             context="tile.load(...)",
@@ -33,13 +32,12 @@ class _TileNamespace:
         return _ops.tload(part, tile)
 
     @staticmethod
-    def store(tile, dst, *, offset=None, offsets=None, sizes=None):
-        if offset is None and offsets is None and sizes is None:
+    def store(tile, dst, *, offsets=None, sizes=None):
+        if offsets is None and sizes is None and _ops._is_partition_tensor_view(dst):
             return _ops.tstore(tile, dst)
         part = _ops._tile_transfer_partition(
             dst,
             tile,
-            offset=offset,
             offsets=offsets,
             sizes=sizes,
             context="tile.store(...)",

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -97,7 +97,6 @@ from ._ops import (             # noqa: F401
     vaxpy, vaddrelu, vsubrelu,
     vsel,
     make_tensor_view, partition_view,
-    load_tile, store_tile,
     alloc_tile,
     mte_load, mte_store, mte_gm_ub, mte_ub_gm, mte_ub_ub, mte_ub_l1,
     mte_gm_l1, mte_l1_ub, mte_gm_l1_frac, mte_l1_bt, mte_l1_fb, mem_bar,

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -97,6 +97,7 @@ from ._ops import (             # noqa: F401
     vaxpy, vaddrelu, vsubrelu,
     vsel,
     make_tensor_view, partition_view,
+    load_tile, store_tile,
     alloc_tile,
     mte_load, mte_store, mte_gm_ub, mte_ub_gm, mte_ub_ub, mte_ub_l1,
     mte_gm_l1, mte_l1_ub, mte_gm_l1_frac, mte_l1_bt, mte_l1_fb, mem_bar,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -75,12 +75,12 @@ class _FakeTileWithPartialValidShape:
 
 expect_raises(
     TypeError,
-    lambda: pto.load_tile(object(), _FakeTileWithoutValidShape(), offset=[0, 0]),
+    lambda: pto.tile.load(object(), _FakeTileWithoutValidShape(), offset=[0, 0]),
     "requires tile valid_shape metadata",
 )
 expect_raises(
     ValueError,
-    lambda: pto.load_tile(object(), _FakeTileWithPartialValidShape(), offset=[0, 0]),
+    lambda: pto.tile.load(object(), _FakeTileWithPartialValidShape(), offset=[0, 0]),
     "tile.valid_shape[1] is None",
 )
 
@@ -151,8 +151,8 @@ def tile_transfer_surface_probe(
     o_view = pto.make_tensor_view(O_ptr, shape=[rows, cols], strides=[cols, 1])
     a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[rows, cols])
     o_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[rows, cols])
-    pto.load_tile(a_view, a_tile, offset=[0, 0])
-    pto.store_tile(o_tile, o_view, offsets=[0, 0])
+    pto.tile.load(a_view, a_tile, offset=[0, 0])
+    pto.tile.store(o_tile, o_view, offsets=[0, 0])
 
 
 @pto.jit(target="a5", insert_sync=False)
@@ -1226,8 +1226,6 @@ def main() -> None:
         "mad_mx",
         "mad_mx_acc",
         "mad_mx_bias",
-        "load_tile",
-        "store_tile",
         "empty_like",
     ]
     for name in expected_public_exports:
@@ -1242,6 +1240,8 @@ def main() -> None:
     expect(hasattr(pto.tile, "load"), "pto.tile.load should be exported from the public tile namespace")
     expect(hasattr(pto.tile, "add"), "pto.tile.add should be exported from the public tile namespace")
     expect(hasattr(pto.tile, "cmps"), "pto.tile.cmps should be exported from the public tile namespace")
+    expect(not hasattr(pto, "load_tile"), "pto.load_tile should not remain on the public pto namespace")
+    expect(not hasattr(pto, "store_tile"), "pto.store_tile should not remain on the public pto namespace")
     expect(not hasattr(pto, "tload"), "legacy pto.tload should not remain on the public pto namespace")
     expect(not hasattr(pto, "tstore"), "legacy pto.tstore should not remain on the public pto namespace")
     expect(not hasattr(pto, "tadd"), "legacy pto.tadd should not remain on the public pto namespace")
@@ -1636,14 +1636,14 @@ def main() -> None:
 
     tile_transfer_text = tile_transfer_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(tile_transfer_text, "tile transfer surface specialization")
-    expect("pto.tload" in tile_transfer_text, "pto.load_tile(...) should lower to pto.tload")
-    expect("pto.tstore" in tile_transfer_text, "pto.store_tile(...) should lower to pto.tstore")
+    expect("pto.tload" in tile_transfer_text, "pto.tile.load(..., offset=...) should lower to pto.tload")
+    expect("pto.tstore" in tile_transfer_text, "pto.tile.store(..., offset=...) should lower to pto.tstore")
     expect(
         re.search(
             r"sizes = \[%[a-zA-Z0-9_]+, %[a-zA-Z0-9_]+\]",
             tile_transfer_text,
         ) is not None,
-        "load_tile/store_tile should infer partition sizes from tile.valid_shape",
+        "pto.tile.load/store overloads should infer partition sizes from tile.valid_shape",
     )
 
     authored_addr_tile_text = authored_addr_tile_surface_probe.compile().mlir_text()

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -75,12 +75,12 @@ class _FakeTileWithPartialValidShape:
 
 expect_raises(
     TypeError,
-    lambda: pto.tile.load(object(), _FakeTileWithoutValidShape(), offset=[0, 0]),
+    lambda: pto.tile.load(object(), _FakeTileWithoutValidShape(), offsets=[0, 0]),
     "requires tile valid_shape metadata",
 )
 expect_raises(
     ValueError,
-    lambda: pto.tile.load(object(), _FakeTileWithPartialValidShape(), offset=[0, 0]),
+    lambda: pto.tile.load(object(), _FakeTileWithPartialValidShape(), offsets=[0, 0]),
     "tile.valid_shape[1] is None",
 )
 
@@ -151,8 +151,8 @@ def tile_transfer_surface_probe(
     o_view = pto.make_tensor_view(O_ptr, shape=[rows, cols], strides=[cols, 1])
     a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[rows, cols])
     o_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[rows, cols])
-    pto.tile.load(a_view, a_tile, offset=[0, 0])
-    pto.tile.store(o_tile, o_view, offsets=[0, 0])
+    pto.tile.load(a_view, a_tile)
+    pto.tile.store(o_tile, o_view)
 
 
 @pto.jit(target="a5", insert_sync=False)
@@ -1636,8 +1636,8 @@ def main() -> None:
 
     tile_transfer_text = tile_transfer_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(tile_transfer_text, "tile transfer surface specialization")
-    expect("pto.tload" in tile_transfer_text, "pto.tile.load(..., offset=...) should lower to pto.tload")
-    expect("pto.tstore" in tile_transfer_text, "pto.tile.store(..., offset=...) should lower to pto.tstore")
+    expect("pto.tload" in tile_transfer_text, "pto.tile.load(tensor, tile) should lower to pto.tload")
+    expect("pto.tstore" in tile_transfer_text, "pto.tile.store(tile, tensor) should lower to pto.tstore")
     expect(
         re.search(
             r"sizes = \[%[a-zA-Z0-9_]+, %[a-zA-Z0-9_]+\]",

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -63,6 +63,28 @@ expect_raises(
 )
 
 
+class _FakeTileWithoutValidShape:
+    shape = (1, 16)
+    valid_shape = None
+
+
+class _FakeTileWithPartialValidShape:
+    shape = (1, 16)
+    valid_shape = [1, None]
+
+
+expect_raises(
+    TypeError,
+    lambda: pto.load_tile(object(), _FakeTileWithoutValidShape(), offset=[0, 0]),
+    "requires tile valid_shape metadata",
+)
+expect_raises(
+    ValueError,
+    lambda: pto.load_tile(object(), _FakeTileWithPartialValidShape(), offset=[0, 0]),
+    "tile.valid_shape[1] is None",
+)
+
+
 @pto.jit(target="a5")
 def host_vec_copy(
     A_ptr: pto.ptr(pto.f32, "gm"),

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -116,6 +116,23 @@ def pointer_runtime_shape_specialization_probe(
     pto.tile.load(x_part, x_tile)
 
 
+@pto.jit(target="a5")
+def tile_transfer_surface_probe(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    O_ptr: pto.ptr(pto.f32, "gm"),
+    rows: pto.i32,
+    cols: pto.i32,
+    *,
+    BLOCK: pto.constexpr = 128,
+):
+    a_view = pto.make_tensor_view(A_ptr, shape=[rows, cols], strides=[cols, 1])
+    o_view = pto.make_tensor_view(O_ptr, shape=[rows, cols], strides=[cols, 1])
+    a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[rows, cols])
+    o_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32, valid_shape=[rows, cols])
+    pto.load_tile(a_view, a_tile, offset=[0, 0])
+    pto.store_tile(o_tile, o_view, offsets=[0, 0])
+
+
 @pto.jit(target="a5", insert_sync=False)
 def host_vec_copy_no_insert_sync(
     A_ptr: pto.ptr(pto.f32, "gm"),
@@ -1187,6 +1204,8 @@ def main() -> None:
         "mad_mx",
         "mad_mx_acc",
         "mad_mx_bias",
+        "load_tile",
+        "store_tile",
         "empty_like",
     ]
     for name in expected_public_exports:
@@ -1591,6 +1610,18 @@ def main() -> None:
             runtime_metadata_text,
         ) is not None,
         "partition_view sizes derived from tensor metadata should remain runtime MLIR values",
+    )
+
+    tile_transfer_text = tile_transfer_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(tile_transfer_text, "tile transfer surface specialization")
+    expect("pto.tload" in tile_transfer_text, "pto.load_tile(...) should lower to pto.tload")
+    expect("pto.tstore" in tile_transfer_text, "pto.store_tile(...) should lower to pto.tstore")
+    expect(
+        re.search(
+            r"sizes = \[%[a-zA-Z0-9_]+, %[a-zA-Z0-9_]+\]",
+            tile_transfer_text,
+        ) is not None,
+        "load_tile/store_tile should infer partition sizes from tile.valid_shape",
     )
 
     authored_addr_tile_text = authored_addr_tile_surface_probe.compile().mlir_text()


### PR DESCRIPTION
## Summary
- extend `pto.tile.load` / `pto.tile.store` to accept tensor views plus optional `offsets=` / `sizes=`, internally composing `partition_view` with tile transfer ops
- default omitted `offsets` to the zero origin and infer transfer sizes from `tile.valid_shape` when ranks match
- update softmax DSL sample, docs, and JIT compile coverage

Related to #734 (item 3).

## Validation
- dev-481211: `python3 ptodsl/tests/test_jit_compile.py` -> PASS
- dev-481211: `python3 ptodsl/examples/softmax_dsl.py` -> emitted MLIR with expected tile transfers
- dev-481211: `ptoas --pto-arch=a5 --pto-level=level3 /tmp/issue734_softmax_dsl_offsets_default.mlir --emit-pto-ir` -> PASS
- dev-481211: `python3 ptodsl/tests/test_docs_as_test.py` -> PASS
- dev-481211: `python3 ptodsl/tests/test_ptoas_frontend_verify.py` -> PASS