### PR TITLE
fix(vpto): normalize mte_ub_gm operands

### DIFF
--- a/lib/PTO/Transforms/VPTOPtrNormalize.cpp
+++ b/lib/PTO/Transforms/VPTOPtrNormalize.cpp
@@ -682,6 +682,18 @@ struct ConvertAccStoreUbOperandPattern
   }
 };
 
+struct ConvertMteUbGmOperandPattern
+    : public OpConversionPattern<pto::MteUbGmOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(pto::MteUbGmOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return rewriteBufferLikeBoundaryOp(op, adaptor, rewriter, "mte_ub_gm source",
+                                       "mte_ub_gm destination");
+  }
+};
+
 struct ConvertLoadOperandToPtrPattern : public OpConversionPattern<pto::PTOLoadOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -872,6 +884,10 @@ struct VPTOPtrNormalizePass
       return isa<pto::PtrType>(op.getSource().getType()) &&
              isa<pto::PtrType>(op.getDestination().getType());
     });
+    target.addDynamicallyLegalOp<pto::MteUbGmOp>([](pto::MteUbGmOp op) {
+      return isa<pto::PtrType>(op.getSource().getType()) &&
+             isa<pto::PtrType>(op.getDestination().getType());
+    });
     target.addDynamicallyLegalOp<pto::PTOLoadOp>(
         [](pto::PTOLoadOp op) { return isa<pto::PtrType>(op.getPtr().getType()); });
     target.addDynamicallyLegalOp<pto::PTOStoreOp>(
@@ -907,6 +923,7 @@ struct VPTOPtrNormalizePass
                  ConvertAccStoreOperandPattern,
                  ConvertAccStoreGmOperandPattern,
                  ConvertAccStoreUbOperandPattern,
+                 ConvertMteUbGmOperandPattern,
                  ConvertLoadOperandToPtrPattern,
                  ConvertStoreOperandToPtrPattern,
                  ConvertPtrNormalizeUnrealizedCastOp>(

--- a/test/lit/vpto/issue_791_mte_ub_gm_ptr_normalize.pto
+++ b/test/lit/vpto/issue_791_mte_ub_gm_ptr_normalize.pto
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression guard for issue 791.
+//
+// Guard item 1: VPTOPtrNormalize must rewrite memref-backed `pto.mte_ub_gm`
+// operands into ptr-form operands before wrapper expansion. If this regresses,
+// the op reaches later passes with a memref source and eventually reintroduces
+// an illegal `pto.castptr` from memref to !pto.ptr.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-ptr-normalize %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=NORMALIZE
+//
+// Guard item 2: after `vpto-expand-wrapper-ops`, the expanded DMA store must
+// consume the normalized ptr directly. In particular, expansion must not create
+// a fresh `pto.castptr %memref -> !pto.ptr<..., ub>` on the source path.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=EXPAND
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @issue_791_min(%out_gm: !pto.ptr<f16, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c16 = arith.constant 16 : index
+    %src = pto.pointer_cast(%c0_i64) %c16, %c16 : memref<16x16xf16, #pto.address_space<vec>>
+    pto.mte_ub_gm %src, %out_gm, %c32_i64
+      nburst(%c16_i64, %c32_i64, %c32_i64)
+      : memref<16x16xf16, #pto.address_space<vec>>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+    return
+  }
+}
+
+// NORMALIZE: // -----// IR Dump After
+// NORMALIZE-SAME: (vpto-ptr-normalize)
+// NORMALIZE-LABEL: func.func @issue_791_min(%arg0: !pto.ptr<f16, gm>) attributes {pto.aicore} {
+// NORMALIZE: %[[SRC:.*]] = pto.castptr %{{.*}} : i64 -> !pto.ptr<f16, ub>
+// NORMALIZE: pto.mte_ub_gm %[[SRC]], %arg0, %{{.*}} nburst(%{{.*}}, %{{.*}}, %{{.*}})
+// NORMALIZE-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+
+// EXPAND: // -----// IR Dump After
+// EXPAND-SAME: (vpto-expand-wrapper-ops)
+// EXPAND-LABEL: func.func @issue_791_min(%arg0: !pto.ptr<f16, gm>) attributes {pto.aicore} {
+// EXPAND: %[[SRC:.*]] = pto.castptr %{{.*}} : i64 -> !pto.ptr<f16, ub>
+// EXPAND-NOT: pto.castptr %{{.*}} : memref<16x16xf16, #pto.address_space<vec>> -> !pto.ptr<f16, ub>
+// EXPAND: pto.copy_ubuf_to_gm %[[SRC]], %arg0, %{{.*}} : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64


### PR DESCRIPTION
## Summary
- add missing `MteUbGmOp` ptr-normalize legality and operand rewrite
- add a focused lit regression for issue 791 covering normalize and wrapper-expansion guard rails
- document the regression guard intent in the new test

## Validation
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-ptr-normalize test/lit/vpto/issue_791_mte_ub_gm_ptr_normalize.pto -o /dev/null 2>&1 | /home/zhangzhendong/ptoas-workspace/llvm-project/build-shared/bin/FileCheck test/lit/vpto/issue_791_mte_ub_gm_ptr_normalize.pto --check-prefix=NORMALIZE`
- `build/tools/ptoas/ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops test/lit/vpto/issue_791_mte_ub_gm_ptr_normalize.pto -o /dev/null 2>&1 | /home/zhangzhendong/ptoas-workspace/llvm-project/build-shared/bin/FileCheck test/lit/vpto/issue_791_mte_ub_gm_ptr_normalize.pto --check-prefix=EXPAND`

Closes #791