### PR TITLE
Fix EmitC index width for remote offsets

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -716,7 +716,7 @@ public:
     });
 
     addConversion([Ctx](IndexType type) -> Type {
-      return emitc::OpaqueType::get(Ctx, "int32_t");
+      return emitc::OpaqueType::get(Ctx, "int64_t");
     });
 
     // vector<4xi16> (e.g. TMRGSORT executedNumList) -> pto::MrgSortExecutedNumList
@@ -875,7 +875,7 @@ public:
 };
 
 static constexpr unsigned kPTOIndexBitWidth =
-    32; // keep consistent with IndexType conversion
+    64; // keep consistent with IndexType conversion
 
 // Forward declarations (definitions below).
 static inline std::string pipeTokFromPipeAttr(mlir::pto::PipeAttr a);
@@ -1059,7 +1059,7 @@ static Attribute getFFTSModeCodegenArg(ConversionPatternRewriter &rewriter,
 }
 
 static Value createFFTSMsg(ConversionPatternRewriter &rewriter, Location loc,
-                           Value eventI32, int64_t fftsMode) {
+                           Value eventId, int64_t fftsMode) {
   auto *ctx = rewriter.getContext();
   auto msgTy = emitc::OpaqueType::get(ctx, "uint16_t");
   auto msgArgs = rewriter.getArrayAttr({
@@ -1070,7 +1070,7 @@ static Value createFFTSMsg(ConversionPatternRewriter &rewriter, Location loc,
       .create<emitc::CallOpaqueOp>(loc, msgTy, "getFFTSMsg",
                                    /*args=*/msgArgs,
                                    /*templateArgs=*/ArrayAttr{},
-                                   /*operands=*/ValueRange{eventI32})
+                                   /*operands=*/ValueRange{eventId})
       .getResult(0);
 }
 
@@ -1081,9 +1081,9 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCall(
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
 
   if (targetArch == PTOArch::A3) {
-    auto i32Ty = emitc::OpaqueType::get(ctx, "int32_t");
+    auto indexTy = emitc::OpaqueType::get(ctx, "int64_t");
     Value eventVal =
-        makeEmitCIntConstant(rewriter, loc, i32Ty, eventIdAttr.getInt());
+        makeEmitCIntConstant(rewriter, loc, indexTy, eventIdAttr.getInt());
     Value msgVal = createFFTSMsg(rewriter, loc, eventVal, fftsMode);
 
     InterCoreSyncCallDesc desc;
@@ -1108,10 +1108,9 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCallDyn(
     pto::PipeAttr pipeAttr, Value eventIdVal, int64_t fftsMode) {
   auto *ctx = rewriter.getContext();
   std::string pipeTok = pipeTokFromPipeAttr(pipeAttr);
-  Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdVal);
 
   if (targetArch == PTOArch::A3) {
-    Value msgVal = createFFTSMsg(rewriter, loc, eventI32, fftsMode);
+    Value msgVal = createFFTSMsg(rewriter, loc, eventIdVal, fftsMode);
 
     InterCoreSyncCallDesc desc;
     desc.callee = "ffts_cross_core_sync";
@@ -1123,6 +1122,7 @@ static InterCoreSyncCallDesc buildInterCoreSyncSetCallDyn(
     return desc;
   }
 
+  Value eventI32 = castInterCoreEventIdToI32(rewriter, loc, eventIdVal);
   InterCoreSyncCallDesc desc;
   desc.callee = "set_intra_block";
   desc.args = rewriter.getArrayAttr({
@@ -3245,29 +3245,32 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
     // Part 1: 指针偏移计算 (Runtime Pointer Arithmetic)
     // -------------------------------------------------------------------------
     
-    // 准备类型: unsigned
-    Type u32Ty = emitc::OpaqueType::get(ctx, "unsigned");
+    // Use the same 64-bit width as lowered MLIR index values so remote
+    // offsets are not truncated before pointer arithmetic.
+    Type indexTy = emitc::OpaqueType::get(ctx, "int64_t");
     
-    // Helper: 创建 unsigned 常量
-    auto mkU32 = [&](int64_t v) -> Value {
+    auto mkIndex = [&](int64_t v) -> Value {
       return rewriter.create<emitc::ConstantOp>(
-          loc, u32Ty, emitc::OpaqueAttr::get(ctx, std::to_string(v)));
+          loc, indexTy, emitc::OpaqueAttr::get(ctx, std::to_string(v)));
+    };
+
+    auto asIndex = [&](Value value) -> Value {
+      if (value.getType() == indexTy)
+        return value;
+      return rewriter.create<emitc::CastOp>(loc, indexTy, value).getResult();
     };
 
     // Helper: 将 OpFoldResult 转为 EmitC Value (用于计算)
     auto ofrToEmitCValue = [&](OpFoldResult ofr) -> Value {
       if (auto v = ofr.dyn_cast<Value>()) {
         Value rv = rewriter.getRemappedValue(v);
-        // 如果类型不匹配，插入 Cast
-        if (rv.getType() != u32Ty)
-             return rewriter.create<emitc::CastOp>(loc, u32Ty, rv).getResult();
-        return rv;
+        return asIndex(rv);
       }
       if (auto attr = ofr.dyn_cast<Attribute>()) {
          if (auto ia = dyn_cast<IntegerAttr>(attr))
-             return mkU32(ia.getValue().getSExtValue());
+             return mkIndex(ia.getValue().getSExtValue());
       }
-      return mkU32(0);
+      return mkIndex(0);
     };
 
     // 1. 获取 Source 的 Strides (支持动态 Stride 收集)
@@ -3306,27 +3309,27 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
     auto staticOffsets = op.getStaticOffsets();
     auto dynamicOffsets = adaptor.getOffsets();
     int dynOffIdx = 0;
-    Value totalOffset = mkU32(0);
+    Value totalOffset = mkIndex(0);
 
     for (int i = 0; i < rank; ++i) {
         // A. 获取 Offset
         Value offVal;
         if (staticOffsets[i] == ShapedType::kDynamic) {
             Value rawDyn = dynamicOffsets[dynOffIdx++];
-            offVal = rewriter.create<emitc::CastOp>(loc, u32Ty, rawDyn);
+            offVal = asIndex(rawDyn);
         } else {
-            offVal = mkU32(staticOffsets[i]);
+            offVal = mkIndex(staticOffsets[i]);
         }
 
         // B. 获取 Stride (用于指针计算)
-        Value strideVal = mkU32(1);
+        Value strideVal = mkIndex(1);
         if (i < (int)sourceStrides.size()) {
             strideVal = ofrToEmitCValue(sourceStrides[i]);
         }
 
         // C. 累加
-        Value term = rewriter.create<emitc::MulOp>(loc, u32Ty, offVal, strideVal);
-        totalOffset = rewriter.create<emitc::AddOp>(loc, u32Ty, totalOffset, term);
+        Value term = rewriter.create<emitc::MulOp>(loc, indexTy, offVal, strideVal);
+        totalOffset = rewriter.create<emitc::AddOp>(loc, indexTy, totalOffset, term);
     }
 
     // 3. 生成新指针
@@ -3421,7 +3424,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
 
     // 2. 生成 Shape 模板参数，之后会右对齐有效维度并补齐到 5 维（高维填 1）
     SmallVector<int64_t> shapeParamsVec;
-    SmallVector<Value> sizeValues; // 每个维度对应的运行时 size（统一为 unsigned）
+    SmallVector<Value> sizeValues; // 每个维度对应的运行时 size（统一为 64-bit index）
     auto resShape = resTy.getShape();
     auto mixedSizes = op.getMixedSizes();
     sizeValues.reserve(rank);
@@ -3436,12 +3439,12 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         sizeValues.push_back(ofrToEmitCValue(mixedSizes[i]));
       else
         sizeValues.push_back(
-            mkU32(resShape[i] == ShapedType::kDynamic ? 1 : resShape[i]));
+            mkIndex(resShape[i] == ShapedType::kDynamic ? 1 : resShape[i]));
     }
 
     // 3. 生成 Stride 模板参数 + 运行时 stride 值（考虑 subview step）
     SmallVector<int64_t> strideTemplateVec;
-    SmallVector<Value> strideValues; // 每个维度对应的运行时 stride（统一为 unsigned）
+    SmallVector<Value> strideValues; // 每个维度对应的运行时 stride（统一为 64-bit index）
     strideTemplateVec.reserve(rank);
     strideValues.reserve(rank);
     auto subViewSteps = op.getMixedStrides();
@@ -3458,7 +3461,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
       if (srcStatic && stepStatic) {
         int64_t finalStride = (*srcStatic) * (*stepStatic);
         strideTemplateVec.push_back(finalStride);
-        strideValues.push_back(mkU32(finalStride));
+        strideValues.push_back(mkIndex(finalStride));
         continue;
       }
 
@@ -3472,7 +3475,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         strideValues.push_back(stepV);
       else
         strideValues.push_back(
-            rewriter.create<emitc::MulOp>(loc, u32Ty, srcV, stepV));
+            rewriter.create<emitc::MulOp>(loc, indexTy, srcV, stepV));
     }
 
     // 3.1 右对齐到 5 维：shape 补 1；已有维度继承原 stride；
@@ -3481,9 +3484,9 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
     SmallVector<int64_t, 5> finalStride;
     buildGlobalTensorShapeAndStride(shapeParamsVec, strideTemplateVec,
                                     finalShape, finalStride);
-    Value oneU32 = mkU32(1);
-    SmallVector<Value, 5> finalShapeValues(5, oneU32);
-    SmallVector<Value, 5> finalStrideValues(5, oneU32);
+    Value oneIndex = mkIndex(1);
+    SmallVector<Value, 5> finalShapeValues(5, oneIndex);
+    SmallVector<Value, 5> finalStrideValues(5, oneIndex);
     int shift = 5 - rank;
 
     // 先放入原始 shape/stride（保持用户提供的值）
@@ -3498,7 +3501,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
       if (i >= shift)
         continue;
       if (finalStride[i] != -1) {
-        finalStrideValues[i] = mkU32(finalStride[i]);
+        finalStrideValues[i] = mkIndex(finalStride[i]);
         continue;
       }
       // 动态推导：stride[i] = shape[i+1] * stride[i+1]
@@ -3506,7 +3509,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         finalStrideValues[i] = finalStrideValues[i + 1];
       } else {
         finalStrideValues[i] = rewriter.create<emitc::MulOp>(
-            loc, u32Ty, finalShapeValues[i + 1], finalStrideValues[i + 1]);
+            loc, indexTy, finalShapeValues[i + 1], finalStrideValues[i + 1]);
       }
     }
 
