### PR TITLE
feat(ptodsl): support gm-slot tpush/tpop pipe flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
             libedit-dev zlib1g-dev libxml2-dev libzstd-dev
           python3 -m pip install --upgrade pip
           # LLVM/MLIR Python bindings are not yet compatible with pybind11 3.x.
-          python3 -m pip install 'pybind11<3' numpy
+          python3 -m pip install setuptools wheel 'pybind11<3' numpy
 
       - name: Define payload paths
         shell: bash

--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -191,12 +191,13 @@ jobs:
 
           need_pip_install=0
           python3 -c "import numpy" >/dev/null 2>&1 || need_pip_install=1
+          python3 -c "import setuptools, wheel" >/dev/null 2>&1 || need_pip_install=1
           python3 -m pybind11 --cmakedir >/dev/null 2>&1 || need_pip_install=1
           python3 -c "import ml_dtypes" >/dev/null 2>&1 || need_pip_install=1
 
           if [[ "${need_pip_install}" -eq 1 ]]; then
             python3 -m pip install --upgrade pip
-            python3 -m pip install 'pybind11<3' numpy ml-dtypes
+            python3 -m pip install setuptools wheel 'pybind11<3' numpy ml-dtypes
           fi
 
       - name: Clean CI work dirs

--- a/_ptoas_build_backend.py
+++ b/_ptoas_build_backend.py
@@ -147,6 +147,10 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
         "PTO_INSTALL_DIR": str(_PTO_INSTALL_DIR),
         "LLVM_BUILD_DIR": str(_LLVM_BUILD_DIR),
         "PTO_WHEEL_DIST_DIR": str(_WHEEL_DIST_DIR),
