### PR TITLE
Align tmp tile contracts with runtime behavior

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -2344,6 +2344,7 @@ For each element (i, j):
 |------|------|-------------|
 | `src0` | `pto.tile_buf` | Dividend tile buffer |
 | `src1` | `pto.tile_buf` | Divisor tile buffer |
+| `tmp` | `pto.tile_buf` | A2/A3 workspace tile. On A5 this operand is kept for ABI compatibility and is not used by the instruction. |
 | `dst` | `pto.tile_buf` | Destination tile buffer |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -2361,15 +2362,15 @@ pto.trem ins(<src0>, <src1>, <tmp> : <src0_type>, <src1_type>, <tmp_type>)
 - **Implementation checks (A2A3)**
   - `src0/src1/dst` element type must match, and must be `i32` or `f32`.
   - `tmp` element type must match `dst`.
-  - `src0/src1/tmp/dst` must use row-major layout (`blayout=row_major`).
+  - `src0/src1/dst` must use row-major layout (`blayout=row_major`).
+  - `tmp` must be a row-major `loc=vec` tile.
   - `src0/src1/dst` must have the same `validRow/validCol`.
-  - `tmp` must provide at least `1` valid row and `tmp.validCol >= dst.validCol`.
+  - `tmp` must provide at least `2` valid rows and `tmp.validCol >= dst.validCol`.
 - **Implementation checks (A5)**
   - `src0/src1/dst` element type must match, and must be one of: `i32`, `i16`, `f16`, `f32`.
-  - `tmp` element type must match `dst`.
-  - `src0/src1/tmp/dst` must use row-major layout (`blayout=row_major`).
+  - `src0/src1/dst` must use row-major layout (`blayout=row_major`).
   - `src0/src1/dst` must have the same `validRow/validCol`.
-  - `tmp` must provide at least `1` valid row and `tmp.validCol >= dst.validCol`.
+  - `tmp` is not used by the A5 implementation. PTO IR still requires it to be a row-major `loc=vec` tile, but no element-type, shape, or valid-shape relation with `src0/src1/dst` is required.
 
 **Hardware Mapping:**
 
@@ -2385,8 +2386,8 @@ pto.trem ins(%a, %b, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16,
              !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16,
              v_row=16, v_col=16, blayout=row_major, slayout=none_box,
              fractal=512, pad=0>,
-             !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16,
-             v_row=1, v_col=16, blayout=row_major, slayout=none_box,
+             !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16,
+             v_row=2, v_col=16, blayout=row_major, slayout=none_box,
              fractal=512, pad=0>)
          outs(%c : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16,
              v_row=16, v_col=16, blayout=row_major, slayout=none_box,
@@ -2801,7 +2802,7 @@ For each element (i, j):
 |------|------|-------------|
 | `src0` | `pto.tile_buf` | Source tile buffer (input activations) |
 | `src1` | `pto.tile_buf` | Slope tile buffer (per-element negative slopes) |
-| `tmp` | `pto.tile_buf` | New temporary source tile buffer for A2/A3. This only a placehold parameter in A5, see examples|
+| `tmp` | `pto.tile_buf` | A2/A3 workspace tile. On A5 this operand is kept for ABI compatibility and is not read by the instruction. |
 | `dst` | `pto.tile_buf` | Destination tile buffer |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -2809,7 +2810,7 @@ For each element (i, j):
 **Assembly Format:**
 
 ```
-pto.tprelu ins(<src0>, <src1> : <src0_type>, <src1_type>)
+pto.tprelu ins(<src0>, <src1>, <tmp> : <src0_type>, <src1_type>, <tmp_type>)
            outs(<dst> : <dst_type>)
 ```
 
@@ -2817,14 +2818,19 @@ pto.tprelu ins(<src0>, <src1> : <src0_type>, <src1_type>)
 
 - **Implementation checks (A2A3)**
   - `dst/src0/src1` element types must be identical, and must be one of: `f16`, `f32`.
-  - `tmp` element types must be `u8`.
-  - All three tiles must use row-major layout (`blayout=row_major`).
-  - For `src0` `src1`: `src valid row == dst valid row` and `src valid column == dst valid column`.
-  - For A3, 2 source Tile, destination Tile, temporary space must in different memory range without overlapping.
+  - `tmp` element type must be an 8-bit integer tile type.
+  - `src0`, `src1`, and `dst` must use row-major layout (`blayout=row_major`) and have the same shape.
+  - `tmp` must be a row-major `loc=vec` tile.
+  - `src0` and `src1` must have the same `validRow/validCol` as `dst`.
+  - `tmp.shape[0] >= dst.validRow + 1`. The A2/A3 `TPRELU` implementation uses one extra physical tmp row as scratch when materializing row cmp-mask addresses for `TSEL`.
+  - `tmp.validCol >= ceil(dst.validCol / 8)`. The tmp valid region stores one packed predicate bit per destination element.
+  - `tmp.validRow` does not need to cover the extra scratch row. PTO IR follows the official A2/A3 runtime contract: the extra row is a physical workspace row addressed through `TSUBVIEW`, not part of the tmp valid region.
+  - On A3, `src0`, `src1`, `tmp`, and `dst` must use different storage ranges without overlap.
 - **Implementation checks (A5)**
   - `dst/src0/src1` element types must be identical and must be one of: `f16`, `f32`.
-  - All three tiles must use row-major layout (`blayout=row_major`).
-    - For `src0` `src1`: `src valid row == dst valid row` and `src valid column == dst valid column`.
+  - `src0`, `src1`, and `dst` must use row-major layout (`blayout=row_major`) and have the same shape.
+  - `src0` and `src1` must have the same `validRow/validCol` as `dst`.
+  - `tmp` is not used by the A5 implementation. PTO IR still requires it to be a row-major `loc=vec` tile, but no shape or valid-shape relation with `src0/src1/dst` is required.
 
 
 **Hardware Mapping:**
@@ -2842,8 +2848,8 @@ pto.tprelu ins(%a, %slopes, %tmp : !pto.tile_buf<loc=vec, dtype=f16, rows=16, co
                !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16,
                v_row=16, v_col=16, blayout=row_major, slayout=none_box,
                fractal=512, pad=0>,
-               !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16,
-               v_row=16, v_col=16, blayout=row_major, slayout=none_box,
+               !pto.tile_buf<loc=vec, dtype=ui8, rows=17, cols=32,
+               v_row=16, v_col=2, blayout=row_major, slayout=none_box,
                fractal=512, pad=0>)
            outs(%c : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16,
                v_row=16, v_col=16, blayout=row_major, slayout=none_box,
@@ -3352,16 +3358,16 @@ pto.trems ins(<src>, <scalar>, <tmp> : <src_type>, <scalar_type>, <tmp_type>)
   - `src/dst` element type must match, and must be `i32` or `f32`.
   - `scalar` type must match the tile element type.
   - `tmp` element type must match `dst`.
-  - `src/tmp/dst` must use row-major layout (`blayout=row_major`).
+  - `src/dst` must use row-major layout (`blayout=row_major`).
+  - `tmp` must be a row-major `loc=vec` tile.
   - `src` and `dst` must have the same `validRow/validCol`.
   - `tmp` must provide at least `1` valid row and `tmp.validCol >= dst.validCol`.
 - **Implementation checks (A5)**
   - `src/dst` element type must match, and must be one of: `i32`, `i16`, `f16`, `f32`.
   - `scalar` type must match the tile element type.
-  - `tmp` element type must match `dst`.
-  - `src/tmp/dst` must use row-major layout (`blayout=row_major`).
+  - `src/dst` must use row-major layout (`blayout=row_major`).
   - `src` and `dst` must have the same `validRow/validCol`.
-  - `tmp` must provide at least `1` valid row and `tmp.validCol >= dst.validCol`.
+  - `tmp` is not used by the A5 implementation. PTO IR still requires it to be a row-major `loc=vec` tile, but no element-type, shape, or valid-shape relation with `src/dst` is required.
 
 **Hardware Mapping:**
 
@@ -4382,7 +4388,7 @@ For each row i:
 | Name | Type | Description |
 |------|------|-------------|
 | `src` | `pto.tile_buf` | Source tile buffer |
-| `tmp` | `pto.tile_buf` | Temporary buffer with the same shape/type as `src` |
+| `tmp` | `pto.tile_buf` | A2/A3 reduction workspace tile. On A5 this operand is kept for ABI compatibility and is not used by the instruction. |
 | `dst` | `pto.tile_buf` | Destination tile buffer containing row-wise indices |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -4399,7 +4405,15 @@ pto.trowargmax ins(<src>, <tmp> : <src_type>, <tmp_type>)
 - **Implementation checks (A2A3)**
   - `src`, `tmp`, and `dst` must use `loc=vec`.
   - `src` must use ND-style tile layout (`blayout=row_major`, `slayout=none_box`).
-  - `tmp` must have the same shape, valid shape, and element type as `src`.
+  - `tmp` must have the same element type as `src`.
+  - `elementPerRepeat = 2048 / bitwidth(src element type)`.
+  - `elementPerBlock = 256 / bitwidth(src element type)`.
+  - PTO IR accepts either a legacy `tmp` whose known `valid_shape` exactly matches `src`, or a smaller workspace tile.
+  - For `src.validCol <= elementPerRepeat`, `tmp` may be either:
+    - a DN single-column tile with `tmp.validCol == 1` and `tmp.validRow >= 2 * src.validRow`, or
+    - an ND tile with `tmp.validRow >= src.validRow` and `tmp.validCol >= 2`.
+  - For `src.validCol > elementPerRepeat`, `tmp.validRow >= src.validRow`, and if the physical row count is statically known it must match `src.rows`.
+  - In the large-column path, the minimum required `tmp.validCol` is `stride`, where `repeats = ceil(src.validCol / elementPerRepeat)` and `stride = (ceil(repeats * 2 / elementPerBlock) + ceil(repeats / elementPerBlock)) * elementPerBlock`.
   - `dst` must use `slayout=none_box` and either:
     - a DN-style column vector tile (`blayout=col_major`, `cols=1`), or
     - a legacy ND-style tile with `valid column == 1`.
@@ -4410,7 +4424,8 @@ pto.trowargmax ins(<src>, <tmp> : <src_type>, <tmp_type>)
     - `src valid row == dst valid row`
     - `dst valid column == 1`
 - **Implementation checks (A5)**
-  - Same constraints as A2/A3.
+  - `src` and `dst` follow the same layout, element-type, and valid-region rules as A2/A3.
+  - `tmp` is not used by the A5 implementation. PTO IR still requires it to be a row-major `loc=vec` tile, but no shape or valid-shape relation with `src/dst` is required.
 
 **Hardware Mapping:**
 
@@ -4423,8 +4438,8 @@ pto.trowargmax ins(<src>, <tmp> : <src_type>, <tmp_type>)
 pto.trowargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32,
                    v_row=16, v_col=32, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>,
-                   !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32,
-                   v_row=16, v_col=32, blayout=row_major, slayout=none_box,
+                   !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=2,
+                   v_row=16, v_col=2, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>)
                outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=1,
                    v_row=16, v_col=1, blayout=col_major, slayout=none_box,
@@ -4525,7 +4540,7 @@ For each row i:
 | Name | Type | Description |
 |------|------|-------------|
 | `src` | `pto.tile_buf` | Source tile buffer |
-| `tmp` | `pto.tile_buf` | Temporary buffer with the same shape/type as `src` |
+| `tmp` | `pto.tile_buf` | A2/A3 reduction workspace tile. On A5 this operand is kept for ABI compatibility and is not used by the instruction. |
 | `dst` | `pto.tile_buf` | Destination tile buffer containing row-wise indices |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -4542,7 +4557,15 @@ pto.trowargmin ins(<src>, <tmp> : <src_type>, <tmp_type>)
 - **Implementation checks (A2A3)**
   - `src`, `tmp`, and `dst` must use `loc=vec`.
   - `src` must use ND-style tile layout (`blayout=row_major`, `slayout=none_box`).
-  - `tmp` must have the same shape, valid shape, and element type as `src`.
+  - `tmp` must have the same element type as `src`.
+  - `elementPerRepeat = 2048 / bitwidth(src element type)`.
+  - `elementPerBlock = 256 / bitwidth(src element type)`.
+  - PTO IR accepts either a legacy `tmp` whose known `valid_shape` exactly matches `src`, or a smaller workspace tile.
+  - For `src.validCol <= elementPerRepeat`, `tmp` may be either:
+    - a DN single-column tile with `tmp.validCol == 1` and `tmp.validRow >= 2 * src.validRow`, or
+    - an ND tile with `tmp.validRow >= src.validRow` and `tmp.validCol >= 2`.
+  - For `src.validCol > elementPerRepeat`, `tmp.validRow >= src.validRow`, and if the physical row count is statically known it must match `src.rows`.
+  - In the large-column path, the minimum required `tmp.validCol` is `stride`, where `repeats = ceil(src.validCol / elementPerRepeat)` and `stride = (ceil(repeats * 2 / elementPerBlock) + ceil(repeats / elementPerBlock)) * elementPerBlock`.
   - `dst` must use `slayout=none_box` and either:
     - a DN-style column vector tile (`blayout=col_major`, `cols=1`), or
     - a legacy ND-style tile with `valid column == 1`.
@@ -4553,7 +4576,8 @@ pto.trowargmin ins(<src>, <tmp> : <src_type>, <tmp_type>)
     - `src valid row == dst valid row`
     - `dst valid column == 1`
 - **Implementation checks (A5)**
-  - Same constraints as A2/A3.
+  - `src` and `dst` follow the same layout, element-type, and valid-region rules as A2/A3.
+  - `tmp` is not used by the A5 implementation. PTO IR still requires it to be a row-major `loc=vec` tile, but no shape or valid-shape relation with `src/dst` is required.
 
 **Hardware Mapping:**
 
@@ -4566,8 +4590,8 @@ pto.trowargmin ins(<src>, <tmp> : <src_type>, <tmp_type>)
 pto.trowargmin ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32,
                    v_row=16, v_col=32, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>,
-                   !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32,
-                   v_row=16, v_col=32, blayout=row_major, slayout=none_box,
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=2,
+                   v_row=16, v_col=2, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>)
                outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=1,
                    v_row=16, v_col=1, blayout=col_major, slayout=none_box,
