### PR TITLE
显式标记 PTO entry

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -113,6 +113,11 @@ jobs:
       VPTO_SIM_WORKSPACE: ${{ github.workspace }}/.work/vpto-sim-ci
       TILELANG_DSL_WORKSPACE: ${{ github.workspace }}/.work/tilelang-dsl-ci
       TILELANG_DSL_UT_WORKSPACE: ${{ github.workspace }}/.work/tilelang-dsl-ut-ci
+      PYPTO_REF: main
+      PYPTO_WORKSPACE: ${{ github.workspace }}/.work/pypto-ci
+      PYPTO_RUN_WORKSPACE: ${{ github.workspace }}/.work/pypto-run-ci
+      PTO_ISA_COMMIT: 016396b57e2c17093f1194e6acd89bb112b0ab24
+      PTO_ISA_ROOT: ${{ github.workspace }}/.work/pto-isa-ci
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -202,6 +207,9 @@ jobs:
           rm -rf "${PTO_INSTALL_DIR}"
           rm -rf "${VPTO_SIM_WORKSPACE}"
           rm -rf "${TILELANG_DSL_WORKSPACE}"
+          rm -rf "${PYPTO_WORKSPACE}"
+          rm -rf "${PYPTO_RUN_WORKSPACE}"
+          rm -rf "${PTO_ISA_ROOT}"
 
       - name: Prepare LLVM source
         shell: bash
@@ -295,6 +303,156 @@ jobs:
           echo "ASCEND_HOME_PATH=${ASCEND_HOME_PATH_DETECTED}" >> "${GITHUB_ENV}"
           echo "PTOAS_BIN=${GITHUB_WORKSPACE}/build/tools/ptoas/ptoas" >> "${GITHUB_ENV}"
 