+        # Keep wheel packaging on the same interpreter pip used to invoke the
+        # backend. This avoids drifting to a different `python3` on PATH in
+        # conda/self-hosted CI environments.
+        "PYTHON": sys.executable,
     })
     subprocess.check_call(
         ["bash", str(_REPO / "docker" / "create_wheel.sh")],

--- a/docker/create_wheel.sh
+++ b/docker/create_wheel.sh
@@ -43,6 +43,12 @@ if [ -z "${PTOAS_PYTHON_PACKAGE_VERSION}" ]; then
 fi
 export PTOAS_PYTHON_PACKAGE_VERSION
 
+"${PYTHON_BIN}" -c "import setuptools, wheel" >/dev/null 2>&1 || {
+  echo "Error: ${PYTHON_BIN} is missing required wheel build modules (setuptools, wheel)" >&2
+  echo "Hint: install them in the active environment before running pip with --no-build-isolation" >&2
+  exit 1
+}
+
 echo "Creating Python wheel..."
 echo "Wheel package version: ${PTOAS_PYTHON_PACKAGE_VERSION}"
 

--- a/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
+++ b/include/PTO/Transforms/InsertSync/PTOIRTranslator.h
@@ -70,6 +70,7 @@ private:
   // --- 内存/Alias 分析 ---
   void UpdateKernelArgMemInfo();
   LogicalResult UpdateAllocTileOpMemInfo(pto::AllocTileOp op);
+  LogicalResult UpdateDeclareGlobalOpMemInfo(pto::DeclareGlobalOp op);
   LogicalResult UpdateDeclareTileMemRefOpMemInfo(pto::DeclareTileMemRefOp op);
   LogicalResult UpdatePointerCastOpMemInfo(pto::PointerCastOp op);
   LogicalResult UpdateMemrefAllocOpMemInfo(memref::AllocOp op);

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -13138,10 +13138,11 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
   PTOArch arch = getTargetArch(op.getOperation());
 
   bool hasGlobalSlotTensor = static_cast<bool>(op.getGmSlotTensor());
+  bool hasGmSlotBuffer = static_cast<bool>(op.getGmSlotBuffer());
   bool hasC2vConsumerBuf = static_cast<bool>(op.getC2vConsumerBuf());
   bool hasV2cConsumerBuf = static_cast<bool>(op.getV2cConsumerBuf());
   if (hasGlobalSlotTensor) {
-    if (op.getGmSlotBuffer() || hasC2vConsumerBuf || hasV2cConsumerBuf) {
+    if (hasGmSlotBuffer || hasC2vConsumerBuf || hasV2cConsumerBuf) {
       return op.emitOpError(
           "globaltensor pipe init expects only 'gm_slot_tensor' and no "
           "'gm_slot_buffer', 'c2v_consumer_buf', or 'v2c_consumer_buf'");
@@ -13149,10 +13150,6 @@ static LogicalResult verifyFrontendInitCommon(InitOpT op,
     if (op.getLocalSlotNumAttr())
       return op.emitOpError(
           "globaltensor pipe init does not use 'local_slot_num'");
-    if (arch == PTOArch::A5) {
-      return op.emitOpError(
-          "globaltensor pipe entries are supported for a2/a3 l2g2l pipes");
-    }
     return verifyFrontendGlobalSlotTensor(
         op.getOperation(), op.getGmSlotTensor(), dirMask, op.getSlotSize());
   }
@@ -13527,7 +13524,7 @@ static LogicalResult verifyTensorEntryMatchesInternalPipeInit(Operation *op,
   Type slotElementType;
   ArrayRef<int64_t> slotShape;
   if (!getTensorLikeElementAndShape(initOp.getGmAddr().getType(),
-                                    slotElementType, slotShape)) {
+slotElementType, slotShape)) {
     return op->emitOpError()
            << "expects !pto.tensor_view pipe entry to use "
               "pto.initialize_l2g2l_pipe gm_addr with tensor/memref slot type";

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -318,6 +318,11 @@ void PTOIRTranslator::RecursionIR(Region *region) {
         return WalkResult::interrupt();
       }
     }
+    else if (auto declareGlobalOp = dyn_cast<pto::DeclareGlobalOp>(op)) {
+      if (failed(UpdateDeclareGlobalOpMemInfo(declareGlobalOp))) {
+        return WalkResult::interrupt();
+      }
+    }
     else if (auto castOp = dyn_cast<pto::PointerCastOp>(op)) {
       if (failed(UpdatePointerCastOpMemInfo(castOp))) return WalkResult::interrupt();
     }
@@ -516,6 +521,44 @@ PTOIRTranslator::UpdateDeclareTileMemRefOpMemInfo(pto::DeclareTileMemRefOp op) {
       res,
       res,
       space,
+      SmallVector<uint64_t>{0},
+      sizeInBytes);
+
+  buffer2MemInfoMap_[res].emplace_back(newMemInfo->clone());
+  return success();
+}
+
+LogicalResult
+PTOIRTranslator::UpdateDeclareGlobalOpMemInfo(pto::DeclareGlobalOp op) {
+  Value res = op.getEntry();
+  auto tensorViewType = dyn_cast<pto::TensorViewType>(res.getType());
+  if (!tensorViewType)
+    return failure();
+
+  uint64_t sizeInBytes = 0;
+  ArrayRef<int64_t> shape = tensorViewType.getShape();
+  bool isStatic = llvm::all_of(shape, [](int64_t dim) {
+    return dim != ShapedType::kDynamic;
+  });
+  if (isStatic) {
+    int64_t elemSize = static_cast<int64_t>(
+        pto::getPTOStorageElemByteSize(tensorViewType.getElementType()));
+    if (elemSize == 0)
+      return failure();
+    int64_t numElements = 1;
+    for (int64_t dim : shape)
+      numElements *= dim;
+    sizeInBytes = static_cast<uint64_t>(numElements * elemSize);
+  }
+
+  // declare_global is a symbolic GM entry placeholder whose address gets bound
+  // later by talloc/tpop. Using the SSA result as both base/root lets
+  // partition_view/tstore/tload and tpush/tpop share one alias chain so
+  // InsertSync can recover the GM-slot handshake ordering.
+  auto newMemInfo = std::make_unique<BaseMemInfo>(
+      res,
+      res,
+      pto::AddressSpace::GM,
       SmallVector<uint64_t>{0},
       sizeInBytes);
 

--- a/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
+++ b/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
@@ -6,11 +6,6 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Please refer to the License for details. You may not use this file except in compliance with the License.
-// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
-// See LICENSE in the root of the software repository for the full text of the License.
-
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -44,6 +39,7 @@ constexpr int8_t kC2VDirMask = 1;
 constexpr int8_t kV2CDirMask = 2;
 constexpr int8_t kBidirectionalDirMask = 3;
 constexpr unsigned kVisitedInitReserveSize = 16;
+constexpr llvm::StringLiteral kFrontendPipeIdAttrName = "__pto.frontend_id";
 
 struct PipePeerKey {
   std::string ownerFunc;
@@ -141,6 +137,15 @@ static std::optional<bool> getUsageNoSplit(PipeSplitUsage usage) {
 
 static std::string getFuncSymbol(func::FuncOp funcOp) {
   return funcOp.getSymName().str();
+}
+
+static PipePeerKey getGlobalTensorPipeKey(Operation *op, int8_t dirMask) {
+  std::string id = "unknown";
+  if (auto idAttr = op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName))
+    id = std::to_string(idAttr.getInt());
+  else
+    id = std::to_string(reinterpret_cast<uintptr_t>(op));
+  return PipePeerKey{"__pto_globaltensor_pipe", "id_" + id, dirMask};
 }
 
 static std::optional<PipePeerKey> getPipePeerKey(Value localAddr,
@@ -250,6 +255,22 @@ struct PTOInferValidatePipeInitPass
         key->dirMask = effectiveDirMask;
         keyedInits[*key].push_back(info.op);
       };
+
+      auto recordGlobalTensor = [&](int8_t effectiveDirMask) {
+        keyedInits[getGlobalTensorPipeKey(info.op, effectiveDirMask)].push_back(
+            info.op);
+      };
+
+      if (auto l2g2l = dyn_cast<InitializeL2G2LPipeOp>(info.op)) {
+        if (!l2g2l.getLocalAddr()) {
+          if (info.dirMask == kBidirectionalDirMask) {
+            recordGlobalTensor(kBidirectionalDirMask);
+          } else {
+            recordGlobalTensor(info.dirMask);
+          }
+          return;
+        }
+      }
 
       if (info.dirMask == kBidirectionalDirMask) {
         recordAddr(getLocalAddrOperand(initOp), kC2VDirMask);

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -118,29 +118,37 @@ static void propagateGlobalTensorStrides(DeclareGlobalOp decl,
 }
 
 template <typename InitOpT>
-static FailureOr<Value> createFrontendPipe(InitOpT initOp, IRRewriter &rewriter,
-                                           PTOArch arch, Type pipeTy,
-                                           int8_t dirMask, int32_t slotNum,
-                                           Value localAddr,
-                                           Value peerLocalAddr = Value{}) {
+static FailureOr<Value> createFrontendGlobalTensorPipe(InitOpT initOp,
+                                                       IRRewriter &rewriter,
+                                                       Type pipeTy,
+                                                       int8_t dirMask,
+                                                       int32_t slotNum) {
   Location loc = initOp.getLoc();
   auto dirAttr = rewriter.getI8IntegerAttr(dirMask);
   auto slotSizeAttr = rewriter.getI32IntegerAttr(initOp.getSlotSize());
   auto slotNumAttr = rewriter.getI32IntegerAttr(slotNum);
   auto noSplitAttr = initOp.getNosplitAttr();
+  auto pipe = rewriter.create<InitializeL2G2LPipeOp>(
+      loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, IntegerAttr{},
+      IntegerAttr{}, noSplitAttr, initOp.getGmSlotTensor(), Value{},
+      Value{});
+  propagateFrontendIdAttr(initOp, pipe.getOperation(), rewriter);
+  return pipe.getPipe();
+}
 
-  if (initOp.getGmSlotTensor()) {
-    if (arch == PTOArch::A5)
-      return initOp.emitOpError(
-          "globaltensor pipe entries are supported for a2/a3 l2g2l pipes");
-
-    auto pipe = rewriter.create<InitializeL2G2LPipeOp>(
-        loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, IntegerAttr{},
-        IntegerAttr{}, noSplitAttr, initOp.getGmSlotTensor(), Value{},
-        Value{});
-    propagateFrontendIdAttr(initOp, pipe.getOperation(), rewriter);
-    return pipe.getPipe();
-  }
+template <typename InitOpT>
+static FailureOr<Value> createFrontendLocalPipe(InitOpT initOp,
+                                                IRRewriter &rewriter,
+                                                PTOArch arch, Type pipeTy,
+                                                int8_t dirMask,
+                                                int32_t slotNum,
+                                                Value localAddr,
+                                                Value peerLocalAddr = Value{}) {
+  Location loc = initOp.getLoc();
+  auto dirAttr = rewriter.getI8IntegerAttr(dirMask);
+  auto slotSizeAttr = rewriter.getI32IntegerAttr(initOp.getSlotSize());
+  auto slotNumAttr = rewriter.getI32IntegerAttr(slotNum);
+  auto noSplitAttr = initOp.getNosplitAttr();
 
   if (arch == PTOArch::A5) {
     if (!localAddr)
@@ -176,9 +184,11 @@ lowerSingleDirectionFrontendInit(InitOpT initOp, IRRewriter &rewriter,
                                  PTOArch arch, Type pipeTy, int8_t dirMask,
                                  Value localAddr) {
   int32_t slotNum = getFrontendSlotNum(initOp);
-  auto pipeOr =
-      createFrontendPipe(initOp, rewriter, arch, pipeTy, dirMask, slotNum,
-                         localAddr);
+  auto pipeOr = initOp.getGmSlotTensor()
+                    ? createFrontendGlobalTensorPipe(initOp, rewriter, pipeTy,
+                                                     dirMask, slotNum)
+                    : createFrontendLocalPipe(initOp, rewriter, arch, pipeTy,
+                                              dirMask, slotNum, localAddr);
   if (failed(pipeOr))
     return failure();
 
@@ -201,10 +211,14 @@ static FailureOr<FrontendPipeHandles>
 lowerBidirectionalFrontendInit(InitOpT initOp, IRRewriter &rewriter,
                                PTOArch arch, Type pipeTy) {
   int32_t slotNum = getFrontendSlotNum(initOp);
-  auto pipeOr = createFrontendPipe(initOp, rewriter, arch, pipeTy,
-                                   kBidirectionalDirMask, slotNum,
-                                   initOp.getC2vConsumerBuf(),
-                                   initOp.getV2cConsumerBuf());
+  auto pipeOr = initOp.getGmSlotTensor()
+                    ? createFrontendGlobalTensorPipe(
+                          initOp, rewriter, pipeTy, kBidirectionalDirMask,
+                          slotNum)
+                    : createFrontendLocalPipe(initOp, rewriter, arch, pipeTy,
+                                              kBidirectionalDirMask, slotNum,
+                                              initOp.getC2vConsumerBuf(),
+                                              initOp.getV2cConsumerBuf());
   if (failed(pipeOr))
     return failure();
 

--- a/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
+++ b/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
@@ -84,6 +84,8 @@ struct PipeComponent {
   bool globalOnly = false;
   unsigned flagWidth = 0;
   std::optional<int32_t> explicitFlagBase;
+  std::optional<int32_t> frontendId;
+  size_t creationOrder = 0;
 };
 
 struct FlagInterval {
@@ -230,6 +232,12 @@ static void setFlagBaseAttr(Operation *op, IntegerAttr attr) {
     setFlagBaseAttr(initOp, attr);
 }
 
+static std::optional<int32_t> getFrontendPipeId(Operation *op) {
+  if (auto attr = op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName))
+    return attr.getInt();
+  return std::nullopt;
+}
+
 static bool samePipeInitSignature(const PipeInitInfo &lhs,
                                   const PipeInitInfo &rhs) {
   return std::tie(lhs.dirMask, lhs.slotSize, lhs.slotNum, lhs.localSlotNum,
@@ -299,6 +307,7 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
     component.slotNum = lhs.slotNum;
     component.localSlotNum = lhs.localSlotNum;
     component.globalOnly = lhs.globalOnly;
+    component.creationOrder = components.size();
     component.flagWidth = component.dirMask == kBidirectionalDirMask
                               ? kBidirectionalFlagWidth
                               : kSingleDirectionFlagWidth;
@@ -322,8 +331,29 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
           "from pto.reserve_buffer or pto.import_reserved_buffer");
     }
 
+    for (Operation *op : component.ops) {
+      if (auto frontendId = getFrontendPipeId(op)) {
+        if (component.frontendId && *component.frontendId != *frontendId) {
+          return op->emitOpError(
+              "conflicting __pto.frontend_id across peer pipe inits");
+        }
+        component.frontendId = *frontendId;
+      }
+    }
+
     components.push_back(std::move(component));
   }
+
+  llvm::stable_sort(components, [](const PipeComponent &lhs,
+                                   const PipeComponent &rhs) {
+    auto sortKey = [](const PipeComponent &component) {
+      if (component.frontendId)
+        return std::tuple(0, *component.frontendId, component.dirMask,
+                          component.creationOrder);
+      return std::tuple(1, 0, int8_t{0}, component.creationOrder);
+    };
+    return sortKey(lhs) < sortKey(rhs);
+  });
 
   return components;
 }

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -1090,7 +1090,7 @@ consumer-side local FIFO buffer and do not take `consumer_buf` or
 |-----------|------|-------------|
 | `consumer_buf` | varies | Required for local tile-entry pipes. Consumer-owned FIFO buffer. The consumer side reserves it with `pto.reserve_buffer`; the producer side imports it with `pto.import_reserved_buffer`. Omit for global-entry pipes. |
 | `id` | `int` | Required. Stable pipe identifier shared by the producer and consumer sides. |
-| `slot_size` | `int` | Required for local tile-entry pipes. Optional for global-entry pipes; defaults to the byte size of one slot of `gm_slot_tensor`. |
+| `slot_size` | `int` | Required for local tile-entry pipes. For global-entry pipes, omit it only when `nosplit=True` and `gm_slot_tensor` already describes one full slot; otherwise pass the full-slot byte size explicitly. |
 | `gm_slot_buffer` | `PtrType` | Optional GM FIFO storage pointer for A2/A3 local tile-entry L2G2L lowering. Do not use with `gm_slot_tensor`. |
 | `gm_slot_tensor` | `TensorView` | Optional. When provided, the pipe uses GlobalTensor-like entries and `alloc/pop` infer the entry descriptor type. |
 | `local_slot_num` | `int` | Optional. Local FIFO slot count override for local tile-entry pipes. |
@@ -1191,6 +1191,7 @@ Declaration (shared between Cube and Vector sides):
 c2v = pto.pipe.c2v(
     gm_slot_tensor=gm_slots,
     id=0,
+    nosplit=True,
 )
 ```
 
@@ -1234,6 +1235,7 @@ Declaration:
 v2c = pto.pipe.v2c(
     gm_slot_tensor=gm_slots,
     id=0,
+    nosplit=True,
 )
 ```
 
@@ -1348,6 +1350,7 @@ def cube_producer(
     c2v = pto.pipe.c2v(
         gm_slot_tensor=gm_view,
         id=0,
+        nosplit=True,
     )
 
     a_part = pto.partition_view(
@@ -1377,6 +1380,7 @@ def vector_consumer(
     c2v = pto.pipe.c2v(
         gm_slot_tensor=gm_view,
         id=0,
+        nosplit=True,
     )
 
     b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)

--- a/ptodsl/ptodsl/_pipe_namespace.py
+++ b/ptodsl/ptodsl/_pipe_namespace.py
@@ -47,6 +47,15 @@ def _infer_global_slot_size(gm_slot_tensor) -> int:
     return count * _element_bytewidth(tensor_view_type.element_type)
 
 
+def _infer_unambiguous_global_slot_size(gm_slot_tensor, *, nosplit, context: str) -> int:
+    if nosplit is True:
+        return _infer_global_slot_size(gm_slot_tensor)
+    raise TypeError(
+        f"{context} requires explicit slot_size for split-capable gm_slot_tensor pipes; "
+        "pass slot_size=... or set nosplit=True when one gm_slot_tensor shape equals one full slot"
+    )
+
+
 def _as_int(value, *, context: str):
     if value is None:
         return None
@@ -280,7 +289,11 @@ class _PipeNamespace:
         if slot_size is None:
             if gm_slot_tensor is None:
                 raise TypeError(f"pipe.{direction}(...) requires slot_size when gm_slot_tensor is not provided")
-            slot_size = _infer_global_slot_size(gm_slot_tensor)
+            slot_size = _infer_unambiguous_global_slot_size(
+                gm_slot_tensor,
+                nosplit=nosplit,
+                context=f"pipe.{direction}(...)",
+            )
         if gm_slot_tensor is not None:
             if consumer_buf is not None:
                 raise TypeError(f"pipe.{direction}(...) does not accept consumer_buf when gm_slot_tensor is provided")
@@ -290,7 +303,7 @@ class _PipeNamespace:
                 raise TypeError(f"pipe.{direction}(...) does not accept local_slot_num when gm_slot_tensor is provided")
             entry_type = unwrap_surface_value(gm_slot_tensor).type
         elif consumer_buf is None:
-            raise TypeError(f"pipe.{direction}(...) requires consumer_buf")
+            raise TypeError(f"pipe.{direction}(...) requires consumer_buf for local pipes")
         descriptor = _PipeDescriptor(
             kind="global" if gm_slot_tensor is not None else "local",
             direction=direction,

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -1892,6 +1892,7 @@ FRAGMENT_FIXTURES = {
             c2v = pto.pipe.c2v(
                 gm_slot_tensor=gm_view,
                 id=0,
+                nosplit=True,
             )
 
             a_part = pto.partition_view(
@@ -1913,6 +1914,7 @@ FRAGMENT_FIXTURES = {
             c2v = pto.pipe.c2v(
                 gm_slot_tensor=gm_view,
                 id=0,
+                nosplit=True,
             )
 
             b_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
@@ -1944,6 +1946,7 @@ FRAGMENT_FIXTURES = {
             v2c = pto.pipe.v2c(
                 gm_slot_tensor=gm_view,
                 id=0,
+                nosplit=True,
             )
 
             src_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)
@@ -1962,6 +1965,7 @@ FRAGMENT_FIXTURES = {
             v2c = pto.pipe.v2c(
                 gm_slot_tensor=gm_view,
                 id=0,
+                nosplit=True,
             )
 
             dst_tile = pto.alloc_tile(shape=[16, 16], dtype=pto.f32)

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -538,10 +538,11 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity), \
-             patch.object(_pipe_namespace, "_infer_global_slot_size", return_value=1024):
+             patch.object(_pipe_namespace, "_infer_unambiguous_global_slot_size", return_value=1024):
             pipe = pto.pipe.c2v(
                 gm_slot_tensor=gm_slot,
                 id=7,
+                nosplit=True,
             )
 
         self.assertEqual(pipe.id, 7)
@@ -565,6 +566,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
 
         expected_init_kwargs = {
             "id": 7,
+            "nosplit": True,
             "gm_slot_tensor": gm_slot,
         }
         aic_init.assert_called_once_with(1, 1024, **expected_init_kwargs)
@@ -650,6 +652,15 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             "v2c_consumer_buf": v2c_buf,
         })
 
+    def test_local_pipe_constructors_still_require_consumer_buffers(self):
+        with self.assertRaises(TypeError) as c2v_exc:
+            pto.pipe.c2v(slot_size=1024, id=3)
+        self.assertIn("requires consumer_buf for local pipes", str(c2v_exc.exception))
+
+        with self.assertRaises(TypeError) as v2c_exc:
+            pto.pipe.v2c(slot_size=2048, id=4)
+        self.assertIn("requires consumer_buf for local pipes", str(v2c_exc.exception))
+
     def test_pipe_constructors_require_explicit_stable_ids(self):
         buf = object()
         with make_context():
@@ -657,7 +668,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         gm_slot = SimpleNamespace(type=gm_slot_type)
 
         with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
-             patch.object(_pipe_namespace, "_infer_global_slot_size", return_value=1024):
+             patch.object(_pipe_namespace, "_infer_unambiguous_global_slot_size", return_value=1024):
             cases = [
                 lambda: pto.pipe.c2v(gm_slot_tensor=gm_slot),
                 lambda: pto.pipe.v2c(gm_slot_tensor=gm_slot),
@@ -684,6 +695,38 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                 with self.subTest(case=case):
                     with self.assertRaises(TypeError):
                         case()
+
+    def test_global_pipe_slot_size_inference_requires_unambiguous_nosplit(self):
+        with make_context():
+            gm_slot_type = _pipe_namespace._pto.TensorViewType.get([16, 16], F32Type.get())
+        gm_slot = SimpleNamespace(type=gm_slot_type)
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity):
+            for case in (
+                lambda: pto.pipe.c2v(gm_slot_tensor=gm_slot, id=11),
+                lambda: pto.pipe.v2c(gm_slot_tensor=gm_slot, id=12),
+            ):
+                with self.subTest(case=case):
+                    with self.assertRaises(TypeError) as exc:
+                        case()
+                    self.assertIn("requires explicit slot_size", str(exc.exception))
+                    self.assertIn("nosplit=True", str(exc.exception))
+
+    def test_global_pipe_allows_explicit_full_slot_size_for_split_consumer_shape(self):
+        with make_context():
+            gm_slot_type = _pipe_namespace._pto.TensorViewType.get([4, 64, 128], F32Type.get())
+        gm_slot = SimpleNamespace(type=gm_slot_type)
+
+        with patch.object(_pipe_namespace, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_pipe_namespace, "wrap_surface_value", side_effect=_identity):
+            pipe = pto.pipe.c2v(
+                gm_slot_tensor=gm_slot,
+                slot_size=262144,
+                id=13,
+            )
+
+        self.assertEqual(pipe.slot_size, 262144)
+        self.assertEqual(pipe.entry_type, gm_slot_type)
 
     def test_local_pipe_transactions_dispatch_to_tile_entry_frontend_ops(self):
         c2v_buf = object()

--- a/test/lit/pto/issue622_v_mte2_eventid_overlap_reproducer.pto
+++ b/test/lit/pto/issue622_v_mte2_eventid_overlap_reproducer.pto
@@ -17,12 +17,12 @@
 // lifetime reuse in isolation.
 //
 // CHECK-LABEL: AICORE void vector_kernel(
-// CHECK: TPOP<TPipe<2, Direction::DIR_C2V, 16384, 8, 2, false>,
+// CHECK: TPOP<TPipe<4, Direction::DIR_C2V, 16384, 8, 2, false>,
 // CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[OUTER_CARRY:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[OUTER_CARRY]]);
 // CHECK-NEXT: TNEG(
 // CHECK-NEXT: set_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[OUTER_TAIL:[0-9]+]]);
-// CHECK-NEXT: TFREE<TPipe<2, Direction::DIR_C2V, 16384, 8, 2, false>,
+// CHECK-NEXT: TFREE<TPipe<4, Direction::DIR_C2V, 16384, 8, 2, false>,
 // CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[OUTER_CARRY]]);
 // CHECK-NEXT: wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[OUTER_TAIL]]);
 // CHECK-NEXT: for (size_t
@@ -30,7 +30,7 @@
 // CHECK-NEXT: set_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[TAIL_HEAD:[0-9]+]]);
 // CHECK-NEXT: set_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[POST_LOOP:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID[[POST_LOOP]]);
-// CHECK-NEXT: TPOP<TPipe<2, Direction::DIR_C2V, 16384, 8, 2, false>,
+// CHECK-NEXT: TPOP<TPipe<4, Direction::DIR_C2V, 16384, 8, 2, false>,
 // CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[POST_POP:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[POST_POP]]);
 // CHECK: wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[TAIL_HEAD]]);

--- a/test/lit/pto/resolve_reserved_buffers_globaltensor_frontend_id_order_a5.pto
+++ b/test/lit/pto/resolve_reserved_buffers_globaltensor_frontend_id_order_a5.pto
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// Guards A5 globaltensor frontend pipe flag-base assignment so frontend ids,
+// not source order, determine the final resolve-reserved-buffers ordering.
+//
+// RUN: ptoas --pto-arch=a5 --mlir-print-ir-after=pto-resolve-reserved-buffers %s -o /dev/null 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel(%gm_qk: !pto.ptr<f32>, %gm_pv: !pto.ptr<f32>, %gm_p: !pto.ptr<f16>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %c256 = arith.constant 256 : index
+
+    %qk_slots = pto.make_tensor_view %gm_qk,
+      shape = [%c128, %c256], strides = [%c256, %c1]
+      : !pto.tensor_view<128x256xf32>
+    %pv_slots = pto.make_tensor_view %gm_pv,
+      shape = [%c128, %c128], strides = [%c128, %c1]
+      : !pto.tensor_view<128x128xf32>
+    %p_slots = pto.make_tensor_view %gm_p,
+      shape = [%c128, %c256], strides = [%c256, %c1]
+      : !pto.tensor_view<128x256xf16>
+
+    // Source order intentionally matches the cv-split demo:
+    // QK(id=0), PV(id=2), P(id=1).
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 131072}
+      (gm_slot_tensor = %qk_slots : !pto.tensor_view<128x256xf32>)
+    pto.aic_initialize_pipe {id = 2, dir_mask = 1, slot_size = 65536}
+      (gm_slot_tensor = %pv_slots : !pto.tensor_view<128x128xf32>)
+    pto.aic_initialize_pipe {id = 1, dir_mask = 2, slot_size = 65536}
+      (gm_slot_tensor = %p_slots : !pto.tensor_view<128x256xf16>)
+    func.return
+  }
+
+  func.func @vector_kernel(%gm_qk: !pto.ptr<f32>, %gm_pv: !pto.ptr<f32>, %gm_p: !pto.ptr<f16>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c256 = arith.constant 256 : index
+
+    %qk_slots = pto.make_tensor_view %gm_qk,
+      shape = [%c64, %c256], strides = [%c256, %c1]
+      : !pto.tensor_view<64x256xf32>
+    %pv_slots = pto.make_tensor_view %gm_pv,
+      shape = [%c64, %c128], strides = [%c128, %c1]
+      : !pto.tensor_view<64x128xf32>
+    %p_slots = pto.make_tensor_view %gm_p,
+      shape = [%c64, %c256], strides = [%c256, %c1]
+      : !pto.tensor_view<64x256xf16>
+
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 131072}
+      (gm_slot_tensor = %qk_slots : !pto.tensor_view<64x256xf32>)
+    pto.aiv_initialize_pipe {id = 2, dir_mask = 1, slot_size = 65536}
+      (gm_slot_tensor = %pv_slots : !pto.tensor_view<64x128xf32>)
+    pto.aiv_initialize_pipe {id = 1, dir_mask = 2, slot_size = 65536}
+      (gm_slot_tensor = %p_slots : !pto.tensor_view<64x256xf16>)
+    func.return
+  }
+}
+
+// CHECK-LABEL: func.func @cube_kernel(
+// CHECK: pto.initialize_l2g2l_pipe{dir_mask = 1, slot_size = 131072, slot_num = 8, flag_base = 0, nosplit = false}
+// CHECK-SAME: __pto.frontend_id = 0 : i32
+// CHECK: pto.initialize_l2g2l_pipe{dir_mask = 1, slot_size = 65536, slot_num = 8, flag_base = 4, nosplit = false}
+// CHECK-SAME: __pto.frontend_id = 2 : i32
+// CHECK: pto.initialize_l2g2l_pipe{dir_mask = 2, slot_size = 65536, slot_num = 8, flag_base = 2, nosplit = false}
+// CHECK-SAME: __pto.frontend_id = 1 : i32
+
+// CHECK-LABEL: func.func @vector_kernel(
+// CHECK: pto.initialize_l2g2l_pipe{dir_mask = 1, slot_size = 131072, slot_num = 8, flag_base = 0, nosplit = false}
+// CHECK-SAME: __pto.frontend_id = 0 : i32
+// CHECK: pto.initialize_l2g2l_pipe{dir_mask = 1, slot_size = 65536, slot_num = 8, flag_base = 4, nosplit = false}
+// CHECK-SAME: __pto.frontend_id = 2 : i32
+// CHECK: pto.initialize_l2g2l_pipe{dir_mask = 2, slot_size = 65536, slot_num = 8, flag_base = 2, nosplit = false}
+// CHECK-SAME: __pto.frontend_id = 1 : i32

--- a/test/lit/pto/tpush_tpop_globaltensor_frontend_a3.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_frontend_a3.pto
@@ -1,5 +1,17 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// Guards A3 frontend gm_slot_tensor lowering for a full-slot globaltensor pipe,
+// including resolve-reserved-buffers IR and final EmitC GlobalTensor ops.
+//
 // RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
 // RUN: ptoas --pto-arch=a3 --mlir-print-ir-after=pto-resolve-reserved-buffers %s 2>&1 >/dev/null | FileCheck %s --check-prefix=RESOLVE
+// RUN: ptoas --pto-arch=a3 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s 2>&1 | FileCheck %s --check-prefix=GSS
 
 module {
   func.func @cube_kernel(
@@ -69,12 +81,17 @@ module {
 // RESOLVE-LABEL: func.func @cube_kernel
 // RESOLVE-NOT: pto.reserve_buffer
 // RESOLVE-NOT: pto.import_reserved_buffer
-// RESOLVE: memref.reinterpret_cast %{{.*}} to offset: [0], sizes: [%{{.*}}, %{{.*}}], strides: [%{{.*}}, %{{.*}}]
-// RESOLVE: pto.initialize_l2g2l_pipe{{.*}}(%{{.*}} : memref<{{.*}}xf32{{.*}}>)
-// RESOLVE: pto.talloc(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe)
-// RESOLVE: pto.tpush(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe)
+// RESOLVE: pto.initialize_l2g2l_pipe{dir_mask = 1, slot_size = 1024, slot_num = 8, flag_base = 0, nosplit = true}
+// RESOLVE: %{{.*}} = pto.declare_global {__pto.globaltensor_strides = array<i64: 16, 1>} -> !pto.tensor_view<16x16xf32>
+// RESOLVE: pto.talloc(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe) {split = 0}
+// RESOLVE: pto.tpush(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe) {split = 0}
 // RESOLVE-LABEL: func.func @vector_kernel
 // RESOLVE-NOT: pto.reserve_buffer
 // RESOLVE-NOT: pto.import_reserved_buffer
-// RESOLVE: pto.tpop(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe)
-// RESOLVE: pto.tfree(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe)
+// RESOLVE: pto.tpop(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe) {split = 0}
+// RESOLVE: pto.tfree(%{{.*}}, %{{.*}} : !pto.tensor_view<16x16xf32>, !pto.pipe) {split = 0}
+
+// GSS-LABEL: AICORE void cube_kernel
+// GSS: TALLOC<TPipe<0, Direction::DIR_C2V, 1024, 8, 8, true>
+// GSS: TSTORE
+// GSS: TPUSH<TPipe<0, Direction::DIR_C2V, 1024, 8, 8, true>

--- a/test/lit/pto/tpush_tpop_globaltensor_frontend_a5.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_frontend_a5.pto
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// Guards A5 frontend gm_slot_tensor lowering through EmitC for both GM-only
+// directions, including DIR_C2V_GM and DIR_V2C_GM selection.
+//
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_c2v_kernel(%gm_slot_buffer : !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>)
+
+    %entry = pto.talloc_to_aiv {id = 0, split = 0}
+      -> !pto.tensor_view<16x16xf32>
+    pto.tpush_to_aiv(%entry : !pto.tensor_view<16x16xf32>) {id = 0, split = 0}
+    func.return
+  }
+
+  func.func @vector_c2v_kernel(%gm_slot_buffer : !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>)
+
+    %entry = pto.tpop_from_aic {id = 0, split = 0}
+      -> !pto.tensor_view<16x16xf32>
+    pto.tfree_from_aic(%entry : !pto.tensor_view<16x16xf32>) {id = 0, split = 0}
+    func.return
+  }
+
+  func.func @vector_v2c_kernel(%gm_slot_buffer : !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>)
+
+    %entry = pto.talloc_to_aic {id = 0, split = 0}
+      -> !pto.tensor_view<16x16xf32>
+    pto.tpush_to_aic(%entry : !pto.tensor_view<16x16xf32>) {id = 0, split = 0}
+    func.return
+  }
+
+  func.func @cube_v2c_kernel(%gm_slot_buffer : !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c16, %c16], strides = [%c16, %c1]
+      : !pto.tensor_view<16x16xf32>
+    pto.aic_initialize_pipe {id = 0, dir_mask = 2, slot_size = 1024}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<16x16xf32>)
+
+    %entry = pto.tpop_from_aiv {id = 0, split = 0}
+      -> !pto.tensor_view<16x16xf32>
+    pto.tfree_from_aiv(%entry : !pto.tensor_view<16x16xf32>) {id = 0, split = 0}
+    func.return
+  }
+}
+
+// CHECK-LABEL: AICORE void cube_c2v_kernel(__gm__ float*
+// CHECK: TPipe<0, Direction::DIR_C2V_GM, 1024, 8, 8, true>({{.*}}, {{.*}}, {{.*}});
+// CHECK: GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND> [[CUBE_C2V_ENTRY:v[0-9]+]](nullptr);
+// CHECK: TALLOC<TPipe<0, Direction::DIR_C2V_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>({{.*}}, [[CUBE_C2V_ENTRY]]);
+// CHECK: TPUSH<TPipe<0, Direction::DIR_C2V_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>({{.*}}, [[CUBE_C2V_ENTRY]]);
+
+// CHECK-LABEL: AICORE void vector_c2v_kernel(__gm__ float*
+// CHECK: TPipe<0, Direction::DIR_C2V_GM, 1024, 8, 8, true>({{.*}}, {{.*}}, {{.*}});
+// CHECK: GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND> [[VEC_C2V_ENTRY:v[0-9]+]](nullptr);
+// CHECK: TPOP<TPipe<0, Direction::DIR_C2V_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>(
+// CHECK: TFREE<TPipe<0, Direction::DIR_C2V_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>(
+
+// CHECK-LABEL: AICORE void vector_v2c_kernel(__gm__ float*
+// CHECK: TPipe<0, Direction::DIR_V2C_GM, 1024, 8, 8, true>({{.*}}, {{.*}}, {{.*}});
+// CHECK: GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND> [[VEC_V2C_ENTRY:v[0-9]+]](nullptr);
+// CHECK: TALLOC<TPipe<0, Direction::DIR_V2C_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>({{.*}}, [[VEC_V2C_ENTRY]]);
+// CHECK: TPUSH<TPipe<0, Direction::DIR_V2C_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>({{.*}}, [[VEC_V2C_ENTRY]]);
+
+// CHECK-LABEL: AICORE void cube_v2c_kernel(__gm__ float*
+// CHECK: TPipe<0, Direction::DIR_V2C_GM, 1024, 8, 8, true>({{.*}}, {{.*}}, {{.*}});
+// CHECK: GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND> [[CUBE_V2C_ENTRY:v[0-9]+]](nullptr);
+// CHECK: TPOP<TPipe<0, Direction::DIR_V2C_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>(
+// CHECK: TFREE<TPipe<0, Direction::DIR_V2C_GM, 1024, 8, 8, true>, GlobalTensor<float, pto::Shape<1, 1, 1, 16, 16>, pto::Stride<256, 256, 256, 16, 1>, pto::Layout::ND>, TileSplitAxis::TILE_NO_SPLIT>(

--- a/test/lit/pto/tpush_tpop_globaltensor_loop_nosplit_a3.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_loop_nosplit_a3.pto
@@ -1,3 +1,14 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// Guards nosplit globaltensor GM-slot pipes on A3 when one FIFO entry spans a
+// multi-tile loop body and must preserve full-slot shape/stride lowering.
+//
 // RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
 
 module {

--- a/test/lit/pto/tpush_tpop_globaltensor_nosplit_conflict_invalid.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_nosplit_conflict_invalid.pto
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// Guards global-only gm_slot_tensor peer validation so cube/vector halves of
+// one logical pipe cannot infer conflicting split usage.
+//
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @cube_kernel(%gm_slot_buffer : !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c4 = arith.constant 4 : index
+    %c128 = arith.constant 128 : index
+    %c16384 = arith.constant 16384 : index
+    %c1 = arith.constant 1 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c4, %c128, %c128], strides = [%c16384, %c128, %c1]
+      : !pto.tensor_view<4x128x128xf32>
+    pto.aic_initialize_pipe {id = 0, dir_mask = 1, slot_size = 262144}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<4x128x128xf32>)
+
+    %entry = pto.talloc_to_aiv {id = 0, split = 0}
+      -> !pto.tensor_view<4x128x128xf32>
+    pto.tpush_to_aiv(%entry : !pto.tensor_view<4x128x128xf32>) {id = 0, split = 0}
+    return
+  }
+
+  func.func @vector_kernel(%gm_slot_buffer : !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c4 = arith.constant 4 : index
+    %c64 = arith.constant 64 : index
+    %c16 = arith.constant 16 : index
+    %c1 = arith.constant 1 : index
+    %c128 = arith.constant 128 : index
+    %c16384 = arith.constant 16384 : index
+    %gm_slots = pto.make_tensor_view %gm_slot_buffer,
+      shape = [%c4, %c64, %c128], strides = [%c16384, %c128, %c1]
+      : !pto.tensor_view<4x64x128xf32>
+    pto.aiv_initialize_pipe {id = 0, dir_mask = 1, slot_size = 262144}
+      (gm_slot_tensor = %gm_slots : !pto.tensor_view<4x64x128xf32>)
+
+    %entry = pto.tpop_from_aic {id = 0, split = 1}
+      -> !pto.tensor_view<4x64x128xf32>
+    pto.tfree_from_aic(%entry : !pto.tensor_view<4x64x128xf32>) {id = 0, split = 1}
+    return
+  }
+}
+
+// CHECK: error: 'pto.initialize_l2g2l_pipe' op conflicting pipe split usage across peer pipe init ops

--- a/test/lit/pto/tpush_tpop_globaltensor_split_half_slot_a3.pto
+++ b/test/lit/pto/tpush_tpop_globaltensor_split_half_slot_a3.pto
@@ -1,3 +1,14 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// Guards split-half-slot globaltensor GM-slot pipes on A3 so split consumers
+// keep the reduced entry shape while reusing the original slot strides.
+//
 // RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
 
 module {


### PR DESCRIPTION
## Summary

This PR extracts the core GM-slot/globaltensor `tpush` / `tpop` support onto a branch based on `official/main`.

Included scope:
- add PTODSL pipe surface APIs and globaltensor pipe surface refinements
- allow A5 GM-slot/globaltensor pipe entry flows needed by `tpush` / `tpop`
- fix globaltensor `flag_base` allocation order for frontend pipe ids
- fix insert-sync handling for GM-slot `tpush` / `tpop`
- fix A5 EmitC lowering for `tpush` / `tpop`

## Notes

To keep this PR self-contained on top of `official/main`, it intentionally does **not** include later mixed-backend / section-region PTODSL work.

Because of that, this PR drops the PTODSL `local_c2v` sample compile test that depended on those later section-generation changes, and keeps the validation focused on:
- PTODSL surface unit coverage already supported on `official/main`
- PTOAS/FileCheck coverage for globaltensor frontend lowering, split handling, verifier behavior, and `flag_base` ordering

## Validation

- `ctest --output-on-failure -R 'ptodsl_(vector_cube_ops|ptoas_frontend_verify)'`
- manual `ptoas + FileCheck` for:
  - `test/lit/pto/tpush_tpop_globaltensor_frontend_a3.pto`
  - `test/lit/pto/tpush_tpop_globaltensor_loop_nosplit_a3.pto`
  - `test/lit/pto/tpush_tpop_globaltensor_split_half_slot_a3.pto`
  - `test/lit/pto/resolve_reserved_buffers_globaltensor_frontend_id_order_a5.pto`
  - `test/lit/pto/frontend_pipe_module_kind_verify_invalid.pto`
  - `test/lit/pto/frontend_pipe_section_kind_verify_invalid.pto`
