### PR TITLE
ci: pin PTOAS builds to clang-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       PTO_BUILD_DIR: ${{ github.workspace }}/build-assert
       PTO_INSTALL_DIR: ${{ github.workspace }}/install-assert
       MLIR_PYTHONPATH: ${{ github.workspace }}/llvm-project/llvm/build-assert/tools/mlir/python_packages/mlir_core
-      LLVM_CACHE_FLAVOR: assert-shared-mlirpy-hardening-v1
+      LLVM_CACHE_FLAVOR: assert-shared-mlirpy-hardening-v2
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -143,6 +143,18 @@ jobs:
           mkdir -p "${PAYLOAD_DIR}/test/npu_validation/scripts"
           mkdir -p "${PAYLOAD_DIR}/test/npu_validation/templates"
 
+      - name: Resolve clang-${{ env.PTOAS_CLANG_MAJOR }} toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          clang_c="$(command -v "clang-${PTOAS_CLANG_MAJOR}")"
+          clang_cxx="$(command -v "clang++-${PTOAS_CLANG_MAJOR}")"
+          echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
+          echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
+          "${clang_c}" --version | head -n 1
+          "${clang_cxx}" --version | head -n 1
+
       - name: Resolve LLVM source SHA
         shell: bash
         run: |
@@ -161,7 +173,7 @@ jobs:
         with:
           path: |
             llvm-project/llvm/build-assert
