### PR TITLE
feat(ptodsl): add AST preprocess control flow

### DIFF
--- a/docs/designs/ptodsl-ast-preprocess-control-flow.md
+++ b/docs/designs/ptodsl-ast-preprocess-control-flow.md
@@ -1,0 +1,251 @@
+# PTODSL AST Rewrite Control Flow Design
+
+## Background
+
+PTODSL uses Python tracing today. Native Python `if` and `for` execute while
+the frontend records IR, so they are compile-time control flow. Device-side
+control flow is already available through explicit APIs:
+
+- `with pto.if_(cond) as br:`
+- `with pto.for_(start, stop, step=step) as iv:`
+- `pto.for_(...).carry(...)`
+
+This is explicit and stable, but it makes dynamic control-flow kernels look
+less like ordinary Python. This design adds a source AST rewrite pass: legal
+Python `if` / `for range(...)` syntax is rewritten before tracing into
+structured IR control flow, while explicit compile-time escape hatches keep
+static specialization readable.
+
+## Goals
+
+- Make native Python control-flow syntax usable by default for runtime control
+  flow in `@pto.jit(...)` kernels and named `@pto.cube` / `@pto.simd` /
+  `@pto.simt` sub-kernels.
+- Use `ast_rewrite` as the public name for the source rewrite feature.
+- Rewrite legal Python `if` / `for range(...)` into existing PTODSL
+  control-flow surfaces.
+- Preserve explicit control flow: existing `pto.if_` / `pto.for_` code remains
+  valid whether AST rewrite is enabled or disabled.
+- Provide explicit compile-time escape hatches:
+  - `pto.const_expr(value)` for native Python `if`.
+  - `pto.static_range(...)` for trace-time loop unrolling.
+- Reserve a structured frontend-options shape so later rewrite passes, such as
+  scalar-expression rewrite, can be enabled or debugged independently.
+
+## User Model
+
+Default mode rewrites supported native Python control flow:
+
+```python
+@pto.jit(target="a5")
+def kernel(rows: pto.i32):
+    for row in range(rows):
+        if row > pto.const(0, dtype=pto.i32):
+            ...
+```
+
+The frontend rewrites the loop to `pto.for_` and the branch to `pto.if_`.
+
+Compile-time control flow stays explicit:
+
+```python
+@pto.jit(target="a5")
+def kernel(*, BLOCK: pto.constexpr = 128):
+    if pto.const_expr(BLOCK == 128):
+        for stage in pto.static_range(4):
+            ...
+```
+
+For future rewrite passes, the frontend should also reserve an options object.
+The exact API can stay small in the first implementation, but the design should
+leave room for feature-specific toggles and debug output:
+
+```python
+@pto.jit(
+    target="a5",
+    frontend_options={
+        "ast_rewrite": True,
+        "rewrite_part": {"control_flow"},
+        "dump_rewritten_source": False,
+    },
+)
+def kernel(...):
+    ...
+```
+
+## Rewrite Strategy
+
+The implementation is source-to-source AST rewriting. The rewrite runs when a
+kernel specialization is compiled, not when the `@pto.jit` decorator is
+evaluated, so closure nonlocals are read at compile time.
+Named sub-kernel decorators keep the original Python function at decoration
+time and apply the same rewrite when the sub-kernel body is traced.
+
+1. `kernel.compile(...)` obtains the function source with `inspect.getsource`
+   when AST rewrite is enabled. If source is not available, PTODSL keeps the
+   original trace-time function so default-on rewrite does not break
+   dynamically generated kernels. The same fallback applies when the source
+   cannot be matched back to a unique function definition.
+2. The source is parsed with Python `ast.parse`, so the input must remain valid
+   Python.
+3. Decorators are removed from the transformed function to avoid recursive
+   decoration.
+4. The AST rewriter transforms supported `if` and `for` statements into calls
+   to existing PTODSL APIs.
+5. The transformed function is compiled and passed to the existing tracing
+   runtime.
+
+The generated IR is still produced by current `pto.if_`, `pto.for_`, and
+`pto.for_(...).carry(...)` implementations.
+
+## If Rewrite
+
+Input:
+
+```python
+if cond:
+    value = lhs + rhs
+else:
+    value = rhs + lhs
+out = value
+```
+
+Rewritten shape:
+
+```python
+with pto.if_(cond) as __br:
+    with __br.then_:
+        value = lhs + rhs
+        __br.assign(value=value)
+    with __br.else_:
+        value = rhs + lhs
+        __br.assign(value=value)
+value = __br.value
+out = value
+```
+
+Live-out names assigned inside both branches are merged through
+`br.assign(...)`. If a live-out name is assigned in only one branch, the
+rewriter captures the pre-branch value and yields it from the missing branch.
+Side-effect-only `if` statements do not create results.
+
+## For Rewrite
+
+Input:
+
+```python
+for i in range(start, stop, step):
+    body(i)
+```
+
+Rewritten shape:
+
+```python
+with pto.for_(start, stop, step=step) as i:
+    body(i)
+```
+
+Loop-carried accumulator input:
+
+```python
+acc = init
+for i in range(n):
+    acc = acc + value(i)
+use(acc)
+```
+
+Rewritten shape:
+
+```python
+__loop = pto.for_(0, n, step=1).carry(acc=acc)
+with __loop:
+    i = __loop.iv
+    acc = __loop.acc
+    acc = acc + value(i)
+    __loop.update(acc=acc)
+acc = __loop.final("acc")
+use(acc)
+```
+
+The first implementation supports accumulator-style loop carry where the
+carried value is read before it is reassigned in the loop body. Last-iteration
+only values that have no initial value are rejected with a diagnostic.
+
+## Compile-Time Escape Hatches
+
+`pto.const_expr(value)` returns Python truthiness and marks the enclosing
+native `if` as compile-time:
+
+```python
+if pto.const_expr(USE_FAST_PATH):
+    ...
+```
+
+Plain Python boolean conditions also stay at trace time after the condition is
+evaluated. This preserves existing constexpr guards such as `if BLOCK == 128:`
+and `if ENABLE:` while still rewriting PTO runtime scalar conditions to
+`pto.if_`.
+
+`pto.static_range(...)` returns Python `range(...)` and marks the loop as
+trace-time unrolled. The loop target keeps normal Python live-after-loop
+semantics because the loop is not rewritten to a device-side region:
+
+```python
+for i in pto.static_range(4):
+    ...
+_ = i
+```
+
+## Limitations
+
+The first version supports:
+
+- `if` / `elif` / `else` through nested rewritten branches.
+- `for name in range(...)` with one to three range arguments.
+- Branch live-out merges where both branches assign the merged names.
+- One-sided branch assignments that merge with the pre-branch value.
+- Accumulator-style loop carry.
+- Nested supported control flow in the kernel body, such as `if` / `for` inside
+  `with` blocks.
+- Nested helper rewriting. Nested Python `def` bodies follow the same
+  AST-rewrite semantics as the outer kernel body.
+
+The first version rejects:
+
+- non-Python syntax;
+- `for-else`;
+- non-`range(...)` runtime loops;
+- tuple/list loop targets;
+- `break` / `continue`;
+- using the runtime loop induction variable after the loop;
+- last-iteration-only loop values with no initial carried value;
+- rewriting nested Python `lambda` / `class` bodies, which keep normal
+  trace-time Python semantics;
+- unsupported Python effects such as relying on list/dict mutation as IR
+  values.
+
+## Compatibility
+
+The compatibility guarantee is for PTODSL's explicit control-flow APIs.
+Existing `with pto.if_(...)` / `with pto.for_(...)` kernels remain valid with
+AST rewrite enabled, because those constructs already spell the intended
+device-side control flow explicitly.
+
+```python
+with pto.if_(cond) as br:
+    ...
+
+with pto.for_(0, rows, step=1) as row:
+    ...
+```
+
+Python-native trace-time control flow should migrate to the explicit
+compile-time helpers:
+
+```python
+if pto.const_expr(USE_FAST_PATH):
+    ...
+
+for stage in pto.static_range(4):
+    ...
+```

--- a/ptodsl/docs/user_guide/01-introduction.md
+++ b/ptodsl/docs/user_guide/01-introduction.md
@@ -176,15 +176,17 @@ PTODSL uses a **tracing** compilation model. When you call `kernel.compile(...)`
 
 This has one critical implication for how you write control flow and scalar logic:
 
-- **Python native control flow** (`for`, `if`, Python arithmetic) runs at trace time. A `for i in range(4)` loop gets unrolled — the device code contains four copies of the body, not a loop instruction. An `if` branch condition is evaluated at trace time, and only the taken branch is recorded.
+- **Python native control flow** (`for`, `if`) is rewritten to device-side control flow by default. A `for i in range(rows)` loop records a device loop, and a runtime `if` records both branches.
 
 - **`pto.for_` / `pto.if_`** are recorded as structured control-flow IR. They preserve loop and branch semantics into the compiler pipeline, where the PTOAS compiler may further optimize them — unrolling, folding, or keeping them as runtime control flow depending on what is known at compile time.
+
+- **`pto.const_expr` / `pto.static_range`** keep control flow at trace time for compile-time specialization and deliberate unrolling.
 
 - **Python scalar expressions** (`alpha * x`, `1.0 / sqrt(d)`) are evaluated at trace time and their results are baked into the IR as constants — the compiler never sees the original expression.
 
 - **PTO scalar instructions** (`scalar.load(...)`, `scalar.max(...)`, `scalar.exp(...)`) are recorded as scalar IR and enter the compiler pipeline, where they may be constant-folded or lowered to runtime scalar operations depending on whether their inputs are compile-time known.
 
-A simple rule of thumb: **Python constructs are resolved before the compiler sees them. PTO constructs are recorded into IR and the compiler decides.**
+A simple rule of thumb: **Python control flow becomes IR by default; use explicit compile-time helpers when you want trace-time behavior. PTO scalar constructs are recorded into IR and the compiler decides.**
 
 Chapter 5 (Control Flow) and Chapter 6 (Scalar & Pointer Operations) cover this in detail.
 

--- a/ptodsl/docs/user_guide/02-quick-start.md
+++ b/ptodsl/docs/user_guide/02-quick-start.md
@@ -121,7 +121,7 @@ def blocked_copy(
 
     tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
 
-    with pto.for_(0, rows, step=1) as row:
+    for row in range(0, rows, 1):
         a_part = pto.partition_view(a_view, offsets=[row, 0], sizes=[1, cols])
         o_part = pto.partition_view(o_view, offsets=[row, 0], sizes=[1, cols])
 
@@ -129,7 +129,7 @@ def blocked_copy(
         pto.tile.store(tile, o_part)
 ```
 
-Here `rows` and `cols` are dynamic launch-time scalars. The loop bound depends on `rows`, so `pto.for_` records a structured loop in the IR rather than unrolling at trace time. The `BLOCK` parameter stays `constexpr` because it is a tuning knob, not data-dependent. Chapter 5 covers this distinction in detail.
+Here `rows` and `cols` are dynamic launch-time scalars. The loop bound depends on `rows`, so the default AST rewrite records a structured loop in the IR rather than unrolling at trace time. The `BLOCK` parameter stays `constexpr` because it is a tuning knob, not data-dependent. Chapter 5 covers this distinction in detail.
 
 ## 2.3 Compile and launch
 
@@ -196,17 +196,14 @@ switch that kernel to `mode="explicit"`:
 def add_rows(a_tile: pto.Tile, b_tile: pto.Tile, o_tile: pto.Tile,
              rows: pto.index, cols: pto.index):
     VEC = pto.elements_per_vreg(pto.f32)
-    with pto.for_(0, rows, step=1) as r:
-        col_loop = pto.for_(0, cols, step=VEC).carry(remained=cols)
-        with col_loop:
-            c = col_loop.iv
-            remained = col_loop.remained
+    for r in range(0, rows, 1):
+        remained = cols
+        for c in range(0, cols, VEC):
             mask, remained = pto.make_mask(pto.f32, remained)
             a_vec = pto.vlds(a_tile[r, c:])
             b_vec = pto.vlds(b_tile[r, c:])
             o_vec = pto.vadd(a_vec, b_vec, mask)
             pto.vsts(o_vec, o_tile[r, c:], mask)
-            col_loop.update(remained=remained)
 
 # Single kernel entry in explicit mode — micro-instruction staging plus SIMD sub-kernel.
 @pto.jit(target="a5", mode="explicit")
@@ -227,7 +224,7 @@ def vec_add_micro(
     o_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
 
     num_blocks = (N + BLOCK - 1) // BLOCK
-    with pto.for_(0, num_blocks, step=1) as i:
+    for i in range(0, num_blocks, 1):
         offset = i * BLOCK
         this_block = scalar.min(N - offset, BLOCK)
         a_part = pto.partition_view(a_view, offsets=[offset], sizes=[this_block])
@@ -253,8 +250,8 @@ def vec_add_micro(
   for the row-wise vector work while keeping instruction staging in the
   explicit entry body.
 
-- **Inside `@pto.simd`**: the outer `pto.for_` iterates over rows, the inner
-  `pto.for_` iterates over column chunks of the hardware vector width
+- **Inside `@pto.simd`**: the outer Python `for range(...)` iterates over rows,
+  and the inner Python `for range(...)` iterates over column chunks of the hardware vector width
   (`elements_per_vreg`). Each iteration loads a vector-width slice into a
   `vreg`, does the addition under a mask (for tail elements), and stores the
   result back. Both loops are recorded as structured control flow IR — the

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -235,7 +235,7 @@ def my_kernel(
     b_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
     o_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
 
-    with pto.for_(0, rows, step=1) as row:
+    for row in range(0, rows, 1):
         a_part = pto.partition_view(a_view, offsets=[row, 0], sizes=[1, cols])
         b_part = pto.partition_view(b_view, offsets=[row, 0], sizes=[1, cols])
         o_part = pto.partition_view(o_view, offsets=[row, 0], sizes=[1, cols])
@@ -266,18 +266,14 @@ def add_rows(
     cols: pto.i32,
 ):
     VEC = pto.elements_per_vreg(pto.f32)
-    initial_remained = cols
-    with pto.for_(0, rows, step=1) as r:
-        col_loop = pto.for_(0, cols, step=VEC).carry(remained=initial_remained)
-        with col_loop:
-            c = col_loop.iv
-            remained = col_loop.remained
+    for r in range(0, rows, 1):
+        remained = cols
+        for c in range(0, cols, VEC):
             mask, remained = pto.make_mask(pto.f32, remained)
             a_vec = pto.vlds(a_tile[r, c:])
             b_vec = pto.vlds(b_tile[r, c:])
             o_vec = pto.vadd(a_vec, b_vec, mask)
             pto.vsts(o_vec, o_tile[r, c:], mask)
-            col_loop.update(remained=remained)
 
 @pto.jit(target="a5", mode="auto")
 def my_kernel(
@@ -297,7 +293,7 @@ def my_kernel(
     b_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
     o_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
 
-    with pto.for_(0, rows, step=1) as row:
+    for row in range(0, rows, 1):
         a_part = pto.partition_view(a_view, offsets=[row, 0], sizes=[1, cols])
         b_part = pto.partition_view(b_view, offsets=[row, 0], sizes=[1, cols])
         o_part = pto.partition_view(o_view, offsets=[row, 0], sizes=[1, cols])
@@ -424,13 +420,17 @@ in two ways:
 2. **As context managers** (`with pto.cube():`, etc.) — inline blocks for
    one-off snippets (see Section 3.4).
 
+Named sub-kernel decorators use the same default AST rewrite model as
+`@pto.jit`: supported Python `if` and `for range(...)` statements lower to
+device-side control flow.
+
 ### 3.3.1 `@pto.cube` — Cube unit
 
 **Role**: `@pto.cube` marks a function that executes on the Cube unit (matrix
 multiplication engine). It consumes UB-resident tiles and explicit cube-local
 scratch buffers.
 
-**Signature**:
+**Signature**: `@pto.cube(fn=None, *, name=None, target="a5")`
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"kernel_entry.cube_signature","symbol":"kernel_entry_cube_signature_probe","compile":{"BLOCK_M":16,"BLOCK_K":16,"BLOCK_N":16}} -->
 ```python
@@ -486,7 +486,7 @@ engine). It operates on vector registers (`vreg`) loaded from UB tiles and
 stores results back to UB tiles. Vector registers are local to the function
 and never cross its boundary.
 
-**Signature**:
+**Signature**: `@pto.simd(fn=None, *, name=None, target="a5")`
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"kernel_entry.simd_signature","symbol":"kernel_entry_simd_signature_probe","compile":{"BLOCK":128}} -->
 ```python
@@ -512,18 +512,14 @@ constants.
 def add_rows(a_tile: pto.Tile, b_tile: pto.Tile, o_tile: pto.Tile,
              rows: pto.i32, cols: pto.i32):
     VEC = pto.elements_per_vreg(pto.f32)
-    initial_remained = cols
-    with pto.for_(0, rows, step=1) as r:
-        col_loop = pto.for_(0, cols, step=VEC).carry(remained=initial_remained)
-        with col_loop:
-            c = col_loop.iv
-            remained = col_loop.remained
+    for r in range(0, rows, 1):
+        remained = cols
+        for c in range(0, cols, VEC):
             mask, remained = pto.make_mask(pto.f32, remained)
             a_vec = pto.vlds(a_tile[r, c:])
             b_vec = pto.vlds(b_tile[r, c:])
             o_vec = pto.vadd(a_vec, b_vec, mask)
             pto.vsts(o_vec, o_tile[r, c:], mask)
-            col_loop.update(remained=remained)
 ```
 
 The boundary contract: `vreg` values (`a_vec`, `b_vec`, `o_vec`) are local to
@@ -543,7 +539,7 @@ instruction appears to operate on a single element (`lds`, `sts`, `a + b`),
 but the same instruction is issued across a large number of work-items
 simultaneously.
 
-**Signature**:
+**Signature**: `@pto.simt(fn=None, *, name=None, target="a5")`
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"kernel_entry.simt_signature","symbol":"kernel_entry_simt_signature_probe","compile":{"BLOCK":8}} -->
 ```python
@@ -567,10 +563,10 @@ def blend_output_rows(
     o_next_tile: pto.Tile,
     row_start: pto.i32, row_stop: pto.i32, valid_dim: pto.i32,
 ):
-    with pto.for_(row_start, row_stop, step=1) as row:
+    for row in range(row_start, row_stop, 1):
         alpha = scalar.load(alpha_tile[row, 0])
         beta = scalar.load(beta_tile[row, 0])
-        with pto.for_(0, valid_dim, step=1) as col:
+        for col in range(0, valid_dim, 1):
             o_prev = scalar.load(o_prev_tile[row, col])
             pv_val = scalar.load(pv_tile[row, col])
             o_next = alpha * o_prev + beta * pv_val

--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -4,14 +4,17 @@ PTODSL uses a **tracing** compilation model. When you call `kernel.compile(...)`
 
 This has one critical implication for how you write loops and branches:
 
-- **Python native `for`/`if`** runs at trace time. A `for i in range(4)` loop gets unrolled — the device code contains four copies of the body, not a loop instruction. An `if` condition is evaluated at trace time, and only the taken branch is recorded.
+- **Python native `for`/`if`** is rewritten to device-side control flow by default in `@pto.jit` bodies and named `@pto.cube` / `@pto.simd` / `@pto.simt` sub-kernels. A `for i in range(rows)` loop records a device loop, and a runtime `if` records both branches.
+- **`pto.const_expr` / `pto.static_range`** keep compile-time Python behavior when you want trace-time specialization or unrolling.
 - **`pto.for_` / `pto.if_`** produce device-side control flow. The loop bound or branch condition can be a runtime value, and the hardware will execute the loop or take the branch dynamically.
 
-**Simple rule: Python control flow = trace time (compile-time). `pto.*` control flow = device-side (runtime).**
+**Simple rule: Python control flow = device-side by default. Use `pto.const_expr` / `pto.static_range` for compile-time control flow.**
 
-## 5.1 Python native `for` — trace-time unrolling
+## 5.1 Trace-time unrolling
 
-When you write a plain Python `for` loop inside a kernel body, Python executes it immediately during tracing. Each iteration records its instructions separately, so the device code gets a linear sequence with the body repeated:
+Use `pto.static_range(...)` when a loop should execute during tracing. Each
+iteration records its instructions separately, so the device code gets a linear
+sequence with the body repeated:
 
 ```python
 @pto.jit(target="a5")
@@ -19,9 +22,9 @@ def unrolled_kernel(A, O, *, N: pto.constexpr):
     a_view = pto.make_tensor_view(A, shape=[N], strides=A.strides)
     o_view = pto.make_tensor_view(O, shape=[N], strides=O.strides)
 
-    # N is constexpr, so range(N) is known at trace time.
+    # N is constexpr, so static_range(N) is known at trace time.
     # The loop unrolls: the device gets N copies of the body.
-    for i in range(N):
+    for i in pto.static_range(N):
         a_part = pto.partition_view(a_view, offsets=[i], sizes=[1])
         o_part = pto.partition_view(o_view, offsets=[i], sizes=[1])
         a_tile = pto.alloc_tile(shape=[1], dtype=pto.f32)
