### PR TITLE
ci: fix watchdog rerun for fork PRs

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -19,6 +19,28 @@ permissions:
   contents: read
 
 jobs:
+  pr-context:
+    if: ${{ github.event_name == 'pull_request' && github.run_attempt == 1 }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Write PR context
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p pr-context
+          printf '%s\n' "${PR_NUMBER}" > pr-context/pr-number
+          printf '%s\n' "${PR_HEAD_SHA}" > pr-context/pr-head-sha
+
+      - name: Upload PR context
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-context
+          path: pr-context
+          if-no-files-found: error
+
   vpto-sim-validation:
     runs-on: [self-hosted, Linux, X64, label-1]
     timeout-minutes: 120

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -28,21 +28,46 @@ jobs:
       }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Rerun self-hosted git failures once
+      - name: Download PR context
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: pr-context
+          path: pr-context
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Rerun self-hosted git failures
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
         run: |
           set -euo pipefail
 
           echo "Inspecting CI workflow run ${RUN_ID} in ${REPO}"
-          run_head_sha="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.head_sha')"
-          pr_number="$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" --jq '.pull_requests[0].number // ""')"
+          run_head_sha="${RUN_HEAD_SHA}"
 
-          if [[ -z "${pr_number}" ]]; then
-            echo "No pull request number found for workflow run ${RUN_ID}; skip rerun."
+          if [[ ! -f pr-context/pr-number || ! -f pr-context/pr-head-sha ]]; then
+            echo "No pr-context artifact found for workflow run ${RUN_ID}; skip rerun."
+            exit 0
+          fi
+
+          pr_number="$(< pr-context/pr-number)"
+          pr_head_sha="$(< pr-context/pr-head-sha)"
+
+          if [[ ! "${pr_number}" =~ ^[0-9]+$ ||
+                ! "${pr_head_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "Invalid pr-context artifact for workflow run ${RUN_ID}; skip rerun."
+            exit 0
+          fi
+
+          if [[ "${pr_head_sha}" != "${run_head_sha}" ]]; then
+            echo "Workflow run ${RUN_ID} does not match pr-context head sha; skip rerun."
+            echo "Run head SHA: ${run_head_sha}"
+            echo "PR context head SHA: ${pr_head_sha}"
             exit 0
           fi
 
@@ -62,44 +87,27 @@ jobs:
             exit 0
           fi
 
-          mapfile -t job_ids < <(
-            gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs?filter=latest&per_page=100" \
-              --jq '.jobs[] | select(.name == "vpto-sim-validation" and .conclusion == "failure") | .id'
-          )
+          git_failure_pattern='(error: RPC failed|Operation timed out|Connection timed out|Failed to connect|Could not resolve host|early EOF|fetch-pack|remote end hung up|GnuTLS recv error|TLS connection|HTTP/2 stream)'
+          log_file="failed.log"
+          step_log_file="failed-git-steps.log"
 
-          if [[ "${#job_ids[@]}" -eq 0 ]]; then
-            echo "No failed vpto-sim-validation job found."
+          echo "Downloading failed logs for workflow run ${RUN_ID}"
+          gh run view "${RUN_ID}" --repo "${REPO}" --log-failed > "${log_file}"
+
+          awk -F'\t' '
+            $2 == "Checkout" || $2 == "Prepare LLVM source (no rebuild)" {
+              print
+            }
+          ' "${log_file}" > "${step_log_file}"
+
+          if [[ ! -s "${step_log_file}" ]]; then
+            echo "No Checkout/Prepare LLVM source logs found in failed jobs; skip rerun."
             exit 0
           fi
 
-          git_failure_pattern='(error: RPC failed|Operation timed out|Connection timed out|Failed to connect|Could not resolve host|early EOF|fetch-pack|remote end hung up|GnuTLS recv error|TLS connection|HTTP/2 stream)'
-          rerun_count=0
-
-          for job_id in "${job_ids[@]}"; do
-            log_file="job-${job_id}.log"
-            step_log_file="job-${job_id}-git-steps.log"
-
-            echo "Downloading logs for job ${job_id}"
-            gh run view "${RUN_ID}" --repo "${REPO}" --job "${job_id}" --log > "${log_file}"
-
-            awk -F'\t' '
-              $2 == "Checkout" || $2 == "Prepare LLVM source (no rebuild)" {
-                print
-              }
-            ' "${log_file}" > "${step_log_file}"
-
-            if [[ ! -s "${step_log_file}" ]]; then
-              echo "No Checkout/Prepare LLVM source logs found for job ${job_id}; skip rerun."
-              continue
-            fi
-
-            if grep -Eiq "${git_failure_pattern}" "${step_log_file}"; then
-              echo "Git/network failure detected in self-hosted checkout/fetch stage; rerunning job ${job_id}."
-              gh api --method POST "repos/${REPO}/actions/jobs/${job_id}/rerun"
-              rerun_count=$((rerun_count + 1))
-            else
-              echo "Failed job ${job_id} did not fail in a recognized git/network stage; skip rerun."
-            fi
-          done
-
-          echo "Rerun requests submitted: ${rerun_count}"
+          if grep -Eiq "${git_failure_pattern}" "${step_log_file}"; then
+            echo "Git/network failure detected in self-hosted checkout/fetch stage; rerunning failed jobs."
+            gh api --method POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"
+          else
+            echo "Failed jobs did not fail in a recognized git/network stage; skip rerun."
+          fi


### PR DESCRIPTION
## 背景

`Watchdog` 需要在 `ci-sim` 因 self-hosted runner 的 git/network 问题失败时触发重试。对于 fork/cross-repo PR，`workflow_run` 事件关联的 workflow run 可能拿不到 PR number，导致 Watchdog 无法确认 PR 状态和 head sha，也就无法安全地触发 rerun。

## 方案

这个 PR 让 `ci-sim` 在 PR workflow 内显式产出 PR context，并由 `Watchdog` 在 `workflow_run` 阶段读取这份 context：

- `ci-sim` 在 `pull_request` 事件下新增 GitHub-hosted `pr-context` job
- `pr-context` 仅在 `github.run_attempt == 1` 时上传，后续 rerun 复用同一个 workflow run 下已有的 artifact
- `pr-context` 上传两个纯文本文件：`pr-number` 和 `pr-head-sha`
- `Watchdog` 使用 `actions/download-artifact@v4` 从失败的 `ci-sim` run 下载 `pr-context` artifact
- `Watchdog` 读取 artifact 中的 PR number 和 PR head sha，作为后续校验依据
- `Watchdog` 校验 PR 仍然 open，并确认当前 PR head sha 与失败 workflow run 的 head sha 一致
- `Watchdog` 从失败 run 的日志中识别 checkout / LLVM fetch 阶段的 git/network failure
- 确认是 git/network failure 后，使用 run 级别的 `rerun-failed-jobs` 重跑失败 job

这样 fork PR 的 `ci-sim` 失败后，Watchdog 可以通过 PR workflow 自己上传的 context artifact 找回 PR 信息，并只对仍然有效的 PR head 触发重试。

## 验证

- YAML 解析通过
- workflow 内所有 `run` 脚本经 PyYAML 抽取后 `bash -n` 通过
- `git diff --check` 通过

额外在 `vpto-dev/PTOAS` 上做了跨仓 PR 对照验证：

- `vpto-dev/PTOAS#2` 验证 fork PR 的 workflow run payload 中 `pull_requests: []`，Watchdog 无法从 workflow run 直接拿到 PR number，`ci-sim` 保持 `run_attempt: 1`
- `vpto-dev/PTOAS#1` 验证 artifact 方案可以让 Watchdog 下载 `pr-context`，识别 checkout / fetch 阶段 git/network failure，并触发 `rerun-failed-jobs`

## 注意

`workflow_run` 使用 default branch 上的 `Watchdog` 定义。本 PR 合入后，后续 PR 的 watchdog 才会按 artifact 逻辑读取 `pr-context`。