-          key: llvm-${{ runner.os }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
+          key: llvm-${{ runner.os }}-clang${{ env.PTOAS_CLANG_MAJOR }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Prepare LLVM source (no rebuild)
         run: |
@@ -189,6 +201,8 @@ jobs:
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DPython3_EXECUTABLE=python3 \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="${PTOAS_CMAKE_C_COMPILER}" \
+            -DCMAKE_CXX_COMPILER="${PTOAS_CMAKE_CXX_COMPILER}" \
             -DLLVM_TARGETS_TO_BUILD="host"
 
           ninja -C "${LLVM_BUILD_DIR}"
@@ -201,19 +215,7 @@ jobs:
         with:
           path: |
             llvm-project/llvm/build-assert
-          key: llvm-${{ runner.os }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
-
-      - name: Resolve clang-${{ env.PTOAS_CLANG_MAJOR }} toolchain
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          clang_c="$(command -v "clang-${PTOAS_CLANG_MAJOR}")"
-          clang_cxx="$(command -v "clang++-${PTOAS_CLANG_MAJOR}")"
-          echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
-          echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
-          "${clang_c}" --version | head -n 1
-          "${clang_cxx}" --version | head -n 1
+          key: llvm-${{ runner.os }}-clang${{ env.PTOAS_CLANG_MAJOR }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Build PTOAS
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ permissions:
   actions: write
   pull-requests: read
 
+env:
+  PTOAS_CLANG_MAJOR: "15"
+
 jobs:
   license-header-check:
     if: ${{ github.event_name == 'pull_request' }}
@@ -117,7 +120,7 @@ jobs:
           sudo apt-get install -y \
             cmake git ninja-build \
             python3 python3-pip python3-venv \
-            clang lld \
+            clang-${PTOAS_CLANG_MAJOR} lld-${PTOAS_CLANG_MAJOR} \
             libedit-dev zlib1g-dev libxml2-dev libzstd-dev
           python3 -m pip install --upgrade pip
           # LLVM/MLIR Python bindings are not yet compatible with pybind11 3.x.
@@ -202,39 +205,13 @@ jobs:
             llvm-project/llvm/build-assert
           key: llvm-${{ runner.os }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
 
-      - name: Resolve default clang toolchain
+      - name: Resolve clang-${{ env.PTOAS_CLANG_MAJOR }} toolchain
         shell: bash
         run: |
           set -euo pipefail
 
-          resolve_default_clang_cxx() {
-            if command -v clang++ >/dev/null 2>&1; then
-              command -v clang++
-              return 0
-            fi
-
-            local clang_bin="$1"
-            local clang_dir clang_name versioned_cxx
-            clang_dir="$(dirname "${clang_bin}")"
-            clang_name="$(basename "${clang_bin}")"
-            if [[ "${clang_name}" =~ ^clang-([0-9.]+)$ ]]; then
-              versioned_cxx="${clang_dir}/clang++-${BASH_REMATCH[1]}"
-              if [[ -x "${versioned_cxx}" ]]; then
-                printf '%s\n' "${versioned_cxx}"
-                return 0
-              fi
-            fi
-
-            versioned_cxx="$(find "${clang_dir}" -maxdepth 1 -type f -name 'clang++-*' | sort -V | tail -n 1 || true)"
-            if [[ -n "${versioned_cxx}" && -x "${versioned_cxx}" ]]; then
-              printf '%s\n' "${versioned_cxx}"
-              return 0
-            fi
-            return 1
-          }
-
-          clang_c="$(command -v clang)"
-          clang_cxx="$(resolve_default_clang_cxx "${clang_c}")"
+          clang_c="$(command -v "clang-${PTOAS_CLANG_MAJOR}")"
+          clang_cxx="$(command -v "clang++-${PTOAS_CLANG_MAJOR}")"
           echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
           echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
           "${clang_c}" --version | head -n 1
@@ -379,14 +356,27 @@ jobs:
             fi
           done
 
+          apt_packages=()
           if [[ "${#missing_tools[@]}" -gt 0 ]]; then
+            apt_packages+=(python3 python3-pip git cmake ninja-build make)
+          fi
+
+          if ! command -v "clang-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1 || \
+             ! command -v "clang++-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
+            apt_packages+=("clang-${PTOAS_CLANG_MAJOR}" "lld-${PTOAS_CLANG_MAJOR}")
+          fi
+
+          if [[ "${#apt_packages[@]}" -gt 0 ]]; then
             if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
               sudo apt-get update
-              sudo apt-get install -y python3 python3-pip git cmake ninja-build make clang
+              sudo apt-get install -y "${apt_packages[@]}"
             else
-              echo "ERROR: missing required tools on self-hosted runner: ${missing_tools[*]}" >&2
-              echo "ERROR: automatic installation requires sudo + apt-get" >&2
-              exit 1
+              if [[ "${#missing_tools[@]}" -gt 0 ]]; then
+                echo "ERROR: missing required tools on self-hosted runner: ${missing_tools[*]}" >&2
+                echo "ERROR: automatic installation requires sudo + apt-get" >&2
+                exit 1
+              fi
+              echo "WARN: clang-${PTOAS_CLANG_MAJOR} is unavailable on self-hosted runner; will try system clang or LLVM clang fallback" >&2
             fi
           fi
 
@@ -450,13 +440,17 @@ jobs:
 
           ninja -C llvm/build-shared
 
-      - name: Resolve default clang toolchain
+      - name: Resolve clang-${{ env.PTOAS_CLANG_MAJOR }} toolchain
         shell: bash
         run: |
           set -euo pipefail
 
-          resolve_default_clang_c() {
+          resolve_clang_c() {
             local fallback_dir="$1"
+            if command -v "clang-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
+              command -v "clang-${PTOAS_CLANG_MAJOR}"
+              return 0
+            fi
             if command -v clang >/dev/null 2>&1; then
               command -v clang
               return 0
@@ -468,46 +462,25 @@ jobs:
             return 1
           }
 
-          resolve_default_clang_cxx() {
+          resolve_clang_cxx() {
+            local fallback_dir="$1"
+            if command -v "clang++-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
+              command -v "clang++-${PTOAS_CLANG_MAJOR}"
+              return 0
+            fi
             if command -v clang++ >/dev/null 2>&1; then
               command -v clang++
               return 0
             fi
-
-            local clang_bin="$1"
-            local fallback_dir="$2"
-            local clang_dir clang_name versioned_cxx
-            clang_dir="$(dirname "${clang_bin}")"
-            clang_name="$(basename "${clang_bin}")"
-            if [[ "${clang_name}" =~ ^clang-([0-9.]+)$ ]]; then
-              versioned_cxx="${clang_dir}/clang++-${BASH_REMATCH[1]}"
-              if [[ -x "${versioned_cxx}" ]]; then
-                printf '%s\n' "${versioned_cxx}"
-                return 0
-              fi
-            fi
-
-            versioned_cxx="$(find "${clang_dir}" -maxdepth 1 -type f -name 'clang++-*' | sort -V | tail -n 1 || true)"
-            if [[ -n "${versioned_cxx}" && -x "${versioned_cxx}" ]]; then
-              printf '%s\n' "${versioned_cxx}"
-              return 0
-            fi
-
             if [[ -n "${fallback_dir}" && -x "${fallback_dir}/clang++" ]]; then
               printf '%s\n' "${fallback_dir}/clang++"
-              return 0
-            fi
-
-            versioned_cxx="$(find "${fallback_dir}" -maxdepth 1 -type f -name 'clang++-*' | sort -V | tail -n 1 || true)"
-            if [[ -n "${versioned_cxx}" && -x "${versioned_cxx}" ]]; then
-              printf '%s\n' "${versioned_cxx}"
               return 0
             fi
             return 1
           }
 
-          clang_c="$(resolve_default_clang_c "${LLVM_DIR}/bin")"
-          clang_cxx="$(resolve_default_clang_cxx "${clang_c}" "${LLVM_DIR}/bin")"
+          clang_c="$(resolve_clang_c "${LLVM_DIR}/bin")"
+          clang_cxx="$(resolve_clang_cxx "${LLVM_DIR}/bin")"
           echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
           echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
           "${clang_c}" --version | head -n 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,6 @@ permissions:
   actions: write
   pull-requests: read
 
-env:
-  PTOAS_CLANG_MAJOR: "15"
-
 jobs:
   license-header-check:
     if: ${{ github.event_name == 'pull_request' }}
@@ -99,6 +96,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-22.04
     env:
+      PTOAS_CLANG_MAJOR: "15"
       LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
       LLVM_REF: feature-vpto
       LLVM_BUILD_DIR: ${{ github.workspace }}/llvm-project/llvm/build-assert
@@ -356,27 +354,15 @@ jobs:
             fi
           done
 
-          apt_packages=()
           if [[ "${#missing_tools[@]}" -gt 0 ]]; then
-            apt_packages+=(python3 python3-pip git cmake ninja-build make)
-          fi
-
-          if [[ "${#apt_packages[@]}" -gt 0 ]]; then
             if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
               sudo apt-get update
-              sudo apt-get install -y "${apt_packages[@]}"
+              sudo apt-get install -y python3 python3-pip git cmake ninja-build make
             else
-              if [[ "${#missing_tools[@]}" -gt 0 ]]; then
-                echo "ERROR: missing required tools on self-hosted runner: ${missing_tools[*]}" >&2
-                echo "ERROR: automatic installation requires sudo + apt-get" >&2
-                exit 1
-              fi
+              echo "ERROR: missing required tools on self-hosted runner: ${missing_tools[*]}" >&2
+              echo "ERROR: automatic installation requires sudo + apt-get" >&2
+              exit 1
             fi
-          fi
-
-          if ! command -v "clang-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1 || \
-             ! command -v "clang++-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
-            echo "WARN: clang-${PTOAS_CLANG_MAJOR} is unavailable on self-hosted runner; will try system clang or LLVM clang fallback" >&2
           fi
 
           python3 -m pip --version >/dev/null 2>&1 || {
@@ -439,62 +425,13 @@ jobs:
 
           ninja -C llvm/build-shared
 
-      - name: Resolve clang-${{ env.PTOAS_CLANG_MAJOR }} toolchain
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          resolve_clang_c() {
-            local fallback_dir="$1"
-            if command -v "clang-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
-              command -v "clang-${PTOAS_CLANG_MAJOR}"
-              return 0
-            fi
-            if command -v clang >/dev/null 2>&1; then
-              command -v clang
-              return 0
-            fi
-            if [[ -n "${fallback_dir}" && -x "${fallback_dir}/clang" ]]; then
-              printf '%s\n' "${fallback_dir}/clang"
-              return 0
-            fi
-            return 1
-          }
-
-          resolve_clang_cxx() {
-            local fallback_dir="$1"
-            if command -v "clang++-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
-              command -v "clang++-${PTOAS_CLANG_MAJOR}"
-              return 0
-            fi
-            if command -v clang++ >/dev/null 2>&1; then
-              command -v clang++
-              return 0
-            fi
-            if [[ -n "${fallback_dir}" && -x "${fallback_dir}/clang++" ]]; then
-              printf '%s\n' "${fallback_dir}/clang++"
-              return 0
-            fi
-            return 1
-          }
-
-          clang_c="$(resolve_clang_c "${LLVM_DIR}/bin")"
-          clang_cxx="$(resolve_clang_cxx "${LLVM_DIR}/bin")"
-          echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
-          echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
-          "${clang_c}" --version | head -n 1
-          "${clang_cxx}" --version | head -n 1
-
       - name: Build PTOAS
         shell: bash
         run: |
           set -euo pipefail
-          rm -rf "${GITHUB_WORKSPACE}/build"
           rm -rf "${PTO_INSTALL_DIR}"
           # LLVM_BUILD_DIR is the env var read by the build backend (_ptoas_build_backend.py).
           LLVM_BUILD_DIR="${LLVM_DIR}" \
-          CMAKE_C_COMPILER="${PTOAS_CMAKE_C_COMPILER}" \
-          CMAKE_CXX_COMPILER="${PTOAS_CMAKE_CXX_COMPILER}" \
             PTO_INSTALL_DIR="${PTO_INSTALL_DIR}" \
             python3 -m pip install . --no-build-isolation --no-deps --ignore-installed --prefix "${PTO_INSTALL_DIR}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,9 +204,12 @@ jobs:
 
       - name: Build PTOAS
         run: |
+          rm -rf "${PTO_BUILD_DIR}"
           rm -rf "${PTO_INSTALL_DIR}"
           # LLVM_BUILD_DIR is the env var read by the build backend (_ptoas_build_backend.py).
           LLVM_BUILD_DIR="${LLVM_DIR}" \
+          CMAKE_C_COMPILER=clang \
+          CMAKE_CXX_COMPILER=clang++ \
             PTO_INSTALL_DIR="${PTO_INSTALL_DIR}" \
             python3 -m pip install . --no-build-isolation --no-deps --ignore-installed --prefix "${PTO_INSTALL_DIR}"
 
@@ -332,7 +335,7 @@ jobs:
         run: |
           set -euo pipefail
           missing_tools=()
-          for tool in python3 git cmake ninja make; do
+          for tool in python3 git cmake ninja make clang clang++; do
             if ! command -v "${tool}" >/dev/null 2>&1; then
               missing_tools+=("${tool}")
             fi
@@ -341,7 +344,7 @@ jobs:
           if [[ "${#missing_tools[@]}" -gt 0 ]]; then
             if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
               sudo apt-get update
-              sudo apt-get install -y python3 python3-pip git cmake ninja-build make
+              sudo apt-get install -y python3 python3-pip git cmake ninja-build make clang
             else
               echo "ERROR: missing required tools on self-hosted runner: ${missing_tools[*]}" >&2
               echo "ERROR: automatic installation requires sudo + apt-get" >&2
@@ -413,9 +416,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE}/build"
           rm -rf "${PTO_INSTALL_DIR}"
           # LLVM_BUILD_DIR is the env var read by the build backend (_ptoas_build_backend.py).
           LLVM_BUILD_DIR="${LLVM_DIR}" \
+          CMAKE_C_COMPILER=clang \
+          CMAKE_CXX_COMPILER=clang++ \
             PTO_INSTALL_DIR="${PTO_INSTALL_DIR}" \
             python3 -m pip install . --no-build-isolation --no-deps --ignore-installed --prefix "${PTO_INSTALL_DIR}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,11 +361,6 @@ jobs:
             apt_packages+=(python3 python3-pip git cmake ninja-build make)
           fi
 
-          if ! command -v "clang-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1 || \
-             ! command -v "clang++-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
-            apt_packages+=("clang-${PTOAS_CLANG_MAJOR}" "lld-${PTOAS_CLANG_MAJOR}")
-          fi
-
           if [[ "${#apt_packages[@]}" -gt 0 ]]; then
             if command -v sudo >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
               sudo apt-get update
@@ -376,8 +371,12 @@ jobs:
                 echo "ERROR: automatic installation requires sudo + apt-get" >&2
                 exit 1
               fi
-              echo "WARN: clang-${PTOAS_CLANG_MAJOR} is unavailable on self-hosted runner; will try system clang or LLVM clang fallback" >&2
             fi
+          fi
+
+          if ! command -v "clang-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1 || \
+             ! command -v "clang++-${PTOAS_CLANG_MAJOR}" >/dev/null 2>&1; then
+            echo "WARN: clang-${PTOAS_CLANG_MAJOR} is unavailable on self-hosted runner; will try system clang or LLVM clang fallback" >&2
           fi
 
           python3 -m pip --version >/dev/null 2>&1 || {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
         run: |
           set -euo pipefail
           missing_tools=()
-          for tool in python3 git cmake ninja make clang; do
+          for tool in python3 git cmake ninja make; do
             if ! command -v "${tool}" >/dev/null 2>&1; then
               missing_tools+=("${tool}")
             fi
@@ -455,6 +455,19 @@ jobs:
         run: |
           set -euo pipefail
 
+          resolve_default_clang_c() {
+            local fallback_dir="$1"
+            if command -v clang >/dev/null 2>&1; then
+              command -v clang
+              return 0
+            fi
+            if [[ -n "${fallback_dir}" && -x "${fallback_dir}/clang" ]]; then
+              printf '%s\n' "${fallback_dir}/clang"
+              return 0
+            fi
+            return 1
+          }
+
           resolve_default_clang_cxx() {
             if command -v clang++ >/dev/null 2>&1; then
               command -v clang++
@@ -462,6 +475,7 @@ jobs:
             fi
 
             local clang_bin="$1"
+            local fallback_dir="$2"
             local clang_dir clang_name versioned_cxx
             clang_dir="$(dirname "${clang_bin}")"
             clang_name="$(basename "${clang_bin}")"
@@ -478,11 +492,22 @@ jobs:
               printf '%s\n' "${versioned_cxx}"
               return 0
             fi
+
+            if [[ -n "${fallback_dir}" && -x "${fallback_dir}/clang++" ]]; then
+              printf '%s\n' "${fallback_dir}/clang++"
+              return 0
+            fi
+
+            versioned_cxx="$(find "${fallback_dir}" -maxdepth 1 -type f -name 'clang++-*' | sort -V | tail -n 1 || true)"
+            if [[ -n "${versioned_cxx}" && -x "${versioned_cxx}" ]]; then
+              printf '%s\n' "${versioned_cxx}"
+              return 0
+            fi
             return 1
           }
 
-          clang_c="$(command -v clang)"
-          clang_cxx="$(resolve_default_clang_cxx "${clang_c}")"
+          clang_c="$(resolve_default_clang_c "${LLVM_DIR}/bin")"
+          clang_cxx="$(resolve_default_clang_cxx "${clang_c}" "${LLVM_DIR}/bin")"
           echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
           echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
           "${clang_c}" --version | head -n 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,14 +202,52 @@ jobs:
             llvm-project/llvm/build-assert
           key: llvm-${{ runner.os }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
 
+      - name: Resolve default clang toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_default_clang_cxx() {
+            if command -v clang++ >/dev/null 2>&1; then
+              command -v clang++
+              return 0
+            fi
+
+            local clang_bin="$1"
+            local clang_dir clang_name versioned_cxx
+            clang_dir="$(dirname "${clang_bin}")"
+            clang_name="$(basename "${clang_bin}")"
+            if [[ "${clang_name}" =~ ^clang-([0-9.]+)$ ]]; then
+              versioned_cxx="${clang_dir}/clang++-${BASH_REMATCH[1]}"
+              if [[ -x "${versioned_cxx}" ]]; then
+                printf '%s\n' "${versioned_cxx}"
+                return 0
+              fi
+            fi
+
+            versioned_cxx="$(find "${clang_dir}" -maxdepth 1 -type f -name 'clang++-*' | sort -V | tail -n 1 || true)"
+            if [[ -n "${versioned_cxx}" && -x "${versioned_cxx}" ]]; then
+              printf '%s\n' "${versioned_cxx}"
+              return 0
+            fi
+            return 1
+          }
+
+          clang_c="$(command -v clang)"
+          clang_cxx="$(resolve_default_clang_cxx "${clang_c}")"
+          echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
+          echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
+          "${clang_c}" --version | head -n 1
+          "${clang_cxx}" --version | head -n 1
+
       - name: Build PTOAS
         run: |
           rm -rf "${PTO_BUILD_DIR}"
           rm -rf "${PTO_INSTALL_DIR}"
           # LLVM_BUILD_DIR is the env var read by the build backend (_ptoas_build_backend.py).
           LLVM_BUILD_DIR="${LLVM_DIR}" \
-          CMAKE_C_COMPILER=clang \
-          CMAKE_CXX_COMPILER=clang++ \
+          CMAKE_C_COMPILER="${PTOAS_CMAKE_C_COMPILER}" \
+          CMAKE_CXX_COMPILER="${PTOAS_CMAKE_CXX_COMPILER}" \
             PTO_INSTALL_DIR="${PTO_INSTALL_DIR}" \
             python3 -m pip install . --no-build-isolation --no-deps --ignore-installed --prefix "${PTO_INSTALL_DIR}"
 
@@ -335,7 +373,7 @@ jobs:
         run: |
           set -euo pipefail
           missing_tools=()
-          for tool in python3 git cmake ninja make clang clang++; do
+          for tool in python3 git cmake ninja make clang; do
             if ! command -v "${tool}" >/dev/null 2>&1; then
               missing_tools+=("${tool}")
             fi
@@ -412,6 +450,44 @@ jobs:
 
           ninja -C llvm/build-shared
 
+      - name: Resolve default clang toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_default_clang_cxx() {
+            if command -v clang++ >/dev/null 2>&1; then
+              command -v clang++
+              return 0
+            fi
+
+            local clang_bin="$1"
+            local clang_dir clang_name versioned_cxx
+            clang_dir="$(dirname "${clang_bin}")"
+            clang_name="$(basename "${clang_bin}")"
+            if [[ "${clang_name}" =~ ^clang-([0-9.]+)$ ]]; then
+              versioned_cxx="${clang_dir}/clang++-${BASH_REMATCH[1]}"
+              if [[ -x "${versioned_cxx}" ]]; then
+                printf '%s\n' "${versioned_cxx}"
+                return 0
+              fi
+            fi
+
+            versioned_cxx="$(find "${clang_dir}" -maxdepth 1 -type f -name 'clang++-*' | sort -V | tail -n 1 || true)"
+            if [[ -n "${versioned_cxx}" && -x "${versioned_cxx}" ]]; then
+              printf '%s\n' "${versioned_cxx}"
+              return 0
+            fi
+            return 1
+          }
+
+          clang_c="$(command -v clang)"
+          clang_cxx="$(resolve_default_clang_cxx "${clang_c}")"
+          echo "PTOAS_CMAKE_C_COMPILER=${clang_c}" >> "${GITHUB_ENV}"
+          echo "PTOAS_CMAKE_CXX_COMPILER=${clang_cxx}" >> "${GITHUB_ENV}"
+          "${clang_c}" --version | head -n 1
+          "${clang_cxx}" --version | head -n 1
+
       - name: Build PTOAS
         shell: bash
         run: |
@@ -420,8 +496,8 @@ jobs:
           rm -rf "${PTO_INSTALL_DIR}"
           # LLVM_BUILD_DIR is the env var read by the build backend (_ptoas_build_backend.py).
           LLVM_BUILD_DIR="${LLVM_DIR}" \
-          CMAKE_C_COMPILER=clang \
-          CMAKE_CXX_COMPILER=clang++ \
+          CMAKE_C_COMPILER="${PTOAS_CMAKE_C_COMPILER}" \
+          CMAKE_CXX_COMPILER="${PTOAS_CMAKE_CXX_COMPILER}" \
             PTO_INSTALL_DIR="${PTO_INSTALL_DIR}" \
             python3 -m pip install . --no-build-isolation --no-deps --ignore-installed --prefix "${PTO_INSTALL_DIR}"
 

--- a/_ptoas_build_backend.py
+++ b/_ptoas_build_backend.py
@@ -17,6 +17,8 @@ Environment variables (all optional):
                                (default: /llvm-workspace/llvm-project/build-shared)
   PTO_BUILD_DIR                Path to PTOAS build dir (default: <repo>/build)
   PTO_INSTALL_DIR              Install prefix (default: <repo>/install)
+  CMAKE_C_COMPILER             Optional C compiler passed through to CMake
+  CMAKE_CXX_COMPILER           Optional C++ compiler passed through to CMake
   PTOAS_PYTHON_PACKAGE_VERSION Wheel version override
 """
 from __future__ import annotations
@@ -113,6 +115,11 @@ def _cmake_configure_and_build():
         f"-DMLIR_PYTHON_PACKAGE_DIR={_MLIR_PY_PKG}",
         f"-DCMAKE_INSTALL_PREFIX={_PTO_INSTALL_DIR}",
     ]
+
+    for compiler_var in ("CMAKE_C_COMPILER", "CMAKE_CXX_COMPILER"):
+        compiler = os.environ.get(compiler_var, "").strip()
+        if compiler:
+            cmake_cmd.append(f"-D{compiler_var}={compiler}")
 
     release_version = os.environ.get("PTOAS_RELEASE_VERSION_OVERRIDE", "")
     if release_version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@
 #                                (default: /llvm-workspace/llvm-project/build-shared)
 #   PTO_BUILD_DIR                Path to PTOAS build dir (default: <repo>/build)
 #   PTO_INSTALL_DIR              Install prefix (default: <repo>/install)
+#   CMAKE_C_COMPILER             Optional C compiler passed through to CMake
+#   CMAKE_CXX_COMPILER           Optional C++ compiler passed through to CMake
 #   PTOAS_PYTHON_PACKAGE_VERSION Wheel version override
 
 [build-system]

--- a/test/samples/Complex/cv_region.py
+++ b/test/samples/Complex/cv_region.py
@@ -6,38 +6,105 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module
-from mlir.dialects import pto
-
+from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, F32Type
+from mlir.dialects import func, arith, pto
 
 def build_sections_test():
     with Context() as ctx:
+        # Register the PTO Dialect
         pto.register_dialect(ctx, load=True)
 
         with Location.unknown(ctx):
-            module = Module.parse(
-                r"""
-module {
-  func.func @test_vector_section_region(%out: !pto.ptr<f32>) {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %one = arith.constant 1.000000e+00 : f32
-    %two = arith.constant 2.000000e+00 : f32
+            m = Module.create()
 
-    pto.section.vector {
-      pto.store_scalar %one, %out[%c0] : !pto.ptr<f32>, f32
-      pto.store_scalar %two, %out[%c1] : !pto.ptr<f32>, f32
-    }
+            # --- 1. Prepare types ---
+            f32 = F32Type.get(ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)  # !pto.ptr<f32>
+            
+            # Define Tile View and Buffer types
+            # Assume a 32x32 float tile
+            tv2_f32 = pto.TensorViewType.get(2, f32, ctx)  # !pto.tensor_view<2xf32>
+            tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
+            
+            # Tile Buffer configuration
+            ub = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
+            bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
+            sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
+            pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
+            fractal_ab_size = pto.TileConfig.fractalABSize
+            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
+            
+            tile_buf_32 = pto.TileBufType.get([32, 32], f32, ub, [32, 32], cfg, ctx)
 
-    return
-  }
-}
-""",
-                ctx,
-            )
-            module.operation.verify()
-            return module
+            # Function signature: (ptr, ptr) -> void
+            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
 
+            with InsertionPoint(m.body):
+                fn = func.FuncOp("test_cube_vector_sections", fn_ty)
+                entry = fn.add_entry_block()
+
+            with InsertionPoint(entry):
+                # --- 2. Common code (outside any section) ---
+                # Corresponds to the code outside #ifdef in C++
+                
+                # Constant definitions
+                c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
+                c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
+                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+
+                arg0, arg1 = entry.arguments
+                
+                # Create Tensor Views (Global Memory Pointers)
+                tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
+                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
+
+                # Create Subviews (slicing)
+                # Note: We keep the name PartitionViewOp as provided.
+                sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
+                sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
+
+                # Allocate Tile Buffers (L1/UB)
+                # These variables need to be accessible in both sections, so they are defined outside.
+                tb0 = pto.AllocTileOp(tile_buf_32).result
+                tb1 = pto.AllocTileOp(tile_buf_32).result
+
+                # --- 3. CUBE Section ---
+                # Corresponds to #if defined(__DAV_CUBE__)
+                # Create Section Op
+                cube_section = pto.SectionCubeOp()
+                # SectionOp is initially empty; we manually add a block.
+                cube_block = cube_section.body.blocks.append()
+                
+                with InsertionPoint(cube_block):
+                    # Perform load (TLoad) on the Cube core
+                    # pto.TLoadOp(sv0, tb0)
+                    # Note: The parameter order of TLoadOp depends on your definition (src, dst) or (dst, src).
+                    # Your C++ definition appears to be (src, dst, ...).
+                    pto.TLoadOp(None, sv0, tb0)
+                    
+                    # Note: SectionOp has NoTerminator, so no yield or return is needed.
+
+                # --- 4. VECTOR Section ---
+                # Corresponds to #if defined(__DAV_VEC__)
+                vec_section = pto.SectionVectorOp()
+                vec_block = vec_section.body.blocks.append()
+                
+                with InsertionPoint(vec_block):
+                    # Perform computation (Abs) and store (TStore) on the Vector core
+                    
+                    # TAbs: dst = abs(src) -> tb1 = abs(tb0)
+                    pto.TAbsOp(tb0, tb1)
+                    
+                    # TStore: dst(GM) = src(UB) -> sv1 = tb1
+                    # Again, note the parameter order; Store is typically (src, dst).
+                    pto.TStoreOp(None, tb1, sv1)
+
+                # --- 5. Function return ---
+                func.ReturnOp([])
+
+            # Verify that the generated IR is valid
+            m.operation.verify()
+            return m
 
 if __name__ == "__main__":
     print(build_sections_test())

--- a/test/samples/Complex/cv_region.py
+++ b/test/samples/Complex/cv_region.py
@@ -6,8 +6,8 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
-from mlir.dialects import arith, func, pto
+from mlir.ir import Context, Location, Module
+from mlir.dialects import pto
 
 
 def build_sections_test():
@@ -15,30 +15,26 @@ def build_sections_test():
         pto.register_dialect(ctx, load=True)
 
         with Location.unknown(ctx):
-            module = Module.create()
-            f32 = F32Type.get(ctx)
-            idx = IndexType.get(ctx)
-            ptr_f32 = pto.PtrType.get(f32, ctx)
-            fn_ty = func.FunctionType.get([ptr_f32], [])
+            module = Module.parse(
+                r"""
+module {
+  func.func @test_vector_section_region(%out: !pto.ptr<f32>) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %one = arith.constant 1.000000e+00 : f32
+    %two = arith.constant 2.000000e+00 : f32
 
-            with InsertionPoint(module.body):
-                fn = func.FuncOp("test_vector_section_region", fn_ty)
-                entry = fn.add_entry_block()
+    pto.section.vector {
+      pto.store_scalar %one, %out[%c0] : !pto.ptr<f32>, f32
+      pto.store_scalar %two, %out[%c1] : !pto.ptr<f32>, f32
+    }
 
-            with InsertionPoint(entry):
-                out = entry.arguments[0]
-                c0 = arith.ConstantOp(idx, 0).result
-                c1 = arith.ConstantOp(idx, 1).result
-                one = arith.ConstantOp(f32, 1.0).result
-                two = arith.ConstantOp(f32, 2.0).result
-
-                vec_section = pto.SectionVectorOp()
-                with InsertionPoint(vec_section.body.blocks.append()):
-                    pto.store_scalar(out, c0, one)
-                    pto.store_scalar(out, c1, two)
-
-                func.ReturnOp([])
-
+    return
+  }
+}
+""",
+                ctx,
+            )
             module.operation.verify()
             return module
 

--- a/test/samples/Complex/cv_region.py
+++ b/test/samples/Complex/cv_region.py
@@ -6,105 +6,42 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, F32Type
-from mlir.dialects import func, arith, pto
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.dialects import arith, func, pto
+
 
 def build_sections_test():
     with Context() as ctx:
-        # Register the PTO Dialect
         pto.register_dialect(ctx, load=True)
 
         with Location.unknown(ctx):
-            m = Module.create()
-
-            # --- 1. Prepare types ---
+            module = Module.create()
             f32 = F32Type.get(ctx)
-            ptr_f32 = pto.PtrType.get(f32, ctx)  # !pto.ptr<f32>
-            
-            # Define Tile View and Buffer types
-            # Assume a 32x32 float tile
-            tv2_f32 = pto.TensorViewType.get(2, f32, ctx)  # !pto.tensor_view<2xf32>
-            tile_view_32 = pto.PartitionTensorViewType.get([32, 32], f32, ctx)
-            
-            # Tile Buffer configuration
-            ub = pto.AddressSpaceAttr.get(pto.AddressSpace.VEC, ctx)
-            bl = pto.BLayoutAttr.get(pto.BLayout.RowMajor, ctx)
-            sl = pto.SLayoutAttr.get(pto.SLayout.NoneBox, ctx)
-            pd = pto.PadValueAttr.get(pto.PadValue.Null, ctx)
-            fractal_ab_size = pto.TileConfig.fractalABSize
-            cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
-            
-            tile_buf_32 = pto.TileBufType.get([32, 32], f32, ub, [32, 32], cfg, ctx)
+            idx = IndexType.get(ctx)
+            ptr_f32 = pto.PtrType.get(f32, ctx)
+            fn_ty = func.FunctionType.get([ptr_f32], [])
 
-            # Function signature: (ptr, ptr) -> void
-            fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
-
-            with InsertionPoint(m.body):
-                fn = func.FuncOp("test_cube_vector_sections", fn_ty)
+            with InsertionPoint(module.body):
+                fn = func.FuncOp("test_vector_section_region", fn_ty)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):
-                # --- 2. Common code (outside any section) ---
-                # Corresponds to the code outside #ifdef in C++
-                
-                # Constant definitions
-                c0 = arith.ConstantOp(IndexType.get(ctx), 0).result
-                c1 = arith.ConstantOp(IndexType.get(ctx), 1).result
-                c32 = arith.ConstantOp(IndexType.get(ctx), 32).result
+                out = entry.arguments[0]
+                c0 = arith.ConstantOp(idx, 0).result
+                c1 = arith.ConstantOp(idx, 1).result
+                one = arith.ConstantOp(f32, 1.0).result
+                two = arith.ConstantOp(f32, 2.0).result
 
-                arg0, arg1 = entry.arguments
-                
-                # Create Tensor Views (Global Memory Pointers)
-                tv0 = pto.MakeTensorViewOp(tv2_f32, arg0, [c32, c32], [c32, c1]).result
-                tv1 = pto.MakeTensorViewOp(tv2_f32, arg1, [c32, c32], [c32, c1]).result
-
-                # Create Subviews (slicing)
-                # Note: We keep the name PartitionViewOp as provided.
-                sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
-                sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
-
-                # Allocate Tile Buffers (L1/UB)
-                # These variables need to be accessible in both sections, so they are defined outside.
-                tb0 = pto.AllocTileOp(tile_buf_32).result
-                tb1 = pto.AllocTileOp(tile_buf_32).result
-
-                # --- 3. CUBE Section ---
-                # Corresponds to #if defined(__DAV_CUBE__)
-                # Create Section Op
-                cube_section = pto.SectionCubeOp()
-                # SectionOp is initially empty; we manually add a block.
-                cube_block = cube_section.body.blocks.append()
-                
-                with InsertionPoint(cube_block):
-                    # Perform load (TLoad) on the Cube core
-                    # pto.TLoadOp(sv0, tb0)
-                    # Note: The parameter order of TLoadOp depends on your definition (src, dst) or (dst, src).
-                    # Your C++ definition appears to be (src, dst, ...).
-                    pto.TLoadOp(None, sv0, tb0)
-                    
-                    # Note: SectionOp has NoTerminator, so no yield or return is needed.
-
-                # --- 4. VECTOR Section ---
-                # Corresponds to #if defined(__DAV_VEC__)
                 vec_section = pto.SectionVectorOp()
-                vec_block = vec_section.body.blocks.append()
-                
-                with InsertionPoint(vec_block):
-                    # Perform computation (Abs) and store (TStore) on the Vector core
-                    
-                    # TAbs: dst = abs(src) -> tb1 = abs(tb0)
-                    pto.TAbsOp(tb0, tb1)
-                    
-                    # TStore: dst(GM) = src(UB) -> sv1 = tb1
-                    # Again, note the parameter order; Store is typically (src, dst).
-                    pto.TStoreOp(None, tb1, sv1)
+                with InsertionPoint(vec_section.body.blocks.append()):
+                    pto.store_scalar(out, c0, one)
+                    pto.store_scalar(out, c1, two)
 
-                # --- 5. Function return ---
                 func.ReturnOp([])
 
-            # Verify that the generated IR is valid
-            m.operation.verify()
-            return m
+            module.operation.verify()
+            return module
+
 
 if __name__ == "__main__":
     print(build_sections_test())

--- a/tools/ptoas/ObjectEmission.cpp
+++ b/tools/ptoas/ObjectEmission.cpp
@@ -772,10 +772,11 @@ llvm::StringRef mlir::pto::CANNToolchain::vptoPublicABISuffix(
     ObjectEmissionDeviceTarget target) const {
   switch (target) {
   case ObjectEmissionDeviceTarget::Vector:
-    return vptoVectorPublicABISuffix.empty() ? ".vector"
-                                             : vptoVectorPublicABISuffix;
+    return vptoVectorPublicABISuffix.empty() ? llvm::StringRef(".vector")
+                                             : llvm::StringRef(vptoVectorPublicABISuffix);
   case ObjectEmissionDeviceTarget::Cube:
-    return vptoCubePublicABISuffix.empty() ? ".cube" : vptoCubePublicABISuffix;
+    return vptoCubePublicABISuffix.empty() ? llvm::StringRef(".cube")
+                                           : llvm::StringRef(vptoCubePublicABISuffix);
   }
   llvm_unreachable("unknown object emission device target");
 }


### PR DESCRIPTION
## Summary
- let the PEP 517 build backend forward `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER` into the PTOAS CMake configure step
- make GitHub CI build PTOAS with the runner default `clang` / `clang++` explicitly instead of relying on whatever compiler CMake picks implicitly
- ensure the self-hosted VPTO SIM runner installs `clang` when it is missing

## Notes
- this keeps `-Werror` unchanged
- this supersedes the earlier draft that switched PTOAS to the VPTO LLVM clang toolchain

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "OK .github/workflows/ci.yml"'`
- targeted backend check to confirm `_ptoas_build_backend.py` appends `-DCMAKE_C_COMPILER=clang` and `-DCMAKE_CXX_COMPILER=clang++` when the env vars are set
