### PR TITLE
fix(vpto): handle dynamic tilelang Qwen decode cases (#782)

### DIFF
--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -379,6 +379,8 @@ static const llvm::StringSet<> &highPrecisionImplementedOps() {
     "pto.trecip",
     "pto.trowexpanddiv",
     "pto.tcolexpanddiv",
+    "pto.texp",
+    "pto.tsqrt",
   };
   return kImplementedOps;
 }
@@ -1183,6 +1185,8 @@ LogicalResult ExpandState::expandTileOpsInFunction(func::FuncOp func,
   // Collect tile ops first (avoid modifying while iterating).
   SmallVector<Operation *, 16> tileOps;
   func.walk([&](Operation *op) {
+    if (isa<pto::TReshapeOp>(op))
+      return;
     if (isa<pto::OpPipeInterface>(op))
       tileOps.push_back(op);
   });

--- a/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
+++ b/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
@@ -74,6 +74,16 @@ struct TileHandleInfo {
   pto::TileBufConfigAttr config;
 };
 
+static std::pair<Value, Value> findSetValidShapeOverride(Value tileBuf) {
+  for (Operation *user : tileBuf.getUsers()) {
+    auto setValid = dyn_cast<pto::SetValidShapeOp>(user);
+    if (!setValid || setValid.getSource() != tileBuf)
+      continue;
+    return {setValid.getValidRow(), setValid.getValidCol()};
+  }
+  return {Value(), Value()};
+}
+
 static std::optional<TileHandleInfo> resolveTileHandle(Value tileBuf,
                                                        Operation *user) {
   if (auto alloc = tileBuf.getDefiningOp<pto::AllocTileOp>()) {
@@ -93,9 +103,29 @@ static std::optional<TileHandleInfo> resolveTileHandle(Value tileBuf,
                           materialize.getConfig()};
   }
 
+  if (auto reshape = tileBuf.getDefiningOp<pto::TReshapeOp>()) {
+    auto sourceInfo = resolveTileHandle(reshape.getSrc(), user);
+    if (!sourceInfo)
+      return std::nullopt;
+
+    auto tileTy = dyn_cast<pto::TileBufType>(reshape.getResult().getType());
+    if (!tileTy) {
+      user->emitError(
+          "FoldTileBufIntrinsics: pto.treshape must produce !pto.tile_buf");
+      return std::nullopt;
+    }
+
+    auto [validRow, validCol] = findSetValidShapeOverride(tileBuf);
+    return TileHandleInfo{sourceInfo->sourceMemref,
+                          sourceInfo->addr,
+                          validRow ? validRow : sourceInfo->validRow,
+                          validCol ? validCol : sourceInfo->validCol,
+                          tileTy.getConfigAttr()};
+  }
+
   user->emitError("FoldTileBufIntrinsics: expected tile_buf to be defined by "
                   "the active materialized tile-handle bridge "
-                  "(pto.alloc_tile or pto.materialize_tile)");
+                  "(pto.alloc_tile, pto.materialize_tile, or pto.treshape)");
   return std::nullopt;
 }
 

--- a/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
+++ b/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
@@ -76,6 +76,12 @@ static bool isForbiddenInsideInferredVectorScope(Operation *op) {
   return isa<pto::VbitsortOp, pto::Vmrgsort4Op>(op);
 }
 
+static bool isCloneableMaskProducer(Operation *op) {
+  return isa<pto::PsetB8Op, pto::PsetB16Op, pto::PsetB32Op, pto::PgeB8Op,
+             pto::PgeB16Op, pto::PgeB32Op, pto::PltB8Op, pto::PltB16Op,
+             pto::PltB32Op>(op);
+}
+
 static bool isVectorScopeBoundaryOperation(Operation *op) {
   return isa<pto::BarrierOp, pto::BarrierSyncOp>(op);
 }
@@ -242,6 +248,67 @@ computeMovedOpsForResultlessScope(ArrayRef<Operation *> ops) {
     }
   }
   return movedOps;
