### PR TITLE
Fix TNotify DDR release fence after MTE3 stores

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6631,18 +6631,28 @@ static void emitPipeBarrier(ConversionPatternRewriter &rewriter, Location loc,
                                        ArrayAttr{}, ValueRange{});
 }
 
+static void emitDsbDdr(ConversionPatternRewriter &rewriter, Location loc) {
+  auto *ctx = rewriter.getContext();
+  auto args = rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, "DSB_DDR")});
+  rewriter.create<emitc::CallOpaqueOp>(loc, TypeRange{}, "dsb", args,
+                                       ArrayAttr{}, ValueRange{});
+}
+
 // Issue #711: TNOTIFY writes its signal on the scalar pipe, and
 // TNOTIFY_IMPL's trailing pipe_barrier(PIPE_ALL) runs *after* that store.
 // If prior pto.tload / pto.tstore work is still in flight on an MTE pipe when
 // the signal lands, the receiver's matching TWAIT can return before the data
 // is visible. Emit only the MTE pipe drains that the pre-lowering analysis
-// proved may be needed before this TNotify.
+// proved may be needed before this TNotify. Issue #744: prior MTE3 stores also
+// need a DDR-domain release fence before publishing the notification signal.
 static void emitTNotifyMteDrain(ConversionPatternRewriter &rewriter,
                                 Location loc, unsigned mask) {
   if (mask & kDrainMte2)
     emitPipeBarrier(rewriter, loc, "PIPE_MTE2");
-  if (mask & kDrainMte3)
+  if (mask & kDrainMte3) {
     emitPipeBarrier(rewriter, loc, "PIPE_MTE3");
+    emitDsbDdr(rewriter, loc);
+  }
 }
 
 static std::string waitCmpTok(pto::WaitCmp cmp) {

--- a/test/lit/pto/issue711_tnotify_mte_drain.pto
+++ b/test/lit/pto/issue711_tnotify_mte_drain.pto
@@ -11,8 +11,10 @@
 // signal on the scalar pipe and only does pipe_barrier(PIPE_ALL) *after* the
 // store, so without an MTE drain the signal can overtake an in-flight
 // pto.tload / pto.tstore (local or peer) and the receiver's matching TWAIT
-// returns before the data is visible. The drain should be precise: only MTE
-// pipes that may have prior in-flight work are drained before TNOTIFY.
+// returns before the data is visible. For prior MTE3 stores, the notification
+// also needs a DDR-domain release fence before publishing the signal. The drain
+// should be precise: only MTE pipes that may have prior in-flight work are
+// drained before TNOTIFY, and MTE2-only cases do not emit a DDR fence.
 
 // RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s
 
@@ -170,12 +172,14 @@ module {
 // CHECK:      TSTORE(
 // CHECK:      pipe_barrier(PIPE_MTE2);
 // CHECK-NEXT: pipe_barrier(PIPE_MTE3);
+// CHECK-NEXT: dsb(DSB_DDR);
 // CHECK-NEXT: pto::comm::TNOTIFY(
 
 // CHECK-LABEL: AICORE void tnotify_drain_after_tload(
 // CHECK:      pto::comm::NotifyOp{{.*}}= pto::comm::NotifyOp::AtomicAdd;
 // CHECK:      TLOAD(
 // CHECK:      pipe_barrier(PIPE_MTE2);
+// CHECK-NOT:  dsb(
 // CHECK-NEXT: pto::comm::TNOTIFY(
 
 // CHECK-LABEL: AICORE void tnotify_after_existing_mte2_barrier(


### PR DESCRIPTION
Summary
- Emit `dsb(DSB_DDR)` before `pto::comm::TNOTIFY` when the existing TNotify drain analysis found prior MTE3 work.
- Keep MTE2-only TNotify drains precise: they still emit only `pipe_barrier(PIPE_MTE2)` and no DDR fence.
- Extend the TNotify drain regression to check the MTE3 fence sequence and the MTE2-only no-fence case.

Motivation
- Fixes #744.
- #711 drains local MTE pipes before TNotify, but prior MTE3 stores also need a DDR-domain release fence so the notification signal cannot become visible before the payload store is visible to receivers.

Design
- Reuse the existing pre-lowering TNotify drain mask.
- For `kDrainMte3`, lower to `pipe_barrier(PIPE_MTE3); dsb(DSB_DDR);` before `TNOTIFY`.
- For `kDrainMte2`, preserve the existing `pipe_barrier(PIPE_MTE2)` behavior without adding `dsb`.

Testing
- Local: `llvm-lit -v build_issue744/test/lit --filter issue711_tnotify_mte_drain`
- Local: `git diff --check`

Risk / Rollback
- Risk: slightly more conservative TNotify lowering when prior MTE3 stores may be in flight.
- Rollback: revert this PR to restore the previous #711-only MTE drain behavior.