+      - name: Checkout PyPTO
+        uses: actions/checkout@v4
+        with:
+          repository: hw-native-sys/pypto
+          ref: ${{ env.PYPTO_REF }}
+          path: ${{ env.PYPTO_WORKSPACE }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout PTO-ISA
+        uses: actions/checkout@v4
+        with:
+          repository: hw-native-sys/pto-isa
+          ref: ${{ env.PTO_ISA_COMMIT }}
+          path: ${{ env.PTO_ISA_ROOT }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Ensure GCC 15 for PyPTO simulator
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          compiler_major() {
+            "$1" -dumpfullversion -dumpversion | cut -d. -f1
+          }
+
+          if command -v g++-15 >/dev/null 2>&1; then
+            if [[ "$(compiler_major "$(command -v g++-15)")" != "15" ]]; then
+              echo "ERROR: g++-15 exists but is not GCC 15: $(g++-15 --version | head -1)" >&2
+              exit 1
+            fi
+            if ! command -v gcc-15 >/dev/null 2>&1; then
+              echo "ERROR: g++-15 exists but gcc-15 is missing." >&2
+              exit 1
+            fi
+            exit 0
+          fi
+
+          if ! command -v x86_64-conda-linux-gnu-g++ >/dev/null 2>&1 || \
+             ! command -v x86_64-conda-linux-gnu-gcc >/dev/null 2>&1 || \
+             [[ "$(compiler_major "$(command -v x86_64-conda-linux-gnu-g++)")" != "15" ]]; then
+            if ! command -v conda >/dev/null 2>&1; then
+              echo "ERROR: PyPTO simulator smoke requires GCC/G++ 15 and conda is unavailable to install it." >&2
+              exit 1
+            fi
+            conda install -y -c conda-forge gcc_linux-64=15 gxx_linux-64=15
+            hash -r
+          fi
+
+          mkdir -p "${PYPTO_WORKSPACE}/.work/bin"
+          ln -sf "$(command -v x86_64-conda-linux-gnu-g++)" "${PYPTO_WORKSPACE}/.work/bin/g++-15"
+          ln -sf "$(command -v x86_64-conda-linux-gnu-gcc)" "${PYPTO_WORKSPACE}/.work/bin/gcc-15"
+          echo "${PYPTO_WORKSPACE}/.work/bin" >> "${GITHUB_PATH}"
+
+      - name: Prepare PyPTO Python dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --index-url https://download.pytorch.org/whl/cpu torch
+          python3 -m pip install scikit-build-core nanobind ninja pytest cloudpickle
+
+      - name: Install PyPTO frontend and runtime
+        shell: bash
+        env:
+          PTO_ISA_ROOT: ${{ env.PTO_ISA_ROOT }}
+        run: |
+          set -euo pipefail
+          rm -rf "${PYPTO_WORKSPACE}/build" "${PYPTO_WORKSPACE}/_skbuild" "${PYPTO_WORKSPACE}/runtime/build"
+          python3 -m pip install --no-build-isolation --no-deps "${PYPTO_WORKSPACE}"
+          # ci_sim only runs PyPTO simulator tests. Keep the runtime install from
+          # auto-detecting onboard platforms from the runner's CANN environment.
+          env -u ASCEND_HOME_PATH python3 -m pip install --no-build-isolation --no-deps "${PYPTO_WORKSPACE}/runtime"
+
+      - name: Run PyPTO PTOAS end-to-end simulator smoke
+        shell: bash
+        env:
+          PTOAS_ROOT: ${{ github.workspace }}/build/tools/ptoas
+          PTO_ISA_ROOT: ${{ env.PTO_ISA_ROOT }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${PYPTO_RUN_WORKSPACE}"
+          cd "${PYPTO_WORKSPACE}"
+
+          run_pypto_pytest() {
+            local platform="$1"
+            local suite_name="$2"
+            local kernels_dir="${PYPTO_RUN_WORKSPACE}/${suite_name}_${platform}"
+            local log_file="${PYPTO_RUN_WORKSPACE}/${suite_name}_${platform}.log"
+            shift 2
+
+            python3 -m pytest "$@" \
+              -v \
+              --platform="${platform}" \
+              --pto-isa-commit="${PTO_ISA_COMMIT}" \
+              --save-kernels \
+              --kernels-dir="${kernels_dir}" \
+              2>&1 | tee "${log_file}"
+          }
+
+          # All suites below compile through PyPTO's PTO backend and run ptoas.
+          # They are split into separate pytest processes to avoid backend global-state conflicts.
+          run_pypto_core_smoke() {
+            local platform="$1"
+            local dyn_valid_shape="tests/st/runtime/control_flow/test_dyn_orch_shape.py::TestDynOrchShapeOperations::test_dyn_orch_valid_shape_add[shape0-valid_shape0-${platform}]"
+            local cross_core="tests/st/runtime/cross_core/test_cross_core.py::TestCrossCore::test_tpush_tpop_v2c_updown[${platform}]"
+            local pypto_smoke_tests=(
+              tests/st/examples/00_hello_world/test_hello_world.py
+              tests/st/examples/02_intermediate/test_softmax.py::TestTileSoftmax::test_tile_softmax
+              tests/st/examples/02_intermediate/test_rms_norm.py::TestRMSNormCore::test_rms_norm_core
+              tests/st/runtime/ops/test_elementwise.py
+              tests/st/runtime/ops/test_assemble.py
+              tests/st/runtime/framework_and_models/test_jit.py::TestJITExecution::test_cache_hit_reuses_compiled_program
+              tests/st/runtime/framework_and_models/test_jit.py::TestJITDynamicBatch::test_one_artifact_serves_multiple_batches
+              tests/st/runtime/framework_and_models/test_compiled_program.py::TestManualWorkerExtraction::test_block_dim_override_runs
+              "${dyn_valid_shape}"
+              "${cross_core}"
+            )
+            run_pypto_pytest "${platform}" core_ptoas "${pypto_smoke_tests[@]}"
+          }
+
+          run_pypto_fa_ptoas_smoke() {
+            local platform="$1"
+            local pypto_fa_tests=(
+              tests/st/runtime/ops/test_cast.py::TestCast::test_tile_cast_col_major_narrow
+              tests/st/runtime/framework_and_models/test_paged_attention.py::TestPagedAttentionKernels::test_qk_matmul_ptoas[16-128-128]
+              tests/st/runtime/framework_and_models/test_paged_attention.py::TestPagedAttentionKernels::test_softmax_prepare_ptoas[16-128]
+              tests/st/runtime/framework_and_models/test_paged_attention.py::TestPagedAttentionKernels::test_softmax_prepare_unaligned_ptoas[16-128-100]
+              tests/st/runtime/framework_and_models/test_paged_attention.py::TestPagedAttentionKernels::test_pv_matmul_ptoas[16-128-128]
+              tests/st/runtime/framework_and_models/test_paged_attention.py::TestPagedAttentionKernels::test_online_update_ptoas[16-128-0-1]
+            )
+            run_pypto_pytest "${platform}" fa_ptoas "${pypto_fa_tests[@]}"
+          }
+
+          run_pypto_int8_codegen_smoke() {
+            local platform="$1"
+            local pypto_int8_tests=(
+              tests/st/codegen/dsl/test_batch_matmul_pipeline.py::test_no_mat_to_mat_tmov
+            )
+            run_pypto_pytest "${platform}" int8_ptoas_codegen "${pypto_int8_tests[@]}"
+          }
+
+          run_pypto_core_smoke a5sim
+          run_pypto_fa_ptoas_smoke a5sim
+          run_pypto_core_smoke a2a3sim
+          run_pypto_fa_ptoas_smoke a2a3sim
+          run_pypto_int8_codegen_smoke a2a3sim
+
       - name: Run VPTO SIM validation
         if: ${{ true }}
         shell: bash
@@ -373,4 +531,13 @@ jobs:
           path: |
             ${{ env.VPTO_SIM_WORKSPACE }}/parallel-runner.log
             ${{ env.VPTO_SIM_WORKSPACE }}/parallel-summary.tsv
+          if-no-files-found: warn
+
+      - name: Upload PyPTO SIM logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypto-sim-smoke-${{ github.run_id }}
+          path: |
+            ${{ env.PYPTO_RUN_WORKSPACE }}/*.log
           if-no-files-found: warn

--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -471,6 +471,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${TILELANG_DSL_WORKSPACE}"
+          export LLVM_BUILD_DIR="${LLVM_DIR}"
+          export MLIR_PYTHON_ROOT="${MLIR_PYTHONPATH}"
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
             PTOAS_BIN="${PTOAS_BIN}" \

--- a/include/PTO/IR/PTO.h
+++ b/include/PTO/IR/PTO.h
@@ -177,7 +177,7 @@ private:
 };
 
 
-/// Function attribute that marks an explicit PTO kernel entry.
+/// Function attributes that mark an explicit PTO kernel entry.
 inline constexpr llvm::StringLiteral kPTOEntryAttrName = "pto.entry";
 inline constexpr llvm::StringLiteral kLegacyHACCEntryAttrName = "hacc.entry";
 inline constexpr llvm::StringLiteral kPTOKernelAttrName = "pto.kernel";
@@ -188,13 +188,9 @@ inline constexpr llvm::StringLiteral kPTOSimtMaxThreadsAttrName =
 inline constexpr llvm::StringLiteral kPTOSimtMaxRegistersAttrName =
     "pto.simt_max_regs";
 
-/// Return true if the operation carries a PTO kernel marker.
-bool hasPTOKernelAttr(Operation *op);
-
-/// Return true if the function is a PTO kernel definition.
-bool isPTOKernelFunction(func::FuncOp func);
-
-/// Return true if the function carries an explicit entry marker.
+/// Return true if the function carries an explicit entry marker. PTO accepts
+/// both the EmitC naming (`pto.entry`) and VPTO naming (`pto.kernel`) as entry
+/// aliases; `hacc.entry` and `pto.aicore` are legacy aliases.
 bool hasExplicitPTOEntryAttr(func::FuncOp func);
 
 /// Return true if the function should be emitted as an AICORE entry.
@@ -203,7 +199,7 @@ bool isPTOEntryFunction(func::FuncOp func);
 /// Validate module-level PTO entry configuration before EmitC lowering.
 LogicalResult validatePTOEntryFunctions(ModuleOp module);
 
-/// Materialize the effective PTO entry selection onto function attributes.
+/// Clear internal PTO entry selection markers from function attributes.
 void annotatePTOEntryFunctions(ModuleOp module);
 
 } // namespace pto

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2511,47 +2511,20 @@ bool mlir::pto::isScalarPtrOrMemRef(Type type) {
   return false;
 }
 
-bool mlir::pto::hasPTOKernelAttr(Operation *op) {
-  return op && (op->hasAttr(kPTOKernelAttrName) ||
-                op->hasAttr(kLegacyPTOAICoreAttrName));
-}
-
-bool mlir::pto::isPTOKernelFunction(func::FuncOp func) {
-  return func && !func.isDeclaration() && hasPTOKernelAttr(func.getOperation());
-}
-
 bool mlir::pto::hasExplicitPTOEntryAttr(func::FuncOp func) {
   return func && (func->hasAttrOfType<UnitAttr>(kPTOEntryAttrName) ||
-                  func->hasAttrOfType<UnitAttr>(kLegacyHACCEntryAttrName));
+                  func->hasAttrOfType<UnitAttr>(kLegacyHACCEntryAttrName) ||
+                  func->hasAttrOfType<UnitAttr>(kPTOKernelAttrName) ||
+                  func->hasAttrOfType<UnitAttr>(kLegacyPTOAICoreAttrName));
 }
 
 static constexpr StringLiteral kEffectivePTOEntryAttrName =
     "pto.internal.entry";
 
-static SmallVector<func::FuncOp> getPTOFunctionDefinitions(ModuleOp module) {
-  SmallVector<func::FuncOp> defs;
-  if (!module)
-    return defs;
-  for (auto func : module.getOps<func::FuncOp>()) {
-    if (!func.isDeclaration())
-      defs.push_back(func);
-  }
-  return defs;
-}
-
 bool mlir::pto::isPTOEntryFunction(func::FuncOp func) {
   if (!func || func.isDeclaration())
     return false;
-  if (auto attr = func->getAttrOfType<BoolAttr>(kEffectivePTOEntryAttrName))
-    return attr.getValue();
-  if (hasExplicitPTOEntryAttr(func))
-    return true;
-
-  ModuleOp module = func->getParentOfType<ModuleOp>();
-  if (!module)
-    return false;
-  SmallVector<func::FuncOp> defs = getPTOFunctionDefinitions(module);
-  return defs.size() == 1 && defs.front() == func;
+  return hasExplicitPTOEntryAttr(func);
 }
 
 LogicalResult mlir::pto::validatePTOEntryFunctions(ModuleOp module) {
@@ -2569,7 +2542,7 @@ LogicalResult mlir::pto::validatePTOEntryFunctions(ModuleOp module) {
   }
 
   for (auto func : module.getOps<func::FuncOp>()) {
-    if (!isPTOEntryFunction(func))
+    if (!hasExplicitPTOEntryAttr(func))
       continue;
     if (func.getFunctionType().getNumResults() != 0) {
       return func.emitOpError()
@@ -2583,23 +2556,8 @@ void mlir::pto::annotatePTOEntryFunctions(ModuleOp module) {
   if (!module)
     return;
 
-  SmallVector<func::FuncOp> defs = getPTOFunctionDefinitions(module);
   for (auto func : module.getOps<func::FuncOp>())
     func->removeAttr(kEffectivePTOEntryAttrName);
-
-  if (defs.empty())
-    return;
-  if (defs.size() == 1) {
-    defs.front()->setAttr(kEffectivePTOEntryAttrName,
-                          BoolAttr::get(module.getContext(), true));
-    return;
-  }
-
-  for (auto func : defs) {
-    func->setAttr(kEffectivePTOEntryAttrName,
-                  BoolAttr::get(module.getContext(),
-                                hasExplicitPTOEntryAttr(func)));
-  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -3689,9 +3689,7 @@ static FailureOr<VcvtContract> buildVcvtContract(pto::VcvtOp op) {
 }
 
 static bool needsV300CtrlModeForVPTOFunc(func::FuncOp funcOp) {
-  if ((!pto::isPTOEntryFunction(funcOp) &&
-       !pto::isPTOKernelFunction(funcOp)) ||
-      funcOp.getBlocks().empty())
+  if (!pto::isPTOEntryFunction(funcOp) || funcOp.getBlocks().empty())
     return false;
 
   bool needsCtrlSetup = false;
@@ -9958,7 +9956,7 @@ static LogicalResult renameKernelFunctionsForKernelKind(ModuleOp module,
   }
 
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
-    if (!pto::hasPTOKernelAttr(funcOp.getOperation()))
+    if (!pto::hasExplicitPTOEntryAttr(funcOp))
       continue;
     if (funcOp.getSymName().ends_with(suffix))
       continue;

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -3660,9 +3660,7 @@ static FailureOr<VcvtContract> buildVcvtContract(pto::VcvtOp op) {
 }
 
 static bool needsV300CtrlModeForVPTOFunc(func::FuncOp funcOp) {
-  if ((!pto::isPTOEntryFunction(funcOp) &&
-       !pto::isPTOKernelFunction(funcOp)) ||
-      funcOp.getBlocks().empty())
+  if (!pto::isPTOEntryFunction(funcOp) || funcOp.getBlocks().empty())
     return false;
 
   bool needsCtrlSetup = false;
@@ -9988,7 +9986,7 @@ static LogicalResult renameKernelFunctionsForKernelKind(ModuleOp module,
   }
 
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
-    if (!pto::hasPTOKernelAttr(funcOp.getOperation()))
+    if (!pto::hasExplicitPTOEntryAttr(funcOp))
       continue;
     if (funcOp.getSymName().ends_with(suffix))
       continue;

--- a/lib/PTO/Transforms/VPTOSplitCVModule.cpp
+++ b/lib/PTO/Transforms/VPTOSplitCVModule.cpp
@@ -38,7 +38,7 @@ static bool hasKernelKindChildModule(ModuleOp module) {
 static bool hasCVSections(ModuleOp module) {
   bool found = false;
   module.walk([&](func::FuncOp funcOp) {
-    if (found || !pto::isPTOKernelFunction(funcOp))
+    if (found || !pto::isPTOEntryFunction(funcOp))
       return WalkResult::advance();
     WalkResult result = funcOp.walk([&](Operation *op) {
       if (isa<SectionCubeOp, SectionVectorOp>(op)) {
@@ -56,7 +56,7 @@ static bool hasCVSections(ModuleOp module) {
 static bool hasSectionKind(ModuleOp module, FunctionKernelKind kind) {
   bool found = false;
   module.walk([&](func::FuncOp funcOp) {
-    if (found || !pto::isPTOKernelFunction(funcOp))
+    if (found || !pto::isPTOEntryFunction(funcOp))
       return WalkResult::advance();
     WalkResult result = funcOp.walk([&](Operation *op) {
       bool matches = kind == FunctionKernelKind::Cube
@@ -121,7 +121,7 @@ static LogicalResult verifyNoNestedSections(ModuleOp module) {
 static LogicalResult verifyKernelFunctionsUseSections(ModuleOp module) {
   LogicalResult status = success();
   module.walk([&](func::FuncOp funcOp) {
-    if (failed(status) || !pto::isPTOKernelFunction(funcOp))
+    if (failed(status) || !pto::isPTOEntryFunction(funcOp))
       return WalkResult::advance();
     if (!hasAnySection(funcOp)) {
       status = funcOp.emitOpError(
@@ -137,7 +137,7 @@ static LogicalResult verifyKernelFunctionsUseSections(ModuleOp module) {
 static LogicalResult verifyUniqueSectionKindsPerFunction(ModuleOp module) {
   LogicalResult status = success();
   module.walk([&](func::FuncOp funcOp) {
-    if (failed(status) || !pto::isPTOKernelFunction(funcOp))
+    if (failed(status) || !pto::isPTOEntryFunction(funcOp))
       return WalkResult::advance();
     unsigned cubeCount = 0;
     unsigned vectorCount = 0;
@@ -164,7 +164,7 @@ static void eraseKernelFunctionsWithoutSectionKind(ModuleOp module,
                                                    FunctionKernelKind kind) {
   SmallVector<func::FuncOp> eraseFuncs;
   module.walk([&](func::FuncOp funcOp) {
-    if (pto::isPTOKernelFunction(funcOp) && !hasSectionKind(funcOp, kind))
+    if (pto::isPTOEntryFunction(funcOp) && !hasSectionKind(funcOp, kind))
       eraseFuncs.push_back(funcOp);
   });
 

--- a/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
+++ b/test/lit/pto/backedge_nested_same_pipe_prune_regression.pto
@@ -4,7 +4,7 @@
 // the later-set / earlier-wait pair is the tighter one and must be kept, while
 // the wider same-pipe pair can be removed before event-id allocation.
 //
-// CHECK-LABEL: __global__ AICORE void backedge_nested_same_pipe_prune()
+// CHECK-LABEL: AICORE void backedge_nested_same_pipe_prune()
 // CHECK: for (size_t {{v[0-9]+}} =
 // CHECK-NEXT: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[INNER:[0-9]+]]);
 // CHECK-NEXT: TMOV({{v[0-9]+}}, {{v[0-9]+}});

--- a/test/lit/pto/empty_func.pto
+++ b/test/lit/pto/empty_func.pto
@@ -6,4 +6,4 @@ module {
   }
 }
 
-// CHECK: __global__ AICORE void hello() {
+// CHECK: AICORE void hello() {

--- a/test/lit/pto/eventid_array_dyn_sync.pto
+++ b/test/lit/pto/eventid_array_dyn_sync.pto
@@ -13,7 +13,7 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void eventid_array_dyn_sync() {
+// CHECK-LABEL: AICORE void eventid_array_dyn_sync() {
 // CHECK: const int64_t {{v[0-9]+}} = 0;
 // CHECK: PTOAS_EventIdArray<4> {{v[0-9]+}};
 // CHECK: {{v[0-9]+}}[{{v[0-9]+}}] = {{v[0-9]+}};

--- a/test/lit/pto/eventid_array_get_set_get.pto
+++ b/test/lit/pto/eventid_array_get_set_get.pto
@@ -16,7 +16,7 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void eventid_array_get_set_get() {
+// CHECK-LABEL: AICORE void eventid_array_get_set_get() {
 // CHECK: PTOAS_EventIdArray<4> [[ARR:v[0-9]+]];
 // CHECK: [[ARR]][{{v[0-9]+}}] = {{v[0-9]+}};
 // CHECK: [[ARR]][{{v[0-9]+}}] = {{v[0-9]+}};

--- a/test/lit/pto/eventid_array_no_cse.pto
+++ b/test/lit/pto/eventid_array_no_cse.pto
@@ -17,7 +17,7 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void eventid_array_no_cse() {
+// CHECK-LABEL: AICORE void eventid_array_no_cse() {
 // CHECK: PTOAS_EventIdArray<4> [[ARR0:v[0-9]+]];
 // CHECK: PTOAS_EventIdArray<4> [[ARR1:v[0-9]+]];
 // CHECK: [[ARR0]][{{v[0-9]+}}] = {{v[0-9]+}};

--- a/test/lit/pto/get_validshape_emitc.pto
+++ b/test/lit/pto/get_validshape_emitc.pto
@@ -21,7 +21,7 @@ module attributes {pto.target_arch = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void get_validshape_emitc()
+// CHECK-LABEL: AICORE void get_validshape_emitc()
 // CHECK: Tile<TileType::Vec, float, 16, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[TILE:v[0-9]+]] = Tile
 // CHECK: int64_t [[ROW:v[0-9]+]] = [[TILE]].GetValidRow();
 // CHECK-NEXT: int64_t [[COL:v[0-9]+]] = [[TILE]].GetValidCol();

--- a/test/lit/pto/insert_sync_level3_enable.pto
+++ b/test/lit/pto/insert_sync_level3_enable.pto
@@ -46,6 +46,6 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void run_partition(
+// CHECK-LABEL: AICORE void run_partition(
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);

--- a/test/lit/pto/insert_sync_level3_enable_gss.pto
+++ b/test/lit/pto/insert_sync_level3_enable_gss.pto
@@ -48,6 +48,6 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void run_partition(
+// CHECK-LABEL: AICORE void run_partition(
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID{{[0-9]+}});
 // CHECK: wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID{{[0-9]+}});

--- a/test/lit/pto/issue226_remove_redundant_pipe_pair.pto
+++ b/test/lit/pto/issue226_remove_redundant_pipe_pair.pto
@@ -4,7 +4,7 @@
 // set/wait pair when the interval contains a complete inner set/wait pair on
 // the same pipe pair, even if those syncs came from different dep roots.
 //
-// CHECK-LABEL: __global__ AICORE void remove_redundant_pipe_pair
+// CHECK-LABEL: AICORE void remove_redundant_pipe_pair
 // CHECK: set_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[M2MTE1:[0-9]+]]);
 // CHECK: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[M2MTE1]]);
 // CHECK-NOT: wait_flag(PIPE_M, PIPE_MTE1, EVENT_ID[[M2MTE1]]);

--- a/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
+++ b/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression.pto
@@ -4,7 +4,7 @@
 // - The carried handshake must still sit in the loop body before the branch.
 // - The if/else must not reorder that wait/set sequence across the branch.
 //
-// CHECK-LABEL: __global__ AICORE void loop_if_else_loop_carried_sync()
+// CHECK-LABEL: AICORE void loop_if_else_loop_carried_sync()
 // CHECK: set_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID1);
 // CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});
 // CHECK: TMOV({{v[0-9]+}}, {{v[0-9]+}});

--- a/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression_gss.pto
+++ b/test/lit/pto/issue454_loop_if_else_loop_carried_sync_regression_gss.pto
@@ -4,7 +4,7 @@
 // GraphSyncSolver often emits PIPE_ALL barriers instead of fine-grained M/MTE1 events here.
 //
 // CHECK-DAG: pipe_barrier(PIPE_ALL)
-// CHECK-LABEL: __global__ AICORE void loop_if_else_loop_carried_sync()
+// CHECK-LABEL: AICORE void loop_if_else_loop_carried_sync()
 // CHECK: for (size_t
 // CHECK: if ((int64_t)
 // CHECK: } else {

--- a/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
+++ b/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression.pto
@@ -4,7 +4,7 @@
 // - Outer loop-carried and inner loop-carried syncs on PIPE_FIX -> PIPE_MTE1 must coexist.
 // - Inner-loop and outer-loop event chains must both keep their set/wait handshake.
 //
-// CHECK-LABEL: __global__ AICORE void nested_loop_same_pipe_pair()
+// CHECK-LABEL: AICORE void nested_loop_same_pipe_pair()
 // CHECK: for (size_t
 // CHECK: wait_flag(PIPE_FIX, PIPE_MTE1, EVENT_ID[[OUT:[0-9]+]]);
 // CHECK: for (size_t

--- a/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression_gss.pto
+++ b/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression_gss.pto
@@ -7,7 +7,7 @@
 // - Outer loop-carried and inner loop-carried syncs on PIPE_M -> PIPE_MTE1 must coexist.
 // - Inner-loop and outer-loop event chains must both keep their set/wait handshake.
 //
-// CHECK-LABEL: __global__ AICORE void nested_loop_same_pipe_pair()
+// CHECK-LABEL: AICORE void nested_loop_same_pipe_pair()
 // CHECK-COUNT-2: for (size_t
 // CHECK: TMATMUL(
 // CHECK: #endif // __DAV_CUBE__

--- a/test/lit/pto/issue533_loop_zero_trip_sync_regression.pto
+++ b/test/lit/pto/issue533_loop_zero_trip_sync_regression.pto
@@ -3,7 +3,7 @@
 // Regression guard for issue #533 (zero-trip loop):
 // a post-loop vector consumer must wait on MTE2->V before TROWEXPANDDIV.
 //
-// CHECK-LABEL: __global__ AICORE void qwen3_scope2_incore_5
+// CHECK-LABEL: AICORE void qwen3_scope2_incore_5
 // CHECK: for (size_t
 // CHECK: }
 // CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[POST:[0-9]+]]);

--- a/test/lit/pto/issue533_loop_zero_trip_sync_regression_gss.pto
+++ b/test/lit/pto/issue533_loop_zero_trip_sync_regression_gss.pto
@@ -3,7 +3,7 @@
 // Regression guard for issue #533 (zero-trip loop):
 // a post-loop vector consumer must wait on MTE2->V before TROWEXPANDDIV.
 //
-// CHECK-LABEL: __global__ AICORE void qwen3_scope2_incore_5
+// CHECK-LABEL: AICORE void qwen3_scope2_incore_5
 // CHECK: for (size_t
 // CHECK: }
 // CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[POST:[0-9]+]]);

--- a/test/lit/pto/issue558_trowargmax_vec_overflow_a5.pto
+++ b/test/lit/pto/issue558_trowargmax_vec_overflow_a5.pto
@@ -12,7 +12,7 @@
 // A5 TROWARGMAX should not treat tmp as a required scratch write in local
 // memory planning, otherwise this shape triggers a false vec overflow.
 // CHECK-NOT: vec overflow
-// CHECK: __global__ AICORE void TROWARGMAX_TMP_OVERFLOW(
+// CHECK: AICORE void TROWARGMAX_TMP_OVERFLOW(
 
 module {
   func.func @TROWARGMAX_TMP_OVERFLOW(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<ui32>) {

--- a/test/lit/pto/issue558_trowargmin_vec_overflow_a5.pto
+++ b/test/lit/pto/issue558_trowargmin_vec_overflow_a5.pto
@@ -12,7 +12,7 @@
 // A5 TROWARGMIN should not treat tmp as a required scratch write in local
 // memory planning, otherwise this shape triggers a false vec overflow.
 // CHECK-NOT: vec overflow
-// CHECK: __global__ AICORE void TROWARGMIN_TMP_OVERFLOW(
+// CHECK: AICORE void TROWARGMIN_TMP_OVERFLOW(
 
 module {
   func.func @TROWARGMIN_TMP_OVERFLOW(%src_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<ui32>) {

--- a/test/lit/pto/issue664_mscatter_pipe_selection.pto
+++ b/test/lit/pto/issue664_mscatter_pipe_selection.pto
@@ -53,7 +53,7 @@ module attributes {pto.target_arch = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void mscatter_pipe_selection(
+// CHECK-LABEL: AICORE void mscatter_pipe_selection(
 // CHECK: TLOAD(
 // CHECK: TLOAD(
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);

--- a/test/lit/pto/issue664_mscatter_pipe_selection_gss.pto
+++ b/test/lit/pto/issue664_mscatter_pipe_selection_gss.pto
@@ -53,7 +53,7 @@ module attributes {pto.target_arch = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void mscatter_pipe_selection(
+// CHECK-LABEL: AICORE void mscatter_pipe_selection(
 // CHECK: TLOAD(
 // CHECK: TLOAD(
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID{{[0-9]+}});

--- a/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape_level2.pto
+++ b/test/lit/pto/issue686_a5_tmov_treshape_dynamic_valid_shape_level2.pto
@@ -24,7 +24,7 @@ module attributes {pto.target_arch = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void a5_tmov_treshape_dynamic_valid_shape_level2()
+// CHECK-LABEL: AICORE void a5_tmov_treshape_dynamic_valid_shape_level2()
 // CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC_ORIG:v[0-9]+]]
 // CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[DST_ORIG:v[0-9]+]]
 // CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, -1, -1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC:v[0-9]+]];

--- a/test/lit/pto/issue780_kernel_kind_not_entry.pto
+++ b/test/lit/pto/issue780_kernel_kind_not_entry.pto
@@ -1,0 +1,13 @@
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @softmax(%arg0: !pto.ptr<f32>, %arg1: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    return
+  }
+}
+
+// CHECK-NOT: extern "C"
+// CHECK-NOT: __global__ AICORE
+// CHECK-LABEL: AICORE void softmax(
+// CHECK: #if defined(__DAV_VEC__)

--- a/test/lit/pto/left_blayout_parser_a3.pto
+++ b/test/lit/pto/left_blayout_parser_a3.pto
@@ -10,5 +10,5 @@ module attributes {"pto.target_arch" = "a3"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void left_blayout_parser_a3() {
+// CHECK-LABEL: AICORE void left_blayout_parser_a3() {
 // CHECK: Tile<TileType::Left, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null>

--- a/test/lit/pto/left_blayout_parser_a5.pto
+++ b/test/lit/pto/left_blayout_parser_a5.pto
@@ -10,5 +10,5 @@ module attributes {"pto.target_arch" = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void left_blayout_parser_a5() {
+// CHECK-LABEL: AICORE void left_blayout_parser_a5() {
 // CHECK: Tile<TileType::Left, float, 32, 32, BLayout::ColMajor, 32, 32, SLayout::RowMajor, 512, PadValue::Null, CompactMode::Null>

--- a/test/lit/pto/low_precision_globaltensor_emitc_a5.pto
+++ b/test/lit/pto/low_precision_globaltensor_emitc_a5.pto
@@ -27,7 +27,7 @@ module {
   }
 }
 
-// A5-LABEL: __global__ AICORE void low_precision_globaltensor_emitc_a5(
+// A5-LABEL: AICORE void low_precision_globaltensor_emitc_a5(
 // A5-DAG: GlobalTensor<hifloat8_t,
 // A5-DAG: GlobalTensor<float8_e4m3_t,
 // A5-DAG: GlobalTensor<float4_e1m2x2_t,

--- a/test/lit/pto/materialize_tile_handles_emitc.pto
+++ b/test/lit/pto/materialize_tile_handles_emitc.pto
@@ -18,7 +18,7 @@ module {
 // IR: pto.alloc_tile addr = {{.*}} : !pto.tile_buf<vec, 16x16xf32>
 // IR-NOT: pto.materialize_tile
 
-// EMITC-LABEL: __global__ AICORE void materialize_tile_handles_emitc()
+// EMITC-LABEL: AICORE void materialize_tile_handles_emitc()
 // EMITC: Tile<TileType::Vec, half, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>
 // EMITC: TASSIGN(
 // EMITC: Tile<TileType::Vec, float, 16, 16, BLayout::RowMajor, 16, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null>

--- a/test/lit/pto/pto_entry_multifunc.pto
+++ b/test/lit/pto/pto_entry_multifunc.pto
@@ -1,8 +1,12 @@
 // RUN: ptoas %s | FileCheck %s
 
 module {
-  func.func @kernel(%arg0: !pto.ptr<f32>, %arg1: i32) attributes {pto.entry} {
+  func.func @kernel(%arg0: !pto.ptr<f32>, %arg1: i32) attributes {pto.kernel} {
     %0 = func.call @helper(%arg1) : (i32) -> i32
+    return
+  }
+
+  func.func @legacy_kernel(%arg0: !pto.ptr<f32>) attributes {pto.aicore} {
     return
   }
 
@@ -13,6 +17,7 @@ module {
   }
 }
 
-// CHECK-LABEL: static AICORE int32_t helper(
-// CHECK-LABEL: __global__ AICORE void kernel(
+// CHECK-DAG: static AICORE int32_t helper(
+// CHECK-DAG: __global__ AICORE void kernel(
+// CHECK-DAG: __global__ AICORE void legacy_kernel(
 // CHECK: helper(

--- a/test/lit/pto/pto_entry_single_func_default.pto
+++ b/test/lit/pto/pto_entry_single_func_default.pto
@@ -6,4 +6,6 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void single_kernel(
+// CHECK-NOT: extern "C"
+// CHECK-NOT: __global__ AICORE
+// CHECK-LABEL: AICORE void single_kernel(

--- a/test/lit/pto/pto_entry_single_nonvoid_non_entry.pto
+++ b/test/lit/pto/pto_entry_single_nonvoid_non_entry.pto
@@ -1,0 +1,11 @@
+// RUN: ptoas %s 2>&1 | FileCheck %s
+
+module {
+  func.func @kernel(%arg0: i32) -> i32 {
+    return %arg0 : i32
+  }
+}
+
+// CHECK-NOT: PTO entry functions must return void
+// CHECK-NOT: __global__ AICORE
+// CHECK-LABEL: AICORE int32_t kernel(

--- a/test/lit/pto/pto_entry_single_nonvoid_rejected.pto
+++ b/test/lit/pto/pto_entry_single_nonvoid_rejected.pto
@@ -1,9 +1,0 @@
-// RUN: not ptoas %s 2>&1 | FileCheck %s
-
-module {
-  func.func @kernel(%arg0: i32) -> i32 {
-    return %arg0 : i32
-  }
-}
-
-// CHECK: PTO entry functions must return void

--- a/test/lit/pto/record_wait_event.pto
+++ b/test/lit/pto/record_wait_event.pto
@@ -10,6 +10,6 @@ module {
 
 // CHECK: pto.set_flag
 // CHECK: pto.wait_flag
-// CHECK-LABEL: __global__ AICORE void sync_ops() {
+// CHECK-LABEL: AICORE void sync_ops() {
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);

--- a/test/lit/pto/syncall_emitc.pto
+++ b/test/lit/pto/syncall_emitc.pto
@@ -11,7 +11,7 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void syncall_emitc(
+// CHECK-LABEL: AICORE void syncall_emitc(
 // CHECK: Tile<TileType::Vec, int32_t, 1, 64
 // CHECK: Tile<TileType::Mat, int32_t, 1, 64
 // CHECK: SYNCALL<SyncAllMode::Soft, SyncCoreType::Mix>(

--- a/test/lit/pto/syncfinder_zero_loop_if_probe.pto
+++ b/test/lit/pto/syncfinder_zero_loop_if_probe.pto
@@ -4,7 +4,7 @@
 // syncFinder learned from the loop body for the post-loop TMOV, the matching
 // wait must be moved before the loop so the zero-trip path is still ordered.
 //
-// CHECK-LABEL: __global__ AICORE void syncfinder_zero_loop_if_probe
+// CHECK-LABEL: AICORE void syncfinder_zero_loop_if_probe
 // CHECK: TLOAD
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP]]);

--- a/test/lit/pto/syncfinder_zero_loop_if_probe_gss.pto
+++ b/test/lit/pto/syncfinder_zero_loop_if_probe_gss.pto
@@ -4,7 +4,7 @@
 // syncFinder learned from the loop body for the post-loop TMOV, the matching
 // wait must be moved before the loop so the zero-trip path is still ordered.
 //
-// CHECK-LABEL: __global__ AICORE void syncfinder_zero_loop_if_probe
+// CHECK-LABEL: AICORE void syncfinder_zero_loop_if_probe
 // CHECK: TLOAD
 // CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP:[0-9]+]]);
 // CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID[[LOOP]]);

--- a/test/lit/pto/taxpy_emitc.pto
+++ b/test/lit/pto/taxpy_emitc.pto
@@ -13,7 +13,7 @@ module {
   }
 }
 
-// A3-LABEL: __global__ AICORE void taxpy_emitc()
+// A3-LABEL: AICORE void taxpy_emitc()
 // A3: TAXPY(
-// A5-LABEL: __global__ AICORE void taxpy_emitc()
+// A5-LABEL: AICORE void taxpy_emitc()
 // A5: TAXPY(

--- a/test/lit/pto/tcolargmax_emitc.pto
+++ b/test/lit/pto/tcolargmax_emitc.pto
@@ -12,5 +12,5 @@ module {
   }
 }
 
-// A3-LABEL: __global__ AICORE void tcolargmax_emitc()
+// A3-LABEL: AICORE void tcolargmax_emitc()
 // A3: TCOLARGMAX(

--- a/test/lit/pto/tcolargmin_emitc.pto
+++ b/test/lit/pto/tcolargmin_emitc.pto
@@ -12,5 +12,5 @@ module {
   }
 }
 
-// A5-LABEL: __global__ AICORE void tcolargmin_emitc()
+// A5-LABEL: AICORE void tcolargmin_emitc()
 // A5: TCOLARGMIN(

--- a/test/lit/pto/textract_a5_scaling_pipe_selection.pto
+++ b/test/lit/pto/textract_a5_scaling_pipe_selection.pto
@@ -16,7 +16,7 @@ module attributes {"pto.target_arch" = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void textract_mat_scaling_sync(
+// CHECK-LABEL: AICORE void textract_mat_scaling_sync(
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
 // CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
 // CHECK-NOT: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);

--- a/test/lit/pto/textract_a5_scaling_pipe_selection_gss.pto
+++ b/test/lit/pto/textract_a5_scaling_pipe_selection_gss.pto
@@ -16,7 +16,7 @@ module attributes {"pto.target_arch" = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void textract_mat_scaling_sync(
+// CHECK-LABEL: AICORE void textract_mat_scaling_sync(
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID{{[0-9]+}});
 // CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID{{[0-9]+}});
 // CHECK-NOT: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID{{[0-9]+}});

--- a/test/lit/pto/thistogram_emitc.pto
+++ b/test/lit/pto/thistogram_emitc.pto
@@ -15,6 +15,6 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void thistogram_emitc()
+// CHECK-LABEL: AICORE void thistogram_emitc()
 // CHECK: THISTOGRAM<HistByte::BYTE_1>(
 // CHECK: THISTOGRAM<HistByte::BYTE_0>(

--- a/test/lit/pto/thistogram_emitc_u32.pto
+++ b/test/lit/pto/thistogram_emitc_u32.pto
@@ -24,7 +24,7 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void thistogram_emitc_u32()
+// CHECK-LABEL: AICORE void thistogram_emitc_u32()
 // CHECK: THISTOGRAM<HistByte::BYTE_3>(
 // CHECK: THISTOGRAM<HistByte::BYTE_2>(
 // CHECK: THISTOGRAM<HistByte::BYTE_1>(

--- a/test/lit/pto/thistogram_legacy_ismsb_emitc.pto
+++ b/test/lit/pto/thistogram_legacy_ismsb_emitc.pto
@@ -15,6 +15,6 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void thistogram_legacy_ismsb_emitc()
+// CHECK-LABEL: AICORE void thistogram_legacy_ismsb_emitc()
 // CHECK: THISTOGRAM<HistByte::BYTE_0>(
 // CHECK: THISTOGRAM<HistByte::BYTE_1>(

--- a/test/lit/pto/tinsert_a3_pipe_selection.pto
+++ b/test/lit/pto/tinsert_a3_pipe_selection.pto
@@ -50,7 +50,7 @@ module attributes {"pto.target_arch" = "a3"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_acc_mat_pipeline_a3(
+// CHECK-LABEL: AICORE void tinsert_acc_mat_pipeline_a3(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: TINSERT(

--- a/test/lit/pto/tinsert_a3_pipe_selection_gss.pto
+++ b/test/lit/pto/tinsert_a3_pipe_selection_gss.pto
@@ -50,7 +50,7 @@ module attributes {"pto.target_arch" = "a3"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_acc_mat_pipeline_a3(
+// CHECK-LABEL: AICORE void tinsert_acc_mat_pipeline_a3(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});
 // CHECK: TINSERT(

--- a/test/lit/pto/tinsert_a5_pipe_selection.pto
+++ b/test/lit/pto/tinsert_a5_pipe_selection.pto
@@ -50,7 +50,7 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_acc_mat_pipeline(
+// CHECK-LABEL: AICORE void tinsert_acc_mat_pipeline(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK-NOT: set_flag(PIPE_M, PIPE_MTE3, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);

--- a/test/lit/pto/tinsert_a5_pipe_selection_gss.pto
+++ b/test/lit/pto/tinsert_a5_pipe_selection_gss.pto
@@ -50,7 +50,7 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_acc_mat_pipeline(
+// CHECK-LABEL: AICORE void tinsert_acc_mat_pipeline(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});
 // CHECK-NOT: set_flag(PIPE_M, PIPE_MTE3, EVENT_ID{{[0-9]+}});
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});

--- a/test/lit/pto/tinsert_verify_a5_f32_ok.pto
+++ b/test/lit/pto/tinsert_verify_a5_f32_ok.pto
@@ -13,5 +13,5 @@ module attributes {"pto.target_arch" = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tinsert_a5_f32_to_f32_ok(
+// CHECK-LABEL: AICORE void tinsert_a5_f32_to_f32_ok(
 // CHECK: TINSERT(

--- a/test/lit/pto/tmov_acc_mat_pipe_selection.pto
+++ b/test/lit/pto/tmov_acc_mat_pipe_selection.pto
@@ -31,7 +31,7 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tmov_acc_mat_pipeline(
+// CHECK-LABEL: AICORE void tmov_acc_mat_pipeline(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // CHECK: TMOV(

--- a/test/lit/pto/tmov_acc_mat_pipe_selection_gss.pto
+++ b/test/lit/pto/tmov_acc_mat_pipe_selection_gss.pto
@@ -31,7 +31,7 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tmov_acc_mat_pipeline(
+// CHECK-LABEL: AICORE void tmov_acc_mat_pipeline(
 // CHECK: set_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});
 // CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});
 // CHECK: TMOV(

--- a/test/lit/pto/tmov_acc_to_vec_mode_a5_emitc.pto
+++ b/test/lit/pto/tmov_acc_to_vec_mode_a5_emitc.pto
@@ -29,9 +29,9 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// A5-LABEL: __global__ AICORE void tmov_acc_to_vec_mode_a5(
+// A5-LABEL: AICORE void tmov_acc_to_vec_mode_a5(
 // A5: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // A5: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 // A5: TMOV<{{.*}}pto::AccToVecMode::DualModeSplitM{{.*}}>(
-// A3-LABEL: __global__ AICORE void tmov_acc_to_vec_mode_a5(
+// A3-LABEL: AICORE void tmov_acc_to_vec_mode_a5(
 // A3: TMOV<{{.*}}pto::AccToVecMode::DualModeSplitM{{.*}}>(

--- a/test/lit/pto/tmov_acc_to_vec_mode_a5_emitc_gss.pto
+++ b/test/lit/pto/tmov_acc_to_vec_mode_a5_emitc_gss.pto
@@ -29,9 +29,9 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// A5-LABEL: __global__ AICORE void tmov_acc_to_vec_mode_a5(
+// A5-LABEL: AICORE void tmov_acc_to_vec_mode_a5(
 // A5: set_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});
 // A5: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID{{[0-9]+}});
 // A5: TMOV<{{.*}}pto::AccToVecMode::DualModeSplitM{{.*}}>(
-// A3-LABEL: __global__ AICORE void tmov_acc_to_vec_mode_a5(
+// A3-LABEL: AICORE void tmov_acc_to_vec_mode_a5(
 // A3: TMOV<{{.*}}pto::AccToVecMode::DualModeSplitM{{.*}}>(

--- a/test/lit/pto/tmov_forms_emitc.pto
+++ b/test/lit/pto/tmov_forms_emitc.pto
@@ -44,7 +44,7 @@ module attributes {"pto.device-spec" = "Ascend950"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tmov_forms(
+// CHECK-LABEL: AICORE void tmov_forms(
 // CHECK: TMOV<{{.*}}ReluPreMode::NormalRelu>([[DST_MAT:[^,]+]], [[SRC:[^)]+]]);
 // CHECK: TMOV<{{.*}}ReluPreMode::NormalRelu>([[DST_MAT_Q:[^,]+]], [[SRC]], [[PRE:[^)]+]]);
 // CHECK: TMOV<{{.*}}pto::AccToVecMode::DualModeSplitM, ReluPreMode::NormalRelu>([[DST_VEC:[^,]+]], [[SRC]]);

--- a/test/lit/pto/tmrgsort_executed_constant_emitc.pto
+++ b/test/lit/pto/tmrgsort_executed_constant_emitc.pto
@@ -18,7 +18,7 @@ module {
   }
 }
 
-// A3-LABEL: __global__ AICORE void tmrgsort_executed_constant_emitc()
+// A3-LABEL: AICORE void tmrgsort_executed_constant_emitc()
 // A3-DAG: pto::MrgSortExecutedNumList [[EXFULL:v[0-9]+]] = pto::MrgSortExecutedNumList{128, 64, 0, 0};
 // A3-DAG: pto::MrgSortExecutedNumList [[EXHIGH:v[0-9]+]] = pto::MrgSortExecutedNumList{50000, 40000, 32768, 65535};
 // A3-DAG: pto::MrgSortExecutedNumList [[EXZERO:v[0-9]+]] = pto::MrgSortExecutedNumList{0, 0, 0, 0};

--- a/test/lit/pto/tpartarg_emitc.pto
+++ b/test/lit/pto/tpartarg_emitc.pto
@@ -17,6 +17,6 @@ module {
   }
 }
 
-// A3-LABEL: __global__ AICORE void tpartarg_emitc()
+// A3-LABEL: AICORE void tpartarg_emitc()
 // A3: TPARTARGMAX(
 // A3: TPARTARGMIN(

--- a/test/lit/pto/tpartmul_emitc.pto
+++ b/test/lit/pto/tpartmul_emitc.pto
@@ -13,5 +13,5 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tpartmul_emitc()
+// CHECK-LABEL: AICORE void tpartmul_emitc()
 // CHECK: TPARTMUL(

--- a/test/lit/pto/treshape_static_valid_shape_emitc.pto
+++ b/test/lit/pto/treshape_static_valid_shape_emitc.pto
@@ -31,7 +31,7 @@ module attributes {pto.target_arch = "a5"} {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void treshape_static_valid_shape_emitc()
+// CHECK-LABEL: AICORE void treshape_static_valid_shape_emitc()
 // CHECK: Tile<TileType::Vec, float, 16, 1, BLayout::ColMajor, 16, 1, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[SRC:v[0-9]+]];
 // CHECK: TASSIGN([[SRC]],
 // CHECK: Tile<TileType::Vec, float, 1, 16, BLayout::RowMajor, 1, 16, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> [[RESHAPED:v[0-9]+]];

--- a/test/lit/pto/trowargmax_emitc.pto
+++ b/test/lit/pto/trowargmax_emitc.pto
@@ -12,5 +12,5 @@ module {
   }
 }
 
-// A3-LABEL: __global__ AICORE void trowargmax_emitc()
+// A3-LABEL: AICORE void trowargmax_emitc()
 // A3: TROWARGMAX(

--- a/test/lit/pto/trowargmin_emitc.pto
+++ b/test/lit/pto/trowargmin_emitc.pto
@@ -12,5 +12,5 @@ module {
   }
 }
 
-// A5-LABEL: __global__ AICORE void trowargmin_emitc()
+// A5-LABEL: AICORE void trowargmin_emitc()
 // A5: TROWARGMIN(

--- a/test/lit/pto/tsync_emitc.pto
+++ b/test/lit/pto/tsync_emitc.pto
@@ -9,5 +9,5 @@ module {
   }
 }
 
-// CHECK-LABEL: __global__ AICORE void tsync_emitc(
+// CHECK-LABEL: AICORE void tsync_emitc(
 // CHECK: TSYNC(

--- a/test/lit/tile_fusion/final_emitc_last_use_level2.pto
+++ b/test/lit/tile_fusion/final_emitc_last_use_level2.pto
@@ -53,7 +53,7 @@ module {
 // IR: pto.tadd{{.*}}{pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64{{.*}}}
 // IR: pto.tstore ins(
 
-// CPP-LABEL: __global__ AICORE void final_emitc_last_use_level2(
+// CPP-LABEL: AICORE void final_emitc_last_use_level2(
 // CPP-NOT: pto.fusion_region
 // CPP-NOT: pto.yield
 // CPP-NOT: PTOAS__LAST_USE__

--- a/test/lit/tile_fusion/mark_last_use_repeated_ssa_level2.pto
+++ b/test/lit/tile_fusion/mark_last_use_repeated_ssa_level2.pto
@@ -48,6 +48,6 @@ module {
 // CHECK: pto.tadd ins(%{{.*}}, %{{.*}} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%{{.*}} : !pto.tile_buf<vec, 32x32xf32>) {pto.fusion.group_id = 0 : i64, pto.fusion.order = 0 : i64, pto.last_use = array<i64: 1, 1, 0>}
 // CHECK-NEXT: pto.tadd ins(%{{.*}}, %{{.*}} : !pto.tile_buf<vec, 32x32xf32>, !pto.tile_buf<vec, 32x32xf32>) outs(%{{.*}} : !pto.tile_buf<vec, 32x32xf32>) {pto.fusion.group_id = 0 : i64, pto.fusion.order = 1 : i64, pto.last_use = array<i64: 1, 1, 0>}
 
-// CPP-LABEL: __global__ AICORE void mark_last_use_repeated_ssa_level2(
+// CPP-LABEL: AICORE void mark_last_use_repeated_ssa_level2(
 // CPP: {{\[\[pto::last_use\(0, 1, 1\)\]\] TADD\(}}
 // CPP: {{\[\[pto::last_use\(0, 1, 1\)\]\] TADD\(}}

--- a/test/lit/tile_fusion/mark_last_use_slot_mask_level2.pto
+++ b/test/lit/tile_fusion/mark_last_use_slot_mask_level2.pto
@@ -69,7 +69,7 @@ module {
 // MARKER: emitc.call_opaque "PTOAS__LAST_USE__TSUBS__0__1"
 // MARKER-NOT: pto::last_use
 
-// CPP-LABEL: __global__ AICORE void mark_last_use_slot_mask_level2(
+// CPP-LABEL: AICORE void mark_last_use_slot_mask_level2(
 // CPP-NOT: PTOAS__LAST_USE__
 // CPP: {{\[\[pto::last_use\(0\)\]\] TEXPANDS\(}}
 // CPP: {{\[\[pto::last_use\(0, 1\)\]\] TADDS\(}}

--- a/test/samples/Abs/abs.py
+++ b/test/samples/Abs/abs.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("abs_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AddPtr/addptr.py
+++ b/test/samples/AddPtr/addptr.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("addptr_const_offset", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AddPtr/addptr_chain.py
+++ b/test/samples/AddPtr/addptr_chain.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("addptr_chain_offset", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AddPtr/addptr_dynamic.py
+++ b/test/samples/AddPtr/addptr_dynamic.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, idx_t, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("addptr_dynamic_offset", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AddPtr/addptr_f16.py
+++ b/test/samples/AddPtr/addptr_f16.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("addptr_f16_offset", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Addc/addc.py
+++ b/test/samples/Addc/addc.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_ternary_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Adds/adds.py
+++ b/test/samples/Adds/adds.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Addsc/addsc.py
+++ b/test/samples/Addsc/addsc.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AllocTile/alloc_tile_addr.py
+++ b/test/samples/AllocTile/alloc_tile_addr.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IntegerType, IntegerAttr, IndexType
 
@@ -41,6 +41,7 @@ def build():
             fn_ty = func.FunctionType.get([i64, i32, i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("alloc_tile_with_addr_demo", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/And/and.py
+++ b/test/samples/And/and.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Ands/ands.py
+++ b/test/samples/Ands/ands.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType, IntegerAttr
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AsyncComm/async_comm.py
+++ b/test/samples/AsyncComm/async_comm.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, F32Type, IntegerType, IntegerAttr, IndexType, Operation
+from mlir.ir import Context, Location, Module, InsertionPoint, F32Type, IntegerType, IntegerAttr, IndexType, Operation, UnitAttr
 from mlir.dialects import arith, func, pto, scf
 
 
@@ -65,6 +65,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_i8, i32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("async_comm_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AsyncComm/tget_async_kernel_impl_like.py
+++ b/test/samples/AsyncComm/tget_async_kernel_impl_like.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     F32Type,
     IndexType,
@@ -98,6 +99,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("tget_async_kernel_impl_like", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/AsyncComm/tput_async_kernel_impl_like.py
+++ b/test/samples/AsyncComm/tput_async_kernel_impl_like.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     F32Type,
     IndexType,
@@ -96,6 +97,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("tput_async_kernel_impl_like", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Bf16/bf16_tile.py
+++ b/test/samples/Bf16/bf16_tile.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     Location,
     InsertionPoint,
@@ -46,6 +47,7 @@ def build():
         fn_ty = func.FunctionType.get([ptr_bf16], [])
         with InsertionPoint(module.body):
             fn = func.FuncOp("bf16_tile", fn_ty)
+            fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
             entry = fn.add_entry_block()
 
         with InsertionPoint(entry):

--- a/test/samples/Ci/ci.py
+++ b/test/samples/Ci/ci.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType, IntegerAttr, BoolAttr
 
@@ -36,6 +36,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_ci_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Cmp/cmp.py
+++ b/test/samples/Cmp/cmp.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -43,6 +43,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_u8], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_cmp_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Cmps/cmps.py
+++ b/test/samples/Cmps/cmps.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -43,6 +43,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_u8], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_cmps_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpand/colexpand.py
+++ b/test/samples/Colexpand/colexpand.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_absolute_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandadd/colexpandadd.py
+++ b/test/samples/Colexpandadd/colexpandadd.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandadd_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpanddiv/colexpanddiv.py
+++ b/test/samples/Colexpanddiv/colexpanddiv.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpanddiv_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpanddiv/colexpanddiv_src1_vcol_mismatch_invalid.py
+++ b/test/samples/Colexpanddiv/colexpanddiv_src1_vcol_mismatch_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -33,6 +33,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpanddiv_src1_vcol_mismatch_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandexpdif/colexpandexpdif.py
+++ b/test/samples/Colexpandexpdif/colexpandexpdif.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandexpdif_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandexpdif/colexpandexpdif_dtype_invalid.py
+++ b/test/samples/Colexpandexpdif/colexpandexpdif_dtype_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import IntegerType
 
@@ -32,6 +32,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandexpdif_dtype_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandmax/colexpandmax.py
+++ b/test/samples/Colexpandmax/colexpandmax.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandmax_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandmin/colexpandmin.py
+++ b/test/samples/Colexpandmin/colexpandmin.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandmin_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandmul/colexpandmul.py
+++ b/test/samples/Colexpandmul/colexpandmul.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandmul_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandsub/colexpandsub.py
+++ b/test/samples/Colexpandsub/colexpandsub.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandsub_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colexpandsub/colexpandsub_src0_layout_invalid.py
+++ b/test/samples/Colexpandsub/colexpandsub_src0_layout_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolexpandsub_src0_layout_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colmax/colmax.py
+++ b/test/samples/Colmax/colmax.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_colmax_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colmin/colmin.py
+++ b/test/samples/Colmin/colmin.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_colmin_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colprod/colprod.py
+++ b/test/samples/Colprod/colprod.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tcolprod_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Colsum/colsum.py
+++ b/test/samples/Colsum/colsum.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, BoolAttr
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_colsum_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/comm_collective.py
+++ b/test/samples/CommSync/comm_collective.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 def build():
@@ -34,6 +34,7 @@ def build():
             )
             with InsertionPoint(module.body):
                 fn = func.FuncOp("comm_collective_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/comm_collective_binding_variants.py
+++ b/test/samples/CommSync/comm_collective_binding_variants.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -35,6 +35,7 @@ def build():
             )
             with InsertionPoint(module.body):
                 fn = func.FuncOp("comm_collective_binding_variants_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/comm_p2p.py
+++ b/test/samples/CommSync/comm_p2p.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -40,6 +40,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_i32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("comm_p2p_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/comm_p2p_binding_variants.py
+++ b/test/samples/CommSync/comm_p2p_binding_variants.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_i32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("comm_p2p_binding_variants_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/tbroadcast_root_binding.py
+++ b/test/samples/CommSync/tbroadcast_root_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto, scf
 
 
@@ -39,6 +39,7 @@ def build():
             )
             with InsertionPoint(module.body):
                 fn = func.FuncOp("TBroadCastKernelImpl", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/tgather_root_binding.py
+++ b/test/samples/CommSync/tgather_root_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto, scf
 
 
@@ -39,6 +39,7 @@ def build():
             )
             with InsertionPoint(module.body):
                 fn = func.FuncOp("TGatherKernelImpl", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/tnotify_atomic_add_binding.py
+++ b/test/samples/CommSync/tnotify_atomic_add_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -27,6 +27,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("TNotifyAtomicAddKernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/treduce_root_binding.py
+++ b/test/samples/CommSync/treduce_root_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto, scf
 
 
@@ -39,6 +39,7 @@ def build():
             )
             with InsertionPoint(module.body):
                 fn = func.FuncOp("TReduceKernelImpl", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/tscatter_root_binding.py
+++ b/test/samples/CommSync/tscatter_root_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto, scf
 
 
@@ -39,6 +39,7 @@ def build():
             )
             with InsertionPoint(module.body):
                 fn = func.FuncOp("TScatterKernelImpl", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/twait_atomic_binding.py
+++ b/test/samples/CommSync/twait_atomic_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto, scf
 
 
@@ -27,6 +27,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, ptr_i32, i32, i32, i32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("TWaitAtomicKernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Complex/cv_region.py
+++ b/test/samples/Complex/cv_region.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, F32Type
+from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, F32Type, UnitAttr
 from mlir.dialects import func, arith, pto
 
 def build_sections_test():
@@ -41,6 +41,7 @@ def build_sections_test():
 
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_cube_vector_sections", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Complex/mix_kernel.py
+++ b/test/samples/Complex/mix_kernel.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, Attribute, IntegerType
+from mlir.ir import Context, Location, Module, InsertionPoint, Attribute, IntegerType, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -64,6 +64,7 @@ def build(M=32, N=32, K=32, TM=32, TN=32, TK=32):
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vector_cube_mixed_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Concat/concat.py
+++ b/test/samples/Concat/concat.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType
 
@@ -40,6 +40,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("concat_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Cvt/cvt_f32_f32.py
+++ b/test/samples/Cvt/cvt_f32_f32.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, BoolAttr
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_cvt_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Div/div.py
+++ b/test/samples/Div/div.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IndexType
+from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_div_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Divs/divs.py
+++ b/test/samples/Divs/divs.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_divs_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Divs2/divs2.py
+++ b/test/samples/Divs2/divs2.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_divs2_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/DynamicTailMatmul/dynamic_tail_matmul.py
+++ b/test/samples/DynamicTailMatmul/dynamic_tail_matmul.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, IntegerType, F16Type, F32Type
+from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, IntegerType, F16Type, F32Type, UnitAttr
 from mlir.dialects import func, arith, pto
 
 
@@ -77,6 +77,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_a, ptr_b, ptr_c, i32, i32, i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("dynamic_tail_matmul_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Exp/exp.py
+++ b/test/samples/Exp/exp.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_exponential_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Expands/expand.py
+++ b/test/samples/Expands/expand.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_expand_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Extract/extract.py
+++ b/test/samples/Extract/extract.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType
 
@@ -89,6 +89,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("extract_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Extract/extract_fp.py
+++ b/test/samples/Extract/extract_fp.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -56,6 +56,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("extract_fp_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fillpad/fillpad.py
+++ b/test/samples/Fillpad/fillpad.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -38,6 +38,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_absolute_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fillpad/fillpad_expand.py
+++ b/test/samples/Fillpad/fillpad_expand.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, InsertionPoint, Location, Module
+from mlir.ir import Context, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("fillpad_expand_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fillpad/fillpad_expand_invalid.py
+++ b/test/samples/Fillpad/fillpad_expand_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, InsertionPoint, Location, Module, MLIRError
+from mlir.ir import Context, InsertionPoint, Location, Module, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -32,6 +32,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("fillpad_expand_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fillpad/fillpad_expand_pad_null_invalid.py
+++ b/test/samples/Fillpad/fillpad_expand_pad_null_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, InsertionPoint, Location, Module, MLIRError
+from mlir.ir import Context, InsertionPoint, Location, Module, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("fillpad_expand_pad_null_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fillpad/fillpad_inplace.py
+++ b/test/samples/Fillpad/fillpad_inplace.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("fillpad_inplace_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fmod/fmod.py
+++ b/test/samples/Fmod/fmod.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tfmod_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fmods/fmods.py
+++ b/test/samples/Fmods/fmods.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tfmods_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Fmods/tfmods_scalar_type_invalid.py
+++ b/test/samples/Fmods/tfmods_scalar_type_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IntegerType
 
@@ -32,6 +32,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tfmods_scalar_type_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Gather/gather.py
+++ b/test/samples/Gather/gather.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 from mlir.ir import IntegerType
 
@@ -38,6 +38,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Gather/gather_legacy.py
+++ b/test/samples/Gather/gather_legacy.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Gatherb/gatherb.py
+++ b/test/samples/Gatherb/gatherb.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.dialects import arith, func, pto
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 
 
 def build():
@@ -45,6 +45,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_u32, ptr_f32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("vec_add_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Gemv/gemv.py
+++ b/test/samples/Gemv/gemv.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType
 
@@ -88,6 +88,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("gemv_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Gemv/gemvacc.py
+++ b/test/samples/Gemv/gemvacc.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType
 
@@ -89,6 +89,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("gemvacc_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Gemv/gemvbias.py
+++ b/test/samples/Gemv/gemvbias.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType
 
@@ -100,6 +100,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("gemvbias_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Gemvmx/gemvmx.py
+++ b/test/samples/Gemvmx/gemvmx.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType
 
@@ -129,6 +129,7 @@ def build():
             )
             with InsertionPoint(m.body):
                 fn = func.FuncOp("gemvmx_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Layout/tensor_view_infer_layout_dn.py
+++ b/test/samples/Layout/tensor_view_infer_layout_dn.py
@@ -16,7 +16,7 @@ This checks that PTOAS can infer `layout=DN` for a 2D column-vector GM view:
 The expected emitted C++ should use `pto::Layout::DN` in GlobalTensor<>.
 """
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -46,6 +46,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tensor_view_infer_layout_dn_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Log/log.py
+++ b/test/samples/Log/log.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_log_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Lrelu/lrelu.py
+++ b/test/samples/Lrelu/lrelu.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/MatMul/tmatmulk.py
+++ b/test/samples/MatMul/tmatmulk.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context, Location, InsertionPoint,
     IndexType, IntegerType, F16Type, F32Type, StringAttr
 )
@@ -137,6 +138,7 @@ def build(
         fn_ty = func.FunctionType.get([ptr_out, ptr_a, ptr_b, ptr_bias, i1], [])
         with InsertionPoint(module.body):
             fn = func.FuncOp("RunTMATMULSplitK", fn_ty)
+            fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
             entry = fn.add_entry_block()
 
         with InsertionPoint(entry):

--- a/test/samples/Matmul_transpose/Matmul_transpose.py
+++ b/test/samples/Matmul_transpose/Matmul_transpose.py
@@ -15,7 +15,7 @@ Reference:
   - pto-as/test/samples/MatMul/tmatmulk.py
 """
 
-from mlir.ir import Context, Location, InsertionPoint, IndexType, IntegerType, F32Type, StringAttr
+from mlir.ir import Context, Location, InsertionPoint, IndexType, IntegerType, F32Type, StringAttr, UnitAttr
 from mlir.dialects import func, arith, scf, pto, builtin
 from mlir.dialects.pto import TLOAD, TMOV_M2L, TMATMUL, TSTORE_ACC, EVENT_ID0
 
@@ -140,6 +140,7 @@ def build(
         )
         with InsertionPoint(module.body):
             fn = func.FuncOp("RunTEXTRACT", fn_ty)
+            fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
             entry = fn.add_entry_block()
 
         with InsertionPoint(entry):

--- a/test/samples/Max/max.py
+++ b/test/samples/Max/max.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("max_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Maxs/maxs.py
+++ b/test/samples/Maxs/maxs.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("maxs_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Mgather/mgather.py
+++ b/test/samples/Mgather/mgather.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, ptr_i32, ptr_i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("mgather_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Min/min.py
+++ b/test/samples/Min/min.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("min_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Mins/mins.py
+++ b/test/samples/Mins/mins.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("maxs_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Movfp/movfp.py
+++ b/test/samples/Movfp/movfp.py
@@ -16,7 +16,7 @@ Important PTO-ISA constraints (a2a3/a5):
   - src must be ACC tile; dst must be MAT tile.
 """
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType, IntegerType
 
@@ -128,6 +128,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, ptr_ui64, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_movfp_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Mrgsort/mrgsort.py
+++ b/test/samples/Mrgsort/mrgsort.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -36,6 +36,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Mrgsort/mrgsort_a5.py
+++ b/test/samples/Mrgsort/mrgsort_a5.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -41,6 +41,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Mrgsort/mrgsort_format2.py
+++ b/test/samples/Mrgsort/mrgsort_format2.py
@@ -15,7 +15,7 @@ Important notes for on-device execution:
   - This testcase covers all three forms in a single function entry so it fits
     the remote validation flow.
 """
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -64,6 +64,7 @@ def build():
             )
             with InsertionPoint(m.body):
                 fn = func.FuncOp("mrgsort_format2_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Mscatter/mscatter.py
+++ b/test/samples/Mscatter/mscatter.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, ptr_i32, ptr_i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("mscatter_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Mul/mul.py
+++ b/test/samples/Mul/mul.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("mul_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Muls/muls.py
+++ b/test/samples/Muls/muls.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_multiple_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Neg/neg.py
+++ b/test/samples/Neg/neg.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("neg_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Not/not.py
+++ b/test/samples/Not/not.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Or/or.py
+++ b/test/samples/Or/or.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_scalar_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Ors/ors.py
+++ b/test/samples/Ors/ors.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType, IntegerAttr
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("ors_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Partadd/partadd.py
+++ b/test/samples/Partadd/partadd.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("partadd_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Partarg/partarg.py
+++ b/test/samples/Partarg/partarg.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.dialects import arith, func, pto
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 
 
 def build():
@@ -43,6 +43,7 @@ def build():
             )
             with InsertionPoint(m.body):
                 fn = func.FuncOp("partarg_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Partmax/partmax.py
+++ b/test/samples/Partmax/partmax.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("partmax_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Partmin/partmin.py
+++ b/test/samples/Partmin/partmin.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("partmin_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Partmul/partmul.py
+++ b/test/samples/Partmul/partmul.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("partmul_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Prelu/prelu.py
+++ b/test/samples/Prelu/prelu.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -41,6 +41,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("prelu_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Print/print.py
+++ b/test/samples/Print/print.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("print_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Print/print_scalar.py
+++ b/test/samples/Print/print_scalar.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 """Test pto.print: format is string attribute, scalar is operand. Generates PRINTF("format", scalar) in C++."""
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -23,6 +23,7 @@ def build():
             fn_ty = func.FunctionType.get([f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("print_scalar_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Recip/recip.py
+++ b/test/samples/Recip/recip.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("recip_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Relu/relu.py
+++ b/test/samples/Relu/relu.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("relu_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rem/rem.py
+++ b/test/samples/Rem/rem.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -38,6 +38,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("recip_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rems/rems.py
+++ b/test/samples/Rems/rems.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -38,6 +38,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("rems_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Reshape/bitcast_dtype_alias.py
+++ b/test/samples/Reshape/bitcast_dtype_alias.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("bitcast_dtype_alias", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Reshape/bitcast_inplace_cvt.py
+++ b/test/samples/Reshape/bitcast_inplace_cvt.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType
 
@@ -45,6 +45,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("bitcast_inplace_cvt", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Reshape/bitcast_same_dtype_invalid.py
+++ b/test/samples/Reshape/bitcast_same_dtype_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("bitcast_same_dtype_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Reshape/reshape.py
+++ b/test/samples/Reshape/reshape.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("reshape_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpand/rowexpand.py
+++ b/test/samples/Rowexpand/rowexpand.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("rowexpand_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandadd/rowexpandadd.py
+++ b/test/samples/Rowexpandadd/rowexpandadd.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandadd_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandadd/rowexpandadd_src1_width_invalid.py
+++ b/test/samples/Rowexpandadd/rowexpandadd_src1_width_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandadd_src1_width_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpanddiv/rowexpanddiv.py
+++ b/test/samples/Rowexpanddiv/rowexpanddiv.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_trowexpanddiv_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandexpdif/rowexpandexpdif.py
+++ b/test/samples/Rowexpandexpdif/rowexpandexpdif.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandexpdif_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandexpdif/rowexpandexpdif_dtype_invalid.py
+++ b/test/samples/Rowexpandexpdif/rowexpandexpdif_dtype_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import IntegerType
 
@@ -32,6 +32,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandexpdif_dtype_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandmax/rowexpandmax.py
+++ b/test/samples/Rowexpandmax/rowexpandmax.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandmax_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandmax/rowexpandmax_a5_tmp_invalid.py
+++ b/test/samples/Rowexpandmax/rowexpandmax_a5_tmp_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -36,6 +36,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandmax_a5_tmp_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandmin/rowexpandmin.py
+++ b/test/samples/Rowexpandmin/rowexpandmin.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandmin_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandmul/rowexpandmul.py
+++ b/test/samples/Rowexpandmul/rowexpandmul.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowexpandmul_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowexpandsub/rowexpandsub.py
+++ b/test/samples/Rowexpandsub/rowexpandsub.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_trowexpandsub_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowmax/rowmax.py
+++ b/test/samples/Rowmax/rowmax.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("rowmax_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowmin/rowmin.py
+++ b/test/samples/Rowmin/rowmin.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("rowmin_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowprod/rowprod.py
+++ b/test/samples/Rowprod/rowprod.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowprod_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowprod/trowprod_tmp_mismatch_invalid.py
+++ b/test/samples/Rowprod/trowprod_tmp_mismatch_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F32Type
 
@@ -33,6 +33,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trowprod_tmp_mismatch_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rowsum/rowsum.py
+++ b/test/samples/Rowsum/rowsum.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -39,6 +39,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("rowsum_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Rsqrt/rsqrt.py
+++ b/test/samples/Rsqrt/rsqrt.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("Rsqrt_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/ScalarPtr/scalar_ptr.py
+++ b/test/samples/ScalarPtr/scalar_ptr.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -26,6 +26,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("ptr_scalar_rw", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Scatter/scatter.py
+++ b/test/samples/Scatter/scatter.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.dialects import arith, func, pto
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 
 
 def build():
@@ -43,6 +43,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_u32, ptr_f32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("Scatter_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sel/sel.py
+++ b/test/samples/Sel/sel.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -42,6 +42,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i8, ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("Sel_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sels/sels.py
+++ b/test/samples/Sels/sels.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType
+from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("sels_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/SetValidShape/set_validshape.py
+++ b/test/samples/SetValidShape/set_validshape.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -33,6 +33,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("set_validshape_demo", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Shl/shl.py
+++ b/test/samples/Shl/shl.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, ptr_i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("shl_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Shls/shls.py
+++ b/test/samples/Shls/shls.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, ptr_i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_shls_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Shr/shr.py
+++ b/test/samples/Shr/shr.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, ptr_i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("shr_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Shrs/shrs.py
+++ b/test/samples/Shrs/shrs.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, ptr_i32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_shrs_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sort32/sort32.py
+++ b/test/samples/Sort32/sort32.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IntegerType, IndexType
 
@@ -42,6 +42,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_u32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("sort32_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sqrt/sqrt.py
+++ b/test/samples/Sqrt/sqrt.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("Sqrt_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Storefp/storefp.py
+++ b/test/samples/Storefp/storefp.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IntegerType, IndexType
 
@@ -50,6 +50,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i8], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tstore_fp_pass", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Storefp/storefp_invalid.py
+++ b/test/samples/Storefp/storefp_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, pto
 from mlir.ir import F16Type, IntegerType, MemRefType
 
@@ -49,6 +49,7 @@ def build():
             fn_ty = func.FunctionType.get([dst_memref_ty], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tstore_fp_invalid_vec_f16_to_i8", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sub/sub.py
+++ b/test/samples/Sub/sub.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("sub_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/SubView/subview.py
+++ b/test/samples/SubView/subview.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("subview_pingpong_demo", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/SubView/subview_boxed_dynamic.py
+++ b/test/samples/SubView/subview_boxed_dynamic.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([idx], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("subview_boxed_dynamic", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/SubView/subview_boxed_invalid.py
+++ b/test/samples/SubView/subview_boxed_invalid.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("subview_invalid_boxed", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/SubView/subview_tsubs.py
+++ b/test/samples/SubView/subview_tsubs.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -33,6 +33,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("subview_tsubs_demo", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/SubView/vadd_pto_pingpong.py
+++ b/test/samples/SubView/vadd_pto_pingpong.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -42,6 +42,7 @@ def build_pingpong():
             
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_double_buffer_step", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
                 
             with InsertionPoint(entry):

--- a/test/samples/Subc/subc.py
+++ b/test/samples/Subc/subc.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("subc_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Subs/subs.py
+++ b/test/samples/Subs/subs.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("subs_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Subsc/subsc.py
+++ b/test/samples/Subsc/subsc.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("subsc_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/sync.py
+++ b/test/samples/Sync/sync.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -40,6 +40,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("sync_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/syncHigh.py
+++ b/test/samples/Sync/syncHigh.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -40,6 +40,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("run_sync_high", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_a5_buf_sync.py
+++ b/test/samples/Sync/test_a5_buf_sync.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, pto
 
 
@@ -18,6 +18,7 @@ def build():
             module = Module.create()
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_a5_buf_sync", func.FunctionType.get([], []))
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_inject_sync_if.py
+++ b/test/samples/Sync/test_inject_sync_if.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     Location,
     Module,
@@ -47,6 +48,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, i1], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_if_sync", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_inject_sync_if_else.py
+++ b/test/samples/Sync/test_inject_sync_if_else.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     Location,
     Module,
@@ -47,6 +48,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, i1], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_if_else_sync", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_inject_sync_intra_pipe_barrier.py
+++ b/test/samples/Sync/test_inject_sync_intra_pipe_barrier.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.ir import F16Type
 from mlir.dialects import func, pto
 
@@ -29,6 +29,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_intra_pipe_barrier_py", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_inject_sync_loop.py
+++ b/test/samples/Sync/test_inject_sync_loop.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     Location,
     Module,
@@ -46,6 +47,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_loop_sync", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_inject_sync_loop_nest.py
+++ b/test/samples/Sync/test_inject_sync_loop_nest.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     Location,
     Module,
@@ -46,6 +47,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_loop_nest_sync", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_inject_sync_two_event_id.py
+++ b/test/samples/Sync/test_inject_sync_two_event_id.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     Location,
     Module,
@@ -45,6 +46,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, ptr_f16, ptr_f16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_two_event_ids", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a3.py
+++ b/test/samples/Sync/test_intercore_sync_a3.py
@@ -8,6 +8,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     F32Type,
     IndexType,
@@ -37,6 +38,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a3", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a3_dyn.py
+++ b/test/samples/Sync/test_intercore_sync_a3_dyn.py
@@ -8,6 +8,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     F32Type,
     IndexType,
@@ -36,6 +37,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a3_dyn", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a3_missing_setffts.py
+++ b/test/samples/Sync/test_intercore_sync_a3_missing_setffts.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, InsertionPoint, Location, Module
+from mlir.ir import Context, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import func, pto
 
 
@@ -20,6 +20,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a3_missing_setffts", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a3_modes.py
+++ b/test/samples/Sync/test_intercore_sync_a3_modes.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-from mlir.ir import Context, IndexType, InsertionPoint, IntegerType, Location, MemRefType, Module
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from mlir.ir import Context, IndexType, InsertionPoint, IntegerType, Location, MemRefType, Module, UnitAttr
 from mlir.dialects import func, pto
 
 
@@ -16,6 +24,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a3_modes", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a5.py
+++ b/test/samples/Sync/test_intercore_sync_a5.py
@@ -8,6 +8,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     F32Type,
     IndexType,
@@ -30,6 +31,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a5", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a5_dyn.py
+++ b/test/samples/Sync/test_intercore_sync_a5_dyn.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -23,6 +23,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a5_dyn", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a5_functional.py
+++ b/test/samples/Sync/test_intercore_sync_a5_functional.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -24,6 +24,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a5_functional", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_intercore_sync_a5_ptoisa_vec.py
+++ b/test/samples/Sync/test_intercore_sync_a5_ptoisa_vec.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -24,6 +24,7 @@ def build():
 
             with InsertionPoint(module.body):
                 fn = func.FuncOp("test_intercore_sync_a5_ptoisa_vec", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_mem_inject_sync_basic.py
+++ b/test/samples/Sync/test_mem_inject_sync_basic.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context,
     Location,
     Module,
@@ -47,6 +48,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16, i1], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_basic_pipeline", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/test_set_wait_unified_api.py
+++ b/test/samples/Sync/test_set_wait_unified_api.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import arith, func, pto
 from mlir.ir import IndexType
 
@@ -25,6 +25,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("test_set_wait_unified_api_py", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Sync/tmatmulk_autosync.py
+++ b/test/samples/Sync/tmatmulk_autosync.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context, Location, InsertionPoint,
     IndexType, IntegerType, F16Type, F32Type, StringAttr
 )
@@ -133,6 +134,7 @@ def build(
         fn_ty = func.FunctionType.get([ptr_out, ptr_a, ptr_b, ptr_bias, i1], [])
         with InsertionPoint(module.body):
             fn = func.FuncOp("RunTMATMULSplitK", fn_ty)
+            fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
             entry = fn.add_entry_block()
 
         with InsertionPoint(entry):

--- a/test/samples/Sync/tmatmulk_autosync_a5.py
+++ b/test/samples/Sync/tmatmulk_autosync_a5.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 from mlir.ir import (
+    UnitAttr,
     Context, Location, InsertionPoint,
     IndexType, IntegerType, F16Type, F32Type, StringAttr
 )
@@ -134,6 +135,7 @@ def build(
         fn_ty = func.FunctionType.get([ptr_out, ptr_a, ptr_b, ptr_bias, i1], [])
         with InsertionPoint(module.body):
             fn = func.FuncOp("RunTMATMULSplitK", fn_ty)
+            fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
             entry = fn.add_entry_block()
 
         with InsertionPoint(entry):

--- a/test/samples/SyncAll/syncall_binding.py
+++ b/test/samples/SyncAll/syncall_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Attribute, Context, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Attribute, Context, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -43,6 +43,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32, i32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("syncall_binding_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/TInsert/tinsert.py
+++ b/test/samples/TInsert/tinsert.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F16Type, F32Type, IndexType
 
@@ -101,6 +101,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f16, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tinsert_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/TInsert/tinsert_fp.py
+++ b/test/samples/TInsert/tinsert_fp.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType, IntegerType
 
@@ -56,6 +56,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tinsert_fp_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/TPrefetch/tprefetch.py
+++ b/test/samples/TPrefetch/tprefetch.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, InsertionPoint, Location, Module, IndexType, F16Type
+from mlir.ir import Context, InsertionPoint, Location, Module, IndexType, F16Type, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -32,6 +32,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f16, ptr_f16], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("tprefetch_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/TPrefetchAsync/tprefetch_async_binding.py
+++ b/test/samples/TPrefetchAsync/tprefetch_async_binding.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module
+from mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from mlir.dialects import arith, func, pto
 
 
@@ -34,6 +34,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_i8], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("tprefetch_async_binding_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/TTri/ttri.py
+++ b/test/samples/TTri/ttri.py
@@ -12,7 +12,7 @@ Generates one lower-triangular and one upper-triangular 32x32 i32 tile and
 stores them into a single output buffer as two consecutive 32x32 slices.
 """
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, IntegerType
+from mlir.ir import Context, Location, Module, InsertionPoint, IndexType, IntegerType, UnitAttr
 from mlir.dialects import func, arith, pto
 
 
@@ -38,6 +38,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i32], [])
             with InsertionPoint(module.body):
                 fn = func.FuncOp("ttri_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/TileSetGetValue/tileSetGetValue.py
+++ b/test/samples/TileSetGetValue/tileSetGetValue.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tile_set_get_value_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/TileSetGetValue/tile_getval_mat_invalid.py
+++ b/test/samples/TileSetGetValue/tile_getval_mat_invalid.py
@@ -10,7 +10,7 @@
 Test that TGetValOp rejects MAT tile_buf (Ascend hardware does not support
 reading from MAT tile_buf to scalar). Verification must fail.
 """
-from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError
+from mlir.ir import Context, Location, Module, InsertionPoint, MLIRError, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -37,6 +37,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tgetval_mat_invalid", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Tpow/tpow.py
+++ b/test/samples/Tpow/tpow.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tpow_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Tpows/tpows.py
+++ b/test/samples/Tpows/tpows.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("tpows_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Trans/trans.py
+++ b/test/samples/Trans/trans.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -36,6 +36,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_transpose_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Trap/trap.py
+++ b/test/samples/Trap/trap.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 """Test pto.trap: generates TRAP() in C++."""
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, pto
 
 
@@ -21,6 +21,7 @@ def build():
             fn_ty = func.FunctionType.get([], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("trap_kernel", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/VectorAddition/vadd_pto_ir.py
+++ b/test/samples/VectorAddition/vadd_pto_ir.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -36,6 +36,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/VectorAddition/vadd_validshape.py
+++ b/test/samples/VectorAddition/vadd_validshape.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType
+from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/VectorAddition/vadd_validshape_dynamic.py
+++ b/test/samples/VectorAddition/vadd_validshape_dynamic.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType
+from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -42,6 +42,7 @@ def build():
             
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_kernel_2d_dynamic", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/VectorAddition/vadd_validshape_hyper.py
+++ b/test/samples/VectorAddition/vadd_validshape_hyper.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType
+from mlir.ir import Context, Location, Module, InsertionPoint, IntegerType, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import F32Type, IndexType
 
@@ -46,6 +46,7 @@ def build_mixed_shape():
 
             with InsertionPoint(m.body):
                 fn = func.FuncOp("vec_add_kernel_mixed_shape", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Xor/xor.py
+++ b/test/samples/Xor/xor.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("xor_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/Xors/xors.py
+++ b/test/samples/Xors/xors.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint
+from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IntegerType, IndexType, IntegerAttr
 
@@ -35,6 +35,7 @@ def build():
             fn_ty = func.FunctionType.get([ptr_i16, ptr_i16], [])
             with InsertionPoint(m.body):
                 fn = func.FuncOp("XorS_kernel_2d", fn_ty)
+                fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -254,7 +254,7 @@ class _AuthoringRenderer:
         kernel_kind = "cube" if self.kernel.kernel_family == "cube" else "vector"
         function_attrs = (
             "attributes { "
-            f"pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<{kernel_kind}> "
+            f"pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<{kernel_kind}> "
             "}"
         )
         lines.append(f'module attributes {{pto.target_arch = "{self.kernel.target}"}} {{')

--- a/tilelang-dsl/python/tilelang_dsl/pybind_renderer.py
+++ b/tilelang-dsl/python/tilelang_dsl/pybind_renderer.py
@@ -316,7 +316,7 @@ class PybindRenderer:
         # Create function in module body
         with InsertionPoint(self._module.body):
             fn = _func_dialect.FuncOp(self.kernel.symbol_name, fn_ty)
-            # Add tilelang.instance attribute
+            fn.attributes["pto.entry"] = _get_mlir_unit_attr(self._ctx)
             fn.attributes["pto.tilelang.instance"] = _get_mlir_unit_attr(self._ctx)
             self._entry_block = fn.add_entry_block()
 

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -2736,7 +2736,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("// tilelang.specialize tile shape=(16, 32) memory_space=ub", text)
         self.assertIn('module attributes {pto.target_arch = "a5"} {', text)
         self.assertIn(
-            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>) attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
+            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=1>) attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
             text,
         )
         module = specialized.mlir_module()
@@ -3325,7 +3325,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         self.assertIn("// tilelang.target = a5", text)
         self.assertIn("// tilelang.op = multi_op_materialize_sub_unique", text)
         self.assertIn(
-            'func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tensor_view<?x?x?x?x?xf32>) attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {',
+            'func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tensor_view<?x?x?x?x?xf32>) attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {',
             text,
         )
 
@@ -4002,7 +4002,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         text = kernel.mlir_text()
         self.assertIn(
             "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>) "
-            "attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
+            "attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
             text,
         )
         self.assertEqual(text.count("pto.get_tensor_view_dim"), 5)
@@ -4024,7 +4024,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         text = kernel.mlir_text()
         self.assertIn(
             "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>) "
-            "attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
+            "attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
             text,
         )
         self.assertEqual(text.count("pto.get_tensor_view_stride"), 5)
@@ -4139,7 +4139,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         text = specialized.mlir_text()
         self.assertIn(
-            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
+            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
             text,
         )
         self.assertIn("scf.for %lane_", text)
@@ -7349,7 +7349,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         text = specialized.mlir_text()
         self.assertIn(
-            "func.func @kernel(%arg0: !pto.tile_buf<loc=vec, dtype=f16, rows=8, cols=128, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg1: !pto.tile_buf<loc=vec, dtype=f16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg2: !pto.tile_buf<loc=vec, dtype=f16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
+            "func.func @kernel(%arg0: !pto.tile_buf<loc=vec, dtype=f16, rows=8, cols=128, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg1: !pto.tile_buf<loc=vec, dtype=f16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg2: !pto.tile_buf<loc=vec, dtype=f16, rows=8, cols=128, v_row=8, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
             text,
         )
         self.assertIn("valid_shape=(?, ?)", text)
@@ -7718,7 +7718,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         text = kernel.mlir_text()
         self.assertIn(
-            "func.func @kernel(%arg0: !pto.ptr<f32, gm>, %arg1: !pto.ptr<f32, gm>, %arg2: i64) attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
+            "func.func @kernel(%arg0: !pto.ptr<f32, gm>, %arg1: !pto.ptr<f32, gm>, %arg2: i64) attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
             text,
         )
         self.assertRegex(
@@ -8519,7 +8519,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
 
         text = specialized.mlir_text()
         self.assertIn(
-            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg2: i32) attributes { pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
+            "func.func @kernel(%arg0: !pto.tensor_view<?x?x?x?x?xf32>, %arg1: !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, %arg2: i32) attributes { pto.entry, pto.tilelang.instance, pto.kernel_kind = #pto.kernel_kind<vector> } {",
             text,
         )
         self.assertRegex(

--- a/tools/ptoas/VPTOHostStubEmission.cpp
+++ b/tools/ptoas/VPTOHostStubEmission.cpp
@@ -77,7 +77,7 @@ static LogicalResult collectVPTOKernelStubDecls(
 
   for (ModuleOp module : modules) {
     module.walk([&](func::FuncOp func) {
-      if (!pto::isPTOKernelFunction(func))
+      if (!pto::isPTOEntryFunction(func))
         return;
 
       std::string logicalName = getLogicalKernelName(func.getSymName());

--- a/tools/ptoas/driver.cpp
+++ b/tools/ptoas/driver.cpp
@@ -367,10 +367,10 @@ mlir::pto::PTOASContext::createTempPath(llvm::StringRef prefix,
   return tempFiles.create(prefix, suffix, path, llvm::errs());
 }
 
-static bool hasPTOKernel(ModuleOp module) {
+static bool hasPTOEntry(ModuleOp module) {
   bool found = false;
   module.walk([&](func::FuncOp func) {
-    if (mlir::pto::isPTOKernelFunction(func)) {
+    if (mlir::pto::isPTOEntryFunction(func)) {
       found = true;
       return WalkResult::interrupt();
     }
@@ -464,7 +464,7 @@ public:
     ModuleOp op = module.get();
     op->setAttr("pto.backend", StringAttr::get(op.getContext(), "vpto"));
 
-    bool emitHostStub = hasPTOKernel(op);
+    bool emitHostStub = hasPTOEntry(op);
     mlir::pto::PTOASCompileResult jobResult;
     if (mlir::pto::compilePTOASModule(
             module, context, mlir::pto::PTOBackend::VPTO, jobResult,
@@ -539,7 +539,7 @@ LogicalResult VPTOBackendJob::run(PTOASContext &context) {
   ModuleOp op = module.get();
   op->setAttr("pto.backend", StringAttr::get(op.getContext(), "vpto"));
 
-  bool emitHostStub = hasPTOKernel(op);
+  bool emitHostStub = hasPTOEntry(op);
   if (mlir::pto::compilePTOASModule(
           module, context, mlir::pto::PTOBackend::VPTO, result,
           emitHostStub) != 0)


### PR DESCRIPTION
## 背景

当前 EmitC entry 判断曾从单函数模块、`pto.kernel_kind` 等信息推断入口，导致 issue 780 这类输入在用户没有显式声明 entry 时也会生成 `extern "C" __global__`。这会让 IR 形态和入口选择变得不可控。

后续确认语义后，本 PR 同时统一 EmitC/VPTO 历史命名：`pto.entry`、`hacc.entry`、`pto.kernel`、`pto.aicore` 都表示显式 PTO kernel entry；`pto.kernel_kind` 只是 vector/cube kind 元数据，不能隐含 entry。

## 修改

- `isPTOEntryFunction` 只认显式 entry alias，不再从单函数模块或 `pto.kernel_kind` 推断入口。
- 移除重复的 `isPTOKernelFunction` / `hasPTOKernelAttr` 公共 helper，VPTO、driver、host stub 统一使用 entry helper，避免 kernel/entry 两套接口继续分叉。
- `annotatePTOEntryFunctions` 不再物化隐式 entry，只清理内部标记。
- ptodsl、tilelang DSL 前端在生成真正可 launch kernel 时显式写入 entry alias；flat AICore PTODSL 保留 `pto.aicore`，不再重复写 `pto.entry`。
- Python sample 中由 `func.FuncOp` 生成的 launchable kernel 显式补 entry，保持旧 sample/runop 行为。
- 更新 lit 期望，并补充 issue 780 相关回归。

## 验证

- `cmake --build build-simt-lowlevel --target ptoas -j 8`
- `/home/mouliangyu/projects/github.com/llvm/llvm-project/build/bin/llvm-lit -v build-simt-lowlevel/test/lit/pto/pto_entry_multifunc.pto build-simt-lowlevel/test/lit/pto/issue780_kernel_kind_not_entry.pto build-simt-lowlevel/test/lit/pto/pto_entry_single_func_default.pto`：3 个通过
- `/home/mouliangyu/projects/github.com/llvm/llvm-project/build/bin/llvm-lit -q build-simt-lowlevel/test/lit`：548 个通过
- `PYTHONPATH="$PWD/tilelang-dsl/python:$PYTHONPATH" python3 -m unittest discover -s tilelang-dsl/tests -p 'test_*.py'`：339 个通过
- `WORK_SPACE="$PWD/.work/vpto-smoke" PTOAS_BIN="$PWD/build-simt-lowlevel/tools/ptoas/ptoas" CASE_NAME="micro-op/binary-vector/vadd" DEVICE=SIM test/vpto/scripts/run_host_vpto_validation.sh`：通过，compare passed
- `PTOAS_BIN="$PWD/build-simt-lowlevel/tools/ptoas/ptoas" python3 test/tilelang_st/script/run_all_st.py -r sim -v a5 -t tadd --smoke -j 1 --without-build`：通过，passed=1 failed=0
- EmitC 旧流程：`PTOAS_BIN="$PWD/build-simt-lowlevel/tools/ptoas/ptoas" test/samples/runop.sh -t Abs` + `test/npu_validation/scripts/generate_testcase.py` + `dav_2201` camodel compare：通过
- `git diff --check`：通过

## 已知无关失败

现有全量 `ctest --test-dir build-simt-lowlevel --output-on-failure` 仍有 ptobc 旧失败：`ptobc_stage9_e2e`、`ptobc_recent_ops_v0_encode`、`ptobc_tscatter_maskpattern_v0_encode`。失败类型与本次 entry/EmitC/VPTO alias 改动无关。