@@ -7333,29 +7336,29 @@ struct PTOPartitionViewToEmitC
                     .getResult(0);
     Value ptr = data;
     if (!dynamicOffsetTerms.empty()) {
-      Type u32Ty = emitc::OpaqueType::get(ctx, "unsigned");
-      auto makeU32 = [&](int64_t value) {
-        return makeEmitCIntConstant(rewriter, op.getLoc(), u32Ty, value);
+      Type indexTy = emitc::OpaqueType::get(ctx, "int64_t");
+      auto makeIndex = [&](int64_t value) {
+        return makeEmitCIntConstant(rewriter, op.getLoc(), indexTy, value);
       };
-      auto asU32 = [&](Value value) -> Value {
-        if (value.getType() == u32Ty)
+      auto asIndex = [&](Value value) -> Value {
+        if (value.getType() == indexTy)
           return value;
-        return rewriter.create<emitc::CastOp>(op.getLoc(), u32Ty, value)
+        return rewriter.create<emitc::CastOp>(op.getLoc(), indexTy, value)
             .getResult();
       };
 
-      Value totalOffset = makeU32(staticLinearOffset);
+      Value totalOffset = makeIndex(staticLinearOffset);
       for (auto [offsetValue, stride] : dynamicOffsetTerms) {
-        Value term = asU32(offsetValue);
+        Value term = asIndex(offsetValue);
         if (stride != 1) {
-          Value strideValue = makeU32(stride);
+          Value strideValue = makeIndex(stride);
           term = rewriter
-                     .create<emitc::MulOp>(op.getLoc(), u32Ty, term,
+                     .create<emitc::MulOp>(op.getLoc(), indexTy, term,
                                            strideValue)
                      .getResult();
         }
         totalOffset = rewriter
-                          .create<emitc::AddOp>(op.getLoc(), u32Ty,
+                          .create<emitc::AddOp>(op.getLoc(), indexTy,
                                                 totalOffset, term)
                           .getResult();
       }

--- a/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
+++ b/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
@@ -5,17 +5,18 @@
 // the wider same-pipe pair can be removed before event-id allocation.
 //
 // CHECK-LABEL: __global__ AICORE void backedge_nested_same_pipe_prune()
-// CHECK: for (size_t v16 = (size_t) v1; v16 < ((size_t) v3); v16 += (size_t) v2) {
+// CHECK: for (size_t {{v[0-9]+}} =
 // CHECK-NEXT: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER:[0-9]+]]);
-// CHECK-NEXT: TMOV(v10, v6);
-// CHECK-NEXT: TMOV(v12, v8);
-// CHECK: TMATMUL(v14, v10, v12);
-// CHECK: TMOV(v8, v14);
-// CHECK-NEXT: TMOV(v6, v14);
+// CHECK-NEXT: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK-NEXT: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK-NEXT: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK-NEXT: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER]]);
 // CHECK-NEXT: }
 // CHECK-NEXT: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER]]);
 // CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+
 
 module {
   func.func @backedge_nested_same_pipe_prune() {

--- a/test/lit/pto/eventid_array_dyn_sync.pto
+++ b/test/lit/pto/eventid_array_dyn_sync.pto
@@ -14,7 +14,7 @@ module {
 }
 
 // CHECK-LABEL: __global__ AICORE void eventid_array_dyn_sync() {
-// CHECK: const int32_t {{v[0-9]+}} = 0;
+// CHECK: const int64_t {{v[0-9]+}} = 0;
 // CHECK: PTOAS_EventIdArray<4> {{v[0-9]+}};
 // CHECK: {{v[0-9]+}}[{{v[0-9]+}}] = {{v[0-9]+}};
 // CHECK: event_t {{v[0-9]+}} = (event_t) {{v[0-9]+}}[{{v[0-9]+}}];

--- a/test/lit/pto/get_validshape_emitc.pto
+++ b/test/lit/pto/get_validshape_emitc.pto
@@ -23,6 +23,6 @@ module attributes {pto.target_arch = "a5"} {
 
 // CHECK-LABEL: __global__ AICORE void get_validshape_emitc()
 // CHECK: Tile<TileType::Vec, float, 16, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]] = Tile
-// CHECK: int32_t [[ROW:v[0-9]+]] = [[TILE]].GetValidRow();
-// CHECK-NEXT: int32_t [[COL:v[0-9]+]] = [[TILE]].GetValidCol();
+// CHECK: int64_t [[ROW:v[0-9]+]] = [[TILE]].GetValidRow();
+// CHECK-NEXT: int64_t [[COL:v[0-9]+]] = [[TILE]].GetValidCol();
 // CHECK-NEXT: [[TILE]].SetValidShape([[ROW]], [[COL]]);

--- a/test/lit/pto/issue157_64bit_view_offset_emitc.pto
+++ b/test/lit/pto/issue157_64bit_view_offset_emitc.pto
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @issue157_subview_remote_offset_i8(
+      %src: memref<?xi8, #pto.address_space<gm>>, %off: index) {
+    %c64 = arith.constant 64 : index
+    %sub = memref.subview %src[%off] [%c64] [1]
+      : memref<?xi8, #pto.address_space<gm>>
+        to memref<?xi8, strided<[1], offset: ?>, #pto.address_space<gm>>
+    %tile = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tload ins(%sub : memref<?xi8, strided<[1], offset: ?>, #pto.address_space<gm>>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @issue157_partition_remote_offset_i8(%src: !pto.ptr<i8>, %off: index) {
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %tv = pto.make_tensor_view %src, shape = [%c1024], strides = [%c1]
+      : !pto.tensor_view<?xi8>
+    %pv = pto.partition_view %tv, offsets = [%off], sizes = [%c64]
+      : !pto.tensor_view<?xi8> -> !pto.partition_tensor_view<?xi8>
+    %tile = pto.alloc_tile
+      : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tload ins(%pv : !pto.partition_tensor_view<?xi8>)
+              outs(%tile : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A3-LABEL: AICORE void issue157_subview_remote_offset_i8
+// A3-SAME: (__gm__ int8_t* [[SUB_SRC:v[0-9]+]], int64_t [[SUB_OFF:v[0-9]+]])
+// A3: const int64_t [[SUB_ONE:v[0-9]+]] = 1;
+// A3: const int64_t {{v[0-9]+}} = 64;
+// A3: const int64_t [[SUB_ZERO:v[0-9]+]] = 0;
+// A3-NOT: unsigned
+// A3: GlobalTensor<int8_t,
+// A3-SAME: ([[SUB_SRC]] + ([[SUB_ZERO]] + [[SUB_OFF]] * [[SUB_ONE]])
+
+// A3-LABEL: AICORE void issue157_partition_remote_offset_i8
+// A3-SAME: (__gm__ int8_t* [[PART_SRC:v[0-9]+]], int64_t [[PART_OFF:v[0-9]+]])
+// A3: const int64_t [[PART_ONE:v[0-9]+]] = 1;
+// A3: const int64_t [[PART_ZERO:v[0-9]+]] = 0;
+// A3-NOT: unsigned
+// A3: GlobalTensor<int8_t,
+// A3-SAME: ([[PART_SRC]] + ([[PART_ZERO]] + [[PART_OFF]] * [[PART_ONE]])

--- a/test/lit/pto/issue428_cube_sync_regression.pto
+++ b/test/lit/pto/issue428_cube_sync_regression.pto
@@ -5,98 +5,98 @@
 // - Preserve the tail drain before the auto tail barrier helper.
 //
 // CHECK-LABEL: tri_inv_block2x2_fp16(
-// CHECK: for (size_t v71 = v20; v71 < v22; v71 += v19) {
+// CHECK: for (size_t [[LOOP0:v[0-9]+]] =
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
-// CHECK: TMOV(v65, v49);
-// CHECK: TMOV(v67, v61);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID2);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
-// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID3);
-// CHECK: TMOV(v67, v51);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID3);
-// CHECK: TMATMUL_ACC(v69, v69, v65, v67);
+// CHECK: TMATMUL_ACC({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID2);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID4);
-// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v71) + (uint32_t) v8) < v21) {
-// CHECK: TMOV(v49, v69);
+// CHECK: if ((int64_t) {{.*}} [[LOOP0]]{{.*}}) {
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID3);
-// CHECK: TMOV(v65, v51);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID4);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID3);
-// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID3);
-// CHECK: TMOV(v51, v69);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
 // CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
 // CHECK: }
-// CHECK: for (size_t v72 = v20; v72 < v22; v72 += v19) {
+// CHECK: for (size_t [[LOOP1:v[0-9]+]] =
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);
-// CHECK: TMOV(v65, v53);
-// CHECK: TMOV(v67, v61);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID6);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID6);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
-// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK: TMOV(v67, v55);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID7);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID7);
-// CHECK: TMATMUL_ACC(v69, v69, v65, v67);
+// CHECK: TMATMUL_ACC({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID6);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID6);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK: if ((int32_t) ((uint32_t) ((int32_t) v72) + (uint32_t) v8) < v21) {
-// CHECK: TMOV(v53, v69);
+// CHECK: if ((int64_t) {{.*}} [[LOOP1]]{{.*}}) {
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID7);
-// CHECK: TMOV(v65, v55);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID7);
-// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID7);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID7);
-// CHECK: TMOV(v55, v69);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);
 // CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID6);
 // CHECK: }
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-// CHECK: TMOV(v53, v69);
-// CHECK: TSTORE(v48, v69);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: TSTORE({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
-// CHECK: TLOAD(v57, v36);
+// CHECK: TLOAD({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID3);
 // CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
-// CHECK: TMOV(v65, v53);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID3);
-// CHECK: TMOV(v67, v57);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID0);
-// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-// CHECK: TMOV(v63, v69);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
 // CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
-// CHECK: TMOV(v65, v63);
-// CHECK: TMOV(v67, v49);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
-// CHECK: TMATMUL(v69, v65, v67);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-// CHECK: TSTORE(v45, v69);
+// CHECK: TSTORE({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID2);
 // CHECK: wait_flag(PIPE_FIX, PIPE_M, EVENT_ID2);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID7);

--- a/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
+++ b/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
@@ -6,27 +6,27 @@
 //
 // CHECK-LABEL: __global__ AICORE void loop_if_else_loop_carried_sync()
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
-// CHECK: TMOV(v10, v6);
-// CHECK: TMOV(v12, v8);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
-// CHECK: TMATMUL(v14, v10, v12);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
-// CHECK: TMOV(v6, v14);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
 // CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID0);
-// CHECK: for (size_t v16 = (size_t) v1; v16 < ((size_t) v3); v16 += (size_t) v2) {
+// CHECK: for (size_t [[IV:v[0-9]+]] =
 // CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
-// CHECK: TMOV(v10, v6);
+// CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
 // CHECK: wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID1);
-// CHECK: TMATMUL(v14, v10, v12);
+// CHECK: TMATMUL({{v[0-9]+}}, {{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID1);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID0);
-// CHECK: if ((int32_t) v16 == v1) {
+// CHECK: if ((int64_t) [[IV]] ==
 // CHECK: } else {
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
 // CHECK: ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);

--- a/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression_gss.pto
+++ b/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression_gss.pto
@@ -6,7 +6,7 @@
 // CHECK-DAG: pipe_barrier(PIPE_ALL)
 // CHECK-LABEL: __global__ AICORE void loop_if_else_loop_carried_sync()
 // CHECK: for (size_t
-// CHECK: if ((int32_t)
+// CHECK: if ((int64_t)
 // CHECK: } else {
 // CHECK: #endif // __DAV_CUBE__
 

--- a/test/lit/pto/issue660_trowexpandmul_set_validshape_preserves_alloc_valid.pto
+++ b/test/lit/pto/issue660_trowexpandmul_set_validshape_preserves_alloc_valid.pto
@@ -39,8 +39,8 @@ module {
   }
 }
 
-// CHECK-DAG: const int32_t [[ROW:v[0-9]+]] = 16;
-// CHECK-DAG: const int32_t [[FULL_COL:v[0-9]+]] = 256;
+// CHECK-DAG: const int64_t [[ROW:v[0-9]+]] = 16;
+// CHECK-DAG: const int64_t [[FULL_COL:v[0-9]+]] = 256;
 // CHECK: Tile<TileType::Vec, float, 16, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST:v[0-9]+]] = Tile<TileType::Vec, float, 16, 256, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>([[ROW]], [[FULL_COL]]);
 // CHECK: TROWEXPANDMUL([[DST]],
 // CHECK: [[DST]].SetValidShape([[ROW]], [[ROW]]);

--- a/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape.pto
+++ b/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape.pto
@@ -32,10 +32,10 @@ module attributes {pto.target_arch = "a5"} {
 // CHECK-NEXT: TRESHAPE([[SRC]], [[SRC_ORIG]]);
 // CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST:v[0-9]+]];
 // CHECK-NEXT: TRESHAPE([[DST]], [[DST_ORIG]]);
-// CHECK: int32_t [[SRC_ROW:v[0-9]+]] = [[SRC_ORIG]].GetValidRow();
-// CHECK-NEXT: int32_t [[SRC_COL:v[0-9]+]] = [[SRC_ORIG]].GetValidCol();
+// CHECK: int64_t [[SRC_ROW:v[0-9]+]] = [[SRC_ORIG]].GetValidRow();
+// CHECK-NEXT: int64_t [[SRC_COL:v[0-9]+]] = [[SRC_ORIG]].GetValidCol();
 // CHECK-NEXT: [[SRC]].SetValidShape([[SRC_COL]], [[SRC_ROW]]);
-// CHECK-NEXT: int32_t [[DST_ROW:v[0-9]+]] = [[DST_ORIG]].GetValidRow();
-// CHECK-NEXT: int32_t [[DST_COL:v[0-9]+]] = [[DST_ORIG]].GetValidCol();
+// CHECK-NEXT: int64_t [[DST_ROW:v[0-9]+]] = [[DST_ORIG]].GetValidRow();
+// CHECK-NEXT: int64_t [[DST_COL:v[0-9]+]] = [[DST_ORIG]].GetValidCol();
 // CHECK-NEXT: [[DST]].SetValidShape([[DST_COL]], [[DST_ROW]]);
 // CHECK-NEXT: TMOV([[DST]], [[SRC]]);

--- a/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape_level2.pto
+++ b/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape_level2.pto
@@ -31,10 +31,10 @@ module attributes {pto.target_arch = "a5"} {
 // CHECK-NEXT: TRESHAPE([[SRC]], [[SRC_ORIG]]);
 // CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST:v[0-9]+]];
 // CHECK-NEXT: TRESHAPE([[DST]], [[DST_ORIG]]);
-// CHECK: int32_t [[SRC_ROW:v[0-9]+]] = [[SRC_ORIG]].GetValidRow();
-// CHECK-NEXT: int32_t [[SRC_COL:v[0-9]+]] = [[SRC_ORIG]].GetValidCol();
+// CHECK: int64_t [[SRC_ROW:v[0-9]+]] = [[SRC_ORIG]].GetValidRow();
+// CHECK-NEXT: int64_t [[SRC_COL:v[0-9]+]] = [[SRC_ORIG]].GetValidCol();
 // CHECK-NEXT: [[SRC]].SetValidShape([[SRC_COL]], [[SRC_ROW]]);
-// CHECK-NEXT: int32_t [[DST_ROW:v[0-9]+]] = [[DST_ORIG]].GetValidRow();
-// CHECK-NEXT: int32_t [[DST_COL:v[0-9]+]] = [[DST_ORIG]].GetValidCol();
+// CHECK-NEXT: int64_t [[DST_ROW:v[0-9]+]] = [[DST_ORIG]].GetValidRow();
+// CHECK-NEXT: int64_t [[DST_COL:v[0-9]+]] = [[DST_ORIG]].GetValidCol();
 // CHECK-NEXT: [[DST]].SetValidShape([[DST_COL]], [[DST_ROW]]);
 // CHECK-NEXT: TMOV([[DST]], [[SRC]]);

--- a/test/lit/pto/issue696_scalar_gm_store_flush.pto
+++ b/test/lit/pto/issue696_scalar_gm_store_flush.pto
@@ -55,7 +55,7 @@ module {
 }
 
 // CPP-LABEL: AICORE void scalar_gm_store_flush
-// CPP-SAME: (__gm__ int32_t* [[DST0:v[0-9]+]], __gm__ int32_t* [[DST1:v[0-9]+]], __gm__ int32_t* [[SRC:v[0-9]+]], int32_t [[IDX:v[0-9]+]])
+// CPP-SAME: (__gm__ int32_t* [[DST0:v[0-9]+]], __gm__ int32_t* [[DST1:v[0-9]+]], __gm__ int32_t* [[SRC:v[0-9]+]], int64_t [[IDX:v[0-9]+]])
 // CPP: [[DST0]][[[IDX]]] =
 // CPP: [[DST1]][{{.*}}] =
 // CPP: [[DST0]][{{.*}}] =
@@ -66,7 +66,7 @@ module {
 // CPP: return;
 
 // CPP-LABEL: AICORE void scalar_gm_store_multi_exit
-// CPP-SAME: (__gm__ int32_t* [[ME_DST:v[0-9]+]], __gm__ int32_t* [[ME_SRC:v[0-9]+]], int32_t [[ME_IDX:v[0-9]+]])
+// CPP-SAME: (__gm__ int32_t* [[ME_DST:v[0-9]+]], __gm__ int32_t* [[ME_SRC:v[0-9]+]], int64_t [[ME_IDX:v[0-9]+]])
 // CPP: [[ME_DST]][[[ME_IDX]]] =
 // CPP: pipe_barrier(PIPE_ALL);
 // CPP-NEXT: dcci((__gm__ void*)0, ENTIRE_DATA_CACHE, CACHELINE_OUT);

--- a/test/lit/pto/kernel_kind_vector_scf_while_emitc.pto
+++ b/test/lit/pto/kernel_kind_vector_scf_while_emitc.pto
@@ -61,15 +61,14 @@ module {
 }
 
 // CHECK: AICORE void vector_while_kernel()
-// CHECK: const int64_t {{v[0-9]+}} = 0;
 // CHECK: const float {{v[0-9]+}} = 10.0f;
 // CHECK: const float {{v[0-9]+}} = 1.0f;
 // CHECK: const bool {{v[0-9]+}} = false;
 // CHECK: const bool {{v[0-9]+}} = true;
-// CHECK: const int32_t {{v[0-9]+}} = 4;
-// CHECK: const int32_t {{v[0-9]+}} = 2;
-// CHECK: const int32_t {{v[0-9]+}} = 1;
-// CHECK: const int32_t {{v[0-9]+}} = 0;
+// CHECK: const int64_t {{v[0-9]+}} = 4;
+// CHECK: const int64_t {{v[0-9]+}} = 2;
+// CHECK: const int64_t {{v[0-9]+}} = 1;
+// CHECK: const int64_t {{v[0-9]+}} = 0;
 // CHECK: using T = float;
 // CHECK: #if defined(__DAV_VEC__)
 // CHECK: set_mask_norm();

--- a/test/lit/pto/ptr_int_cast.pto
+++ b/test/lit/pto/ptr_int_cast.pto
@@ -33,7 +33,7 @@ module {
 // IR-NOT: !pto.ptr
 
 // CPP-LABEL: AICORE void ptr_int_cast_kernel
-// CPP-SAME: (__gm__ uint64_t* [[SRC:v[0-9]+]], __gm__ uint32_t* [[DST:v[0-9]+]], int32_t [[IDX:v[0-9]+]])
+// CPP-SAME: (__gm__ uint64_t* [[SRC:v[0-9]+]], __gm__ uint32_t* [[DST:v[0-9]+]], int64_t [[IDX:v[0-9]+]])
 // CPP: int64_t [[ADDR:v[0-9]+]] = reinterpret_cast<int64_t>([[SRC]]);
 // CPP: __gm__ uint32_t* [[SRC32:v[0-9]+]] = reinterpret_cast<__gm__ uint32_t*>({{.*}}[[ADDR]]
 // CPP: uint32_t [[VAL:v[0-9]+]] = [[SRC32]][{{.*}}];
@@ -49,8 +49,8 @@ module {
 // IR-NOT: !pto.ptr
 
 // CPP-LABEL: AICORE void ptrtoint_addptr_multi_consumer
-// CPP-SAME: (__gm__ uint64_t* [[SRC64:v[0-9]+]], __gm__ uint64_t* [[DST64:v[0-9]+]], __gm__ int64_t* [[DSTADDR:v[0-9]+]], int32_t [[IDX2:v[0-9]+]])
-// CPP: const int32_t [[ZERO:v[0-9]+]] = 0;
+// CPP-SAME: (__gm__ uint64_t* [[SRC64:v[0-9]+]], __gm__ uint64_t* [[DST64:v[0-9]+]], __gm__ int64_t* [[DSTADDR:v[0-9]+]], int64_t [[IDX2:v[0-9]+]])
+// CPP: const int64_t [[ZERO:v[0-9]+]] = 0;
 // CPP: const int64_t [[ELEM_BYTES:v[0-9]+]] = 8;
 // CPP: uint64_t [[A:v[0-9]+]] = [[SRC64]][[[IDX2]]];
 // CPP: int64_t [[ADDR2:v[0-9]+]] = reinterpret_cast<int64_t>([[SRC64]]);

--- a/test/lit/pto/set_validshape_if.pto
+++ b/test/lit/pto/set_validshape_if.pto
@@ -31,7 +31,7 @@ module {
   }
 }
 
-// CHECK-DAG: const int32_t [[C32:v[0-9]+]] = 32;
+// CHECK-DAG: const int64_t [[C32:v[0-9]+]] = 32;
 // CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]] = Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>([[C32]], [[C32]]);
 // CHECK: TASSIGN([[TILE]],
 // CHECK: if (

--- a/test/lit/pto/set_validshape_local_lowering.pto
+++ b/test/lit/pto/set_validshape_local_lowering.pto
@@ -15,7 +15,7 @@ module {
   }
 }
 
-// CHECK-DAG: const int32_t [[C32:v[0-9]+]] = 32;
+// CHECK-DAG: const int64_t [[C32:v[0-9]+]] = 32;
 // CHECK: Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]] = Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>([[C32]], [[C32]]);
 // CHECK: TASSIGN([[TILE]], [[ADDR:v[0-9]+]]);
 // CHECK: [[TILE]].SetValidShape([[ROW:v[0-9]+]], [[COL:v[0-9]+]])

--- a/test/lit/pto/syncfinder_zero_loop_if_probe.pto
+++ b/test/lit/pto/syncfinder_zero_loop_if_probe.pto
@@ -9,7 +9,7 @@
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP]]);
 // CHECK-NEXT: for (size_t
-// CHECK: if ((int32_t)
+// CHECK: if ((int64_t)
 // CHECK: TMOV
 // CHECK: }
 // CHECK: }

--- a/test/lit/pto/syncfinder_zero_loop_if_probe_gss.pto
+++ b/test/lit/pto/syncfinder_zero_loop_if_probe_gss.pto
@@ -9,7 +9,7 @@
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP]]);
 // CHECK-NEXT: for (size_t
-// CHECK: if ((int32_t)
+// CHECK: if ((int64_t)
 // CHECK: TMOV
 // CHECK: }
 // CHECK: }

--- a/test/samples/Qwen3DecodeA3/qwen3_decode_golden_lib.py
+++ b/test/samples/Qwen3DecodeA3/qwen3_decode_golden_lib.py
@@ -13,7 +13,7 @@ from validation_runtime import (
     bf16_to_float32,
     float32_to_bf16,
     load_case_meta,
-    load_int32_assignments,
+    load_integer_assignments,
     load_strided_2d,
     rng,
     store_strided_2d,
@@ -570,7 +570,7 @@ BUILDERS = {
 def run_case(case_name: str):
     meta = load_case_meta()
     generator = rng()
-    ints = load_int32_assignments()
+    ints = load_integer_assignments()
     buffers, golden = BUILDERS[case_name](meta, generator, ints)
     write_buffers(meta, buffers)
     write_golden(meta, golden)

--- a/test/samples/Qwen3DecodeA5/qwen3_decode_golden_lib.py
+++ b/test/samples/Qwen3DecodeA5/qwen3_decode_golden_lib.py
@@ -13,7 +13,7 @@ from validation_runtime import (
     bf16_to_float32,
     float32_to_bf16,
     load_case_meta,
-    load_int32_assignments,
+    load_integer_assignments,
     load_strided_2d,
     rng,
     store_strided_2d,
@@ -568,7 +568,7 @@ BUILDERS = {
 def run_case(case_name: str):
     meta = load_case_meta()
     generator = rng()
-    ints = load_int32_assignments()
+    ints = load_integer_assignments()
     buffers, golden = BUILDERS[case_name](meta, generator, ints)
     write_buffers(meta, buffers)
     write_golden(meta, golden)

--- a/test/samples/validation_runtime.py
+++ b/test/samples/validation_runtime.py
@@ -83,6 +83,12 @@ def load_int32_assignments(main_cpp: str = 'main.cpp') -> List[int]:
     return load_scalar_assignments('int32_t', main_cpp=main_cpp)
 
 
+def load_integer_assignments(main_cpp: str = 'main.cpp') -> List[int]:
+    text = Path(main_cpp).read_text(encoding='utf-8')
+    pattern = r'\b(?:u?int(?:8|16|32|64)_t|int|unsigned)\s+\w+\s*=\s*(-?(?:0x[0-9A-Fa-f]+|\d+));'
+    return [int(value, 0) for value in re.findall(pattern, text)]
+
+
 def rng():
     return np.random.default_rng(SEED)
 


### PR DESCRIPTION
问题背景
pto-isa Issue 157 暴露出 PTOAS 在 EmitC 代码生成阶段会把 MLIR index 类型统一降成 int32_t。这会影响远端地址/offset 相关场景，例如 CommRemoteOffset_i8 这类 offset 本应具备 64-bit 地址表达能力，但最终生成的 C++ 形参或常量可能变成 int32_t，存在截断风险。

解决方案
本 PR 将 EmitC lowering 中的 IndexType 映射从 int32_t 调整为 int64_t，并同步把 kPTOIndexBitWidth 从 32 改为 64，保证 index 类型转换和常量/整数物化逻辑一致。相关 FileCheck 测试也更新为检查生成的 C++ 使用 int64_t index 参数和常量。