@@ -31,7 +34,9 @@ def unrolled_kernel(A, O, *, N: pto.constexpr):
         pto.tile.store(o_tile, o_part)
 ```
 
-This works when the loop bound is a compile-time constant (like a `constexpr` parameter). But if `N` comes from a tensor shape and varies per launch, `range(N)` would trace a different number of iterations each time — you would get a cache miss and recompilation on every new value. For dynamic bounds, use `pto.for_`.
+This works when the loop bound is a compile-time constant, such as a
+`constexpr` parameter. For dynamic bounds, use native `range(...)` in the
+default AST rewrite mode or use explicit `pto.for_`.
 
 ## 5.2 `pto.for_` — device-side loops
 
@@ -54,7 +59,7 @@ Compare the two approaches:
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"control_flow.compare_loops","symbol":"control_flow_compare_loops_probe","compile":{"BLOCK":8}} -->
 ```python
 # Trace-time unrolling — BLOCK must be constexpr
-for i in range(BLOCK):
+for i in pto.static_range(BLOCK):
     pto.tile.load(pto.partition_view(a_view, offsets=[0, 0], sizes=[1, cols]), tile)
 
 # Device-side loop — num_blocks can be dynamic
@@ -224,15 +229,14 @@ def kernel(
     num_blocks = (N + BLOCK - 1) // BLOCK
 
     # N and num_blocks are runtime values derived from tensor metadata.
-    # They can drive device-side control flow such as pto.for_(...),
-    # but they are not Python integers and cannot be used in range(...).
+    # They can drive native range(...) loops in the default AST rewrite mode.
     with pto.for_(0, num_blocks, step=1) as i:
         ...
 
-    if UNROLL:
+    if pto.const_expr(UNROLL):
         # Trace-time: UNROLL and NUM_BLOCKS are both known during tracing.
         # Each iteration records separately, so the loop is fully unrolled.
-        for i in range(NUM_BLOCKS):
+        for i in pto.static_range(NUM_BLOCKS):
             ...
     else:
         # The non-unrolled path can still use a device-side loop whose bound
@@ -243,12 +247,293 @@ def kernel(
 
 This lets you write a single kernel that specializes into different strategies based on constexpr knobs, while still using runtime tensor metadata for device-side control flow.
 
-## 5.5 Summary
+## 5.5 Native Python control-flow rewrite
+
+`@pto.jit` rewrites supported native Python control flow before tracing. In the
+default mode, plain Python `if` and `for range(...)` in the rewritten scope
+become device-side control flow. Use `pto.const_expr(...)` and
+`pto.static_range(...)` when you want trace-time behavior.
+
+### Runtime branches
+
+By default, a native Python `if` becomes a device-side conditional:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_branch_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_branch_kernel():
+    lhs = pto.const(4, dtype=pto.i32)
+    rhs = pto.const(2, dtype=pto.i32)
+
+    if lhs > rhs:
+        total = lhs + rhs
+    else:
+        total = rhs + lhs
+
+    _ = total
+```
+
+The assigned value `total` is live after the branch, so PTODSL rewrites the
+branch into a `pto.if_` with automatic merge.
+
+If a live-out value is assigned in only one branch, PTODSL keeps the old value
+on the missing branch:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_old_value_branch_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_old_value_branch_kernel():
+    lhs = pto.const(4, dtype=pto.i32)
+    rhs = pto.const(2, dtype=pto.i32)
+    total = rhs
+
+    if lhs > rhs:
+        total = lhs + rhs
+
+    _ = total
+```
+
+Side-effect-only branches are also supported:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_side_effect_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_side_effect_kernel():
+    cond = pto.const(1, dtype=pto.i1)
+    if cond:
+        pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+### Runtime loops
+
+Native `range(...)` loops become device-side loops:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_loop_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_loop_kernel(rows: pto.i32):
+    for row in range(0, rows, 1):
+        _ = row
+        pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+The supported range forms are:
+
+```python
+range(stop)
+range(start, stop)
+range(start, stop, step)
+```
+
+The loop target must be a simple name.
+
+### Loop-carried values
+
+Accumulator-style loops are rewritten through `pto.for_(...).carry(...)`:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_accumulator_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_accumulator_kernel(rows: pto.i32):
+    one = pto.const(1, dtype=pto.i32)
+    acc = pto.const(0, dtype=pto.i32)
+
+    for _ in range(rows):
+        acc = acc + one
+
+    _ = acc
+```
+
+This lowers to an `scf.for` with `iter_args`.
+
+The first implementation requires a carried value to have an initial value and
+to be read before it is reassigned in the loop body. If you need a more complex
+loop state pattern, use the explicit API:
+
+```python
+loop = pto.for_(0, rows, step=1).carry(acc=acc)
+with loop:
+    acc = loop.acc
+    acc = acc + one
+    loop.update(acc=acc)
+acc = loop.final("acc")
+```
+
+### Compile-time control flow
+
+In the default AST rewrite mode, plain `if` and `range(...)` are runtime
+control flow. Use explicit compile-time helpers when you want trace-time
+behavior.
+
+Use `pto.const_expr(...)` for trace-time branches:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_static_branch_kernel","compile":{"ENABLE":true}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_static_branch_kernel(*, ENABLE: pto.constexpr = True):
+    if pto.const_expr(ENABLE):
+        pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+Use `pto.static_range(...)` for trace-time unrolling:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_static_loop_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_static_loop_kernel():
+    for _ in pto.static_range(2):
+        pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+`pto.static_range(...)` keeps Python `for` semantics. The loop target remains
+available after the loop:
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_static_loop_target_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_static_loop_target_kernel():
+    for stage in pto.static_range(2):
+        pto.pipe_barrier(pto.Pipe.ALL)
+    _ = stage
+```
+
+### Compatibility and nested helpers
+
+AST rewrite defaults to `True` on `@pto.jit` and named sub-kernel decorators.
+
+Explicit control-flow APIs continue to work alongside rewritten Python control
+flow:
+
+```python
+with pto.if_(cond) as br:
+    ...
+
+with pto.for_(0, rows, step=1) as row:
+    ...
+```
+
+For `@pto.jit`, the rewrite runs when a specialization is compiled, so Python
+closure values are read at compile time rather than when the decorator is
+evaluated. Named sub-kernel decorators use the same source rewrite semantics
+when their body is traced.
+
+Nested Python helper bodies follow the same rule as the outer kernel body:
+their supported Python `if` and `for range(...)` statements are rewritten to
+runtime control flow by default.
+
+Functions created by `exec`, REPLs, notebooks, or other dynamic generators may
+not expose retrievable Python source through `inspect.getsource(...)`. In that
+case, or when the source cannot be matched back to a unique function
+definition, PTODSL falls back to the original trace-time Python function
+instead of rewriting it. Use source-backed functions for native Python runtime
+`if` / `for range(...)`; fallback tracing still only supports ordinary Python
+compile-time control flow.
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"ast_rewrite_nested_helper_kernel","compile":{}} -->
+```python
+@pto.jit(target="a5")
+def ast_rewrite_nested_helper_kernel():
+    cond = pto.const(1, dtype=pto.i1)
+
+    def helper(enabled):
+        if enabled:
+            for _ in range(2):
+                pto.pipe_barrier(pto.Pipe.ALL)
+
+    helper(cond)
+```
+
+Helper-local compile-time control flow still uses `pto.const_expr(...)` and
+`pto.static_range(...)`.
+Plain Python boolean guards also remain trace-time branches. This keeps
+constexpr comparisons such as `if BLOCK == 128:` and boolean flags such as
+`if ENABLE:` compatible with the default rewrite mode. Device-side conditions
+must be PTO scalar values and lower through rewritten Python `if` or explicit
+`pto.if_`.
+
+### Debugging legacy tracing
+
+`ast_rewrite=False` is a developer/debug escape hatch. It restores legacy
+trace-time Python control flow for a specific `@pto.jit` kernel or named
+sub-kernel so you can isolate rewrite issues while developing PTODSL itself.
+It is not the recommended user-facing mode for new examples or kernels.
+
+```python
+@pto.jit(target="a5", ast_rewrite=False)
+def debug_kernel(*, BLOCK: pto.constexpr = 4):
+    for _ in range(BLOCK):
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.simd(ast_rewrite=False)
+def debug_simd_helper():
+    if pto.const_expr(True):
+        pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+The same switch is available through `frontend_options`:
+
+```python
+@pto.jit(
+    target="a5",
+    frontend_options={
+        "ast_rewrite": False,
+    },
+)
+def debug_options_disable_rewrite_kernel(*, BLOCK: pto.constexpr = 4):
+    for _ in range(BLOCK):
+        pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+Do not pass conflicting values through both spellings. For example,
+`@pto.jit(ast_rewrite=False, frontend_options={"ast_rewrite": True})` is
+rejected.
+
+When this mode is disabled for a function, native Python `if` / `for` executes
+while tracing that function. Runtime device-side control flow should still use
+the default rewrite mode, or explicit `pto.if_` / `pto.for_` APIs when you need
+manual control.
+
+The structured `frontend_options` argument is reserved for frontend rewrite
+debugging and future rewrite passes. Today it accepts the same AST rewrite
+switch plus a rewrite-part selector:
+
+```python
+@pto.jit(
+    target="a5",
+    frontend_options={
+        "ast_rewrite": True,
+        "rewrite_part": {"control_flow"},
+        "dump_rewritten_source": False,
+    },
+)
+def debug_frontend_options_kernel():
+    pto.pipe_barrier(pto.Pipe.ALL)
+```
+
+`rewrite_part` currently only accepts `"control_flow"`. Future frontend
+rewrite passes should add their selector names here. `dump_rewritten_source`
+is reserved for debugging output and currently must remain `False`.
+
+### Unsupported patterns
+
+The first version does not support:
+
+- `break` or `continue` in rewritten runtime loops;
+- `for ... else`;
+- runtime loops over iterables other than `range(...)`;
+- tuple/list loop targets;
+- using the runtime loop induction variable after the loop;
+- last-iteration-only loop values without an initial carried value.
+
+Use explicit `pto.if_` / `pto.for_` if a kernel needs one of those patterns.
+
+## 5.6 Summary
 
 | Construct | When evaluated | Use for |
 |-----------|---------------|---------|
-| Python `for` | Trace time | Bounds known at compile time (constexpr), deliberate unrolling |
-| Python `if` | Trace time | Conditions known at compile time, variant selection |
+| Python `for` / `if` | Device-side | Native syntax for dynamic loops and branches |
+| `pto.const_expr` / `pto.static_range` | Trace time | Compile-time branches and unrolling |
 | `pto.for_` | Device-side | Dynamic bounds, runtime loop counts |
 | `pto.for_(...).carry(...)` | Device-side | Loops with accumulated state across iterations |
 | `pto.if_` | Device-side | Runtime conditions, data-dependent branching |

--- a/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
+++ b/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
@@ -116,10 +116,10 @@ def blend_output_rows(
     o_next_tile: pto.Tile,
     row_start: pto.i32, row_stop: pto.i32, valid_dim: pto.i32,
 ):
-    with pto.for_(row_start, row_stop, step=1) as row:
+    for row in range(row_start, row_stop, 1):
         alpha = scalar.load(alpha_tile[row, 0])
         beta = scalar.load(beta_tile[row, 0])
-        with pto.for_(0, valid_dim, step=1) as col:
+        for col in range(0, valid_dim, 1):
             o_prev = scalar.load(o_prev_tile[row, col])
             pv_val = scalar.load(pv_tile[row, col])
             o_next = alpha * o_prev + beta * pv_val
@@ -367,13 +367,13 @@ This is the standard stride for chunking column loops in SIMD kernels:
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"scalar_ops.chunk_loop","symbol":"scalar_ops_chunk_loop_probe","compile":{"BLOCK":128}} -->
 ```python
 VEC = pto.elements_per_vreg(pto.f32)
-with pto.for_(0, cols, step=VEC) as c:
+for c in range(0, cols, VEC):
     ...
 ```
 
 ## 6.6 Per-element tile traversal in @pto.simt
 
-`@pto.simt` kernels are the natural home for per-element scalar work. A typical pattern uses nested `pto.for_` loops to walk over a tile row by row, column by column:
+`@pto.simt` kernels are the natural home for per-element scalar work. A typical pattern uses nested Python `for range(...)` loops to walk over a tile row by row, column by column; the default AST rewrite lowers them to runtime loops:
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"scalar_ops.simt_scale","symbol":"scalar_ops_simt_scale_probe","compile":{"BLOCK":8}} -->
 ```python
@@ -385,8 +385,8 @@ def elementwise_scale(
     rows: pto.i32,
     cols: pto.i32,
 ):
-    with pto.for_(0, rows, step=1) as r:
-        with pto.for_(0, cols, step=1) as c:
+    for r in range(0, rows, 1):
+        for c in range(0, cols, 1):
             val = scalar.load(src_tile[r, c])
             scaled = val * scale
             scalar.store(scaled, dst_tile[r, c])
@@ -408,10 +408,10 @@ def blend_with_per_row_coeffs(
     rows: pto.i32,
     cols: pto.i32,
 ):
-    with pto.for_(0, rows, step=1) as r:
+    for r in range(0, rows, 1):
         alpha = scalar.load(alpha_tile[r, 0])   # read once per row
         beta = scalar.load(beta_tile[r, 0])     # read once per row
-        with pto.for_(0, cols, step=1) as c:
+        for c in range(0, cols, 1):
             o_prev = scalar.load(o_prev_tile[r, c])
             pv_val = scalar.load(pv_tile[r, c])
             o_next = alpha * o_prev + beta * pv_val

--- a/ptodsl/docs/user_guide/09-predicate-and-mask-ops.md
+++ b/ptodsl/docs/user_guide/09-predicate-and-mask-ops.md
@@ -45,15 +45,12 @@ The recommended front door for creating masks is `pto.make_mask`. It dispatches 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"tail.chunked_inner_loop","symbol":"tail_chunked_inner_loop_probe","compile":{"BLOCK":128}} -->
 ```python
 VEC = pto.elements_per_vreg(pto.f32)
-col_loop = pto.for_(0, cols, step=VEC).carry(remained=cols)
-with col_loop:
-    c = col_loop.iv
-    remained = col_loop.remained
+remained = cols
+for c in range(0, cols, VEC):
     mask, remained = pto.make_mask(pto.f32, remained)
     vec = pto.vlds(tile[r, c:])
     # ... operate under mask ...
     pto.vsts(vec, out_tile[r, c:], mask)
-    col_loop.update(remained=remained)
 ```
 
 `make_mask` generates a tail mask from the remaining count: the first `min(remained, VL)` lanes are active, and `remained` is decremented by `VL` for the next iteration. On the final partial chunk, fewer than `VL` lanes are active. PTODSL handles the hardware `i32` tail-mask operand internally, so loop-carried `index` metadata can flow through `make_mask` without manual casts.
@@ -367,21 +364,17 @@ The mask granularity must match the vector element type. Using a `mask_b16` with
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"tail.vector_pattern","symbol":"tail_vector_pattern_probe","compile":{"BLOCK":128}} -->
 ```python
 VEC = pto.elements_per_vreg(pto.f32)
-with pto.for_(0, rows, step=1) as r:
-    col_loop = pto.for_(0, cols, step=VEC).carry(remained=cols)
-    with col_loop:
-        c = col_loop.iv
-        remained = col_loop.remained
+for r in range(0, rows, 1):
+    remained = cols
+    for c in range(0, cols, VEC):
         mask, remained = pto.make_mask(pto.f32, remained)
 
         vec = pto.vlds(tile[r, c:])
         vec = pto.vexp(vec, mask)
         pto.vsts(vec, out_tile[r, c:], mask)
-
-        col_loop.update(remained=remained)
 ```
 
-The `mask` gates the `vexp` (masked-off lanes produce 0) and the `vsts` (masked-off lanes are not written). `col_loop` carries the remaining count across iterations, so the final partial chunk correctly masks only the valid tail elements.
+The `mask` gates the `vexp` (masked-off lanes produce 0) and the `vsts` (masked-off lanes are not written). The `remained` assignment makes the remaining count loop-carried after AST rewrite, so the final partial chunk correctly masks only the valid tail elements.
 
 ---
 

--- a/ptodsl/docs/user_guide/11-flash-attention-walkthrough.md
+++ b/ptodsl/docs/user_guide/11-flash-attention-walkthrough.md
@@ -270,7 +270,7 @@ row-major padded physical width just to satisfy row-byte alignment.
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"flash_attention.l1_loop_body","symbol":"flash_attention_l1_loop_body_probe","compile":{"BLOCK_Q":128,"BLOCK_KV":128,"HEAD_DIM":128,"CAUSAL":false,"NUM_STAGES":2}} -->
 ```python
-with pto.for_(0, q_blocks, step=1) as qi:
+for qi in range(0, q_blocks, 1):
     q_rows = _block_valid_extent(seq_q, qi, Br)
     q_part = pto.partition_view(q_head, offsets=[0, qi * Br, 0, 0],
                                 sizes=[1, q_rows, 1, dim])
@@ -296,14 +296,10 @@ with pto.for_(0, q_blocks, step=1) as qi:
     l_prev_tile.fill(0.0)
     o_prev_tile.fill(0.0)
 
-    kv_loop = pto.for_(0, kv_blocks, step=1).carry(
-        m=m_prev_tile, l=l_prev_tile, o=o_prev_tile,
-    )
-    with kv_loop:
-        kj = kv_loop.iv
-        m_cur = kv_loop.m
-        l_cur = kv_loop.l
-        o_cur = kv_loop.o
+    m_cur = m_prev_tile
+    l_cur = l_prev_tile
+    o_cur = o_prev_tile
+    for kj in range(0, kv_blocks, 1):
         kv_rows = _block_valid_extent(seq_k, kj, Bc)
         k_part = pto.partition_view(k_head,
                     offsets=[0, kj * Bc, 0, 0], sizes=[1, kv_rows, 1, dim])
@@ -332,10 +328,11 @@ with pto.for_(0, q_blocks, step=1) as qi:
             meta_ptr,
         )
 
-        kv_loop.update(m=m_next_tile, l=l_next_tile, o=o_next_tile)
+        m_cur = m_next_tile
+        l_cur = l_next_tile
+        o_cur = o_next_tile
 
-    o_final_tile = kv_loop.final("o")
-    pto.tile.store(o_final_tile, o_part)
+    pto.tile.store(o_cur, o_part)
 ```
 
 Key points:
@@ -343,7 +340,7 @@ Key points:
 - **Static physical shape, dynamic valid extent**: `alloc_tile(shape=...)` stays constexpr. Tail handling is expressed by updating `valid_shape` before each block load and sub-kernel call.
 - **`tile.load` at the kernel entry boundary**: Q is loaded once per Q block using a tile op into the MAT-backed bridge tile `q_mat`. The compiler auto-inserts the necessary `set_flag`/`wait_flag` pairs.
 - **State initialization**: `fill(float("-inf"))` and `fill(0.0)` initialize the online-softmax accumulators before the first KV block.
-- **Carry state**: the inner `kv_loop` carries three ping-pong tiles (`m`, `l`, `o`) across iterations using `.carry(...)` / `.update(...)` / `.final(...)`. After each KV block, the loop updates the carried values to the `_next` tiles. After the loop, `.final("o")` extracts the final output accumulator.
+- **Carry state**: the inner Python loop carries three ping-pong tiles (`m_cur`, `l_cur`, `o_cur`) across iterations. After each KV block, assignments to the `_next` tiles become loop-carried state after AST rewrite. After the loop, `o_cur` is the final output accumulator.
 - **`tile.store` at the kernel entry boundary**: writes the final result for this Q block back to GM.
 
 ## 11.4 Explicit orchestration
@@ -511,11 +508,11 @@ def online_softmax_rows(
 ):
 ```
 
