### PR TITLE
fix(vpto): split vecscope inference follow-ups

### DIFF
--- a/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
+++ b/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
@@ -44,10 +44,16 @@ struct NestedRegionSummary {
   bool hasBoundaryOperation = false;
 };
 
-struct EscapingVectorScopeValue {
+struct EscapingMovedValue {
   Value value;
   Operation *producer = nullptr;
   Operation *user = nullptr;
+  bool requiresDiagnostic = false;
+};
+
+struct ResultlessScopePlan {
+  SmallVector<Operation *, 16> hoistOps;
+  SmallVector<Operation *, 16> moveOps;
 };
 
 static VPTOInferenceOpClass classifyOperationForInference(Operation *op);
@@ -186,41 +192,71 @@ static bool isUserInsideCluster(Operation *user,
   return false;
 }
 
-static bool canMoveIntoResultlessScope(ArrayRef<Operation *> ops) {
-  llvm::SmallPtrSet<Operation *, 16> opSet;
-  for (Operation *op : ops)
-    opSet.insert(op);
+static bool anyUserIsMoved(Value result,
+                           const llvm::SmallPtrSetImpl<Operation *> &movedOps) {
+  for (Operation *user : result.getUsers()) {
+    if (isUserInsideCluster(user, movedOps))
+      return true;
+  }
+  return false;
+}
 
+static llvm::SmallPtrSet<Operation *, 16>
+computeMovedOpsForResultlessScope(ArrayRef<Operation *> ops) {
+  llvm::SmallPtrSet<Operation *, 16> movedOps;
   for (Operation *op : ops) {
-    for (Value result : op->getResults()) {
-      for (Operation *user : result.getUsers()) {
-        if (!isUserInsideCluster(user, opSet))
-          return false;
+    if (classifyOperationForInference(op) == VPTOInferenceOpClass::Vector)
+      movedOps.insert(op);
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Operation *op : llvm::reverse(ops)) {
+      if (movedOps.contains(op) ||
+          classifyOperationForInference(op) !=
+              VPTOInferenceOpClass::SafeScalar)
+        continue;
+
+      bool hasMovedUser = false;
+      bool allUsersMoved = true;
+      for (Value result : op->getResults()) {
+        for (Operation *user : result.getUsers()) {
+          if (isUserInsideCluster(user, movedOps)) {
+            hasMovedUser = true;
+            continue;
+          }
+          if (!isUserInsideCluster(user, movedOps)) {
+            allUsersMoved = false;
+            break;
+          }
+        }
+        if (!allUsersMoved)
+          break;
+      }
+
+      if (hasMovedUser && allUsersMoved) {
+        movedOps.insert(op);
+        changed = true;
       }
     }
   }
-  return true;
+  return movedOps;
 }
 
-static bool
-findEscapingVectorScopeResult(ArrayRef<Operation *> ops,
-                              EscapingVectorScopeValue &escapingValue) {
-  llvm::SmallPtrSet<Operation *, 16> opSet;
-  for (Operation *op : ops)
-    opSet.insert(op);
-
-  for (Operation *op : ops) {
+static bool findEscapingMovedResult(
+    const llvm::SmallPtrSetImpl<Operation *> &movedOps,
+    EscapingMovedValue &escapingValue) {
+  for (Operation *op : movedOps) {
     for (Value result : op->getResults()) {
-      if (!isVecScopeType(result.getType()))
-        continue;
-
       for (Operation *user : result.getUsers()) {
-        if (isUserInsideCluster(user, opSet))
+        if (isUserInsideCluster(user, movedOps))
           continue;
 
         escapingValue.value = result;
         escapingValue.producer = op;
         escapingValue.user = user;
+        escapingValue.requiresDiagnostic = isVecScopeType(result.getType());
         return true;
       }
     }
@@ -229,7 +265,7 @@ findEscapingVectorScopeResult(ArrayRef<Operation *> ops,
 }
 
 static LogicalResult
-emitEscapingVectorScopeValueError(const EscapingVectorScopeValue &escapingValue) {
+emitEscapingVectorScopeValueError(const EscapingMovedValue &escapingValue) {
   Operation *producer = escapingValue.producer;
   if (!producer)
     return failure();
@@ -246,12 +282,82 @@ emitEscapingVectorScopeValueError(const EscapingVectorScopeValue &escapingValue)
   return failure();
 }
 
-static void wrapCluster(ArrayRef<Operation *> ops, MLIRContext *context) {
+// classify which operations need to be moved into a vecscope, which can be hoisted out of the
+// vecscope, and check for any vector-scope-typed values that would escape the vecscope if we were to
+// move the candidate operations into a resultless vecscope. Returns failure if the candidate cluster
+// is not suitable for vecscope inference.
+static LogicalResult
+buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
+                         EscapingMovedValue &escapingValue) {
   if (ops.empty() || !hasVectorOperation(ops))
+    return failure();
+
+  llvm::SmallPtrSet<Operation *, 16> movedOps =
+      computeMovedOpsForResultlessScope(ops);
+  if (movedOps.empty())
+    return failure();
+
+  if (findEscapingMovedResult(movedOps, escapingValue))
+    return failure();
+
+  llvm::SmallPtrSet<Operation *, 16> hoistedOps;
+  for (Operation *op : ops) {
+    if (movedOps.contains(op) ||
+        classifyOperationForInference(op) != VPTOInferenceOpClass::SafeScalar)
+      continue;
+
+    for (Value result : op->getResults()) {
+      if (anyUserIsMoved(result, movedOps)) {
+        hoistedOps.insert(op);
+        break;
+      }
+    }
+  }
+
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (Operation *op : llvm::reverse(ops)) {
+      if (movedOps.contains(op) || hoistedOps.contains(op) ||
+          classifyOperationForInference(op) !=
+              VPTOInferenceOpClass::SafeScalar)
+        continue;
+
+      bool feedsHoistedOp = false;
+      for (Value result : op->getResults()) {
+        for (Operation *user : result.getUsers()) {
+          if (isUserInsideCluster(user, hoistedOps)) {
+            feedsHoistedOp = true;
+            break;
+          }
+        }
+        if (feedsHoistedOp)
+          break;
+      }
+
+      if (feedsHoistedOp) {
+        hoistedOps.insert(op);
+        changed = true;
+      }
+    }
+  }
+
+  plan.hoistOps.clear();
+  plan.moveOps.clear();
+  for (Operation *op : ops) {
+    if (hoistedOps.contains(op))
+      plan.hoistOps.push_back(op);
+    if (movedOps.contains(op))
+      plan.moveOps.push_back(op);
+  }
+  return success();
+}
+
+static void wrapCluster(const ResultlessScopePlan &plan, MLIRContext *context) {
+  if (plan.moveOps.empty())
     return;
 
-  Operation *first = ops.front();
-  Operation *last = ops.back();
+  Operation *first = plan.moveOps.front();
   Block *parentBlock = first->getBlock();
 
   IRRewriter rewriter(context);
@@ -259,18 +365,26 @@ static void wrapCluster(ArrayRef<Operation *> ops, MLIRContext *context) {
   auto scope = rewriter.create<pto::VecScopeOp>(first->getLoc());
   scope.getBody().push_back(new Block());
 
+  for (Operation *op : plan.hoistOps) {
+    if (op->getBlock() == parentBlock && scope->isBeforeInBlock(op))
+      op->moveBefore(scope);
+  }
+
   Block &scopeBody = scope.getBody().front();
-  scopeBody.getOperations().splice(scopeBody.end(), parentBlock->getOperations(),
-                                   Block::iterator(first),
-                                   std::next(Block::iterator(last)));
+  for (Operation *op : plan.moveOps) {
+    scopeBody.getOperations().splice(scopeBody.end(),
+                                     parentBlock->getOperations(),
+                                     Block::iterator(op));
+  }
 }
 
 static LogicalResult wrapGreedySubclusters(ArrayRef<Operation *> ops,
                                            MLIRContext *context) {
   for (size_t begin = 0; begin < ops.size();) {
     size_t bestEnd = begin;
-    EscapingVectorScopeValue escapingValue;
-    bool sawEscapingVectorScopeResult = false;
+    ResultlessScopePlan bestPlan;
+    EscapingMovedValue escapingValue;
+    bool sawEscapingMovedResult = false;
 
     for (size_t end = ops.size(); end > begin; --end) {
       ArrayRef<Operation *> candidate = ops.slice(begin, end - begin);
@@ -279,26 +393,31 @@ static LogicalResult wrapGreedySubclusters(ArrayRef<Operation *> ops,
 
       // Prefer the largest suffix-preserving candidate that actually needs a
       // vecscope and can be moved into today's resultless pto.vecscope form.
-      if (canMoveIntoResultlessScope(candidate)) {
+      ResultlessScopePlan plan;
+      EscapingMovedValue candidateEscapingValue;
+      if (succeeded(buildResultlessScopePlan(candidate, plan,
+                                             candidateEscapingValue))) {
         bestEnd = end;
+        bestPlan = std::move(plan);
         break;
       }
 
-      if (!sawEscapingVectorScopeResult &&
-          findEscapingVectorScopeResult(candidate, escapingValue))
-        sawEscapingVectorScopeResult = true;
+      if (!sawEscapingMovedResult && candidateEscapingValue.producer) {
+        escapingValue = candidateEscapingValue;
+        sawEscapingMovedResult = true;
+      }
     }
 
     if (bestEnd == begin) {
       if (classifyOperationForInference(ops[begin]) ==
               VPTOInferenceOpClass::Vector &&
-          sawEscapingVectorScopeResult)
+          sawEscapingMovedResult && escapingValue.requiresDiagnostic)
         return emitEscapingVectorScopeValueError(escapingValue);
       ++begin;
       continue;
     }
 
-    wrapCluster(ops.slice(begin, bestEnd - begin), context);
+    wrapCluster(bestPlan, context);
     begin = bestEnd;
   }
   return success();

--- a/test/lit/vpto/auto_vecscope_infer_control_flow_results.pto
+++ b/test/lit/vpto/auto_vecscope_infer_control_flow_results.pto
@@ -1,0 +1,57 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @auto_vecscope_keeps_scf_results_outside_resultless_scope(%cond: i1) -> i32 {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c64 = arith.constant 64 : index
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i64 = arith.constant 0 : i64
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+
+    %loop_result = scf.for %i = %c0 to %c2 step %c1 iter_args(%acc = %c0_i32) -> (i32) {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %vec = pto.vlds %ub[%i] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+      pto.vsts %vec, %ub[%i], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+      %next = arith.addi %acc, %c1_i32 : i32
+      scf.yield %next : i32
+    }
+    pto.barrier #pto.pipe<PIPE_ALL>
+    %after_loop = arith.addi %loop_result, %c1_i32 : i32
+
+    %branch_result = scf.if %cond -> (i32) {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %vec = pto.vlds %ub[%c64] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+      pto.vsts %vec, %ub[%c64], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+      scf.yield %after_loop : i32
+    } else {
+      scf.yield %c0_i32 : i32
+    }
+    pto.barrier #pto.pipe<PIPE_ALL>
+    %final = arith.addi %branch_result, %c1_i32 : i32
+    return %final : i32
+  }
+  }
+}
+
+// CHECK-LABEL: func.func @auto_vecscope_keeps_scf_results_outside_resultless_scope
+// CHECK: %[[LOOP:.*]] = scf.for
+// CHECK: pto.vecscope {
+// CHECK: pto.pset_b32
+// CHECK: pto.vlds
+// CHECK: pto.vsts
+// CHECK: }
+// CHECK: pto.barrier
+// CHECK: %[[AFTER_LOOP:.*]] = arith.addi %[[LOOP]]
+// CHECK: %[[IF:.*]] = arith.select %arg0, %[[AFTER_LOOP]], %c0_i32 : i32
+// CHECK: pto.vecscope {
+// CHECK: pto.pset_b32
+// CHECK: pto.vlds
+// CHECK: pto.vsts
+// CHECK: }
+// CHECK: pto.barrier
+// CHECK: %[[FINAL:.*]] = arith.addi %[[IF]]
+// CHECK: return %[[FINAL]]

--- a/test/lit/vpto/auto_vecscope_infer_escape_error.pto
+++ b/test/lit/vpto/auto_vecscope_infer_escape_error.pto
@@ -1,6 +1,7 @@
 // RUN: ! ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - 2>&1 | FileCheck %s
 
 module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @auto_vecscope_infer_escape_error() {
     %c0 = arith.constant 0 : index
     %c0_i64 = arith.constant 0 : i64
@@ -11,6 +12,7 @@ module attributes {pto.target_arch = "a5"} {
     %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
     pto.vsts %vec, %ub[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
     return
+  }
   }
 }
 

--- a/test/lit/vpto/auto_vecscope_infer_shared_ptr_capture.pto
+++ b/test/lit/vpto/auto_vecscope_infer_shared_ptr_capture.pto
@@ -1,0 +1,38 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @auto_vecscope_infer_shared_ptr_capture(%gm_out: !pto.ptr<ui16, gm>) {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c2048_i64 = arith.constant 2048 : i64
+    %cst = arith.constant -5.000000e-01 : f32
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+
+    %src_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %store_mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %src = pto.vlds %ub_in[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %packed_f16 = pto.vcvt %src, %src_mask {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
+    %packed_u32 = pto.vbitcast %packed_f16 : !pto.vreg<128xf16> -> !pto.vreg<64xui32>
+    %packed_u16 = pto.vpack %packed_u32, "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+    %ub_out = pto.castptr %c2048_i64 : i64 -> !pto.ptr<ui16, ub>
+    pto.vsts %packed_u16, %ub_out[%c0], %store_mask {dist = "NORM_B16"} : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
+    pto.barrier #pto.pipe<PIPE_ALL>
+    %gm_out_base = pto.addptr %gm_out, %c0 : <ui16, gm> -> <ui16, gm>
+    pto.copy_ubuf_to_gm %ub_out, %gm_out_base, %c0_i64, %c1_i64, %c256_i64, %c0_i64, %c256_i64, %c256_i64 : !pto.ptr<ui16, ub>, !pto.ptr<ui16, gm>, i64, i64, i64, i64, i64, i64
+    return
+  }
+  }
+}
+
+// CHECK-LABEL: func.func @auto_vecscope_infer_shared_ptr_capture
+// CHECK: %[[UBOUT:.*]] = pto.castptr %c2048_i64 : i64 -> !pto.ptr<ui16, ub>
+// CHECK: pto.vecscope {
+// CHECK: pto.vcvt
+// CHECK: pto.vpack
+// CHECK: pto.vsts %{{.*}}, %[[UBOUT]][%c0], %{{.*}}
+// CHECK: }
+// CHECK: pto.barrier
+// CHECK: pto.copy_ubuf_to_gm %[[UBOUT]], %{{.*}}, %c0_i64, %c1_i64, %c256_i64, %c0_i64, %c256_i64, %c256_i64

--- a/test/lit/vpto/auto_vecscope_infer_vmulscvt_pack.pto
+++ b/test/lit/vpto/auto_vecscope_infer_vmulscvt_pack.pto
@@ -1,0 +1,31 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @auto_vecscope_infer_vmulscvt_pack() {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui16, ub>
+
+    %src_mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %store_mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+    %src = pto.vlds %ub_in[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %packed_f16 = pto.vcvt %src, %src_mask {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xf16>
+    %packed_u32 = pto.vbitcast %packed_f16 : !pto.vreg<128xf16> -> !pto.vreg<64xui32>
+    %packed_u16 = pto.vpack %packed_u32, "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+    pto.vsts %packed_u16, %ub_out[%c0], %store_mask : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
+    return
+  }
+  }
+}
+
+// CHECK-LABEL: func.func @auto_vecscope_infer_vmulscvt_pack
+// CHECK: pto.vecscope {
+// CHECK: pto.pset_b32
+// CHECK-NEXT: pto.pset_b16
+// CHECK: pto.vlds
+// CHECK: pto.vcvt
+// CHECK: pto.vbitcast
+// CHECK: pto.vpack
+// CHECK: pto.vsts


### PR DESCRIPTION
## Summary

Split the VPTO auto-vecscope inference work out of the PTODSL public-surface PR.

This PR carries the vecscope inference implementation and its follow-up fixes together with focused lit coverage, so the PTODSL surface PR can stay centered on the exported Python API, docs, and surface-level tests.

## What changed

- add the VPTO auto-vecscope inference implementation updates in `PTOInferVPTOVecScope.cpp`
- add focused lit coverage for:
  - shared pointer capture inside inferred vecscope
  - vmulscvt pack inference coverage
  - control-flow results staying outside resultless `pto.vecscope`
  - the existing vec-result escape diagnostic path

## Validation

- `/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto test/lit/vpto/auto_vecscope_infer_control_flow_results.pto -o - | FileCheck test/lit/vpto/auto_vecscope_infer_control_flow_results.pto`
- `bash -lc '/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto test/lit/vpto/auto_vecscope_infer_escape_error.pto -o - > /tmp/vecscope_escape_split.out 2>&1; test $? -ne 0; FileCheck test/lit/vpto/auto_vecscope_infer_escape_error.pto < /tmp/vecscope_escape_split.out'`
- `/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto test/lit/vpto/auto_vecscope_infer_shared_ptr_capture.pto -o - | FileCheck test/lit/vpto/auto_vecscope_infer_shared_ptr_capture.pto`
- `/home/zhangzhendong/ptoas-workspace/PTOAS/build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto test/lit/vpto/auto_vecscope_infer_vmulscvt_pack.pto -o - | FileCheck test/lit/vpto/auto_vecscope_infer_vmulscvt_pack.pto`