@@ -4866,7 +4890,7 @@ For each column j:
 | Name | Type | Description |
 |------|------|-------------|
 | `src` | `pto.tile_buf` | Source tile buffer |
-| `tmp` | `pto.tile_buf` | Temporary buffer with the same shape/type as `src` |
+| `tmp` | `pto.tile_buf` | A2/A3 reduction workspace tile. On A5 this operand is kept for ABI compatibility and is not used by the instruction. |
 | `dst` | `pto.tile_buf` | Destination tile buffer containing column-wise indices |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -4882,8 +4906,13 @@ pto.tcolargmax ins(<src>, <tmp> : <src_type>, <tmp_type>)
 
 - **Implementation checks (A2A3)**
   - `src`, `tmp`, and `dst` must use `loc=vec`.
-  - All tiles must use ND-style tile layout (`blayout=row_major`, `slayout=none_box`).
-  - `tmp` must have the same shape, valid shape, and element type as `src`.
+  - `src` and `dst` must use ND-style tile layout (`blayout=row_major`, `slayout=none_box`).
+  - `tmp` must be a row-major `loc=vec` tile and must have the same element type as `src`.
+  - `elementPerRepeat = 2048 / bitwidth(src element type)`.
+  - `elementPerBlock = 256 / bitwidth(src element type)`.
+  - PTO IR accepts either a legacy `tmp` whose known `valid_shape` exactly matches `src`, or a smaller workspace tile.
+  - For the workspace form, `tmp.validRow >= 1`.
+  - The minimum required `tmp.validCol` is `stride`, where `repeats = ceil(src.validCol / elementPerRepeat)` and `stride = (ceil(repeats * 2 / elementPerBlock) + ceil(repeats / elementPerBlock)) * elementPerBlock`.
   - `src` element type must be `f16` or `f32`.
   - `dst` element type must be `i32` or `ui32`.
   - Runtime valid checks:
@@ -4891,7 +4920,8 @@ pto.tcolargmax ins(<src>, <tmp> : <src_type>, <tmp_type>)
     - `dst valid row == 1`
     - `src valid column == dst valid column`
 - **Implementation checks (A5)**
-  - Same constraints as A2/A3.
+  - `src` and `dst` follow the same layout, element-type, and valid-region rules as A2/A3.
+  - `tmp` is not used by the A5 implementation. PTO IR still requires it to be a row-major `loc=vec` tile, but no shape or valid-shape relation with `src/dst` is required.
 
 **Hardware Mapping:**
 
@@ -4904,8 +4934,8 @@ pto.tcolargmax ins(<src>, <tmp> : <src_type>, <tmp_type>)
 pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32,
                    v_row=16, v_col=32, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>,
-                   !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32,
-                   v_row=16, v_col=32, blayout=row_major, slayout=none_box,
+                   !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32,
+                   v_row=1, v_col=32, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>)
                outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32,
                    v_row=1, v_col=32, blayout=row_major, slayout=none_box,
@@ -4987,7 +5017,7 @@ For each column j:
 | Name | Type | Description |
 |------|------|-------------|
 | `src` | `pto.tile_buf` | Source tile buffer |
-| `tmp` | `pto.tile_buf` | Temporary buffer with the same shape/type as `src` |
+| `tmp` | `pto.tile_buf` | A2/A3 reduction workspace tile. On A5 this operand is kept for ABI compatibility and is not used by the instruction. |
 | `dst` | `pto.tile_buf` | Destination tile buffer containing column-wise indices |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -5003,8 +5033,13 @@ pto.tcolargmin ins(<src>, <tmp> : <src_type>, <tmp_type>)
 
 - **Implementation checks (A2A3)**
   - `src`, `tmp`, and `dst` must use `loc=vec`.
-  - All tiles must use ND-style tile layout (`blayout=row_major`, `slayout=none_box`).
-  - `tmp` must have the same shape, valid shape, and element type as `src`.
+  - `src` and `dst` must use ND-style tile layout (`blayout=row_major`, `slayout=none_box`).
+  - `tmp` must be a row-major `loc=vec` tile and must have the same element type as `src`.
+  - `elementPerRepeat = 2048 / bitwidth(src element type)`.
+  - `elementPerBlock = 256 / bitwidth(src element type)`.
+  - PTO IR accepts either a legacy `tmp` whose known `valid_shape` exactly matches `src`, or a smaller workspace tile.
+  - For the workspace form, `tmp.validRow >= 1`.
+  - The minimum required `tmp.validCol` is `stride`, where `repeats = ceil(src.validCol / elementPerRepeat)` and `stride = (ceil(repeats * 2 / elementPerBlock) + ceil(repeats / elementPerBlock)) * elementPerBlock`.
   - `src` element type must be `f16` or `f32`.
   - `dst` element type must be `i32` or `ui32`.
   - Runtime valid checks:
@@ -5012,7 +5047,8 @@ pto.tcolargmin ins(<src>, <tmp> : <src_type>, <tmp_type>)
     - `dst valid row == 1`
     - `src valid column == dst valid column`
 - **Implementation checks (A5)**
-  - Same constraints as A2/A3.
+  - `src` and `dst` follow the same layout, element-type, and valid-region rules as A2/A3.
+  - `tmp` is not used by the A5 implementation. PTO IR still requires it to be a row-major `loc=vec` tile, but no shape or valid-shape relation with `src/dst` is required.
 
 **Hardware Mapping:**
 
@@ -5025,8 +5061,8 @@ pto.tcolargmin ins(<src>, <tmp> : <src_type>, <tmp_type>)
 pto.tcolargmin ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32,
                    v_row=16, v_col=32, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>,
-                   !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32,
-                   v_row=16, v_col=32, blayout=row_major, slayout=none_box,
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32,
+                   v_row=1, v_col=32, blayout=row_major, slayout=none_box,
                    fractal=512, pad=0>)
                outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32,
                    v_row=1, v_col=32, blayout=row_major, slayout=none_box,

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -133,6 +133,15 @@ static LogicalResult verifyVecTileCommonA2A3(Operation *op, Type ty,
                                              StringRef name);
 static LogicalResult verifyVecTileCommonA5(Operation *op, Type ty,
                                            StringRef name);
