### PR TITLE
fix(ptodsl): support index bitwise event ids

### DIFF
--- a/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
+++ b/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
@@ -166,6 +166,17 @@ step = (N + BLOCK - 1) // BLOCK               # Python int arithmetic (trace-tim
 
 When both operands are PTO scalars (loaded from device memory or produced by another device-side op), `+`, `-`, `*`, `/` produce device-side arithmetic instructions. When one operand is a Python scalar (trace-time constant), the tracer embeds it as an immediate.
 
+### Bitwise operators
+
+PTO integer scalars support Python bitwise operators `&`, `|`, and `^`. Runtime `index` values, such as loop induction variables produced by `pto.for_` or by AST-rewritten `for range(...)` loops, also support these operators for low-bit masks and parity checks.
+
+The common use case is double-buffering or flag-slot selection:
+
+- `i & 1` selects an alternating slot from a runtime loop index.
+- The result of an `index` bitwise expression remains index-like, so it can be passed to APIs that accept runtime index values, such as dynamic synchronization `event_id`.
+
+For fixed-width bit manipulation where the exact integer width matters, cast to an explicit integer type first and keep the expression in that integer domain.
+
 ### Math functions: `scalar.*`
 
 Non-trivial scalar math functions live under the top-level `scalar` namespace (imported as `from ptodsl import scalar`). They are intentionally separate from the `pto.*` namespace:

--- a/ptodsl/docs/user_guide/10-sync-ops.md
+++ b/ptodsl/docs/user_guide/10-sync-ops.md
@@ -57,6 +57,16 @@ In PTODSL, `event_id` may be either:
 
 Events are per-pipeline-pair: the same `event_id=0` used between `MTE2 → V` is independent from `event_id=0` used between `MTE3 → V`.
 
+Runtime loop indices can be used to select alternating event slots. This is useful for double-buffered pipelines:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
+```python
+with pto.for_(0, 4, step=1) as stage:
+    event = stage & 1
+    pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=event)
+    pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=event)
+```
+
 ---
 
 ## 10.2 Pipeline synchronization: `set_flag`, `wait_flag`, `pipe_barrier`

--- a/ptodsl/ptodsl/_runtime_scalar_ops.py
+++ b/ptodsl/ptodsl/_runtime_scalar_ops.py
@@ -262,11 +262,6 @@ def emit_runtime_compare(op_name: str, lhs, rhs):
 def emit_runtime_bitwise_op(op_name: str, lhs, rhs):
     """Lower one authored runtime scalar bitwise operator."""
     lhs, rhs, kind = normalize_runtime_binary_operands(lhs, rhs)
-    if kind != "integer":
-        raise TypeError(
-            f"runtime scalar bitwise operator '{op_name}' expects integer-like operands, got {lhs.type} and {rhs.type}"
-        )
-
     op_cls = {
         "and": arith.AndIOp,
         "or": arith.OrIOp,
@@ -274,6 +269,14 @@ def emit_runtime_bitwise_op(op_name: str, lhs, rhs):
     }.get(op_name)
     if op_cls is None:
         raise TypeError(f"unsupported runtime scalar bitwise operator '{op_name}'")
+
+    if kind == "index":
+        return op_cls(lhs, rhs).result
+
+    if kind != "integer":
+        raise TypeError(
+            f"runtime scalar bitwise operator '{op_name}' expects integer-like operands, got {lhs.type} and {rhs.type}"
+        )
 
     authored_type = lhs.type
     result = op_cls(_strip_integer_signedness(lhs), _strip_integer_signedness(rhs)).result

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1418,6 +1418,19 @@ def explicit_runtime_index_bitwise_event_probe():
     with pto.for_(0, 4, step=1) as i:
         pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=i & 1)
         pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=(i | 0) ^ 1)
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=1 & i)
+        pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=0 | i)
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=1 ^ i)
+
+
+@pto.jit(target="a5", ast_rewrite=False)
+def explicit_runtime_index_integer_bitwise_event_probe():
+    one = pto.const(1, dtype=pto.i32)
+    zero = pto.const(0, dtype=pto.i32)
+    with pto.for_(0, 4, step=1) as i:
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=i & one)
+        pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=zero | i)
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=one ^ i)
 
 
 @pto.jit(target="a5")
@@ -1750,6 +1763,7 @@ def main() -> None:
     public_mask_surface_probe.verify()
     public_sync_surface_probe.verify()
     explicit_runtime_index_bitwise_event_probe.verify()
+    explicit_runtime_index_integer_bitwise_event_probe.verify()
     ast_runtime_index_bitwise_event_probe.verify()
     public_data_movement_surface_probe.verify()
 