-The simd kernel iterates over rows with `pto.for_`, processing one row per iteration:
+The simd kernel iterates over rows with Python `for range(...)`, and AST rewrite lowers the loop to runtime IR:
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"flash_attention.online_softmax_loop","symbol":"flash_attention_online_softmax_loop_probe","compile":{"BLOCK":16}} -->
 ```python
-with pto.for_(row_start, row_stop, step=1) as row:
+for row in range(row_start, row_stop, 1):
     col_mask = pto.make_mask(pto.f32, valid_cols)
 
     s_row   = pto.vlds(s_tile[row, 0:])
@@ -593,11 +590,11 @@ Three scalar stores write the loop bounds into the metadata buffer. `meta_ptr` i
 @pto.simt
 def blend_output_rows(o_prev_tile, pv_tile, alpha_tile, beta_tile,
                       o_next_tile, row_start, row_stop, valid_dim):
-    with pto.for_(row_start, row_stop, step=1) as row:
+    for row in range(row_start, row_stop, 1):
         alpha = scalar.load(alpha_tile[row, 0])
         beta  = scalar.load(beta_tile[row, 0])
 
-        with pto.for_(0, valid_dim, step=1) as col:
+        for col in range(0, valid_dim, 1):
             o_prev = scalar.load(o_prev_tile[row, col])
             pv_val = scalar.load(pv_tile[row, col])
             o_next = alpha * o_prev + beta * pv_val
@@ -654,7 +651,7 @@ After all KV blocks: the top-level kernel issues `tile.store(o_final_tile, o_par
 
 ## 11.9 Design patterns in this sketch
 
-**Ping-pong state for online accumulators**: `m_prev`/`m_next`, `l_prev`/`l_next`, `o_prev`/`o_next` make the state transition explicit. After each KV block, the caller swaps the ping-pong pair (via `kv_loop.update(...)`) rather than aliasing in place.
+**Ping-pong state for online accumulators**: `m_prev`/`m_next`, `l_prev`/`l_next`, `o_prev`/`o_next` make the state transition explicit. After each KV block, the caller swaps the ping-pong pair by assigning the `_next` tiles to the loop-carried Python variables rather than aliasing in place.
 
 **Scratch reuse**: `rhs_l0b` serves both `K` (in `qk_matmul`) and `V` (in `pv_matmul`). `pv_acc_tile` reuses the accumulator from QK^T. The caller (top-level kernel) allocates once; the explicit-mode body passes them to both cube sub-kernels.
 

--- a/ptodsl/docs/user_guide/12-additional-examples.md
+++ b/ptodsl/docs/user_guide/12-additional-examples.md
@@ -31,9 +31,9 @@ def mat_add(
     num_m = (M + BLOCK_M - 1) // BLOCK_M
     num_n = (N_ + BLOCK_N - 1) // BLOCK_N
 
-    with pto.for_(0, num_m, step=1) as mi:
+    for mi in range(0, num_m, 1):
         m_off = mi * BLOCK_M
-        with pto.for_(0, num_n, step=1) as ni:
+        for ni in range(0, num_n, 1):
             n_off = ni * BLOCK_N
 
             a_part = pto.partition_view(a_view, offsets=[block_idx, m_off, n_off], sizes=[1, BLOCK_M, BLOCK_N])
@@ -83,19 +83,15 @@ def add_rows_with_tail(a_tile: pto.Tile, b_tile: pto.Tile, o_tile: pto.Tile,
                        rows: pto.i32, cols: pto.i32):
     VEC = pto.elements_per_vreg(pto.f32)          # 64 for f32
 
-    with pto.for_(0, rows, step=1) as r:
-        col_loop = pto.for_(0, cols, step=VEC).carry(remained=cols)
-        with col_loop:
-            c = col_loop.iv
-            remained = col_loop.remained
+    for r in range(0, rows, 1):
+        remained = cols
+        for c in range(0, cols, VEC):
             mask, remained = pto.make_mask(pto.f32, remained)
 
             a_vec = pto.vlds(a_tile[r, c:])       # load under mask
             b_vec = pto.vlds(b_tile[r, c:])
             o_vec = pto.vadd(a_vec, b_vec, mask)  # compute under mask
             pto.vsts(o_vec, o_tile[r, c:], mask)  # store under mask
-
-            col_loop.update(remained=remained)
 ```
 
 The pattern:
@@ -103,7 +99,7 @@ The pattern:
 1. **Chunk**: Each iteration processes `VEC` elements (one vector register's worth).
 2. **Mask**: `make_mask` returns a predicate and the updated remainder. On the last iteration, where `remained < VEC`, the mask has `remained` valid lanes followed by inactive lanes.
 3. **Guard**: `vlds`, `vadd`, and `vsts` all accept the mask — inactive lanes are neither loaded, computed, nor stored.
-4. **Carry**: `.carry(remained=cols)` carries the remaining column count across iterations. `col_loop.update(remained=remained)` feeds the updated count to the next iteration.
+4. **Carry**: assigning `remained` in the Python loop body makes it loop-carried state after AST rewrite.
 
 ### 12.2.2 Tile-level tail handling
 
@@ -130,7 +126,7 @@ def vec_add_with_tail(
 
     num_blocks = (N + BLOCK - 1) // BLOCK
 
-    with pto.for_(0, num_blocks, step=1) as i:
+    for i in range(0, num_blocks, 1):
         offset = i * BLOCK
         this_block = scalar.min(BLOCK, N - offset)
 
@@ -221,16 +217,16 @@ def gemm(
     num_n = (N_ + BLOCK_N - 1) // BLOCK_N
     num_k = (K_ + BLOCK_K - 1) // BLOCK_K
 
-    with pto.for_(0, num_m, step=1) as mi:
+    for mi in range(0, num_m, 1):
         m_off = mi * BLOCK_M
-        with pto.for_(0, num_n, step=1) as ni:
+        for ni in range(0, num_n, 1):
             n_off = ni * BLOCK_N
             o_part = pto.partition_view(o_view, offsets=[m_off, n_off],
                                         sizes=[BLOCK_M, BLOCK_N])
 
             o_tile.fill(0.0)
 
-            with pto.for_(0, num_k, step=1) as ki:
+            for ki in range(0, num_k, 1):
                 k_off = ki * BLOCK_K
 
                 a_part = pto.partition_view(a_view, offsets=[m_off, k_off],
@@ -311,42 +307,34 @@ def online_layernorm(
     num_blocks = (N + BLOCK - 1) // BLOCK
 
     # Pass 1: running Welford state across blocks.
-    stats_loop = pto.for_(0, num_blocks, step=1).carry(
-        mu=pto.f32(0.0), n=pto.f32(0.0), m2=pto.f32(0.0)
-    )
-    with stats_loop:
-        i = stats_loop.iv
+    mu = pto.f32(0.0)
+    n = pto.f32(0.0)
+    m2 = pto.f32(0.0)
+    for i in range(0, num_blocks, 1):
         offset = i * BLOCK
         this_block = scalar.min(BLOCK, N - offset)
         x_part = pto.partition_view(x_view, offsets=[offset], sizes=[this_block])
         pto.tile.load(x_part, x_tile)
         x_tile.valid_shape = [this_block]
 
-        elem_loop = pto.for_(0, this_block, step=1).carry(
-            mu=stats_loop.mu, n=stats_loop.n, m2=stats_loop.m2
-        )
-        with elem_loop:
-            j = elem_loop.iv
+        for j in range(0, this_block, 1):
             x = scalar.load(x_tile.as_ptr(), j)
-            n_next = elem_loop.n + 1.0
-            delta = x - elem_loop.mu
-            mu_next = elem_loop.mu + delta / n_next
+            n_next = n + 1.0
+            delta = x - mu
+            mu_next = mu + delta / n_next
             delta2 = x - mu_next
-            m2_next = elem_loop.m2 + delta * delta2
-            elem_loop.update(mu=mu_next, n=n_next, m2=m2_next)
+            m2_next = m2 + delta * delta2
 
-        stats_loop.update(
-            mu=elem_loop.final("mu"),
-            n=elem_loop.final("n"),
-            m2=elem_loop.final("m2"),
-        )
+            mu = mu_next
+            n = n_next
+            m2 = m2_next
 
-    mean = stats_loop.final("mu")
-    count = stats_loop.final("n")
-    inv_std = 1.0 / scalar.sqrt(stats_loop.final("m2") / count + pto.f32(1.0e-5))
+    mean = mu
+    count = n
+    inv_std = 1.0 / scalar.sqrt(m2 / count + pto.f32(1.0e-5))
 
     # Pass 2: apply (x - mean) / sqrt(var + eps) block by block.
-    with pto.for_(0, num_blocks, step=1) as i:
+    for i in range(0, num_blocks, 1):
         offset = i * BLOCK
         this_block = scalar.min(BLOCK, N - offset)
         x_part = pto.partition_view(x_view, offsets=[offset], sizes=[this_block])
@@ -356,7 +344,7 @@ def online_layernorm(
         x_tile.valid_shape = [this_block]
         o_tile.valid_shape = [this_block]
 
-        with pto.for_(0, this_block, step=1) as j:
+        for j in range(0, this_block, 1):
             x = scalar.load(x_tile.as_ptr(), j)
             y = (x - mean) * inv_std
             scalar.store(y, o_tile.as_ptr(), j)
@@ -366,10 +354,10 @@ def online_layernorm(
 
 **Key points**:
 
-- **Carry state**: `.carry(mu=..., n=..., m2=...)` on both loops keeps the running Welford state in SSA form. The outer loop carries state across blocks; the inner loop carries state across elements inside one block.
+- **Carry state**: assigning `mu`, `n`, and `m2` inside the Python loops makes them loop-carried state after AST rewrite. The outer loop carries state across blocks; the inner loop carries state across elements inside one block.
 - **Tail handling**: `scalar.min(BLOCK, N - offset)` computes the live width of the current block, and `tile.valid_shape = [this_block]` keeps the tile contract aligned with that tail.
 - **No special tile op required**: the normalization pass is written explicitly with `scalar.load(...)`, scalar arithmetic, `scalar.sqrt(...)`, and `scalar.store(...)`. There is no dependency on a dedicated `tnormalize` op.
-- **Compare to flash attention**: the flash attention carry in Chapter 11 moves several tiles through ping-pong buffers. Here the carried state is only three scalars, so the same `.carry(...)` surface reads more like a conventional streaming reduction.
+- **Compare to flash attention**: the flash attention carry in Chapter 11 moves several tiles through ping-pong buffers. Here the carried state is only three scalars, so the rewritten Python surface reads like a conventional streaming reduction.
 
 ## 12.5 Design guidelines
 

--- a/ptodsl/examples/flash_attention_sketch.py
+++ b/ptodsl/examples/flash_attention_sketch.py
@@ -51,9 +51,10 @@ Design rules illustrated here:
    Hiding these dependencies with in-place aliases makes the algorithm harder
    to read and obscures what the DSL needs to express.
 
-Because this demo targets a tracing-style frontend, any control flow that
-must reach MLIR is expressed with structured DSL constructs such as
-``pto.for_`` instead of native Python ``for`` loops.
+Because PTODSL rewrites JIT function ASTs by default, runtime Python
+``if`` / ``for range(...)`` in this demo lowers to structured MLIR control
+flow. Use ``pto.const_expr`` / ``pto.static_range`` only for intentionally
+compile-time control flow.
 
 Scalar literals and simple index/integer conversions are also written in the
 authored PTODSL surface. The current frontend lowers these through tracing
@@ -286,7 +287,7 @@ def flash_attention_kernel(
     meta_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32, valid_shape=[1, 3])
     meta_ptr = meta_tile.as_ptr()
 
-    with pto.for_(0, q_blocks, step=1) as qi:
+    for qi in range(0, q_blocks, 1):
         q_rows = _block_valid_extent(seq_q, qi, Br)
         q_part = pto.partition_view(q_head, offsets=[0, qi * Br, 0, 0], sizes=[1, q_rows, 1, dim])
         o_part = pto.partition_view(o_head, offsets=[0, qi * Br, 0, 0], sizes=[1, q_rows, 1, dim])
@@ -313,16 +314,10 @@ def flash_attention_kernel(
         l_prev_tile.fill(0.0)
         o_prev_tile.fill(0.0)
 
-        kv_loop = pto.for_(0, kv_blocks, step=1).carry(
-            m=m_prev_tile,
-            l=l_prev_tile,
-            o=o_prev_tile,
-        )
-        with kv_loop:
-            kj = kv_loop.iv
-            m_cur = kv_loop.m
-            l_cur = kv_loop.l
-            o_cur = kv_loop.o
+        m_cur = m_prev_tile
+        l_cur = l_prev_tile
+        o_cur = o_prev_tile
+        for kj in range(0, kv_blocks, 1):
             kv_rows = _block_valid_extent(seq_k, kj, Bc)
             k_part = pto.partition_view(k_head, offsets=[0, kj * Bc, 0, 0], sizes=[1, kv_rows, 1, dim])
             v_part = pto.partition_view(v_head, offsets=[0, kj * Bc, 0, 0], sizes=[1, kv_rows, 1, dim])
@@ -364,16 +359,13 @@ def flash_attention_kernel(
                 meta_ptr,
             )
 
-            # Loop-carried state is still explicit, but the authored surface no
-            # longer mirrors raw scf.iter_args / scf.yield spellings.
-            kv_loop.update(
-                m=m_next_tile,
-                l=l_next_tile,
-                o=o_next_tile,
-            )
+            # Loop-carried state stays visible in Python while AST rewrite
+            # lowers it to scf.iter_args / scf.yield.
+            m_cur = m_next_tile
+            l_cur = l_next_tile
+            o_cur = o_next_tile
 
-        o_final_tile = kv_loop.final("o")
-        pto.tile.store(o_final_tile, o_part)
+        pto.tile.store(o_cur, o_part)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -467,7 +459,7 @@ def online_softmax_rows(
     ``alpha`` and ``beta`` are kept explicitly because the output update needs
     both the old accumulator and the newly computed ``P @ V`` contribution.
     """
-    with pto.for_(row_start, row_stop, step=1) as row:
+    for row in range(row_start, row_stop, 1):
         col_mask = pto.make_mask(pto.f32, valid_cols)
 
         s_row = pto.vlds(s_tile[row, 0:])
@@ -515,11 +507,11 @@ def blend_output_rows(
     while the final blend is expressed here as explicit scalar work-items over
     the tile domain.
     """
-    with pto.for_(row_start, row_stop, step=1) as row:
+    for row in range(row_start, row_stop, 1):
         alpha = scalar.load(alpha_tile[row, 0])
         beta = scalar.load(beta_tile[row, 0])
 
-        with pto.for_(0, valid_dim, step=1) as col:
+        for col in range(0, valid_dim, 1):
             o_prev = scalar.load(o_prev_tile[row, col])
             pv_val = scalar.load(pv_tile[row, col])
 

--- a/ptodsl/examples/flash_attention_softmax_launch.py
+++ b/ptodsl/examples/flash_attention_softmax_launch.py
@@ -119,22 +119,13 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
         pto.wait_flag("MTE2", "V", event_id=0)
 
         with pto.simd():
-            row_loop = pto.for_(0, runtime_rows, step=lane_num).carry(remained=runtime_rows)
-            with row_loop:
-                row_base = row_loop.iv
-                remaining_rows = row_loop.remained
+            remaining_rows = runtime_rows
+            for row_base in range(0, runtime_rows, lane_num):
                 active_rows, remaining_after_pack = pto.make_mask(pto.f32, remaining_rows)
                 running_max = pto.vlds(scores_tile[0, row_base:])
                 running_sum = pto.vbr(1.0)
 
-                softmax_loop = pto.for_(1, runtime_seq, step=1).carry(
-                    running_max=running_max,
-                    running_sum=running_sum,
-                )
-                with softmax_loop:
-                    col = softmax_loop.iv
-                    running_max = softmax_loop.running_max
-                    running_sum = softmax_loop.running_sum
+                for col in range(1, runtime_seq, 1):
                     col_vec = pto.vlds(scores_tile[col, row_base:])
                     merged_max = pto.vmax(running_max, col_vec, active_rows)
                     running_delta = pto.vsub(running_max, merged_max, active_rows)
@@ -142,20 +133,20 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
                     running_sum_scaled = pto.vmul(scaled_running, running_sum, active_rows)
                     col_delta = pto.vsub(col_vec, merged_max, active_rows)
                     col_exp = pto.vexp(col_delta, active_rows)
-                    merged_sum = pto.vadd(running_sum_scaled, col_exp, active_rows)
-                    softmax_loop.update(running_max=merged_max, running_sum=merged_sum)
+                    running_sum = pto.vadd(running_sum_scaled, col_exp, active_rows)
+                    running_max = merged_max
 
-                final_max = softmax_loop.final("running_max")
-                final_sum = softmax_loop.final("running_sum")
+                final_max = running_max
+                final_sum = running_sum
 
-                with pto.for_(0, runtime_seq, step=1) as col:
+                for col in range(0, runtime_seq, 1):
                     col_vec = pto.vlds(scores_tile[col, row_base:])
                     out_delta = pto.vsub(col_vec, final_max, active_rows)
                     exp_vec = pto.vexp(out_delta, active_rows)
                     out_vec = pto.vdiv(exp_vec, final_sum, active_rows)
                     pto.vsts(out_vec, out_tile[col, row_base:], active_rows)
 
-                row_loop.update(remained=remaining_after_pack)
+                remaining_rows = remaining_after_pack
 
         pto.set_flag("V", "MTE3", event_id=0)
         pto.wait_flag("V", "MTE3", event_id=0)

--- a/ptodsl/examples/softmax_dsl.py
+++ b/ptodsl/examples/softmax_dsl.py
@@ -9,10 +9,10 @@
 """
 Row-wise softmax kernel – compile-only DSL builder.
 
-This sample mirrors the launchable softmax demo. It uses a transposed logical
-GM view so each UB row holds one score column, then processes 64 rows in
-parallel with the online-softmax recurrence using only public PTODSL surface
-syntax.
+This sample mirrors the launchable softmax demo. It uses native Python
+``if`` / ``for range(...)`` in the JIT body; the default PTODSL AST rewrite
+turns those into runtime control flow. Use ``pto.const_expr`` /
+``pto.static_range`` only when a branch or loop is intentionally compile-time.
 """
 
 from pathlib import Path
@@ -56,80 +56,68 @@ def _make_softmax_kernel(name: str, *, rows: int, seq: int):
         scores_tile_bytes = seq * physical_rows * pto.bytewidth(pto.f32)
         has_rows = runtime_rows > 0
 
-        with pto.if_(has_rows) as has_rows_br:
-            with has_rows_br.then_:
-                scores_view = pto.make_tensor_view(
-                    scores_ptr,
-                    shape=[seq, rows],
-                    strides=[1, seq],
-                )
-                out_view = pto.make_tensor_view(
-                    out_ptr,
-                    shape=[seq, rows],
-                    strides=[1, seq],
-                )
-                scores_tile = pto.alloc_tile(
-                    shape=[seq, physical_rows],
-                    dtype=pto.float32,
-                    addr=pto.const(0, dtype=pto.i64),
-                    valid_shape=[runtime_seq, runtime_rows],
-                )
-                out_tile = pto.alloc_tile(
-                    shape=[seq, physical_rows],
-                    dtype=pto.float32,
-                    addr=pto.const(scores_tile_bytes, dtype=pto.i64),
-                    valid_shape=[runtime_seq, runtime_rows],
-                )
+        if has_rows:
+            scores_view = pto.make_tensor_view(
+                scores_ptr,
+                shape=[seq, rows],
+                strides=[1, seq],
+            )
+            out_view = pto.make_tensor_view(
+                out_ptr,
+                shape=[seq, rows],
+                strides=[1, seq],
+            )
+            scores_tile = pto.alloc_tile(
+                shape=[seq, physical_rows],
+                dtype=pto.float32,
+                addr=pto.const(0, dtype=pto.i64),
+                valid_shape=[runtime_seq, runtime_rows],
+            )
+            out_tile = pto.alloc_tile(
+                shape=[seq, physical_rows],
+                dtype=pto.float32,
+                addr=pto.const(scores_tile_bytes, dtype=pto.i64),
+                valid_shape=[runtime_seq, runtime_rows],
+            )
 
-                pto.tile.load(scores_view, scores_tile)
+            pto.tile.load(scores_view, scores_tile)
 
-                pto.set_flag("MTE2", "V", event_id=0)
-                pto.wait_flag("MTE2", "V", event_id=0)
+            pto.set_flag("MTE2", "V", event_id=0)
+            pto.wait_flag("MTE2", "V", event_id=0)
 
-                with pto.simd():
-                    row_loop = pto.for_(0, runtime_rows, step=packed_rows).carry(remained=runtime_rows)
-                    with row_loop:
-                        row_base = row_loop.iv
-                        remaining_rows = row_loop.remained
-                        active_rows, remaining_after_pack = pto.make_mask(pto.f32, remaining_rows)
-                        running_max = pto.vlds(scores_tile[0, row_base:])
-                        running_sum = pto.vbr(1.0)
+            with pto.simd():
+                remaining_rows = runtime_rows
+                for row_base in range(0, runtime_rows, packed_rows):
+                    active_rows, remaining_rows = pto.make_mask(pto.f32, remaining_rows)
+                    running_max = pto.vlds(scores_tile[0, row_base:])
+                    running_sum = pto.vbr(1.0)
 
-                        softmax_loop = pto.for_(1, runtime_seq, step=1).carry(
-                            running_max=running_max,
-                            running_sum=running_sum,
-                        )
-                        with softmax_loop:
-                            col = softmax_loop.iv
-                            running_max = softmax_loop.running_max
-                            running_sum = softmax_loop.running_sum
-                            col_vec = pto.vlds(scores_tile[col, row_base:])
-                            merged_max = pto.vmax(running_max, col_vec, active_rows)
-                            running_delta = pto.vsub(running_max, merged_max, active_rows)
-                            scaled_running = pto.vexp(running_delta, active_rows)
-                            running_sum_scaled = pto.vmul(scaled_running, running_sum, active_rows)
-                            col_delta = pto.vsub(col_vec, merged_max, active_rows)
-                            col_exp = pto.vexp(col_delta, active_rows)
-                            merged_sum = pto.vadd(running_sum_scaled, col_exp, active_rows)
-                            softmax_loop.update(running_max=merged_max, running_sum=merged_sum)
+                    for col in range(1, runtime_seq, 1):
+                        col_vec = pto.vlds(scores_tile[col, row_base:])
+                        merged_max = pto.vmax(running_max, col_vec, active_rows)
+                        running_delta = pto.vsub(running_max, merged_max, active_rows)
+                        scaled_running = pto.vexp(running_delta, active_rows)
+                        running_sum_scaled = pto.vmul(scaled_running, running_sum, active_rows)
+                        col_delta = pto.vsub(col_vec, merged_max, active_rows)
+                        col_exp = pto.vexp(col_delta, active_rows)
+                        running_sum = pto.vadd(running_sum_scaled, col_exp, active_rows)
+                        running_max = merged_max
 
-                        final_max = softmax_loop.final("running_max")
-                        final_sum = softmax_loop.final("running_sum")
+                    final_max = running_max
+                    final_sum = running_sum
 
-                        with pto.for_(0, runtime_seq, step=1) as col:
-                            col_vec = pto.vlds(scores_tile[col, row_base:])
-                            out_delta = pto.vsub(col_vec, final_max, active_rows)
-                            exp_vec = pto.vexp(out_delta, active_rows)
-                            out_vec = pto.vdiv(exp_vec, final_sum, active_rows)
-                            pto.vsts(out_vec, out_tile[col, row_base:], active_rows)
+                    for col in range(0, runtime_seq, 1):
+                        col_vec = pto.vlds(scores_tile[col, row_base:])
+                        out_delta = pto.vsub(col_vec, final_max, active_rows)
+                        exp_vec = pto.vexp(out_delta, active_rows)
+                        out_vec = pto.vdiv(exp_vec, final_sum, active_rows)
+                        pto.vsts(out_vec, out_tile[col, row_base:], active_rows)
 
-                        row_loop.update(remained=remaining_after_pack)
+            pto.set_flag("V", "MTE3", event_id=0)
+            pto.wait_flag("V", "MTE3", event_id=0)
 
-                pto.set_flag("V", "MTE3", event_id=0)
-                pto.wait_flag("V", "MTE3", event_id=0)
-
-                pto.tile.store(out_tile, out_view)
-                pto.pipe_barrier(pto.Pipe.ALL)
+            pto.tile.store(out_tile, out_view)
+            pto.pipe_barrier(pto.Pipe.ALL)
 
     return kernel
 

--- a/ptodsl/examples/tadd_dsl.py
+++ b/ptodsl/examples/tadd_dsl.py
@@ -20,7 +20,7 @@ The Python code maps 1-to-1 to the MLIR IR lines:
       …
       pto.simd {                              # with pto.simd():
         %0 = pto.castptr %c4096_i64 …        #   pto.castptr(c4096_i64, …)
-        scf.for %arg0 = %c0 to %c16 … {      #   with pto.for_(c0, c16, step=c1) as i:
+        scf.for %arg0 = %c0 to %c16 … {      #   for i in range(c0, c16, c1):
           %mask, _ = pto.plt_b32 …           #     pto.plt_b32(c64_i32)
           …
         }
@@ -49,7 +49,7 @@ def TADD():
         ptr_src      = pto.castptr(c4096_i64, ptr_f32_ub)
         ptr_dst      = pto.castptr(c0_i64,    ptr_f32_ub)
 
-        with pto.for_(c0, c16, step=c1) as tile_idx:
+        for tile_idx in range(c0, c16, c1):
             mask, _      = pto.plt_b32(c64_i32)
             tile_off     = s.muli(tile_idx, c64)
             va           = pto.vlds(pto.addptr(ptr_src, tile_off), c0, vf32)

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1,0 +1,739 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+"""Source-to-source AST rewrite for ``@pto.jit(ast_rewrite=True)``."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import inspect
+import textwrap
+from dataclasses import dataclass
+
+
+class PTODSLAstRewriteError(SyntaxError):
+    """Raised when AST rewrite sees unsupported Python control flow."""
+
+
+def rewrite_jit_function(fn):
+    """Return a function whose Python if/for control flow lowers to PTODSL APIs."""
+    try:
+        source = inspect.getsource(fn)
+    except (OSError, TypeError) as exc:
+        # Dynamically-created functions from exec/REPL/notebook contexts may
+        # not have retrievable source. Keep existing tracing behavior for those
+        # functions instead of making default-on AST rewrite a compatibility
+        # break; native Python runtime control flow will still fail during
+        # tracing with the usual PTODSL diagnostics.
+        _ = exc
+        return fn
+
+    tree = ast.parse(textwrap.dedent(source))
+    function_def = _find_function_def(tree, fn.__name__)
+    if function_def is None:
+        return fn
+
+    function_def.decorator_list = []
+    closure_vars = inspect.getclosurevars(fn)
+    _inject_closure_defaults(function_def, closure_vars.nonlocals)
+    _sanitize_signature_for_exec(function_def)
+    rewriter = _ControlFlowRewriter()
+    function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
+    tree = ast.Module(body=[function_def], type_ignores=[])
+    ast.fix_missing_locations(tree)
+
+    locals_ns = {}
+    try:
+        source_file = inspect.getsourcefile(fn)
+    except (OSError, TypeError):
+        source_file = None
+    code = compile(tree, source_file or "<ptodsl-ast-rewrite>", "exec")
+    globals_ns = fn.__globals__
+    restored_globals = _temporarily_bind_globals(globals_ns, closure_vars.nonlocals)
+    try:
+        exec(code, globals_ns, locals_ns)
+    finally:
+        _restore_globals(globals_ns, restored_globals)
+    rewritten = locals_ns[function_def.name]
+    rewritten.__defaults__ = fn.__defaults__
+    rewritten_kwdefaults = dict(rewritten.__kwdefaults__ or {})
+    rewritten_kwdefaults.update(closure_vars.nonlocals)
+    if fn.__kwdefaults__:
+        rewritten_kwdefaults.update(fn.__kwdefaults__)
+    rewritten.__kwdefaults__ = rewritten_kwdefaults
+    rewritten.__annotations__ = dict(getattr(fn, "__annotations__", {}))
+    rewritten.__doc__ = fn.__doc__
+    rewritten.__module__ = fn.__module__
+    rewritten.__qualname__ = fn.__qualname__
+    return rewritten
+
+
+def _find_function_def(tree, name: str):
+    matches = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    ]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+_MISSING_GLOBAL = object()
+
+
+def _temporarily_bind_globals(globals_ns, bindings):
+    restored = {}
+    for name, value in bindings.items():
+        restored[name] = globals_ns.get(name, _MISSING_GLOBAL)
+        globals_ns[name] = value
+    return restored
+
+
+def _restore_globals(globals_ns, restored):
+    for name, value in restored.items():
+        if value is _MISSING_GLOBAL:
+            globals_ns.pop(name, None)
+        else:
+            globals_ns[name] = value
+
+
+def _inject_closure_defaults(function_def, closure_bindings):
+    if not closure_bindings:
+        return
+    existing = {
+        arg.arg
+        for arg in (
+            list(function_def.args.posonlyargs)
+            + list(function_def.args.args)
+            + list(function_def.args.kwonlyargs)
+        )
+    }
+    if function_def.args.vararg is not None:
+        existing.add(function_def.args.vararg.arg)
+    if function_def.args.kwarg is not None:
+        existing.add(function_def.args.kwarg.arg)
+
+    for name in closure_bindings:
+        if name in existing:
+            continue
+        function_def.args.kwonlyargs.append(ast.arg(arg=name))
+        function_def.args.kw_defaults.append(ast.Constant(None))
+
+
+def _sanitize_signature_for_exec(function_def):
+    args = function_def.args
+    args.defaults = [ast.Constant(None) for _ in args.defaults]
+    args.kw_defaults = [
+        ast.Constant(None) if default is not None else None
+        for default in args.kw_defaults
+    ]
+    for arg in (
+        list(args.posonlyargs)
+        + list(args.args)
+        + list(args.kwonlyargs)
+    ):
+        arg.annotation = None
+    if args.vararg is not None:
+        args.vararg.annotation = None
+    if args.kwarg is not None:
+        args.kwarg.annotation = None
+    function_def.returns = None
+
+
+@dataclass(frozen=True)
+class _NameInfo:
+    loads: set[str]
+    stores: set[str]
+
+
+class _NameInfoVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.loads = set()
+        self.stores = set()
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, ast.Load):
+            self.loads.add(node.id)
+        elif isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.stores.add(node.id)
+
+    def visit_AugAssign(self, node):
+        self._visit_augassign_target_load(node.target)
+        self.visit(node.value)
+        self.visit(node.target)
+
+    def _visit_augassign_target_load(self, node):
+        if isinstance(node, ast.Name):
+            self.loads.add(node.id)
+            return
+        if isinstance(node, (ast.Attribute, ast.Subscript)):
+            self.visit(node.value)
+            return
+        self.visit(node)
+
+    def visit_FunctionDef(self, node):
+        self.stores.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self._visit_arguments_defaults(node.args)
+        self.loads.update(_function_free_vars(node))
+
+    def visit_AsyncFunctionDef(self, node):
+        self.visit_FunctionDef(node)
+
+    def visit_Lambda(self, node):
+        self._visit_arguments_defaults(node.args)
+        self.loads.update(_lambda_free_vars(node))
+
+    def visit_ClassDef(self, node):
+        self.stores.add(node.name)
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self.loads.update(_class_body_free_vars(node))
+
+    def _visit_arguments_defaults(self, args):
+        for default in args.defaults:
+            self.visit(default)
+        for default in args.kw_defaults:
+            if default is not None:
+                self.visit(default)
+
+
+def _name_info(node) -> _NameInfo:
+    visitor = _NameInfoVisitor()
+    if isinstance(node, list):
+        for item in node:
+            visitor.visit(item)
+    else:
+        visitor.visit(node)
+    return _NameInfo(visitor.loads, visitor.stores)
+
+
+class _ScopeBindingVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.stores = set()
+        self.globals = set()
+        self.nonlocals = set()
+
+    def visit_Name(self, node):
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.stores.add(node.id)
+
+    def visit_FunctionDef(self, node):
+        self.stores.add(node.name)
+
+    def visit_AsyncFunctionDef(self, node):
+        self.visit_FunctionDef(node)
+
+    def visit_Lambda(self, node):
+        return
+
+    def visit_ClassDef(self, node):
+        self.stores.add(node.name)
+
+    def visit_Global(self, node):
+        self.globals.update(node.names)
+
+    def visit_Nonlocal(self, node):
+        self.nonlocals.update(node.names)
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            self.stores.add(alias.asname or alias.name.split(".", 1)[0])
+
+    def visit_ImportFrom(self, node):
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            self.stores.add(alias.asname or alias.name)
+
+
+def _argument_names(args) -> set[str]:
+    names = {arg.arg for arg in list(args.posonlyargs) + list(args.args) + list(args.kwonlyargs)}
+    if args.vararg is not None:
+        names.add(args.vararg.arg)
+    if args.kwarg is not None:
+        names.add(args.kwarg.arg)
+    return names
+
+
+def _local_bindings(stmts) -> tuple[set[str], set[str]]:
+    visitor = _ScopeBindingVisitor()
+    for stmt in stmts:
+        visitor.visit(stmt)
+    local_stores = visitor.stores - visitor.globals - visitor.nonlocals
+    return local_stores, visitor.globals
+
+
+def _function_free_vars(node) -> set[str]:
+    local_stores, globals_declared = _local_bindings(node.body)
+    bound = _argument_names(node.args) | local_stores
+    body_info = _name_info(node.body)
+    return body_info.loads - bound - globals_declared
+
+
+def _lambda_free_vars(node) -> set[str]:
+    bound = _argument_names(node.args)
+    body_info = _name_info(node.body)
+    return body_info.loads - bound
+
+
+def _class_body_free_vars(node) -> set[str]:
+    local_stores, globals_declared = _local_bindings(node.body)
+    body_info = _name_info(node.body)
+    return body_info.loads - local_stores - globals_declared
+
+
+def _target_stores(node) -> set[str]:
+    return _name_info(node).stores
+
+
+def _live_before_block(stmts, live_after) -> set[str]:
+    live = set(live_after)
+    for stmt in reversed(stmts):
+        live = _live_before_stmt(stmt, live)
+    return live
+
+
+def _live_before_stmt(stmt, live_after) -> set[str]:
+    if isinstance(stmt, ast.If):
+        test_info = _name_info(stmt.test)
+        return (
+            set(test_info.loads)
+            | _live_before_block(stmt.body, live_after)
+            | _live_before_block(stmt.orelse, live_after)
+        )
+    if isinstance(stmt, ast.For):
+        iter_info = _name_info(stmt.iter)
+        target_stores = _target_stores(stmt.target)
+        body_info = _name_info(stmt.body)
+        orelse_info = _name_info(stmt.orelse)
+        assigned = target_stores | body_info.stores | orelse_info.stores
+        return (
+            (set(live_after) - assigned)
+            | set(iter_info.loads)
+            | (_live_before_block(stmt.body, set()) - target_stores)
+            | _live_before_block(stmt.orelse, set())
+        )
+    info = _name_info(stmt)
+    return (set(live_after) - info.stores) | info.loads
+
+
+def _read_before_assignment_names(stmts):
+    return _live_before_block(stmts, set())
+
+
+def _is_pto_attr_call(node, name: str) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == name
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "pto"
+    )
+
+
+def _is_range_call(node) -> bool:
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "range"
+
+
+def _range_triplet(call):
+    if not _is_range_call(call):
+        raise PTODSLAstRewriteError("ast_rewrite=True only rewrites for-loops over range(...)")
+    if call.keywords:
+        raise PTODSLAstRewriteError("ast_rewrite=True range(...) loops do not support keyword arguments")
+    args = call.args
+    if len(args) == 1:
+        return ast.Constant(0), args[0], ast.Constant(1)
+    if len(args) == 2:
+        return args[0], args[1], ast.Constant(1)
+    if len(args) == 3:
+        return args[0], args[1], args[2]
+    raise PTODSLAstRewriteError("ast_rewrite=True range(...) loops require 1 to 3 arguments")
+
+
+def _pto_attr(name: str, ctx=ast.Load()):
+    return ast.Attribute(value=ast.Name(id="pto", ctx=ast.Load()), attr=name, ctx=ctx)
+
+
+def _name(name: str, ctx=ast.Load()):
+    return ast.Name(id=name, ctx=ctx)
+
+
+class _ControlFlowRewriter:
+    def __init__(self):
+        self._counter = 0
+
+    def _fresh(self, prefix: str) -> str:
+        value = f"__pto_ast_{prefix}_{self._counter}"
+        self._counter += 1
+        return value
+
+    def rewrite_block(self, stmts, *, live_after, allow_loop_control=False):
+        rewritten_reversed = []
+        live = set(live_after)
+        for stmt in reversed(stmts):
+            rewritten = self.rewrite_stmt(
+                stmt,
+                live_after=live,
+                allow_loop_control=allow_loop_control,
+            )
+            rewritten_reversed[:0] = rewritten
+            live = _live_before_stmt(stmt, live)
+        return rewritten_reversed
+
+    def rewrite_stmt(self, stmt, *, live_after, allow_loop_control=False):
+        if isinstance(stmt, ast.If):
+            return self._rewrite_if(
+                stmt,
+                live_after=live_after,
+                allow_loop_control=allow_loop_control,
+            )
+        if isinstance(stmt, ast.For):
+            return self._rewrite_for(
+                stmt,
+                live_after=live_after,
+                allow_loop_control=allow_loop_control,
+            )
+        if isinstance(stmt, (ast.Break, ast.Continue)):
+            if allow_loop_control:
+                return [stmt]
+            raise PTODSLAstRewriteError("ast_rewrite=True does not support break/continue in rewritten control flow")
+        return [
+            self._rewrite_nested(
+                stmt,
+                live_after=live_after,
+                allow_loop_control=allow_loop_control,
+            )
+        ]
+
+    def _rewrite_nested(self, stmt, *, live_after, allow_loop_control=False):
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            stmt.body = self.rewrite_block(
+                stmt.body,
+                live_after=set(),
+                allow_loop_control=False,
+            )
+            return stmt
+        if isinstance(stmt, (ast.Lambda, ast.ClassDef)):
+            return stmt
+        for field, value in ast.iter_fields(stmt):
+            if field in {"body", "orelse", "finalbody"} and isinstance(value, list):
+                setattr(
+                    stmt,
+                    field,
+                    self.rewrite_block(
+                        value,
+                        live_after=live_after,
+                        allow_loop_control=allow_loop_control,
+                    ),
+                )
+            elif isinstance(value, ast.AST):
+                self._rewrite_nested(
+                    value,
+                    live_after=live_after,
+                    allow_loop_control=allow_loop_control,
+                )
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        self._rewrite_nested(
+                            item,
+                            live_after=live_after,
+                            allow_loop_control=allow_loop_control,
+                        )
+        return stmt
+
+    def _rewrite_if(self, stmt, *, live_after, allow_loop_control=False):
+        if _is_pto_attr_call(stmt.test, "const_expr"):
+            stmt.body = self.rewrite_block(
+                stmt.body,
+                live_after=live_after,
+                allow_loop_control=allow_loop_control,
+            )
+            stmt.orelse = self.rewrite_block(
+                stmt.orelse,
+                live_after=live_after,
+                allow_loop_control=allow_loop_control,
+            )
+            return [stmt]
+
+        cond_name = self._fresh("cond")
+        then_info = _name_info(stmt.body)
+        else_info = _name_info(stmt.orelse)
+        assigned_any = then_info.stores | else_info.stores
+        merge_names = tuple(sorted(live_after & assigned_any))
+        old_value_names = {
+            name: self._fresh(f"old_{name}")
+            for name in merge_names
+            if name not in then_info.stores or name not in else_info.stores
+        }
+
+        branch_live_after = set(live_after) | set(merge_names)
+        then_body = self.rewrite_block(
+            stmt.body,
+            live_after=branch_live_after,
+            allow_loop_control=False,
+        )
+        else_body = self.rewrite_block(
+            stmt.orelse,
+            live_after=branch_live_after,
+            allow_loop_control=False,
+        )
+        trace_time_if = ast.If(
+            test=_name(cond_name),
+            body=copy.deepcopy(then_body) or [ast.Pass()],
+            orelse=copy.deepcopy(else_body) or [ast.Pass()],
+        )
+        branch_name = self._fresh("br")
+
+        dynamic_then_body = copy.deepcopy(then_body)
+        dynamic_else_body = copy.deepcopy(else_body)
+        if merge_names:
+            dynamic_then_body.append(
+                self._branch_assign(
+                    branch_name,
+                    merge_names,
+                    old_value_names=old_value_names,
+                    assigned_names=then_info.stores,
+                )
+            )
+            dynamic_else_body.append(
+                self._branch_assign(
+                    branch_name,
+                    merge_names,
+                    old_value_names=old_value_names,
+                    assigned_names=else_info.stores,
+                )
+            )
+
+        with_stmt = ast.With(
+            items=[
+                ast.withitem(
+                    context_expr=ast.Call(func=_pto_attr("if_"), args=[_name(cond_name)], keywords=[]),
+                    optional_vars=_name(branch_name, ast.Store()),
+                )
+            ],
+            body=[
+                ast.With(
+                    items=[
+                        ast.withitem(
+                            context_expr=ast.Attribute(
+                                value=_name(branch_name),
+                                attr="then_",
+                                ctx=ast.Load(),
+                            ),
+                            optional_vars=None,
+                        )
+                    ],
+                    body=dynamic_then_body or [ast.Pass()],
+                    type_comment=None,
+                )
+            ],
+            type_comment=None,
+        )
+        if stmt.orelse or dynamic_else_body:
+            with_stmt.body.append(
+                ast.With(
+                    items=[
+                        ast.withitem(
+                            context_expr=ast.Attribute(
+                                value=_name(branch_name),
+                                attr="else_",
+                                ctx=ast.Load(),
+                            ),
+                            optional_vars=None,
+                        )
+                    ],
+                    body=dynamic_else_body or [ast.Pass()],
+                    type_comment=None,
+                )
+            )
+        dynamic_body = [with_stmt]
+        dynamic_body.extend(
+            ast.Assign(
+                targets=[_name(name, ast.Store())],
+                value=ast.Attribute(value=_name(branch_name), attr=name, ctx=ast.Load()),
+            )
+            for name in merge_names
+        )
+
+        result = [
+            ast.Assign(
+                targets=[_name(cond_name, ast.Store())],
+                value=stmt.test,
+            )
+        ]
+        result.extend(
+            ast.Assign(
+                targets=[_name(old_name, ast.Store())],
+                value=_name(name),
+            )
+            for name, old_name in old_value_names.items()
+        )
+        result.append(
+            ast.copy_location(
+                ast.If(
+                    test=ast.Call(
+                        func=_name("isinstance"),
+                        args=[_name(cond_name), _name("bool")],
+                        keywords=[],
+                    ),
+                    body=[trace_time_if],
+                    orelse=dynamic_body,
+                ),
+                stmt,
+            )
+        )
+        return result
+
+    def _branch_assign(self, branch_name, names, *, old_value_names, assigned_names):
+        return ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(value=_name(branch_name), attr="assign", ctx=ast.Load()),
+                args=[],
+                keywords=[
+                    ast.keyword(
+                        arg=name,
+                        value=_name(name if name in assigned_names else old_value_names[name]),
+                    )
+                    for name in names
+                ],
+            )
+        )
+
+    def _rewrite_for(self, stmt, *, live_after, allow_loop_control=False):
+        if _is_pto_attr_call(stmt.iter, "static_range"):
+            stmt.body = self.rewrite_block(
+                stmt.body,
+                live_after=live_after,
+                allow_loop_control=True,
+            )
+            stmt.orelse = self.rewrite_block(
+                stmt.orelse,
+                live_after=live_after,
+                allow_loop_control=allow_loop_control,
+            )
+            return [stmt]
+
+        if stmt.orelse:
+            raise PTODSLAstRewriteError("ast_rewrite=True does not support for-else on runtime loops")
+        if not isinstance(stmt.target, ast.Name):
+            raise PTODSLAstRewriteError("ast_rewrite=True runtime for-loops require a simple name target")
+        if stmt.target.id in live_after:
+            raise PTODSLAstRewriteError(
+                "ast_rewrite=True runtime for-loops cannot expose the loop induction variable outside the loop yet; "
+                f"use explicit pto.for_(...) for {stmt.target.id!r}"
+            )
+
+        start, stop, step = _range_triplet(stmt.iter)
+        body_info = _name_info(stmt.body)
+        reads_before = _read_before_assignment_names(stmt.body)
+        assigned_live_after = body_info.stores & set(live_after)
+        loop_carried = tuple(sorted(body_info.stores & reads_before))
+        unsupported_last_values = sorted(assigned_live_after - set(loop_carried))
+        if unsupported_last_values:
+            raise PTODSLAstRewriteError(
+                "ast_rewrite=True runtime for-loops cannot expose last-iteration-only values yet; "
+                f"use explicit pto.for_(...).carry(...) for {unsupported_last_values}"
+            )
+
+        loop_name = self._fresh("loop")
+        loop_live_after = set(live_after) | set(loop_carried)
+        body = self.rewrite_block(stmt.body, live_after=loop_live_after)
+
+        if loop_carried:
+            setup = ast.Assign(
+                targets=[_name(loop_name, ast.Store())],
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Call(
+                            func=_pto_attr("for_"),
+                            args=[start, stop],
+                            keywords=[ast.keyword(arg="step", value=step)],
+                        ),
+                        attr="carry",
+                        ctx=ast.Load(),
+                    ),
+                    args=[],
+                    keywords=[
+                        ast.keyword(arg=name, value=_name(name))
+                        for name in loop_carried
+                    ],
+                ),
+            )
+            prologue = [
+                ast.Assign(
+                    targets=[_name(stmt.target.id, ast.Store())],
+                    value=ast.Attribute(value=_name(loop_name), attr="iv", ctx=ast.Load()),
+                )
+            ]
+            prologue.extend(
+                ast.Assign(
+                    targets=[_name(name, ast.Store())],
+                    value=ast.Attribute(value=_name(loop_name), attr=name, ctx=ast.Load()),
+                )
+                for name in loop_carried
+            )
+            body = prologue + body + [
+                ast.Expr(
+                    value=ast.Call(
+                        func=ast.Attribute(value=_name(loop_name), attr="update", ctx=ast.Load()),
+                        args=[],
+                        keywords=[
+                            ast.keyword(arg=name, value=_name(name))
+                            for name in loop_carried
+                        ],
+                    )
+                )
+            ]
+            with_stmt = ast.With(
+                items=[ast.withitem(context_expr=_name(loop_name), optional_vars=None)],
+                body=body or [ast.Pass()],
+                type_comment=None,
+            )
+            result = [ast.copy_location(setup, stmt), ast.copy_location(with_stmt, stmt)]
+            for name in loop_carried:
+                result.append(
+                    ast.Assign(
+                        targets=[_name(name, ast.Store())],
+                        value=ast.Call(
+                            func=ast.Attribute(value=_name(loop_name), attr="final", ctx=ast.Load()),
+                            args=[ast.Constant(name)],
+                            keywords=[],
+                        ),
+                    )
+                )
+            return result
+
+        with_stmt = ast.With(
+            items=[
+                ast.withitem(
+                    context_expr=ast.Call(
+                        func=_pto_attr("for_"),
+                        args=[start, stop],
+                        keywords=[ast.keyword(arg="step", value=step)],
+                    ),
+                    optional_vars=_name(stmt.target.id, ast.Store()),
+                )
+            ],
+            body=body or [ast.Pass()],
+            type_comment=None,
+        )
+        return [ast.copy_location(with_stmt, stmt)]
+
+
+__all__ = [
+    "PTODSLAstRewriteError",
+    "rewrite_jit_function",
+]

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -17,6 +17,8 @@ Public API
                           – ``scf.for`` with optional named carry state via ``.carry(...)``
 ``if_(cond)``             – ``scf.if`` via explicit branch handle + automatic named merge
 ``yield_(*vals)``         – ``scf.yield``
+``static_range(...)``     – trace-time ``range(...)`` escape hatch for AST rewrite
+``const_expr(value)``     – trace-time ``if`` escape hatch for AST rewrite
 """
 
 from ._bootstrap import make_context  # noqa: F401
@@ -47,6 +49,18 @@ class _VecScopeCM:
 def vecscope() -> _VecScopeCM:
     """Return a context manager that emits ``pto.vecscope { … }``."""
     return _VecScopeCM()
+
+
+# ── compile-time control-flow helpers ─────────────────────────────────────────
+
+def static_range(*args):
+    """Return ``range(*args)`` for trace-time unrolling under AST rewrite."""
+    return range(*args)
+
+
+def const_expr(value):
+    """Return Python truthiness for trace-time branches under AST rewrite."""
+    return bool(value)
 
 
 # ── for_ ──────────────────────────────────────────────────────────────────────
@@ -573,6 +587,6 @@ def yield_(*vals):
 
 
 __all__ = [
-    "vecscope", "LoopHandle", "BranchHandle",
+    "vecscope", "static_range", "const_expr", "LoopHandle", "BranchHandle",
     "for_", "if_", "yield_",
 ]

--- a/ptodsl/ptodsl/_jit.py
+++ b/ptodsl/ptodsl/_jit.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Mapping
 
 from ._diagnostics import invalid_jit_mode_error
 from ._kernel_compilation import CompiledKernelHandle, KernelCompiler
@@ -24,6 +25,8 @@ from mlir.ir import InsertionPoint
 
 
 _MODULE_ATTRS = ("pto.target_arch", "pto.kernel_kind", "pto.mode")
+_SUPPORTED_FRONTEND_OPTION_KEYS = {"ast_rewrite", "rewrite_part", "dump_rewritten_source"}
+_SUPPORTED_REWRITE_PARTS = {"control_flow"}
 
 
 def _normalize_mode(mode: str, *, fn=None) -> str:
@@ -50,6 +53,49 @@ def _normalize_mode(mode: str, *, fn=None) -> str:
 def _module_attr_map(module):
     attrs = module.operation.attributes
     return {name: str(attrs[name]) for name in _MODULE_ATTRS if name in attrs}
+
+
+def _normalize_frontend_options(*, ast_rewrite, frontend_options):
+    if frontend_options is None:
+        return True if ast_rewrite is None else bool(ast_rewrite)
+    if not isinstance(frontend_options, Mapping):
+        raise TypeError("@pto.jit frontend_options must be a mapping")
+
+    unknown = set(frontend_options) - _SUPPORTED_FRONTEND_OPTION_KEYS
+    if unknown:
+        raise ValueError(f"@pto.jit frontend_options has unsupported keys: {sorted(unknown)!r}")
+
+    option_ast_rewrite = frontend_options.get("ast_rewrite")
+    if option_ast_rewrite is not None and not isinstance(option_ast_rewrite, bool):
+        raise TypeError("@pto.jit frontend_options['ast_rewrite'] must be a bool")
+    if ast_rewrite is not None and option_ast_rewrite is not None and bool(ast_rewrite) != option_ast_rewrite:
+        raise ValueError("@pto.jit ast_rewrite conflicts with frontend_options['ast_rewrite']")
+
+    enabled = option_ast_rewrite if option_ast_rewrite is not None else (True if ast_rewrite is None else bool(ast_rewrite))
+
+    rewrite_part = frontend_options.get("rewrite_part", {"control_flow"})
+    if isinstance(rewrite_part, str):
+        rewrite_parts = {rewrite_part}
+    else:
+        try:
+            rewrite_parts = set(rewrite_part)
+        except TypeError as exc:
+            raise TypeError("@pto.jit frontend_options['rewrite_part'] must be a string or iterable of strings") from exc
+    unsupported_parts = rewrite_parts - _SUPPORTED_REWRITE_PARTS
+    if unsupported_parts:
+        raise ValueError(
+            "@pto.jit frontend_options['rewrite_part'] currently only supports "
+            f"{sorted(_SUPPORTED_REWRITE_PARTS)!r}; got unsupported parts: {sorted(unsupported_parts)!r}"
+        )
+    if enabled and "control_flow" not in rewrite_parts:
+        raise ValueError("@pto.jit ast_rewrite=True requires rewrite_part to include 'control_flow'")
+
+    dump_rewritten_source = frontend_options.get("dump_rewritten_source", False)
+    if not isinstance(dump_rewritten_source, bool):
+        raise TypeError("@pto.jit frontend_options['dump_rewritten_source'] must be a bool")
+    if dump_rewritten_source:
+        raise ValueError("@pto.jit frontend_options['dump_rewritten_source']=True is reserved but not implemented yet")
+    return enabled
 
 
 def merge_jit_modules(*kernels: KernelHandle):
@@ -89,6 +135,8 @@ def jit(
     kernel_kind: str = "vector",
     mode: str = "auto",
     insert_sync: bool | None = None,
+    ast_rewrite: bool | None = None,
+    frontend_options: Mapping | None = None,
 ):
     """
     Decorator that wraps a Python function as a PTODSL JIT kernel template.
@@ -102,6 +150,14 @@ def jit(
     insert_sync: ``True``/``False`` to explicitly control PTOAS sync insertion
                  for launch builds. ``None`` keeps the mode-based default
                  behavior.
+    ast_rewrite:
+                 ``True`` enables AST rewriting of Python ``if`` /
+                 ``for range(...)`` into device-side PTODSL control flow.
+                 Defaults to ``True``. ``False`` is intended for frontend
+                 debugging and trace-time compatibility checks.
+    frontend_options:
+                 Reserved structured frontend options. Currently supports
+                 ``ast_rewrite`` and ``rewrite_part={"control_flow"}``.
 
     The decorated function is replaced by a :class:`KernelHandle` that:
 
@@ -111,6 +167,10 @@ def jit(
       default specialization for convenience.
     - emits a flat aicore launch-entry module by default.
     """
+    normalized_ast_rewrite = _normalize_frontend_options(
+        ast_rewrite=ast_rewrite,
+        frontend_options=frontend_options,
+    )
 
     def decorator(fn):
         fn_name = name or fn.__name__
@@ -135,6 +195,7 @@ def jit(
             ),
             kernel_signature,
             fn,
+            ast_rewrite=normalized_ast_rewrite,
         )
         return KernelHandle(fn.__name__, compiler)
 

--- a/ptodsl/ptodsl/_kernel_compilation.py
+++ b/ptodsl/ptodsl/_kernel_compilation.py
@@ -9,6 +9,9 @@
 
 from __future__ import annotations
 
+import inspect
+
+from ._ast_rewrite import rewrite_jit_function
 from ._runtime.launch import LaunchHandle, parse_launch_spec
 from ._tracing import ModuleArtifact, SignatureTracingRuntime
 
@@ -52,18 +55,33 @@ class CompiledKernelHandle(ModuleArtifact):
 class KernelCompiler:
     """Per-kernel specialization cache and module builder."""
 
-    def __init__(self, py_name: str, module_spec, kernel_signature, callback):
+    def __init__(
+        self,
+        py_name: str,
+        module_spec,
+        kernel_signature,
+        callback,
+        *,
+        ast_rewrite=True,
+    ):
         self._py_name = py_name
         self._module_spec = module_spec
         self._kernel_signature = kernel_signature
         self._callback = callback
         self._kernel_identity = id(callback)
+        self._ast_rewrite = ast_rewrite
         self._compiled_cache = {}
 
     def compile(self, **constexpr_bindings):
         normalized_bindings = self._kernel_signature.bind_constexpr_bindings(constexpr_bindings)
+        kernel_identity = self._kernel_identity
+        if self._ast_rewrite:
+            kernel_identity = (
+                kernel_identity,
+                _closure_cache_signature(self._callback),
+            )
         specialization_key = self._kernel_signature.specialization_key(
-            self._kernel_identity,
+            kernel_identity,
             normalized_bindings,
         )
 
@@ -71,10 +89,11 @@ class KernelCompiler:
         if cached is not None:
             return cached
 
+        callback = rewrite_jit_function(self._callback) if self._ast_rewrite else self._callback
         runtime = SignatureTracingRuntime(
             self._module_spec,
             self._kernel_signature,
-            self._callback,
+            callback,
             constexpr_bindings=normalized_bindings,
         )
         compiled = CompiledKernelHandle(
@@ -91,6 +110,49 @@ class KernelCompiler:
 
     def cached_specializations(self):
         return tuple(self._compiled_cache.values())
+
+
+def _closure_cache_signature(fn):
+    try:
+        closure_vars = inspect.getclosurevars(fn)
+    except TypeError:
+        return ()
+    return tuple(
+        (name, _cache_signature_atom(value))
+        for name, value in sorted(closure_vars.nonlocals.items())
+    )
+
+
+def _cache_signature_atom(value):
+    try:
+        hash(value)
+    except TypeError:
+        if isinstance(value, dict):
+            items = (
+                (_cache_signature_atom(key), _cache_signature_atom(item))
+                for key, item in value.items()
+            )
+            return (
+                "dict",
+                tuple(sorted(items, key=repr)),
+            )
+        if isinstance(value, (list, tuple)):
+            return (
+                type(value).__name__,
+                tuple(_cache_signature_atom(item) for item in value),
+            )
+        if isinstance(value, set):
+            return (
+                "set",
+                tuple(
+                    sorted(
+                        (_cache_signature_atom(item) for item in value),
+                        key=repr,
+                    )
+                ),
+            )
+        return (type(value).__name__, repr(value))
+    return value
 
 
 __all__ = [

--- a/ptodsl/ptodsl/_subkernels.py
+++ b/ptodsl/ptodsl/_subkernels.py
@@ -21,6 +21,7 @@ from ._diagnostics import (
     subkernel_host_tensor_boundary_error,
     subkernel_signature_boundary_error,
 )
+from ._ast_rewrite import rewrite_jit_function
 from ._host_tensors import TensorSpec, looks_like_host_tensor
 from ._surface_values import unwrap_surface_value
 from ._tracing import current_runtime, current_session
@@ -44,16 +45,18 @@ class SubkernelSpec:
 class SubkernelTemplate:
     """Callable decorated PTODSL subkernel surface."""
 
-    def __init__(self, spec: SubkernelSpec, py_fn):
+    def __init__(self, spec: SubkernelSpec, py_fn, *, ast_rewrite: bool = True):
         self.spec = spec
         self.py_fn = py_fn
+        self._ast_rewrite = ast_rewrite
         self.signature = inspect.signature(py_fn)
         self._validate_definition()
         update_wrapper(self, py_fn)
 
     def emit_body(self, *args, **kwargs):
         """Emit this subkernel body into the currently active trace."""
-        result = self.py_fn(*args, **kwargs)
+        py_fn = rewrite_jit_function(self.py_fn) if self._ast_rewrite else self.py_fn
+        result = py_fn(*args, **kwargs)
         self._validate_result(result)
         return result
 
@@ -130,10 +133,18 @@ def _validate_subkernel_placement(role: KernelRole, outer_frame, *, inline: bool
 class _SubkernelSurface:
     """Dual-use surface that supports both decorators and inline context-manager scopes."""
 
-    def __init__(self, role: KernelRole, *, name: str | None = None, target: str = "a5"):
+    def __init__(
+        self,
+        role: KernelRole,
+        *,
+        name: str | None = None,
+        target: str = "a5",
+        ast_rewrite: bool = True,
+    ):
         self._role = role
         self._name = name
         self._target = target
+        self._ast_rewrite = ast_rewrite
         self._session_cm = None
 
     def __call__(self, fn):
@@ -144,6 +155,7 @@ class _SubkernelSurface:
                 target=self._target,
             ),
             fn,
+            ast_rewrite=self._ast_rewrite,
         )
 
     def __enter__(self):
@@ -172,26 +184,39 @@ class _SubkernelSurface:
             self._session_cm = None
 
 
-def _subkernel_decorator(role: KernelRole, *, name: str | None = None, target: str = "a5"):
-    return _SubkernelSurface(role, name=name, target=target)
+def _subkernel_decorator(
+    role: KernelRole,
+    *,
+    name: str | None = None,
+    target: str = "a5",
+    ast_rewrite: bool = True,
+):
+    return _SubkernelSurface(role, name=name, target=target, ast_rewrite=ast_rewrite)
 
 
-def _decorate_subkernel(role: KernelRole, fn=None, *, name: str | None = None, target: str = "a5"):
+def _decorate_subkernel(
+    role: KernelRole,
+    fn=None,
+    *,
+    name: str | None = None,
+    target: str = "a5",
+    ast_rewrite: bool = True,
+):
     if fn is not None:
-        return _subkernel_decorator(role, name=name, target=target)(fn)
-    return _subkernel_decorator(role, name=name, target=target)
+        return _subkernel_decorator(role, name=name, target=target, ast_rewrite=ast_rewrite)(fn)
+    return _subkernel_decorator(role, name=name, target=target, ast_rewrite=ast_rewrite)
 
 
-def cube(fn=None, *, name: str | None = None, target: str = "a5"):
-    return _decorate_subkernel(KernelRole.CUBE, fn, name=name, target=target)
+def cube(fn=None, *, name: str | None = None, target: str = "a5", ast_rewrite: bool = True):
+    return _decorate_subkernel(KernelRole.CUBE, fn, name=name, target=target, ast_rewrite=ast_rewrite)
 
 
-def simd(fn=None, *, name: str | None = None, target: str = "a5"):
-    return _decorate_subkernel(KernelRole.SIMD, fn, name=name, target=target)
+def simd(fn=None, *, name: str | None = None, target: str = "a5", ast_rewrite: bool = True):
+    return _decorate_subkernel(KernelRole.SIMD, fn, name=name, target=target, ast_rewrite=ast_rewrite)
 
 
-def simt(fn=None, *, name: str | None = None, target: str = "a5"):
-    return _decorate_subkernel(KernelRole.SIMT, fn, name=name, target=target)
+def simt(fn=None, *, name: str | None = None, target: str = "a5", ast_rewrite: bool = True):
+    return _decorate_subkernel(KernelRole.SIMT, fn, name=name, target=target, ast_rewrite=ast_rewrite)
 
 
 __all__ = [

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -114,6 +114,7 @@ from ._ops import (             # noqa: F401
 # ── Control flow ──────────────────────────────────────────────────────────────
 from ._control_flow import (    # noqa: F401
     for_, if_, yield_,
+    const_expr, static_range,
     LoopHandle, BranchHandle,
 )
 

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -303,7 +303,7 @@ FRAGMENT_FIXTURES = {
             a_view = pto.make_tensor_view(A_ptr, shape=[rows, cols], strides=[cols, 1])
             o_view = pto.make_tensor_view(O_ptr, shape=[rows, cols], strides=[cols, 1])
             tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
-            with pto.for_(0, rows, step=1) as row:
+            for row in range(0, rows, 1):
                 a_part = pto.partition_view(a_view, offsets=[row, 0], sizes=[1, cols])
                 o_part = pto.partition_view(o_view, offsets=[row, 0], sizes=[1, cols])
                 pto.tile.load(a_part, tile)
@@ -506,7 +506,7 @@ FRAGMENT_FIXTURES = {
             cols = pto.const(BLOCK, dtype=pto.i32)
             tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
             out_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
-            with pto.for_(0, 1, step=1) as r:
+            for r in pto.static_range(1):
                 {SNIPPET_PLACEHOLDER}
         """
     ),
@@ -697,7 +697,7 @@ FRAGMENT_FIXTURES = {
             b_tile: pto.Tile,
             o_tile: pto.Tile,
         ):
-            with pto.for_(0, 1, step=1) as r:
+            for r in range(0, 1, 1):
                 c = pto.const(0, dtype=pto.index)
                 mask, _ = pto.make_mask(pto.f32, pto.const(16, dtype=pto.i32))
                 {SNIPPET_PLACEHOLDER}
@@ -720,7 +720,7 @@ FRAGMENT_FIXTURES = {
             beta_tile: pto.Tile,
             o_next_tile: pto.Tile,
         ):
-            with pto.for_(0, 1, step=1) as row:
+            for row in range(0, 1, 1):
                 col = pto.const(0, dtype=pto.index)
                 o_prev = scalar.load(o_prev_tile[row, col])
                 pv_val = scalar.load(pv_tile[row, col])
@@ -1058,7 +1058,7 @@ FRAGMENT_FIXTURES = {
         ):
             tile = pto.alloc_tile(shape=[2, BLOCK], dtype=pto.f32)
             col = 0
-            with pto.for_(0, 1, step=1) as row:
+            for row in range(0, 1, 1):
                 {SNIPPET_PLACEHOLDER}
         """
     ),
@@ -1119,7 +1119,7 @@ FRAGMENT_FIXTURES = {
         def compute_ops_vector_probe(*, BLOCK: pto.constexpr = 128):
             inp_tile = pto.alloc_tile(shape=[2, BLOCK], dtype=pto.f32)
             out_tile = pto.alloc_tile(shape=[2, BLOCK], dtype=pto.f32)
-            with pto.for_(0, 1, step=1) as row:
+            for row in range(0, 1, 1):
                 compute_ops_vector_helper(inp_tile, out_tile, row)
         """
     ),
@@ -1642,7 +1642,7 @@ FRAGMENT_FIXTURES = {
             row_stop: pto.i32,
             valid_cols: pto.i32,
         ):
-            with pto.for_(row_start, row_stop, step=1) as row:
+            for row in range(row_start, row_stop, 1):
                 col_mask = pto.make_mask(pto.f32, valid_cols)
                 s_row = pto.vlds(s_tile[row, 0:])
                 m_prev = scalar.load(m_prev_tile[row, 0])
@@ -1686,7 +1686,7 @@ FRAGMENT_FIXTURES = {
             row_stop: pto.i32,
             valid_cols: pto.i32,
         ):
-            with pto.for_(row_start, row_stop, step=1) as row:
+            for row in range(row_start, row_stop, 1):
                 col_mask = pto.make_mask(pto.f32, valid_cols)
                 p_row = pto.vexp(pto.vlds(s_tile[row, 0:]), col_mask)
                 m_next = scalar.load(m_prev_tile[row, 0])

--- a/ptodsl/tests/test_ast_rewrite_example_ir.py
+++ b/ptodsl/tests/test_ast_rewrite_example_ir.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import re
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "ptodsl"))
+
+from ptodsl import pto
+from ptodsl._bootstrap import make_context
+from mlir.ir import Module
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def expect_parse_roundtrip_and_verify(text: str, label: str) -> None:
+    with make_context() as ctx:
+        parsed = Module.parse(text, ctx)
+        parsed.operation.verify()
+        roundtrip_text = str(parsed)
+    expect(
+        roundtrip_text == text,
+        f"{label} should survive Module.parse(...) round-trip without textual drift",
+    )
+
+
+def mlir_op_sequence(text: str) -> list[str]:
+    ops = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        match = re.search(r"(?:%[\w#]+(?:\s*:\s*[^=]+)?\s*=\s*)?([a-z][\w]*\.[\w_]+)", stripped)
+        if match is not None:
+            ops.append(match.group(1))
+    return ops
+
+
+def load_example(filename: str, module_name: str):
+    demo_path = REPO_ROOT / "ptodsl" / "examples" / filename
+    spec = spec_from_file_location(module_name, demo_path)
+    expect(spec is not None and spec.loader is not None, f"unable to create import spec for {demo_path}")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def compare_modules(
+    ast_rewrite_text: str,
+    explicit_text: str,
+    *,
+    label: str,
+    required_patterns: tuple[str, ...],
+) -> None:
+    expect_parse_roundtrip_and_verify(ast_rewrite_text, f"AST-rewrite {label} example MLIR")
+    expect_parse_roundtrip_and_verify(explicit_text, f"explicit {label} baseline MLIR")
+    expect(
+        mlir_op_sequence(ast_rewrite_text) == mlir_op_sequence(explicit_text),
+        f"{label} AST-rewrite example should emit the same operation sequence as explicit control-flow baseline",
+    )
+    for pattern in required_patterns:
+        expect(
+            ast_rewrite_text.count(pattern) == explicit_text.count(pattern),
+            f"{label} AST-rewrite example should match explicit baseline count for {pattern}",
+        )
+
+
+def make_explicit_tadd_kernel():
+    from ptodsl import scalar
+
+    s = scalar
+
+    @pto.jit(name="explicit_TADD", kernel_kind="vector", target="a5")
+    def kernel():
+        c0_i64 = pto.const(0, dtype=pto.int64)
+        c16 = pto.const(16, dtype=pto.index)
+        c4096_i64 = pto.const(4096, dtype=pto.int64)
+        c0 = pto.const(0)
+        c1 = pto.const(1)
+        c64_i32 = pto.const(64, dtype=pto.int32)
+        c64 = pto.const(64)
+
+        with pto.simd():
+            ptr_f32_ub = pto.ptr(pto.float32, "ub")
+            vf32 = pto.vreg_type(64, pto.float32)
+            ptr_src = pto.castptr(c4096_i64, ptr_f32_ub)
+            ptr_dst = pto.castptr(c0_i64, ptr_f32_ub)
+
+            with pto.for_(c0, c16, step=c1) as tile_idx:
+                mask, _ = pto.plt_b32(c64_i32)
+                tile_off = s.muli(tile_idx, c64)
+                va = pto.vlds(pto.addptr(ptr_src, tile_off), c0, vf32)
+                ptr_dst_tile = pto.addptr(ptr_dst, tile_off)
+                vb = pto.vlds(ptr_dst_tile, c0, vf32)
+                vc = pto.vadd(va, vb, mask)
+                pto.vsts(vc, ptr_dst_tile, c0, mask)
+
+    return kernel
+
+
+def make_explicit_softmax_kernel(name: str, *, rows: int, seq: int):
+    @pto.jit(
+        name=name,
+        kernel_kind="vector",
+        target="a5",
+        mode="explicit",
+        insert_sync=False,
+    )
+    def kernel(
+        scores_ptr: pto.ptr(pto.f32, "gm"),
+        out_ptr: pto.ptr(pto.f32, "gm"),
+        runtime_rows: pto.i32,
+        runtime_seq: pto.i32,
+    ):
+        packed_rows = pto.elements_per_vreg(pto.f32)
+        physical_rows = ((rows + packed_rows - 1) // packed_rows) * packed_rows
+        scores_tile_bytes = seq * physical_rows * pto.bytewidth(pto.f32)
+        has_rows = runtime_rows > 0
+
+        with pto.if_(has_rows) as has_rows_br:
+            with has_rows_br.then_:
+                scores_view = pto.make_tensor_view(
+                    scores_ptr,
+                    shape=[seq, rows],
+                    strides=[1, seq],
+                )
+                out_view = pto.make_tensor_view(
+                    out_ptr,
+                    shape=[seq, rows],
+                    strides=[1, seq],
+                )
+                scores_tile = pto.alloc_tile(
+                    shape=[seq, physical_rows],
+                    dtype=pto.float32,
+                    addr=pto.const(0, dtype=pto.i64),
+                    valid_shape=[runtime_seq, runtime_rows],
+                )
+                out_tile = pto.alloc_tile(
+                    shape=[seq, physical_rows],
+                    dtype=pto.float32,
+                    addr=pto.const(scores_tile_bytes, dtype=pto.i64),
+                    valid_shape=[runtime_seq, runtime_rows],
+                )
+
+                pto.tile.load(scores_view, scores_tile)
+
+                pto.set_flag("MTE2", "V", event_id=0)
+                pto.wait_flag("MTE2", "V", event_id=0)
+
+                with pto.simd():
+                    row_loop = pto.for_(0, runtime_rows, step=packed_rows).carry(remained=runtime_rows)
+                    with row_loop:
+                        row_base = row_loop.iv
+                        remaining_rows = row_loop.remained
+                        active_rows, remaining_after_pack = pto.make_mask(pto.f32, remaining_rows)
+                        running_max = pto.vlds(scores_tile[0, row_base:])
+                        running_sum = pto.vbr(1.0)
+
+                        softmax_loop = pto.for_(1, runtime_seq, step=1).carry(
+                            running_max=running_max,
+                            running_sum=running_sum,
+                        )
+                        with softmax_loop:
+                            col = softmax_loop.iv
+                            running_max = softmax_loop.running_max
+                            running_sum = softmax_loop.running_sum
+                            col_vec = pto.vlds(scores_tile[col, row_base:])
+                            merged_max = pto.vmax(running_max, col_vec, active_rows)
+                            running_delta = pto.vsub(running_max, merged_max, active_rows)
+                            scaled_running = pto.vexp(running_delta, active_rows)
+                            running_sum_scaled = pto.vmul(scaled_running, running_sum, active_rows)
+                            col_delta = pto.vsub(col_vec, merged_max, active_rows)
+                            col_exp = pto.vexp(col_delta, active_rows)
+                            merged_sum = pto.vadd(running_sum_scaled, col_exp, active_rows)
+                            softmax_loop.update(running_max=merged_max, running_sum=merged_sum)
+
+                        final_max = softmax_loop.final("running_max")
+                        final_sum = softmax_loop.final("running_sum")
+
+                        with pto.for_(0, runtime_seq, step=1) as col:
+                            col_vec = pto.vlds(scores_tile[col, row_base:])
+                            out_delta = pto.vsub(col_vec, final_max, active_rows)
+                            exp_vec = pto.vexp(out_delta, active_rows)
+                            out_vec = pto.vdiv(exp_vec, final_sum, active_rows)
+                            pto.vsts(out_vec, out_tile[col, row_base:], active_rows)
+
+                        row_loop.update(remained=remaining_after_pack)
+
+                pto.set_flag("V", "MTE3", event_id=0)
+                pto.wait_flag("V", "MTE3", event_id=0)
+
+                pto.tile.store(out_tile, out_view)
+                pto.pipe_barrier(pto.Pipe.ALL)
+
+    return kernel
+
+
+def make_explicit_launch_softmax_kernel(name: str, *, rows: int, seq: int):
+    @pto.jit(
+        name=name,
+        target="a5",
+        mode="explicit",
+        insert_sync=False,
+    )
+    def kernel(
+        scores_ptr: pto.ptr(pto.f32, "gm"),
+        out_ptr: pto.ptr(pto.f32, "gm"),
+        runtime_seq: pto.i32,
+        runtime_rows: pto.i32,
+    ):
+        lane_num = pto.elements_per_vreg(pto.f32)
+        physical_rows = ((rows + lane_num - 1) // lane_num) * lane_num
+        scores_tile_bytes = seq * physical_rows * pto.bytewidth(pto.f32)
+        total_elems = runtime_rows * runtime_seq
+
+        scores_view = pto.make_tensor_view(
+            scores_ptr,
+            shape=[1, 1, 1, runtime_seq, runtime_rows],
+            strides=[total_elems, total_elems, total_elems, runtime_rows, 1],
+        )
+        out_view = pto.make_tensor_view(
+            out_ptr,
+            shape=[1, 1, 1, runtime_seq, runtime_rows],
+            strides=[total_elems, total_elems, total_elems, runtime_rows, 1],
+        )
+        scores_part = pto.partition_view(
+            scores_view,
+            offsets=[0, 0, 0, 0, 0],
+            sizes=[1, 1, 1, runtime_seq, runtime_rows],
+        )
+        out_part = pto.partition_view(
+            out_view,
+            offsets=[0, 0, 0, 0, 0],
+            sizes=[1, 1, 1, runtime_seq, runtime_rows],
+        )
+
+        scores_tile = pto.alloc_tile(
+            shape=[seq, physical_rows],
+            dtype=pto.float32,
+            addr=0,
+            valid_shape=[runtime_seq, runtime_rows],
+            blayout="RowMajor",
+        )
+        out_tile = pto.alloc_tile(
+            shape=[seq, physical_rows],
+            dtype=pto.float32,
+            addr=scores_tile_bytes,
+            valid_shape=[runtime_seq, runtime_rows],
+            blayout="RowMajor",
+        )
+
+        pto.tile.load(scores_part, scores_tile)
+        out_tile.fill(0.0)
+
+        pto.set_flag("MTE2", "V", event_id=0)
+        pto.wait_flag("MTE2", "V", event_id=0)
+
+        with pto.simd():
+            row_loop = pto.for_(0, runtime_rows, step=lane_num).carry(remained=runtime_rows)
+            with row_loop:
+                row_base = row_loop.iv
+                remaining_rows = row_loop.remained
+                active_rows, remaining_after_pack = pto.make_mask(pto.f32, remaining_rows)
+                running_max = pto.vlds(scores_tile[0, row_base:])
+                running_sum = pto.vbr(1.0)
+
+                softmax_loop = pto.for_(1, runtime_seq, step=1).carry(
+                    running_max=running_max,
+                    running_sum=running_sum,
+                )
+                with softmax_loop:
+                    col = softmax_loop.iv
+                    running_max = softmax_loop.running_max
+                    running_sum = softmax_loop.running_sum
+                    col_vec = pto.vlds(scores_tile[col, row_base:])
+                    merged_max = pto.vmax(running_max, col_vec, active_rows)
+                    running_delta = pto.vsub(running_max, merged_max, active_rows)
+                    scaled_running = pto.vexp(running_delta, active_rows)
+                    running_sum_scaled = pto.vmul(scaled_running, running_sum, active_rows)
+                    col_delta = pto.vsub(col_vec, merged_max, active_rows)
+                    col_exp = pto.vexp(col_delta, active_rows)
+                    merged_sum = pto.vadd(running_sum_scaled, col_exp, active_rows)
+                    softmax_loop.update(running_max=merged_max, running_sum=merged_sum)
+
+                final_max = softmax_loop.final("running_max")
+                final_sum = softmax_loop.final("running_sum")
+
+                with pto.for_(0, runtime_seq, step=1) as col:
+                    col_vec = pto.vlds(scores_tile[col, row_base:])
+                    out_delta = pto.vsub(col_vec, final_max, active_rows)
+                    exp_vec = pto.vexp(out_delta, active_rows)
+                    out_vec = pto.vdiv(exp_vec, final_sum, active_rows)
+                    pto.vsts(out_vec, out_tile[col, row_base:], active_rows)
+
+                row_loop.update(remained=remaining_after_pack)
+
+        pto.set_flag("V", "MTE3", event_id=0)
+        pto.wait_flag("V", "MTE3", event_id=0)
+
+        pto.tile.store(out_tile, out_part)
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+    return kernel
+
+
+def make_explicit_flash_attention_kernel(example):
+    @pto.jit(
+        name="explicit_flash_attention_kernel",
+        target="a5",
+        mode="explicit",
+        insert_sync=False,
+    )
+    def kernel(
+        Q_ptr: pto.ptr(pto.f32, "gm"),
+        K_ptr: pto.ptr(pto.f32, "gm"),
+        V_ptr: pto.ptr(pto.f32, "gm"),
+        O_ptr: pto.ptr(pto.f32, "gm"),
+        batch: pto.i32,
+        seq_q: pto.i32,
+        seq_k: pto.i32,
+        heads: pto.i32,
+        dim: pto.i32,
+        *,
+        BLOCK_Q: pto.constexpr = 128,
+        BLOCK_KV: pto.constexpr = 128,
+        HEAD_DIM: pto.constexpr = 128,
+        CAUSAL: pto.constexpr = False,
+        NUM_STAGES: pto.constexpr = 2,
+    ):
+        q_strides = [seq_q * heads * dim, heads * dim, dim, 1]
+        kv_strides = [seq_k * heads * dim, heads * dim, dim, 1]
+        o_strides = [seq_q * heads * dim, heads * dim, dim, 1]
+
+        q_view = pto.make_tensor_view(Q_ptr, shape=[batch, seq_q, heads, dim], strides=q_strides)
+        k_view = pto.make_tensor_view(K_ptr, shape=[batch, seq_k, heads, dim], strides=kv_strides)
+        v_view = pto.make_tensor_view(V_ptr, shape=[batch, seq_k, heads, dim], strides=kv_strides)
+        o_view = pto.make_tensor_view(O_ptr, shape=[batch, seq_q, heads, dim], strides=o_strides)
+
+        block_idx = pto.get_block_idx()
+        block_num = pto.get_block_num()
+        subblock_idx = pto.get_subblock_idx()
+        subblock_num = pto.get_subblock_num()
+        _ = block_num
+        _ = subblock_idx
+        _ = subblock_num
+
+        batch_idx = block_idx // heads
+        head_idx = block_idx % heads
+
+        q_head = pto.partition_view(q_view, offsets=[batch_idx, 0, head_idx, 0], sizes=[1, seq_q, 1, dim])
+        k_head = pto.partition_view(k_view, offsets=[batch_idx, 0, head_idx, 0], sizes=[1, seq_k, 1, dim])
+        v_head = pto.partition_view(v_view, offsets=[batch_idx, 0, head_idx, 0], sizes=[1, seq_k, 1, dim])
+        o_head = pto.partition_view(o_view, offsets=[batch_idx, 0, head_idx, 0], sizes=[1, seq_q, 1, dim])
+
+        Br = BLOCK_Q
+        Bc = BLOCK_KV
+        D = HEAD_DIM
+        full_br = pto.const(Br)
+        full_bc = pto.const(Bc)
+        one = pto.const(1)
+
+        q_blocks = (seq_q + Br - 1) // Br
+        kv_blocks = (seq_k + Bc - 1) // Bc
+
+        q_mat = pto.alloc_tile(
+            shape=[Br, D],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.MAT,
+            valid_shape=[full_br, dim],
+            blayout="ColMajor",
+            slayout="RowMajor",
+        )
+        k_mat = pto.alloc_tile(
+            shape=[Bc, D],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.MAT,
+            valid_shape=[full_bc, dim],
+            blayout="ColMajor",
+            slayout="RowMajor",
+        )
+        v_mat = pto.alloc_tile(
+            shape=[Bc, D],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.MAT,
+            valid_shape=[full_bc, dim],
+            blayout="ColMajor",
+            slayout="RowMajor",
+        )
+
+        o_prev_tile = pto.alloc_tile(shape=[Br, D], dtype=pto.f32, valid_shape=[full_br, dim])
+        o_next_tile = pto.alloc_tile(shape=[Br, D], dtype=pto.f32, valid_shape=[full_br, dim])
+        m_prev_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
+        m_next_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
+        l_prev_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
+        l_next_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
+
+        s_tile = pto.alloc_tile(shape=[Br, Bc], dtype=pto.f32, valid_shape=[full_br, full_bc])
+        p_tile = pto.alloc_tile(shape=[Br, Bc], dtype=pto.f32, valid_shape=[full_br, full_bc])
+        p_mat = pto.alloc_tile(
+            shape=[Br, Bc],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.MAT,
+            valid_shape=[full_br, full_bc],
+            blayout="ColMajor",
+            slayout="RowMajor",
+        )
+        pv_tile = pto.alloc_tile(shape=[Br, D], dtype=pto.f32, valid_shape=[full_br, dim])
+        alpha_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
+        beta_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
+
+        q_l0a = pto.alloc_tile(
+            shape=[Br, D],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.LEFT,
+            valid_shape=[full_br, dim],
+        )
+        p_l0a = pto.alloc_tile(
+            shape=[Br, Bc],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.LEFT,
+            valid_shape=[full_br, full_bc],
+        )
+        rhs_l0b = pto.alloc_tile(
+            shape=[Bc, D],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.RIGHT,
+            valid_shape=[full_bc, dim],
+        )
+        qk_acc_tile = pto.alloc_tile(
+            shape=[Br, Bc],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.ACC,
+            valid_shape=[full_br, full_bc],
+        )
+        pv_acc_tile = pto.alloc_tile(
+            shape=[Br, D],
+            dtype=pto.f32,
+            memory_space=pto.MemorySpace.ACC,
+            valid_shape=[full_br, dim],
+        )
+
+        meta_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32, valid_shape=[1, 3])
+        meta_ptr = meta_tile.as_ptr()
+
+        with pto.for_(0, q_blocks, step=1) as qi:
+            q_rows = example._block_valid_extent(seq_q, qi, Br)
+            q_part = pto.partition_view(q_head, offsets=[0, qi * Br, 0, 0], sizes=[1, q_rows, 1, dim])
+            o_part = pto.partition_view(o_head, offsets=[0, qi * Br, 0, 0], sizes=[1, q_rows, 1, dim])
+
+            q_mat.valid_shape = [q_rows, dim]
+            o_prev_tile.valid_shape = [q_rows, dim]
+            o_next_tile.valid_shape = [q_rows, dim]
+            m_prev_tile.valid_shape = [q_rows, one]
+            m_next_tile.valid_shape = [q_rows, one]
+            l_prev_tile.valid_shape = [q_rows, one]
+            l_next_tile.valid_shape = [q_rows, one]
+            alpha_tile.valid_shape = [q_rows, one]
+            beta_tile.valid_shape = [q_rows, one]
+            p_mat.valid_shape = [q_rows, full_bc]
+            pv_tile.valid_shape = [q_rows, dim]
+            q_l0a.valid_shape = [q_rows, dim]
+
+            pto.tile.load(q_part, q_mat)
+            m_prev_tile.fill(float("-inf"))
+            l_prev_tile.fill(0.0)
+            o_prev_tile.fill(0.0)
+
+            kv_loop = pto.for_(0, kv_blocks, step=1).carry(
+                m=m_prev_tile,
+                l=l_prev_tile,
+                o=o_prev_tile,
+            )
+            with kv_loop:
+                kj = kv_loop.iv
+                m_cur = kv_loop.m
+                l_cur = kv_loop.l
+                o_cur = kv_loop.o
+                kv_rows = example._block_valid_extent(seq_k, kj, Bc)
+                k_part = pto.partition_view(k_head, offsets=[0, kj * Bc, 0, 0], sizes=[1, kv_rows, 1, dim])
+                v_part = pto.partition_view(v_head, offsets=[0, kj * Bc, 0, 0], sizes=[1, kv_rows, 1, dim])
+
+                k_mat.valid_shape = [kv_rows, dim]
+                v_mat.valid_shape = [kv_rows, dim]
+                s_tile.valid_shape = [q_rows, kv_rows]
+                p_tile.valid_shape = [q_rows, kv_rows]
+                p_mat.valid_shape = [q_rows, kv_rows]
+                pv_tile.valid_shape = [q_rows, dim]
+                p_l0a.valid_shape = [q_rows, kv_rows]
+                rhs_l0b.valid_shape = [kv_rows, dim]
+                qk_acc_tile.valid_shape = [q_rows, kv_rows]
+                pv_acc_tile.valid_shape = [q_rows, dim]
+
+                example.kv_block_process(
+                    q_mat,
+                    k_part,
+                    v_part,
+                    k_mat,
+                    v_mat,
+                    o_cur,
+                    o_next_tile,
+                    m_cur,
+                    l_cur,
+                    m_next_tile,
+                    l_next_tile,
+                    s_tile,
+                    p_tile,
+                    p_mat,
+                    pv_tile,
+                    alpha_tile,
+                    beta_tile,
+                    q_l0a,
+                    p_l0a,
+                    rhs_l0b,
+                    qk_acc_tile,
+                    pv_acc_tile,
+                    meta_ptr,
+                )
+                kv_loop.update(m=m_next_tile, l=l_next_tile, o=o_next_tile)
+
+            pto.tile.store(kv_loop.final("o"), o_part)
+
+        _ = CAUSAL
+        _ = NUM_STAGES
+
+    return kernel
+
+
+EXPLICIT_TADD = make_explicit_tadd_kernel()
+EXPLICIT_SOFTMAX_ROWS64_SEQ128 = make_explicit_softmax_kernel(
+    "explicit_softmax_rows64_seq128",
+    rows=64,
+    seq=128,
+)
+EXPLICIT_SOFTMAX_ROWS81_SEQ96 = make_explicit_softmax_kernel(
+    "explicit_softmax_rows81_seq96",
+    rows=81,
+    seq=96,
+)
+EXPLICIT_LAUNCH_SOFTMAX_ROWS64_SEQ128 = make_explicit_launch_softmax_kernel(
+    "explicit_launch_softmax_rows64_seq128",
+    rows=64,
+    seq=128,
+)
+EXPLICIT_LAUNCH_SOFTMAX_ROWS81_SEQ96 = make_explicit_launch_softmax_kernel(
+    "explicit_launch_softmax_rows81_seq96",
+    rows=81,
+    seq=96,
+)
+
+
+def explicit_softmax_module():
+    return pto.merge_jit_modules(EXPLICIT_SOFTMAX_ROWS64_SEQ128, EXPLICIT_SOFTMAX_ROWS81_SEQ96)
+
+
+def explicit_launch_softmax_module():
+    return pto.merge_jit_modules(EXPLICIT_LAUNCH_SOFTMAX_ROWS64_SEQ128, EXPLICIT_LAUNCH_SOFTMAX_ROWS81_SEQ96)
+
+
+def main() -> None:
+    tadd_example = load_example("tadd_dsl.py", "ptodsl_tadd_ast_rewrite_example")
+    compare_modules(
+        str(tadd_example.build()),
+        str(EXPLICIT_TADD.mlir_module()),
+        label="tadd_dsl",
+        required_patterns=("scf.for", "pto.vadd", "pto.vsts"),
+    )
+
+    softmax_example = load_example("softmax_dsl.py", "ptodsl_softmax_ast_rewrite_example")
+    compare_modules(
+        str(softmax_example.build()),
+        str(explicit_softmax_module()),
+        label="softmax_dsl",
+        required_patterns=("scf.if", "scf.for", "iter_args(", "scf.yield", "pto.vexp", "pto.vdiv"),
+    )
+
+    launch_softmax_example = load_example(
+        "flash_attention_softmax_launch.py",
+        "ptodsl_flash_attention_softmax_launch_ast_rewrite_example",
+    )
+    compare_modules(
+        str(launch_softmax_example.emit_mlir()),
+        str(explicit_launch_softmax_module()),
+        label="flash_attention_softmax_launch",
+        required_patterns=("scf.for", "iter_args(", "scf.yield", "pto.vexp", "pto.vdiv"),
+    )
+
+    flash_attention_example = load_example(
+        "flash_attention_sketch.py",
+        "ptodsl_flash_attention_ast_rewrite_example",
+    )
+    explicit_flash_attention_kernel = make_explicit_flash_attention_kernel(flash_attention_example)
+    compare_modules(
+        flash_attention_example.flash_attention_kernel.compile(
+            BLOCK_Q=64,
+            BLOCK_KV=128,
+            HEAD_DIM=128,
+            CAUSAL=True,
+        ).mlir_text(),
+        explicit_flash_attention_kernel.compile(
+            BLOCK_Q=64,
+            BLOCK_KV=128,
+            HEAD_DIM=128,
+            CAUSAL=True,
+        ).mlir_text(),
+        label="flash_attention_sketch",
+        required_patterns=("scf.for", "iter_args(", "scf.yield", "func.call", "pto.mad"),
+    )
+
+    print("ptodsl_ast_rewrite_example_ir: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/tests/test_docs_as_test.py
+++ b/ptodsl/tests/test_docs_as_test.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 import json
+import linecache
 import re
 import shutil
 import subprocess
@@ -269,8 +270,11 @@ def execute_source(
     }
     if extra_namespace is not None:
         namespace.update(extra_namespace)
+    filename = f"{block.path}::codeblock:{block.start_line}"
+    source_lines = source.splitlines(keepends=True)
+    linecache.cache[filename] = (len(source), None, source_lines, filename)
     try:
-        exec(compile(source, str(block.path), "exec"), namespace, namespace)
+        exec(compile(source, filename, "exec"), namespace, namespace)
     except Exception as exc:
         raise AssertionError(
             f"{block_label(block, symbol)}: snippet execution failed: {exc.__class__.__name__}: {exc}"

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -56,6 +56,16 @@ def expect_parse_roundtrip_and_verify(text: str, label: str) -> None:
     )
 
 
+def mlir_op_sequence(text: str) -> list[str]:
+    ops = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        match = re.search(r"(?:%[\w#]+(?:\s*:\s*[^=]+)?\s*=\s*)?([a-z][\w]*\.[\w_]+)", stripped)
+        if match is not None:
+            ops.append(match.group(1))
+    return ops
+
+
 expect_raises(
     TypeError,
     lambda: pto.for_(0, 1, step=1, iter_args=(0,)),
@@ -305,10 +315,22 @@ def simt_tid_probe():
     pto.get_tid_z()
 
 
+@pto.simd
+def ast_subkernel_runtime_for_helper(rows: pto.i32):
+    for row in range(0, rows, 1):
+        _ = row
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
 @pto.jit(target="a5")
 def simt_helper_lowering_probe(*, TRACE_TOKEN: pto.constexpr = 0):
     simt_tid_probe()
     simt_tid_probe()
+
+
+@pto.jit(target="a5")
+def ast_subkernel_runtime_for_probe(rows: pto.i32):
+    ast_subkernel_runtime_for_helper(rows)
 
 
 @pto.jit(target="a5")
@@ -324,15 +346,18 @@ def carry_loop_lowering_probe(*, BLOCK: pto.constexpr = 128):
     l_prev.fill(0.0)
     o_prev.fill(0.0)
 
-    kv_loop = pto.for_(0, 4, step=1).carry(m=m_prev, l=l_prev, o=o_prev)
-    with kv_loop:
-        kv_loop.m.fill(1.0)
-        kv_loop.l.fill(2.0)
-        kv_loop.o.fill(3.0)
-        kv_loop.update(m=m_next, l=l_next, o=o_next)
+    m = m_prev
+    l = l_prev
+    o = o_prev
+    for _ in range(0, 4, 1):
+        m.fill(1.0)
+        l.fill(2.0)
+        o.fill(3.0)
+        m = m_next
+        l = l_next
+        o = o_next
 
-    final_o = kv_loop.final("o")
-    final_o.fill(4.0)
+    o.fill(4.0)
 
 
 @pto.jit(target="a5")
@@ -367,6 +392,372 @@ def branch_handle_merge_probe():
     diff = br.diff
     merged = total + diff
     _ = merged
+
+
+@pto.jit(target="a5")
+def ast_if_side_effect_probe():
+    cond = pto.const(1, dtype=pto.i1)
+    if cond:
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_if_merge_probe():
+    lhs = pto.const(4, dtype=pto.i32)
+    rhs = pto.const(2, dtype=pto.i32)
+    if lhs > rhs:
+        total = lhs + rhs
+        diff = lhs - rhs
+    else:
+        total = rhs + lhs
+        diff = rhs - lhs
+    merged = total + diff
+    _ = merged
+
+
+@pto.jit(target="a5")
+def ast_if_old_value_merge_probe():
+    lhs = pto.const(4, dtype=pto.i32)
+    rhs = pto.const(2, dtype=pto.i32)
+    total = rhs
+    if lhs > rhs:
+        total = lhs + rhs
+    merged = total + rhs
+    _ = merged
+
+
+@pto.jit(target="a5")
+def ast_if_branch_local_temp_liveness_probe():
+    c0 = pto.const(0, dtype=pto.i1)
+    c1 = pto.const(1, dtype=pto.i1)
+    one = pto.const(1, dtype=pto.i32)
+    zero = pto.const(0, dtype=pto.i32)
+
+    if c0:
+        tmp = one
+        _ = tmp
+
+    if c1:
+        tmp = one
+        out = tmp + one
+    else:
+        out = zero
+
+    _ = out
+
+
+@pto.jit(target="a5")
+def ast_nested_with_if_merge_probe():
+    lhs = pto.const(4, dtype=pto.i32)
+    rhs = pto.const(2, dtype=pto.i32)
+    with pto.simt():
+        if lhs > rhs:
+            value = lhs + rhs
+        else:
+            value = rhs + lhs
+    merged = value + rhs
+    _ = merged
+
+
+@pto.jit(target="a5")
+def ast_runtime_for_probe(rows: pto.i32):
+    for row in range(0, rows, 1):
+        _ = row
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_runtime_for_carry_probe(rows: pto.i32):
+    one = pto.const(1, dtype=pto.i32)
+    acc = pto.const(0, dtype=pto.i32)
+    for _ in range(rows):
+        acc = acc + one
+    _ = acc
+
+
+@pto.jit(target="a5")
+def ast_runtime_for_augassign_carry_probe(rows: pto.i32):
+    one = pto.const(1, dtype=pto.i32)
+    acc = pto.const(0, dtype=pto.i32)
+    for _ in range(rows):
+        acc += one
+    _ = acc
+
+
+@pto.jit(target="a5")
+def ast_runtime_for_branch_local_temp_probe(rows: pto.i32):
+    cond = pto.const(1, dtype=pto.i1)
+    one = pto.const(1, dtype=pto.i32)
+    zero = pto.const(0, dtype=pto.i32)
+
+    for _ in range(rows):
+        if cond:
+            tmp = one
+            out = tmp + one
+        else:
+            tmp = zero
+            out = tmp + zero
+        _ = out
+
+
+@pto.jit(target="a5", ast_rewrite=False)
+def ast_rewrite_disabled_nested_helper_python_control_probe():
+    def helper(enabled):
+        if enabled:
+            for _ in range(2):
+                pto.pipe_barrier(pto.Pipe.ALL)
+
+    helper(True)
+
+
+@pto.jit(target="a5")
+def ast_nested_helper_ast_rewrite_probe(rows: pto.i32):
+    cond = pto.const(1, dtype=pto.i1)
+
+    def helper(limit, enabled):
+        one = pto.const(1, dtype=pto.i32)
+        acc = pto.const(0, dtype=pto.i32)
+        for _ in range(limit):
+            acc += one
+        if enabled:
+            acc = acc + one
+        return acc
+
+    value = helper(rows, cond)
+    _ = value
+
+
+@pto.jit(target="a5")
+def ast_nested_helper_freevar_if_merge_probe():
+    lhs = pto.const(4, dtype=pto.i32)
+    rhs = pto.const(2, dtype=pto.i32)
+
+    if lhs > rhs:
+        x = lhs + rhs
+    else:
+        x = rhs + lhs
+
+    def helper():
+        return x + rhs
+
+    y = helper()
+    _ = y
+
+
+@pto.jit(target="a5")
+def ast_nested_helper_name_store_liveness_probe():
+    lhs = pto.const(4, dtype=pto.i32)
+    rhs = pto.const(2, dtype=pto.i32)
+
+    if lhs > rhs:
+        helper = lhs
+    else:
+        helper = rhs
+
+    def helper():
+        return lhs + rhs
+
+    y = helper()
+    _ = y
+
+
+@pto.jit(target="a5", name="ast_control_flow_equiv_explicit")
+def ast_control_flow_equiv_explicit_probe(rows: pto.i32):
+    one = pto.const(1, dtype=pto.i32)
+    acc = pto.const(0, dtype=pto.i32)
+
+    def helper(limit, initial):
+        total = initial
+        loop = pto.for_(0, limit, step=1).carry(total=total)
+        with loop:
+            i = loop.iv
+            total = loop.total
+            cond = i > pto.const(0)
+            with pto.if_(cond) as br:
+                with br.then_:
+                    br.assign(total=total + one)
+                with br.else_:
+                    br.assign(total=total)
+            total = br.total
+            loop.update(total=total)
+        return loop.final("total")
+
+    acc = helper(rows, acc)
+    _ = acc
+
+
+@pto.jit(target="a5", name="ast_control_flow_equiv_native")
+def ast_control_flow_equiv_native_probe(rows: pto.i32):
+    one = pto.const(1, dtype=pto.i32)
+    acc = pto.const(0, dtype=pto.i32)
+
+    def helper(limit, initial):
+        total = initial
+        for i in range(limit):
+            if i > pto.const(0):
+                total = total + one
+        return total
+
+    acc = helper(rows, acc)
+    _ = acc
+
+
+def make_ast_closure_kernel(limit: int):
+    @pto.jit(target="a5")
+    def ast_closure_kernel():
+        for _ in pto.static_range(limit):
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+    return ast_closure_kernel
+
+
+ast_closure_kernel_probe = make_ast_closure_kernel(3)
+
+
+def make_ast_rebound_closure_kernel():
+    limit = 2
+
+    @pto.jit(target="a5")
+    def ast_rebound_closure_kernel():
+        for _ in pto.static_range(limit):
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+    limit = 4
+    return ast_rebound_closure_kernel
+
+
+ast_rebound_closure_kernel_probe = make_ast_rebound_closure_kernel()
+
+
+def make_ast_mutable_closure_cache_kernel():
+    limit = 2
+
+    @pto.jit(target="a5")
+    def ast_mutable_closure_cache_kernel():
+        for _ in pto.static_range(limit):
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+    def set_limit(value: int):
+        nonlocal limit
+        limit = value
+
+    return ast_mutable_closure_cache_kernel, set_limit
+
+
+ast_mutable_closure_cache_kernel_probe, set_ast_mutable_closure_cache_limit = (
+    make_ast_mutable_closure_cache_kernel()
+)
+
+
+def make_ast_signature_closure_default_kernel(limit: int):
+    @pto.jit(target="a5")
+    def ast_signature_closure_default_kernel(*, BLOCK: pto.constexpr = limit):
+        for _ in pto.static_range(BLOCK):
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+    return ast_signature_closure_default_kernel
+
+
+ast_signature_closure_default_kernel_probe = make_ast_signature_closure_default_kernel(2)
+
+
+def make_ast_rebound_subkernel_probe():
+    limit = 2
+
+    @pto.simd
+    def helper():
+        for _ in pto.static_range(limit):
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+    limit = 4
+
+    @pto.jit(target="a5")
+    def ast_rebound_subkernel_probe(*, TRACE_TOKEN: pto.constexpr = 0):
+        helper()
+
+    return ast_rebound_subkernel_probe
+
+
+ast_rebound_subkernel_probe = make_ast_rebound_subkernel_probe()
+
+
+def make_sourceless_ast_rewrite_kernel():
+    namespace = {"pto": pto}
+    exec(
+        """
+@pto.jit(target="a5")
+def sourceless_ast_rewrite_kernel():
+    if True:
+        pto.pipe_barrier(pto.Pipe.ALL)
+""",
+        namespace,
+    )
+    return namespace["sourceless_ast_rewrite_kernel"]
+
+
+sourceless_ast_rewrite_kernel_probe = make_sourceless_ast_rewrite_kernel()
+
+
+def make_sourceless_subkernel_entry():
+    namespace = {"pto": pto}
+    exec(
+        """
+@pto.simd
+def sourceless_subkernel_helper():
+    if True:
+        pto.pipe_barrier(pto.Pipe.ALL)
+""",
+        namespace,
+    )
+    helper = namespace["sourceless_subkernel_helper"]
+
+    @pto.jit(target="a5")
+    def sourceless_subkernel_entry_probe(*, TRACE_TOKEN: pto.constexpr = 0):
+        helper()
+
+    return sourceless_subkernel_entry_probe
+
+
+sourceless_subkernel_entry_probe = make_sourceless_subkernel_entry()
+
+
+@pto.jit(target="a5")
+def ast_static_control_flow_probe(*, ENABLE: pto.constexpr = True):
+    if pto.const_expr(ENABLE):
+        for _ in pto.static_range(2):
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_python_bool_guard_probe(
+    *,
+    BLOCK: pto.constexpr = 128,
+    ENABLE: pto.constexpr = True,
+):
+    if BLOCK == 128:
+        pto.pipe_barrier(pto.Pipe.ALL)
+    if ENABLE:
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_static_range_loop_target_live_after_probe():
+    for stage in pto.static_range(3):
+        pto.pipe_barrier(pto.Pipe.ALL)
+    _ = stage
+
+
+@pto.jit(target="a5")
+def ast_static_range_break_continue_probe():
+    for stage in pto.static_range(4):
+        if pto.const_expr(stage == 2):
+            break
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+    for stage in pto.static_range(4):
+        if pto.const_expr(stage % 2 == 0):
+            continue
+        pto.pipe_barrier(pto.Pipe.ALL)
 
 
 @pto.jit(target="a5")
@@ -453,7 +844,7 @@ def tile_slice_vector_probe(inp_tile: pto.Tile, out_tile: pto.Tile, row: pto.ind
 def tile_slice_surface_probe(*, BLOCK: pto.constexpr = 128):
     inp_tile = pto.alloc_tile(shape=[2, BLOCK], dtype=pto.f32)
     out_tile = pto.alloc_tile(shape=[2, BLOCK], dtype=pto.f32)
-    with pto.for_(0, 1, step=1) as row:
+    for row in range(0, 1, 1):
         tile_slice_vector_probe(inp_tile, out_tile, row)
 
 
@@ -502,12 +893,10 @@ def tile_valid_shape_update_1d_probe(
 def make_mask_index_roundtrip_probe(
     cols: pto.i32,
 ):
-    col_loop = pto.for_(0, cols, step=64).carry(remained=cols)
-    with col_loop:
-        remained = col_loop.remained
-        mask, remained_after_pack = pto.make_mask(pto.f32, remained)
+    remained = cols
+    for _ in range(0, cols, 64):
+        mask, remained = pto.make_mask(pto.f32, remained)
         _ = mask
-        col_loop.update(remained=remained_after_pack)
 
 
 @pto.jit(target="a5")
@@ -515,8 +904,8 @@ def integer_loop_bound_probe(*, BLOCK: pto.constexpr = 8):
     row_start = pto.const(0, dtype=pto.i32)
     row_stop = pto.const(BLOCK, dtype=pto.i32)
     valid_dim = pto.const(BLOCK // 2, dtype=pto.i32)
-    with pto.for_(row_start, row_stop, step=1) as row:
-        with pto.for_(0, valid_dim, step=1) as col:
+    for row in range(row_start, row_stop, 1):
+        for col in range(0, valid_dim, 1):
             _ = row
             _ = col
 
@@ -1784,6 +2173,20 @@ def main() -> None:
     expect("pto.get_tid_y" in simt_text, "SIMT helper body should contain pto.get_tid_y")
     expect("pto.get_tid_z" in simt_text, "SIMT helper body should contain pto.get_tid_z")
 
+    ast_subkernel_runtime_for_text = ast_subkernel_runtime_for_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_subkernel_runtime_for_text,
+        "AST-rewritten subkernel runtime for specialization",
+    )
+    expect(
+        ast_subkernel_runtime_for_text.count("scf.for") == 1,
+        "@pto.simd helper should rewrite Python range(...) loops into runtime scf.for",
+    )
+    expect(
+        "pto.barrier <PIPE_ALL>" in ast_subkernel_runtime_for_text,
+        "rewritten @pto.simd helper body should lower inside the caller trace",
+    )
+
     carry_text = carry_loop_lowering_probe.compile(BLOCK=32).mlir_text()
     expect_parse_roundtrip_and_verify(carry_text, "carry loop specialization")
     expect("scf.for" in carry_text, "carry loop should lower to scf.for")
@@ -1824,6 +2227,320 @@ def main() -> None:
     expect(
         "arith.addi" in branch_merge_text and "arith.subi" in branch_merge_text,
         "merged branch values should remain usable as ordinary runtime scalars after the conditional",
+    )
+
+    ast_if_side_effect_text = ast_if_side_effect_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ast_if_side_effect_text, "AST-rewritten side-effect if specialization")
+    expect(
+        ast_if_side_effect_text.count("scf.if") == 1,
+        "ast_rewrite=True Python if should lower to one scf.if for runtime conditions",
+    )
+    expect(
+        "pto.barrier <PIPE_ALL>" in ast_if_side_effect_text,
+        "ast_rewrite=True if body should lower into the scf.if then branch",
+    )
+
+    ast_if_merge_text = ast_if_merge_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ast_if_merge_text, "AST-rewritten if-merge specialization")
+    expect(
+        re.search(r"scf\.if %\d+ -> \(i32, i32\)", ast_if_merge_text) is not None,
+        "ast_rewrite=True Python if/else live-outs should lower to scf.if results",
+    )
+    expect(
+        ast_if_merge_text.count("scf.yield") >= 2,
+        "ast_rewrite=True Python if/else live-outs should materialize branch yields",
+    )
+
+    ast_if_old_value_merge_text = ast_if_old_value_merge_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ast_if_old_value_merge_text, "AST-rewritten old-value if-merge specialization")
+    expect(
+        re.search(r"scf\.if %\d+ -> \(i32\)", ast_if_old_value_merge_text) is not None,
+        "ast_rewrite=True one-sided Python if assignment should merge the old value through scf.if",
+    )
+    expect(
+        ast_if_old_value_merge_text.count("scf.yield") >= 2,
+        "ast_rewrite=True old-value if merge should yield from both branches",
+    )
+
+    ast_if_branch_local_temp_liveness_text = ast_if_branch_local_temp_liveness_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_if_branch_local_temp_liveness_text,
+        "AST-rewritten if branch-local temp liveness specialization",
+    )
+    expect(
+        "old_tmp" not in ast_if_branch_local_temp_liveness_text,
+        "branch-local temporaries should not be merged as old live-out values",
+    )
+
+    ast_nested_with_if_merge_text = ast_nested_with_if_merge_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ast_nested_with_if_merge_text, "AST-rewritten nested with if-merge specialization")
+    expect(
+        re.search(r"scf\.if %\d+ -> \(i32\)", ast_nested_with_if_merge_text) is not None,
+        "ast_rewrite=True nested with block should preserve outer live-out liveness for if merge",
+    )
+
+    ast_runtime_for_text = ast_runtime_for_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ast_runtime_for_text, "AST-rewritten runtime for specialization")
+    expect(
+        ast_runtime_for_text.count("scf.for") == 1,
+        "ast_rewrite=True Python range(...) should lower to one scf.for",
+    )
+
+    ast_runtime_for_carry_text = ast_runtime_for_carry_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ast_runtime_for_carry_text, "AST-rewritten runtime carry for specialization")
+    expect(
+        "iter_args(" in ast_runtime_for_carry_text and "scf.yield" in ast_runtime_for_carry_text,
+        "ast_rewrite=True accumulator loops should lower through scf.for iter_args",
+    )
+
+    ast_runtime_for_augassign_carry_text = ast_runtime_for_augassign_carry_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_runtime_for_augassign_carry_text,
+        "AST-rewritten augassign runtime carry for specialization",
+    )
+    expect(
+        "iter_args(" in ast_runtime_for_augassign_carry_text and "scf.yield" in ast_runtime_for_augassign_carry_text,
+        "ast_rewrite=True accumulator loops using += should lower through scf.for iter_args",
+    )
+
+    ast_runtime_for_branch_local_temp_text = ast_runtime_for_branch_local_temp_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_runtime_for_branch_local_temp_text,
+        "AST-rewritten runtime for branch-local temp specialization",
+    )
+    expect(
+        "iter_args(" not in ast_runtime_for_branch_local_temp_text,
+        "branch-local temporaries should not be inferred as loop-carried state",
+    )
+
+    ast_rewrite_disabled_nested_helper_python_control_text = (
+        ast_rewrite_disabled_nested_helper_python_control_probe.compile().mlir_text()
+    )
+    expect_parse_roundtrip_and_verify(
+        ast_rewrite_disabled_nested_helper_python_control_text,
+        "AST rewrite disabled nested Python helper control specialization",
+    )
+    expect(
+        "scf.if" not in ast_rewrite_disabled_nested_helper_python_control_text
+        and "scf.for" not in ast_rewrite_disabled_nested_helper_python_control_text,
+        "ast_rewrite=False should keep nested helper function bodies as trace-time Python",
+    )
+    expect(
+        ast_rewrite_disabled_nested_helper_python_control_text.count("pto.barrier <PIPE_ALL>") == 2,
+        "nested Python helper should keep trace-time if/range behavior",
+    )
+
+    ast_nested_helper_ast_rewrite_text = ast_nested_helper_ast_rewrite_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_nested_helper_ast_rewrite_text,
+        "AST-rewritten nested helper function specialization",
+    )
+    expect(
+        ast_nested_helper_ast_rewrite_text.count("scf.for") == 1,
+        "default AST rewrite should rewrite range(...) loops inside nested helpers",
+    )
+    expect(
+        ast_nested_helper_ast_rewrite_text.count("scf.if") == 1,
+        "default AST rewrite should rewrite runtime if statements inside nested helpers",
+    )
+    expect(
+        "iter_args(" in ast_nested_helper_ast_rewrite_text and "scf.yield" in ast_nested_helper_ast_rewrite_text,
+        "rewritten nested helpers should preserve loop-carried and branch live-out values",
+    )
+
+    ast_nested_helper_freevar_if_merge_text = ast_nested_helper_freevar_if_merge_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_nested_helper_freevar_if_merge_text,
+        "AST-rewritten nested helper freevar if-merge specialization",
+    )
+    expect(
+        re.search(r"scf\.if %\d+ -> \(i32\)", ast_nested_helper_freevar_if_merge_text) is not None,
+        "nested helper free variables should keep outer branch assignments live for SSA merge",
+    )
+
+    ast_nested_helper_name_store_liveness_text = ast_nested_helper_name_store_liveness_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_nested_helper_name_store_liveness_text,
+        "AST-rewritten nested helper name-store liveness specialization",
+    )
+    expect(
+        re.search(r"scf\.if %\d+ ->", ast_nested_helper_name_store_liveness_text) is None,
+        "nested function definitions should store their function name and kill earlier liveness",
+    )
+
+    ast_control_flow_equiv_explicit_text = ast_control_flow_equiv_explicit_probe.compile().mlir_text()
+    ast_control_flow_equiv_native_text = ast_control_flow_equiv_native_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_control_flow_equiv_explicit_text,
+        "explicit control-flow integration specialization",
+    )
+    expect_parse_roundtrip_and_verify(
+        ast_control_flow_equiv_native_text,
+        "native AST-rewritten control-flow integration specialization",
+    )
+    expect(
+        mlir_op_sequence(ast_control_flow_equiv_native_text) == mlir_op_sequence(ast_control_flow_equiv_explicit_text),
+        "native Python for/if rewrite should emit the same operation sequence as explicit pto.for_/pto.if_",
+    )
+    for pattern in ("scf.for", "scf.if", "iter_args(", "scf.yield", "arith.addi"):
+        expect(
+            ast_control_flow_equiv_native_text.count(pattern) == ast_control_flow_equiv_explicit_text.count(pattern),
+            f"native AST rewrite should match explicit control-flow count for {pattern}",
+        )
+
+    ast_closure_kernel_text = ast_closure_kernel_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(ast_closure_kernel_text, "AST-rewritten closure kernel specialization")
+    expect(
+        ast_closure_kernel_text.count("pto.barrier <PIPE_ALL>") == 3,
+        "ast_rewrite=True factory kernels should preserve captured Python closure values",
+    )
+
+    ast_rebound_closure_kernel_text = ast_rebound_closure_kernel_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_rebound_closure_kernel_text,
+        "AST-rewritten rebound closure kernel specialization",
+    )
+    expect(
+        ast_rebound_closure_kernel_text.count("pto.barrier <PIPE_ALL>") == 4,
+        "ast_rewrite=True should read nonlocal closure values at compile time",
+    )
+
+    ast_mutable_closure_cache_first = ast_mutable_closure_cache_kernel_probe.compile()
+    ast_mutable_closure_cache_first_text = ast_mutable_closure_cache_first.mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_mutable_closure_cache_first_text,
+        "AST-rewritten mutable closure cache first specialization",
+    )
+    expect(
+        ast_mutable_closure_cache_first_text.count("pto.barrier <PIPE_ALL>") == 2,
+        "first mutable closure specialization should use the initial nonlocal value",
+    )
+    set_ast_mutable_closure_cache_limit(4)
+    ast_mutable_closure_cache_second = ast_mutable_closure_cache_kernel_probe.compile()
+    ast_mutable_closure_cache_second_text = ast_mutable_closure_cache_second.mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_mutable_closure_cache_second_text,
+        "AST-rewritten mutable closure cache second specialization",
+    )
+    expect(
+        ast_mutable_closure_cache_second is not ast_mutable_closure_cache_first,
+        "AST rewrite closure changes should participate in the specialization cache key",
+    )
+    expect(
+        ast_mutable_closure_cache_second_text.count("pto.barrier <PIPE_ALL>") == 4,
+        "changed mutable closure specialization should recompile with the new nonlocal value",
+    )
+
+    ast_signature_closure_default_text = ast_signature_closure_default_kernel_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_signature_closure_default_text,
+        "AST-rewritten signature closure default specialization",
+    )
+    expect(
+        ast_signature_closure_default_text.count("pto.barrier <PIPE_ALL>") == 2,
+        "ast_rewrite=True should resolve closure names used by signature defaults",
+    )
+
+    ast_rebound_subkernel_text = ast_rebound_subkernel_probe.compile(TRACE_TOKEN=1).mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_rebound_subkernel_text,
+        "AST-rewritten rebound subkernel specialization",
+    )
+    expect(
+        ast_rebound_subkernel_text.count("pto.barrier <PIPE_ALL>") == 4,
+        "named subkernels should read nonlocal closure values when traced",
+    )
+
+    sourceless_ast_rewrite_text = sourceless_ast_rewrite_kernel_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        sourceless_ast_rewrite_text,
+        "source-less AST rewrite fallback specialization",
+    )
+    expect(
+        sourceless_ast_rewrite_text.count("pto.barrier <PIPE_ALL>") == 1,
+        "source-less kernels should fall back to original trace-time Python execution",
+    )
+
+    sourceless_subkernel_text = sourceless_subkernel_entry_probe.compile(TRACE_TOKEN=1).mlir_text()
+    expect_parse_roundtrip_and_verify(
+        sourceless_subkernel_text,
+        "source-less subkernel AST rewrite fallback specialization",
+    )
+    expect(
+        sourceless_subkernel_text.count("pto.barrier <PIPE_ALL>") == 1,
+        "source-less subkernels should fall back to original trace-time Python execution",
+    )
+
+    ast_python_bool_guard_enabled_text = ast_python_bool_guard_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_python_bool_guard_enabled_text,
+        "AST Python bool guard enabled specialization",
+    )
+    expect(
+        "scf.if" not in ast_python_bool_guard_enabled_text,
+        "Python bool guards should remain trace-time branches under ast_rewrite=True",
+    )
+    expect(
+        ast_python_bool_guard_enabled_text.count("pto.barrier <PIPE_ALL>") == 2,
+        "Python bool guards should execute enabled trace-time branches",
+    )
+    ast_python_bool_guard_disabled_text = ast_python_bool_guard_probe.compile(
+        BLOCK=64,
+        ENABLE=False,
+    ).mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_python_bool_guard_disabled_text,
+        "AST Python bool guard disabled specialization",
+    )
+    expect(
+        "scf.if" not in ast_python_bool_guard_disabled_text,
+        "disabled Python bool guards should not lower to runtime branches",
+    )
+    expect(
+        "pto.barrier <PIPE_ALL>" not in ast_python_bool_guard_disabled_text,
+        "disabled Python bool guards should skip their trace-time branches",
+    )
+
+    ast_static_enabled_text = ast_static_control_flow_probe.compile(ENABLE=True).mlir_text()
+    expect_parse_roundtrip_and_verify(ast_static_enabled_text, "AST static control-flow enabled specialization")
+    expect(
+        "scf.if" not in ast_static_enabled_text and "scf.for" not in ast_static_enabled_text,
+        "pto.const_expr/pto.static_range should keep compile-time control flow under ast_rewrite=True",
+    )
+    expect(
+        ast_static_enabled_text.count("pto.barrier <PIPE_ALL>") == 2,
+        "pto.static_range(2) should unroll at trace time under ast_rewrite=True",
+    )
+    ast_static_range_loop_target_live_after_text = ast_static_range_loop_target_live_after_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_static_range_loop_target_live_after_text,
+        "AST static_range loop target live-after specialization",
+    )
+    expect(
+        "scf.for" not in ast_static_range_loop_target_live_after_text,
+        "pto.static_range(...) should keep Python loop semantics under ast_rewrite=True",
+    )
+    expect(
+        ast_static_range_loop_target_live_after_text.count("pto.barrier <PIPE_ALL>") == 3,
+        "pto.static_range(...) should allow the Python loop target to remain live after unrolling",
+    )
+    ast_static_range_break_continue_text = ast_static_range_break_continue_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_static_range_break_continue_text,
+        "AST static_range break/continue specialization",
+    )
+    expect(
+        "scf.for" not in ast_static_range_break_continue_text,
+        "pto.static_range(...) break/continue should stay in trace-time Python control flow",
+    )
+    expect(
+        ast_static_range_break_continue_text.count("pto.barrier <PIPE_ALL>") == 4,
+        "pto.static_range(...) should preserve Python break/continue behavior under ast_rewrite=True",
+    )
+    ast_static_disabled_text = ast_static_control_flow_probe.compile(ENABLE=False).mlir_text()
+    expect(
+        "pto.barrier <PIPE_ALL>" not in ast_static_disabled_text,
+        "pto.const_expr(False) should skip the trace-time branch under ast_rewrite=True",
     )
 
     runtime_scalar_text = runtime_scalar_operator_probe.compile(BLOCK=8).mlir_text()

--- a/ptodsl/tests/test_jit_diagnostics.py
+++ b/ptodsl/tests/test_jit_diagnostics.py
@@ -14,6 +14,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ptodsl"))
 
 from ptodsl import pto
+from ptodsl._ast_rewrite import PTODSLAstRewriteError
 from ptodsl._host_tensors import inspect_host_tensor_metadata
 
 
@@ -33,13 +34,13 @@ def expect_raises(callback, exc_type, *message_fragments: str) -> None:
         raise AssertionError(f"expected {exc_type.__name__} to be raised")
 
 
-@pto.jit(target="a5")
+@pto.jit(target="a5", ast_rewrite=False)
 def native_python_if_runtime_const_probe():
     if pto.const(1):
         pto.pipe_barrier(pto.Pipe.ALL)
 
 
-@pto.jit(target="a5")
+@pto.jit(target="a5", ast_rewrite=False)
 def native_python_range_runtime_metadata_probe(rows: pto.i32):
     for _ in range(rows):
         pto.pipe_barrier(pto.Pipe.ALL)
@@ -148,6 +149,110 @@ def define_legacy_tensor_spec_entry_probe():
     @pto.jit(target="a5")
     def bad_probe(A: pto.tensor_spec(rank=2, dtype=pto.f32)):
         pto.pipe_barrier(pto.Pipe.ALL)
+
+    return bad_probe
+
+
+def define_frontend_options_conflict_probe():
+    @pto.jit(target="a5", ast_rewrite=False, frontend_options={"ast_rewrite": True})
+    def bad_probe():
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+    return bad_probe
+
+
+def define_frontend_options_scalar_rewrite_probe():
+    @pto.jit(target="a5", frontend_options={"rewrite_part": {"control_flow", "scalar"}})
+    def bad_probe():
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+    return bad_probe
+
+
+def define_frontend_options_dump_source_probe():
+    @pto.jit(target="a5", frontend_options={"dump_rewritten_source": True})
+    def bad_probe():
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+    return bad_probe
+
+
+def define_ast_if_undefined_old_value_probe():
+    @pto.jit(target="a5")
+    def bad_probe():
+        cond = pto.const(1, dtype=pto.i1)
+        lhs = pto.const(4, dtype=pto.i32)
+        if cond:
+            value = lhs
+        _ = value
+
+    return bad_probe
+
+
+def define_ast_for_else_probe():
+    @pto.jit(target="a5")
+    def bad_probe(rows: pto.i32):
+        for _ in range(rows):
+            pto.pipe_barrier(pto.Pipe.ALL)
+        else:
+            pto.mem_bar(pto.BarrierType.VST_VLD)
+
+    return bad_probe
+
+
+def define_ast_for_non_range_probe():
+    @pto.jit(target="a5")
+    def bad_probe():
+        for _ in [0, 1]:
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+    return bad_probe
+
+
+def define_ast_for_tuple_target_probe():
+    @pto.jit(target="a5")
+    def bad_probe(rows: pto.i32):
+        for _, other in range(rows):
+            _ = other
+
+    return bad_probe
+
+
+def define_ast_for_break_probe():
+    @pto.jit(target="a5")
+    def bad_probe(rows: pto.i32):
+        for _ in range(rows):
+            break
+
+    return bad_probe
+
+
+def define_ast_runtime_for_constexpr_break_probe():
+    @pto.jit(target="a5")
+    def bad_probe(rows: pto.i32):
+        for _ in range(rows):
+            if pto.const_expr(True):
+                break
+
+    return bad_probe
+
+
+def define_ast_for_last_value_probe():
+    @pto.jit(target="a5")
+    def bad_probe(rows: pto.i32):
+        for i in range(rows):
+            last = i
+        _ = last
+
+    return bad_probe
+
+
+def define_ast_for_loop_target_live_after_probe():
+    @pto.jit(target="a5")
+    def bad_probe(rows: pto.i32):
+        for i in range(rows):
+            pto.pipe_barrier(pto.Pipe.ALL)
+        _ = i
 
     return bad_probe
 
@@ -334,6 +439,66 @@ def main() -> None:
         "@pto.jit positional parameter 'A' still uses legacy host-tensor entry annotation",
         "no longer accepts pto.tensor_spec(...)",
         "pto.make_tensor_view(...)",
+    )
+    expect_raises(
+        define_frontend_options_conflict_probe,
+        ValueError,
+        "ast_rewrite conflicts with frontend_options",
+    )
+    expect_raises(
+        define_frontend_options_scalar_rewrite_probe,
+        ValueError,
+        "rewrite_part",
+        "currently only supports",
+        "scalar",
+    )
+    expect_raises(
+        define_frontend_options_dump_source_probe,
+        ValueError,
+        "dump_rewritten_source",
+        "reserved but not implemented",
+    )
+    expect_raises(
+        lambda: define_ast_if_undefined_old_value_probe().compile(),
+        NameError,
+        "value",
+    )
+    expect_raises(
+        lambda: define_ast_for_else_probe().compile(),
+        PTODSLAstRewriteError,
+        "does not support for-else",
+    )
+    expect_raises(
+        lambda: define_ast_for_non_range_probe().compile(),
+        PTODSLAstRewriteError,
+        "only rewrites for-loops over range(...)",
+    )
+    expect_raises(
+        lambda: define_ast_for_tuple_target_probe().compile(),
+        PTODSLAstRewriteError,
+        "runtime for-loops require a simple name target",
+    )
+    expect_raises(
+        lambda: define_ast_for_break_probe().compile(),
+        PTODSLAstRewriteError,
+        "does not support break/continue",
+    )
+    expect_raises(
+        lambda: define_ast_runtime_for_constexpr_break_probe().compile(),
+        PTODSLAstRewriteError,
+        "does not support break/continue",
+    )
+    expect_raises(
+        lambda: define_ast_for_last_value_probe().compile(),
+        PTODSLAstRewriteError,
+        "cannot expose last-iteration-only values yet",
+        "last",
+    )
+    expect_raises(
+        lambda: define_ast_for_loop_target_live_after_probe().compile(),
+        PTODSLAstRewriteError,
+        "cannot expose the loop induction variable outside the loop yet",
+        "i",
     )
     expect_raises(
         make_tensor_view_missing_metadata_probe.compile,


### PR DESCRIPTION
## Summary
- add opt-in @pto.jit(preprocess=True) AST rewriting for Python if/for range control flow
- add pto.const_expr and pto.static_range compile-time escape hatches
- document design and user guide usage, including docs-as-test coverage
- Related to #734