### PR TITLE
Fix macOS wheel hardening cache gating

### DIFF
--- a/_ptoas_build_backend.py
+++ b/_ptoas_build_backend.py
@@ -94,6 +94,10 @@ def build_sdist(sdist_directory, config_settings=None):
     )
 
 
+def _should_use_linux_hardening_cache() -> bool:
+    return sys.platform.startswith("linux")
+
+
 def _cmake_configure_and_build():
     """CMake configure + Ninja build + install."""
     _BUILD_DIR.mkdir(parents=True, exist_ok=True)
@@ -126,7 +130,7 @@ def _cmake_configure_and_build():
         cmake_cmd.append(f"-DPTOAS_RELEASE_VERSION_OVERRIDE={release_version}")
 
     hardening_cache = _REPO / "cmake" / "LinuxHardeningCache.cmake"
-    if hardening_cache.exists():
+    if _should_use_linux_hardening_cache() and hardening_cache.exists():
         cmake_cmd.insert(1, f"-C{hardening_cache}")
 
     subprocess.check_call(cmake_cmd)


### PR DESCRIPTION
## Summary
- gate `LinuxHardeningCache.cmake` so the PEP 517 backend only injects it on Linux
- keep macOS wheel builds from passing Linux-only linker flags to Darwin `ld`

## Root Cause
The macOS wheel workflow calls `pip install . --no-build-isolation`, which goes through `_ptoas_build_backend.py`.
That backend was unconditionally prepending `-C cmake/LinuxHardeningCache.cmake` to the CMake configure command.
On macOS this injected Linux-only linker flags (`-Wl,-z,relro` and `-Wl,-z,now`), causing CMake's compiler sanity check to fail before PTOAS itself started building.

The failing release run was:
- `Build Wheel (macOS)` run `27112146068`

The decisive error was:
- `ld: unknown options: -z -z`

## Introduced By
Local blame/history points to merge commit `26f5e93c0c6ae8ffeca1bc8c5dc908634b149d34` (PR #725) as the point where the unconditional hardening-cache injection was introduced.

## Validation
- inspected failed logs from run `27112146068`
- ran a local Python check that verifies:
  - macOS/non-Linux path does not prepend `-C .../LinuxHardeningCache.cmake`
  - Linux path still prepends the hardening cache