@@ -2744,6 +2758,13 @@ def main() -> None:
         explicit_runtime_index_bitwise_event_text,
         "explicit runtime index bitwise event specialization",
     )
+    explicit_runtime_index_integer_bitwise_event_text = (
+        explicit_runtime_index_integer_bitwise_event_probe.compile().mlir_text()
+    )
+    expect_parse_roundtrip_and_verify(
+        explicit_runtime_index_integer_bitwise_event_text,
+        "explicit runtime index/integer bitwise event specialization",
+    )
     ast_runtime_index_bitwise_event_text = ast_runtime_index_bitwise_event_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(
         ast_runtime_index_bitwise_event_text,
@@ -2773,12 +2794,32 @@ def main() -> None:
     expect("arith.ori" in explicit_runtime_index_bitwise_event_text, "explicit pto.for_ index | event id should lower to arith.ori")
     expect("arith.xori" in explicit_runtime_index_bitwise_event_text, "explicit pto.for_ index ^ event id should lower to arith.xori")
     expect(
-        explicit_runtime_index_bitwise_event_text.count("pto.wait_flag_dyn") == 1,
+        re.search(r"arith\.andi .* : index", explicit_runtime_index_bitwise_event_text) is not None,
+        "index & literal event id should stay in the index type domain",
+    )
+    expect(
+        "arith.index_cast" not in explicit_runtime_index_bitwise_event_text,
+        "index/literal bitwise event ids should not lower through fixed-width integer casts",
+    )
+    expect(
+        explicit_runtime_index_bitwise_event_text.count("pto.wait_flag_dyn") == 3,
         "explicit pto.for_ index bitwise event id should lower to pto.wait_flag_dyn",
     )
     expect(
-        explicit_runtime_index_bitwise_event_text.count("pto.set_flag_dyn") == 1,
+        explicit_runtime_index_bitwise_event_text.count("pto.set_flag_dyn") == 2,
         "explicit pto.for_ index bitwise event id should lower to pto.set_flag_dyn",
+    )
+    expect(
+        explicit_runtime_index_integer_bitwise_event_text.count("arith.index_cast") >= 2,
+        "index/integer bitwise event ids should coerce integer runtime scalars to index",
+    )
+    expect(
+        explicit_runtime_index_integer_bitwise_event_text.count("pto.wait_flag_dyn") == 2,
+        "index/integer bitwise event ids should lower waits to pto.wait_flag_dyn",
+    )
+    expect(
+        explicit_runtime_index_integer_bitwise_event_text.count("pto.set_flag_dyn") == 1,
+        "index/integer bitwise event ids should lower sets to pto.set_flag_dyn",
     )
     expect("arith.andi" in ast_runtime_index_bitwise_event_text, "AST rewritten range loop index & event id should lower to arith.andi")
     expect(

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1413,6 +1413,19 @@ def public_sync_surface_probe():
     pto.wait_intra_flag(pto.Pipe.V, dynamic_event)
 
 
+@pto.jit(target="a5", ast_rewrite=False)
+def explicit_runtime_index_bitwise_event_probe():
+    with pto.for_(0, 4, step=1) as i:
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=i & 1)
+        pto.set_flag(pto.Pipe.MTE2, pto.Pipe.V, event_id=(i | 0) ^ 1)
+
+
+@pto.jit(target="a5")
+def ast_runtime_index_bitwise_event_probe():
+    for i in range(0, 4):
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=i & 1)
+
+
 @pto.jit(target="a5", mode="explicit")
 def public_data_movement_surface_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
@@ -1736,6 +1749,8 @@ def main() -> None:
     public_mask_bitcast_probe.verify()
     public_mask_surface_probe.verify()
     public_sync_surface_probe.verify()
+    explicit_runtime_index_bitwise_event_probe.verify()
+    ast_runtime_index_bitwise_event_probe.verify()
     public_data_movement_surface_probe.verify()
 
     with make_context() as ctx, Location.unknown(ctx):
@@ -2724,6 +2739,16 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(mask_surface_text, "public mask surface specialization")
     sync_surface_text = public_sync_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(sync_surface_text, "public sync surface specialization")
+    explicit_runtime_index_bitwise_event_text = explicit_runtime_index_bitwise_event_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        explicit_runtime_index_bitwise_event_text,
+        "explicit runtime index bitwise event specialization",
+    )
+    ast_runtime_index_bitwise_event_text = ast_runtime_index_bitwise_event_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_runtime_index_bitwise_event_text,
+        "AST runtime index bitwise event specialization",
+    )
     data_movement_surface_text = public_data_movement_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(data_movement_surface_text, "public data movement surface specialization")
     vector_post_update_surface_text = vector_post_update_surface_probe.compile().mlir_text()