+static LogicalResult verifyVecTileStorage(Operation *op, Type ty,
+                                          StringRef name);
+static LogicalResult verifyNDStyleVecTile(Operation *op, Type ty,
+                                          StringRef name);
+static LogicalResult verifyColReductionValidRegion(Operation *op, Type srcTy,
+                                                   Type dstTy,
+                                                   bool requireNonZeroSrc);
+static LogicalResult verifyColArgReductionDstLayout(Operation *op, Type ty,
+                                                    StringRef name);
 static LogicalResult verifyVecTileUnaryOp(Operation *op, Type srcTy, Type dstTy,
                                           StringRef srcName = "src",
                                           StringRef dstName = "dst",
@@ -1899,17 +1908,209 @@ static LogicalResult verifyTRowReductionWithTmpCommon(Operation *op, Type srcTy,
   return success();
 }
 
-static LogicalResult verifyTRowArgReductionCommon(Operation *op, Type srcTy,
+static std::optional<int64_t> getVectorRepeatElements(Type elemTy) {
+  unsigned elemBits = elemTy ? getPTOStorageElemBitWidth(elemTy) : 0;
+  if (elemBits == 0 || 2048 % elemBits != 0)
+    return std::nullopt;
+  return static_cast<int64_t>(2048 / elemBits);
+}
+
+static std::optional<int64_t> getVectorBlockElements(Type elemTy) {
+  unsigned elemBits = elemTy ? getPTOStorageElemBitWidth(elemTy) : 0;
+  if (elemBits == 0 || 256 % elemBits != 0)
+    return std::nullopt;
+  return static_cast<int64_t>(256 / elemBits);
+}
+
+static int64_t ceilDivInt64(int64_t numerator, int64_t denominator) {
+  assert(denominator > 0 && "denominator must be positive");
+  assert(numerator >= 0 && "numerator must be non-negative");
+  return (numerator + denominator - 1) / denominator;
+}
+
+static std::optional<int64_t> getArgReductionTmpMinStride(Type elemTy,
+                                                          int64_t srcValidCols) {
+  if (srcValidCols == ShapedType::kDynamic || srcValidCols < 0)
+    return std::nullopt;
+  auto repeatElems = getVectorRepeatElements(elemTy);
+  auto blockElems = getVectorBlockElements(elemTy);
+  if (!repeatElems || !blockElems)
+    return std::nullopt;
+  int64_t repeats = ceilDivInt64(srcValidCols, *repeatElems);
+  return (ceilDivInt64(repeats * 2, *blockElems) +
+          ceilDivInt64(repeats, *blockElems)) *
+         *blockElems;
+}
+
+static bool hasExactKnownValidShape(Type lhsTy, Type rhsTy) {
+  return getValidShapeVec(lhsTy) == getValidShapeVec(rhsTy);
+}
+
+static LogicalResult verifyTColArgTmpA2A3(Operation *op, Type srcTy,
+                                          Type tmpTy) {
+  if (failed(verifyVecTileCommon(op, tmpTy, "tmp")) ||
+      failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp")))
+    return failure();
+
+  if (hasExactKnownValidShape(srcTy, tmpTy))
+    return success();
+
+  auto srcValid = getValidShapeVec(srcTy);
+  auto tmpValid = getValidShapeVec(tmpTy);
+  if (srcValid.size() != 2 || tmpValid.size() != 2)
+    return op->emitOpError("expects src and tmp to have rank-2 valid_shape");
+  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1)
+    return op->emitOpError("expects A2/A3 tmp valid_shape[0] to be at least 1");
+  if (srcValid[1] != ShapedType::kDynamic) {
+    auto minStride = getArgReductionTmpMinStride(getElemTy(srcTy), srcValid[1]);
+    if (!minStride)
+      return op->emitOpError("failed to infer A2/A3 tmp stride from src element type");
+    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < *minStride)
+      return op->emitOpError()
+             << "expects A2/A3 tmp valid_shape[1] to be at least "
+             << *minStride << " for src valid_shape[1] = " << srcValid[1];
+  }
+  return success();
+}
+
+static LogicalResult verifyTColArgReductionOpA2A3(Operation *op, Type srcTy,
                                                   Type tmpTy, Type dstTy) {
+  if (failed(verifyNDStyleVecTile(op, srcTy, "src")) ||
+      failed(verifyTColArgTmpA2A3(op, srcTy, tmpTy)) ||
+      failed(verifyColArgReductionDstLayout(op, dstTy, "dst")))
+    return failure();
+  if (failed(verifyColReductionValidRegion(op, srcTy, dstTy,
+                                           /*requireNonZeroSrc=*/true)))
+    return failure();
+  Type srcElemTy = getElemTy(srcTy);
+  unsigned srcElemBits = srcElemTy ? getPTOStorageElemBitWidth(srcElemTy) : 0;
+  if (!(mlir::isa<IntegerType, FloatType>(srcElemTy) &&
+        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+    return op->emitOpError(
+        "expects src/tmp element type to be 1, 2, or 4 bytes wide");
+  auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
+  if (!dstInt || dstInt.getWidth() != 32)
+    return op->emitOpError("expects dst element type to be i32 or ui32");
+  return success();
+}
+
+static LogicalResult verifyTColArgReductionOpA5(Operation *op, Type srcTy,
+                                                Type tmpTy, Type dstTy) {
+  if (failed(verifyNDStyleVecTile(op, srcTy, "src")) ||
+      failed(verifyVecTileCommon(op, tmpTy, "tmp")) ||
+      failed(verifyColArgReductionDstLayout(op, dstTy, "dst")))
+    return failure();
+  if (failed(verifyColReductionValidRegion(op, srcTy, dstTy,
+                                           /*requireNonZeroSrc=*/true)))
+    return failure();
+  Type srcElemTy = getElemTy(srcTy);
+  unsigned srcElemBits = srcElemTy ? getPTOStorageElemBitWidth(srcElemTy) : 0;
+  if (!(mlir::isa<IntegerType, FloatType>(srcElemTy) &&
+        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
+    return op->emitOpError(
+        "expects src element type to be 1, 2, or 4 bytes wide");
+  auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
+  if (!dstInt || dstInt.getWidth() != 32)
+    return op->emitOpError("expects dst element type to be i32 or ui32");
+  return success();
+}
+
+static LogicalResult verifyTRowArgTmpA2A3(Operation *op, Type srcTy,
+                                          Type tmpTy) {
+  if (failed(verifyVecTileStorage(op, tmpTy, "tmp")) ||
+      failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp")))
+    return failure();
+
+  if (hasExactKnownValidShape(srcTy, tmpTy))
+    return success();
+
+  auto srcShape = getShapeVec(srcTy);
+  auto tmpShape = getShapeVec(tmpTy);
+  auto srcValid = getValidShapeVec(srcTy);
+  auto tmpValid = getValidShapeVec(tmpTy);
+  if (srcShape.size() != 2 || tmpShape.size() != 2 || srcValid.size() != 2 ||
+      tmpValid.size() != 2)
+    return op->emitOpError("expects src and tmp to be rank-2 tiles");
+
+  auto repeatElems = getVectorRepeatElements(getElemTy(srcTy));
+  if (!repeatElems)
+    return op->emitOpError("failed to infer A2/A3 tmp contract from src element type");
+
+  if (srcValid[1] != ShapedType::kDynamic && srcValid[1] <= *repeatElems) {
+    auto tmpTile = dyn_cast<pto::TileBufType>(tmpTy);
+    auto layout = tmpTile ? getTileBufLogicalLayout(tmpTile) : std::nullopt;
+    if (layout && *layout == pto::Layout::DN) {
+      if (tmpShape[1] != ShapedType::kDynamic && tmpShape[1] != 1)
+        return op->emitOpError("expects A2/A3 tmp DN layout to have shape[1] == 1");
+      if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] != 1)
+        return op->emitOpError(
+            "expects A2/A3 tmp DN layout to have valid_shape[1] == 1");
+      if (srcValid[0] != ShapedType::kDynamic && tmpValid[0] != ShapedType::kDynamic &&
+          tmpValid[0] < srcValid[0] * 2)
+        return op->emitOpError()
+               << "expects A2/A3 tmp DN layout to have valid_shape[0] >= "
+               << (srcValid[0] * 2);
+      return success();
+    }
+
+    if (!layout || *layout != pto::Layout::ND)
+      return op->emitOpError(
+          "expects A2/A3 tmp to use DN 1-col or ND 2-col layout when src valid_shape[1] fits in one repeat");
+    if (failed(verifyVecTileCommon(op, tmpTy, "tmp")))
+      return failure();
+    if (srcValid[0] != ShapedType::kDynamic && tmpValid[0] != ShapedType::kDynamic &&
+        tmpValid[0] < srcValid[0])
+      return op->emitOpError("expects A2/A3 tmp valid_shape[0] to cover src valid rows");
+    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < 2)
+      return op->emitOpError(
+          "expects A2/A3 tmp valid_shape[1] to be at least 2 in the small-col ND path");
+    return success();
+  }
+
+  if (failed(verifyVecTileCommon(op, tmpTy, "tmp")))
+    return failure();
+  if (srcShape[0] != ShapedType::kDynamic && tmpShape[0] != ShapedType::kDynamic &&
+      tmpShape[0] != srcShape[0])
+    return op->emitOpError("expects A2/A3 tmp shape[0] to match src shape[0]");
+  if (srcValid[0] != ShapedType::kDynamic && tmpValid[0] != ShapedType::kDynamic &&
+      tmpValid[0] < srcValid[0])
+    return op->emitOpError("expects A2/A3 tmp valid_shape[0] to cover src valid rows");
+  if (srcValid[1] != ShapedType::kDynamic) {
+    auto minStride = getArgReductionTmpMinStride(getElemTy(srcTy), srcValid[1]);
+    if (!minStride)
+      return op->emitOpError("failed to infer A2/A3 tmp stride from src element type");
+    if (tmpValid[1] != ShapedType::kDynamic && tmpValid[1] < *minStride)
+      return op->emitOpError()
+             << "expects A2/A3 tmp valid_shape[1] to be at least "
+             << *minStride << " for src valid_shape[1] = " << srcValid[1];
+  }
+  return success();
+}
+
+static LogicalResult verifyTRowArgReductionOpA2A3(Operation *op, Type srcTy,
+                                                  Type tmpTy, Type dstTy) {
+  if (failed(verifyRowReductionSrcLayout(op, srcTy, "src")) ||
+      failed(verifyTRowArgTmpA2A3(op, srcTy, tmpTy)) ||
+      failed(verifyRowReductionDstLayout(op, dstTy, "dst")))
+    return failure();
+  if (failed(verifyRowReductionValidRegion(op, srcTy, dstTy,
+                                           /*allowEmptyMarker=*/false)))
+    return failure();
+  Type srcElem = getElemTy(srcTy);
+  if (!isSupportedRowReductionElemType(srcElem))
+    return op->emitOpError("expects src element type to be i16/i32/f16/f32");
+  auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
+  if (!dstInt || dstInt.getWidth() != 32)
+    return op->emitOpError("expects dst element type to be i32 or ui32");
+  return success();
+}
+
+static LogicalResult verifyTRowArgReductionOpA5(Operation *op, Type srcTy,
+                                                Type tmpTy, Type dstTy) {
   if (failed(verifyRowReductionSrcLayout(op, srcTy, "src")) ||
       failed(verifyVecTileCommon(op, tmpTy, "tmp")) ||
       failed(verifyRowReductionDstLayout(op, dstTy, "dst")))
     return failure();
-  if (failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp")) ||
-      failed(verifyTileBufSameValidShape(op, srcTy, tmpTy, "src", "tmp")))
-    return failure();
-  // Arg reductions still emit a real per-row index, so the empty-region no-op
-  // marker is not accepted here (unlike plain trowmax/trowsum above).
   if (failed(verifyRowReductionValidRegion(op, srcTy, dstTy,
                                            /*allowEmptyMarker=*/false)))
     return failure();
@@ -4133,30 +4334,6 @@ static LogicalResult verifyTColReductionOpWithArchDispatch(
   return dispatchVerifierByArch(op, verifyA2A3, verifyA5);
 }
 
-static LogicalResult verifyTColArgReductionOpCommon(Operation *op, Type srcTy,
-                                                    Type tmpTy, Type dstTy) {
-  if (failed(verifyNDStyleVecTile(op, srcTy, "src")) ||
-      failed(verifyVecTileCommon(op, tmpTy, "tmp")) ||
-      failed(verifyColArgReductionDstLayout(op, dstTy, "dst")))
-    return failure();
-  if (failed(verifyTileBufSameElemType(op, srcTy, tmpTy, "src", "tmp")) ||
-      failed(verifyTileBufSameValidShape(op, srcTy, tmpTy, "src", "tmp")))
-    return failure();
-  if (failed(verifyColReductionValidRegion(op, srcTy, dstTy,
-                                           /*requireNonZeroSrc=*/true)))
-    return failure();
-  Type srcElemTy = getElemTy(srcTy);
-  unsigned srcElemBits = srcElemTy ? getPTOStorageElemBitWidth(srcElemTy) : 0;
-  if (!(mlir::isa<IntegerType, FloatType>(srcElemTy) &&
-        (srcElemBits == 8 || srcElemBits == 16 || srcElemBits == 32)))
-    return op->emitOpError(
-        "expects src/tmp element type to be 1, 2, or 4 bytes wide");
-  auto dstInt = dyn_cast<IntegerType>(getElemTy(dstTy));
-  if (!dstInt || dstInt.getWidth() != 32)
-    return op->emitOpError("expects dst element type to be i32 or ui32");
-  return success();
-}
-
 static bool hasCompatibleKnownExtent(int64_t lhs, int64_t rhs) {
   return lhs == ShapedType::kDynamic || rhs == ShapedType::kDynamic || lhs == rhs;
 }
@@ -5317,12 +5494,16 @@ LogicalResult pto::TColMaxOp::verify() {
 }
 
 LogicalResult pto::TColArgMaxOp::verify() {
-  auto verifyByArch = [&]() -> LogicalResult {
-    return verifyTColArgReductionOpCommon(*this, getSrc().getType(),
-                                          getTmp().getType(), getDst().getType());
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyTColArgReductionOpA2A3(*this, getSrc().getType(),
+                                        getTmp().getType(), getDst().getType());
+  };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyTColArgReductionOpA5(*this, getSrc().getType(),
+                                      getTmp().getType(), getDst().getType());
   };
 
-  return dispatchVerifierByArch(getOperation(), verifyByArch, verifyByArch);
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
 LogicalResult pto::TColMinOp::verify() {
@@ -5335,12 +5516,16 @@ LogicalResult pto::TColMinOp::verify() {
 }
 
 LogicalResult pto::TColArgMinOp::verify() {
-  auto verifyByArch = [&]() -> LogicalResult {
-    return verifyTColArgReductionOpCommon(*this, getSrc().getType(),
-                                          getTmp().getType(), getDst().getType());
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyTColArgReductionOpA2A3(*this, getSrc().getType(),
+                                        getTmp().getType(), getDst().getType());
+  };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyTColArgReductionOpA5(*this, getSrc().getType(),
+                                      getTmp().getType(), getDst().getType());
   };
 
-  return dispatchVerifierByArch(getOperation(), verifyByArch, verifyByArch);
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
 
@@ -8471,9 +8656,9 @@ mlir::LogicalResult mlir::pto::TPReluOp::verify() {
         failed(verifyTileBufSameValidShape(*this, t1, td, "src1", "dst")))
       return failure();
 
-    auto s0 = getShapeVec(t0), s1 = getShapeVec(t1), st = getShapeVec(tt), sd = getShapeVec(td);
-    if (s0 != s1 || s0 != st || s0 != sd) {
-      emitOpError("expects src0/src1/tmp/dst to have the same shape");
+    auto s0 = getShapeVec(t0), s1 = getShapeVec(t1), sd = getShapeVec(td);
+    if (s0 != s1 || s0 != sd) {
+      emitOpError("expects src0/src1/dst to have the same shape");
       return failure();
     }
     return std::make_tuple(t0, t1, tt, td);
@@ -8488,8 +8673,25 @@ mlir::LogicalResult mlir::pto::TPReluOp::verify() {
     auto tmpIntTy = mlir::dyn_cast<IntegerType>(tmpElem);
     if (!tmpIntTy || tmpIntTy.getWidth() != 8)
       return emitOpError("expects A2/A3 tmp element type to be u8");
-    if (!isRowMajorTileBuf(tt))
-      return emitOpError("expects tmp to use row-major layout");
+    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
+      return failure();
+    auto tmpShape = getShapeVec(tt);
+    auto dstValid = getValidShapeVec(td);
+    auto tmpValid = getValidShapeVec(tt);
+    if (tmpShape.size() != 2 || dstValid.size() != 2 || tmpValid.size() != 2)
+      return emitOpError("expects tmp and dst to be rank-2 tiles");
+    if (dstValid[0] != ShapedType::kDynamic && tmpShape[0] != ShapedType::kDynamic &&
+        tmpShape[0] < dstValid[0] + 1)
+        return emitOpError()
+             << "expects A2/A3 tmp shape[0] to be at least dst valid_shape[0] + 1 ("
+             << (dstValid[0] + 1) << ")";
+    if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic) {
+      int64_t packedMaskCols = llvm::divideCeil(dstValid[1], int64_t{8});
+      if (tmpValid[1] < packedMaskCols)
+        return emitOpError()
+               << "expects A2/A3 tmp valid_shape[1] to be at least ceil(dst valid_shape[1] / 8) ("
+               << packedMaskCols << ")";
+    }
     if (auto arch = getVerifierArchName(getOperation());
         arch && arch->equals_insensitive("a3")) {
       if (getSrc0() == getSrc1() || getSrc0() == getTmp() || getSrc0() == getDst() ||
@@ -8503,6 +8705,12 @@ mlir::LogicalResult mlir::pto::TPReluOp::verify() {
   auto verifyA5 = [&]() -> LogicalResult {
     auto tysOr = verifyCommon();
     if (failed(tysOr))
+      return failure();
+    auto [t0, t1, tt, td] = *tysOr;
+    (void)t0;
+    (void)t1;
+    (void)td;
+    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
       return failure();
     return success();
   };
@@ -8692,28 +8900,32 @@ mlir::LogicalResult mlir::pto::TRemOp::verify() {
       failed(verifyTileBufSameValidShape(*this, src0Ty, src1Ty, "src0", "src1")) ||
       failed(verifyTileBufSameValidShape(*this, src0Ty, dstTy, "src0", "dst")))
     return failure();
-  if (getElemTy(tmpTy) != getElemTy(dstTy))
-    return emitOpError("expects tmp and dst to have the same element type");
   if (!isRowMajorTileBuf(src0Ty) || !isRowMajorTileBuf(src1Ty) ||
-      !isRowMajorTileBuf(tmpTy) || !isRowMajorTileBuf(dstTy))
-    return emitOpError("expects src0, src1, tmp, and dst to use row-major layout");
+      !isRowMajorTileBuf(dstTy))
+    return emitOpError("expects src0, src1, and dst to use row-major layout");
   auto dstValid = getValidShapeVec(dstTy);
   auto tmpValid = getValidShapeVec(tmpTy);
   if (dstValid.size() != 2 || tmpValid.size() != 2)
     return emitOpError("expects tmp and dst to be rank-2 tiles");
-  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 0)
-    return emitOpError("expects tmp to have non-negative valid rows");
-  if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
-      tmpValid[1] < dstValid[1])
-    return emitOpError("expects tmp valid columns to cover dst valid columns");
 
   Type elem = getElemTy(src0Ty);
   auto verifyA2A3 = [&]() -> LogicalResult {
+    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp")))
+      return failure();
+    if (getElemTy(tmpTy) != getElemTy(dstTy))
+      return emitOpError("expects tmp and dst to have the same element type");
+    if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 2)
+      return emitOpError("expects A2/A3 tmp valid_shape[0] to be at least 2");
+    if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
+        tmpValid[1] < dstValid[1])
+      return emitOpError("expects A2/A3 tmp valid columns to cover dst valid columns");
     if (!(elem.isInteger(32) || elem.isF32()))
       return emitOpError("expects A2/A3 trem element type to be i32/f32");
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
+    if (failed(verifyVecTileCommon(*this, tmpTy, "tmp")))
+      return failure();
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
       return emitOpError("expects A5 trem element type to be i32/i16/f16/f32");
     return success();
@@ -8743,10 +8955,8 @@ mlir::LogicalResult mlir::pto::TRemSOp::verify() {
   if (failed(verifyTileBufSameElemType(*this, ts, td, "src", "dst")) ||
       failed(verifyTileBufSameValidShape(*this, ts, td, "src", "dst")))
     return failure();
-  if (getElemTy(tt) != getElemTy(td))
-    return emitOpError("expects tmp and dst to have the same element type");
-  if (!isRowMajorTileBuf(ts) || !isRowMajorTileBuf(tt) || !isRowMajorTileBuf(td))
-    return emitOpError("expects src, tmp, and dst to use row-major layout");
+  if (!isRowMajorTileBuf(ts) || !isRowMajorTileBuf(td))
+    return emitOpError("expects src and dst to use row-major layout");
   Type elem = getElemTy(ts);
   if (scalarTy != elem)
     return emitOpError("expects scalar type to match the tile element type");
@@ -8754,17 +8964,23 @@ mlir::LogicalResult mlir::pto::TRemSOp::verify() {
   auto tmpValid = getValidShapeVec(tt);
   if (dstValid.size() != 2 || tmpValid.size() != 2)
     return emitOpError("expects tmp and dst to be rank-2 tiles");
-  if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 0)
-    return emitOpError("expects tmp to have non-negative valid rows");
-  if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
-      tmpValid[1] < dstValid[1])
-    return emitOpError("expects tmp valid columns to cover dst valid columns");
   auto verifyA2A3 = [&]() -> LogicalResult {
+    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
+      return failure();
+    if (getElemTy(tt) != getElemTy(td))
+      return emitOpError("expects tmp and dst to have the same element type");
+    if (tmpValid[0] != ShapedType::kDynamic && tmpValid[0] < 1)
+      return emitOpError("expects A2/A3 tmp valid_shape[0] to be at least 1");
+    if (dstValid[1] != ShapedType::kDynamic && tmpValid[1] != ShapedType::kDynamic &&
+        tmpValid[1] < dstValid[1])
+      return emitOpError("expects A2/A3 tmp valid columns to cover dst valid columns");
     if (!(elem.isInteger(32) || elem.isF32()))
       return emitOpError("expects A2/A3 trems element type to be i32/f32");
     return success();
   };
   auto verifyA5 = [&]() -> LogicalResult {
+    if (failed(verifyVecTileCommon(*this, tt, "tmp")))
+      return failure();
     if (!(elem.isInteger(32) || elem.isInteger(16) || elem.isF16() || elem.isF32()))
       return emitOpError("expects A5 trems element type to be i32/i16/f16/f32");
     return success();
@@ -9961,12 +10177,16 @@ mlir::LogicalResult mlir::pto::TRowMaxOp::verify() {
 }
 
 mlir::LogicalResult mlir::pto::TRowArgMaxOp::verify() {
-  auto verifyByArch = [&]() -> LogicalResult {
-    return verifyTRowArgReductionCommon(*this, getSrc().getType(),
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyTRowArgReductionOpA2A3(*this, getSrc().getType(),
                                         getTmp().getType(), getDst().getType());
   };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyTRowArgReductionOpA5(*this, getSrc().getType(),
+                                      getTmp().getType(), getDst().getType());
+  };
 
-  return dispatchVerifierByArch(getOperation(), verifyByArch, verifyByArch);
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
 
@@ -9980,12 +10200,16 @@ mlir::LogicalResult mlir::pto::TRowMinOp::verify() {
 }
 
 mlir::LogicalResult mlir::pto::TRowArgMinOp::verify() {
-  auto verifyByArch = [&]() -> LogicalResult {
-    return verifyTRowArgReductionCommon(*this, getSrc().getType(),
+  auto verifyA2A3 = [&]() -> LogicalResult {
+    return verifyTRowArgReductionOpA2A3(*this, getSrc().getType(),
                                         getTmp().getType(), getDst().getType());
   };
+  auto verifyA5 = [&]() -> LogicalResult {
+    return verifyTRowArgReductionOpA5(*this, getSrc().getType(),
+                                      getTmp().getType(), getDst().getType());
+  };
 
-  return dispatchVerifierByArch(getOperation(), verifyByArch, verifyByArch);
+  return dispatchVerifierByArch(getOperation(), verifyA2A3, verifyA5);
 }
 
 
@@ -12036,14 +12260,16 @@ PTO_DEFINE_UNARY_EFFECTS(TColProdOp, getSrcMutable(), getDstMutable())
 void TColArgMaxOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  PTO_ADD_WRITE(getTmpMutable());
+  if (getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 
 void TColArgMinOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  PTO_ADD_WRITE(getTmpMutable());
+  if (getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 
@@ -12219,14 +12445,16 @@ void TRemOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrc0Mutable());
   PTO_ADD_READ(getSrc1Mutable());
-  PTO_ADD_WRITE(getTmpMutable());
+  if (getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 
 void TRemSOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
-  PTO_ADD_WRITE(getTmpMutable());
+  if (getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -75,6 +75,10 @@ static int64_t alignUpBytes(int64_t value, int64_t align) {
   return value + (safeAlign - rem);
 }
 
+static size_t plannerAlignBitsFromBytes(size_t alignBytes) {
+  return std::max<size_t>(alignBytes, 1) * kBitsPerByte;
+}
+
 static LocalMemSpec getLocalMemSpec(Operation *op, AddressSpace as) {
   switch (as) {
   case AddressSpace::VEC:
@@ -294,8 +298,12 @@ static LogicalResult assignAutoReserveBufferBases(
     // Reserve-buffer allocation intentionally happens after normal MemPlan.
     // Reconstruct the already occupied byte ranges from the planned local
     // buffers, then place reserve_buffer into the first aligned hole.
-    int64_t occupiedSizeBytes =
-        alignUpBytes(ceilDivBitsToBytes(bufferInfo.constBits), /*align=*/1);
+    int64_t occupiedSizeBytes = ceilDivBitsToBytes(bufferInfo.constBits);
+    if (bufferInfo.operation) {
+      auto spec = getLocalMemSpec(bufferInfo.operation, bufferInfo.bufferScope);
+      occupiedSizeBytes =
+          alignUpBytes(occupiedSizeBytes, std::max<int64_t>(spec.alignBytes, 1));
+    }
     for (uint64_t offsetBytes : offsetsIt->second) {
       occupiedByAddressSpace[bufferInfo.bufferScope].push_back(
           OccupiedByteRange{static_cast<int64_t>(offsetBytes),
@@ -1581,19 +1589,24 @@ std::pair<size_t, size_t>
 MemPlan::GetBufferSpaceInfo(pto::AddressSpace &space) const {
   switch (space) {
   case pto::AddressSpace::VEC:
-    return std::make_pair(ubAlignSize, ubSpaceSize);
+    return std::make_pair(plannerAlignBitsFromBytes(ubAlignSize), ubSpaceSize);
   case pto::AddressSpace::MAT:
-    return std::make_pair(l1AlignSize, l1SpaceSize);
+    return std::make_pair(plannerAlignBitsFromBytes(l1AlignSize), l1SpaceSize);
   case pto::AddressSpace::ACC:
-    return std::make_pair(l0cAlignSize, l0cSpaceSize);
+    return std::make_pair(plannerAlignBitsFromBytes(l0cAlignSize),
+                          l0cSpaceSize);
   case pto::AddressSpace::LEFT:
-    return std::make_pair(l0aAlignSize, l0aSpaceSize);
+    return std::make_pair(plannerAlignBitsFromBytes(l0aAlignSize),
+                          l0aSpaceSize);
   case pto::AddressSpace::RIGHT:
-    return std::make_pair(l0bAlignSize, l0bSpaceSize);
+    return std::make_pair(plannerAlignBitsFromBytes(l0bAlignSize),
+                          l0bSpaceSize);
   case pto::AddressSpace::BIAS:
-    return std::make_pair(biasAlignSize, biasSpaceSize);
+    return std::make_pair(plannerAlignBitsFromBytes(biasAlignSize),
+                          biasSpaceSize);
   case pto::AddressSpace::SCALING:
-    return std::make_pair(scalingAlignSize, scalingSpaceSize);
+    return std::make_pair(plannerAlignBitsFromBytes(scalingAlignSize),
+                          scalingSpaceSize);
   case pto::AddressSpace::Zero:
   case pto::AddressSpace::GM:
     return std::make_pair(size_t{0}, size_t{0});

--- a/lib/TileOps/tprelu_template.py
+++ b/lib/TileOps/tprelu_template.py
@@ -26,7 +26,8 @@ def template_tprelu(src0: pto.Tile, src1: pto.Tile, tmp: pto.Tile, dst: pto.Tile
         dst[i, j] = src0[i, j] > 0 ? src0[i, j] : src0[i, j] * src1[i, j]
     
     Supported data types: f16, f32
-    tmp is a workspace buffer with same dtype as src0.
+    A5 keeps the tmp operand in the ABI for cross-arch compatibility, but this
+    implementation does not read or write it.
     """
     dtype = dst.element_type
     valid_rows, valid_cols = dst.valid_shape

--- a/lib/TileOps/trem_template.py
+++ b/lib/TileOps/trem_template.py
@@ -22,6 +22,8 @@ import tilelang_dsl as pto
     advanced=True,
 )
 def template_trem(src0: pto.Tile, src1: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
+    # A5 keeps tmp in the ABI for compatibility with A2/A3, but the template
+    # computes directly in registers and never touches it.
     dtype = dst.element_type
     valid_rows, valid_cols = dst.valid_shape
 

--- a/lib/TileOps/trems_template.py
+++ b/lib/TileOps/trems_template.py
@@ -29,6 +29,8 @@ import tilelang_dsl as pto
     advanced=True,
 )
 def template_trems(src: pto.Tile, scalar: pto.AnyType, tmp: pto.Tile, dst: pto.Tile):
+    # A5 keeps tmp in the ABI for compatibility with A2/A3, but this template
+    # computes directly in registers and never touches it.
     dtype = src.element_type
     valid_rows, valid_cols = src.valid_shape
 

--- a/scripts/ptoas_env.sh
+++ b/scripts/ptoas_env.sh
@@ -108,11 +108,14 @@ _ptoas_run_legacy_smoke_test() {
 	echo "test set_env: OK"
 }
 
-_ptoas_prepend_path PYTHONPATH "${PTO_PYTHON_BUILD_ROOT}"
+# Prefer the in-tree PTO Python overlay plus LLVM's full MLIR package first.
+# The install prefix may only contain the PTO overlay fragments, and when it is
+# placed ahead of mlir_core it can shadow the real MLIR Python bindings.
 _ptoas_prepend_path PYTHONPATH "${PTO_INSTALL_DIR}"
-_ptoas_prepend_path PYTHONPATH "${MLIR_PYTHON_ROOT}"
 _ptoas_prepend_path PYTHONPATH "${PTO_PYTHON_ROOT}"
 _ptoas_prepend_path PYTHONPATH "${PTOAS_PYTHON_SITE}"
+_ptoas_prepend_path PYTHONPATH "${MLIR_PYTHON_ROOT}"
+_ptoas_prepend_path PYTHONPATH "${PTO_PYTHON_BUILD_ROOT}"
 
 _ptoas_prepend_path LD_LIBRARY_PATH "${LLVM_BUILD_DIR}/lib"
 _ptoas_prepend_path LD_LIBRARY_PATH "${PTO_INSTALL_DIR}/lib"

--- a/test/lit/pto/issue554_tcolarg_invalid_width.pto
+++ b/test/lit/pto/issue554_tcolarg_invalid_width.pto
@@ -1,5 +1,5 @@
-// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
-// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s
+// RUN: not ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+// RUN: not ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
 
 module {
   func.func @issue554_tcolargmax_i64_rejected() {
@@ -13,4 +13,5 @@ module {
   }
 }
 
-// CHECK: error: 'pto.tcolargmax' op expects src/tmp element type to be 1, 2, or 4 bytes wide
+// A3: error: 'pto.tcolargmax' op expects src/tmp element type to be 1, 2, or 4 bytes wide
+// A5: error: 'pto.tcolargmax' op expects src element type to be 1, 2, or 4 bytes wide

--- a/test/lit/pto/tcolarg_tmp_contract_a3_invalid.pto
+++ b/test/lit/pto/tcolarg_tmp_contract_a3_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a3_tcolargmax_tmp_too_small() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=15, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=256, v_row=1, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=15, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=256, v_row=1, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tcolargmax' op expects A2/A3 tmp valid_shape[1] to be at least 16 for src valid_shape[1] = 255

--- a/test/lit/pto/tmp_contract_a5_non_same_shape.pto
+++ b/test/lit/pto/tmp_contract_a5_non_same_shape.pto
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+// A5 keeps tmp in the ABI for these ops, but the implementation does not
+// require tmp to match src/dst shape or valid_shape.
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a5_tcolargmax_tmp_placeholder() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=15, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=256, v_row=1, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=15, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=256, v_row=1, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @a5_tcolargmin_tmp_placeholder() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=15, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=256, v_row=1, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tcolargmin ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=256, v_row=15, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=256, v_row=1, v_col=255, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @a5_trem_tmp_placeholder() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trem ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @a5_trems_tmp_placeholder() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %scalar = arith.constant 3.000000e+00 : f32
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trems ins(%src, %scalar, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=8, v_row=1, v_col=1, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @a5_tcolargmax_tmp_placeholder
+// CHECK: pto.tcolargmax
+// CHECK-LABEL: func.func @a5_tcolargmin_tmp_placeholder
+// CHECK: pto.tcolargmin
+// CHECK-LABEL: func.func @a5_trem_tmp_placeholder
+// CHECK: pto.trem
+// CHECK-LABEL: func.func @a5_trems_tmp_placeholder
+// CHECK: pto.trems

--- a/test/lit/pto/tprelu_tmp_contract_a3_invalid.pto
+++ b/test/lit/pto/tprelu_tmp_contract_a3_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a3_tprelu_tmp_too_short() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=32, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=16, cols=32, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tprelu' op expects A2/A3 tmp shape[0] to be at least dst valid_shape[0] + 1 (17)

--- a/test/lit/pto/tprelu_tmp_runtime_contract_a3_valid.pto
+++ b/test/lit/pto/tprelu_tmp_runtime_contract_a3_valid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 --emit-pto-ir %s -o - 2>&1 | FileCheck %s
+
+// CHECK-LABEL: func.func @a3_tprelu_tmp_runtime_row_ok
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a3_tprelu_tmp_runtime_row_ok() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=17, cols=32, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=17, cols=32, v_row=16, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/pto/tprelu_tmp_valid_col_a3_invalid.pto
+++ b/test/lit/pto/tprelu_tmp_valid_col_a3_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a3_tprelu_tmp_valid_col_too_small() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=17, cols=32, v_row=16, v_col=7, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tprelu ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=17, cols=32, v_row=16, v_col=7, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=63, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.tprelu' op expects A2/A3 tmp valid_shape[1] to be at least ceil(dst valid_shape[1] / 8) (8)

--- a/test/lit/pto/trem_emitc.pto
+++ b/test/lit/pto/trem_emitc.pto
@@ -4,13 +4,15 @@ module {
   func.func @trem_tmp_form() {
     %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16, v_row=2, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.trem ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trem ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=16, v_row=2, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 }
 
 // A3: pto.trem ins([[SRC0:%[0-9]+]], [[SRC1:%[0-9]+]], [[TMP:%[0-9]+]] : memref<1x16xf32
+// A3-SAME: memref<1x16xf32
+// A3-SAME: memref<2x16xf32
 // A3: outs([[DST:%[0-9]+]] : memref<1x16xf32
 // A3: TREM([[VDST:v[0-9]+]], [[VSRC0:v[0-9]+]], [[VSRC1:v[0-9]+]], [[VTMP:v[0-9]+]]);

--- a/test/lit/pto/trem_tmp_contract_a3_invalid.pto
+++ b/test/lit/pto/trem_tmp_contract_a3_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a3_trem_tmp_too_short() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trem ins(%src0, %src1, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.trem' op expects A2/A3 tmp valid_shape[0] to be at least 2

--- a/test/lit/pto/trems_tmp_contract_a3_invalid.pto
+++ b/test/lit/pto/trems_tmp_contract_a3_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a3_trems_tmp_too_short() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %scalar = arith.constant 3.000000e+00 : f32
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=0, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.trems ins(%src, %scalar, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=0, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.trems' op expects A2/A3 tmp valid_shape[0] to be at least 1

--- a/test/lit/pto/trowarg_tmp_contract_a3_invalid.pto
+++ b/test/lit/pto/trowarg_tmp_contract_a3_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module attributes {"pto.device-spec" = "Ascend910B3"} {
+  func.func @a3_trowargmax_tmp_too_small() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=13, v_col=127, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=13, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=1, v_row=13, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    pto.trowargmax ins(%src, %tmp : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=13, v_col=127, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=8, v_row=13, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                   outs(%dst : !pto.tile_buf<loc=vec, dtype=ui32, rows=16, cols=1, v_row=13, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.trowargmax' op expects A2/A3 tmp valid_shape[1] to be at least 16 for src valid_shape[1] = 127

--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -276,7 +276,7 @@ def _split_cpp_args(text: str):
 
 def _extract_aicore_functions(text: str):
     pattern = re.compile(
-        r"(?P<global>__global__\s+)?AICORE\s+void\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)\s*\{",
+        r"(?P<extern_c>extern\s+\"C\"\s+)?(?P<global>__global__\s+)?AICORE\s+void\s+(?P<name>\w+)\s*\((?P<params>[^)]*)\)\s*\{",
         re.S,
     )
     functions = []
@@ -294,6 +294,7 @@ def _extract_aicore_functions(text: str):
                 "params_blob": params_blob,
                 "raw_params": _split_params_blob(params_blob),
                 "is_global": bool(match.group("global")),
+                "is_extern_c": bool(match.group("extern_c")),
                 "text": text[match.start():end_index + 1],
             }
         )
@@ -508,7 +509,7 @@ def _append_mixed_kernel_wrapper(
 
     wrapper = (
         "\n\n"
-        f"__global__ AICORE void {kernel_name}({', '.join(raw_params)}) {{\n"
+        f"extern \"C\" __global__ AICORE void {kernel_name}({', '.join(raw_params)}) {{\n"
         + ("\n".join(shared_decls) + ("\n\n" if shared_decls else ""))
         + "\n".join(wrapper_blocks)
         + ("\n  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);" if (aic_has_tail or aiv_has_tail) else "")
@@ -1098,10 +1099,12 @@ def _infer_aicore_arch(kernel_text: str, soc_version: str) -> str:
         # kernels with dav-c310-{vec|cube}.
         return "dav-c310-cube" if needs_cube else "dav-c310-vec"
     if "910b" in sv:
+        # A3 board validation follows the official a2a3 PTO-ISA ST setup:
+        # build vec/cube kernels with dav-c220 and MEMORY_BASE rather than
+        # the A5 dav-c310/REGISTER_BASE path.
         if has_mixed_section_sync:
-            return "dav-c310"
-        # Ascend910B* (e.g. Ascend910B1) uses dav-c310 toolchain arch.
-        return "dav-c310-cube" if needs_cube else "dav-c310-vec"
+            return "dav-c220"
+        return "dav-c220-cube" if needs_cube else "dav-c220-vec"
 
     # Default to Ascend910 (dav-c220) when SoC is unknown.
     return "dav-c220-cube" if needs_cube else "dav-c220-vec"
@@ -1610,7 +1613,7 @@ def generate_testcase(
             if "950" in sv or "a5" in sv:
                 aicore_arch = "dav-c310"
             elif "910b" in sv:
-                aicore_arch = "dav-c310"
+                aicore_arch = "dav-c220"
             else:
                 aicore_arch = "dav-c220"
         elif has_cube_only_section:
@@ -1618,7 +1621,7 @@ def generate_testcase(
             # while forcing `__DAV_CUBE__` makes AIC pipe synchronization fail
             # legality checks on A5.
             sv = (soc_version or "").lower()
-            if "950" in sv or "a5" in sv or "910b" in sv:
+            if "950" in sv or "a5" in sv:
                 aicore_arch = "dav-c310-cube"
             else:
                 aicore_arch = "dav-c220-cube"
@@ -1627,7 +1630,7 @@ def generate_testcase(
             if "950" in sv or "a5" in sv:
                 aicore_arch = "dav-c310-vec"
             elif "910b" in sv:
-                aicore_arch = "dav-c310-vec"
+                aicore_arch = "dav-c220-vec"
             else:
                 aicore_arch = "dav-c220-vec"
         elif has_dav_cube or has_dav_vec:
@@ -1637,7 +1640,7 @@ def generate_testcase(
             if "950" in sv or "a5" in sv:
                 aicore_arch = "dav-c310-vec"
             elif "910b" in sv:
-                aicore_arch = "dav-c310-vec"
+                aicore_arch = "dav-c220-vec"
             else:
                 aicore_arch = "dav-c220-vec"
         else:
@@ -2245,10 +2248,12 @@ def generate_testcase(
     (output_dir / "launch.cpp").write_text(launch_cpp, encoding="utf-8")
 
     # pto-isa selects instruction implementations based on MEMORY_BASE vs
-    # REGISTER_BASE. Ascend A5 (e.g. Ascend950) and Ascend910B use REGISTER_BASE.
+    # REGISTER_BASE. A3 board validation follows the official a2a3 ST setup,
+    # so Ascend910B still uses MEMORY_BASE. Only A5-class targets use
+    # REGISTER_BASE here.
     mem_base_define = "MEMORY_BASE"
     sv = (soc_version or "").lower()
-    if "910b" in sv or "950" in sv or "a5" in sv:
+    if "950" in sv or "a5" in sv:
         mem_base_define = "REGISTER_BASE"
     if uses_prefetch_async_runtime and not is_a5_soc:
         mem_base_define = "MEMORY_BASE"

--- a/test/samples/Prelu/prelu-pto.cpp
+++ b/test/samples/Prelu/prelu-pto.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static AICORE inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+
+extern "C" __global__ AICORE void prelu_kernel_2d(__gm__ float* v1, __gm__ float* v2, __gm__ float* v3) {
+  unsigned v4 = 0;
+  const int32_t v5 = 32;
+  const int32_t v6 = 1;
+  const int64_t v7 = 0;
+  const int64_t v8 = 4096;
+  const int64_t v9 = 8192;
+  const int64_t v10 = 12288;
+  using T = float;
+
+  #if defined(__DAV_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  pto::Shape<1, 1, 1, 32, 32> v11 = pto::Shape<1, 1, 1, 32, 32>();
+  pto::Stride<1024, 1024, 1024, 32, 1> v12 = pto::Stride<1024, 1024, 1024, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v13 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v1 + (v4 + v4 * (unsigned) v5 + v4 * (unsigned) v6), v11, v12);
+  pto::Shape<1, 1, 1, 32, 32> v14 = pto::Shape<1, 1, 1, 32, 32>();
+  pto::Stride<1024, 1024, 1024, 32, 1> v15 = pto::Stride<1024, 1024, 1024, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v16 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v2 + (v4 + v4 * (unsigned) v5 + v4 * (unsigned) v6), v14, v15);
+  pto::Shape<1, 1, 1, 32, 32> v17 = pto::Shape<1, 1, 1, 32, 32>();
+  pto::Stride<1024, 1024, 1024, 32, 1> v18 = pto::Stride<1024, 1024, 1024, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v19 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v3 + (v4 + v4 * (unsigned) v5 + v4 * (unsigned) v6), v17, v18);
+  Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v20;
+  uint64_t v21 = (uint64_t) v7;
+  TASSIGN(v20, v21);
+  Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v22;
+  uint64_t v23 = (uint64_t) v8;
+  TASSIGN(v22, v23);
+  Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v24;
+  uint64_t v25 = (uint64_t) v9;
+  TASSIGN(v24, v25);
+  Tile<TileType::Vec, uint8_t, 33, 32, BLayout::RowMajor, 32, 4, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v26;
+  uint64_t v27 = (uint64_t) v10;
+  TASSIGN(v26, v27);
+  TLOAD(v20, v13);
+  TLOAD(v22, v16);
+  TPRELU(v24, v20, v22, v26);
+  TSTORE(v19, v24);
+  #endif // __DAV_VEC__
+
+  return;
+}

--- a/test/samples/Prelu/prelu-pto.pto
+++ b/test/samples/Prelu/prelu-pto.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {"pto.device-spec" = "Ascend910B1"} {
+  func.func @prelu_kernel_2d(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %src0_view = pto.make_tensor_view %arg0, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src1_view = pto.make_tensor_view %arg1, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst_view = pto.make_tensor_view %arg2, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+
+    %src0_part = pto.partition_view %src0_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %src1_part = pto.partition_view %src1_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %src0_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=33, cols=32, v_row=32, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0_part : !pto.partition_tensor_view<32x32xf32>) outs(%src0_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1_part : !pto.partition_tensor_view<32x32xf32>) outs(%src1_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tprelu ins(%src0_tile, %src1_tile, %tmp_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui8, rows=33, cols=32, v_row=32, v_col=4, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}

--- a/test/samples/Prelu/prelu.py
+++ b/test/samples/Prelu/prelu.py
@@ -31,9 +31,12 @@ def build():
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
-            # pto.tprelu verifier: tmp must be uint8 (TPreluCheck in pto-isa).
+            # Match the official passing A3 ST kernel:
+            #   - physical tmp rows = dst rows + 1
+            #   - physical tmp cols = ceil(ceil(dst cols / 8) / 32B) * 32B
+            #   - runtime valid tmp shape = [dst.validRow, ceil(dst.validCol / 8)]
             u8 = IntegerType.get_unsigned(8, ctx)
-            tile_buf_u8 = pto.TileBufType.get([32, 32], u8, vec, [32, 32], cfg, ctx)
+            tile_buf_u8 = pto.TileBufType.get([33, 32], u8, vec, [32, 4], cfg, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
@@ -58,11 +61,11 @@ def build():
                 sv0 = pto.PartitionViewOp(tile_view_32, tv0, offsets=[c0, c0], sizes=[c32, c32]).result
                 sv1 = pto.PartitionViewOp(tile_view_32, tv1, offsets=[c0, c0], sizes=[c32, c32]).result
 
-                # tb0/tb1/tb2: f32; tb_tmp: uint8 (pto.tprelu requires tmp to be uint8_t).
+                # tb0/tb1/tb2: f32; tb_tmp: ui8 A3 workspace tile.
                 tb0 = pto.AllocTileOp(tile_buf_32).result
                 tb1 = pto.AllocTileOp(tile_buf_32).result
-                tb_tmp = pto.AllocTileOp(tile_buf_u8).result
                 tb2 = pto.AllocTileOp(tile_buf_32).result
+                tb_tmp = pto.AllocTileOp(tile_buf_u8).result
 
                 # pto.load_dps_tb ins(%sv) outs(%tb)
                 pto.TLoadOp(None, sv0, tb0)  # result=None

--- a/test/samples/Rem/rem-pto.cpp
+++ b/test/samples/Rem/rem-pto.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "pto/pto-inst.hpp"
+using namespace pto;
+
+enum class PTOAutoSyncTailMode : int {
+  kBarrierAll = 0,
+  kSetWaitMte3ToSEvent0 = 1,
+};
+
+static AICORE inline void ptoas_auto_sync_tail(
+    PTOAutoSyncTailMode mode = PTOAutoSyncTailMode::kBarrierAll) {
+  switch (mode) {
+  case PTOAutoSyncTailMode::kSetWaitMte3ToSEvent0:
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID0);
+    break;
+  case PTOAutoSyncTailMode::kBarrierAll:
+  default:
+    pipe_barrier(PIPE_ALL);
+    break;
+  }
+}
+
+extern "C" __global__ AICORE void rem_kernel_2d(__gm__ float* v1, __gm__ float* v2, __gm__ float* v3) {
+  unsigned v4 = 0;
+  const int32_t v5 = 32;
+  const int32_t v6 = 1;
+  const int64_t v7 = 0;
+  const int64_t v8 = 4096;
+  const int64_t v9 = 12288;
+  const int64_t v10 = 8192;
+  using T = float;
+
+  #if defined(__DAV_VEC__)
+  set_mask_norm();
+  set_vector_mask(-1, -1);
+  pto::Shape<1, 1, 1, 32, 32> v11 = pto::Shape<1, 1, 1, 32, 32>();
+  pto::Stride<1024, 1024, 1024, 32, 1> v12 = pto::Stride<1024, 1024, 1024, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v13 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v1 + (v4 + v4 * (unsigned) v5 + v4 * (unsigned) v6), v11, v12);
+  pto::Shape<1, 1, 1, 32, 32> v14 = pto::Shape<1, 1, 1, 32, 32>();
+  pto::Stride<1024, 1024, 1024, 32, 1> v15 = pto::Stride<1024, 1024, 1024, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v16 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v2 + (v4 + v4 * (unsigned) v5 + v4 * (unsigned) v6), v14, v15);
+  pto::Shape<1, 1, 1, 32, 32> v17 = pto::Shape<1, 1, 1, 32, 32>();
+  pto::Stride<1024, 1024, 1024, 32, 1> v18 = pto::Stride<1024, 1024, 1024, 32, 1>();
+  GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND> v19 = GlobalTensor<float, pto::Shape<1, 1, 1, 32, 32>, pto::Stride<1024, 1024, 1024, 32, 1>, pto::Layout::ND>(v3 + (v4 + v4 * (unsigned) v5 + v4 * (unsigned) v6), v17, v18);
+  Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v20;
+  uint64_t v21 = (uint64_t) v7;
+  TASSIGN(v20, v21);
+  Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v22;
+  uint64_t v23 = (uint64_t) v8;
+  TASSIGN(v22, v23);
+  Tile<TileType::Vec, float, 2, 32, BLayout::RowMajor, 2, 32, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v24;
+  uint64_t v25 = (uint64_t) v9;
+  TASSIGN(v24, v25);
+  Tile<TileType::Vec, float, 32, 32, BLayout::RowMajor, 32, 32, SLayout::NoneBox, 512, PadValue::Null, CompactMode::Null> v26;
+  uint64_t v27 = (uint64_t) v10;
+  TASSIGN(v26, v27);
+  TLOAD(v20, v13);
+  TLOAD(v22, v16);
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  TREM(v26, v20, v22, v24);
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  TSTORE(v19, v26);
+  #endif // __DAV_VEC__
+
+  ptoas_auto_sync_tail(PTOAutoSyncTailMode::kBarrierAll);
+  return;
+}

--- a/test/samples/Rem/rem-pto.pto
+++ b/test/samples/Rem/rem-pto.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {"pto.device-spec" = "Ascend910B1"} {
+  func.func @rem_kernel_2d(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>, %arg2: !pto.ptr<f32>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+
+    %src0_view = pto.make_tensor_view %arg0, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %src1_view = pto.make_tensor_view %arg1, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst_view = pto.make_tensor_view %arg2, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+
+    %src0_part = pto.partition_view %src0_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %src1_part = pto.partition_view %src1_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %src0_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0_part : !pto.partition_tensor_view<32x32xf32>) outs(%src0_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1_part : !pto.partition_tensor_view<32x32xf32>) outs(%src1_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trem ins(%src0_tile, %src1_tile, %tmp_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}

--- a/test/samples/Rem/rem.py
+++ b/test/samples/Rem/rem.py
@@ -31,6 +31,9 @@ def build():
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            # A2/A3 TREM workspace contract only needs 2 valid rows and
+            # validCol covering dst.validCol.
+            tile_buf_tmp = pto.TileBufType.get([2, 32], f32, vec, [2, 32], cfg, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
@@ -55,7 +58,7 @@ def build():
 
                 tb0 = pto.AllocTileOp(tile_buf_32).result
                 tb1 = pto.AllocTileOp(tile_buf_32).result
-                tmp = pto.AllocTileOp(tile_buf_32).result
+                tmp = pto.AllocTileOp(tile_buf_tmp).result
                 tb2 = pto.AllocTileOp(tile_buf_32).result
 
                 pto.TLoadOp(None, sv0, tb0)  # result=None

--- a/test/samples/Rems/rems-pto.pto
+++ b/test/samples/Rems/rems-pto.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {"pto.device-spec" = "Ascend910B1"} {
+  func.func @rems_kernel_2d(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<f32>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %scalar = arith.constant 3.140000e+00 : f32
+
+    %src_view = pto.make_tensor_view %arg0, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %dst_view = pto.make_tensor_view %arg1, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+
+    %src_part = pto.partition_view %src_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+
+    %src_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src_part : !pto.partition_tensor_view<32x32xf32>) outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.trems ins(%src_tile, %scalar, %tmp_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+              outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_part : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}

--- a/test/samples/Rems/rems.py
+++ b/test/samples/Rems/rems.py
@@ -31,6 +31,9 @@ def build():
             fractal_ab_size = pto.TileConfig.fractalABSize
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
             tile_buf_32 = pto.TileBufType.get([32, 32], f32, vec, [32, 32], cfg, ctx)
+            # A2/A3 TREMS workspace contract only needs 1 valid row and
+            # validCol covering dst.validCol.
+            tile_buf_tmp = pto.TileBufType.get([1, 32], f32, vec, [1, 32], cfg, ctx)
 
             fn_ty = func.FunctionType.get([ptr_f32, ptr_f32], [])
             with InsertionPoint(m.body):
@@ -56,7 +59,7 @@ def build():
 
                 # %5/%6/%7 = pto.alloc_tile : <32x32xf32>
                 tb0 = pto.AllocTileOp(tile_buf_32).result
-                tmp = pto.AllocTileOp(tile_buf_32).result
+                tmp = pto.AllocTileOp(tile_buf_tmp).result
                 tb1 = pto.AllocTileOp(tile_buf_32).result
 
                 pto.TLoadOp(None, sv0, tb0)  # result=None

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -20,7 +20,7 @@ PTOAS_OUT_DIR="${PTOAS_OUT_DIR:-}"
 PTO_BUILD_DIR="${PTO_BUILD_DIR:-}"
 PTOAS_ENABLE_INSERT_SYNC="${PTOAS_ENABLE_INSERT_SYNC:-1}"
 PTOAS_FLAGS="${PTOAS_FLAGS:-}"
-PTO_PTO_DIRS="${PTO_PTO_DIRS:-Sync Qwen3DecodeA3 Qwen3DecodeA5 DeepseekV4DecodeA3 DeepseekV4DecodeA5 CommSync}"
+PTO_PTO_DIRS="${PTO_PTO_DIRS:-Sync Qwen3DecodeA3 Qwen3DecodeA5 DeepseekV4DecodeA3 DeepseekV4DecodeA5 CommSync Prelu Rem Rems}"
 ENABLE_BC=0
 
 usage() {
@@ -38,7 +38,7 @@ Env:
   PTO_BUILD_DIR  # build directory root that contains tools/ptoas and tools/ptobc (optional)
   PTOAS_FLAGS  # extra flags passed to ptoas (e.g. --enable-insert-sync)
   PTOAS_ENABLE_INSERT_SYNC  # 1 to append --enable-insert-sync to PTOAS_FLAGS (default: 1)
-  PTO_PTO_DIRS  # space-separated dirs to run .pto directly (default: Sync Qwen3DecodeA3 Qwen3DecodeA5 DeepseekV4DecodeA3 DeepseekV4DecodeA5)
+  PTO_PTO_DIRS  # space-separated dirs to run .pto directly (default: Sync Qwen3DecodeA3 Qwen3DecodeA5 DeepseekV4DecodeA3 DeepseekV4DecodeA5 CommSync Prelu Rem Rems)
 
 Flags:
   --enablebc  # enable: python -> .pto -> ptobc -> .pto -> ptoas
@@ -306,6 +306,10 @@ process_one_dir() {
         ;;
     esac
     base="$(basename "$f" .py)"
+    if [[ -f "${dir}/${base}-pto.pto" ]]; then
+      echo -e "${A}(${base}.py)\tSKIP\tprefer checked-in direct PTO sample: ${base}-pto.pto"
+      continue
+    fi
     local expect_fail=0
     case "$base" in
       *_invalid|*_xfail) expect_fail=1 ;;
@@ -1340,7 +1344,8 @@ PY
 
       # TODO(ptobc): Keep ptoas regression coverage for patterns that are not
       # yet supported by ptobc roundtrip; re-enable once ptobc catches up.
-      if [[ "$base" == "test_if_else_tile_result" || \
+      if [[ "$base" == "prelu-pto" || \
+            "$base" == "test_if_else_tile_result" || \
             "$base" == "test_tmov_col_major_16x1_align_a5" || \
             "$base" == "test_tmov_row_major_1x16_control_a5" || \
             "$base" == "decode_projection_incore_0" || \

--- a/test/tilelang_st/npu/a5/src/st/testcase/tcolargmax/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcolargmax/cases.py
@@ -11,15 +11,8 @@
 
 """Single source of truth for tcolargmax ST test cases.
 
-Each case defines:
-  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
-  - dtype:       numpy dtype for input data (e.g. np.float32).
-  - shape:       (rows, cols) — allocated tile dimensions for input (src and tmp).
-  - valid_shape: (valid_rows, valid_cols) — effective computation region for input (src and tmp).
-  - dst_shape:       (1, cols) — allocated tile dimensions for output (indices).
-  - dst_valid_shape: (1, valid_cols) — effective computation region for output (indices).
-  - dst_dtype:       numpy dtype for output indices (np.int32).
-  - eps:         tolerance for numpy.allclose (atol and rtol).
+Each case now also carries explicit src/tmp fields so A5 tmp placeholders are
+not conflated with src shape.
 
 gen_data.py and compare.py both import this list to avoid redundant definitions.
 """
@@ -208,3 +201,19 @@ CASES = [
         "eps": 0,
     },
 ]
+
+
+def _a5_tmp_placeholder_shape(dtype):
+    return (1, max(1, 32 // np.dtype(dtype).itemsize))
+
+
+def _augment_case(case):
+    case = dict(case)
+    case.setdefault("src_shape", case["shape"])
+    case.setdefault("src_valid_shape", case["valid_shape"])
+    case.setdefault("tmp_shape", _a5_tmp_placeholder_shape(case["dtype"]))
+    case.setdefault("tmp_valid_shape", (1, 1))
+    return case
+
+
+CASES = [_augment_case(case) for case in CASES]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tcolargmax/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcolargmax/gen_data.py
@@ -19,8 +19,8 @@ for case in CASES:
     setup_case_rng(case)
 
     dtype = case["dtype"]
-    shape = case["shape"]
-    valid_shape = case["valid_shape"]
+    shape = case["src_shape"]
+    valid_shape = case["src_valid_shape"]
     dst_shape = case["dst_shape"]
     dst_valid_shape = case["dst_valid_shape"]
     dst_dtype = case["dst_dtype"]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tcolargmin/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcolargmin/cases.py
@@ -11,15 +11,8 @@
 
 """Single source of truth for tcolargmin ST test cases.
 
-Each case defines:
-  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
-  - dtype:       numpy dtype for input data (e.g. np.float32).
-  - shape:       (rows, cols) — allocated tile dimensions for input (src and tmp).
-  - valid_shape: (valid_rows, valid_cols) — effective computation region for input (src and tmp).
-  - dst_shape:       (1, cols) — allocated tile dimensions for output (indices).
-  - dst_valid_shape: (1, valid_cols) — effective computation region for output (indices).
-  - dst_dtype:       numpy dtype for output indices (np.int32).
-  - eps:         tolerance for numpy.allclose (atol and rtol).
+Each case now also carries explicit src/tmp fields so A5 tmp placeholders are
+not conflated with src shape.
 
 gen_data.py and compare.py both import this list to avoid redundant definitions.
 """
@@ -208,3 +201,19 @@ CASES = [
         "eps": 0,
     },
 ]
+
+
+def _a5_tmp_placeholder_shape(dtype):
+    return (1, max(1, 32 // np.dtype(dtype).itemsize))
+
+
+def _augment_case(case):
+    case = dict(case)
+    case.setdefault("src_shape", case["shape"])
+    case.setdefault("src_valid_shape", case["valid_shape"])
+    case.setdefault("tmp_shape", _a5_tmp_placeholder_shape(case["dtype"]))
+    case.setdefault("tmp_valid_shape", (1, 1))
+    return case
+
+
+CASES = [_augment_case(case) for case in CASES]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tcolargmin/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcolargmin/gen_data.py
@@ -19,8 +19,8 @@ for case in CASES:
     setup_case_rng(case)
 
     dtype = case["dtype"]
-    shape = case["shape"]
-    valid_shape = case["valid_shape"]
+    shape = case["src_shape"]
+    valid_shape = case["src_valid_shape"]
     dst_shape = case["dst_shape"]
     dst_valid_shape = case["dst_valid_shape"]
     dst_dtype = case["dst_dtype"]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tprelu/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tprelu/cases.py
@@ -11,12 +11,8 @@
 
 """Single source of truth for tprelu ST test cases.
 
-Each case defines:
-  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
-  - dtype:       numpy dtype (e.g. np.float16, np.float32).
-  - shape:       (rows, cols) — allocated tile dimensions.
-  - valid_shape: (valid_rows, valid_cols) — effective computation region.
-  - eps:         tolerance for numpy.allclose (atol and rtol).
+Each case now also carries explicit src/tmp/dst fields so A5 tmp placeholders
+are not conflated with src shape.
 
 gen_data.py and compare.py both import this list to avoid redundant definitions.
 """
@@ -81,3 +77,21 @@ CASES = [
         "eps": 1e-6,
     },
 ]
+
+
+def _a5_tmp_placeholder_shape(dtype):
+    return (1, max(1, 32 // np.dtype(dtype).itemsize))
+
+
+def _augment_case(case):
+    case = dict(case)
+    case.setdefault("src_shape", case["shape"])
+    case.setdefault("src_valid_shape", case["valid_shape"])
+    case.setdefault("tmp_shape", _a5_tmp_placeholder_shape(case["dtype"]))
+    case.setdefault("tmp_valid_shape", (1, 1))
+    case.setdefault("dst_shape", case["shape"])
+    case.setdefault("dst_valid_shape", case["valid_shape"])
+    return case
+
+
+CASES = [_augment_case(case) for case in CASES]

--- a/test/tilelang_st/npu/a5/src/st/testcase/tprelu/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tprelu/compare.py
@@ -27,8 +27,8 @@ def main():
             continue
 
         case_dir = case["name"]
-        shape = case["shape"]
-        vr, vc = case["valid_shape"]
+        shape = case["dst_shape"]
+        vr, vc = case["dst_valid_shape"]
 
         golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
         output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tprelu/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tprelu/gen_data.py
@@ -19,8 +19,9 @@ for case in CASES:
     setup_case_rng(case)
 
     dtype = case["dtype"]
-    shape = case["shape"]
-    valid_shape = case["valid_shape"]
+    shape = case["src_shape"]
+    valid_shape = case["src_valid_shape"]
+    dst_shape = case["dst_shape"]
 
     rows, cols = shape
     vr, vc = valid_shape
@@ -28,7 +29,7 @@ for case in CASES:
     input0 = np.random.uniform(-8, high=8, size=(rows, cols)).astype(dtype)
     input1 = np.random.uniform(-8, high=8, size=(rows, cols)).astype(dtype)
 
-    golden = np.zeros((rows, cols), dtype=dtype)
+    golden = np.zeros(dst_shape, dtype=dtype)
     for i in range(vr):
         for j in range(vc):
             if input0[i, j] > 0:
@@ -37,4 +38,4 @@ for case in CASES:
                 golden[i, j] = dtype(input0[i, j] * input1[i, j])
 
     save_case_data(case["name"], {"input0": input0, "input1": input1, "golden": golden})
-    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")
+    print(f"[INFO] gen_data: {case['name']} src_shape={shape} src_valid_shape={valid_shape} dst_shape={dst_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/trem/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trem/cases.py
@@ -10,12 +10,8 @@
 
 """Single source of truth for trem ST test cases.
 
-Each case defines:
-  - name:        case identifier, used as subdirectory name and by main.cpp kCases[].
-  - dtype:       numpy dtype (e.g. np.float32).
-  - shape:       (rows, cols) — allocated tile dimensions.
-  - valid_shape: (valid_rows, valid_cols) — effective computation region.
-  - eps:         tolerance for numpy.allclose (atol and rtol).
+Each case now also carries explicit src/tmp/dst fields so A5 tmp placeholders
+are not conflated with src shape.
 
 gen_data.py and compare.py both import this list to avoid redundant definitions.
 """
@@ -38,3 +34,21 @@ CASES = [
         "eps": 1e-6,
     },
 ]
+
+
+def _a5_tmp_placeholder_shape(dtype):
+    return (1, max(1, 32 // np.dtype(dtype).itemsize))
+
+
+def _augment_case(case):
+    case = dict(case)
+    case.setdefault("src_shape", case["shape"])
+    case.setdefault("src_valid_shape", case["valid_shape"])
+    case.setdefault("tmp_shape", _a5_tmp_placeholder_shape(case["dtype"]))
+    case.setdefault("tmp_valid_shape", (1, 1))
+    case.setdefault("dst_shape", case["shape"])
+    case.setdefault("dst_valid_shape", case["valid_shape"])
+    return case
+
+
+CASES = [_augment_case(case) for case in CASES]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trem/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trem/compare.py
@@ -26,8 +26,8 @@ def main():
             continue
 
         case_dir = case["name"]
-        shape = case["shape"]
-        vr, vc = case["valid_shape"]
+        shape = case["dst_shape"]
+        vr, vc = case["dst_valid_shape"]
 
         golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
         output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)

--- a/test/tilelang_st/npu/a5/src/st/testcase/trem/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trem/gen_data.py
@@ -18,15 +18,16 @@ for case in CASES:
     setup_case_rng(case)
 
     dtype = case["dtype"]
-    shape = case["shape"]
-    valid_shape = case["valid_shape"]
+    shape = case["src_shape"]
+    valid_shape = case["src_valid_shape"]
+    dst_shape = case["dst_shape"]
 
     input1 = np.random.randint(1, 10, size=shape).astype(dtype)
     input2 = np.random.randint(1, 10, size=shape).astype(dtype)
 
-    golden = np.zeros(shape, dtype=dtype)
+    golden = np.zeros(dst_shape, dtype=dtype)
     vr, vc = valid_shape
     golden[:vr, :vc] = np.remainder(input1[:vr, :vc], input2[:vr, :vc])
 
     save_case_data(case["name"], {"input1": input1, "input2": input2, "golden": golden})
-    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__}")
+    print(f"[INFO] gen_data: {case['name']} src_shape={shape} src_valid_shape={valid_shape} dst_shape={dst_shape} dtype={dtype.__name__}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/trems/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trems/cases.py
@@ -18,8 +18,8 @@
 
 """Single source of truth for trems ST test cases.
 
-trems: integer remainder via vdiv, dst = src - trunc(src/scalar) * scalar.
-All types: f32, f16, i32, i16.
+The case model now carries explicit src/tmp/dst fields so A5 tmp placeholders
+are not conflated with src shape.
 """
 
 import numpy as np
@@ -54,3 +54,21 @@ CASES = [
         "eps": 1e-6,
     },
 ]
+
+
+def _a5_tmp_placeholder_shape(dtype):
+    return (1, max(1, 32 // np.dtype(dtype).itemsize))
+
+
+def _augment_case(case):
+    case = dict(case)
+    case.setdefault("src_shape", case["shape"])
+    case.setdefault("src_valid_shape", case["valid_shape"])
+    case.setdefault("tmp_shape", _a5_tmp_placeholder_shape(case["dtype"]))
+    case.setdefault("tmp_valid_shape", (1, 1))
+    case.setdefault("dst_shape", case["shape"])
+    case.setdefault("dst_valid_shape", case["valid_shape"])
+    return case
+
+
+CASES = [_augment_case(case) for case in CASES]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trems/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trems/compare.py
@@ -34,8 +34,8 @@ def main():
             continue
 
         case_dir = case["name"]
-        shape = case["shape"]
-        vr, vc = case["valid_shape"]
+        shape = case["dst_shape"]
+        vr, vc = case["dst_valid_shape"]
 
         golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dtype"]).reshape(shape)
         output = np.fromfile(os.path.join(case_dir, "output.bin"), dtype=case["dtype"]).reshape(shape)

--- a/test/tilelang_st/npu/a5/src/st/testcase/trems/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trems/gen_data.py
@@ -29,12 +29,13 @@ for case in CASES:
     setup_case_rng(case)
 
     dtype = case["dtype"]
-    shape = case["shape"]
-    valid_shape = case["valid_shape"]
+    shape = case["src_shape"]
+    valid_shape = case["src_valid_shape"]
+    dst_shape = case["dst_shape"]
 
     input1 = np.random.randint(1, 10, size=shape).astype(dtype)
 
-    golden = np.zeros(shape, dtype=dtype)
+    golden = np.zeros(dst_shape, dtype=dtype)
     vr, vc = valid_shape
     scalar_val = dtype(SCALAR)
     if np.issubdtype(dtype, np.floating):
@@ -43,4 +44,4 @@ for case in CASES:
         golden[:vr, :vc] = (input1[:vr, :vc] % scalar_val).astype(dtype, copy=False)
 
     save_case_data(case["name"], {"input1": input1, "golden": golden})
-    print(f"[INFO] gen_data: {case['name']} shape={shape} valid_shape={valid_shape} dtype={dtype.__name__} scalar={SCALAR}")
+    print(f"[INFO] gen_data: {case['name']} src_shape={shape} src_valid_shape={valid_shape} dst_shape={dst_shape} dtype={dtype.__name__} scalar={SCALAR}")

--- a/test/tilelang_st/npu/a5/src/st/testcase/trowargmax/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trowargmax/cases.py
@@ -213,3 +213,19 @@ CASES = [
         "eps": 0,
     },
 ]
+
+
+def _a5_tmp_placeholder_shape(dtype):
+    return (1, max(1, 32 // np.dtype(dtype).itemsize))
+
+
+def _augment_case(case):
+    case = dict(case)
+    case.setdefault("src_shape", case["shape"])
+    case.setdefault("src_valid_shape", case["valid_shape"])
+    case.setdefault("tmp_shape", _a5_tmp_placeholder_shape(case["dtype"]))
+    case.setdefault("tmp_valid_shape", (1, 1))
+    return case
+
+
+CASES = [_augment_case(case) for case in CASES]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trowargmax/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trowargmax/compare.py
@@ -27,7 +27,7 @@ def main():
             continue
 
         case_dir = case["name"]
-        vr, vc = case["valid_shape"]
+        vr, vc = case["src_valid_shape"]
         out_shape = (vr, 1)
 
         golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dst_dtype"], count=np.prod(out_shape)).reshape(out_shape)

--- a/test/tilelang_st/npu/a5/src/st/testcase/trowargmax/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trowargmax/gen_data.py
@@ -20,8 +20,8 @@ for case in CASES:
 
     dtype = case["dtype"]
     dst_dtype = case["dst_dtype"]
-    shape = case["shape"]
-    valid_shape = case["valid_shape"]
+    shape = case["src_shape"]
+    valid_shape = case["src_valid_shape"]
 
     if dtype in (np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32):
         dtype_info = np.iinfo(dtype)

--- a/test/tilelang_st/npu/a5/src/st/testcase/trowargmin/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trowargmin/cases.py
@@ -213,3 +213,19 @@ CASES = [
         "eps": 0,
     },
 ]
+
+
+def _a5_tmp_placeholder_shape(dtype):
+    return (1, max(1, 32 // np.dtype(dtype).itemsize))
+
+
+def _augment_case(case):
+    case = dict(case)
+    case.setdefault("src_shape", case["shape"])
+    case.setdefault("src_valid_shape", case["valid_shape"])
+    case.setdefault("tmp_shape", _a5_tmp_placeholder_shape(case["dtype"]))
+    case.setdefault("tmp_valid_shape", (1, 1))
+    return case
+
+
+CASES = [_augment_case(case) for case in CASES]

--- a/test/tilelang_st/npu/a5/src/st/testcase/trowargmin/compare.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trowargmin/compare.py
@@ -27,7 +27,7 @@ def main():
             continue
 
         case_dir = case["name"]
-        vr, vc = case["valid_shape"]
+        vr, vc = case["src_valid_shape"]
         out_shape = (vr, 1)
 
         golden = np.fromfile(os.path.join(case_dir, "golden.bin"), dtype=case["dst_dtype"], count=np.prod(out_shape)).reshape(out_shape)

--- a/test/tilelang_st/npu/a5/src/st/testcase/trowargmin/gen_data.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/trowargmin/gen_data.py
@@ -20,8 +20,8 @@ for case in CASES:
 
     dtype = case["dtype"]
     dst_dtype = case["dst_dtype"]
-    shape = case["shape"]
-    valid_shape = case["valid_shape"]
+    shape = case["src_shape"]
+    valid_shape = case["src_valid_shape"]
 
     if dtype in (np.int8, np.uint8, np.int16, np.uint16, np.int32, np.uint32):
         dtype_info = np.iinfo(dtype)


### PR DESCRIPTION
对齐 tmp tile contract 与 runtime/pto-isa 的实际行为，修正 PTO IR verifier、tmp 内存规划和相关 sample/ST 用例，避免因 tmp 形状或 valid shape 约束不一致导致的错误分配、校验误判以及运行结果异常。同步更新文档和回归测试，覆盖 A2/A3 与 A5 的差异化 tmp 语义。

涉及的 op：

pto.tprelu
pto.trem
pto.trems
pto.trowargmax
pto.trowargmin
pto.tcolargmax
pto.tcolargmin