+}
+
+static Operation *getAncestorInBlock(Operation *op, Block &block) {
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    if (cur->getBlock() == &block)
+      return cur;
+  }
+  return nullptr;
+}
+
+static bool isUseBeforeInBlock(OpOperand *lhs, OpOperand *rhs, Block &block) {
+  Operation *lhsAncestor = getAncestorInBlock(lhs->getOwner(), block);
+  Operation *rhsAncestor = getAncestorInBlock(rhs->getOwner(), block);
+  if (!lhsAncestor || !rhsAncestor || lhsAncestor == rhsAncestor)
+    return false;
+  return lhsAncestor->isBeforeInBlock(rhsAncestor);
+}
+
+static void keepEarliestUseFirst(SmallVectorImpl<OpOperand *> &uses,
+                                 Block &block) {
+  if (uses.size() < 2)
+    return;
+
+  unsigned earliest = 0;
+  for (unsigned i = 1, e = uses.size(); i < e; ++i) {
+    if (isUseBeforeInBlock(uses[i], uses[earliest], block))
+      earliest = i;
+  }
+  if (earliest != 0)
+    std::swap(uses.front(), uses[earliest]);
+}
+
+static void cloneSharedMaskProducers(Block &block, MLIRContext *context) {
+  IRRewriter rewriter(context);
+  SmallVector<Operation *, 32> ops;
+  for (Operation &op : block)
+    ops.push_back(&op);
+
+  for (Operation *op : ops) {
+    if (!isCloneableMaskProducer(op))
+      continue;
+
+    for (OpResult result : op->getOpResults()) {
+      if (!isa<pto::MaskType>(result.getType()) || result.use_empty())
+        continue;
+
+      SmallVector<OpOperand *, 8> uses;
+      for (OpOperand &use : result.getUses())
+        uses.push_back(&use);
+      if (uses.size() < 2)
+        continue;
+
+      keepEarliestUseFirst(uses, block);
+      for (OpOperand *use : ArrayRef<OpOperand *>(uses).drop_front()) {
+        Operation *user = use->getOwner();
+        rewriter.setInsertionPoint(user);
+        Operation *clone = rewriter.clone(*op);
+        use->set(clone->getResult(result.getResultNumber()));
+      }
+    }
+  }
 }
 
 static bool findEscapingMovedResult(
@@ -424,6 +491,8 @@ static LogicalResult wrapGreedySubclusters(ArrayRef<Operation *> ops,
 }
 
 static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
+  cloneSharedMaskProducers(block, context);
+
   SmallVector<Operation *, 16> pending;
 
   auto flush = [&]() -> LogicalResult {

--- a/lib/TileOps/tcvt_template.py
+++ b/lib/TileOps/tcvt_template.py
@@ -11,6 +11,20 @@
 import tilelang_dsl as pto
 
 
+def _config_value(config, name):
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _matches_layout(value, expected, expected_name):
+    if value is None:
+        return False
+    return value == expected or value == expected_name or str(value).lower().endswith(expected_name)
+
+
 def _supports_basic_rowwise_tcvt(
     src=None,
     dst=None,
@@ -31,13 +45,13 @@ def _supports_basic_rowwise_tcvt(
     dst_config = dst.config
     if src_config is None or dst_config is None:
         return False
-    if src_config.b_layout != pto.BLayout.ROW_MAJOR:
+    if not _matches_layout(_config_value(src_config, "b_layout"), pto.BLayout.ROW_MAJOR, "row_major"):
         return False
-    if dst_config.b_layout != pto.BLayout.ROW_MAJOR:
+    if not _matches_layout(_config_value(dst_config, "b_layout"), pto.BLayout.ROW_MAJOR, "row_major"):
         return False
-    if src_config.s_layout != pto.SLayout.NONE_BOX:
+    if not _matches_layout(_config_value(src_config, "s_layout"), pto.SLayout.NONE_BOX, "none_box"):
         return False
-    if dst_config.s_layout != pto.SLayout.NONE_BOX:
+    if not _matches_layout(_config_value(dst_config, "s_layout"), pto.SLayout.NONE_BOX, "none_box"):
         return False
     return True
 
@@ -62,13 +76,13 @@ def _supports_bf16_to_fp4_rowwise_tcvt(
     dst_config = dst.config
     if src_config is None or dst_config is None:
         return False
-    if src_config.b_layout != pto.BLayout.ROW_MAJOR:
+    if not _matches_layout(_config_value(src_config, "b_layout"), pto.BLayout.ROW_MAJOR, "row_major"):
         return False
-    if dst_config.b_layout != pto.BLayout.ROW_MAJOR:
+    if not _matches_layout(_config_value(dst_config, "b_layout"), pto.BLayout.ROW_MAJOR, "row_major"):
         return False
-    if src_config.s_layout != pto.SLayout.NONE_BOX:
+    if not _matches_layout(_config_value(src_config, "s_layout"), pto.SLayout.NONE_BOX, "none_box"):
         return False
-    if dst_config.s_layout != pto.SLayout.NONE_BOX:
+    if not _matches_layout(_config_value(dst_config, "s_layout"), pto.SLayout.NONE_BOX, "none_box"):
         return False
     return True
 

--- a/lib/TileOps/texp_template.py
+++ b/lib/TileOps/texp_template.py
@@ -11,42 +11,23 @@
 import tilelang_dsl as pto
 from exp_hp import _tl_exp_precision
 
-@pto.inline_proc
-def template_texp_hp_impl(src: pto.Tile, dst: pto.Tile):
-    dtype = dst.element_type
-    valid_rows, valid_cols = dst.valid_shape
-    
-    for row in range(0, valid_rows, 1):
-        remained = valid_cols
-        for col in range(0, valid_cols, pto.get_lanes(dtype)):
-            mask, remained = pto.make_mask(dtype, remained)
-            vinput = pto.vlds(src[row, col:])
-            result = _tl_exp_precision(vinput, mask, dtype)
-            pto.vsts(result, dst[row, col:], mask)
-    return
-
-@pto.inline_proc
-def template_texp_impl(src: pto.Tile, dst: pto.Tile):
-    dtype = dst.element_type
-    valid_rows, valid_cols = dst.valid_shape
-    
-    for row in range(0, valid_rows, 1):
-        remained = valid_cols
-        for col in range(0, valid_cols, pto.get_lanes(dtype)):
-            mask, remained = pto.make_mask(dtype, remained)
-            vinput = pto.vlds(src[row, col:])
-            result = pto.vexp(vinput, mask)
-            pto.vsts(result, dst[row, col:], mask)
-    return
-
 @pto.vkernel(
     target="a5",
     op="pto.texp"
 )
 def template_texp(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
     precision_type = pto.get_op_attr("precisionType", "default")
-    if pto.constexpr(precision_type == "high_precision"):
-        template_texp_hp_impl(src, dst)
-    else:
-        template_texp_impl(src, dst)
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            if pto.constexpr(precision_type == "high_precision"):
+                result = _tl_exp_precision(vinput, mask, dtype)
+            else:
+                result = pto.vexp(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
     return

--- a/lib/TileOps/tfillpad_expand_template.py
+++ b/lib/TileOps/tfillpad_expand_template.py
@@ -75,8 +75,11 @@ def template_tfillpad_expand(src: pto.Tile, dst: pto.Tile):
 
     # PadValue handling - dtype-specific
     if pto.constexpr(dtype == pto.f32):
-        if pto.constexpr(dst.pad_value == pto.PadValue.ZERO and has_valid_expansion):
-            fill_scalar = pto.f32(_NEG1_F32)
+        if pto.constexpr(dst.pad_value == pto.PadValue.ZERO):
+            if has_valid_expansion:
+                fill_scalar = pto.f32(_NEG1_F32)
+            else:
+                fill_scalar = pto.f32(0.0)
         elif pto.constexpr(dst.pad_value != pto.PadValue.NULL):
             fill_scalar = dst.pad_value.eval()
         else:
@@ -136,7 +139,7 @@ def template_tfillpad_expand(src: pto.Tile, dst: pto.Tile):
             pto.vsts(data, dst[row, col:], mask)
 
     # Phase 2: Fill col padding
-    if pto.constexpr(aligned_col < dst_valid_cols):
+    if aligned_col < dst_valid_cols:
         for row in range(0, dst_valid_rows, 1):
             remained = dst_valid_cols - aligned_col
             for col in range(aligned_col, dst_valid_cols, lanes):
@@ -145,7 +148,7 @@ def template_tfillpad_expand(src: pto.Tile, dst: pto.Tile):
                 pto.vsts(vec, dst[row, col:], mask)
 
     # Phase 3: Copy tail valid lanes
-    if pto.constexpr(has_tail):
+    if has_tail:
         for row in range(0, src_valid_rows, 1):
             remained = src_valid_cols - aligned_col
             mask_copy, remained = pto.make_mask(dtype, remained)

--- a/lib/TileOps/tfillpad_template.py
+++ b/lib/TileOps/tfillpad_template.py
@@ -81,8 +81,11 @@ def template_tfillpad(src: pto.Tile, dst: pto.Tile):
 
     # PadValue handling - dtype-specific (inline to avoid external call)
     if pto.constexpr(dtype == pto.f32):
-        if pto.constexpr(dst.pad_value == pto.PadValue.ZERO and has_valid_expansion):
-            fill_scalar = pto.f32(_NEG1_F32)
+        if pto.constexpr(dst.pad_value == pto.PadValue.ZERO):
+            if has_valid_expansion:
+                fill_scalar = pto.f32(_NEG1_F32)
+            else:
+                fill_scalar = pto.f32(0.0)
         elif pto.constexpr(dst.pad_value != pto.PadValue.NULL):
             fill_scalar = dst.pad_value.eval()
         else:
@@ -142,7 +145,7 @@ def template_tfillpad(src: pto.Tile, dst: pto.Tile):
             pto.vsts(data, dst[row, col:], mask)
 
     # Phase 2: Fill cols from aligned_col to dst_cols-1
-    if pto.constexpr(aligned_col < dst_cols):
+    if aligned_col < dst_cols:
         for row in range(0, src_valid_rows, 1):
             remained = dst_cols - aligned_col
             for col in range(aligned_col, dst_cols, lanes):
@@ -151,7 +154,7 @@ def template_tfillpad(src: pto.Tile, dst: pto.Tile):
                 pto.vsts(vec, dst[row, col:], mask)
 
     # Phase 3: Copy tail valid lanes
-    if pto.constexpr(has_tail):
+    if has_tail:
         for row in range(0, src_valid_rows, 1):
             remained = src_valid_cols - aligned_col
             mask_copy, remained = pto.make_mask(dtype, remained)

--- a/lib/TileOps/trowexpanddiv_template.py
+++ b/lib/TileOps/trowexpanddiv_template.py
@@ -20,13 +20,37 @@ import tilelang_dsl as pto
 from div_hp import _div_ieee754_f32_impl, _div_ieee754_f16_impl
 
 
+def _config_value(config, name):
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _matches_layout(value, expected, expected_name):
+    if value is None:
+        return False
+    return value == expected or value == expected_name or str(value).lower().endswith(expected_name)
+
+
+def _is_row_major(tile: pto.Tile) -> bool:
+    return _matches_layout(_config_value(tile.config, "b_layout"), pto.BLayout.ROW_MAJOR, "row_major")
+
+
+def _is_col_major(tile: pto.Tile) -> bool:
+    return _matches_layout(_config_value(tile.config, "b_layout"), pto.BLayout.COL_MAJOR, "col_major")
+
+
+def _is_col_major_row_scalar(tile: pto.Tile) -> bool:
+    shape = tuple(tile.shape)
+    return len(shape) == 2 and _is_col_major(tile) and shape[1] == 1
+
+
 def _constraint_trowexpanddiv_row_major(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile) -> bool:
     """Constraint for RowMajor layout trowexpanddiv template."""
-    # All tiles must be RowMajor layout
-    src0_row_major = src0.config.b_layout == pto.BLayout.ROW_MAJOR
-    src1_row_major = src1.config.b_layout == pto.BLayout.ROW_MAJOR
-    dst_row_major = dst.config.b_layout == pto.BLayout.ROW_MAJOR
-    return src0_row_major and src1_row_major and dst_row_major
+    src1_supported = _is_row_major(src1) or _is_col_major_row_scalar(src1)
+    return _is_row_major(src0) and src1_supported and _is_row_major(dst)
 
 
 @pto.vkernel(

--- a/lib/TileOps/trowexpandmul_template.py
+++ b/lib/TileOps/trowexpandmul_template.py
@@ -13,13 +13,37 @@ from pathlib import Path
 import tilelang_dsl as pto
 
 
+def _config_value(config, name):
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _matches_layout(value, expected, expected_name):
+    if value is None:
+        return False
+    return value == expected or value == expected_name or str(value).lower().endswith(expected_name)
+
+
+def _is_row_major(tile: pto.Tile) -> bool:
+    return _matches_layout(_config_value(tile.config, "b_layout"), pto.BLayout.ROW_MAJOR, "row_major")
+
+
+def _is_col_major(tile: pto.Tile) -> bool:
+    return _matches_layout(_config_value(tile.config, "b_layout"), pto.BLayout.COL_MAJOR, "col_major")
+
+
+def _is_col_major_row_scalar(tile: pto.Tile) -> bool:
+    shape = tuple(tile.shape)
+    return len(shape) == 2 and _is_col_major(tile) and shape[1] == 1
+
+
 def _constraint_trowexpandmul_row_major(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile) -> bool:
     """Constraint for RowMajor layout trowexpandmul template."""
-    # All tiles must be RowMajor layout
-    src0_row_major = src0.config.b_layout == pto.BLayout.ROW_MAJOR
-    src1_row_major = src1.config.b_layout == pto.BLayout.ROW_MAJOR
-    dst_row_major = dst.config.b_layout == pto.BLayout.ROW_MAJOR
-    return src0_row_major and src1_row_major and dst_row_major
+    src1_supported = _is_row_major(src1) or _is_col_major_row_scalar(src1)
+    return _is_row_major(src0) and src1_supported and _is_row_major(dst)
 
 
 @pto.vkernel(

--- a/lib/TileOps/trowexpandsub_template.py
+++ b/lib/TileOps/trowexpandsub_template.py
@@ -13,13 +13,37 @@ from pathlib import Path
 import tilelang_dsl as pto
 
 
+def _config_value(config, name):
+    if config is None:
+        return None
+    if isinstance(config, dict):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _matches_layout(value, expected, expected_name):
+    if value is None:
+        return False
+    return value == expected or value == expected_name or str(value).lower().endswith(expected_name)
+
+
+def _is_row_major(tile: pto.Tile) -> bool:
+    return _matches_layout(_config_value(tile.config, "b_layout"), pto.BLayout.ROW_MAJOR, "row_major")
+
+
+def _is_col_major(tile: pto.Tile) -> bool:
+    return _matches_layout(_config_value(tile.config, "b_layout"), pto.BLayout.COL_MAJOR, "col_major")
+
+
+def _is_col_major_row_scalar(tile: pto.Tile) -> bool:
+    shape = tuple(tile.shape)
+    return len(shape) == 2 and _is_col_major(tile) and shape[1] == 1
+
+
 def _constraint_trowexpandsub_row_major(src0: pto.Tile, src1: pto.Tile, dst: pto.Tile) -> bool:
     """Constraint for RowMajor layout trowexpandsub template."""
-    # All tiles must be RowMajor layout
-    src0_row_major = src0.config.b_layout == pto.BLayout.ROW_MAJOR
-    src1_row_major = src1.config.b_layout == pto.BLayout.ROW_MAJOR
-    dst_row_major = dst.config.b_layout == pto.BLayout.ROW_MAJOR
-    return src0_row_major and src1_row_major and dst_row_major
+    src1_supported = _is_row_major(src1) or _is_col_major_row_scalar(src1)
+    return _is_row_major(src0) and src1_supported and _is_row_major(dst)
 
 
 @pto.vkernel(

--- a/lib/TileOps/tsqrt_template.py
+++ b/lib/TileOps/tsqrt_template.py
@@ -11,42 +11,23 @@
 import tilelang_dsl as pto
 from sqrt_hp import _tl_sqrt_precision
 
-@pto.inline_proc
-def template_tsqrt_hp_impl(src: pto.Tile, dst: pto.Tile):
-    dtype = dst.element_type
-    valid_rows, valid_cols = dst.valid_shape
-    
-    for row in range(0, valid_rows, 1):
-        remained = valid_cols
-        for col in range(0, valid_cols, pto.get_lanes(dtype)):
-            mask, remained = pto.make_mask(dtype, remained)
-            vinput = pto.vlds(src[row, col:])
-            result = _tl_sqrt_precision(vinput, mask, dtype)
-            pto.vsts(result, dst[row, col:], mask)
-    return
-
-@pto.inline_proc
-def template_tsqrt_impl(src: pto.Tile, dst: pto.Tile):
-    dtype = dst.element_type
-    valid_rows, valid_cols = dst.valid_shape
-    
-    for row in range(0, valid_rows, 1):
-        remained = valid_cols
-        for col in range(0, valid_cols, pto.get_lanes(dtype)):
-            mask, remained = pto.make_mask(dtype, remained)
-            vinput = pto.vlds(src[row, col:])
-            result = pto.vsqrt(vinput, mask)
-            pto.vsts(result, dst[row, col:], mask)
-    return
-
 @pto.vkernel(
     target="a5",
     op="pto.tsqrt"
 )
 def template_tsqrt(src: pto.Tile, dst: pto.Tile):
+    dtype = dst.element_type
+    valid_rows, valid_cols = dst.valid_shape
     precision_type = pto.get_op_attr("precisionType", "default")
-    if pto.constexpr(precision_type == "high_precision"):
-        template_tsqrt_hp_impl(src, dst)
-    else:
-        template_tsqrt_impl(src, dst)
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, pto.get_lanes(dtype)):
+            mask, remained = pto.make_mask(dtype, remained)
+            vinput = pto.vlds(src[row, col:])
+            if pto.constexpr(precision_type == "high_precision"):
+                result = _tl_sqrt_precision(vinput, mask, dtype)
+            else:
+                result = pto.vsqrt(vinput, mask)
+            pto.vsts(result, dst[row, col:], mask)
     return

--- a/tilelang-dsl/python/tilelang_dsl/daemon_core.py
+++ b/tilelang-dsl/python/tilelang_dsl/daemon_core.py
@@ -29,12 +29,14 @@ from .kernel import (
     KernelRegistry,
     VKernelDescriptor,
     select_kernel,
-    AnyType,
 )
 from .types import (
     MemorySpace,
+    ScalarType,
     TileSpecialization,
     TileConfig,
+    WildcardType,
+    is_integer_dtype,
 )
 import tilelang_dsl as pto
 
@@ -274,9 +276,11 @@ def _import_and_find_descriptors(py_file: Path) -> list[VKernelDescriptor]:
     Returns:
         List of VKernelDescriptor objects
     """
-    template_parent = py_file.parent.parent
-    if str(template_parent) not in sys.path:
-        sys.path.insert(0, str(template_parent))
+    import_roots = (py_file.parent, py_file.parent.parent)
+    for root in reversed(import_roots):
+        root_text = str(root)
+        if root_text not in sys.path:
+            sys.path.insert(0, root_text)
 
     module_name = f"_tl_template_{py_file.stem}"
     spec = importlib.util.spec_from_file_location(module_name, str(py_file))
@@ -476,9 +480,18 @@ def _dtype_matches(dtype_sig: Any, dtype_spec: Any) -> bool:
     Returns:
         True if matches
     """
-    # AnyType matches any dtype (wildcard)
-    if dtype_sig == AnyType:
-        return True
+    if isinstance(dtype_sig, WildcardType):
+        if dtype_sig.name == "AnyType":
+            return isinstance(dtype_spec, ScalarType)
+        if dtype_sig.name == "AnyFloat":
+            return isinstance(dtype_spec, ScalarType) and dtype_spec.name in {
+                "f16",
+                "bf16",
+                "f32",
+            }
+        if dtype_sig.name == "AnyInt":
+            return isinstance(dtype_spec, ScalarType) and is_integer_dtype(dtype_spec)
+        return False
     
     # Normal matching logic
     if hasattr(dtype_sig, "name") and hasattr(dtype_spec, "name"):


### PR DESCRIPTION
## Summary

Fix VPTO TileLang expansion for dynamic valid-shape Qwen decode cases.

This change handles several dynamic tile-buffer patterns that appeared in
Qwen3DecodeA5 level3 VPTO emission:

- avoid expanding `pto.treshape` through TileLang when no TileLang template exists
- allow folded tile-buffer intrinsics to resolve handles through `pto.treshape`
- support dynamic valid-shape metadata in `tsqrt`, `texp`, `tfillpad`, and `tfillpad_expand` templates
- allow row-expand ops to use `col_major` single-column row-scalar tiles
- clone shared mask producers before inferred VPTO vecscope wrapping
- fix daemon-side dtype wildcard matching and template import paths for TileLang kernel selection
- make `tcvt` constraints accept both object-style and dict-like tile configs

## Validation

Ran the requested Qwen3DecodeA5 VPTO level3 cases:

```sh
ptoas prep_5d/post_rmsnorm.pto --emit-vpto --pto-backend=vpto --pto-level=level3
ptoas prep_5d/qwen3_decode_incore_5.pto --emit-vpto --pto-backend=vpto --pto-level=level3
ptoas prep_5d/qwen3_decode_incore_7.pto --emit-vpto --pto-backend=vpto --pto-level=level3
ptoas prep_5d/qwen3_decode_incore_12.pto --emit-vpto --pto-backend=vpto --pto-level=level3
ptoas prep_5d/rmsnorm.pto --emit-vpto --pto-backend=vpto --pto-level=level3
ptoas prep_5d/rope_kv_cache.pto --emit-vpto --pto-backend=vpto --pto-level=level3
```

Also verified daemon-core selection for:

- `pto.trowexpanddiv(f32, f32, f32)`
- `pto.tcvt(f32, bf16)`