@@ -2744,6 +2769,22 @@ def main() -> None:
     expect("pto.wait_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]" in sync_surface_text, "wait_flag(..., event_id=0) should lower static event ids to pto.wait_flag")
     expect("pto.set_flag_dyn[<PIPE_V>, <PIPE_MTE3>, %c3]" in sync_surface_text, "set_flag(..., event_id=dynamic_event) should lower runtime event ids to pto.set_flag_dyn")
     expect("pto.wait_flag_dyn[<PIPE_V>, <PIPE_MTE3>, %c3]" in sync_surface_text, "wait_flag(..., event_id=dynamic_event) should lower runtime event ids to pto.wait_flag_dyn")
+    expect("arith.andi" in explicit_runtime_index_bitwise_event_text, "explicit pto.for_ index & event id should lower to arith.andi")
+    expect("arith.ori" in explicit_runtime_index_bitwise_event_text, "explicit pto.for_ index | event id should lower to arith.ori")
+    expect("arith.xori" in explicit_runtime_index_bitwise_event_text, "explicit pto.for_ index ^ event id should lower to arith.xori")
+    expect(
+        explicit_runtime_index_bitwise_event_text.count("pto.wait_flag_dyn") == 1,
+        "explicit pto.for_ index bitwise event id should lower to pto.wait_flag_dyn",
+    )
+    expect(
+        explicit_runtime_index_bitwise_event_text.count("pto.set_flag_dyn") == 1,
+        "explicit pto.for_ index bitwise event id should lower to pto.set_flag_dyn",
+    )
+    expect("arith.andi" in ast_runtime_index_bitwise_event_text, "AST rewritten range loop index & event id should lower to arith.andi")
+    expect(
+        ast_runtime_index_bitwise_event_text.count("pto.wait_flag_dyn") == 1,
+        "AST rewritten range loop index bitwise event id should lower to pto.wait_flag_dyn",
+    )
     expect("pto.sync.set <PIPE_FIX>, 0" in sync_surface_text, "set_cross_flag(Pipe.FIX, 0) should lower to pto.sync.set")
     expect("pto.sync.wait <PIPE_FIX>, 0" in sync_surface_text, "wait_cross_flag(Pipe.FIX, 0) should lower to pto.sync.wait")
     expect("pto.sync.set <PIPE_MTE3>, %c3" in sync_surface_text, "set_intra_flag(Pipe.MTE3, dynamic_event) should lower dynamic event ids through pto.sync.set")

--- a/ptodsl/tests/test_jit_diagnostics.py
+++ b/ptodsl/tests/test_jit_diagnostics.py
@@ -13,7 +13,7 @@ import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ptodsl"))
 
-from ptodsl import pto
+from ptodsl import pto, scalar
 from ptodsl._ast_rewrite import PTODSLAstRewriteError
 from ptodsl._host_tensors import inspect_host_tensor_metadata
 
@@ -56,6 +56,13 @@ def float_loop_bound_probe():
 def float_addptr_offset_probe():
     tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32, valid_shape=[1, 4])
     _ = pto.addptr(tile.as_ptr(), pto.const(1.5, dtype=pto.f32))
+
+
+@pto.jit(target="a5")
+def float_bitwise_probe():
+    tile = pto.alloc_tile(shape=[1, 8], dtype=pto.f32, valid_shape=[1, 1])
+    value = scalar.load(tile[0, 0])
+    _ = value & 1
 
 
 @pto.jit(target="a5")
@@ -374,6 +381,12 @@ def main() -> None:
         "addptr(ptr, offset)",
         "expects an index-like scalar",
         "f32",
+    )
+    expect_raises(
+        float_bitwise_probe.compile,
+        TypeError,
+        "runtime scalar bitwise operator",
+        "expects integer-like operands",
     )
     expect_raises(
         carry_update_mismatch_probe.compile,


### PR DESCRIPTION
Fixes https://github.com/mouliangyu/PTOAS/issues/484

## Summary
- allow runtime index values to use PTODSL bitwise operators (`&`, `|`, `^`)
- cover explicit `pto.for_` and AST-rewritten `range(...)` loops for dynamic sync event ids
- document index bitwise parity usage for double-buffered event slots

## Validation
- `python3 -m py_compile ptodsl/ptodsl/_runtime_scalar_ops.py ptodsl/tests/test_jit_compile.py ptodsl/tests/test_docs_as_test.py`
- `git diff --check`
- `python3 ptodsl/tests/test_jit_compile.py`
- `python3 ptodsl/tests/test_docs_as_test.py`
- `python3 ptodsl/tests/test_ptoas_frontend_verify.py`