### PR TITLE
ci: skip ci-sim on non-vpto PRs

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   pr-context:
@@ -41,12 +42,70 @@ jobs:
           path: pr-context
           if-no-files-found: error
 
+  detect-vpto-sim-changes:
+    runs-on: ubuntu-22.04
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Detect PR changes relevant to VPTO SIM validation
+        if: ${{ github.event_name == 'pull_request' }}
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ github.token }}
+          filters: |
+            relevant:
+              - '.github/workflows/ci_sim.yml'
+              - 'scripts/sim_dsl.sh'
+              - 'test/vpto/**'
+              - 'test/tilelang_st/**'
+              - 'test/dsl-st/**'
+              - 'tilelang-dsl/**'
+              - 'ptodsl/**'
+              - 'tools/ptoas/**'
+              - 'lib/TileOps/**'
+              - 'include/PTO/IR/VPTO*.td'
+              - 'lib/PTO/IR/VPTO.cpp'
+              - 'include/PTO/Transforms/Passes.h'
+              - 'include/PTO/Transforms/Passes.td'
+              - 'include/PTO/Transforms/*VPTO*'
+              - 'include/PTO/Transforms/**/*VPTO*'
+              - 'lib/PTO/Transforms/CMakeLists.txt'
+              - 'lib/PTO/Transforms/ExpandTileOp.cpp'
+              - 'lib/PTO/Transforms/FoldTileBufIntrinsics.cpp'
+              - 'lib/PTO/Transforms/*VPTO*'
+              - 'lib/PTO/Transforms/**/*VPTO*'
+
+      - name: Decide whether to run VPTO SIM validation
+        id: decide
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_RELEVANT: ${{ steps.filter.outputs.relevant || 'false' }}
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+            echo "should_run=true" >> "${GITHUB_OUTPUT}"
+            echo "Running vpto-sim-validation on ${EVENT_NAME}"
+          elif [[ "${PR_RELEVANT}" == "true" ]]; then
+            echo "should_run=true" >> "${GITHUB_OUTPUT}"
+            echo "Running vpto-sim-validation because the PR touched VPTO-related paths"
+          else
+            echo "should_run=false" >> "${GITHUB_OUTPUT}"
+            echo "Skipping vpto-sim-validation because the PR did not touch VPTO-related paths"
+          fi
+
   vpto-sim-validation:
+    needs: detect-vpto-sim-changes
     runs-on: [self-hosted, Linux, X64, label-1]
     timeout-minutes: 120
     concurrency:
       group: vpto-sim-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
+    if: >-
+      ${{
+        needs.detect-vpto-sim-changes.outputs.should_run == 'true'
+      }}
     env:
       LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
       LLVM_REF: feature-vpto


### PR DESCRIPTION
## Summary
- supersede #787, which was accidentally opened against a temporary base branch instead of `main`
- keep the `ci-sim` workflow running on every PR so `pr-context` and `watchdog` still work
- skip the heavy `vpto-sim-validation` job when a PR does not touch VPTO / DSL / `ci_sim.yml` paths

## Validation
- `python3` YAML parse of `.github/workflows/ci_sim.yml`
- `git diff --check`
