### PR TITLE
ci: build PTOAS with VPTO clang

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -156,9 +156,21 @@ jobs:
           path: /llvm-workspace/llvm-project/build-release
           key: llvm-${{ steps.llvm-source.outputs.sha }}-manylinux_2_34-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
 
+      - name: Resolve VPTO clang toolchain
+        run: |
+          test -x "${LLVM_BUILD_DIR}/bin/clang"
+          test -x "${LLVM_BUILD_DIR}/bin/clang++"
+          echo "PTOAS_CC=${LLVM_BUILD_DIR}/bin/clang" >> "$GITHUB_ENV"
+          echo "PTOAS_CXX=${LLVM_BUILD_DIR}/bin/clang++" >> "$GITHUB_ENV"
+          "${LLVM_BUILD_DIR}/bin/clang" --version | head -n 1
+          "${LLVM_BUILD_DIR}/bin/clang++" --version | head -n 1
+
       - name: Build PTOAS
         run: |
           export PATH="${PY_PATH}/bin:$PATH"
+          rm -rf "${PTO_BUILD_DIR}" "${PTO_INSTALL_DIR}"
+          CC="${PTOAS_CC}" \
+          CXX="${PTOAS_CXX}" \
           PTOAS_RELEASE_VERSION_OVERRIDE="${PTOAS_VERSION}" \
           pip install . --no-build-isolation
 

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -155,8 +155,20 @@ jobs:
           path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-release
           key: llvm-${{ steps.llvm-source.outputs.sha }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
 
+      - name: Resolve VPTO clang toolchain
+        run: |
+          test -x "${LLVM_BUILD_DIR}/bin/clang"
+          test -x "${LLVM_BUILD_DIR}/bin/clang++"
+          echo "PTOAS_CC=${LLVM_BUILD_DIR}/bin/clang" >> "$GITHUB_ENV"
+          echo "PTOAS_CXX=${LLVM_BUILD_DIR}/bin/clang++" >> "$GITHUB_ENV"
+          "${LLVM_BUILD_DIR}/bin/clang" --version | head -n 1
+          "${LLVM_BUILD_DIR}/bin/clang++" --version | head -n 1
+
       - name: Build PTOAS
         run: |
+          rm -rf "${PTO_BUILD_DIR}" "${PTO_INSTALL_DIR}"
+          CC="${PTOAS_CC}" \
+          CXX="${PTOAS_CXX}" \
           PTOAS_RELEASE_VERSION_OVERRIDE="${PTOAS_VERSION}" \
           pip install . --no-build-isolation
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,10 +202,25 @@ jobs:
             llvm-project/llvm/build-assert
           key: llvm-${{ runner.os }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
 
+      - name: Resolve VPTO clang toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x "${LLVM_DIR}/bin/clang"
+          test -x "${LLVM_DIR}/bin/clang++"
+          echo "PTOAS_CC=${LLVM_DIR}/bin/clang" >> "${GITHUB_ENV}"
+          echo "PTOAS_CXX=${LLVM_DIR}/bin/clang++" >> "${GITHUB_ENV}"
+          "${LLVM_DIR}/bin/clang" --version | head -n 1
+          "${LLVM_DIR}/bin/clang++" --version | head -n 1
+
       - name: Build PTOAS
         run: |
+          rm -rf "${PTO_BUILD_DIR}"
           rm -rf "${PTO_INSTALL_DIR}"
-          # LLVM_BUILD_DIR is the env var read by the build backend (_ptoas_build_backend.py).
+          # Build PTOAS with the clang that ships in the cached VPTO LLVM tree so
+          # -Werror diagnostics follow the exact LLVM fork consumed by the build.
+          CC="${PTOAS_CC}" \
+          CXX="${PTOAS_CXX}" \
           LLVM_BUILD_DIR="${LLVM_DIR}" \
             PTO_INSTALL_DIR="${PTO_INSTALL_DIR}" \
             python3 -m pip install . --no-build-isolation --no-deps --ignore-installed --prefix "${PTO_INSTALL_DIR}"
@@ -409,12 +424,25 @@ jobs:
 
           ninja -C llvm/build-shared
 
+      - name: Resolve VPTO clang toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x "${LLVM_DIR}/bin/clang"
+          test -x "${LLVM_DIR}/bin/clang++"
+          echo "PTOAS_CC=${LLVM_DIR}/bin/clang" >> "${GITHUB_ENV}"
+          echo "PTOAS_CXX=${LLVM_DIR}/bin/clang++" >> "${GITHUB_ENV}"
+          "${LLVM_DIR}/bin/clang" --version | head -n 1
+          "${LLVM_DIR}/bin/clang++" --version | head -n 1
+
       - name: Build PTOAS
         shell: bash
         run: |
           set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE}/build"
           rm -rf "${PTO_INSTALL_DIR}"
-          # LLVM_BUILD_DIR is the env var read by the build backend (_ptoas_build_backend.py).
+          CC="${PTOAS_CC}" \
+          CXX="${PTOAS_CXX}" \
           LLVM_BUILD_DIR="${LLVM_DIR}" \
             PTO_INSTALL_DIR="${PTO_INSTALL_DIR}" \
             python3 -m pip install . --no-build-isolation --no-deps --ignore-installed --prefix "${PTO_INSTALL_DIR}"


### PR DESCRIPTION
## Summary
- pin PTOAS GitHub workflow builds to the clang/clang++ binaries produced by the VPTO LLVM build
- stop PTOAS CI jobs from depending on the runner default compiler when `-Werror` is enabled
- align Linux, macOS, and SIM validation workflows on the same compiler-selection rule

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; [".github/workflows/ci.yml", ".github/workflows/build_wheel.yml", ".github/workflows/build_wheel_mac.yml"].each { |f| YAML.load_file(f); puts "OK #{f}" }'`
