### PR TITLE
[WIP] A2/A3 LLVM lowering

### DIFF
--- a/_ptoas_build_backend.py
+++ b/_ptoas_build_backend.py
@@ -35,17 +35,40 @@ import zipfile
 from pathlib import Path
 
 _REPO = Path(__file__).parent.resolve()
-_LLVM_BUILD_DIR = Path(
-    os.environ.get("LLVM_BUILD_DIR",
-                   "/llvm-workspace/llvm-project/build-shared")
-)
+
+def _find_llvm_dir():
+    """Return an LLVM install or build-tree prefix, resolving in order:
+
+    1. ``LLVM_BUILD_DIR`` / ``LLVM_INSTALL_DIR`` env vars
+    2. Auto-detect common install locations by probing ``lib/cmake/llvm``
+    3. Default build-tree path
+    """
+    for key in ("LLVM_BUILD_DIR", "LLVM_INSTALL_DIR"):
+        if key in os.environ:
+            return Path(os.environ[key])
+
+    for cand in ("/usr/local/llvm", "/usr/local/Ascend/latest/compiler",
+                 "/opt/llvm"):
+        if (Path(cand) / "lib" / "cmake" / "llvm").is_dir():
+            return Path(cand)
+
+    return Path("/llvm-workspace/llvm-project/build-shared")
+
+
+_LLVM_BUILD_DIR = _find_llvm_dir()
 _PTO_INSTALL_DIR = Path(
     os.environ.get("PTO_INSTALL_DIR", str(_REPO / "install"))
 )
 _BUILD_DIR = Path(os.environ.get("PTO_BUILD_DIR", str(_REPO / "build")))
-_MLIR_PY_PKG = (
-    _LLVM_BUILD_DIR / "tools" / "mlir" / "python_packages" / "mlir_core"
-)
+_MLIR_PY_PKG = None
+if "MLIR_PYTHON_PACKAGE_DIR" in os.environ:
+    _MLIR_PY_PKG = Path(os.environ["MLIR_PYTHON_PACKAGE_DIR"])
+elif "LLVM_INSTALL_DIR" in os.environ:
+    _MLIR_PY_PKG = Path(os.environ["LLVM_INSTALL_DIR"]) / "python_packages" / "mlir_core"
+else:
+    _installed = _LLVM_BUILD_DIR / "python_packages" / "mlir_core"
+    _build_tree = _LLVM_BUILD_DIR / "tools" / "mlir" / "python_packages" / "mlir_core"
+    _MLIR_PY_PKG = _installed if _installed.exists() else _build_tree
 _WHEEL_DIST_DIR = _BUILD_DIR / "wheel-dist"
 
 
@@ -98,7 +121,7 @@ def _should_use_linux_hardening_cache() -> bool:
     return sys.platform.startswith("linux")
 
 
-def _cmake_configure_and_build():
+def _cmake_configure_and_build(skip_install=False):
     """CMake configure + Ninja build + install."""
     _BUILD_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -110,6 +133,7 @@ def _cmake_configure_and_build():
         "cmake", "-GNinja",
         f"-S{_REPO}", f"-B{_BUILD_DIR}",
         "-DCMAKE_BUILD_TYPE=Release",
+        "-DPTO_ENABLE_PYTHON_BINDING=ON",
         f"-DLLVM_DIR={_LLVM_BUILD_DIR}/lib/cmake/llvm",
         f"-DMLIR_DIR={_LLVM_BUILD_DIR}/lib/cmake/mlir",
         f"-DPython3_ROOT_DIR={sys.prefix}",
@@ -135,7 +159,8 @@ def _cmake_configure_and_build():
 
     subprocess.check_call(cmake_cmd)
     subprocess.check_call(["ninja", "-C", str(_BUILD_DIR)])
-    subprocess.check_call(["ninja", "-C", str(_BUILD_DIR), "install"])
+    if not skip_install:
+        subprocess.check_call(["ninja", "-C", str(_BUILD_DIR), "install"])
 
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
@@ -175,7 +200,7 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     installs a .pth file pointing sys.path at the build tree.  No files are
     copied into site-packages except the .pth file itself.
     """
-    _cmake_configure_and_build()
+    _cmake_configure_and_build(skip_install=True)
 
     version = os.environ.get("PTOAS_PYTHON_PACKAGE_VERSION", "0.1.0")
 
@@ -183,10 +208,14 @@ def build_editable(wheel_directory, config_settings=None, metadata_directory=Non
     pth_paths = [
         # mlir.* namespace + _pto.so (installed there by CMake)
         str(_MLIR_PY_PKG),
-        # _pto.so output directory (CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+        # generated files (_pto.so, _pto_ops_gen.py) under mlir/ namespace
         str(_BUILD_DIR / "python"),
+        # handwritten Python sources (pto/dialects/pto.py, etc.)
+        str(_REPO / "python"),
         # ptodsl pure-Python sub-package
         str(_REPO / "ptodsl"),
+        # runtime resources installed by CMake (tilelang_dsl, TileOps, etc.)
+        str(_PTO_INSTALL_DIR),
     ]
 
     pth_content = "\n".join(pth_paths) + "\n"

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,84 @@
+# PTOAS development environment with NPU support (CANN 9.0.0)
+#
+# Usage:
+#   docker build -f docker/Dockerfile.dev -t ptoas-dev-cann900 .
+#
+# This image provides the toolchain for building and running PTOAS on NPU.
+# It does NOT contain PTOAS itself -- mount PTOAS source at /workspace and
+# run `pip install -e .` inside the container.
+
+# ---- Base: CANN 9.0.0 (provides bisheng, CANN runtime, Python 3.12) ----
+FROM quay.io/ascend/cann:9.0.0-910b-ubuntu22.04-py3.12
+
+# ---- Build args (matching CI) ----
+ARG LLVM_REPO=https://github.com/vpto-dev/llvm-project.git
+ARG LLVM_REF=feature-vpto
+ARG PTO_ISA_REPO=https://gitcode.com/cann/pto-isa.git
+ARG PTO_ISA_COMMIT=662d7f2a916d6bbde3109ce4a16ed5c28f5d900a
+
+# ---- Paths ----
+ENV LLVM_SOURCE_DIR=/opt/llvm-project
+ENV LLVM_BUILD_DIR=/opt/llvm-project/build
+ENV LLVM_INSTALL_DIR=/usr/local/llvm
+ENV ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0
+ENV PTO_LIB_PATH=/opt/pto-isa
+
+# =========================================================================
+# 1. System dependencies
+# =========================================================================
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake ninja-build git build-essential clang lld \
+    libedit-dev zlib1g-dev libxml2-dev libzstd-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# =========================================================================
+# 2. Python dependencies
+# =========================================================================
+RUN pip install --no-cache-dir 'pybind11<3' numpy pyyaml
+
+# =========================================================================
+# 3. Build LLVM/MLIR (vpto fork, feature-vpto branch)
+# =========================================================================
+RUN git clone --depth 1 --branch "${LLVM_REF}" "${LLVM_REPO}" "${LLVM_SOURCE_DIR}"
+
+WORKDIR ${LLVM_SOURCE_DIR}
+
+RUN cmake -G Ninja -S llvm -B "${LLVM_BUILD_DIR}" \
+    -DLLVM_ENABLE_PROJECTS="mlir;clang" \
+    -DBUILD_SHARED_LIBS=ON \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+    -DPython3_EXECUTABLE=python3 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_TARGETS_TO_BUILD="host" \
+    -DCMAKE_INSTALL_PREFIX="${LLVM_INSTALL_DIR}" \
+    -DLLVM_INSTALL_UTILS=ON
+
+RUN ninja -C "${LLVM_BUILD_DIR}"
+
+RUN cmake --install "${LLVM_BUILD_DIR}"
+
+# =========================================================================
+# 4. Clone pto-isa (headers for bisheng compilation of generated kernels)
+# =========================================================================
+RUN git clone "${PTO_ISA_REPO}" "${PTO_LIB_PATH}" \
+    && cd "${PTO_LIB_PATH}" && git checkout "${PTO_ISA_COMMIT}"
+
+# =========================================================================
+# 5. Torch + torch-npu (for on-device kernel launch)
+# =========================================================================
+RUN pip install --no-cache-dir torch==2.9.0 --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --no-cache-dir torch-npu==2.9.0
+
+# =========================================================================
+# 6. Environment
+# =========================================================================
+ENV PATH="${LLVM_INSTALL_DIR}/bin:${ASCEND_HOME_PATH}/compiler/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${LLVM_INSTALL_DIR}/lib:${ASCEND_HOME_PATH}/lib64:${ASCEND_HOME_PATH}/lib64/plugin/opskernel:${ASCEND_HOME_PATH}/lib64/plugin/nnengine:${ASCEND_HOME_PATH}/opp/built-in/op_impl/ai_core/tbe/op_tiling/lib/linux/aarch64:${LD_LIBRARY_PATH}"
+ENV MLIR_PYTHON_ROOT="${LLVM_INSTALL_DIR}/python_packages/mlir_core"
+
+ENV BISHENG_OPTS="-I${PTO_LIB_PATH}/include/pto -fPIC -shared -O2 -std=c++17 --npu-arch=dav-2201 -DMEMORY_BASE"
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/docs/designs/a2a3-dma-builtins.md
+++ b/docs/designs/a2a3-dma-builtins.md
@@ -1,0 +1,3423 @@
+# A2/A3 DMA Copy and Control Builtin Inventory
+
+## 1. Collection Constraints
+
+- Collection root: `.local/cann`, which is a symlink to `/home/mouliangyu/.local/ascend/beta.1/cann` in this workspace.
+- Architecture scope: A2/A3 DMA/copy builtins exposed as `copy*` CCE builtin aliases, plus companion `set_*` controls used for DMA loop/stride/padding and fixpipe/fix-state setup; not vector compute `vcopy` and not A5 `vector_*` value-operand interfaces.
+- Builtin-name mapping source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h` and `cce_aicore_intrinsics_3101.h`, using `clang_builtin_alias(__builtin_cce_copy*)` and `clang_builtin_alias(__builtin_cce_set_*)` declarations.
+- Complete C++ signature sources: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h` for A2/A3 explicit wrapper signatures and CANN `// ->` packing comments, plus `.local/cann/tools/tikicpulib/lib/include/stub_fun.h` for additional `copy*` and companion `set_*` signatures that map to the same builtin aliases.
+- Included signatures must map to a `__builtin_cce_copy*` or selected companion `__builtin_cce_set_*` alias and must not contain C++ reference parameters. Stub declarations using `const T&` or `T&` `tag*` parameters are treated as higher-level wrapper forms and are excluded.
+- Excluded entries include `vcopy`, unrelated scalar/system controls, vector mask controls already covered by `a2a3-vector-builtins.md`, OPP/AscendC wrapper implementations, namespace-duplicate declarations, generic `copy*` aliases without a complete signature in the scanned sources, and declarations with C++ reference parameters.
+- LLVM IR declarations are exact `declare` lines copied from local `ccec -save-temps` device `.ll` output. Actual probe calls are the exact `call` lines observed inside the generated probe kernel, so the listed IR signature is the compiler-emitted intrinsic signature for that probe, not a hand-derived signature.
+- Entries marked as not captured do not have an exact local LLVM IR signature in this document. The local probe either did not cover that overload or `ccec` rejected it for the tested target feature set; this mark does not imply that the builtin has no lowering on every target.
+- A single LLVM intrinsic can correspond to many C++ builtin overloads. In these cases the C++ overloads are only type/parameter conveniences; after overload resolution they lower to the same intrinsic shape, commonly with pointer address spaces plus one packed `i64` control operand.
+- Parameter packing is source-derived, not inferred. The document uses CANN `// ->` comments as the authoritative wrapper packing formula; CANN `ASM:` comments identify the bottom-level operation/register but do not provide a bitfield formula; direct `uint64_t config` or `config0/config1` forms are already-packed bottom-level forms.
+- `stub_fun.h` contains many declaration-only overloads without `// ->` comments. For those signatures the document records the complete C++ signature but does not invent a packing formula; use the nearest CANN `// ->` overload only when the signature is materially the same.
+- Copy inventory count: 54 builtin names with complete signatures, 762 complete C++ signatures, 117 signatures with CANN packing comments, and 12 observed LLVM intrinsic names from partial probes. Companion control inventory count: 58 builtin names and 65 complete C++ signatures; 41 companion signatures have captured LLVM IR declarations.
+- Alias names with no complete non-reference signature in the scanned sources: `__builtin_cce_copy_cbuf_to_cbuf_loopenhance`, `__builtin_cce_copy_cbuf_to_gm_align_no_padding`, `__builtin_cce_copy_cbuf_to_gm_multi_nz2dn`, `__builtin_cce_copy_cbuf_to_gm_multi_nz2nd`, `__builtin_cce_copy_gm_to_ubuf_align_no_padding`, `__builtin_cce_copy_ubuf_to_gm_align_no_padding`.
+
+## 2. Builtin Signatures
+
+- `__builtin_cce_copy_cbuf_to_bt`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:941`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.MOV.L1.TO.BT`
+    - `llvm.hivm.MOV.L1.TO.BT.cfg`
+    - `llvm.hivm.andb64rr`
+    - `llvm.hivm.shli64ri`
+    - `llvm.hivm.orb64rr`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.MOV.L1.TO.BT.cfg(i64, ptr addrspace(2) nocapture readonly, i64, i64, i64, i64, i64) #1`
+    - `declare i64 @llvm.hivm.andb64rr(i64, i64) #2`
+    - `declare i64 @llvm.hivm.shli64ri(i64, i64) #2`
+    - `declare i64 @llvm.hivm.orb64rr(i64, i64) #2`
+    - `declare void @llvm.hivm.MOV.L1.TO.BT(i64, ptr addrspace(2) nocapture readonly, i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.MOV.L1.TO.BT(i64 1, ptr addrspace(2) null, i64 281479271743504), !dbg !10`
+    - `call void @llvm.hivm.MOV.L1.TO.BT(i64 1, ptr addrspace(2) null, i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ bfloat16_t *src, bool convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1008.
+      - Parameter packing: Header packing comment: `/* #429 */ __builtin_cce_copy_cbuf_to_bt(dst, src, ((convControl & 0x1) << 3 | (nBurst & 0xfff) << 4 | (lenBurst & 0xffff) << 16 | (sourceGap & 0xffff) << 32 | (dstGap & 0xffff) << 48))`
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ bfloat16_t *src, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1003.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ float *src, bool convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1028.
+      - Parameter packing: Header packing comment: `/* #436 */ __builtin_cce_copy_cbuf_to_bt(dst, src, ((convControl & 0x1) << 3 | (nBurst & 0xfff) << 4 | (lenBurst & 0xffff) << 16 | (sourceGap & 0xffff) << 32 | (dstGap & 0xffff) << 48))`
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ float *src, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1023.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ half *src, bool convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1018.
+      - Parameter packing: Header packing comment: `/* #433 */ __builtin_cce_copy_cbuf_to_bt(dst, src, ((convControl & 0x1) << 3 | (nBurst & 0xfff) << 4 | (lenBurst & 0xffff) << 16 | (sourceGap & 0xffff) << 32 | (dstGap & 0xffff) << 48))`
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ half *src, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1013.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ int32_t *src, bool convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1038.
+      - Parameter packing: Header packing comment: `/* #439 */ __builtin_cce_copy_cbuf_to_bt(dst, src, ((convControl & 0x1) << 3 | (nBurst & 0xfff) << 4 | (lenBurst & 0xffff) << 16 | (sourceGap & 0xffff) << 32 | (dstGap & 0xffff) << 48))`
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ int32_t *src, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1033.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ bfloat16_t* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1085; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1088.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ bfloat16_t* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap, uint8_t fixVal);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1091; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1094.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ bfloat16_t* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1019; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1022.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ float* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1049; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1052.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ float* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap, uint8_t fixVal);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1055; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1058.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ float* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1031; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1034.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ half* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1061; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1064.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ half* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap, uint8_t fixVal);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1067; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1070.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ half* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1025; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1028.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ int32_t* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1073; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1076.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ int32_t* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap, uint8_t fixVal);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1079; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1082.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ int32_t* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1037; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1040.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ void* src, uint16_t convControl, uint16_t nBurst, uint16_t lenBurst, uint16_t sourceGap, uint16_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1043; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1046.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_bt(uint64_t dst, __cbuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1013; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1016.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_copy_cbuf_to_fbuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:945`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.MOV.L1.TO.FB.v220`
+    - `llvm.hivm.MOV.L1.TO.FB.v220.cfg`
+    - `llvm.hivm.andb64rr`
+    - `llvm.hivm.shli64ri`
+    - `llvm.hivm.orb64rr`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.MOV.L1.TO.FB.v220(ptr addrspace(7) nocapture writeonly, ptr addrspace(2) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.MOV.L1.TO.FB.v220.cfg(ptr addrspace(7) nocapture writeonly, ptr addrspace(2) nocapture readonly, i64, i64, i64, i64) #1`
+    - `declare i64 @llvm.hivm.andb64rr(i64, i64) #2`
+    - `declare i64 @llvm.hivm.shli64ri(i64, i64) #2`
+    - `declare i64 @llvm.hivm.orb64rr(i64, i64) #2`
+  - Actual probe calls:
+    - `call void @llvm.hivm.MOV.L1.TO.FB.v220(ptr addrspace(7) null, ptr addrspace(2) null, i64 1), !dbg !10`
+    - `call void @llvm.hivm.MOV.L1.TO.FB.v220(ptr addrspace(7) null, ptr addrspace(2) null, i64 281479271743504), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_fbuf(__fbuf__ void *dst, __cbuf__ void *src, uint16_t burstNum, uint16_t burstLen, uint16_t srcGapSize, uint16_t dstGapSize);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1048.
+      - Parameter packing: Header packing comment: `/* #452 */ __builtin_cce_copy_cbuf_to_fbuf(dst, src, ((burstNum & 0xfff) << 4 | (burstLen & 0xffff) << 16 | (srcGapSize & 0xffff) << 32 | (dstGapSize & 0xffff) << 48))`
+    - `void __builtin_cce_copy_cbuf_to_fbuf(__fbuf__ void *dst, __cbuf__ void *src, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1043.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_fbuf(__fbuf__ void* dst, __cbuf__ void* src, uint16_t burstNum, uint16_t burstLen, uint16_t srcGapSize, uint16_t dstGapSize);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1103; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1106.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_fbuf(__fbuf__ void* dst, __cbuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1097; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1100.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_copy_cbuf_to_fbuf_v2`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:947`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_fbuf_v2(__fbuf__ void *dst, __cbuf__ void *src, uint16_t burst_num, uint16_t burst_len, uint16_t src_stride, uint16_t dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1058.
+      - Parameter packing: Header packing comment: `/* #454 */ __builtin_cce_copy_cbuf_to_fbuf_v2(dst, src, ((burst_num & 0xfff) << 4 | (burst_len & 0xffff) << 16 | (src_stride & 0xffff) << 32 | (dst_stride & 0xffff) << 48))`
+    - `void __builtin_cce_copy_cbuf_to_fbuf_v2(__fbuf__ void *dst, __cbuf__ void *src, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1053.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_fbuf_v2(__fbuf__ void * dst, __cbuf__ void * src, uint16_t burst_num, uint16_t burst_len, uint16_t src_stride, uint16_t dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:20468.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_fbuf_v2(__fbuf__ void * dst, __cbuf__ void * src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:20467.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_copy_cbuf_to_gm`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:949`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_gm(__gm__ void* dst, __cbuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1109.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_gm(__gm__ void* dst, __cbuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1110.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_cbuf_to_gm_align`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:951`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ float* dst, __cbuf__ float* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1112.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ half* dst, __cbuf__ half* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1111.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ int16_t* dst, __cbuf__ int16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1113.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ int32_t* dst, __cbuf__ int32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1114.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ int8_t* dst, __cbuf__ int8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1115.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ uint16_t* dst, __cbuf__ uint16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1116.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ uint32_t* dst, __cbuf__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1117.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align(__gm__ uint8_t* dst, __cbuf__ uint8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1118.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_cbuf_to_gm_align_v2`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:955`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ float* dst, __cbuf__ float* src, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2586.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ float* tag1, __cbuf__ float* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2595.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ float* tag1, __cbuf__ float* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2603.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ float* tag1, __cbuf__ float* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2611.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ half* dst, __cbuf__ half* src, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2587.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ half* tag1, __cbuf__ half* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2596.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ half* tag1, __cbuf__ half* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2604.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int16_t* tag1, __cbuf__ int16_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2592.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int16_t* tag1, __cbuf__ int16_t* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2600.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int16_t* tag1, __cbuf__ int16_t* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2608.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int32_t* tag1, __cbuf__ int32_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2594.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int32_t* tag1, __cbuf__ int32_t* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2602.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int32_t* tag1, __cbuf__ int32_t* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2610.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int8_t* dst, __cbuf__ int8_t* src, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2588.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int8_t* tag1, __cbuf__ int8_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2590.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int8_t* tag1, __cbuf__ int8_t* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2598.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ int8_t* tag1, __cbuf__ int8_t* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2606.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint16_t* tag1, __cbuf__ uint16_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2591.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint16_t* tag1, __cbuf__ uint16_t* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2599.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint16_t* tag1, __cbuf__ uint16_t* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2607.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint32_t* tag1, __cbuf__ uint32_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2593.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint32_t* tag1, __cbuf__ uint32_t* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2601.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint32_t* tag1, __cbuf__ uint32_t* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2609.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint8_t* tag1, __cbuf__ uint8_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2589.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint8_t* tag1, __cbuf__ uint8_t* tag2, uint8_t tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2597.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ uint8_t* tag1, __cbuf__ uint8_t* tag2, uint8_t tag3, uint16_t tag4, uint16_t tag5, uint16_t tag6, uint16_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2605.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ void * dst_addr, __cbuf__ void * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2584.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_gm_align_v2(__gm__ void * dst_addr, __cbuf__ void * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t l2_cache_ctl, uint64_t burst_dst_stride, uint32_t burst_src_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2585.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_cbuf_to_pt`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:961`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_pt(uint64_t dst, __cbuf__ void* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcGap, uint16_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:20458.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_cbuf_to_pt(uint64_t dst, __cbuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:20457.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_copy_cbuf_to_ubuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:963`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.MOV.L1.TO.UB`
+    - `llvm.hivm.MOV.L1.TO.UB.cfg`
+    - `llvm.hivm.andb64rr`
+    - `llvm.hivm.shli64ri`
+    - `llvm.hivm.orb64rr`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.MOV.L1.TO.UB.cfg(ptr addrspace(6) nocapture writeonly, ptr addrspace(2) nocapture readonly, i64, i64, i64, i64, i64) #1`
+    - `declare i64 @llvm.hivm.andb64rr(i64, i64) #2`
+    - `declare i64 @llvm.hivm.shli64ri(i64, i64) #2`
+    - `declare i64 @llvm.hivm.orb64rr(i64, i64) #2`
+    - `declare void @llvm.hivm.MOV.L1.TO.UB(ptr addrspace(6) nocapture writeonly, ptr addrspace(2) nocapture readonly, i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.MOV.L1.TO.UB(ptr addrspace(6) null, ptr addrspace(2) null, i64 281479271743504)`
+    - `call void @llvm.hivm.MOV.L1.TO.UB(ptr addrspace(6) null, ptr addrspace(2) null, i64 1)`
+  - Probe targets used: `dav-m200`
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_cbuf_to_ubuf(__ubuf__ void *dst_addr, __cbuf__ void *src_addr, bool sub_blockid, uint16_t burst_num, uint16_t burst_len, uint16_t src_gap, uint16_t dst_gap);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1068.
+      - Parameter packing: Header packing comment: `/* #558 */ __builtin_cce_copy_cbuf_to_ubuf(dst_addr, src_addr, ((sub_blockid & 0x1) << 0 | (burst_num & 0xfff) << 4 | (burst_len & 0xffff) << 16 | (src_gap & 0xffff) << 32 | (dst_gap & 0xffff) << 48))`
+    - `void __builtin_cce_copy_cbuf_to_ubuf(__ubuf__ void *dst_addr, __cbuf__ void *src_addr, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1063.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_ubuf(__ubuf__ void* dst, __cbuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1119; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1122.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_cbuf_to_ubuf(__ubuf__ void* dst, __cbuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1125; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1128.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_depthwise_cc_to_ubuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:965`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ float* dst, __cc__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1137.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ float* dst, __cc__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1138.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ float* dst, __cc__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1133.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ float* dst, __cc__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1134.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ half* dst, __cc__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1135.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1136.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ half* dst, __cc__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1131.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_depthwise_cc_to_ubuf(__ubuf__ half* dst, __cc__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1132.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:967`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf(__cbuf__ void* dst, __gm__ void* src, uint64_t config, pad_t padMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1139.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf(__cbuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, pad_t padMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1140.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_align`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:969`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ float* dst, __gm__ float* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1504.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ half* dst, __gm__ half* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1501.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ int16_t* dst, __gm__ int16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1499.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ int32_t* dst, __gm__ int32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1502.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ int8_t* dst, __gm__ int8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1497.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ uint16_t* dst, __gm__ uint16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1500.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ uint32_t* dst, __gm__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1503.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align(__cbuf__ uint8_t* dst, __gm__ uint8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1498.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_align_v2`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:971`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ bfloat16_t *dst_addr, __gm__ bfloat16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1073.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ bfloat16_t *dst_addr, __gm__ bfloat16_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1078.
+      - Parameter packing: Header packing comment: `/* #595 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float *dst_addr, __gm__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1123.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float *dst_addr, __gm__ float *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1128.
+      - Parameter packing: Header packing comment: `/* #619 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float8_e4m3_t *dst_addr, __gm__ float8_e4m3_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1083.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float8_e4m3_t *dst_addr, __gm__ float8_e4m3_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1088.
+      - Parameter packing: Header packing comment: `/* #600 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float8_e5m2_t *dst_addr, __gm__ float8_e5m2_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1093.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float8_e5m2_t *dst_addr, __gm__ float8_e5m2_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1098.
+      - Parameter packing: Header packing comment: `/* #604 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float8_e8m0_t *dst_addr, __gm__ float8_e8m0_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1103.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float8_e8m0_t *dst_addr, __gm__ float8_e8m0_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1108.
+      - Parameter packing: Header packing comment: `/* #608 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ half *dst_addr, __gm__ half *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1113.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ half *dst_addr, __gm__ half *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1118.
+      - Parameter packing: Header packing comment: `/* #613 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ hifloat8_t *dst_addr, __gm__ hifloat8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1133.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ hifloat8_t *dst_addr, __gm__ hifloat8_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1138.
+      - Parameter packing: Header packing comment: `/* #624 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int16_t *dst_addr, __gm__ int16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1143.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int16_t *dst_addr, __gm__ int16_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1148.
+      - Parameter packing: Header packing comment: `/* #629 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int32_t *dst_addr, __gm__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1153.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int32_t *dst_addr, __gm__ int32_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1158.
+      - Parameter packing: Header packing comment: `/* #637 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int8_t *dst_addr, __gm__ int8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1163.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int8_t *dst_addr, __gm__ int8_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1168.
+      - Parameter packing: Header packing comment: `/* #645 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint16_t *dst_addr, __gm__ uint16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1173.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint16_t *dst_addr, __gm__ uint16_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1178.
+      - Parameter packing: Header packing comment: `/* #653 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint32_t *dst_addr, __gm__ uint32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1183.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint32_t *dst_addr, __gm__ uint32_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1188.
+      - Parameter packing: Header packing comment: `/* #659 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint8_t *dst_addr, __gm__ uint8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1193.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint8_t *dst_addr, __gm__ uint8_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1198.
+      - Parameter packing: Header packing comment: `/* #665 */ __builtin_cce_copy_gm_to_cbuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ bfloat16_t * dst_addr, __gm__ bfloat16_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2672; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2675.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ bfloat16_t * dst_addr, __gm__ bfloat16_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2678; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2681.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float * dst_addr, __gm__ float * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2696; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2699.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ float * dst_addr, __gm__ float * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2702; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2705.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ fp8_e4m3fn_t * dst_addr, __gm__ fp8_e4m3fn_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2792; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2795.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ fp8_e4m3fn_t * dst_addr, __gm__ fp8_e4m3fn_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2798; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2801.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ fp8_e5m2_t * dst_addr, __gm__ fp8_e5m2_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2780; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2783.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ fp8_e5m2_t * dst_addr, __gm__ fp8_e5m2_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2786; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2789.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ half * dst_addr, __gm__ half * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2684; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2687.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ half * dst_addr, __gm__ half * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2690; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2693.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ half* dst, __gm__ half* src, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2828; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2831.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ hifloat8_t * dst_addr, __gm__ hifloat8_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2804; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2807.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ hifloat8_t * dst_addr, __gm__ hifloat8_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2810; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2813.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int16_t * dst_addr, __gm__ int16_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2708; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2711.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int16_t * dst_addr, __gm__ int16_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2714; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2717.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int32_t * dst_addr, __gm__ int32_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2720; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2723.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int32_t * dst_addr, __gm__ int32_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2726; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2729.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int8_t* dst, __gm__ int8_t* src, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2834; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2837.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int8_t* dst_addr, __gm__ int8_t* src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2732; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2735.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ int8_t* dst_addr, __gm__ int8_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2738; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2741.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint16_t * dst_addr, __gm__ uint16_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2744; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2747.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint16_t * dst_addr, __gm__ uint16_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2750; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2753.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint16_t* tag1, __gm__ uint16_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2846; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2849.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint32_t * dst_addr, __gm__ uint32_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2756; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2759.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint32_t * dst_addr, __gm__ uint32_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2762; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2765.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint32_t* dst, __gm__ uint32_t* src, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2816; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2819.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint8_t* dst, __gm__ uint8_t* src, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2822; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2825.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint8_t* dst_addr, __gm__ uint8_t* src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2768; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2771.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint8_t* dst_addr, __gm__ uint8_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2774; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2777.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_align_v2(__cbuf__ uint8_t* tag1, __gm__ uint8_t* tag2, int tag3, const uint16_t tag4, uint32_t tag5, uint32_t tag6, uint64_t tag7);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2840; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2843.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_multi_dn2nz`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:973`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ bfloat16_t *dst_addr, __gm__ bfloat16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1203.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ bfloat16_t *dst_addr, __gm__ bfloat16_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1208.
+      - Parameter packing: Header packing comment: `/* #670 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float *dst_addr, __gm__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1253.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float *dst_addr, __gm__ float *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1258.
+      - Parameter packing: Header packing comment: `/* #692 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float8_e4m3_t *dst_addr, __gm__ float8_e4m3_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1213.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float8_e4m3_t *dst_addr, __gm__ float8_e4m3_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1218.
+      - Parameter packing: Header packing comment: `/* #674 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float8_e5m2_t *dst_addr, __gm__ float8_e5m2_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1223.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float8_e5m2_t *dst_addr, __gm__ float8_e5m2_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1228.
+      - Parameter packing: Header packing comment: `/* #678 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float8_e8m0_t *dst_addr, __gm__ float8_e8m0_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1233.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float8_e8m0_t *dst_addr, __gm__ float8_e8m0_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1238.
+      - Parameter packing: Header packing comment: `/* #682 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ half *dst_addr, __gm__ half *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1243.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ half *dst_addr, __gm__ half *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1248.
+      - Parameter packing: Header packing comment: `/* #686 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ hifloat8_t *dst_addr, __gm__ hifloat8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1263.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ hifloat8_t *dst_addr, __gm__ hifloat8_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1268.
+      - Parameter packing: Header packing comment: `/* #698 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int16_t *dst_addr, __gm__ int16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1273.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int16_t *dst_addr, __gm__ int16_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1278.
+      - Parameter packing: Header packing comment: `/* #702 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int32_t *dst_addr, __gm__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1283.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int32_t *dst_addr, __gm__ int32_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1288.
+      - Parameter packing: Header packing comment: `/* #706 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int8_t *dst_addr, __gm__ int8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1293.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int8_t *dst_addr, __gm__ int8_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1298.
+      - Parameter packing: Header packing comment: `/* #710 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint16_t *dst_addr, __gm__ uint16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1303.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint16_t *dst_addr, __gm__ uint16_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1308.
+      - Parameter packing: Header packing comment: `/* #716 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint32_t *dst_addr, __gm__ uint32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1313.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint32_t *dst_addr, __gm__ uint32_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1318.
+      - Parameter packing: Header packing comment: `/* #720 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint8_t *dst_addr, __gm__ uint8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1323.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint8_t *dst_addr, __gm__ uint8_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1328.
+      - Parameter packing: Header packing comment: `/* #724 */ __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctl & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ bfloat16_t* dst, __gm__ bfloat16_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1337; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1340.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ bfloat16_t* dst_addr, __gm__ bfloat16_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1343; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1346.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float* dst, __gm__ float* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1361; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1364.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ float* dst_addr, __gm__ float* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1367; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1370.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ fp8_e4m3fn_t* dst, __gm__ fp8_e4m3fn_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1397; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1400.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ fp8_e4m3fn_t* dst_addr, __gm__ fp8_e4m3fn_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1403; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1406.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ fp8_e5m2_t* dst, __gm__ fp8_e5m2_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1409; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1412.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ fp8_e5m2_t* dst_addr, __gm__ fp8_e5m2_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1415; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1418.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ half* dst, __gm__ half* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1349; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1352.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ half* dst_addr, __gm__ half* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1355; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1358.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ hifloat8_t* dst, __gm__ hifloat8_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1421; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1424.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ hifloat8_t* dst_addr, __gm__ hifloat8_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1427; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1430.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int16_t* dst, __gm__ int16_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1433; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1436.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int16_t* dst_addr, __gm__ int16_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1439; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1442.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int32_t* dst, __gm__ int32_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1457; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1460.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int32_t* dst_addr, __gm__ int32_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1463; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1466.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int8_t* dst, __gm__ int8_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1373; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1376.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ int8_t* dst_addr, __gm__ int8_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1379; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1382.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint16_t* dst, __gm__ uint16_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1445; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1448.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint16_t* dst_addr, __gm__ uint16_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1451; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1454.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint32_t* dst, __gm__ uint32_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1469; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1472.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint32_t* dst_addr, __gm__ uint32_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1475; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1478.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint8_t* dst, __gm__ uint8_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1385; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1388.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_dn2nz(__cbuf__ uint8_t* dst_addr, __gm__ uint8_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1391; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1394.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_multi_nd2nz`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:975`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ bfloat16_t *dst, __gm__ bfloat16_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1333.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ bfloat16_t *dst_addr, __gm__ bfloat16_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1338.
+      - Parameter packing: Header packing comment: `/* #730 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float *dst, __gm__ float *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1383.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float *dst_addr, __gm__ float *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1388.
+      - Parameter packing: Header packing comment: `/* #759 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float8_e4m3_t *dst, __gm__ float8_e4m3_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1343.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float8_e4m3_t *dst_addr, __gm__ float8_e4m3_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1348.
+      - Parameter packing: Header packing comment: `/* #736 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float8_e5m2_t *dst, __gm__ float8_e5m2_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1353.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float8_e5m2_t *dst_addr, __gm__ float8_e5m2_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1358.
+      - Parameter packing: Header packing comment: `/* #741 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float8_e8m0_t *dst, __gm__ float8_e8m0_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1363.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float8_e8m0_t *dst_addr, __gm__ float8_e8m0_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1368.
+      - Parameter packing: Header packing comment: `/* #746 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ half *dst, __gm__ half *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1373.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ half *dst_addr, __gm__ half *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1378.
+      - Parameter packing: Header packing comment: `/* #751 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ hifloat8_t *dst, __gm__ hifloat8_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1393.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ hifloat8_t *dst_addr, __gm__ hifloat8_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1398.
+      - Parameter packing: Header packing comment: `/* #766 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int16_t *dst, __gm__ int16_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1403.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int16_t *dst_addr, __gm__ int16_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1408.
+      - Parameter packing: Header packing comment: `/* #772 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int32_t *dst, __gm__ int32_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1413.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int32_t *dst_addr, __gm__ int32_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1418.
+      - Parameter packing: Header packing comment: `/* #778 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int8_t *dst, __gm__ int8_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1423.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int8_t *dst_addr, __gm__ int8_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1428.
+      - Parameter packing: Header packing comment: `/* #783 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint16_t *dst, __gm__ uint16_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1433.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint16_t *dst_addr, __gm__ uint16_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1438.
+      - Parameter packing: Header packing comment: `/* #791 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint32_t *dst, __gm__ uint32_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1443.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint32_t *dst_addr, __gm__ uint32_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1448.
+      - Parameter packing: Header packing comment: `/* #797 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint8_t *dst, __gm__ uint8_t *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1453.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint8_t *dst_addr, __gm__ uint8_t *src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctrl_mode, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1458.
+      - Parameter packing: Header packing comment: `/* #802 */ __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(dst_addr, src_addr, ((sid & 0xf) << 0 | (loop1_src_stride & 0xffffffffff) << 4 | (l2_cache_ctrl_mode & 0xf) << 44 | (n_value & 0xffff) << 48), ((d_value & 0x1fffff) << 0 | (loop4_src_stride & 0xffffffffff) << 21 | (smallc0_en & 0x1) << 61))`
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ bfloat16_t* dst, __gm__ bfloat16_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1205; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1208.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ bfloat16_t* dst_addr, __gm__ bfloat16_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1211; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1214.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float* dst, __gm__ float* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1217; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1220.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ float* dst_addr, __gm__ float* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1223; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1226.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ fp8_e4m3fn_t* dst, __gm__ fp8_e4m3fn_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1313; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1316.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ fp8_e4m3fn_t* dst_addr, __gm__ fp8_e4m3fn_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1319; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1322.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ fp8_e5m2_t* dst, __gm__ fp8_e5m2_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1301; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1304.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ fp8_e5m2_t* dst_addr, __gm__ fp8_e5m2_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1307; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1310.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ half* dst, __gm__ half* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1193; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1196.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ half* dst_addr, __gm__ half* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1199; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1202.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ hifloat8_t* dst, __gm__ hifloat8_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1325; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1328.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ hifloat8_t* dst_addr, __gm__ hifloat8_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1331; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1334.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int16_t* dst, __gm__ int16_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1229; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1232.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int16_t* dst_addr, __gm__ int16_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1235; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1238.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int32_t* dst, __gm__ int32_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1253; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1256.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int32_t* dst_addr, __gm__ int32_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1259; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1262.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int8_t* dst, __gm__ int8_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1241; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1244.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ int8_t* dst_addr, __gm__ int8_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1247; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1250.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint16_t* dst, __gm__ uint16_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1265; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1268.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint16_t* dst_addr, __gm__ uint16_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1271; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1274.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint32_t* dst, __gm__ uint32_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1289; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1292.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint32_t* dst_addr, __gm__ uint32_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1295; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1298.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint8_t* dst, __gm__ uint8_t* src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1277; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1280.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz(__cbuf__ uint8_t* dst_addr, __gm__ uint8_t* src_addr, uint8_t sid, uint64_t loop1_src_stride, uint8_t l2_cache_ctl, uint16_t n_value, uint32_t d_value, uint64_t loop4_src_stride, bool smallc0_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1283; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1286.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:977`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ bfloat16_t* dst, __gm__ bfloat16_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1143.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ bfloat16_t* dst, __gm__ bfloat16_t* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1144.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ half* dst, __gm__ half* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1141.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ half* dst, __gm__ half* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1142.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ int16_t* dst, __gm__ int16_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1145.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ int16_t* dst, __gm__ int16_t* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1146.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ uint16_t* dst, __gm__ uint16_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1147.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b16(__cbuf__ uint16_t* dst, __gm__ uint16_t* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1148.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b32s`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:979`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b32s(__cbuf__ float* dst, __gm__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1149.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b32s(__cbuf__ float* dst, __gm__ float* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1150.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b32s(__cbuf__ int32_t* dst, __gm__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1151.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b32s(__cbuf__ int32_t* dst, __gm__ int32_t* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1152.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b32s(__cbuf__ uint32_t* dst, __gm__ uint32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1153.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b32s(__cbuf__ uint32_t* dst, __gm__ uint32_t* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1154.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b8`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:981`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b8(__cbuf__ int8_t* dst, __gm__ int8_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1155.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b8(__cbuf__ int8_t* dst, __gm__ int8_t* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1156.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b8(__cbuf__ uint8_t* dst, __gm__ uint8_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1157.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_cbuf_multi_nd2nz_b8(__cbuf__ uint8_t* dst, __gm__ uint8_t* src, uint8_t sid, uint16_t ndNum, uint16_t nValue, uint16_t dValue, uint16_t srcNdMatrixStride, uint16_t srcDValue, uint16_t dstNzC0Stride, uint16_t dstNzNStride, uint16_t dstNzMatrixStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1158.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_cbuf_v2`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:983`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_cbuf_v2(__cbuf__ void *dst, __gm__ void *src, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1463.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_cbuf_v2(__cbuf__ void *dst, __gm__ void *src, uint8_t sid, uint32_t nBurst, uint32_t lenBurst, uint8_t padFUncMode, uint8_t l2Ctrl, uint64_t srcStride, uint32_t dstStride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1468.
+      - Parameter packing: Header packing comment: `/* #824 */ __builtin_cce_copy_gm_to_cbuf_v2(dst, src, ((sid & 0xf) << 0 | (nBurst & 0x1ffff) << 4 | (lenBurst & 0x1ffff) << 25 | (padFUncMode & 0xf) << 56 | (l2Ctrl & 0xf) << 60), ((srcStride & 0xfffffffff) << 0 | (dstStride & 0x1ffff) << 40))`
+
+- `__builtin_cce_copy_gm_to_ubuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:985`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.MOV.OUT.TO.UB`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.MOV.OUT.TO.UB(ptr addrspace(6) nocapture writeonly, ptr addrspace(1) nocapture readonly, i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.MOV.OUT.TO.UB(ptr addrspace(6) null, ptr addrspace(1) null, i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf(__ubuf__ void* dst, __gm__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1481.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf(__ubuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1482.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_align`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:987`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ float* dst, __gm__ float* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1496.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ half* dst, __gm__ half* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1493.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ int16_t* dst, __gm__ int16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1491.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ int32_t* dst, __gm__ int32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1494.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ int8_t* dst, __gm__ int8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1489.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ uint16_t* dst, __gm__ uint16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1492.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ uint32_t* dst, __gm__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1495.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align(__ubuf__ uint8_t* dst, __gm__ uint8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1490.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_align_b16`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:989`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_align_b16(__ubuf__ void* dst, __gm__ void* src, uint64_t config, uint64_t gapConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1483.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_b16(__ubuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1484.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_align_b32`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:991`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_align_b32(__ubuf__ void* dst, __gm__ void* src, uint64_t config, uint64_t gapConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1485.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_b32(__ubuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1486.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_align_b8`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:993`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_align_b8(__ubuf__ void* dst, __gm__ void* src, uint64_t config, uint64_t gapConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1487.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_b8(__ubuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1488.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_align_v2`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:997`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ bfloat16_t *dst_addr, __gm__ bfloat16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1473.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ bfloat16_t *dst_addr, __gm__ bfloat16_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1478.
+      - Parameter packing: Header packing comment: `/* #881 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float *dst_addr, __gm__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1523.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float *dst_addr, __gm__ float *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1528.
+      - Parameter packing: Header packing comment: `/* #905 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float8_e4m3_t *dst_addr, __gm__ float8_e4m3_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1483.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float8_e4m3_t *dst_addr, __gm__ float8_e4m3_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1488.
+      - Parameter packing: Header packing comment: `/* #886 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float8_e5m2_t *dst_addr, __gm__ float8_e5m2_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1493.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float8_e5m2_t *dst_addr, __gm__ float8_e5m2_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1498.
+      - Parameter packing: Header packing comment: `/* #890 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float8_e8m0_t *dst_addr, __gm__ float8_e8m0_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1503.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float8_e8m0_t *dst_addr, __gm__ float8_e8m0_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1508.
+      - Parameter packing: Header packing comment: `/* #894 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ half *dst_addr, __gm__ half *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1513.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ half *dst_addr, __gm__ half *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1518.
+      - Parameter packing: Header packing comment: `/* #899 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ hifloat8_t *dst_addr, __gm__ hifloat8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1533.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ hifloat8_t *dst_addr, __gm__ hifloat8_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1538.
+      - Parameter packing: Header packing comment: `/* #910 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int16_t *dst_addr, __gm__ int16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1543.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int16_t *dst_addr, __gm__ int16_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1548.
+      - Parameter packing: Header packing comment: `/* #915 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int32_t *dst_addr, __gm__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1553.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int32_t *dst_addr, __gm__ int32_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1558.
+      - Parameter packing: Header packing comment: `/* #923 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int8_t *dst_addr, __gm__ int8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1563.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int8_t *dst_addr, __gm__ int8_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1568.
+      - Parameter packing: Header packing comment: `/* #931 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint16_t *dst_addr, __gm__ uint16_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1573.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint16_t *dst_addr, __gm__ uint16_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1578.
+      - Parameter packing: Header packing comment: `/* #939 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint32_t *dst_addr, __gm__ uint32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1583.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint32_t *dst_addr, __gm__ uint32_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1588.
+      - Parameter packing: Header packing comment: `/* #945 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint8_t *dst_addr, __gm__ uint8_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1593.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint8_t *dst_addr, __gm__ uint8_t *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1598.
+      - Parameter packing: Header packing comment: `/* #951 */ __builtin_cce_copy_gm_to_ubuf_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (left_padding_count & 0x3f) << 46 | (right_padding_count & 0x3f) << 52 | (data_select_bit & 0x1) << 58 | (l2_cache_ctl & 0xf) << 60), ((burst_src_stride & 0xffffffffff) << 0 | (burst_dst_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ bfloat16_t * dst_addr, __gm__ bfloat16_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2900; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2903.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ bfloat16_t * dst_addr, __gm__ bfloat16_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2906; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2909.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float * dst_addr, __gm__ float * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2936; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2939.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float * dst_addr, __gm__ float * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2942; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2945.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ float* dst_addr, __gm__ float* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2930; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2933.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ fp8_e4m3fn_t * dst_addr, __gm__ fp8_e4m3fn_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3068; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3071.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ fp8_e4m3fn_t * dst_addr, __gm__ fp8_e4m3fn_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3074; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3077.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ fp8_e5m2_t * dst_addr, __gm__ fp8_e5m2_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3056; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3059.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ fp8_e5m2_t * dst_addr, __gm__ fp8_e5m2_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3062; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3065.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ half * dst_addr, __gm__ half * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2918; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2921.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ half * dst_addr, __gm__ half * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2924; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2927.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ half* dst_addr, __gm__ half* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2912; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2915.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ hifloat8_t * dst_addr, __gm__ hifloat8_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3080; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3083.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ hifloat8_t * dst_addr, __gm__ hifloat8_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3086; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3089.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int16_t * dst_addr, __gm__ int16_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2954; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2957.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int16_t * dst_addr, __gm__ int16_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2960; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2963.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int16_t* dst_addr, __gm__ int16_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2948; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2951.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int32_t * dst_addr, __gm__ int32_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2972; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2975.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int32_t * dst_addr, __gm__ int32_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2978; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2981.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int32_t* dst_addr, __gm__ int32_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2966; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2969.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int8_t* dst_addr, __gm__ int8_t* src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2990; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2993.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int8_t* dst_addr, __gm__ int8_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2996; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2999.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ int8_t* dst_addr, __gm__ int8_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2984; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2987.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint16_t * dst_addr, __gm__ uint16_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3008; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3011.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint16_t * dst_addr, __gm__ uint16_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3014; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3017.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint16_t* dst_addr, __gm__ uint16_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3002; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3005.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint32_t * dst_addr, __gm__ uint32_t * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3026; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3029.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint32_t * dst_addr, __gm__ uint32_t * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3032; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3035.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint32_t* dst_addr, __gm__ uint32_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3020; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3023.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint8_t* dst_addr, __gm__ uint8_t* src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3044; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3047.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint8_t* dst_addr, __gm__ uint8_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool constant_padding_ctl, uint8_t l2_cache_ctl, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3050; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3053.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ uint8_t* dst_addr, __gm__ uint8_t* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3038; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3041.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ void* dst_addr, __gm__ void* src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3098; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3101.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_align_v2(__ubuf__ void* dst_addr, __gm__ void* src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t left_padding_count, uint8_t right_padding_count, bool data_select_bit, uint64_t burst_src_stride, uint32_t burst_dst_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3092; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:3095.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_pad_b16`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:999`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_pad_b16(__ubuf__ void* dst, __gm__ void* src, uint64_t config, uint64_t paddingConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1505.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_pad_b16(__ubuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, uint8_t leftPaddingNum, uint8_t rightPaddingNum);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1506.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_pad_b32`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1001`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_pad_b32(__ubuf__ void* dst, __gm__ void* src, uint64_t config, uint64_t paddingConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1507.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_pad_b32(__ubuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, uint8_t leftPaddingNum, uint8_t rightPaddingNum);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1508.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_gm_to_ubuf_pad_b8`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1003`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_gm_to_ubuf_pad_b8(__ubuf__ void* dst, __gm__ void* src, uint64_t config, uint64_t paddingConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1509.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_gm_to_ubuf_pad_b8(__ubuf__ void* dst, __gm__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, uint8_t leftPaddingNum, uint8_t rightPaddingNum);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1510.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cbuf_to_cc`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1005`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ bfloat16_t* dst, __cbuf__ bfloat16_t* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1516.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ bfloat16_t* dst, __cbuf__ bfloat16_t* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1515.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ bfloat16_t* dst, __cbuf__ float* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1518.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ bfloat16_t* dst, __cbuf__ float* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1517.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ float* dst, __cbuf__ float* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1520.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ float* dst, __cbuf__ float* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1519.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ half* dst, __cbuf__ float* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1514.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ half* dst, __cbuf__ float* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1513.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ half* dst, __cbuf__ half* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1512.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ half* dst, __cbuf__ half* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1511.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ int32_t* dst, __cbuf__ int32_t* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1522.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ int32_t* dst, __cbuf__ int32_t* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1521.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ uint32_t* dst, __cbuf__ uint32_t* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1524.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cbuf_to_cc(__cc__ uint32_t* dst, __cbuf__ uint32_t* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1523.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_copy_matrix_cc_to_cbuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1007`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1603.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1608.
+      - Parameter packing: Header packing comment: `/* #1007 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1683.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1688.
+      - Parameter packing: Header packing comment: `/* #1056 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1673.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1678.
+      - Parameter packing: Header packing comment: `/* #1053 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e4m3_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1623.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e4m3_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1628.
+      - Parameter packing: Header packing comment: `/* #1014 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e4m3_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1703.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e4m3_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1708.
+      - Parameter packing: Header packing comment: `/* #1072 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e5m2_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1633.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e5m2_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1638.
+      - Parameter packing: Header packing comment: `/* #1017 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e5m2_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1713.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float8_e5m2_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1718.
+      - Parameter packing: Header packing comment: `/* #1076 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1613.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1618.
+      - Parameter packing: Header packing comment: `/* #1011 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1693.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1698.
+      - Parameter packing: Header packing comment: `/* #1067 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ hifloat8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1643.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ hifloat8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1648.
+      - Parameter packing: Header packing comment: `/* #1020 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ hifloat8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1723.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ hifloat8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1728.
+      - Parameter packing: Header packing comment: `/* #1080 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int32_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1753.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int32_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1758.
+      - Parameter packing: Header packing comment: `/* #1123 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1653.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1658.
+      - Parameter packing: Header packing comment: `/* #1031 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1733.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1738.
+      - Parameter packing: Header packing comment: `/* #1100 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1663.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1668.
+      - Parameter packing: Header packing comment: `/* #1043 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1743.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1748.
+      - Parameter packing: Header packing comment: `/* #1112 */ __builtin_cce_copy_matrix_cc_to_cbuf(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t * dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2121; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2124.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1549; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1552.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1555; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1558.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ bfloat16_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2067; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2070.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1561; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1564.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1615; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1618.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1609; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1612.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ float* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2091; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2094.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ fp8_e4m3fn_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2127; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2130.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1525; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1528.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1543; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1546.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1537; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1540.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1531; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1534.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1627; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1630.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1645; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1648.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1639; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1642.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1633; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1636.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2073; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2076.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ half* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2097; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2100.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ hifloat8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2133; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2136.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int16_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1651; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1654.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int16_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1657; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1660.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int32_t * dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2115; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2118.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int32_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1621; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1624.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1717; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1720.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1711; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1714.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1567; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1570.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1585; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1588.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1579; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1582.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1573; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1576.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1663; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1666.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1681; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1684.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1675; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1678.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1669; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1672.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2079; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2082.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ int8_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2103; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2106.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1591; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1594.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1603; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1606.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1597; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1600.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1687; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1690.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1705; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1708.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1699; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1702.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1693; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1696.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2085; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2088.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf(__cbuf__ uint8_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2109; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2112.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_cbuf_b4`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1009`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_b4(__cbuf__ void* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1723.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_b4(__cbuf__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1724.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_b4(__cbuf__ void* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1725.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_b4(__cbuf__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1726.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_cbuf_s4`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1011`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1763.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1768.
+      - Parameter packing: Header packing comment: `/* #1142 */ __builtin_cce_copy_matrix_cc_to_cbuf_s4(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1773.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1778.
+      - Parameter packing: Header packing comment: `/* #1151 */ __builtin_cce_copy_matrix_cc_to_cbuf_s4(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1731.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1733.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1732.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1734.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1736.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_cbuf_s4(__cbuf__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1735.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_gm`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1013`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1783.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1788.
+      - Parameter packing: Header packing comment: `/* #1185 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1863.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1868.
+      - Parameter packing: Header packing comment: `/* #1234 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1853.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1858.
+      - Parameter packing: Header packing comment: `/* #1229 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e4m3_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1803.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e4m3_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1808.
+      - Parameter packing: Header packing comment: `/* #1192 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e4m3_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1883.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e4m3_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1888.
+      - Parameter packing: Header packing comment: `/* #1250 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e5m2_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1813.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e5m2_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1818.
+      - Parameter packing: Header packing comment: `/* #1195 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e5m2_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1893.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float8_e5m2_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1898.
+      - Parameter packing: Header packing comment: `/* #1254 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1793.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1798.
+      - Parameter packing: Header packing comment: `/* #1189 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1873.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1878.
+      - Parameter packing: Header packing comment: `/* #1245 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ hifloat8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1823.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ hifloat8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1828.
+      - Parameter packing: Header packing comment: `/* #1198 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ hifloat8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1903.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ hifloat8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1908.
+      - Parameter packing: Header packing comment: `/* #1258 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int32_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1933.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int32_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1938.
+      - Parameter packing: Header packing comment: `/* #1300 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1833.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1838.
+      - Parameter packing: Header packing comment: `/* #1208 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1913.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1918.
+      - Parameter packing: Header packing comment: `/* #1277 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1843.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1848.
+      - Parameter packing: Header packing comment: `/* #1219 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1923.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1928.
+      - Parameter packing: Header packing comment: `/* #1289 */ __builtin_cce_copy_matrix_cc_to_gm(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t * dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2019; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2022.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1941; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1944.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1953; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1956.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1947; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1950.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ bfloat16_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1965; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1968.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1761; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1764.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1827; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1830.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1821; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1824.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1815; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1818.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ float* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1989; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1992.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ fp8_e4m3fn_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2025; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2028.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1737; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1740.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1755; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1758.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1749; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1752.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1743; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1746.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ half* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2037; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2040.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1839; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1842.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1857; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1860.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1851; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1854.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1845; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1848.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1971; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1974.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ half* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1995; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1998.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ hifloat8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2031; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2034.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int16_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1863; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1866.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int16_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1869; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1872.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int16_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1959; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1962.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int32_t * dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2013; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2016.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int32_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1833; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1836.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1935; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1938.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1929; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1932.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1923; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1926.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1767; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1770.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1785; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1788.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1779; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1782.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1773; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1776.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1875; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1878.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1893; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1896.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1887; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1890.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1881; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1884.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1977; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1980.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ int8_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2001; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2004.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1791; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1794.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1809; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1812.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1803; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1806.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1797; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1800.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1899; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1902.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1917; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1920.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1911; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1914.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1905; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1908.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1983; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:1986.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm(__gm__ uint8_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2007; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2010.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_gm_b4`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1015`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_gm_b4(__gm__ void* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2283.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_b4(__gm__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2284.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_b4(__gm__ void* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2285.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_b4(__gm__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2286.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_gm_s4`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1017`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1943.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1948.
+      - Parameter packing: Header packing comment: `/* #1319 */ __builtin_cce_copy_matrix_cc_to_gm_s4(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1953.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t l2_cache_ctl, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1958.
+      - Parameter packing: Header packing comment: `/* #1328 */ __builtin_cce_copy_matrix_cc_to_gm_s4(dst_addr, src_addr, ((sid & 0xf) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (l2_cache_ctl & 0xf) << 16 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2291.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2293.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2292.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2294.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2296.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_gm_s4(__gm__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2295.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_ub`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1019`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.FIX.L0C.TO.UB.f2h.ELEWISE`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.FIX.L0C.TO.UB.f2h.ELEWISE(ptr addrspace(6) nocapture writeonly, ptr addrspace(5) nocapture readonly, i64, i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.FIX.L0C.TO.UB.f2h.ELEWISE(ptr addrspace(6) null, ptr addrspace(5) null, i64 1, i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1963.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1968.
+      - Parameter packing: Header packing comment: `/* #1358 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2043.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2048.
+      - Parameter packing: Header packing comment: `/* #1402 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2033.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2038.
+      - Parameter packing: Header packing comment: `/* #1399 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e4m3_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1983.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e4m3_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1988.
+      - Parameter packing: Header packing comment: `/* #1364 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e4m3_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2063.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e4m3_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2068.
+      - Parameter packing: Header packing comment: `/* #1416 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e5m2_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1993.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e5m2_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1998.
+      - Parameter packing: Header packing comment: `/* #1367 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e5m2_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2073.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float8_e5m2_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2078.
+      - Parameter packing: Header packing comment: `/* #1420 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1973.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:1978.
+      - Parameter packing: Header packing comment: `/* #1361 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2053.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2058.
+      - Parameter packing: Header packing comment: `/* #1412 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ hifloat8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2003.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ hifloat8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2008.
+      - Parameter packing: Header packing comment: `/* #1370 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ hifloat8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2083.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ hifloat8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2088.
+      - Parameter packing: Header packing comment: `/* #1424 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int32_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2113.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int32_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2118.
+      - Parameter packing: Header packing comment: `/* #1462 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2013.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2018.
+      - Parameter packing: Header packing comment: `/* #1380 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2093.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2098.
+      - Parameter packing: Header packing comment: `/* #1442 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2023.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2028.
+      - Parameter packing: Header packing comment: `/* #1390 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2103.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2108.
+      - Parameter packing: Header packing comment: `/* #1452 */ __builtin_cce_copy_matrix_cc_to_ub(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2309; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2312.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t* dst_addr, __cc__ float* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2211; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2214.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2139; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2142.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t* dst_addr, __cc__ int32_t* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2265; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2268.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ bfloat16_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2193; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2196.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2357; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2360.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2369; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2372.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2363; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2366.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float* dst_addr, __cc__ float* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2235; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2238.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ float* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2163; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2166.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ fp8_e4m3fn_t * dst_addr, __cc__ float* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2271; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2274.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ fp8_e4m3fn_t * dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2199; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2202.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2297; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2300.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2315; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2318.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2303; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2306.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2375; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2378.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2387; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2390.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2381; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2384.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst_addr, __cc__ float* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2217; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2220.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2145; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2148.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst_addr, __cc__ int32_t* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2241; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2244.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ half* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2169; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2172.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ hifloat8_t* dst_addr, __cc__ float* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2277; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2280.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ hifloat8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2205; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2208.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2429; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2432.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2441; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2444.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2435; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2438.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int32_t* dst_addr, __cc__ int32_t* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2259; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2262.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int32_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2187; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2190.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2321; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2324.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2333; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2336.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2327; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2330.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2393; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2396.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2405; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2408.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2399; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2402.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst_addr, __cc__ float* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2223; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2226.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2151; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2154.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst_addr, __cc__ int32_t* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2247; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2250.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ int8_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2175; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2178.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2339; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2342.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2351; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2354.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2345; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2348.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2411; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2414.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2423; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2426.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2417; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2420.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst_addr, __cc__ float* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2229; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2232.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst_addr, __cc__ float* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2157; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2160.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst_addr, __cc__ int32_t* src_addr, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2253; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2256.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub(__ubuf__ uint8_t* dst_addr, __cc__ int32_t* src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_cfg, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2181; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2184.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_ub_s4`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1021`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void *dst_addr, __cc__ float *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2123.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void *dst_addr, __cc__ float *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2128.
+      - Parameter packing: Header packing comment: `/* #1477 */ __builtin_cce_copy_matrix_cc_to_ub_s4(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void *dst_addr, __cc__ int32_t *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2133.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void *dst_addr, __cc__ int32_t *src_addr, uint8_t sid, uint16_t n_size, uint16_t m_size, uint32_t loop_dst_stride, uint16_t loop_src_stride, uint8_t dual_dst_ctl, bool sub_blockid, uint8_t clip_relu_pre, uint8_t unit_flag_ctl, uint64_t quant_pre, uint8_t relu_pre, bool split_en, bool NZ2ND_en, uint64_t quant_post, uint8_t relu_post, bool clip_relu_post, bool loop_enhance_en, uint8_t eltwise_op, bool eltwise_antq_en, bool loop_enhance_merge_en, bool C0_pad_en, bool wino_post_en, bool broadcast_en, bool NZ2DN_en);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2138.
+      - Parameter packing: Header packing comment: `/* #1486 */ __builtin_cce_copy_matrix_cc_to_ub_s4(dst_addr, src_addr, ((sid & 0x) << 0 | (n_size & 0xfff) << 4 | (m_size & 0xffff) << 16 | (loop_dst_stride & 0xffffffff) << 32), ((loop_src_stride & 0xffff) << 0 | (dual_dst_ctl & 0x3) << 16 | (sub_blockid & 0x1) << 18 | (quant_pre & 0x20) << 24 | (clip_relu_pre & 0x3) << 30 | (unit_flag_ctl & 0x3) << 32 | (quant_pre & 0x1f) << 34 | (relu_pre & 0x7) << 39 | (split_en & 0x1) << 42 | (NZ2ND_en & 0x1) << 43 | (quant_post & 0x1f) << 44 | (relu_post & 0x7) << 49 | (clip_relu_post & 0x1) << 52 | (loop_enhance_en & 0x1) << 53 | (eltwise_op & 0x7) << 54 | (eltwise_antq_en & 0x1) << 57 | (loop_enhance_merge_en & 0x1) << 58 | (C0_pad_en & 0x1) << 59 | (wino_post_en & 0x1) << 60 | (broadcast_en & 0x1) << 61 | (NZ2DN_en & 0x1) << 62))`
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void* dst, __cc__ float* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2450.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2452.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void* dst, __cc__ float* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2451.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void* dst, __cc__ int32_t* src, uint64_t xm, uint64_t xt);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2453.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, QuantMode_post quant_post, uint8_t relu_post, bool clip_relu_post, uint8_t eltwiseOP, uint8_t eltwise_antq_cfg, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2455.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ub_s4(__ubuf__ void* dst, __cc__ int32_t* src, uint8_t sid, uint16_t NSize, uint16_t MSize, uint32_t dstStride_dst_D, uint16_t srcStride, uint8_t clip_relu_pre, uint8_t UnitFlagMode, QuantMode_t QuantPRE, uint8_t ReLUPRE, bool channelSplit, bool NZ2ND_EN, bool C0_Pad_EN);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2454.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_cc_to_ubuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1023`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ float* dst, __cc__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2460.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ float* dst, __cc__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2461.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2458.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2459.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2456.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2457.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2462.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2463.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ int16_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2464.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ int16_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2465.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2466.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2467.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2468.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2469.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ uint32_t* dst, __cc__ uint32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2470.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ uint32_t* dst, __cc__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2471.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2472.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_cc_to_ubuf(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2473.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_matrix_ubuf_to_cc`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1025`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ float* dst, __ubuf__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2476.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ float* dst, __ubuf__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2477.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ float* dst, __ubuf__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2478.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ float* dst, __ubuf__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2479.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ half* dst, __ubuf__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2474.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ half* dst, __ubuf__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2475.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ int32_t* dst, __ubuf__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2480.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ int32_t* dst, __ubuf__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2481.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2482.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_matrix_ubuf_to_cc(__cc__ uint32_t* dst, __ubuf__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2483.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_small_matrix_cc_to_ubuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1027`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2484.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2485.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ int16_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2486.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ int16_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2487.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2488.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2489.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2490.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2491.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ uint32_t* dst, __cc__ uint32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2492.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ uint32_t* dst, __cc__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2493.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2494.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_cc_to_ubuf(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2495.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_small_matrix_ubuf_to_cc`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1029`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_small_matrix_ubuf_to_cc(__cc__ int32_t* dst, __ubuf__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2496.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_ubuf_to_cc(__cc__ int32_t* dst, __ubuf__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2497.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_small_matrix_ubuf_to_cc(__cc__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2498.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_small_matrix_ubuf_to_cc(__cc__ uint32_t* dst, __ubuf__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2499.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_cbuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1031`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_cbuf(__cbuf__ void *dst_addr, __ubuf__ void *src_addr, bool sub_blockid, uint16_t burst_num, uint16_t burst_len, uint16_t src_gap, uint16_t dst_gap);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2148.
+      - Parameter packing: Header packing comment: `/* #1558 */ __builtin_cce_copy_ubuf_to_cbuf(dst_addr, src_addr, ((sub_blockid & 0x1) << 0 | (burst_num & 0xfff) << 4 | (burst_len & 0xffff) << 16 | (src_gap & 0xffff) << 32 | (dst_gap & 0xffff) << 48))`
+    - `void __builtin_cce_copy_ubuf_to_cbuf(__cbuf__ void *dst_addr, __ubuf__ void *src_addr, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2143.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_cbuf(__cbuf__ void* dst, __ubuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2500; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2503.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_cbuf(__cbuf__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2506; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2509.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_fbuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1033`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_fbuf(__fbuf__ void* dst, __ubuf__ void* src, CvtMode_t cvtMode, uint16_t burstNum, uint16_t burstLen, uint16_t srcGapSize, uint16_t dstGapSize);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2513.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_fbuf(__fbuf__ void* dst, __ubuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2512.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_copy_ubuf_to_gm`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1035`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.MOV.UB.TO.OUT`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.MOV.UB.TO.OUT(ptr addrspace(1) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.MOV.UB.TO.OUT(ptr addrspace(1) null, ptr addrspace(6) null, i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm(__gm__ void* dst, __ubuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2514.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm(__gm__ void* dst, __ubuf__ void* src, uint64_t config, bm_t byteMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2515.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2517.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, bm_t byteMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2516.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_align`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1037`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ float* dst, __ubuf__ float* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2531.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ half* dst, __ubuf__ half* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2528.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ int16_t* dst, __ubuf__ int16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2526.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ int32_t* dst, __ubuf__ int32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2529.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ int8_t* dst, __ubuf__ int8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2524.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2527.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ uint32_t* dst, __ubuf__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2530.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align(__gm__ uint8_t* dst, __ubuf__ uint8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2525.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_align_b16`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1039`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_align_b16(__gm__ void* dst, __ubuf__ void* src, uint64_t config, uint64_t gapConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2518.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_b16(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2519.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_align_b32`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1041`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_align_b32(__gm__ void* dst, __ubuf__ void* src, uint64_t config, uint64_t gapConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2520.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_b32(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2521.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_align_b8`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1043`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_align_b8(__gm__ void* dst, __ubuf__ void* src, uint64_t config, uint64_t gapConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2522.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_b8(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint8_t leftPaddingNum, uint8_t rightPaddingNum, uint32_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2523.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_align_v2`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1047`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ void *dst_addr, __ubuf__ void *src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2153.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ void *dst_addr, __ubuf__ void *src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t l2_cache_ctl, uint64_t burst_dst_stride, uint32_t burst_src_stride);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2158.
+      - Parameter packing: Header packing comment: `/* #1605 */ __builtin_cce_copy_ubuf_to_gm_align_v2(dst_addr, src_addr, ((sid & 0xf) << 0 | (burst_num & 0x1fffff) << 4 | (burst_len & 0x1fffff) << 25 | (l2_cache_ctl & 0xf) << 60), ((burst_dst_stride & 0xffffffffff) << 0 | (burst_src_stride & 0x1fffff) << 40))`
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ float* dst, __ubuf__ float* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2666; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2669.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ half* dst, __ubuf__ half* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2648; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2651.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ int16_t* dst, __ubuf__ int16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2636; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2639.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ int32_t* dst, __ubuf__ int32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2654; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2657.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ int8_t* dst, __ubuf__ int8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2624; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2627.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2642; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2645.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ uint32_t* dst, __ubuf__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2660; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2663.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ uint8_t* dst, __ubuf__ uint8_t* src, uint8_t sid, uint16_t nBurst, uint32_t lenBurst, uint64_t srcGap, uint32_t dstGap);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2630; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2633.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ void * dst_addr, __ubuf__ void * src_addr, uint64_t config0, uint64_t config1);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2612; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2615.
+      - Parameter packing: Direct bottom-level form: `config0, config1` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_align_v2(__gm__ void * dst_addr, __ubuf__ void * src_addr, uint8_t sid, uint32_t burst_num, uint32_t burst_len, uint8_t l2_cache_ctl, uint64_t burst_dst_stride, uint32_t burst_src_stride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2618; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2621.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_pad_b16`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1049`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_pad_b16(__gm__ void* dst, __ubuf__ void* src, uint64_t config, uint64_t paddingConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2532.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_pad_b16(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, uint8_t leftPaddingNum, uint8_t rightPaddingNum);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2533.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_pad_b32`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1051`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_pad_b32(__gm__ void* dst, __ubuf__ void* src, uint64_t config, uint64_t paddingConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2534.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_pad_b32(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, uint8_t leftPaddingNum, uint8_t rightPaddingNum);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2535.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_gm_pad_b8`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1053`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_gm_pad_b8(__gm__ void* dst, __ubuf__ void* src, uint64_t config, uint64_t paddingConfig);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2536.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_gm_pad_b8(__gm__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, uint8_t leftPaddingNum, uint8_t rightPaddingNum);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2537.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_ubuf_to_ubuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1055`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_ubuf_to_ubuf(__ubuf__ void *dst, __ubuf__ void *src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcGap, uint16_t dstGap);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2163.
+      - Parameter packing: Header packing comment: `/* #1644 */ __builtin_cce_copy_ubuf_to_ubuf(dst, src, ((dstGap & 0xffff) << 48 | (srcGap & 0xffff) << 32 | (lenBurst & 0xffff) << 16 | (nBurst & 0xffff) << 0))`
+    - `void __builtin_cce_copy_ubuf_to_ubuf(__ubuf__ void *dst, __ubuf__ void *src, uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:2168.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_ubuf(__ubuf__ void* dst, __ubuf__ void* src, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2550; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2553.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_ubuf_to_ubuf(__ubuf__ void* dst, __ubuf__ void* src, uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2538; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2541.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_ubuf_to_ubuf(__ubuf__ void* dst, __ubuf__ void* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2544; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2547.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_vector_cc_to_ubuf`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1057`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ float* dst, __cc__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2560.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ float* dst, __cc__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2561.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ half* dst, __cc__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2558.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ half* dst, __cc__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2559.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ half* dst, __cc__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2556.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ half* dst, __cc__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2557.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ half* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2562.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ half* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2563.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ int16_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2564.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ int16_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2565.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2566.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ int32_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2567.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2568.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ int8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2569.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ uint32_t* dst, __cc__ uint32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2570.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ uint32_t* dst, __cc__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2571.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2572.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_cc_to_ubuf(__ubuf__ uint8_t* dst, __cc__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2573.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+- `__builtin_cce_copy_vector_ubuf_to_cc`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:1059`
+  - Observed LLVM intrinsic names: Not captured by the partial local probe.
+  - Observed LLVM IR declarations: Not captured by the partial local probe.
+  - Complete C++ signatures:
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ float* dst, __ubuf__ float* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2576.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ float* dst, __ubuf__ float* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2577.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ float* dst, __ubuf__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2578.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ float* dst, __ubuf__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2579.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ half* dst, __ubuf__ half* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2574.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ half* dst, __ubuf__ half* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2575.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ int32_t* dst, __ubuf__ int32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2580.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ int32_t* dst, __ubuf__ int32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2581.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2582.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_copy_vector_ubuf_to_cc(__cc__ uint32_t* dst, __ubuf__ uint32_t* src, uint8_t sid, uint16_t nBurst, uint16_t lenBurst, uint16_t srcStride, uint16_t dstStride, ConvRelu_t crMode);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:2583.
+      - Parameter packing: No CANN `// ->` packing comment found for this signature in the scanned headers.
+
+## 3. Companion Set/Control Builtins
+
+- Scope: `set_*` builtins commonly paired with `copy*` DMA flows for loop sizing/striding, ND-DMA padding/parameters, and fixpipe/fix-state configuration.
+- Excluded here: vector mask controls such as `set_vector_mask`, `set_mask_count`, `set_mask_norm`, and `set_cmpmask`; those are documented with vector builtins in `a2a3-vector-builtins.md`.
+- Companion control count: 58 builtin names and 65 complete C++ signatures.
+- LLVM IR probe coverage: 41 of 65 signatures captured device LLVM IR; 35 builtin names have at least one captured LLVM intrinsic; 38 unique LLVM intrinsic names were observed.
+- The listed LLVM IR declarations and actual probe calls are exact lines from the captured `.ll` files. For uncaptured entries, this section intentionally leaves the IR signature absent instead of deriving one from the C++ signature.
+- `Not captured` means the local target sweep rejected the signature for the tested targets. The C++ signature and CANN packing/ASM comment remain header-derived.
+- For `set_*` entries whose CANN header only says `ASM: MOV <REGISTER>, config`, the bottom-level C++ parameter is already the register/control payload. The header does not expose a higher-level bitfield pack unless a separate `// ->` line is listed under that exact signature.
+
+- `__builtin_cce_set_cube_stride_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2037`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_cube_stride_para(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6892.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_deqscale`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2047`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.DEQSCALE.h`
+    - `llvm.hivm.SET.DEQSCALE.i`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.DEQSCALE.h(half) #1`
+    - `declare void @llvm.hivm.SET.DEQSCALE.i(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.DEQSCALE.h(half 0xH3C00)`
+    - `call void @llvm.hivm.SET.DEQSCALE.i(i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_deqscale(half config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6705.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_set_deqscale(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6706.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_elt_antiq_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:805`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.ELT.ANTIQ.PARA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.ELT.ANTIQ.PARA(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.ELT.ANTIQ.PARA(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_elt_antiq_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4159; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6707.
+      - Parameter packing: Direct control form; header operation comment: `MOV		ELT_ANTIQ_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_elt_src_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:807`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.ELT.SRC.PARA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.ELT.SRC.PARA(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.ELT.SRC.PARA(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_elt_src_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4164; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6709.
+      - Parameter packing: Direct control form; header operation comment: `MOV		ELT_SRC_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_fcol2img`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2055`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.FCOL2IMG`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.FCOL2IMG(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.FCOL2IMG(i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fcol2img(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6712.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_fix_clip_relu`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:811`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.FIX.CLIP.RELU`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.FIX.CLIP.RELU(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.FIX.CLIP.RELU(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fix_clip_relu(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4174; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6714.
+      - Parameter packing: Direct control form; header operation comment: `MOV		FIX_CLIP_RELU, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_fixp_addr`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:813`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.FIXP.ADDR`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.FIXP.ADDR(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.FIXP.ADDR(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fixp_addr(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4179; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6715.
+      - Parameter packing: Direct control form; header operation comment: `MOV		FIXP_ADDR, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_fixp_nz_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2063`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fixp_nz_para(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:20470.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_fm_step_pos`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2067`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fm_step_pos(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6862.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_fmatrix`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:817`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.FMATRIX`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.FMATRIX(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.FMATRIX(i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fmatrix(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4194; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6740; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6743.
+      - Parameter packing: Direct control form; header operation comment: `MOV		FMATRIX, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_fmatrix_b`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:819`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.FMATRIX.B`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.FMATRIX.B(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.FMATRIX.B(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fmatrix_b(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4199; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6747; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6750.
+      - Parameter packing: Direct control form; header operation comment: `MOV		FMATRIX_B, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_fmatrix_dual_0`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2073`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fmatrix_dual_0(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6753.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_fmatrix_dual_1`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2075`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fmatrix_dual_1(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6754.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_fpc`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:821`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.FPC`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.FPC(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.FPC(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fpc(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4204; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6757; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6760.
+      - Parameter packing: Direct control form; header operation comment: `MOV		FPC, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_fpdeq`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2085`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_fpdeq(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6764.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_kernel`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2143`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_kernel(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6893.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_loop0_stride_nddma`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:837`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP0.STRIDE.NDDMA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP0.STRIDE.NDDMA(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP0.STRIDE.NDDMA(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop0_stride_nddma(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4279; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19564; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19567.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP0_STRIDE_NDDMA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop1_stride_l1toout`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:839`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop1_stride_l1toout(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4284.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP1_STRIDE_L1TOOUT, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop1_stride_nddma`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:841`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP1.STRIDE.NDDMA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP1.STRIDE.NDDMA(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP1.STRIDE.NDDMA(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop1_stride_nddma(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4289; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19570; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19573.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP1_STRIDE_NDDMA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop1_stride_outtol1`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:843`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop1_stride_outtol1(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4294; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19534; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19537.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP1_STRIDE_OUTTOL1, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop1_stride_outtoub`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:845`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP1.STRIDE.OUTTOUB`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP1.STRIDE.OUTTOUB(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP1.STRIDE.OUTTOUB(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop1_stride_outtoub(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4299; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19516; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19519.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP1_STRIDE_OUTTOUB, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop1_stride_ubtoout`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:847`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP1.STRIDE.UBTOOUT`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP1.STRIDE.UBTOOUT(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP1.STRIDE.UBTOOUT(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop1_stride_ubtoout(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4304; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19552; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19555.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP1_STRIDE_UBTOOUT, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop2_stride_l1toout`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:849`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop2_stride_l1toout(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4309.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP2_STRIDE_L1TOOUT, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop2_stride_nddma`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:851`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP2.STRIDE.NDDMA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP2.STRIDE.NDDMA(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP2.STRIDE.NDDMA(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop2_stride_nddma(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4314; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19576; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19579.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP2_STRIDE_NDDMA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop2_stride_outtol1`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:853`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop2_stride_outtol1(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4319; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19540; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19543.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP2_STRIDE_OUTTOL1, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop2_stride_outtoub`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:855`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP2.STRIDE.OUTTOUB`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP2.STRIDE.OUTTOUB(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP2.STRIDE.OUTTOUB(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop2_stride_outtoub(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4324; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19522; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19525.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP2_STRIDE_OUTTOUB, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop2_stride_ubtoout`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:857`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP2.STRIDE.UBTOOUT`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP2.STRIDE.UBTOOUT(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP2.STRIDE.UBTOOUT(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop2_stride_ubtoout(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4329; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19558; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19561.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP2_STRIDE_UBTOOUT, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop3_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:859`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP3.PARA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP3.PARA(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP3.PARA(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop3_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4334; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6795; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6798.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP3_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop3_stride_nddma`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:861`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP3.STRIDE.NDDMA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP3.STRIDE.NDDMA(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP3.STRIDE.NDDMA(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop3_stride_nddma(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4339; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19582; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19585.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP3_STRIDE_NDDMA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop4_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:863`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop4_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4344; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:20453.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP4_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop4_stride_nddma`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:865`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP4.STRIDE.NDDMA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP4.STRIDE.NDDMA(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP4.STRIDE.NDDMA(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop4_stride_nddma(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4349; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19588; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19591.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP4_STRIDE_NDDMA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop_size_l1toout`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:867`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop_size_l1toout(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4354.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP_SIZE_L1TOOUT, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop_size_outtol1`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:869`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop_size_outtol1(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4359; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19528; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19531.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP_SIZE_OUTTOL1, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop_size_outtoub`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:871`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP.SIZE.OUTTOUB`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP.SIZE.OUTTOUB(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP.SIZE.OUTTOUB(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop_size_outtoub(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4364; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19510; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19513.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP_SIZE_OUTTOUB, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_loop_size_ubtoout`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:873`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LOOP.SIZE.UBTOOUT`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LOOP.SIZE.UBTOOUT(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LOOP.SIZE.UBTOOUT(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_loop_size_ubtoout(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4369; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19546; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19549.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LOOP_SIZE_UBTOOUT, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_lrelu_alpha`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:875`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.LRELU.ALPHA.f32`
+    - `llvm.hivm.SET.LRELU.ALPHA.f16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.LRELU.ALPHA.f32(float) #1`
+    - `declare void @llvm.hivm.SET.LRELU.ALPHA.f16(half) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.LRELU.ALPHA.f32(float 1.000000e+00)`
+    - `call void @llvm.hivm.SET.LRELU.ALPHA.f16(half 0xH3C00)`
+  - Probe targets used: `dav-m200`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_lrelu_alpha(float config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4379; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6805.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LRELU_ALPHA, config`; pipe: `PIPE_S`.
+    - `void __builtin_cce_set_lrelu_alpha(half config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4374; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6804.
+      - Parameter packing: Direct control form; header operation comment: `MOV		LRELU_ALPHA, config`; pipe: `PIPE_S`.
+    - `void __builtin_cce_set_lrelu_alpha(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6803.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_matrix_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2233`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_matrix_para(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6891.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_mov_pad_val`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:881`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.MOV.PAD.VAL`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.MOV.PAD.VAL(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.MOV.PAD.VAL(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_mov_pad_val(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4394; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6808; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6811.
+      - Parameter packing: Direct control form; header operation comment: `MOV		MOV_PAD_VAL, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_mte2_antiq_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:883`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_mte2_antiq_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4399; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6711.
+      - Parameter packing: Direct control form; header operation comment: `MOV		MTE2_ANTIQ_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_mte2_nz_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:885`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_mte2_nz_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4404; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19489; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19492.
+      - Parameter packing: Direct control form; header operation comment: `MOV		MTE2_NZ_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_mte2_src_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:887`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_mte2_src_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4409; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19495; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19498.
+      - Parameter packing: Direct control form; header operation comment: `MOV		MTE2_SRC_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_mte3_nz_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2247`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_mte3_nz_para(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6890.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_nd_para`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:889`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.ND.PARA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.ND.PARA(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.ND.PARA(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_nd_para(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4414; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6816.
+      - Parameter packing: Direct control form; header operation comment: `MOV		ND_PARA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_pad_cnt_nddma`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:891`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.PAD.CNT.NDDMA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.PAD.CNT.NDDMA(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.PAD.CNT.NDDMA(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_pad_cnt_nddma(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4419; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19594; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19597.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PAD_CNT_NDDMA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_pad_val_nddma`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:893`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.PAD.VAL.NDDMA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.PAD.VAL.NDDMA(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.PAD.VAL.NDDMA(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_pad_val_nddma(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4424; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19504; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:19507.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PAD_VAL_NDDMA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_pad_val_outtol1`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:895`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_pad_val_outtol1(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4429; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6815.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PAD_VAL_OUTTOL1, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_pad_val_outtoub`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:897`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.PAD.VAL.OUTTOUB`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.PAD.VAL.OUTTOUB(i64) #3`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.PAD.VAL.OUTTOUB(i64 1), !dbg !10`
+  - Probe targets used: `dav-c310-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_pad_val_outtoub(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4434; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6814.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PAD_VAL_OUTTOUB, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_padding`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:899`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.PADDING.f16`
+    - `llvm.hivm.SET.PADDING`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.PADDING.f16(half) #1`
+    - `declare void @llvm.hivm.SET.PADDING(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.PADDING.f16(half 0xH3C00)`
+    - `call void @llvm.hivm.SET.PADDING(i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_padding(half config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4444; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6823; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6826.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PADDING, config`; pipe: `PIPE_S`.
+    - `void __builtin_cce_set_padding(int16_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4449; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6829; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6832.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PADDING, config`; pipe: `PIPE_S`.
+    - `void __builtin_cce_set_padding(uint16_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4454; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6835; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6838.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PADDING, config`; pipe: `PIPE_S`.
+    - `void __builtin_cce_set_padding(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4439; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6817; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6820.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PADDING, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_padding_b`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:901`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_padding_b(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4459; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:20455.
+      - Parameter packing: Direct control form; header operation comment: `MOV		PADDING_B, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_quant_post`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:907`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.QUANT.POST`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.QUANT.POST(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.QUANT.POST(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_quant_post(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4474; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6853.
+      - Parameter packing: Direct control form; header operation comment: `MOV		QUANT_POST, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_quant_pre`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:909`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.QUANT.PRE.v300`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.QUANT.PRE.v300(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.QUANT.PRE.v300(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_quant_pre(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4479; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6855; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6858.
+      - Parameter packing: Direct control form; header operation comment: `MOV		QUANT_PRE, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_relu_alpha`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:911`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.RELU.ALPHA`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.RELU.ALPHA(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.RELU.ALPHA(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_relu_alpha(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4484; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6865.
+      - Parameter packing: Direct control form; header operation comment: `MOV		RELU_ALPHA, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_reqscale`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2277`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_reqscale(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6867.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_rpn_cor_ir`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:913`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.RPN.COR.IR`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.RPN.COR.IR(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.RPN.COR.IR(i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_rpn_cor_ir(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4489; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6868.
+      - Parameter packing: Header packing comment: `/* #3326 */ __builtin_cce_mov_vspr(19, config)`
+
+- `__builtin_cce_set_rpn_offset`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2281`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.RPN.OFFSET`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.RPN.OFFSET(half) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.RPN.OFFSET(half 0xH3C00)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_rpn_offset(half config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6869.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_st_atomic_cfg`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:915`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.ST.ATOMIC.CFG`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.ST.ATOMIC.CFG(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.ST.ATOMIC.CFG(i64 1), !dbg !10`
+  - Probe targets used: `dav-m300`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_st_atomic_cfg(atomic_type_t type, atomic_op_t op);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4499; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6874; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6877.
+      - Parameter packing: Header packing comment: `/* #4073 */ __builtin_cce_set_st_atomic_cfg(((type & 0x7) << 0 | (op & 0x3) << 3))`
+    - `void __builtin_cce_set_st_atomic_cfg(uint64_t config);`
+      - Signature source: .local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4494; .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6873.
+      - Parameter packing: Direct control form; header operation comment: `MOV		ST_ATOMIC_CFG, config`; pipe: `PIPE_S`.
+
+- `__builtin_cce_set_vpipe`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2301`
+  - Observed LLVM intrinsic names:
+    - `llvm.hivm.SET.VPIPE`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.VPIPE(i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.VPIPE(i64 1)`
+  - Probe targets used: `dav-m200`
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_vpipe(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6888.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.
+
+- `__builtin_cce_set_vsp`
+  - C++ wrapper alias source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2303`
+  - Observed LLVM intrinsic names: Not captured by the local target sweep.
+  - Observed LLVM IR declarations: Not captured by the local target sweep.
+  - Complete C++ signatures:
+    - `void __builtin_cce_set_vsp(uint64_t config);`
+      - Signature source: .local/cann/tools/tikicpulib/lib/include/stub_fun.h:6889.
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed/control operand; no `// ->` wrapper packing comment is needed.

--- a/docs/designs/a2a3-llvm-impl.md
+++ b/docs/designs/a2a3-llvm-impl.md
@@ -1,0 +1,290 @@
+# A3 VPTO LLVM Lowering Pipeline
+
+## Overview
+
+The A3 (`dav-c220-vec`) backend reuses the same top-level VPTO emission pipeline
+as A5 (`dav-c310-vec`) but replaces the TileLang-template expansion path with a
+direct pointer-based lowering of binary tile operations to UB intrinsics.
+
+## Pipeline: Shared vs Divergent
+
+### Shared passes (arch-independent)
+
+```
+runPipeline(module, march, diagOS, emit):
+  1. VPTOSplitCVModule            — split cube/vector sections into child modules
+  2. VPTONormalizeContainer       — canonicalize kernel container shape
+  3. VPTOPtrNormalize             — normalize ptr-like values into !pto.ptr
+  4. VPTOPtrCastCleanup           — collapse transient ptr-memref-ptr bridge casts
+  5. VPTOExpandWrapperOps         — expand DMA/bridge/mad/acc-store wrappers
+  6. PTOInferVPTOVecScope         — infer vecscope regions
+  7. PrepareVPTOLLVMLowering      — materialize vecscope carrier loops
+  8. LowerVPTOOpsPass             — pattern-based op → LLVM intrinsic lowering
+  9. LowerVPTOTypesPass           — type conversion (pto.ptr → llvm.ptr)
+ 10. Arith / SCF / CF / Func → LLVM  (standard MLIR conversion passes)
+ 11. ReconcileUnrealizedCasts     — cleanup
+```
+
+### Divergence: pre-VPTO backend pipeline
+
+```
+lowerPTOToVPTOBackend(pm):
+
+  ┌─ A3 ────────────────────────────────────────────────────┐
+  │ LowerPTOToUBufOps                                        │
+  │   pto.tadd / tsub / tmul / tdiv                         │
+  │   → pto.ub.vadd / vsub / vmul / vdiv                    │
+  │   + pto.ub.set_mask / set_mask_count / set_mask_norm    │
+  │   (pointer-based, !pto.ptr<f32, ub>, no memref)         │
+  └─────────────────────────────────────────────────────────┘
+
+  ┌─ A5 ────────────────────────────────────────────────────┐
+  │ ExpandTileOp                                             │
+  │   → TileLang DSL template expansion                     │
+  │ InlineLibCall → FoldTileBufIntrinsics                   │
+  │   pto.tadd → pto.vlds / vadd / vsts                     │
+  │   (memref-based, vreg values)                            │
+  └─────────────────────────────────────────────────────────┘
+```
+
+### Divergence inside shared passes
+
+| Pass | A3 (`dav-c220-vec`) | A5 (`dav-c310-vec`) |
+|---|---|---|
+| **VPTOExpandWrapperOps** | v220 DMA: `nBurst=1`, `lenBurst>>5`, `scf.for` software loops | Standard DMA: dual-config calls, `nBurst` loop pairs |
+| **LowerVPTOOpsPass** | UB binary ops → `llvm.hivm.VADD/VSUB/VMUL/VDIV.f32` + mask via `SBITSET1/SBITSET0` on CTRL[56] | Vector ops → `llvm.hivm.ADD/LOAD/STORE` |
+| **CopyOp (DMA)** | 1-config: `MOV.OUT.TO.UB.v220` / `MOV.UB.TO.OUT.v220.1` | 2-config: `MOV.OUT.TO.UB.ALIGN.V2.s32.DV` / `MOV.UB.TO.OUT.ALIGN.V2.DV` |
+| **makeDeviceEmissionOptions** | `dav-c220-vec`, features: `+ASAN,+ATOMIC,+FFTSBlk,+MOVX8,+MSTX,+MathOp` | `dav-c310-vec`, features: `+ArchV130,+F8e4m3,+F8e5m2,+Fp4e1m2x2,+LDExtRefine` |
+| **configureVPTOOpLoweringTarget** | UB ops (`UBVaddOp`, `UBSetMaskOp`, etc.) marked illegal | Not present |
+
+## TADD → ub.vadd: Tile-size lowering examples
+
+### Repeat & stride calculation
+
+```
+elementsPerRepeat = 256 / sizeof(element)          // 64 for f32, 128 for f16, 32 for f64
+totalElements     = rows × cols
+totalRepeats      = totalElements / elementsPerRepeat
+
+blockStrides  = (1, 1, 1)                          // always contiguous
+repStride     = elementsPerRepeat / 8              // 8 for f32, 16 for f16, 4 for f64
+```
+
+### CCE VADD config layout (i64)
+
+| Bits | Field |
+|---|---|
+| 7:0 | repeat |
+| 15:8 | dst block stride |
+| 23:16 | src0 block stride |
+| 31:24 | src1 block stride |
+| 39:32 | dst repeat stride |
+| 47:40 | src0 repeat stride |
+| 55:48 | src1 repeat stride |
+| 63:56 | simdFlag (=1) |
+
+### Example 1: 1×64 f32 — Direct count mode
+
+Input:
+```mlir
+%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64>
+pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
+```
+
+Computed: `elementsPerRepeat=64`, `totalElements=64`, `totalRepeats=1`.
+
+Output:
+```mlir
+%ub_dst = pto.tile_buf_addr %dst : !pto.tile_buf<...> → !pto.ptr<f32, ub>
+%ub_s0  = pto.tile_buf_addr %src0 : !pto.tile_buf<...> → !pto.ptr<f32, ub>
+%ub_s1  = pto.tile_buf_addr %src1 : !pto.tile_buf<...> → !pto.ptr<f32, ub>
+%c1 = arith.constant 1 : i64
+%c8 = arith.constant 8 : i64
+
+pto.ub.set_mask_count                            // SBITSET1(ctrl, 56)
+pto.ub.vadd %ub_dst, %ub_s0, %ub_s1,             // VADD: repeat=1, all strides=1/1/1/8/8/8
+     %c1, %c1, %c1, %c1, %c8, %c8, %c8
+pto.ub.set_mask_norm                             // SBITSET0(ctrl, 56)
+pto.ub.set_mask %c-1_i64, %c0_i64                // full mask (mask0=-1, mask1=0)
+```
+
+After LLVM lowering:
+```mlir
+llvm.call @llvm.hivm.SBITSET1(%ctrl, %c56)       // enter count mode
+llvm.call @llvm.hivm.MOVEMASK(%c0, %c-1)         // mask[0] = -1
+llvm.call @llvm.hivm.MOVEMASK(%c1, %c0)          // mask[1] = 0 (64-lane f32)
+llvm.call @llvm.hivm.VADD.f32(%ub_dst, %ub_s0, %ub_s1, %config)
+llvm.call @llvm.hivm.SBITSET0(%ctrl, %c56)       // exit count mode
+```
+
+### Example 2: 4×64 f32 — Multi-row count mode with scf.for
+
+Input:
+```mlir
+%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64>
+pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
+```
+
+Computed: `headRepeats=4`, `elementsPerRow=64`, `repeat=1` per row.
+
+Output:
+```mlir
+%c0 = arith.constant 0 : index
+%c1 = arith.constant 1 : i64
+%c4 = arith.constant 4 : index
+%c8 = arith.constant 8 : i64
+
+%ub_dst = pto.tile_buf_addr %dst : !pto.ptr<f32, ub>
+%ub_s0  = pto.tile_buf_addr %src0 : !pto.ptr<f32, ub>
+%ub_s1  = pto.tile_buf_addr %src1 : !pto.ptr<f32, ub>
+
+%row_dst = pto.addptr %ub_dst, %c0 : !pto.ptr<f32, ub>
+%row_s0  = pto.addptr %ub_s0, %c0 : !pto.ptr<f32, ub>
+%row_s1  = pto.addptr %ub_s1, %c0 : !pto.ptr<f32, ub>
+
+scf.for %i = %c0 to %c4 step %c1 {
+  %off = arith.index_cast %i : index to i64
+  %rd = pto.addptr %row_dst, %off : !pto.ptr<f32, ub>
+  %r0 = pto.addptr %row_s0, %off : !pto.ptr<f32, ub>
+  %r1 = pto.addptr %row_s1, %off : !pto.ptr<f32, ub>
+
+  pto.ub.set_mask_count
+  pto.ub.vadd %rd, %r0, %r1, %c1, %c1, %c1, %c1, %c8, %c8, %c8
+  pto.ub.set_mask_norm
+}
+pto.ub.set_mask %c-1_i64, %c0_i64
+```
+
+### Example 3: 16×64 f32 — Larger multi-row
+
+Input:
+```mlir
+%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64>
+pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
+```
+
+Same pattern as 4×64 but `scf.for` iterates 16 times. One `VADD` per row:
+```
+scf.for %i = 0 to 16 step 1 {
+  pto.ub.set_mask_count
+  pto.ub.vadd ...   // repeat=1 per row
+  pto.ub.set_mask_norm
+}
+```
+
+### Example 4: 32×32 f32 — Square tile
+
+Input:
+```mlir
+%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32>
+pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
+```
+
+Computed: `totalElements=1024`, `elementsPerRepeat=64`, `totalRepeats=16`. With `headRepeats=32` rows, each row has `32/64 = 1` repeat → same `scf.for` per-row pattern, 32 iterations.
+
+### Example 5: 4×96 f32, v_col=32 — Multiple repeats per row
+
+Input:
+```mlir
+%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32>
+pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
+```
+
+Computed: `totalV = 4×32 = 128`, `elementsPerRepeat = 64`, `totalRepeats = 128/64 = 2` per call but `totalV > REPEAT_MAX(255)` triggers count mode.
+
+Output: count mode, 2 repeats per row, 4 rows via scf.for.
+
+### Example 6: 16×1024 f32 — Chunked (repeat > 255)
+
+Input:
+```mlir
+%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024>
+pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
+```
+
+Computed: `totalElements=16384`, `elementsPerRepeat=64`, `totalRepeats=256`, which equals `REPEAT_MAX`. Count mode, no `scf.for` (single VADD with repeat=256):
+
+```mlir
+pto.ub.set_mask_count
+pto.ub.set_mask %c256_i64, %c0_i64     // mask0 = 256 (count mode: mask count in mask[0])
+pto.ub.vadd %dst, %src0, %src1, %c256, %c1, %c1, %c1, %c8, %c8, %c8
+pto.ub.set_mask_norm
+pto.ub.set_mask %c-1_i64, %c0_i64      // restore full mask
+```
+
+### Example 7: A5 — No UB lowering
+
+On A5 targets, `pto.tadd` passes through `LowerPTOToUBufOps` unchanged and is later expanded via `ExpandTileOp` into the TileLang DSL template path:
+
+```mlir
+// VPTO IR (after ExpandTileOp + inlining):
+pto.vecscope {
+  %v0 = pto.vlds %src0_memref : memref<...>
+  %v1 = pto.vlds %src1_memref : memref<...>
+  %v2 = pto.vadd %v0, %v1 : !pto.vreg<f32>
+  pto.vsts %v2, %dst_memref : memref<...>
+}
+```
+
+No `pto.ub.vadd` or `llvm.hivm.VADD.f32` appears.
+
+### Mask / control-flow modes
+
+| Mode | Condition | Pattern |
+|---|---|---|
+| **count mode** | `totalV > kRepeatMax` (255) or row-repeat with count | `SBITSET1(ctrl,56)` → `MOVEMASK(0,count)` → `VADD` → `SBITSET0(ctrl,56)` |
+| **norm mode (head+tail)** | `totalRepeats ≤ kRepeatMax` | Head VADD → tail mask VADD |
+| **norm mode small** | `v_col < 32`, head+tail ≤ max | Same as head+tail but per chunk via `scf.for` |
+| **norm mode 1L** | Single row, repeat ≤ max | Direct norm mode VADD |
+| **full mask** | After all VADDs | `MOVEMASK(0,-1)` + `MOVEMASK(1,0)` for 64-lane f32 |
+
+### C220 COUNT mode limitation
+
+On `dav-c220-vec`, count mode only supports `repeat=1`. Multi-element count mode
+(`repeat > 1`) causes CCE errors. As a result:
+
+- **repeat=1**: direct count mode (no loop)
+- **repeat>1, rows=1**: split into per-chunk `scf.for` with repeat=1 each (`modeCount1L`)
+- **repeat>1, rows>1**: per-row `scf.for` with repeat=1 each (`modeNormal1L`)
+- **repeat=0** (`modeCount1L`): broken on C220, routed to head+tail path
+
+Test cases `1×80` and `256×64` are excluded from on-device tests due to this
+limitation; they fall back to the head+tail norm path.
+
+## Full lowering chain: TADD example
+
+```
+PTO DSL:          pto.tile.add(a_tile, b_tile, c_tile)
+    ↓
+PTO IR:           pto.tadd ins(%a, %b) outs(%c)
+    ↓ LowerPTOToUBufOps (A3 only)
+UB IR:            pto.ub.set_mask_count
+                  pto.ub.vadd %dst, %src0, %src1, repeat=1, blkStrides=(1,1,1), repStrides=(8,8,8)
+                  pto.ub.set_mask_norm
+                  pto.ub.set_mask %c-1, %c0
+    ↓ Lower copy ops
+Copy IR:          pto.copy_gm_to_ubuf / pto.copy_ubuf_to_gm  (v220 DMA)
+    ↓ LowerVPTOOpsPass (A3 patterns)
+LLVM IR:          llvm.call @llvm.hivm.SBITSET1(%ctrl, %56)
+                  llvm.call @llvm.hivm.MOVEMASK(%0, %-1)
+                  llvm.call @llvm.hivm.MOVEMASK(%1, %0)
+                  llvm.call @llvm.hivm.VADD.f32(%dst, %src0, %src1, %config)
+                  llvm.call @llvm.hivm.SBITSET0(%ctrl, %56)
+                  llvm.call @llvm.hivm.MOV.OUT.TO.UB.v220(...)
+                  llvm.call @llvm.hivm.MOV.UB.TO.OUT.v220.1(...)
+    ↓ bisheng
+Binary:           native AICORE binary
+```
+
+## Summary table
+
+| Aspect | A3 | A5 |
+|---|---|---|
+| **Lowering strategy** | Direct pointer-based: `pto.tadd → ub.vadd → llvm.hivm.VADD` | Template expansion: `pto.tadd → TileLang DSL → vlds/vadd/vsts` |
+| **Memory model** | `!pto.ptr<f32, ub>` pointers, no memref | `memref` alloc/load/store |
+| **DMA** | v220 single-config, software loops | Dual-config, hardware nBurst loops |
+| **Mask/control** | `SBITSET1/SBITSET0` on CTRL bit 56 for count mode | `SET_FLAG/WAIT_FLAG` synchronization |
+| **Passes added** | `LowerPTOToUBufOps` (1 new pass) | `ExpandTileOp` + `InlineLibCall` + `FoldTileBufIntrinsics` |
+| **New ops (6)** | `pto.ub.{vadd,vsub,vmul,vdiv,set_mask_count,set_mask_norm}` | none |
+| **Intrinsics** | `llvm.hivm.{VADD,VSUB,VMUL,VDIV}.f32` | `llvm.hivm.{ADD,LOAD,STORE}` |
+| **Relevant files** | `LowerPTOToUBufOps.cpp`, `VPTOUbOps.td`, `VPTOUbOps.cpp`, `VPTOLLVMEmitter.cpp`, `VPTOExpandWrapperOps.cpp`, `ObjectEmission.cpp` | `ExpandTileOp.cpp`, `FoldTileBufIntrinsics.cpp`, `VPTOLLVMEmitter.cpp` |

--- a/docs/designs/a2a3-tadd-spec.md
+++ b/docs/designs/a2a3-tadd-spec.md
@@ -1,0 +1,37 @@
+# a2a3 llvm lowering spec
+These specifications are for lowering on A2 and A3, i.e. pto -> vpto -> llvm.
+
+## instruction mapping pto -> pto.ub.* 
+- pto.tadd to pto.ub.vadd
+- pto.tload to pto.ub.gm_to_ub
+- pto.tstore to pto.ub.ub_to_gm
+
+to lower tile level instructions use the npu-coding mcp to get the raw cce implemtation that maps very closely to pto.ub.* instructions
+
+## instruction mapping pto.ub.* -> llvm
+- at the llvm level use ony intrisics valid for dav-c220-vec as listed in /docs/designs/a2a3-intrinsics.md and /docs/designs/a2a3-dma-builtins.md
+- address space for gm is 1
+- address space for ub is 6
+
+## instruction for compiling llvm
+- bisheng should use dav-c220-vec as the target arch (the one for A2 and A3)
+
+# General guidelines
+- try to reuse most to the A5 pipeline
+- do not use ExpandTileOp
+- do not use dav-c310-vec for A2 A3 pipeline
+- use dav-c220-vec for A2 A3 pipeline
+- never use tilelang
+- test running e2e example
+```sh
+python ptodsl/examples/tadd_launch_a3.py
+```
+# Testing
+- add a test for every pto.ub.* op
+- add a test for every lowering pto.* -> pto.ub.*
+- tests should use captures to check arguments of the ops not just a mnemonic check
+- use this docker image cce-mlir-dev-npu-aarch64-llvm19-cann900
+- full command  
+```sh
+docker run --rm -i -v $(pwd):/workspace -v /tmp/opencode/ptoas-cce-build:/tmp/ptoas-build -v /tmp/opencode/ptoas-cce-install:/tmp/ptoas-install --ipc=host --privileged --device=/dev/davinci0 --device=/dev/davinci1 --device=/dev/davinci2 --device=/dev/davinci3 --device=/dev/davinci4 --device=/dev/davinci5 --device=/dev/davinci6 --device=/dev/davinci7 --device=/dev/davinci_manager --device=/dev/devmm_svm --device=/dev/hisi_hdc -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro -v /etc/ascend_install.info:/etc/ascend_install.info:ro --user $(id -u):$(id -g) -e HOME=/tmp --entrypoint bash cce-mlir-dev-npu-aarch64-llvm19-cann900 
+```

--- a/docs/designs/a2a3-vector-builtins.md
+++ b/docs/designs/a2a3-vector-builtins.md
@@ -1,0 +1,3660 @@
+# A2/A3 Vector Builtin Inventory
+
+## 1. Collection Constraints
+
+- Collection root: `.local/cann`, which is a symlink to `/home/mouliangyu/.local/ascend/beta.1/cann` in this workspace.
+- Architecture scope: A2/A3 vector builtins whose callable C++ form uses memory pointers, not the A5-style `vector_*` value operands, plus the A2/A3 vector mask/control builtins that configure vector execution state.
+- C++ signature source: `.local/cann/tools/tikicpulib/lib/include/stub_fun.h`, filtered to declarations with pointer operands and without any `vector_*` parameter for vector compute builtins; mask/control builtins are included from the same source when they directly affect vector mask or compare-mask state.
+- Builtin-name mapping source: `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h` and `cce_aicore_intrinsics_3101.h`, using `clang_builtin_alias(__builtin_cce_...)` declarations.
+- Included vector compute signatures must satisfy all of these conditions: function name is a vector builtin wrapper such as `v*` or `vector_dup`; at least one operand is a pointer, usually `__ubuf__ T*`; no operand uses the A5/new-vector `vector_*` types; the wrapper can be mapped to a `__builtin_cce_*` alias in the CCE headers; and direct `__builtin_cce_*` compilation emits a vector `llvm.hivm.*` call.
+- Included mask/control signatures are limited to `set_cmpmask`, `set_mask_count`, `set_mask_norm`, `set_vector_mask`, and `set_vector_mask_dup`; these are listed separately because their operands are mask pointers or scalar `uint64_t` values rather than vector data operands.
+- Excluded entries include all `__clang_cce_vector_intrinsics.h` vector-value builtins, all `vector_*` input/output declarations from `stub_fun.h`, high-level AscendC wrappers, unrelated scalar/system builtins, x86/standard Clang builtins, OPP operator implementations, names without a complete pointer-form or mask/control signature in the scanned files, and wrapper-only stub declarations that ccec rejects as direct builtin calls.
+- Overloads are preserved because the same builtin name can have different pointer element types, scalar operands, packed `uint64_t config` forms, and expanded repeat/stride forms.
+- LLVM intrinsic names were probed by compiling every candidate pointer-form overload with `.local/cann/x86_64-linux/bin/ccec -c -save-temps -xcce`, disassembling the emitted device bitcode with LLVM 15 `llvm-dis`, and extracting actual `call @llvm.hivm.*` targets from the generated probe function body.
+- Probe targets were tried in this order until a vector `llvm.hivm.*` call was captured: `dav-m200-vec`, `dav-m200`, `dav-m300`, `dav-c220-vec`, `dav-c310-vec`, `dav-m210-vec`, `dav-l300-vec`, `dav-l300`, `dav-t300`, `dav-t200`, `dav-t210`, `dav-l310`, `dav-l311`, `dav-l311-eff`, `dav-l510`, `dav-s200`, `dav-c220`, `dav-c310`, `dav-m310`, `dav-m201`, `dav-n350`, `dav-920r1-vec`, `dav-920r1`, `dav-510r2`, `dav-380r1-cube`, `dav-c100`, `dav-l100`, `dav-l100-es`, `dav-l200`, `dav-l210`, `dav-m100`, `dav-s200-es`, `dav-t100`, `dav-t100-es`.
+- LLVM intrinsic-name coverage for vector compute builtins: 200 of 200 builtin names have at least one captured intrinsic name; 929 of 939 candidate pointer-form overload signatures captured an actual vector `llvm.hivm.*` call target; 10 candidate stub declarations were rejected by ccec with `parameters too many` and are excluded as non-bottom-level direct builtin signatures.
+- Mask/control builtin coverage: 5 additional builtin names and 5 complete C++ signatures were probed on `dav-m200-vec`; their IR declarations and actual probe calls are listed in the mask/control section.
+- Parameter packing coverage for vector compute builtins: 12 signatures have packing text copied from CANN `// ->` header comments, 336 signatures are direct already-packed `uint64_t` forms, and 581 signatures have no matching CANN `// ->` packing comment in the scanned headers.
+- `No CANN // -> packing comment found` means no textual packing formula was present in the scanned CANN headers for that exact wrapper parameter list; this document does not infer or synthesize missing formulas from LLVM IR.
+- Inventory count: 205 unique builtin names, 934 verified bottom-level signatures, and 354 unique observed LLVM intrinsic names or declarations.
+
+## 2. Builtin Signatures
+
+- `__builtin_cce_v4dtrans`
+  - LLVM intrinsic names:
+    - `llvm.hivm.V4DTRANS.b16`
+    - `llvm.hivm.V4DTRANS.b32`
+    - `llvm.hivm.V4DTRANS.b8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.V4DTRANS.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.V4DTRANS.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.V4DTRANS.b8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_v4dtrans(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint16_t imageSize, uint16_t nChannel, bool conversionMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `v4dtrans` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_v4dtrans(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_v4dtrans(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint16_t imageSize, uint16_t nChannel, bool conversionMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `v4dtrans` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_v4dtrans(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_v4dtrans(__ubuf__ uint8_t* dst, __ubuf__ uint8_t* src, uint16_t imageSize, uint16_t nChannel, bool conversionMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `v4dtrans` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_v4dtrans(__ubuf__ uint8_t* dst, __ubuf__ uint8_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vabs`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VABS.f16`
+    - `llvm.hivm.VABS.f32`
+    - `llvm.hivm.VABS.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VABS.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VABS.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VABS.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vabs(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vabs(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4597): `/* #4160 */ __builtin_cce_vabs(dst, src, ((repeat & 0xff) << 56 | (dstBlockStride & 0xffff) << 0 | (srcBlockStride & 0xffff) << 16 | (dstRepeatStride & 0xff) << 32 | (dstRepeatStride & 0xf00) << 44 | (srcRepeatStride & 0xfff) << 40))`
+    - `void __builtin_cce_vabs(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4597): `/* #4160 */ __builtin_cce_vabs(dst, src, ((repeat & 0xff) << 56 | (dstBlockStride & 0xffff) << 0 | (srcBlockStride & 0xffff) << 16 | (dstRepeatStride & 0xff) << 32 | (dstRepeatStride & 0xf00) << 44 | (srcRepeatStride & 0xfff) << 40))`
+    - `void __builtin_cce_vabs(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vabs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vabs(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vabs(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4597): `/* #4160 */ __builtin_cce_vabs(dst, src, ((repeat & 0xff) << 56 | (dstBlockStride & 0xffff) << 0 | (srcBlockStride & 0xffff) << 16 | (dstRepeatStride & 0xff) << 32 | (dstRepeatStride & 0xf00) << 44 | (srcRepeatStride & 0xfff) << 40))`
+    - `void __builtin_cce_vabs(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4597): `/* #4160 */ __builtin_cce_vabs(dst, src, ((repeat & 0xff) << 56 | (dstBlockStride & 0xffff) << 0 | (srcBlockStride & 0xffff) << 16 | (dstRepeatStride & 0xff) << 32 | (dstRepeatStride & 0xf00) << 44 | (srcRepeatStride & 0xfff) << 40))`
+    - `void __builtin_cce_vabs(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vabs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vabs(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vabs(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4597): `/* #4160 */ __builtin_cce_vabs(dst, src, ((repeat & 0xff) << 56 | (dstBlockStride & 0xffff) << 0 | (srcBlockStride & 0xffff) << 16 | (dstRepeatStride & 0xff) << 32 | (dstRepeatStride & 0xf00) << 44 | (srcRepeatStride & 0xfff) << 40))`
+    - `void __builtin_cce_vabs(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4597): `/* #4160 */ __builtin_cce_vabs(dst, src, ((repeat & 0xff) << 56 | (dstBlockStride & 0xffff) << 0 | (srcBlockStride & 0xffff) << 16 | (dstRepeatStride & 0xff) << 32 | (dstRepeatStride & 0xf00) << 44 | (srcRepeatStride & 0xfff) << 40))`
+    - `void __builtin_cce_vabs(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vabs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vadd`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADD.f16`
+    - `llvm.hivm.VADD.f32`
+    - `llvm.hivm.VADD.s16`
+    - `llvm.hivm.VADD.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADD.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VADD.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VADD.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VADD.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vadd(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadd(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadd(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t repeat);`
+      - Parameter packing: Direct bottom-level form: `repeat` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadd(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadd(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadd(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadd(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadd(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadd(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadd(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadd(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vadddeqrelu`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADDDEQRELU`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADDDEQRELU(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vadddeqrelu(__ubuf__ half* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadddeqrelu(__ubuf__ half* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadddeqrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadddeqrelu(__ubuf__ half* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadddeqrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vaddrelu`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADDRELU.f16`
+    - `llvm.hivm.VADDRELU.f32`
+    - `llvm.hivm.VADDRELU.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADDRELU.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VADDRELU.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VADDRELU.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vaddrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddrelu(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddrelu(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddrelu(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vaddreluconv_f162s8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADDRELUCONV.f162s8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADDRELUCONV.f162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vaddreluconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddreluconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddreluconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vaddreluconv_f322f16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADDRELUCONV.f322f16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADDRELUCONV.f322f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vaddreluconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddreluconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_f322f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddreluconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_f322f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vaddreluconv_s162s8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADDRELUCONV.s162s8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADDRELUCONV.s162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vaddreluconv_s162s8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddreluconv_s162s8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_s162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddreluconv_s162s8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_s162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vaddreluconv_vdeqs162b8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADDRELUCONV.VDEQs162b8`
+    - `llvm.hivm.VADDRELUCONV.VDEQs162b8.1`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADDRELUCONV.VDEQs162b8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+    - `declare void @llvm.hivm.VADDRELUCONV.VDEQs162b8.1(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-s200`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vaddreluconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddreluconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4607): `/* #4201 */ __builtin_cce_vaddreluconv_vdeqs162b8(dst, src0, src1, ((repeat & 0xff) << 56 | (dstBlockStride & 0xff) << 0 | (src0BlockStride & 0xff) << 8 | (src1BlockStride & 0xff) << 16 | (dstRepeatStride & 0xff) << 24 | (src0RepeatStride & 0xff) << 32 | (src1RepeatStride & 0xff) << 40), h)`
+    - `void __builtin_cce_vaddreluconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_vdeqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaddreluconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaddreluconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4602): `/* #4202 */ __builtin_cce_vaddreluconv_vdeqs162b8(dst, src0, src1, ((repeat & 0xff) << 56 | (dstBlockStride & 0xff) << 0 | (src0BlockStride & 0xff) << 8 | (src1BlockStride & 0xff) << 16 | (dstRepeatStride & 0xff) << 24 | (src0RepeatStride & 0xff) << 32 | (src1RepeatStride & 0xff) << 40), h)`
+    - `void __builtin_cce_vaddreluconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaddreluconv_vdeqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vadds`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VADDS.f16`
+    - `llvm.hivm.VADDS.f32`
+    - `llvm.hivm.VADDS.s16`
+    - `llvm.hivm.VADDS.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VADDS.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VADDS.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+    - `declare void @llvm.hivm.VADDS.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VADDS.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vadds(__ubuf__ float* dst, __ubuf__ float* src, float a, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadds(__ubuf__ float* dst, __ubuf__ float* src, float a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ float* dst, __ubuf__ float* src, float a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ float* dst, __ubuf__ float* src, float a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ half* dst, __ubuf__ half* src, half a, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadds(__ubuf__ half* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ half* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ half* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, int16_t a, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadds(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, int16_t a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, int16_t a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, int16_t a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, int32_t a, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vadds(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, int32_t a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, int32_t a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vadds(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, int32_t a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vadds` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vand`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VAND.s16`
+    - `llvm.hivm.VAND.u16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VAND.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VAND.u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vand(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vand(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1StrideBlock, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vand` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vand(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1StrideBlock, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vand` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vand(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vand(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1StrideBlock, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vand` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vand(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1StrideBlock, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vand` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vaxpy`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VAXPY.f16`
+    - `llvm.hivm.VAXPY.f32`
+    - `llvm.hivm.VAXPY.fmix`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VAXPY.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VAXPY.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+    - `declare void @llvm.hivm.VAXPY.fmix(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ float* src, float a, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ float* src, float a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ float* src, float a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ float* src, float a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ half* src, half a, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ float* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ half* dst, __ubuf__ half* src, half a, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vaxpy(__ubuf__ half* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ half* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vaxpy(__ubuf__ half* dst, __ubuf__ half* src, half a, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vaxpy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vbi`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VBI.f16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VBI.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vbi(__ubuf__ half* dst, __ubuf__ uint16_t* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vbi(__ubuf__ half* dst, __ubuf__ uint16_t* src0, __ubuf__ half* src1, uint8_t hRepeat, bool repeatMode, uint16_t dstBlockStride, uint16_t vROffset, uint8_t vRepeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vbi` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vbrcb`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VBRCB.b16`
+    - `llvm.hivm.VBRCB.b32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VBRCB.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VBRCB.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vbrcb(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint16_t dstBlockStride, uint16_t dstRepeatStride, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vbrcb` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vbrcb(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vbrcb(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint16_t dstBlockStride, uint16_t dstRepeatStride, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vbrcb` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vbrcb(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vbs`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VBS32.V300.f16`
+    - `llvm.hivm.VBS32.V300.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VBS32.V300.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64) #1`
+    - `declare void @llvm.hivm.VBS32.V300.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64) #1`
+  - Probe targets used: `dav-m300`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vbs(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ uint32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vbs(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ uint32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vcadd`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCADD.f16`
+    - `llvm.hivm.VCADD.f16.order`
+    - `llvm.hivm.VCADD.f32`
+    - `llvm.hivm.VCADD.f32.order`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCADD.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCADD.f16.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCADD.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCADD.f32.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcadd(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcadd(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config, bool MASK);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcadd(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcadd(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool mode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcadd(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcadd(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcadd(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config, bool MASK);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcadd(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcadd(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool mode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcadd(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_s162s32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.s162s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.s162s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_s162s32(__ubuf__ int32_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_s162s32(__ubuf__ int32_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_s162s32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_s162u32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.s162u32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.s162u32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_s162u32(__ubuf__ uint32_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_s162u32(__ubuf__ uint32_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_s162u32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_s162u8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.s162u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.s162u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_s162u8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_s162u8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_s162u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_s322s16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.s322s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.s322s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_s322s16(__ubuf__ int16_t* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_s322s16(__ubuf__ int16_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_s322s16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_s322u16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.s322u16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.s322u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_s322u16(__ubuf__ uint16_t* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_s322u16(__ubuf__ uint16_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_s322u16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_s322u8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.s322u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.s322u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_s322u8(__ubuf__ uint8_t* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_s322u8(__ubuf__ uint8_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_s322u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u162s32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u162s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u162s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u162s32(__ubuf__ int32_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u162s32(__ubuf__ int32_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u162s32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u162u32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u162u32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u162u32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u162u32(__ubuf__ uint32_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u162u32(__ubuf__ uint32_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u162u32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u162u8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u162u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u162u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u162u8(__ubuf__ uint8_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u162u8(__ubuf__ uint8_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u162u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u322s16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u322s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u322s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u322s16(__ubuf__ int16_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u322s16(__ubuf__ int16_t* dst, __ubuf__ uint32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u322s16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u322u16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u322u16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u322u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u322u16(__ubuf__ uint16_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u322u16(__ubuf__ uint16_t* dst, __ubuf__ uint32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u322u16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u322u8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u322u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u322u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u322u8(__ubuf__ uint8_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u322u8(__ubuf__ uint8_t* dst, __ubuf__ uint32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u322u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u82s16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u82s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u82s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u82s16(__ubuf__ int16_t* dst, __ubuf__ uint8_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u82s16(__ubuf__ int16_t* dst, __ubuf__ uint8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u82s16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u82s32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u82s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u82s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u82s32(__ubuf__ int32_t* dst, __ubuf__ uint8_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u82s32(__ubuf__ int32_t* dst, __ubuf__ uint8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u82s32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u82u16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u82u16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u82u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u82u16(__ubuf__ uint16_t* dst, __ubuf__ uint8_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u82u16(__ubuf__ uint16_t* dst, __ubuf__ uint8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u82u16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcbd_u82u32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCBD.u82u32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCBD.u82u32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcbd_u82u32(__ubuf__ uint32_t* dst, __ubuf__ uint8_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcbd_u82u32(__ubuf__ uint32_t* dst, __ubuf__ uint8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcbd_u82u32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcgadd`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCGADD.f16`
+    - `llvm.hivm.VCGADD.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCGADD.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCGADD.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcgadd(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcgadd(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgadd(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgadd(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcgadd(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgadd(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcgmax`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCGMAX.f16`
+    - `llvm.hivm.VCGMAX.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCGMAX.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCGMAX.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcgmax(__ubuf__ float* dst, __ubuf__ float* src, uint64_t confg);`
+      - Parameter packing: Direct bottom-level form: `confg` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcgmax(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgmax(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgmax(__ubuf__ half* dst, __ubuf__ half* src, uint64_t confg);`
+      - Parameter packing: Direct bottom-level form: `confg` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcgmax(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgmax(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcgmin`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCGMIN.f16`
+    - `llvm.hivm.VCGMIN.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCGMIN.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCGMIN.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcgmin(__ubuf__ float* dst, __ubuf__ float* src, uint64_t confg);`
+      - Parameter packing: Direct bottom-level form: `confg` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcgmin(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgmin(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgmin(__ubuf__ half* dst, __ubuf__ half* src, uint64_t confg);`
+      - Parameter packing: Direct bottom-level form: `confg` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcgmin(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcgmin(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t src0Stride, uint16_t src1Stride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcgmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vci`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCI.f16`
+    - `llvm.hivm.VCI.f32`
+    - `llvm.hivm.VCI.s16`
+    - `llvm.hivm.VCI.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCI.f16(ptr addrspace(6) nocapture writeonly, half, i64) #1`
+    - `declare void @llvm.hivm.VCI.f32(ptr addrspace(6) nocapture writeonly, float, i64) #1`
+    - `declare void @llvm.hivm.VCI.s16(ptr addrspace(6) nocapture writeonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCI.s32(ptr addrspace(6) nocapture writeonly, i64, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vci(__ubuf__ float* dst, float src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vci(__ubuf__ float* dst, float src, uint8_t repeat, uint16_t dstStride, uint8_t srcStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vci` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vci(__ubuf__ half* dst, half src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vci(__ubuf__ half* dst, half src, uint8_t repeat, uint16_t dstStride, uint8_t srcStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vci` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vci(__ubuf__ int16_t* dst, int16_t src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vci(__ubuf__ int16_t* dst, int16_t src, uint8_t repeat, uint16_t dstStride, uint8_t srcStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vci` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vci(__ubuf__ int32_t* dst, int32_t src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vci(__ubuf__ int32_t* dst, int32_t src, uint8_t repeat, uint16_t dstStride, uint8_t srcStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vci` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmax`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMAX.f16`
+    - `llvm.hivm.VCMAX.f16.order`
+    - `llvm.hivm.VCMAX.f16.order.v220`
+    - `llvm.hivm.VCMAX.f32.order`
+    - `llvm.hivm.VCMAX.f32.order.v220`
+    - `llvm.hivm.VCMAX.s16.order`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMAX.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMAX.f16.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMAX.f16.order.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMAX.f32.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMAX.f32.order.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMAX.s16.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmax(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config, Order_t order);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmax(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config, bool order);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmax(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, Order_t order);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmax(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool order);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmax(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmax(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config, Order_t order);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmax(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config, bool order);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmax(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmax(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, Order_t order);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmax(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmax(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool order);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmax(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint64_t config, bool order);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmax(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool order);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmin`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMIN.f16`
+    - `llvm.hivm.VCMIN.f16.order`
+    - `llvm.hivm.VCMIN.f16.order.v220`
+    - `llvm.hivm.VCMIN.f32.order`
+    - `llvm.hivm.VCMIN.f32.order.v220`
+    - `llvm.hivm.VCMIN.s16.order`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMIN.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMIN.f16.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMIN.f16.order.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMIN.f32.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMIN.f32.order.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCMIN.s16.order(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmin(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config, Order_t order);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmin(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config, bool MASK);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmin(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, Order_t order);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmin(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool MASK);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmin(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmin(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config, Order_t order);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmin(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config, bool MASK);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmin(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmin(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, Order_t order);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmin(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmin(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool MASK);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmin(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint64_t config, bool MASK);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmin(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstRepeatStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool MASK);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmp_eq`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMP.EQ.f16`
+    - `llvm.hivm.VCMP.EQ.f32`
+    - `llvm.hivm.VCMP.EQ.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMP.EQ.f16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.EQ.f32(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.EQ.s16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmp_eq(__ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_eq(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmp_ge`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMP.GE.f16`
+    - `llvm.hivm.VCMP.GE.f32`
+    - `llvm.hivm.VCMP.GE.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMP.GE.f16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.GE.f32(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.GE.s16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmp_ge(__ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ge(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmp_gt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMP.GT.f16`
+    - `llvm.hivm.VCMP.GT.f32`
+    - `llvm.hivm.VCMP.GT.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMP.GT.f16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.GT.f32(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.GT.s16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmp_gt(__ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_gt(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmp_le`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMP.LE.f16`
+    - `llvm.hivm.VCMP.LE.f32`
+    - `llvm.hivm.VCMP.LE.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMP.LE.f16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.LE.f32(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.LE.s16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmp_le(__ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_le(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_le(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_le(__ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_le(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_le(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_le(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_le(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_le(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmp_lt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMP.LT.f16`
+    - `llvm.hivm.VCMP.LT.f32`
+    - `llvm.hivm.VCMP.LT.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMP.LT.f16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.LT.f32(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.LT.s16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmp_lt(__ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_lt(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmp_ne`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMP.NE.f16`
+    - `llvm.hivm.VCMP.NE.f32`
+    - `llvm.hivm.VCMP.NE.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMP.NE.f16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.NE.f32(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMP.NE.s16(ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmp_ne(__ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmp_ne(__ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmp_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpv_eq`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPV.EQ.f16`
+    - `llvm.hivm.VCMPV.EQ.f32`
+    - `llvm.hivm.VCMPV.EQ.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPV.EQ.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMPV.EQ.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMPV.EQ.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpv_eq(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_eq(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpv_eq(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_eq(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpv_eq(__ubuf__ uint8_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_eq(__ubuf__ uint8_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpv_ge`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPV.GE.f16`
+    - `llvm.hivm.VCMPV.GE.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPV.GE.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMPV.GE.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpv_ge(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_ge(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpv_ge(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_ge(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpv_gt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPV.GT.f16`
+    - `llvm.hivm.VCMPV.GT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPV.GT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMPV.GT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpv_gt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_gt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpv_gt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_gt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpv_le`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPV.LE.f16`
+    - `llvm.hivm.VCMPV.LE.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPV.LE.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMPV.LE.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpv_le(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_le(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpv_le(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_le(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpv_lt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPV.LT.f16`
+    - `llvm.hivm.VCMPV.LT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPV.LT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMPV.LT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpv_lt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_lt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpv_lt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_lt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpv_ne`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPV.NE.f16`
+    - `llvm.hivm.VCMPV.NE.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPV.NE.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCMPV.NE.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpv_ne(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_ne(__ubuf__ uint8_t* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpv_ne(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpv_ne(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpv_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpvs_eq`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPVS.EQ.f16`
+    - `llvm.hivm.VCMPVS.EQ.f32`
+    - `llvm.hivm.VCMPVS.EQ.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPVS.EQ.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VCMPVS.EQ.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+    - `declare void @llvm.hivm.VCMPVS.EQ.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_eq(__ubuf__ uint8_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t src0BlockStride, uint16_t dstRepeatStride, uint16_t src0RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_eq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpvs_ge`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPVS.GE.f16`
+    - `llvm.hivm.VCMPVS.GE.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPVS.GE.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VCMPVS.GE.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpvs_ge(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_ge(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_ge(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_ge(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_ge(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_ge(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ge` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpvs_gt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPVS.GT.f16`
+    - `llvm.hivm.VCMPVS.GT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPVS.GT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VCMPVS.GT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpvs_gt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_gt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_gt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_gt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_gt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_gt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_gt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpvs_le`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPVS.LE.f16`
+    - `llvm.hivm.VCMPVS.LE.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPVS.LE.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VCMPVS.LE.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpvs_le(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_le(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_le(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_le(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_le(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_le(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_le` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpvs_lt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPVS.LT.f16`
+    - `llvm.hivm.VCMPVS.LT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPVS.LT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VCMPVS.LT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpvs_lt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_lt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_lt(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_lt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_lt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_lt(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_lt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcmpvs_ne`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCMPVS.NE.f16`
+    - `llvm.hivm.VCMPVS.NE.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCMPVS.NE.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VCMPVS.NE.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcmpvs_ne(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_ne(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_ne(__ubuf__ uint8_t* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_ne(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcmpvs_ne(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcmpvs_ne(__ubuf__ uint8_t* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcmpvs_ne` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconcat`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONCAT.f16`
+    - `llvm.hivm.VCONCAT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONCAT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONCAT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconcat(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconcat(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint8_t stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconcat` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconcat(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconcat(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint8_t stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconcat` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_bf162f32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.bf162f32.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.bf162f32.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_bf162f32(__ubuf__ float* dst, __ubuf__ bfloat16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_bf162f32(__ubuf__ float* dst, __ubuf__ bfloat16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_bf162f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_bf162s32a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.bf162s32a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.bf162s32a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_bf162s32a(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_bf162s32a(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_bf162s32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_bf162s32c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.bf162s32c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.bf162s32c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_bf162s32c(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_bf162s32c(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_bf162s32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_bf162s32f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.bf162s32f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.bf162s32f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_bf162s32f(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_bf162s32f(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_bf162s32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_bf162s32r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.bf162s32r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.bf162s32r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_bf162s32r(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_bf162s32r(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_bf162s32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_bf162s32z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.bf162s32z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.bf162s32z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_bf162s32z(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_bf162s32z(__ubuf__ int32_t* dst, __ubuf__ bfloat16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_bf162s32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_deq`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.DEQ`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.DEQ(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_deq(__ubuf__ half* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_deq(__ubuf__ half* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_deq(__ubuf__ half* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deq` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_deqs162b8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.DEQs162s8`
+    - `llvm.hivm.VCONV.DEQs162u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.DEQs162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCONV.DEQs162u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_deqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint64_t config, bool halfBlock);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_deqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool halfBlock);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_deqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint64_t config, bool halfBlock);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_deqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool halfBlock);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_deqs162b8h`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.deq.s162Sc8h.v220`
+    - `llvm.hivm.VCONV.deq.s162Uc8h.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.deq.s162Sc8h.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.deq.s162Uc8h.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_deqs162b8h(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_deqs162b8h(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deqs162b8h` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_deqs162b8h(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_deqs162b8h(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deqs162b8h` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_deqs162b8l`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.deq.s162Sc8l.v220`
+    - `llvm.hivm.VCONV.deq.s162Uc8l.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.deq.s162Sc8l.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.deq.s162Uc8l.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_deqs162b8l(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_deqs162b8l(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deqs162b8l` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_deqs162b8l(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_deqs162b8l(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_deqs162b8l` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162f32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162f32(__ubuf__ float* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162f32(__ubuf__ float* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162f32(__ubuf__ float* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162f32(__ubuf__ float* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s16a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s16a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s16a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s16a(__ubuf__ int16_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s16a(__ubuf__ int16_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s16a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s16c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s16c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s16c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s16c(__ubuf__ int16_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s16c(__ubuf__ int16_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s16c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s16f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s16f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s16f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s16f(__ubuf__ int16_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s16f(__ubuf__ int16_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s16f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s16r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s16r`
+    - `llvm.hivm.VCONV.f162s16r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s16r(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.f162s16r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s16r(__ubuf__ int16_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s16r(__ubuf__ int16_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s16r(__ubuf__ int16_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s16z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s16z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s16z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s16z(__ubuf__ int16_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s16z(__ubuf__ int16_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s16z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s32a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s32a`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s32a(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s32a(__ubuf__ int32_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s32a(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32a(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32a(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s32c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s32c`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s32c(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s32c(__ubuf__ int32_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s32c(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32c(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32c(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s32f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s32f`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s32f(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s32f(__ubuf__ int32_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s32f(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32f(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32f(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s32r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s32r`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s32r(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s32r(__ubuf__ int32_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s32r(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32r(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32r(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s32z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s32z`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s32z(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s32z(__ubuf__ int32_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s32z(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32z(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s32z(__ubuf__ int32_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s4`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s4`
+    - `llvm.hivm.VCONV.f162s4.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s4(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.f162s4.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s4(__ubuf__ void* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s4(__ubuf__ void* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s4` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s4(__ubuf__ void* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s4` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s4a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s4a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s4a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s4a(__ubuf__ void* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s4a(__ubuf__ void* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s4a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s4c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s4c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s4c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s4c(__ubuf__ void* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s4c(__ubuf__ void* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s4c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s4f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s4f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s4f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s4f(__ubuf__ void* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s4f(__ubuf__ void* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s4f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s4r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s4r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s4r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s4r(__ubuf__ void* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s4r(__ubuf__ void* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s4r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s4z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s4z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s4z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s4z(__ubuf__ void* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s4z(__ubuf__ void* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s4z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s8a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s8a`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s8a(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s8a(__ubuf__ int8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s8a(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8a(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8a(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s8c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s8c`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s8c(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s8c(__ubuf__ int8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s8c(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8c(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8c(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s8f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s8f`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s8f(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s8f(__ubuf__ int8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s8f(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8f(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8f(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s8r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s8r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s8r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s8r(__ubuf__ int8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s8r(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162s8z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162s8z`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162s8z(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162s8z(__ubuf__ int8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162s8z(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8z(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162s8z(__ubuf__ int8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162s8z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162u8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162u8(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162u8(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162u8a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162u8a`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162u8a(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162u8a(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162u8a(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8a(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8a(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162u8c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162u8c`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162u8c(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162u8c(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162u8c(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8c(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8c(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162u8f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162u8f`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162u8f(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162u8f(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162u8f(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8f(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8f(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162u8r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162u8r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162u8r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162u8r(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162u8r(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f162u8z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f162u8z`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f162u8z(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f162u8z(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f162u8z(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8z(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f162u8z(__ubuf__ uint8_t* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f162u8z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322bf16a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322bf16a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322bf16a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322bf16a(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322bf16a(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322bf16a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322bf16c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322bf16c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322bf16c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322bf16c(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322bf16c(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322bf16c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322bf16f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322bf16f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322bf16f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322bf16f(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322bf16f(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322bf16f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322bf16r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322bf16r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322bf16r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322bf16r(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322bf16r(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322bf16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322bf16z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322bf16z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322bf16z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322bf16z(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322bf16z(__ubuf__ bfloat16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322bf16z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f16a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f16a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f16a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f16a(__ubuf__ half* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f16a(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f16c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f16c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f16c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f16c(__ubuf__ half* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f16c(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f16f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f16f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f16f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f16f(__ubuf__ half* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f16f(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f16o`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f16o`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f16o(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f16o(__ubuf__ half* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f16o(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16o` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322f16o(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16o` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322f16o(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16o` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f16r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f16r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f16r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f16r(__ubuf__ half* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f16r(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f16z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f16z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f16z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f16z(__ubuf__ half* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f16z(__ubuf__ half* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f16z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f32a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f32a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f32a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f32a(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f32a(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f32c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f32c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f32c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f32c(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f32c(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f32f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f32f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f32f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f32f(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f32f(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f32r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f32r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f32r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f32r(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f32r(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322f32z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322f32z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322f32z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322f32z(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322f32z(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322f32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s16a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s16a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s16a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s16a(__ubuf__ int16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s16a(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s16c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s16c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s16c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s16c(__ubuf__ int16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s16c(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s16f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s16f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s16f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s16f(__ubuf__ int16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s16f(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s16r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s16r`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s16r(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s16r(__ubuf__ int16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s16r(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s16r(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s16r(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s16z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s16z`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s16z(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s16z(__ubuf__ int16_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s16z(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s16z(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s16z(__ubuf__ int16_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s16z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s32a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s32a`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s32a(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s32a(__ubuf__ int32_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s32a(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32a(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32a(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s32c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s32c`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s32c(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s32c(__ubuf__ int32_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s32c(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32c(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32c(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s32f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s32f`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s32f(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s32f(__ubuf__ int32_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s32f(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32f(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32f(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s32r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s32r`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s32r(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s32r(__ubuf__ int32_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s32r(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32r(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32r(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s32z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s32z`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s32z(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s32z(__ubuf__ int32_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s32z(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32z(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_f322s32z(__ubuf__ int32_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s64a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s64a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s64a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s64a(__ubuf__ int64_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s64a(__ubuf__ int64_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s64a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s64c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s64c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s64c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s64c(__ubuf__ int64_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s64c(__ubuf__ int64_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s64c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s64f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s64f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s64f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s64f(__ubuf__ int64_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s64f(__ubuf__ int64_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s64f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s64r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s64r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s64r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s64r(__ubuf__ int64_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s64r(__ubuf__ int64_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s64r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_f322s64z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.f322s64z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.f322s64z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_f322s64z(__ubuf__ int64_t* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_f322s64z(__ubuf__ int64_t* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_f322s64z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s162f16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s162f16`
+    - `llvm.hivm.VCONV.s162f16.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s162f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.s162f16.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s162f16(__ubuf__ half* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s162f16(__ubuf__ half* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_s162f16(__ubuf__ half* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s162f16a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s162f16a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s162f16a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s162f16a(__ubuf__ half* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s162f16a(__ubuf__ half* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f16a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s162f16c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s162f16c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s162f16c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s162f16c(__ubuf__ half* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s162f16c(__ubuf__ half* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f16c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s162f16f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s162f16f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s162f16f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s162f16f(__ubuf__ half* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s162f16f(__ubuf__ half* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f16f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s162f16r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s162f16r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s162f16r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s162f16r(__ubuf__ half* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s162f16r(__ubuf__ half* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f16r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s162f16z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s162f16z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s162f16z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s162f16z(__ubuf__ half* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s162f16z(__ubuf__ half* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f16z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s162f32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s162f32`
+    - `llvm.hivm.VCONV.s162f32.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s162f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.s162f32.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s162f32(__ubuf__ float* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s162f32(__ubuf__ float* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_s162f32(__ubuf__ float* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s162f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322f32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322f32(__ubuf__ float* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322f32(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_s322f32(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_s322f32(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322f32a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322f32a.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322f32a.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322f32a(__ubuf__ float* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322f32a(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322f32c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322f32c.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322f32c.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322f32c(__ubuf__ float* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322f32c(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322f32f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322f32f.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322f32f.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322f32f(__ubuf__ float* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322f32f(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322f32r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322f32r.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322f32r.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322f32r(__ubuf__ float* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322f32r(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322f32z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322f32z.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322f32z.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322f32z(__ubuf__ float* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322f32z(__ubuf__ float* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322f32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322s16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322s16.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322s16.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322s16(__ubuf__ int16_t* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322s16(__ubuf__ int16_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322s16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s322s64`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s322s64.1.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s322s64.1.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s322s64(__ubuf__ int64_t* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s322s64(__ubuf__ int64_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s322s64` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s42f16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s42f16.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s42f16.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s42f16(__ubuf__ half* dst, __ubuf__ void* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s42f16(__ubuf__ half* dst, __ubuf__ void* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s42f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s642f32a`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s642f32a.1.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s642f32a.1.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s642f32a(__ubuf__ float* dst, __ubuf__ int64_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s642f32a(__ubuf__ float* dst, __ubuf__ int64_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s642f32a` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s642f32c`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s642f32c.1.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s642f32c.1.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s642f32c(__ubuf__ float* dst, __ubuf__ int64_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s642f32c(__ubuf__ float* dst, __ubuf__ int64_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s642f32c` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s642f32f`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s642f32f.1.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s642f32f.1.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s642f32f(__ubuf__ float* dst, __ubuf__ int64_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s642f32f(__ubuf__ float* dst, __ubuf__ int64_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s642f32f` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s642f32r`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s642f32r.1.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s642f32r.1.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s642f32r(__ubuf__ float* dst, __ubuf__ int64_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s642f32r(__ubuf__ float* dst, __ubuf__ int64_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s642f32r` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s642f32z`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s642f32z.1.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s642f32z.1.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s642f32z(__ubuf__ float* dst, __ubuf__ int64_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s642f32z(__ubuf__ float* dst, __ubuf__ int64_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s642f32z` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s642s32`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s642s32.1.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s642s32.1.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s642s32(__ubuf__ int32_t* dst, __ubuf__ int64_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s642s32(__ubuf__ int32_t* dst, __ubuf__ int64_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s642s32` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_s82f16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.s82f16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.s82f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_s82f16(__ubuf__ half* dst, __ubuf__ int8_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_s82f16(__ubuf__ half* dst, __ubuf__ int8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s82f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_s82f16(__ubuf__ half* dst, __ubuf__ int8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s82f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_s82f16(__ubuf__ half* dst, __ubuf__ int8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_s82f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_u82f16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.u82f16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.u82f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_u82f16(__ubuf__ half* dst, __ubuf__ uint8_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_u82f16(__ubuf__ half* dst, __ubuf__ uint8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_u82f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_u82f16(__ubuf__ half* dst, __ubuf__ uint8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_u82f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_u82f16(__ubuf__ half* dst, __ubuf__ uint8_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_u82f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_vdeqs162b8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.VDEQs162s8`
+    - `llvm.hivm.VCONV.VDEQs162u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.VDEQs162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VCONV.VDEQs162u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint64_t config, bool halfBlock);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool halfBlock);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_vdeqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint64_t config, bool halfBlock);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool halfBlock);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_vdeqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_vdeqs162b8h`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.vdeq.s162Sc8h.v220`
+    - `llvm.hivm.VCONV.vdeq.s162Uc8h.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.vdeq.s162Sc8h.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.vdeq.s162Uc8h.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_vdeqs162b8h(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_vdeqs162b8h(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_vdeqs162b8h` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_vdeqs162b8h(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_vdeqs162b8h(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_vdeqs162b8h` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vconv_vdeqs162b8l`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCONV.vdeq.s162Sc8l.v220`
+    - `llvm.hivm.VCONV.vdeq.s162Uc8l.v220`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCONV.vdeq.s162Sc8l.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCONV.vdeq.s162Uc8l.v220(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vconv_vdeqs162b8l(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_vdeqs162b8l(__ubuf__ int8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_vdeqs162b8l` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vconv_vdeqs162b8l(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vconv_vdeqs162b8l(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vconv_vdeqs162b8l` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcopy`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCOPY.s16`
+    - `llvm.hivm.VCOPY.s32`
+    - `llvm.hivm.VCOPY.u16`
+    - `llvm.hivm.VCOPY.u32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCOPY.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCOPY.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCOPY.u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCOPY.u32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcopy(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcopy(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstStride, uint16_t srcStride, uint16_t dstRepeatSize, uint16_t srcRepeatSize);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcopy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcopy(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcopy(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstStride, uint16_t srcStride, uint16_t dstRepeatSize, uint16_t srcRepeatSize);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcopy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcopy(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcopy(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstStride, uint16_t srcStride, uint16_t dstRepeatSize, uint16_t srcRepeatSize);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcopy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcopy(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcopy(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint8_t repeat, uint16_t dstStride, uint16_t srcStride, uint16_t dstRepeatSize, uint16_t srcRepeatSize);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcopy` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vcpadd`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VCPADD.f16`
+    - `llvm.hivm.VCPADD.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VCPADD.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VCPADD.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vcpadd(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcpadd(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcpadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcpadd(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcpadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcpadd(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vcpadd(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcpadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vcpadd(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vcpadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vdiv`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VDIV.f16`
+    - `llvm.hivm.VDIV.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VDIV.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VDIV.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vdiv(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vdiv(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vdiv` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vdiv(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vdiv` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vdiv(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vdiv(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vdiv` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vdiv(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vdiv` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vdp`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VDP.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VDP.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vdp(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint16_t numPixel, uint8_t numMaxDisparity, uint16_t offsetPixel, uint16_t dynamicAddrRange, bool isBeginPixel, bool isPathReverse, bool pathMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vdp` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vdp(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vector_dup`
+  - LLVM intrinsic names:
+    - `llvm.hivm.MOVEV.bf16`
+    - `llvm.hivm.MOVEV.f16`
+    - `llvm.hivm.MOVEV.f32`
+    - `llvm.hivm.MOVEV.s16`
+    - `llvm.hivm.MOVEV.s32`
+    - `llvm.hivm.MOVEV.u16`
+    - `llvm.hivm.MOVEV.u32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.MOVEV.bf16(ptr addrspace(6) nocapture writeonly, bfloat, i64) #1`
+    - `declare void @llvm.hivm.MOVEV.f16(ptr addrspace(6) nocapture writeonly, half, i64) #1`
+    - `declare void @llvm.hivm.MOVEV.f32(ptr addrspace(6) nocapture writeonly, float, i64) #1`
+    - `declare void @llvm.hivm.MOVEV.s16(ptr addrspace(6) nocapture writeonly, i64, i64) #1`
+    - `declare void @llvm.hivm.MOVEV.s32(ptr addrspace(6) nocapture writeonly, i64, i64) #1`
+    - `declare void @llvm.hivm.MOVEV.u16(ptr addrspace(6) nocapture writeonly, i64, i64) #1`
+    - `declare void @llvm.hivm.MOVEV.u32(ptr addrspace(6) nocapture writeonly, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vector_dup(__ubuf__ bfloat16_t* dst, bfloat16_t src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vector_dup(__ubuf__ bfloat16_t* dst, bfloat16_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ float* dst, float src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vector_dup(__ubuf__ float* dst, float src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ float* dst, float src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ float* dst, float src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ half* dst, half src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vector_dup(__ubuf__ half* dst, half src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ half* dst, half src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ half* dst, half src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ int16_t* dst, int16_t src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vector_dup(__ubuf__ int16_t* dst, int16_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ int16_t* dst, int16_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ int16_t* dst, int16_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ int32_t* dst, int32_t src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vector_dup(__ubuf__ int32_t* dst, int32_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ int32_t* dst, int32_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ int32_t* dst, int32_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint16_t* dst, uint16_t src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint16_t* dst, uint16_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint16_t* dst, uint16_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint16_t* dst, uint16_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint32_t* dst, uint32_t src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint32_t* dst, uint32_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint32_t* dst, uint32_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vector_dup(__ubuf__ uint32_t* dst, uint32_t src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vector_dup` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vexp`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VEXP.f16`
+    - `llvm.hivm.VEXP.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VEXP.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VEXP.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vexp(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vexp(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vexp` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vexp(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vexp` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vexp(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vexp` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vexp(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vexp(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vexp` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vexp(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vexp` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vexp(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vexp` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vextract`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VEXTRACT.f16`
+    - `llvm.hivm.VEXTRACT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VEXTRACT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VEXTRACT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vextract(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vextract(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint8_t stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vextract` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vextract(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vextract(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint8_t stride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vextract` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vgather`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VGATHER.b16`
+    - `llvm.hivm.VGATHER.b32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VGATHER.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VGATHER.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vgather(__ubuf__ uint16_t* dst, __ubuf__ uint32_t* src, uint32_t offsetAddr, bool repeatStrideMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vgather` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vgather(__ubuf__ uint16_t* dst, __ubuf__ uint32_t* src, uint32_t offsetAddr, uint16_t dstRepeatStride, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vgather` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vgather(__ubuf__ uint16_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vgather(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t offsetAddr, bool repeatStrideMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vgather` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vgather(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t offsetAddr, uint16_t dstRepeatStride, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vgather` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vgather(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vgatherb`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VGATHERB.b16`
+    - `llvm.hivm.VGATHERB.b32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VGATHERB.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VGATHERB.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vgatherb(__ubuf__ uint16_t* dst, __ubuf__ uint32_t* src, uint32_t offsetAddr, uint16_t dstRepeatStride, uint8_t dstBlockStride, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vgatherb` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vgatherb(__ubuf__ uint16_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vgatherb(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t offsetAddr, uint16_t dstRepeatStride, uint8_t dstBlockStride, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vgatherb` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vgatherb(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vld_va_reg`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VLD.VA.REG`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VLD.VA.REG(i64, ptr addrspace(6) nocapture, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vld_va_reg(ub_addr8_t dst, __ubuf__ uint64_t* src, vpart_t config);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vld_va_reg` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vln`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VLN.f16`
+    - `llvm.hivm.VLN.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VLN.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VLN.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vln(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vln(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vln` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vln(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vln` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vln(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vln` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vln(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vln(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vln` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vln(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vln` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vln(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vln` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vlrelu`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VLRELU.f16`
+    - `llvm.hivm.VLRELU.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VLRELU.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VLRELU.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vlrelu(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vlrelu(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t src0BlockStride, uint16_t dstRepeatStride, uint16_t src0RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vlrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vlrelu(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t src0BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vlrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vlrelu(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vlrelu(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t src0BlockStride, uint16_t dstRepeatStride, uint16_t src0RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vlrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vlrelu(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t src0BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vlrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmadd`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMADD.f16`
+    - `llvm.hivm.VMADD.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMADD.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMADD.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmadd(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmadd(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmadd(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmadd(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmadd(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmadd(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmadd` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmaddrelu`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMADDRELU.f16`
+    - `llvm.hivm.VMADDRELU.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMADDRELU.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMADDRELU.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmaddrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmaddrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaddrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaddrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmaddrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaddrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaddrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmax`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMAX.f16`
+    - `llvm.hivm.VMAX.f32`
+    - `llvm.hivm.VMAX.s16`
+    - `llvm.hivm.VMAX.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMAX.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMAX.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMAX.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMAX.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmax(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmax(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmax(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmax(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmax(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmax(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmax(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmax(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmax(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmax(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmax(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmax(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmax` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmaxs`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMAXS.f16`
+    - `llvm.hivm.VMAXS.f32`
+    - `llvm.hivm.VMAXS.s16`
+    - `llvm.hivm.VMAXS.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMAXS.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VMAXS.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+    - `declare void @llvm.hivm.VMAXS.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VMAXS.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmaxs(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmaxs(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaxs(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaxs(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmaxs(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaxs(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaxs(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmaxs(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaxs(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaxs(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmaxs(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmaxs(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmaxs` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmin`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMIN.f16`
+    - `llvm.hivm.VMIN.f32`
+    - `llvm.hivm.VMIN.s16`
+    - `llvm.hivm.VMIN.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMIN.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMIN.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMIN.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMIN.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmin(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmin(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmin(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmin(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmin(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmin(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmin(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmin(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmin(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmin(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmin(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmin(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmin` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmins`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMINS.f16`
+    - `llvm.hivm.VMINS.f32`
+    - `llvm.hivm.VMINS.s16`
+    - `llvm.hivm.VMINS.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMINS.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VMINS.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+    - `declare void @llvm.hivm.VMINS.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VMINS.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmins(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmins(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmins(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmins(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmins(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmins(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmins(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmins(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmins(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmins(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmins(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmins(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmins` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmla`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMLA.f16`
+    - `llvm.hivm.VMLA.f32`
+    - `llvm.hivm.VMLA.fmix`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMLA.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMLA.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMLA.fmix(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmla(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmla(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmla` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmla(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmla` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmla(__ubuf__ float* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmla(__ubuf__ float* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmla` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmla(__ubuf__ float* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmla` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmla(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmla(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmla` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmla(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmla` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmrgsort4`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMRGSORT.f16`
+    - `llvm.hivm.VMRGSORT.f16.V300`
+    - `llvm.hivm.VMRGSORT.f32`
+    - `llvm.hivm.VMRGSORT.f32.V300`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMRGSORT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMRGSORT.f16.V300(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VMRGSORT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMRGSORT.f32.V300(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-m200-vec, dav-m300`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmrgsort4(__ubuf__ float* const arg0, __ubuf__ float** const arg1, uint64_t arg2);`
+      - Parameter packing: Direct bottom-level form: `arg2` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmrgsort4(__ubuf__ float* dst, __ubuf__ float** src, uint8_t repeat, uint16_t regionProposalLi0, uint16_t regionProposalLi1, uint16_t regionProposalLi2, uint16_t regionProposalLi3, bool isAllStored, uint8_t maskSignal);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4637): `/* #5078 */ __builtin_cce_vmrgsort4(dst, src, ((regionProposalLi0 & 0xffff) << 0 | (regionProposalLi1 & 0xffff) << 16 | (regionProposalLi2 & 0xffff) << 32 | (regionProposalLi3 & 0xffff) << 48), ((repeat & 0xff) << 0 | (isAllStored & 0x1) << 12 | (maskSignal & 0xf) << 8))`
+    - `void __builtin_cce_vmrgsort4(__ubuf__ float* dst, __ubuf__ float** src0, uint64_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `src1, config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmrgsort4(__ubuf__ half* const arg0, __ubuf__ half** const arg1, uint64_t arg2);`
+      - Parameter packing: Direct bottom-level form: `arg2` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmrgsort4(__ubuf__ half* dst, __ubuf__ half** src, uint8_t repeat, uint16_t regionProposalLi0, uint16_t regionProposalLi1, uint16_t regionProposalLi2, uint16_t regionProposalLi3, bool isAllStored, uint8_t maskSignal);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4637): `/* #5078 */ __builtin_cce_vmrgsort4(dst, src, ((regionProposalLi0 & 0xffff) << 0 | (regionProposalLi1 & 0xffff) << 16 | (regionProposalLi2 & 0xffff) << 32 | (regionProposalLi3 & 0xffff) << 48), ((repeat & 0xff) << 0 | (isAllStored & 0x1) << 12 | (maskSignal & 0xf) << 8))`
+    - `void __builtin_cce_vmrgsort4(__ubuf__ half* dst, __ubuf__ half** src0, uint64_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `src1, config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vmul`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMUL.f16`
+    - `llvm.hivm.VMUL.f32`
+    - `llvm.hivm.VMUL.s16`
+    - `llvm.hivm.VMUL.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMUL.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMUL.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMUL.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VMUL.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmul(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmul(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmul(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmul(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmul(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmul(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmul(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmul(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmul(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmul(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmul(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmul(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmul` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmulconv_f162s8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMULCONV.f162s8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMULCONV.f162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmulconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmulconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmulconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmulconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmulconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmulconv_f162u8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMULCONV.f162u8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMULCONV.f162u8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmulconv_f162u8(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmulconv_f162u8(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmulconv_f162u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmulconv_f162u8(__ubuf__ uint8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmulconv_f162u8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vmuls`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VMULS.f16`
+    - `llvm.hivm.VMULS.f32`
+    - `llvm.hivm.VMULS.s16`
+    - `llvm.hivm.VMULS.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VMULS.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, half, i64) #1`
+    - `declare void @llvm.hivm.VMULS.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, float, i64) #1`
+    - `declare void @llvm.hivm.VMULS.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VMULS.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vmuls(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmuls(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ float* dst, __ubuf__ float* src0, float src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmuls(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ half* dst, __ubuf__ half* src0, half src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmuls(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, int16_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vmuls(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vmuls(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, int32_t src1, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vmuls` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vnot`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VNOT.s16`
+    - `llvm.hivm.VNOT.u16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VNOT.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VNOT.u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vnot(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vnot(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vnot` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vnot(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vnot` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vnot(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vnot` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vnot(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vnot(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vnot` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vnot(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vnot` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vnot(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vnot` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vor`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VOR.s16`
+    - `llvm.hivm.VOR.u16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VOR.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VOR.u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vor(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vor(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vor` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vor(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vor` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vor(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vor(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vor` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vor(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vor` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vpadding`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VPADDING.b16`
+    - `llvm.hivm.VPADDING.b32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VPADDING.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VPADDING.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vpadding(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vpadding(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, uint8_t padMode, bool padSide);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vpadding` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vpadding(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vpadding(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, uint8_t padMode, bool padSide);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vpadding` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vrec`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VREC.f16`
+    - `llvm.hivm.VREC.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VREC.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VREC.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vrec(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vrec(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrec` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrec(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrec` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrec(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrec` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrec(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vrec(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrec` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrec(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrec` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrec(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrec` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vreduce`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VREDUCE.b16`
+    - `llvm.hivm.VREDUCE.b32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VREDUCE.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VREDUCE.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vreduce(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vreduce(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vreduce` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vreduce(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint8_t repeat, uint8_t src0BlockStride, uint8_t patternMode, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vreduce` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vreduce(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src0, __ubuf__ uint32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vreduce(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src0, __ubuf__ uint32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vreduce` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vreduce(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src0, __ubuf__ uint32_t* src1, uint8_t repeat, uint8_t src0BlockStride, uint8_t patternMode, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vreduce` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vreducev2`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VREDUCEv2.b16`
+    - `llvm.hivm.VREDUCEv2.b32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VREDUCEv2.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VREDUCEv2.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vreducev2(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint16_t repeat, uint8_t src0BlockStride, uint8_t patternMode, uint16_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vreducev2` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vreducev2(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src0, __ubuf__ uint16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vreducev2(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src0, __ubuf__ uint32_t* src1, uint16_t repeat, uint8_t src0BlockStride, uint8_t patternMode, uint16_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vreducev2` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vreducev2(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src0, __ubuf__ uint32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vrelu`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VRELU.f16`
+    - `llvm.hivm.VRELU.f32`
+    - `llvm.hivm.VRELU.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VRELU.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VRELU.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VRELU.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vrelu(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vrelu(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vrelu(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vrelu(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrelu(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vrsqrt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VRSQRT.f16`
+    - `llvm.hivm.VRSQRT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VRSQRT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VRSQRT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vrsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vrsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vrsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vrsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vrsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vscatter`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSCATTER.b16`
+    - `llvm.hivm.VSCATTER.b32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSCATTER.b16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSCATTER.b32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vscatter(__ubuf__ uint32_t* dst, __ubuf__ uint16_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vscatter(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+- `__builtin_cce_vsel`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSEL.f16`
+    - `llvm.hivm.VSEL.f16.1`
+    - `llvm.hivm.VSEL.f32`
+    - `llvm.hivm.VSEL.f32.1`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSEL.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSEL.f16.1(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSEL.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSEL.f32.1(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ void* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ void* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ void* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ void* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ void* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ void* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ void* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsel(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ void* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, uint8_t selectMode, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsel` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vshl`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSHL.s16`
+    - `llvm.hivm.VSHL.s32`
+    - `llvm.hivm.VSHL.u16`
+    - `llvm.hivm.VSHL.u32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSHL.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VSHL.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VSHL.u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+    - `declare void @llvm.hivm.VSHL.u32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vshl(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint32_t shlDistance, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshl(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint32_t shlDistance, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshl(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint32_t shlDistance, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshl(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t shlDistance, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshl(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshl(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t shlDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshl` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vshr`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSHR.s16`
+    - `llvm.hivm.VSHR.s32`
+    - `llvm.hivm.VSHR.u16`
+    - `llvm.hivm.VSHR.u32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSHR.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64, i64) #1`
+    - `declare void @llvm.hivm.VSHR.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64, i64) #1`
+    - `declare void @llvm.hivm.VSHR.u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64, i64) #1`
+    - `declare void @llvm.hivm.VSHR.u32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vshr(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, int32_t shrDistance, uint64_t config, bool round);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshr(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, int32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshr(__ubuf__ int16_t* dst, __ubuf__ int16_t* src, int32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshr(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, int32_t shrDistance, uint64_t config, bool round);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshr(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, int32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshr(__ubuf__ int32_t* dst, __ubuf__ int32_t* src, int32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshr(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint32_t shrDistance, uint64_t config, bool round);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshr(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshr(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src, uint32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshr(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t shrDistance, uint64_t config, bool round);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vshr(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vshr(__ubuf__ uint32_t* dst, __ubuf__ uint32_t* src, uint32_t shrDistance, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode, bool round);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vshr` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsort`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSORT.f16`
+    - `llvm.hivm.VSORT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSORT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSORT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-t210`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsort(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsort(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsort` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsort(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsort(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsort` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsqrt`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSQRT.f16`
+    - `llvm.hivm.VSQRT.f32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSQRT.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSQRT.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsqrt(__ubuf__ float* dst, __ubuf__ float* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint16_t dstRepeatStride, uint16_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsqrt(__ubuf__ half* dst, __ubuf__ half* src, uint8_t repeat, uint16_t dstBlockStride, uint16_t srcBlockStride, uint8_t dstRepeatStride, uint8_t srcRepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsqrt` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsub`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSUB.f16`
+    - `llvm.hivm.VSUB.f32`
+    - `llvm.hivm.VSUB.s16`
+    - `llvm.hivm.VSUB.s32`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSUB.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSUB.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSUB.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSUB.s32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsub(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsub(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsub(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsub(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsub(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsub(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsub(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsub(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsub(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsub(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsub(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsub(__ubuf__ int32_t* dst, __ubuf__ int32_t* src0, __ubuf__ int32_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsub` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsubrelu`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSUBRELU.f16`
+    - `llvm.hivm.VSUBRELU.f32`
+    - `llvm.hivm.VSUBRELU.s16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSUBRELU.f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSUBRELU.f32(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+    - `declare void @llvm.hivm.VSUBRELU.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture readonly, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsubrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubrelu(__ubuf__ float* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubrelu(__ubuf__ half* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubrelu(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubrelu(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubrelu(__ubuf__ int16_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubrelu` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsubreluconv_f162s8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSUBRELUCONV.f162s8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSUBRELUCONV.f162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsubreluconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubreluconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubreluconv_f162s8(__ubuf__ int8_t* dst, __ubuf__ half* src0, __ubuf__ half* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_f162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsubreluconv_f322f16`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSUBRELUCONV.f322f16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSUBRELUCONV.f322f16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsubreluconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubreluconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_f322f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubreluconv_f322f16(__ubuf__ half* dst, __ubuf__ float* src0, __ubuf__ float* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_f322f16` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsubreluconv_s162s8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSUBRELUCONV.s162s8`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSUBRELUCONV.s162s8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-c220-vec, dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsubreluconv_s162s8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubreluconv_s162s8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_s162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubreluconv_s162s8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_s162s8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vsubreluconv_vdeqs162b8`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VSUBRELUCONV.VDEQs162b8`
+    - `llvm.hivm.VSUBRELUCONV.VDEQs162b8.1`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VSUBRELUCONV.VDEQs162b8(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+    - `declare void @llvm.hivm.VSUBRELUCONV.VDEQs162b8.1(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly, ptr addrspace(6) nocapture, i64, i64) #1`
+  - Probe targets used: `dav-s200`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vsubreluconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubreluconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4657): `/* #5307 */ __builtin_cce_vsubreluconv_vdeqs162b8(dst, src0, src1, ((repeat & 0xff) << 56 | (dstBlockStride & 0xff) << 0 | (src0BlockStride & 0xff) << 8 | (src1BlockStride & 0xff) << 16 | (dstRepeatStride & 0xff) << 24 | (src0RepeatStride & 0xff) << 32 | (src1RepeatStride & 0xff) << 40), h)`
+    - `void __builtin_cce_vsubreluconv_vdeqs162b8(__ubuf__ int8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_vdeqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vsubreluconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint64_t config, bool h);`
+      - Parameter packing: Direct bottom-level form: `config` is already supplied as the packed operand; no `// ->` wrapper packing comment is needed.
+    - `void __builtin_cce_vsubreluconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool h);`
+      - Parameter packing: Header packing comment (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4652): `/* #5308 */ __builtin_cce_vsubreluconv_vdeqs162b8(dst, src0, src1, ((repeat & 0xff) << 56 | (dstBlockStride & 0xff) << 0 | (src0BlockStride & 0xff) << 8 | (src1BlockStride & 0xff) << 16 | (dstRepeatStride & 0xff) << 24 | (src0RepeatStride & 0xff) << 32 | (src1RepeatStride & 0xff) << 40), h)`
+    - `void __builtin_cce_vsubreluconv_vdeqs162b8(__ubuf__ uint8_t* dst, __ubuf__ int16_t* src0, __ubuf__ int16_t* src1, uint8_t repeat, uint8_t dstBlockStride, uint8_t src0BlockStride, uint8_t src1BlockStride, uint8_t dstRepeatStride, uint8_t src0RepeatStride, uint8_t src1RepeatStride, bool repeatStrideMode, bool strideSizeMode, bool h);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vsubreluconv_vdeqs162b8` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_vtranspose`
+  - LLVM intrinsic names:
+    - `llvm.hivm.VTRANSPOSE.s16`
+    - `llvm.hivm.VTRANSPOSE.u16`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.VTRANSPOSE.s16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly) #1`
+    - `declare void @llvm.hivm.VTRANSPOSE.u16(ptr addrspace(6) nocapture writeonly, ptr addrspace(6) nocapture readonly) #1`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ pointer-form signatures:
+    - `void __builtin_cce_vtranspose(__ubuf__ int16_t* dst, __ubuf__ int16_t* src);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vtranspose` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+    - `void __builtin_cce_vtranspose(__ubuf__ uint16_t* dst, __ubuf__ uint16_t* src);`
+      - Parameter packing: No CANN `// ->` packing comment found for wrapper `vtranspose` with this parameter list in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_set_cmpmask`
+  - Category: A2/A3 vector mask/control builtin.
+  - C++ wrapper alias: `set_cmpmask` in `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics.h:2027`.
+  - Stub signature source: `.local/cann/tools/tikicpulib/lib/include/stub_fun.h:6692`.
+  - LLVM intrinsic names:
+    - `llvm.hivm.SET.CMPMASK`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.CMPMASK(ptr addrspace(6) nocapture readonly) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.SET.CMPMASK(ptr addrspace(6) null)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ mask/control signatures:
+    - `void __builtin_cce_set_cmpmask(__ubuf__ void* src);`
+      - Parameter packing: Direct bottom-level form: `src` is a UB pointer to the compare-mask source; no CANN `// ->` wrapper packing comment was found in `cce_aicore_intrinsics_3101.h`.
+- `__builtin_cce_set_mask_count`
+  - Category: A2/A3 vector mask/control builtin.
+  - C++ wrapper alias: `set_mask_count` in `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:877`.
+  - Stub signature source: `.local/cann/tools/tikicpulib/lib/include/stub_fun.h:6806`.
+  - LLVM intrinsic names:
+    - `llvm.hivm.SET.MASK.COUNT`
+    - `llvm.hivm.GET.CTRL`
+    - `llvm.hivm.SBITSET1`
+    - `llvm.hivm.SET.CTRL`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.MASK.COUNT() #1`
+    - `declare i64 @llvm.hivm.GET.CTRL() #1`
+    - `declare i64 @llvm.hivm.SBITSET1(i64, i64) #2`
+    - `declare void @llvm.hivm.SET.CTRL(i64) #1`
+  - Actual probe calls:
+    - `%1 = call i64 @llvm.hivm.GET.CTRL()`
+    - `%2 = call i64 @llvm.hivm.SBITSET1(i64 %1, i64 56)`
+    - `call void @llvm.hivm.SET.CTRL(i64 %2)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ mask/control signatures:
+    - `void __builtin_cce_set_mask_count();`
+      - Parameter packing: Header wrapper expansion (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4385): `/* #3885 */ __builtin_cce_set_ctrl(/* #3406 */ __builtin_cce_sbitset1(/* #1952 */ __builtin_cce_get_ctrl(), 56))`
+- `__builtin_cce_set_mask_norm`
+  - Category: A2/A3 vector mask/control builtin.
+  - C++ wrapper alias: `set_mask_norm` in `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:879`.
+  - Stub signature source: `.local/cann/tools/tikicpulib/lib/include/stub_fun.h:6807`.
+  - LLVM intrinsic names:
+    - `llvm.hivm.SET.MASK.NORM`
+    - `llvm.hivm.GET.CTRL`
+    - `llvm.hivm.SBITSET0`
+    - `llvm.hivm.SET.CTRL`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.MASK.NORM() #1`
+    - `declare i64 @llvm.hivm.GET.CTRL() #1`
+    - `declare i64 @llvm.hivm.SBITSET0(i64, i64) #2`
+    - `declare void @llvm.hivm.SET.CTRL(i64) #1`
+  - Actual probe calls:
+    - `%1 = call i64 @llvm.hivm.GET.CTRL()`
+    - `%2 = call i64 @llvm.hivm.SBITSET0(i64 %1, i64 56)`
+    - `call void @llvm.hivm.SET.CTRL(i64 %2)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ mask/control signatures:
+    - `void __builtin_cce_set_mask_norm();`
+      - Parameter packing: Header wrapper expansion (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4390): `/* #3885 */ __builtin_cce_set_ctrl(/* #3405 */ __builtin_cce_sbitset0(/* #1952 */ __builtin_cce_get_ctrl(), 56))`
+- `__builtin_cce_set_vector_mask`
+  - Category: A2/A3 vector mask/control builtin.
+  - C++ wrapper alias: `set_vector_mask` in `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:917`.
+  - Stub signature source: `.local/cann/tools/tikicpulib/lib/include/stub_fun.h:6886`.
+  - LLVM intrinsic names:
+    - `llvm.hivm.SET.VECTOR.MASK`
+    - `llvm.hivm.MOVEMASK`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.VECTOR.MASK(i64, i64) #1`
+    - `declare void @llvm.hivm.MOVEMASK(i64, i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.MOVEMASK(i64 1, i64 1)`
+    - `call void @llvm.hivm.MOVEMASK(i64 0, i64 2)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ mask/control signatures:
+    - `void __builtin_cce_set_vector_mask(uint64_t mask1, uint64_t mask0);`
+      - Parameter packing: Header wrapper expansion (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4505-.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4506): `/* #5432 */ movemask(1, mask1); /* #5432 */ movemask(0, mask0)`
+- `__builtin_cce_set_vector_mask_dup`
+  - Category: A2/A3 vector mask/control builtin.
+  - C++ wrapper alias: `set_vector_mask_dup` in `.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:919`.
+  - Stub signature source: `.local/cann/tools/tikicpulib/lib/include/stub_fun.h:6887`.
+  - LLVM intrinsic names:
+    - `llvm.hivm.SET.VECTOR.MASK.dup`
+    - `llvm.hivm.MOVEMASK`
+  - Observed LLVM IR declarations:
+    - `declare void @llvm.hivm.SET.VECTOR.MASK.dup(i64) #1`
+    - `declare void @llvm.hivm.MOVEMASK(i64, i64) #1`
+  - Actual probe calls:
+    - `call void @llvm.hivm.MOVEMASK(i64 1, i64 1)`
+    - `call void @llvm.hivm.MOVEMASK(i64 0, i64 1)`
+  - Probe targets used: `dav-m200-vec`
+  - Complete C++ mask/control signatures:
+    - `void __builtin_cce_set_vector_mask_dup(uint64_t mask);`
+      - Parameter packing: Header wrapper expansion (.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4511-.local/cann/x86_64-linux/ccec_compiler/lib/clang/15.0.5/include/cce_aicore_intrinsics_3101.h:4512): `/* #5432 */ movemask(1, mask); /* #5432 */ movemask(0, mask)`

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -77,6 +77,7 @@ class PTO_Op<string mnemonic, list<Trait> traits = []>
     : Op<PTO_Dialect, mnemonic, !listconcat(traits, [ ])>;
 
 include "PTO/IR/VPTOOps.td"
+include "PTO/IR/VPTOUbOps.td"
 
 //===----------------------------------------------------------------------===//
 // Pointer/View Ops (for your front-end IR)

--- a/include/PTO/IR/VPTOUbOps.td
+++ b/include/PTO/IR/VPTOUbOps.td
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- VPTOUbOps.td - PTO raw ubuf ops (a2a3) ----------------*- tablegen -*-===//
+
+#ifndef MLIR_DIALECT_PTO_IR_VPTOUBOPS
+#define MLIR_DIALECT_PTO_IR_VPTOUBOPS
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "PTO/IR/VPTOInterfaces.td"
+
+class PTO_UBufBinaryOp<string mnemonic, list<Trait> traits = []>
+    : PTO_Op<mnemonic,
+      !listconcat(traits, [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>])> {
+  let summary = "Raw ubuf binary operation mapping to llvm.hivm intrinsics.";
+  let description = [{
+    Lowers to `llvm.hivm` intrinsics for the a2a3 (dav-c220-vec) backend.
+    Operates directly on ubuf pointers rather than vreg values.
+
+    The repeat / block-stride / repeat-stride operands are packed into a single
+    `i64` config during lowering, following the bit layout defined in
+    `cce_aicore_intrinsics_3101.h`.
+  }];
+
+  let arguments = (ins
+    PTO_BufferType:$dst,
+    PTO_BufferType:$src0,
+    PTO_BufferType:$src1,
+    I64:$repeat,
+    I64:$dstBlockStride,
+    I64:$src0BlockStride,
+    I64:$src1BlockStride,
+    I64:$dstRepeatStride,
+    I64:$src0RepeatStride,
+    I64:$src1RepeatStride
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $dst `,` $src0 `,` $src1 `,`
+    $repeat `,` $dstBlockStride `,` $src0BlockStride `,`
+    $src1BlockStride `,` $dstRepeatStride `,` $src0RepeatStride `,`
+    $src1RepeatStride
+    attr-dict `:` type($dst) `,` type($src0) `,` type($src1) `,`
+    type($repeat) `,` type($dstBlockStride) `,` type($src0BlockStride) `,`
+    type($src1BlockStride) `,` type($dstRepeatStride) `,`
+    type($src0RepeatStride) `,` type($src1RepeatStride)
+  }];
+}
+
+def PTO_UBVaddOp : PTO_UBufBinaryOp<"ub.vadd">;
+def PTO_UBVsubOp : PTO_UBufBinaryOp<"ub.vsub">;
+def PTO_UBVmulOp : PTO_UBufBinaryOp<"ub.vmul">;
+def PTO_UBVdivOp : PTO_UBufBinaryOp<"ub.vdiv">;
+
+def PTO_UBSetMaskOp : PTO_Op<"ub.set_mask", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Set vector mask lanes for UB buffer pipe operations";
+  let description = [{
+    Configures the hardware vector mask registers. Subsequent `pto.ub.*`
+    operations in the same basic block execute under this mask.
+
+    Each bit in the mask corresponds to one element lane. `mask0` covers
+    lanes 0–63, `mask1` covers lanes 64–127.
+    Use `mask0=-1, mask1=-1` to restore full-write mode (all lanes active).
+  }];
+
+  let arguments = (ins I64:$mask0, I64:$mask1);
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $mask0 `,` $mask1 attr-dict `:` type($mask0) `,` type($mask1)
+  }];
+}
+
+def PTO_UBSetMaskCountOp : PTO_Op<"ub.set_mask_count", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Set count mode for UB buffer pipe operations";
+  let description = [{
+    Toggles the hardware control register into count mode (bit 56 set).
+    In count mode, subsequent `pto.ub.*` operations use `MASK[0]` as an
+    element count rather than a per-lane bitmask. `repeat=0` signals the
+    hardware to use the count register.
+
+    Use `pto.ub.set_mask_norm` to restore normal mask mode.
+  }];
+
+  let arguments = (ins);
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    attr-dict
+  }];
+}
+
+def PTO_UBSetMaskNormOp : PTO_Op<"ub.set_mask_norm", [
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
+  let summary = "Restore normal mask mode for UB buffer pipe operations";
+  let description = [{
+    Toggles the hardware control register out of count mode (bit 56 cleared).
+    Subsequent `pto.ub.*` operations interpret `MASK[0..1]` as per-lane
+    bitmasks (normal mode).
+
+    Always pair with a preceding `pto.ub.set_mask_count` or restore after
+    count-mode operations.
+  }];
+
+  let arguments = (ins);
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    attr-dict
+  }];
+}
+
+#endif // MLIR_DIALECT_PTO_IR_VPTOUBOPS

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -95,6 +95,7 @@ std::unique_ptr<Pass> createPTOValidateVPTOEmissionIRPass();
 std::unique_ptr<Pass> createExpandTileOpPass();
 std::unique_ptr<Pass> createExpandTileOpPass(const ExpandTileOpOptions &options);
 std::unique_ptr<Pass> createFoldTileBufIntrinsicsPass();
+std::unique_ptr<Pass> createLowerPTOToUBufOpsPass();
 std::unique_ptr<Pass>
 createPTOInlineLibCallPass(const PTOInlineLibCallOptions &options = {});
 void registerPTOViewToMemrefPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -441,6 +441,27 @@ def FoldTileBufIntrinsics : Pass<"pto-fold-tile-buf-intrinsics", "mlir::func::Fu
   ];
 }
 
+def LowerPTOToUBufOps : Pass<"pto-lower-to-ubuf-ops", "mlir::func::FuncOp"> {
+  let summary = "Lower eligible pto.tadd/tsub/tmul/tdiv to pto.ub.vadd/vsub/vmul/vdiv on a2a3 targets";
+  let description = [{
+    Converts pto.tadd/tsub/tmul/tdiv on UB tiles to pto.ub.vadd/vsub/vmul/vdiv
+    when targeting a3 (dav-c220-vec).  Computes repeat count and repeat strides
+    from the tile shape metadata and emits tile_buf_addr ops to extract UB
+    pointers.  pto.ub.* binary ops are later lowered to llvm.hivm.VADD/VSUB/VMUL/VDIV.*
+    by the VPTOLLVMEmitter.
+
+    Ops that do not meet the eligibility criteria (wrong arch, non-UB space,
+    dynamic shapes, unaligned repeats) pass through to the existing ExpandTileOp
+    TileLang path unchanged.
+  }];
+  let constructor = "mlir::pto::createLowerPTOToUBufOpsPass()";
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::func::FuncDialect",
+    "mlir::arith::ArithDialect"
+  ];
+}
+
 def PTOInlineLibCall : Pass<"pto-inline-libcall", "ModuleOp"> {
   let summary = "Materialize OP-Lib instance bodies and inline OP-Lib calls";
   let description = [{

--- a/lib/PTO/IR/CMakeLists.txt
+++ b/lib/PTO/IR/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_mlir_dialect_library(PTOIR
   PTO.cpp
   VPTO.cpp
+  VPTOUbOps.cpp
   PTOAttrs.cpp
   PTOSyncUtils.cpp
   PTOTypeDefs.cpp

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -7589,3 +7589,95 @@ void MteL0cUbOp::getEffects(
   effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable());
   effects.emplace_back(MemoryEffects::Write::get(), &getDestinationMutable());
 }
+
+//===----------------------------------------------------------------------===//
+// UBVaddOp
+//===----------------------------------------------------------------------===//
+
+void UBVaddOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc0Mutable());
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc1Mutable());
+  effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());
+}
+
+LogicalResult UBVaddOp::verify() {
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
+      !isBufferLike(getSrc1().getType()))
+    return emitOpError("requires pointer-like operands");
+  if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+    return emitOpError("requires UB-backed operands");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// UBVsubOp
+//===----------------------------------------------------------------------===//
+
+void UBVsubOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc0Mutable());
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc1Mutable());
+  effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());
+}
+
+LogicalResult UBVsubOp::verify() {
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
+      !isBufferLike(getSrc1().getType()))
+    return emitOpError("requires pointer-like operands");
+  if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+    return emitOpError("requires UB-backed operands");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// UBVmulOp
+//===----------------------------------------------------------------------===//
+
+void UBVmulOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc0Mutable());
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc1Mutable());
+  effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());
+}
+
+LogicalResult UBVmulOp::verify() {
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
+      !isBufferLike(getSrc1().getType()))
+    return emitOpError("requires pointer-like operands");
+  if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+    return emitOpError("requires UB-backed operands");
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// UBVdivOp
+//===----------------------------------------------------------------------===//
+
+void UBVdivOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc0Mutable());
+  effects.emplace_back(MemoryEffects::Read::get(), &getSrc1Mutable());
+  effects.emplace_back(MemoryEffects::Write::get(), &getDstMutable());
+}
+
+LogicalResult UBVdivOp::verify() {
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc0().getType()) ||
+      !isBufferLike(getSrc1().getType()))
+    return emitOpError("requires pointer-like operands");
+  if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc0().getType()) != MemoryRole::UB ||
+      classifyMemoryRole(getSrc1().getType()) != MemoryRole::UB)
+    return emitOpError("requires UB-backed operands");
+  return success();
+}

--- a/lib/PTO/IR/VPTOUbOps.cpp
+++ b/lib/PTO/IR/VPTOUbOps.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- VPTOUbOps.cpp --------------------------------------------------===//
+
+#include "PTO/IR/PTO.h"
+
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace pto {
+
+//===----------------------------------------------------------------------===//
+// UBSetMaskOp
+//===----------------------------------------------------------------------===//
+
+void UBSetMaskOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+LogicalResult UBSetMaskOp::verify() {
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// UBSetMaskCountOp
+//===----------------------------------------------------------------------===//
+
+void UBSetMaskCountOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+LogicalResult UBSetMaskCountOp::verify() {
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// UBSetMaskNormOp
+//===----------------------------------------------------------------------===//
+
+void UBSetMaskNormOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(),
+                       SideEffects::DefaultResource::get());
+}
+
+LogicalResult UBSetMaskNormOp::verify() {
+  return success();
+}
+
+} // namespace pto
+} // namespace mlir

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -36,6 +36,7 @@ add_mlir_dialect_library(PTOTransforms
   PTOValidateIntToPtrUses.cpp
   ExpandTileOp.cpp
   FoldTileBufIntrinsics.cpp
+  LowerPTOToUBufOps.cpp
   PTOLowerToOpLibCalls.cpp
   PTOInstantiateAndInlineOpLib.cpp
   PTOToEmitC.cpp

--- a/lib/PTO/Transforms/LowerPTOToUBufOps.cpp
+++ b/lib/PTO/Transforms/LowerPTOToUBufOps.cpp
@@ -1,0 +1,1076 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- LowerPTOToUBufOps.cpp - Lower pto.tadd/tsub/tmul/tdiv on a2a3 -----===//
+//===----------------------------------------------------------------------===//
+//
+// Lowers pto.tadd/tsub/tmul/tdiv to pto.ub.vadd/vsub/vmul/vdiv on a3.
+// Uses the full CCE dispatch tree from TBinOp.hpp with all modes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_LOWERPTOTOUBUFOPS
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+namespace {
+
+static constexpr int64_t kRepeatMax = 255;
+static constexpr int64_t kRepeatStrideMax = 255;
+static constexpr int64_t kSmallRptBinOp = 4;
+static constexpr int64_t kDefaultRepeatStride = 8;
+static constexpr unsigned kMaskLen = 64;
+
+//===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
+
+static unsigned getElementSize(Type elemTy) {
+  if (elemTy.isF16() || elemTy.isBF16())
+    return 2;
+  if (elemTy.isF32())
+    return 4;
+  if (auto intTy = dyn_cast<IntegerType>(elemTy)) {
+    unsigned width = intTy.getWidth();
+    if (width == 16 || width == 32)
+      return width / 8;
+  }
+  return 0;
+}
+
+static Type getStoredElemType(Type ty) {
+  if (auto tbTy = dyn_cast<pto::TileBufType>(ty))
+    return tbTy.getElementType();
+  if (auto mrTy = dyn_cast<MemRefType>(ty))
+    return mrTy.getElementType();
+  if (auto ptrTy = dyn_cast<pto::PtrType>(ty))
+    return ptrTy.getElementType();
+  return Type();
+}
+
+/// Returns true if the type lives in UB (VEC) address space.
+static std::optional<bool> isUBMemorySpaceImpl(Type ty) {
+  if (auto tbTy = dyn_cast<pto::TileBufType>(ty)) {
+    auto msAttr =
+        dyn_cast_or_null<pto::AddressSpaceAttr>(tbTy.getMemorySpace());
+    if (!msAttr)
+      return false;
+    return msAttr.getAddressSpace() == pto::AddressSpace::VEC;
+  }
+  if (auto mrTy = dyn_cast<MemRefType>(ty)) {
+    auto msAttr =
+        dyn_cast_or_null<pto::AddressSpaceAttr>(mrTy.getMemorySpace());
+    if (!msAttr)
+      return false;
+    return msAttr.getAddressSpace() == pto::AddressSpace::VEC;
+  }
+  if (auto ptrTy = dyn_cast<pto::PtrType>(ty))
+    return ptrTy.getMemorySpace().getAddressSpace() == pto::AddressSpace::VEC;
+  return std::nullopt;
+}
+
+/// Returns true if the given type is confirmed UB memory space.
+static bool isUBMemorySpace(Type ty) {
+  auto result = isUBMemorySpaceImpl(ty);
+  return result.has_value() && result.value();
+}
+
+static bool isRowMajor(pto::TileBufType tbTy) {
+  auto config = tbTy.getConfigAttr();
+  if (!config)
+    return true;
+  return config.getBLayout().getValue() != pto::BLayout::ColMajor;
+}
+
+static pto::PtrType getUBPtrType(MLIRContext *ctx, Type elemTy) {
+  auto msAttr = pto::AddressSpaceAttr::get(ctx, pto::AddressSpace::VEC);
+  return pto::PtrType::get(ctx, elemTy, msAttr);
+}
+
+static std::pair<int64_t, int64_t>
+computeContMaskValues(unsigned nElements) {
+  int64_t mask0 = (nElements >= kMaskLen)
+      ? static_cast<int64_t>(0xFFFFFFFFFFFFFFFFULL)
+      : static_cast<int64_t>((1ULL << nElements) - 1ULL);
+  int64_t mask1 = (nElements > kMaskLen)
+      ? static_cast<int64_t>((1ULL << (nElements - kMaskLen)) - 1ULL)
+      : 0LL;
+  return {mask0, mask1};
+}
+
+struct TileShapeInfo {
+  int64_t vRows;
+  int64_t vCols;
+  int64_t cols;
+  int64_t rows;
+  unsigned elemSize;
+  unsigned elementsPerRepeat;
+  unsigned blockSizeElem;
+};
+
+static std::optional<TileShapeInfo> extractTileShapeInfo(
+    Operation *op,
+    const DenseMap<Value, SmallVector<int64_t, 2>> &tileShapes) {
+  auto opDst = op->getOperand(2);
+  Type dstTy = opDst.getType();
+  if (!isUBMemorySpace(dstTy))
+    return std::nullopt;
+
+  Type elemTy;
+  ArrayRef<int64_t> shape;
+  ArrayRef<int64_t> validShape;
+  if (auto tbTy = dyn_cast<pto::TileBufType>(dstTy)) {
+    elemTy = tbTy.getElementType();
+    shape = tbTy.getShape();
+    validShape = tbTy.getValidShape();
+    if (!isRowMajor(tbTy))
+      return std::nullopt;
+  } else if (auto mrTy = dyn_cast<MemRefType>(dstTy)) {
+    elemTy = mrTy.getElementType();
+    shape = mrTy.getShape();
+  } else if (isa<pto::PtrType>(dstTy)) {
+    auto it = tileShapes.find(opDst);
+    if (it == tileShapes.end())
+      return std::nullopt;
+    elemTy = cast<pto::PtrType>(dstTy).getElementType();
+    shape = llvm::ArrayRef(it->second);
+  } else {
+    return std::nullopt;
+  }
+  unsigned elemSize = getElementSize(elemTy);
+  if (elemSize == 0)
+    return std::nullopt;
+
+  if (shape.size() < 2)
+    return std::nullopt;
+
+  int64_t rows = shape[0];
+  int64_t cols = shape[1];
+  int64_t vRows = (!validShape.empty() &&
+                   validShape[0] != ShapedType::kDynamic)
+                      ? validShape[0] : rows;
+  int64_t vCols = (validShape.size() >= 2 &&
+                   validShape[1] != ShapedType::kDynamic)
+                      ? validShape[1] : cols;
+  if (vRows == ShapedType::kDynamic || vCols == ShapedType::kDynamic ||
+      rows == ShapedType::kDynamic || cols == ShapedType::kDynamic)
+    return std::nullopt;
+
+  TileShapeInfo info;
+  info.vRows = vRows;
+  info.vCols = vCols;
+  info.cols = cols;
+  info.rows = rows;
+  info.elemSize = elemSize;
+  info.elementsPerRepeat = 256 / elemSize;
+  info.blockSizeElem = 32 / elemSize;
+  return info;
+}
+
+static bool canLower(Operation *op,
+                     const DenseMap<Value, SmallVector<int64_t, 2>> &tileShapes) {
+  return extractTileShapeInfo(op, tileShapes).has_value();
+}
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+struct LowerPTOToUBufOpsPass
+    : public pto::impl::LowerPTOToUBufOpsBase<LowerPTOToUBufOpsPass> {
+  using LowerPTOToUBufOpsBase::LowerPTOToUBufOpsBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (func.isExternal())
+      return;
+    auto mod = func->getParentOfType<ModuleOp>();
+    if (!mod)
+      return;
+    auto archAttr = mod->getAttrOfType<StringAttr>("pto.target_arch");
+    if (!archAttr || archAttr.getValue() != "a3")
+      return;
+
+    MLIRContext *ctx = &getContext();
+    OpBuilder builder(ctx);
+
+    // A3: sequential memory planning for alloc_tile buffers.  Must run first
+    // so lowering sees PtrType from CastPtrOp instead of tile_buf.
+    DenseMap<Value, SmallVector<int64_t, 2>> tileShapes;
+    {
+      SmallVector<pto::AllocTileOp> allocOps;
+      func.walk([&](pto::AllocTileOp op) { allocOps.push_back(op); });
+      uint64_t offset = 0;
+      constexpr uint64_t ubBankAlignment = 65536;
+      for (auto op : allocOps) {
+        auto tbTy = cast<pto::TileBufType>(op.getResult().getType());
+        auto shape = tbTy.getShape();
+        uint64_t numElems = 1;
+        for (auto d : shape)
+          numElems *= d;
+        uint64_t elemSize = getElementSize(tbTy.getElementType());
+        uint64_t totalBytes = numElems * elemSize;
+        builder.setInsertionPoint(op);
+        auto addrConst = builder.create<arith::ConstantOp>(
+            op.getLoc(), builder.getI64IntegerAttr(offset));
+        auto ptrTy = pto::PtrType::get(
+            ctx, tbTy.getElementType(),
+            pto::AddressSpaceAttr::get(ctx, pto::AddressSpace::VEC));
+        auto pc = builder.create<pto::CastPtrOp>(
+            op.getLoc(), ptrTy, addrConst.getResult());
+        tileShapes[pc.getResult()] = SmallVector<int64_t, 2>(shape);
+        op.getResult().replaceAllUsesWith(pc.getResult());
+        op.erase();
+        uint64_t paddedBytes = (totalBytes + ubBankAlignment - 1) / ubBankAlignment * ubBankAlignment;
+        offset += paddedBytes;
+      }
+    }
+
+    // ---- tadd → pto.ub.vadd ----
+    {
+      SmallVector<pto::TAddOp> ops;
+      func.walk([&](pto::TAddOp op) { ops.push_back(op); });
+      for (auto op : ops) {
+        if (!canLower(op, tileShapes))
+          continue;
+        auto info = extractTileShapeInfo(op, tileShapes);
+        if (!info)
+          continue;
+        auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
+            builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
+        if (!dstPtr)
+          continue;
+        dispatch<pto::UBVaddOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
+                                ptrType, *info);
+        op.erase();
+      }
+    }
+
+    // ---- tsub → pto.ub.vsub ----
+    {
+      SmallVector<pto::TSubOp> ops;
+      func.walk([&](pto::TSubOp op) { ops.push_back(op); });
+      for (auto op : ops) {
+        if (!canLower(op, tileShapes))
+          continue;
+        auto info = extractTileShapeInfo(op, tileShapes);
+        if (!info)
+          continue;
+        auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
+            builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
+        if (!dstPtr)
+          continue;
+        dispatch<pto::UBVsubOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
+                                ptrType, *info);
+        op.erase();
+      }
+    }
+
+    // ---- tmul → pto.ub.vmul ----
+    {
+      SmallVector<pto::TMulOp> ops;
+      func.walk([&](pto::TMulOp op) { ops.push_back(op); });
+      for (auto op : ops) {
+        if (!canLower(op, tileShapes))
+          continue;
+        auto info = extractTileShapeInfo(op, tileShapes);
+        if (!info)
+          continue;
+        auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
+            builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
+        if (!dstPtr)
+          continue;
+        dispatch<pto::UBVmulOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
+                                ptrType, *info);
+        op.erase();
+      }
+    }
+
+    // ---- tdiv → pto.ub.vdiv ----
+    {
+      SmallVector<pto::TDivOp> ops;
+      func.walk([&](pto::TDivOp op) { ops.push_back(op); });
+      for (auto op : ops) {
+        if (!canLower(op, tileShapes))
+          continue;
+        auto info = extractTileShapeInfo(op, tileShapes);
+        if (!info)
+          continue;
+        auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
+            builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
+        if (!dstPtr)
+          continue;
+        dispatch<pto::UBVdivOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
+                                ptrType, *info);
+        op.erase();
+      }
+    }
+
+    // ---- tload → mte_gm_ub ----
+    SmallVector<pto::TLoadOp> tloadOps;
+    func.walk([&](pto::TLoadOp op) { tloadOps.push_back(op); });
+    for (auto op : tloadOps) {
+      builder.setInsertionPoint(op);
+      if (succeeded(lowerTLoad(op, builder, tileShapes)))
+        op.erase();
+    }
+
+    // ---- tstore → mte_ub_gm ----
+    SmallVector<pto::TStoreOp> tstoreOps;
+    func.walk([&](pto::TStoreOp op) { tstoreOps.push_back(op); });
+    for (auto op : tstoreOps) {
+      builder.setInsertionPoint(op);
+      if (succeeded(lowerTStore(op, builder, tileShapes)))
+        op.erase();
+    }
+
+    // ---- cleanup dead PTO ops ----
+    SmallVector<Operation *> toErase;
+    func.walk([&](Operation *op) {
+      if (isa<pto::PartitionViewOp, pto::MakeTensorViewOp>(op))
+        toErase.push_back(op);
+    });
+    for (auto *op : llvm::reverse(toErase)) {
+      if (op->use_empty())
+        op->erase();
+    }
+  }
+
+private:
+  //===--------------------------------------------------------------------===//
+  // Helpers
+  //===--------------------------------------------------------------------===//
+
+  Value i64c(int64_t val, Location loc, OpBuilder &b) {
+    return b.create<arith::ConstantOp>(loc, b.getI64IntegerAttr(val));
+  }
+  Value idxc(int64_t val, Location loc, OpBuilder &b) {
+    return b.create<arith::ConstantOp>(
+               loc, b.getIntegerAttr(b.getIndexType(), val))
+        .getResult();
+  }
+  Value i64c0(Location loc, OpBuilder &b) { return i64c(0, loc, b); }
+  Value i64c1(Location loc, OpBuilder &b) { return i64c(1, loc, b); }
+  Value i64cM1(Location loc, OpBuilder &b) { return i64c(-1, loc, b); }
+  Value i64c8(Location loc, OpBuilder &b) { return i64c(kDefaultRepeatStride, loc, b); }
+  Value idxc0(Location loc, OpBuilder &b) { return idxc(0, loc, b); }
+  Value idxc1(Location loc, OpBuilder &b) { return idxc(1, loc, b); }
+
+  template <typename UBop>
+  void emitUBBinOp(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                   Value repeat, Value repStride) {
+    b.create<UBop>(loc, dst, s0, s1, repeat,
+                   i64c1(loc, b), i64c1(loc, b), i64c1(loc, b),
+                   repStride, repStride, i64c0(loc, b));
+  }
+
+  void vadd(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+            Value repeat, Value repStride) {
+    emitUBBinOp<pto::UBVaddOp>(loc, b, dst, s0, s1, repeat, repStride);
+  }
+  void vsub(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+            Value repeat, Value repStride) {
+    emitUBBinOp<pto::UBVsubOp>(loc, b, dst, s0, s1, repeat, repStride);
+  }
+  void vmul(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+            Value repeat, Value repStride) {
+    emitUBBinOp<pto::UBVmulOp>(loc, b, dst, s0, s1, repeat, repStride);
+  }
+  void vdiv(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+            Value repeat, Value repStride) {
+    emitUBBinOp<pto::UBVdivOp>(loc, b, dst, s0, s1, repeat, repStride);
+  }
+
+  std::tuple<Value, Value, Value, pto::PtrType>
+  lowerBinaryOpCommon(OpBuilder &builder, MLIRContext *ctx, Operation *op,
+                      Value dstVal, Value src0Val, Value src1Val,
+                      const DenseMap<Value, SmallVector<int64_t, 2>> &tileShapes) {
+    Location loc = op->getLoc();
+    builder.setInsertionPoint(op);
+    Type elemTy = getStoredElemType(dstVal.getType());
+    auto ptrType = getUBPtrType(ctx, elemTy);
+
+    auto emitAddr = [&](Value tile) -> Value {
+      if (isa<pto::PtrType>(tile.getType()))
+        return tile;
+      auto addrOp = builder.create<pto::TileBufAddrOp>(loc, ptrType, tile);
+      return addrOp.getDst();
+    };
+
+    Value dstPtr = emitAddr(dstVal);
+    Value src0Ptr = emitAddr(src0Val);
+    Value src1Ptr = emitAddr(src1Val);
+    return {dstPtr, src0Ptr, src1Ptr, ptrType};
+  }
+
+  template <typename UBop>
+  void modeNorm1L(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                  pto::PtrType ptrTy, const TileShapeInfo &info) {
+    int64_t epr = info.elementsPerRepeat;
+    int64_t totalV = info.vRows * info.vCols;
+    int64_t headRepeats = totalV / epr;
+    int64_t tailElements = totalV % epr;
+
+    if (headRepeats > 1) {
+      auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                          idxc(headRepeats, loc, b), idxc1(loc, b));
+      b.setInsertionPointToStart(forOp.getBody());
+      Value iv = forOp.getInductionVar();
+      Value off = b.create<arith::MulIOp>(loc, iv, idxc(epr, loc, b)).getResult();
+      Value rd = addPtr(loc, b, dst, ptrTy, off);
+      Value r0 = addPtr(loc, b, s0, ptrTy, off);
+      Value r1 = addPtr(loc, b, s1, ptrTy, off);
+      b.create<pto::UBSetMaskCountOp>(loc);
+      b.create<pto::UBSetMaskOp>(loc, i64c(epr, loc, b), i64c0(loc, b));
+      emitUBBinOp<UBop>(loc, b, rd, r0, r1, i64c1(loc, b), i64c8(loc, b));
+      b.create<pto::UBSetMaskNormOp>(loc);
+      b.setInsertionPointAfter(forOp);
+      if (tailElements > 0) {
+        Value offT = idxc(headRepeats * epr, loc, b);
+        Value td = addPtr(loc, b, dst, ptrTy, offT);
+        Value ts0 = addPtr(loc, b, s0, ptrTy, offT);
+        Value ts1 = addPtr(loc, b, s1, ptrTy, offT);
+        b.create<pto::UBSetMaskCountOp>(loc);
+        b.create<pto::UBSetMaskOp>(loc, i64c(tailElements, loc, b), i64c0(loc, b));
+        emitUBBinOp<UBop>(loc, b, td, ts0, ts1, i64c1(loc, b), i64c8(loc, b));
+        b.create<pto::UBSetMaskNormOp>(loc);
+      }
+      return;
+    }
+
+    b.create<pto::UBSetMaskCountOp>(loc);
+    b.create<pto::UBSetMaskOp>(loc, i64c(totalV, loc, b), i64c0(loc, b));
+    emitUBBinOp<UBop>(loc, b, dst, s0, s1, i64c1(loc, b), i64c8(loc, b));
+    b.create<pto::UBSetMaskNormOp>(loc);
+    fullMask(loc, b);
+  }
+
+  void setMask(Location loc, OpBuilder &b, unsigned n) {
+    auto [m0, m1] = computeContMaskValues(n);
+    b.create<pto::UBSetMaskOp>(loc, i64c(m0, loc, b), i64c(m1, loc, b));
+  }
+
+  void fullMask(Location loc, OpBuilder &b) {
+    b.create<pto::UBSetMaskOp>(loc, i64cM1(loc, b), i64c0(loc, b));
+  }
+
+  Value addPtr(Location loc, OpBuilder &b, Value base, pto::PtrType ptrTy,
+                Value off) {
+    return b.create<pto::AddPtrOp>(loc, ptrTy, base, off);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // tload → mte_gm_ub / tstore → mte_ub_gm
+  //===--------------------------------------------------------------------===//
+
+  struct DmaViewInfo {
+    Value gmPtr;
+    SmallVector<Value> sizes;
+    SmallVector<Value> strides;
+    SmallVector<Value> offsets;
+  };
+
+  static FailureOr<DmaViewInfo> extractDmaViewInfo(pto::TLoadOp op) {
+    auto pvOp = op.getSrc().getDefiningOp<pto::PartitionViewOp>();
+    if (!pvOp)
+      return failure();
+    auto mtvOp = pvOp.getSource().getDefiningOp<pto::MakeTensorViewOp>();
+    if (!mtvOp)
+      return failure();
+    DmaViewInfo info;
+    info.gmPtr = mtvOp.getPtr();
+    info.sizes.assign(pvOp.getSizes().begin(), pvOp.getSizes().end());
+    info.strides.assign(mtvOp.getStrides().begin(),
+                        mtvOp.getStrides().end());
+    info.offsets.assign(pvOp.getOffsets().begin(), pvOp.getOffsets().end());
+    return info;
+  }
+
+  Value computeGMByteOffset(Location loc, OpBuilder &b,
+                            const DmaViewInfo &viewInfo, unsigned elemSize) {
+    Value totalOff = idxc0(loc, b);
+    for (size_t i = 0; i < viewInfo.offsets.size() &&
+                        i < viewInfo.strides.size(); ++i) {
+      APInt constOff;
+      if (matchPattern(viewInfo.offsets[i], m_ConstantInt(&constOff)) &&
+          constOff.isZero())
+        continue;
+      Value dimOff = b.create<arith::MulIOp>(loc, viewInfo.offsets[i],
+                                             viewInfo.strides[i]).getResult();
+      totalOff = b.create<arith::AddIOp>(loc, totalOff, dimOff).getResult();
+    }
+    if (elemSize > 1)
+      totalOff = b.create<arith::MulIOp>(loc, totalOff,
+                                         idxc(elemSize, loc, b)).getResult();
+    return totalOff;
+  }
+
+  Value offsetGMPtrByBytes(Location loc, OpBuilder &b, Value gmPtr,
+                           Value byteOff) {
+    APInt constOff;
+    if (matchPattern(byteOff, m_ConstantInt(&constOff)) && constOff.isZero())
+      return gmPtr;
+    auto origPtrTy = cast<pto::PtrType>(gmPtr.getType());
+    auto bytePtrTy = pto::PtrType::get(b.getContext(), b.getI8Type(),
+                                       origPtrTy.getMemorySpace());
+    Value bytePtr = b.create<pto::CastPtrOp>(loc, bytePtrTy, gmPtr);
+    Value offIdx = byteOff;
+    if (!offIdx.getType().isIndex())
+      offIdx = b.create<arith::IndexCastOp>(loc, b.getIndexType(), byteOff)
+                   .getResult();
+    Value offsetBytePtr =
+        b.create<pto::AddPtrOp>(loc, bytePtrTy, bytePtr, offIdx);
+    return b.create<pto::CastPtrOp>(loc, origPtrTy, offsetBytePtr);
+  }
+
+  Value i64Cast(Location loc, OpBuilder &b, Value indexVal) {
+    return b.create<arith::IndexCastOp>(loc, b.getI64Type(), indexVal)
+        .getResult();
+  }
+
+  LogicalResult emitMteGmUb(Location loc, OpBuilder &b, Value gmPtr,
+                             Value ubPtr, const DmaViewInfo &viewInfo,
+                             Type elemTy, ArrayRef<int64_t> tileShape) {
+    if (tileShape.size() < 2) return failure();
+    int64_t ubCols = tileShape[1];
+    unsigned elemSize = getElementSize(elemTy);
+    unsigned nd = viewInfo.sizes.size();
+    if (nd < 2) return failure();
+
+    Value nburstCount = viewInfo.sizes[nd - 2];
+    Value lenBurstElts = viewInfo.sizes[nd - 1];
+    Value lenBurst = b.create<arith::MulIOp>(loc,
+        b.create<arith::IndexCastOp>(loc, b.getI64Type(), lenBurstElts)
+            .getResult(), i64c(elemSize, loc, b)).getResult();
+    Value nburstSrcStride = b.create<arith::MulIOp>(loc,
+        b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+            viewInfo.strides[nd - 2]).getResult(),
+        i64c(elemSize, loc, b)).getResult();
+    Value ubRowStride = b.create<arith::MulIOp>(loc, i64c(ubCols, loc, b),
+                                                i64c(elemSize, loc, b)).getResult();
+    pto::DmaLoopConfig nburst{i64Cast(loc, b, nburstCount),
+                              nburstSrcStride, ubRowStride};
+
+    SmallVector<pto::DmaLoopConfig> loops;
+    for (int i = nd - 3; i >= 0; --i) {
+      Value count = b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+          viewInfo.sizes[i]).getResult();
+      Value srcStride = b.create<arith::MulIOp>(loc,
+          b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+              viewInfo.strides[i]).getResult(),
+          i64c(elemSize, loc, b)).getResult();
+      Value innerElems = i64c1(loc, b);
+      for (int j = i + 1; j < (int)nd; ++j) {
+        Value dimSize = b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+            viewInfo.sizes[j]).getResult();
+        innerElems = b.create<arith::MulIOp>(loc, innerElems, dimSize).getResult();
+      }
+      Value dstStride = b.create<arith::MulIOp>(loc, innerElems,
+          i64c(elemSize, loc, b)).getResult();
+      loops.push_back({count, srcStride, dstStride});
+    }
+    b.create<pto::MteGmUbOp>(loc, gmPtr, ubPtr, i64c0(loc, b), lenBurst,
+        nburst, llvm::ArrayRef(loops), std::nullopt);
+    return success();
+  }
+
+  LogicalResult emitMteUbGm(Location loc, OpBuilder &b, Value ubPtr,
+                             Value gmPtr, const DmaViewInfo &viewInfo,
+                             Type elemTy, ArrayRef<int64_t> tileShape) {
+    if (tileShape.size() < 2) return failure();
+    int64_t ubCols = tileShape[1];
+    unsigned elemSize = getElementSize(elemTy);
+    unsigned nd = viewInfo.sizes.size();
+    if (nd < 2) return failure();
+
+    Value nburstCount = viewInfo.sizes[nd - 2];
+    Value lenBurstElts = viewInfo.sizes[nd - 1];
+    Value lenBurst = b.create<arith::MulIOp>(loc,
+        b.create<arith::IndexCastOp>(loc, b.getI64Type(), lenBurstElts)
+            .getResult(), i64c(elemSize, loc, b)).getResult();
+    Value nburstSrcStride = b.create<arith::MulIOp>(loc,
+        i64c(ubCols, loc, b), i64c(elemSize, loc, b)).getResult();
+    Value nburstDstStride = b.create<arith::MulIOp>(loc,
+        b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+            viewInfo.strides[nd - 2]).getResult(),
+        i64c(elemSize, loc, b)).getResult();
+    pto::DmaLoopConfig nburst{i64Cast(loc, b, nburstCount),
+                              nburstSrcStride, nburstDstStride};
+
+    SmallVector<pto::DmaLoopConfig> loops;
+    for (int i = nd - 3; i >= 0; --i) {
+      Value count = b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+          viewInfo.sizes[i]).getResult();
+      Value innerElems = i64c1(loc, b);
+      for (int j = i + 1; j < (int)nd; ++j) {
+        Value dimSize = b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+            viewInfo.sizes[j]).getResult();
+        innerElems = b.create<arith::MulIOp>(loc, innerElems, dimSize).getResult();
+      }
+      Value srcStride = b.create<arith::MulIOp>(loc, innerElems,
+          i64c(elemSize, loc, b)).getResult();
+      Value dstStride = b.create<arith::MulIOp>(loc,
+          b.create<arith::IndexCastOp>(loc, b.getI64Type(),
+              viewInfo.strides[i]).getResult(),
+          i64c(elemSize, loc, b)).getResult();
+      loops.push_back({count, srcStride, dstStride});
+    }
+    b.create<pto::MteUbGmOp>(loc, ubPtr, gmPtr, lenBurst, nburst,
+                             llvm::ArrayRef(loops));
+    return success();
+  }
+
+  LogicalResult lowerTLoad(pto::TLoadOp op, OpBuilder &b,
+                            const DenseMap<Value, SmallVector<int64_t, 2>> &tileShapes) {
+    Location loc = op.getLoc();
+    auto viewInfo = extractDmaViewInfo(op);
+    if (failed(viewInfo)) return failure();
+    Type dstType = op.getDst().getType();
+    if (!isUBMemorySpace(dstType)) return failure();
+    Type elemTy = getStoredElemType(dstType);
+    if (!elemTy) return failure();
+    unsigned elemSize = getElementSize(elemTy);
+    if (elemSize == 0) return failure();
+
+    auto it = tileShapes.find(op.getDst());
+    if (it == tileShapes.end()) return failure();
+
+    Value byteOff = computeGMByteOffset(loc, b, *viewInfo, elemSize);
+    Value gmPtr = offsetGMPtrByBytes(loc, b, viewInfo->gmPtr, byteOff);
+    return emitMteGmUb(loc, b, gmPtr, op.getDst(), *viewInfo, elemTy,
+                       llvm::ArrayRef(it->second));
+  }
+
+  LogicalResult lowerTStore(pto::TStoreOp op, OpBuilder &b,
+                             const DenseMap<Value, SmallVector<int64_t, 2>> &tileShapes) {
+    Location loc = op.getLoc();
+    Type srcType = op.getSrc().getType();
+    if (!isUBMemorySpace(srcType)) return failure();
+    Type elemTy = getStoredElemType(srcType);
+    if (!elemTy) return failure();
+    unsigned elemSize = getElementSize(elemTy);
+    if (elemSize == 0) return failure();
+
+    auto it = tileShapes.find(op.getSrc());
+    if (it == tileShapes.end()) return failure();
+
+    auto pvOp = op.getDst().getDefiningOp<pto::PartitionViewOp>();
+    if (!pvOp) return failure();
+    auto mtvOp = pvOp.getSource().getDefiningOp<pto::MakeTensorViewOp>();
+    if (!mtvOp) return failure();
+
+    DmaViewInfo viewInfo;
+    viewInfo.gmPtr = mtvOp.getPtr();
+    viewInfo.sizes.assign(pvOp.getSizes().begin(), pvOp.getSizes().end());
+    viewInfo.strides.assign(mtvOp.getStrides().begin(), mtvOp.getStrides().end());
+    viewInfo.offsets.assign(pvOp.getOffsets().begin(), pvOp.getOffsets().end());
+
+    Value byteOff = computeGMByteOffset(loc, b, viewInfo, elemSize);
+    Value gmPtr = offsetGMPtrByBytes(loc, b, viewInfo.gmPtr, byteOff);
+    return emitMteUbGm(loc, b, op.getSrc(), gmPtr, viewInfo, elemTy,
+                       llvm::ArrayRef(it->second));
+  }
+
+  //===--------------------------------------------------------------------===//
+  // CCE dispatch tree — mirrors TBinOp.hpp BinaryInstr
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void dispatch(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                pto::PtrType ptrTy, const TileShapeInfo &info) {
+    int64_t epr = info.elementsPerRepeat;
+    int64_t cols = info.cols;
+    int64_t rows = info.rows;
+    int64_t vRows = info.vRows;
+    int64_t vCols = info.vCols;
+
+    // 1. Small tile
+    if (rows <= kRepeatMax && cols < static_cast<int64_t>(epr)) {
+      modeSmall<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+      return;
+    }
+
+    // 2. Continuous at compile time
+    if (vCols == cols || vRows == 1) {
+      int64_t totalV = vRows * vCols;
+      int64_t totalRpts = (totalV + epr - 1) / epr;
+      bool nonVLAligned =
+          (vCols > static_cast<int64_t>(epr)) && ((vCols % epr) != 0);
+
+      if (nonVLAligned || totalRpts > kRepeatMax)
+        modeCount1L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+      else
+        modeNorm1L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+      return;
+    }
+
+    // 3. Non-continuous
+    int64_t normColRepeat = cols / epr;
+    if (normColRepeat > 1 && vRows * normColRepeat < kSmallRptBinOp) {
+      modeCount2L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+    } else if (vRows < normColRepeat + 1) {
+      if (vCols % epr > 0)
+        modeCount2L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+      else
+        modeColVLAlign<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+    } else {
+      modeRowRpt<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bin1LNormModeSmall
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void modeSmall(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                 pto::PtrType ptrTy, const TileShapeInfo &info) {
+    int64_t rs = info.cols / static_cast<int64_t>(info.blockSizeElem);
+
+    if (info.vRows > 1) {
+      auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                         idxc(info.vRows, loc, b), idxc1(loc, b));
+      b.setInsertionPointToStart(forOp.getBody());
+      Value iv = forOp.getInductionVar();
+      Value off = b.create<arith::MulIOp>(loc, iv, idxc(info.cols, loc, b)).getResult();
+      Value rd = addPtr(loc, b, dst, ptrTy, off);
+      Value r0 = addPtr(loc, b, s0, ptrTy, off);
+      Value r1 = addPtr(loc, b, s1, ptrTy, off);
+      b.create<pto::UBSetMaskCountOp>(loc);
+      b.create<pto::UBSetMaskOp>(loc, i64c(info.vCols, loc, b), i64c0(loc, b));
+      emitUBBinOp<UBop>(loc, b, rd, r0, r1, i64c1(loc, b), i64c(rs, loc, b));
+      b.create<pto::UBSetMaskNormOp>(loc);
+      b.setInsertionPointAfter(forOp);
+      return;
+    }
+
+    b.create<pto::UBSetMaskCountOp>(loc);
+    b.create<pto::UBSetMaskOp>(loc, i64c(info.vCols, loc, b), i64c0(loc, b));
+    emitUBBinOp<UBop>(loc, b, dst, s0, s1, i64c1(loc, b), i64c(rs, loc, b));
+    b.create<pto::UBSetMaskNormOp>(loc);
+    fullMask(loc, b);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bin1LCountMode
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void modeCount1L(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                   pto::PtrType ptrTy, const TileShapeInfo &info) {
+    int64_t totalV = info.vRows * info.vCols;
+    b.create<pto::UBSetMaskCountOp>(loc);
+    b.create<pto::UBSetMaskOp>(loc, i64c(totalV, loc, b), i64c0(loc, b));
+    emitUBBinOp<UBop>(loc, b, dst, s0, s1, i64c0(loc, b), i64c8(loc, b));
+    b.create<pto::UBSetMaskNormOp>(loc);
+    fullMask(loc, b);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bin2LNormModeColVLAlign
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void modeColVLAlign(Location loc, OpBuilder &b, Value dst, Value s0,
+                      Value s1, pto::PtrType ptrTy, const TileShapeInfo &info) {
+    int64_t epr = info.elementsPerRepeat;
+    int64_t headRepeats = info.vCols / epr;
+    int64_t rowStride = info.cols;
+
+    auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                      idxc(info.vRows, loc, b), idxc1(loc, b));
+    b.setInsertionPointToStart(forOp.getBody());
+    Value iv = forOp.getInductionVar();
+    Value off = b.create<arith::MulIOp>(loc, iv, idxc(rowStride, loc, b))
+                    .getResult();
+    Value rd = addPtr(loc, b, dst, ptrTy, off);
+    Value rs0 = addPtr(loc, b, s0, ptrTy, off);
+    Value rs1 = addPtr(loc, b, s1, ptrTy, off);
+    emitUBBinOp<UBop>(loc, b, rd, rs0, rs1, i64c(headRepeats, loc, b), i64c8(loc, b));
+    b.setInsertionPointAfter(forOp);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bin2LCountMode – row-by-row count mode
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void modeCount2L(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                   pto::PtrType ptrTy, const TileShapeInfo &info) {
+    int64_t rowStride = info.cols;
+    b.create<pto::UBSetMaskCountOp>(loc);
+    b.create<pto::UBSetMaskOp>(loc, i64c(info.vCols, loc, b),
+                               i64c0(loc, b));
+
+    auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                      idxc(info.vRows, loc, b), idxc1(loc, b));
+    b.setInsertionPointToStart(forOp.getBody());
+    Value iv = forOp.getInductionVar();
+    Value off = b.create<arith::MulIOp>(loc, iv, idxc(rowStride, loc, b))
+                    .getResult();
+    Value rd = addPtr(loc, b, dst, ptrTy, off);
+    Value rs0 = addPtr(loc, b, s0, ptrTy, off);
+    Value rs1 = addPtr(loc, b, s1, ptrTy, off);
+    emitUBBinOp<UBop>(loc, b, rd, rs0, rs1, i64c0(loc, b), i64c8(loc, b));
+    b.setInsertionPointAfter(forOp);
+
+    b.create<pto::UBSetMaskNormOp>(loc);
+    fullMask(loc, b);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bin2LNormModeRowRpt
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void modeRowRpt(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                  pto::PtrType ptrTy, const TileShapeInfo &info) {
+    int64_t be = info.blockSizeElem;
+    int64_t rowStride = info.cols;
+    int64_t rs = rowStride / be;
+    bool condRowRpt = (info.vRows <= kRepeatMax) && (rs <= kRepeatStrideMax);
+
+    if (condRowRpt)
+      rowRptFast<UBop>(loc, b, dst, s0, s1, ptrTy, info, rs);
+    else
+      rowRptChunked<UBop>(loc, b, dst, s0, s1, ptrTy, info, rowStride, rs);
+  }
+
+  template <typename UBop>
+  void rowRptFast(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                  pto::PtrType ptrTy, const TileShapeInfo &info, int64_t rs) {
+    int64_t epr = info.elementsPerRepeat;
+    int64_t numLoop = info.vCols / epr;
+    int64_t tailElements = info.vCols % epr;
+
+    for (int64_t i = 0; i < numLoop; i++) {
+      Value rd = addPtr(loc, b, dst, ptrTy, idxc(i * epr, loc, b));
+      Value r0 = addPtr(loc, b, s0, ptrTy, idxc(i * epr, loc, b));
+      Value r1 = addPtr(loc, b, s1, ptrTy, idxc(i * epr, loc, b));
+      emitUBBinOp<UBop>(loc, b, rd, r0, r1, i64c(info.vRows, loc, b), i64c(rs, loc, b));
+    }
+
+    if (tailElements > 0) {
+      Value off = idxc(numLoop * epr, loc, b);
+      Value rd = addPtr(loc, b, dst, ptrTy, off);
+      Value r0 = addPtr(loc, b, s0, ptrTy, off);
+      Value r1 = addPtr(loc, b, s1, ptrTy, off);
+      setMask(loc, b, tailElements);
+      emitUBBinOp<UBop>(loc, b, rd, r0, r1, i64c(info.vRows, loc, b), i64c(rs, loc, b));
+      fullMask(loc, b);
+    }
+  }
+
+  template <typename UBop>
+  void rowRptChunked(Location loc, OpBuilder &b, Value dst, Value s0,
+                     Value s1, pto::PtrType ptrTy, const TileShapeInfo &info,
+                     int64_t rowStride, int64_t rs) {
+    int64_t epr = info.elementsPerRepeat;
+    int64_t rptPerLine = info.vCols / epr;
+    int64_t remainElem = info.vCols % epr;
+
+    if (info.vRows > static_cast<int64_t>(epr)) {
+      if (rptPerLine > 0)
+        headRows<UBop>(loc, b, dst, s0, s1, ptrTy, info, rowStride, rptPerLine);
+      if (remainElem > 0) {
+        Value off = idxc(rptPerLine * epr, loc, b);
+        tailRows<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+                 addPtr(loc, b, s0, ptrTy, off),
+                 addPtr(loc, b, s1, ptrTy, off), ptrTy, info, rowStride, rs,
+                 remainElem);
+      }
+    } else {
+      if (remainElem == 0) {
+        headRows<UBop>(loc, b, dst, s0, s1, ptrTy, info, rowStride,
+                 info.vCols / epr);
+      } else if (rptPerLine > 0) {
+        headRows<UBop>(loc, b, dst, s0, s1, ptrTy, info, rowStride, rptPerLine);
+        Value off = idxc(rptPerLine * epr, loc, b);
+        tailRows<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+                 addPtr(loc, b, s0, ptrTy, off),
+                 addPtr(loc, b, s1, ptrTy, off), ptrTy, info, rowStride, rs,
+                 remainElem);
+      } else {
+        tailRows<UBop>(loc, b, dst, s0, s1, ptrTy, info, rowStride, rs, remainElem);
+      }
+    }
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bin2LNormModeHead – chunked per-row head
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void headRows(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                pto::PtrType ptrTy, const TileShapeInfo &info,
+                int64_t rowStride, int64_t rptPerLine) {
+    int64_t epr = info.elementsPerRepeat;
+    int64_t numLoop = rptPerLine / kRepeatMax;
+    int64_t remain = rptPerLine % kRepeatMax;
+    int64_t chunkElems = kRepeatMax * epr;
+
+    auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                      idxc(info.vRows, loc, b),
+                                      idxc1(loc, b));
+    b.setInsertionPointToStart(forOp.getBody());
+    Value iv = forOp.getInductionVar();
+    Value rowBase =
+        b.create<arith::MulIOp>(loc, iv, idxc(rowStride, loc, b)).getResult();
+
+    if (numLoop > 0) {
+      auto inner = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                        idxc(numLoop, loc, b), idxc1(loc, b));
+      b.setInsertionPointToStart(inner.getBody());
+      Value jv = inner.getInductionVar();
+      Value co = b.create<arith::MulIOp>(loc, jv, idxc(chunkElems, loc, b))
+                     .getResult();
+      Value off = b.create<arith::AddIOp>(loc, rowBase, co).getResult();
+      emitUBBinOp<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+           addPtr(loc, b, s0, ptrTy, off), addPtr(loc, b, s1, ptrTy, off),
+           i64c(kRepeatMax, loc, b), i64c8(loc, b));
+      b.setInsertionPointAfter(inner);
+    }
+
+    if (remain > 0) {
+      Value co = idxc(numLoop * chunkElems, loc, b);
+      Value off = b.create<arith::AddIOp>(loc, rowBase, co).getResult();
+      emitUBBinOp<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+           addPtr(loc, b, s0, ptrTy, off), addPtr(loc, b, s1, ptrTy, off),
+           i64c(remain, loc, b), i64c8(loc, b));
+    }
+    b.setInsertionPointAfter(forOp);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Bin2LNormModeTail – masked per-row tail
+  //===--------------------------------------------------------------------===//
+
+  template <typename UBop>
+  void tailRows(Location loc, OpBuilder &b, Value dst, Value s0, Value s1,
+                pto::PtrType ptrTy, const TileShapeInfo &info,
+                int64_t rowStride, int64_t rs, unsigned remainPerLine) {
+    bool strideOver =
+        (rowStride / info.blockSizeElem > kRepeatStrideMax);
+    setMask(loc, b, remainPerLine);
+
+    int64_t numLoop = 0;
+    int64_t remainAfterLoop = info.vRows;
+    if (info.vRows > kRepeatMax) {
+      numLoop = info.vRows / kRepeatMax;
+      remainAfterLoop = info.vRows % kRepeatMax;
+
+      auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                        idxc(numLoop, loc, b), idxc1(loc, b));
+      b.setInsertionPointToStart(forOp.getBody());
+      Value iv = forOp.getInductionVar();
+      if (strideOver)
+        tailStrideOverChunk<UBop>(loc, b, iv, dst, s0, s1, ptrTy, rowStride);
+      else
+        tailStrideOkChunk<UBop>(loc, b, iv, dst, s0, s1, ptrTy, rowStride, rs);
+      b.setInsertionPointAfter(forOp);
+    }
+
+    if (remainAfterLoop > 0) {
+      if (strideOver)
+        tailStrideOverRemain<UBop>(loc, b, dst, s0, s1, ptrTy, rowStride, numLoop,
+                             remainAfterLoop);
+      else
+        tailStrideOkRemain<UBop>(loc, b, dst, s0, s1, ptrTy, rowStride, rs, numLoop,
+                           remainAfterLoop);
+    }
+
+    fullMask(loc, b);
+  }
+
+  template <typename UBop>
+  void tailStrideOverChunk(Location loc, OpBuilder &b, Value iv, Value dst,
+                           Value s0, Value s1, pto::PtrType ptrTy,
+                           int64_t rowStride) {
+    auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b),
+                                      idxc(kRepeatMax, loc, b), idxc1(loc, b));
+    b.setInsertionPointToStart(forOp.getBody());
+    Value jv = forOp.getInductionVar();
+    Value baseOff = b.create<arith::MulIOp>(
+        loc, iv, idxc(kRepeatMax * rowStride, loc, b)).getResult();
+    Value rowOff =
+        b.create<arith::MulIOp>(loc, jv, idxc(rowStride, loc, b)).getResult();
+    Value off = b.create<arith::AddIOp>(loc, baseOff, rowOff).getResult();
+    emitUBBinOp<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+         addPtr(loc, b, s0, ptrTy, off), addPtr(loc, b, s1, ptrTy, off),
+         i64c1(loc, b), i64c1(loc, b));
+    b.setInsertionPointAfter(forOp);
+  }
+
+  template <typename UBop>
+  void tailStrideOkChunk(Location loc, OpBuilder &b, Value iv, Value dst,
+                         Value s0, Value s1, pto::PtrType ptrTy,
+                         int64_t rowStride, int64_t rs) {
+    Value off = b.create<arith::MulIOp>(
+        loc, iv, idxc(kRepeatMax * rowStride, loc, b)).getResult();
+    emitUBBinOp<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+         addPtr(loc, b, s0, ptrTy, off), addPtr(loc, b, s1, ptrTy, off),
+         i64c(kRepeatMax, loc, b), i64c(rs, loc, b));
+  }
+
+  template <typename UBop>
+  void tailStrideOverRemain(Location loc, OpBuilder &b, Value dst, Value s0,
+                            Value s1, pto::PtrType ptrTy, int64_t rowStride,
+                            int64_t numLoop, int64_t remain) {
+    auto forOp = b.create<scf::ForOp>(loc, idxc0(loc, b), idxc(remain, loc, b),
+                                      idxc1(loc, b));
+    b.setInsertionPointToStart(forOp.getBody());
+    Value jv = forOp.getInductionVar();
+    Value baseOff = idxc(numLoop * kRepeatMax * rowStride, loc, b);
+    Value rowOff =
+        b.create<arith::MulIOp>(loc, jv, idxc(rowStride, loc, b)).getResult();
+    Value off = b.create<arith::AddIOp>(loc, baseOff, rowOff).getResult();
+    emitUBBinOp<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+         addPtr(loc, b, s0, ptrTy, off), addPtr(loc, b, s1, ptrTy, off),
+         i64c1(loc, b), i64c1(loc, b));
+    b.setInsertionPointAfter(forOp);
+  }
+
+  template <typename UBop>
+  void tailStrideOkRemain(Location loc, OpBuilder &b, Value dst, Value s0,
+                          Value s1, pto::PtrType ptrTy, int64_t rowStride,
+                          int64_t rs, int64_t numLoop, int64_t remain) {
+    Value off = idxc(numLoop * kRepeatMax * rowStride, loc, b);
+    emitUBBinOp<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
+         addPtr(loc, b, s0, ptrTy, off), addPtr(loc, b, s1, ptrTy, off),
+         i64c(remain, loc, b), i64c(rs, loc, b));
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace pto {
+std::unique_ptr<Pass> createLowerPTOToUBufOpsPass() {
+  return std::make_unique<LowerPTOToUBufOpsPass>();
+}
+} // namespace pto
+} // namespace mlir

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -31,6 +32,17 @@ namespace pto {
 using namespace mlir;
 
 namespace {
+
+enum class DmaArch { A2A3, A5 };
+
+static DmaArch getDmaArch(ModuleOp mod) {
+  if (!mod)
+    return DmaArch::A2A3;
+  auto arch = mod->getAttrOfType<StringAttr>("pto.target_arch");
+  if (arch && arch.getValue() == "a5")
+    return DmaArch::A5;
+  return DmaArch::A2A3;
+}
 
 static pto::AddressSpaceAttr getPointerMemorySpace(Attribute memorySpace,
                                                    MLIRContext *ctx) {
@@ -711,7 +723,7 @@ static FailureOr<LoadCbufToCbControl>
 deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
                           Value mStart, Value kStart, bool transpose,
                           PatternRewriter &rewriter) {
-  unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
+  unsigned elemBitWidth = elementType.getIntOrFloatBitWidth();
   if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
     return failure();
   uint64_t elemBytes = elemBitWidth / 8;
@@ -750,7 +762,7 @@ static FailureOr<LoadCbufToCbControl>
 deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
                           Value mStart, Value kStart, bool transpose,
                           PatternRewriter &rewriter) {
-  unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
+  unsigned elemBitWidth = elementType.getIntOrFloatBitWidth();
   if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
     return failure();
   uint64_t elemBytes = elemBitWidth / 8;
@@ -950,7 +962,9 @@ public:
 };
 
 struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
-  using OpRewritePattern<pto::MteGmUbOp>::OpRewritePattern;
+  DmaArch dmaArch;
+  explicit ExpandDmaLoadPattern(MLIRContext *ctx, DmaArch arch)
+      : OpRewritePattern(ctx), dmaArch(arch) {}
 
   LogicalResult matchAndRewrite(pto::MteGmUbOp op,
                                 PatternRewriter &rewriter) const override {
@@ -960,24 +974,38 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
     SmallVector<pto::DmaLoopConfig> loops =
         collectLoopConfigs(op.getLoopCounts(), op.getLoopSrcStrides(),
                            op.getLoopDstStrides());
-    ArrayRef<pto::DmaLoopConfig> hwLoops = ArrayRef<pto::DmaLoopConfig>(loops).take_front(2);
-    ArrayRef<pto::DmaLoopConfig> swLoops = ArrayRef<pto::DmaLoopConfig>(loops).drop_front(hwLoops.size());
 
+    SmallVector<pto::DmaLoopConfig> allLoops;
+    ArrayRef<pto::DmaLoopConfig> hwLoops;
+    ArrayRef<pto::DmaLoopConfig> swLoops;
     Value loop1Count;
     Value loop2Size = one;
-    if (hwLoops.size() == 2) {
-      rewriter.create<pto::SetLoop2StrideOutToUbOp>(
-          loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
-      loop2Size = hwLoops[0].count;
-      loop1Count = hwLoops[1].count;
-      rewriter.create<pto::SetLoop1StrideOutToUbOp>(
-          loc, hwLoops[1].srcStride, hwLoops[1].dstStride);
-      rewriter.create<pto::SetLoopSizeOutToUbOp>(loc, loop2Size, loop1Count);
-    } else if (hwLoops.size() == 1) {
-      loop1Count = hwLoops[0].count;
-      rewriter.create<pto::SetLoop1StrideOutToUbOp>(
-          loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
-      rewriter.create<pto::SetLoopSizeOutToUbOp>(loc, loop2Size, loop1Count);
+
+    if (dmaArch == DmaArch::A5) {
+      hwLoops = ArrayRef<pto::DmaLoopConfig>(loops).take_front(2);
+      swLoops = ArrayRef<pto::DmaLoopConfig>(loops).drop_front(hwLoops.size());
+      if (hwLoops.size() == 2) {
+        rewriter.create<pto::SetLoop2StrideOutToUbOp>(
+            loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
+        loop2Size = hwLoops[0].count;
+        loop1Count = hwLoops[1].count;
+        rewriter.create<pto::SetLoop1StrideOutToUbOp>(
+            loc, hwLoops[1].srcStride, hwLoops[1].dstStride);
+        rewriter.create<pto::SetLoopSizeOutToUbOp>(loc, loop2Size, loop1Count);
+      } else if (hwLoops.size() == 1) {
+        loop1Count = hwLoops[0].count;
+        rewriter.create<pto::SetLoop1StrideOutToUbOp>(
+            loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
+        rewriter.create<pto::SetLoopSizeOutToUbOp>(loc, loop2Size, loop1Count);
+      }
+    } else {
+      allLoops.append(loops);
+      pto::DmaLoopConfig nburstCfg;
+      nburstCfg.count = op.getNBurst();
+      nburstCfg.srcStride = op.getNburstSrcStride();
+      nburstCfg.dstStride = op.getNburstDstStride();
+      allLoops.push_back(nburstCfg);
+      swLoops = ArrayRef<pto::DmaLoopConfig>(allLoops);
     }
 
     Value leftPadding = op.getLeftPaddingCount();
@@ -990,8 +1018,11 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
         loc, rewriter.getI1Type(),
         rewriter.getBoolAttr(static_cast<bool>(op.getPadValue())));
 
+    bool hasPad = static_cast<bool>(op.getPadValue());
     if (Value padValue = op.getPadValue())
       rewriter.create<pto::SetMovPadValOp>(loc, padValue);
+
+    Value effectiveNBurst = (dmaArch == DmaArch::A5) ? op.getNBurst() : one;
 
     buildSoftwareLoopNest(
         rewriter, loc, swLoops, zero, zero,
@@ -999,12 +1030,15 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
           Value source = offsetPointerByBytes(op.getSource(), srcOffset, rewriter, loc);
           Value destination =
               offsetPointerByBytes(op.getDestination(), dstOffset, rewriter, loc);
-          rewriter.create<pto::CopyGmToUbufOp>(
-              loc, source, destination, zero, op.getNBurst(), op.getLenBurst(),
+          auto copyOp = rewriter.create<pto::CopyGmToUbufOp>(
+              loc, source, destination, zero, effectiveNBurst, op.getLenBurst(),
               leftPadding, rightPadding, dataSelect, op.getL2CacheCtl(),
               op.getNburstSrcStride(), op.getNburstDstStride());
+          if (hasPad)
+            copyOp->setAttr("has_pad", UnitAttr::get(copyOp->getContext()));
         });
-    if (shouldRestoreDmaLoopSize(loop1Count, loop2Size))
+    if (dmaArch == DmaArch::A5 &&
+        shouldRestoreDmaLoopSize(loop1Count, loop2Size))
       rewriter.create<pto::SetLoopSizeOutToUbOp>(loc, one, one);
     rewriter.eraseOp(op);
     return success();
@@ -1012,7 +1046,9 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
 };
 
 struct ExpandDmaStorePattern : public OpRewritePattern<pto::MteUbGmOp> {
-  using OpRewritePattern<pto::MteUbGmOp>::OpRewritePattern;
+  DmaArch dmaArch;
+  explicit ExpandDmaStorePattern(MLIRContext *ctx, DmaArch arch)
+      : OpRewritePattern(ctx), dmaArch(arch) {}
 
   LogicalResult matchAndRewrite(pto::MteUbGmOp op,
                                 PatternRewriter &rewriter) const override {
@@ -1022,27 +1058,42 @@ struct ExpandDmaStorePattern : public OpRewritePattern<pto::MteUbGmOp> {
     SmallVector<pto::DmaLoopConfig> loops =
         collectLoopConfigs(op.getLoopCounts(), op.getLoopSrcStrides(),
                            op.getLoopDstStrides());
-    ArrayRef<pto::DmaLoopConfig> hwLoops =
-        ArrayRef<pto::DmaLoopConfig>(loops).take_front(2);
-    ArrayRef<pto::DmaLoopConfig> swLoops =
-        ArrayRef<pto::DmaLoopConfig>(loops).drop_front(hwLoops.size());
 
+    SmallVector<pto::DmaLoopConfig> allLoops;
+    ArrayRef<pto::DmaLoopConfig> hwLoops;
+    ArrayRef<pto::DmaLoopConfig> swLoops;
     Value loop1Count;
     Value loop2Size = one;
-    if (hwLoops.size() == 2) {
-      rewriter.create<pto::SetLoop2StrideUbToOutOp>(
-          loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
-      loop2Size = hwLoops[0].count;
-      loop1Count = hwLoops[1].count;
-      rewriter.create<pto::SetLoop1StrideUbToOutOp>(
-          loc, hwLoops[1].srcStride, hwLoops[1].dstStride);
-      rewriter.create<pto::SetLoopSizeUbToOutOp>(loc, loop2Size, loop1Count);
-    } else if (hwLoops.size() == 1) {
-      loop1Count = hwLoops[0].count;
-      rewriter.create<pto::SetLoop1StrideUbToOutOp>(
-          loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
-      rewriter.create<pto::SetLoopSizeUbToOutOp>(loc, loop2Size, loop1Count);
+
+    if (dmaArch == DmaArch::A5) {
+      hwLoops = ArrayRef<pto::DmaLoopConfig>(loops).take_front(2);
+      swLoops =
+          ArrayRef<pto::DmaLoopConfig>(loops).drop_front(hwLoops.size());
+      if (hwLoops.size() == 2) {
+        rewriter.create<pto::SetLoop2StrideUbToOutOp>(
+            loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
+        loop2Size = hwLoops[0].count;
+        loop1Count = hwLoops[1].count;
+        rewriter.create<pto::SetLoop1StrideUbToOutOp>(
+            loc, hwLoops[1].srcStride, hwLoops[1].dstStride);
+        rewriter.create<pto::SetLoopSizeUbToOutOp>(loc, loop2Size, loop1Count);
+      } else if (hwLoops.size() == 1) {
+        loop1Count = hwLoops[0].count;
+        rewriter.create<pto::SetLoop1StrideUbToOutOp>(
+            loc, hwLoops[0].srcStride, hwLoops[0].dstStride);
+        rewriter.create<pto::SetLoopSizeUbToOutOp>(loc, loop2Size, loop1Count);
+      }
+    } else {
+      allLoops.append(loops);
+      pto::DmaLoopConfig nburstCfg;
+      nburstCfg.count = op.getNBurst();
+      nburstCfg.srcStride = op.getNburstSrcStride();
+      nburstCfg.dstStride = op.getNburstDstStride();
+      allLoops.push_back(nburstCfg);
+      swLoops = ArrayRef<pto::DmaLoopConfig>(allLoops);
     }
+
+    Value effectiveNBurst = (dmaArch == DmaArch::A5) ? op.getNBurst() : one;
 
     buildSoftwareLoopNest(
         rewriter, loc, swLoops, zero, zero,
@@ -1051,10 +1102,11 @@ struct ExpandDmaStorePattern : public OpRewritePattern<pto::MteUbGmOp> {
           Value destination =
               offsetPointerByBytes(op.getDestination(), dstOffset, rewriter, loc);
           rewriter.create<pto::CopyUbufToGmOp>(
-              loc, source, destination, zero, op.getNBurst(), op.getLenBurst(),
+              loc, source, destination, zero, effectiveNBurst, op.getLenBurst(),
               zero, op.getNburstDstStride(), op.getNburstSrcStride());
         });
-    if (shouldRestoreDmaLoopSize(loop1Count, loop2Size))
+    if (dmaArch == DmaArch::A5 &&
+        shouldRestoreDmaLoopSize(loop1Count, loop2Size))
       rewriter.create<pto::SetLoopSizeUbToOutOp>(loc, one, one);
     rewriter.eraseOp(op);
     return success();
@@ -1324,8 +1376,7 @@ struct ExpandRightLoadMxPattern : public OpRewritePattern<pto::MteL1L0bMxOp> {
     if (!sourceType)
       return rewriter.notifyMatchFailure(op, "expected typed L1 source");
 
-    unsigned elemBitWidth =
-        pto::getPTOStorageElemBitWidth(sourceType.getElementType());
+    unsigned elemBitWidth = sourceType.getElementType().getIntOrFloatBitWidth();
     if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
       return rewriter.notifyMatchFailure(op, "unsupported element type");
     uint64_t elemBytes = elemBitWidth / 8;
@@ -1662,8 +1713,12 @@ struct VPTOExpandWrapperOpsPass
     if (func.isExternal())
       return;
 
+    DmaArch dmaArch = getDmaArch(func->getParentOfType<ModuleOp>());
+
     RewritePatternSet patterns(&getContext());
-    patterns.add<ExpandUvldPattern, ExpandDmaLoadPattern, ExpandDmaStorePattern,
+    patterns.add(std::make_unique<ExpandDmaLoadPattern>(&getContext(), dmaArch));
+    patterns.add(std::make_unique<ExpandDmaStorePattern>(&getContext(), dmaArch));
+    patterns.add<ExpandUvldPattern,
                  ExpandMteUbUbPattern, ExpandMteUbL1Pattern, ExpandCubeLoadPattern,
                  ExpandCubeStorePattern, ExpandBiasLoadPattern,
                  ExpandFpLoadPattern,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Transforms/Patterns.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
@@ -1480,6 +1481,45 @@ packCopyGmToUbConfig1(Operation *anchor, ValueRange operands) {
   return packLoopPair(anchor, operands[9], operands[10]);
 }
 
+static FailureOr<Value>
+packCopyGmToUbCfgV220(Operation *anchor, ValueRange operands) {
+  OpBuilder builder(anchor);
+  builder.setInsertionPoint(anchor);
+  Location loc = anchor->getLoc();
+
+  auto getI64Operand = [&](unsigned idx) -> Value {
+    return castIntegerLikeTo(anchor, operands[idx], builder.getI64Type());
+  };
+
+  Value sid = getI64Operand(2);
+  Value lenBurst = getI64Operand(4);
+  if (!sid || !lenBurst)
+    return failure();
+
+  auto shl = [&](Value value, uint64_t amount) -> Value {
+    return builder.create<arith::ShLIOp>(loc, value,
+                                         getI64Constant(builder, loc, amount));
+  };
+  auto bitOr = [&](Value lhs, Value rhs) -> Value {
+    return builder.create<arith::OrIOp>(loc, lhs, rhs);
+  };
+
+  Value cfg = sid;
+  auto oneI64 = builder
+                    .create<arith::ConstantOp>(loc,
+                                               builder.getI64IntegerAttr(1))
+                    .getResult();
+  cfg = bitOr(cfg, shl(oneI64, 4));
+  auto bytesPer32B = builder
+                         .create<arith::ConstantOp>(
+                             loc, builder.getI64IntegerAttr(5))
+                         .getResult();
+  auto lenIn32B =
+      builder.create<arith::ShRUIOp>(loc, lenBurst, bytesPer32B).getResult();
+  cfg = bitOr(cfg, shl(lenIn32B, 16));
+  return cfg;
+}
+
 [[maybe_unused]] static FailureOr<Value>
 packCopyGmToUbConfig0(Operation *anchor, Value sid, Value nBurst,
                       Value lenBurst, Value leftPadding, Value rightPadding,
@@ -1535,6 +1575,48 @@ packCopyUbToGmConfig1(Operation *anchor, ValueRange operands) {
   if (operands.size() != 8)
     return failure();
   return packLoopPair(anchor, operands[6], operands[7]);
+}
+
+static FailureOr<Value>
+packCopyUbToGmCfgV220(Operation *anchor, ValueRange operands) {
+  if (operands.size() != 8)
+    return failure();
+
+  OpBuilder builder(anchor);
+  builder.setInsertionPoint(anchor);
+  Location loc = anchor->getLoc();
+
+  auto getI64Operand = [&](unsigned idx) -> Value {
+    return castIntegerLikeTo(anchor, operands[idx], builder.getI64Type());
+  };
+
+  Value sid = getI64Operand(2);
+  Value lenBurst = getI64Operand(4);
+  if (!sid || !lenBurst)
+    return failure();
+
+  auto shl = [&](Value value, uint64_t amount) -> Value {
+    return builder.create<arith::ShLIOp>(loc, value,
+                                         getI64Constant(builder, loc, amount));
+  };
+  auto bitOr = [&](Value lhs, Value rhs) -> Value {
+    return builder.create<arith::OrIOp>(loc, lhs, rhs);
+  };
+
+  Value cfg = sid;
+  auto oneI64 = builder
+                    .create<arith::ConstantOp>(loc,
+                                               builder.getI64IntegerAttr(1))
+                    .getResult();
+  cfg = bitOr(cfg, shl(oneI64, 4));
+  auto bytesPer32B = builder
+                         .create<arith::ConstantOp>(
+                             loc, builder.getI64IntegerAttr(5))
+                         .getResult();
+  auto lenIn32B =
+      builder.create<arith::ShRUIOp>(loc, lenBurst, bytesPer32B).getResult();
+  cfg = bitOr(cfg, shl(lenIn32B, 16));
+  return cfg;
 }
 
 [[maybe_unused]] static FailureOr<Value>
@@ -2965,18 +3047,35 @@ static StringRef getReductionUnaryStem() {
 }
 
 static FailureOr<StringRef> buildCopyGmToUbCallee(MLIRContext *context,
-                                                  Type sourceType) {
+                                                  Type sourceType,
+                                                  const std::string &march,
+                                                  bool hasPadding) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
     return failure();
   Type elementType = ptrType.getElementType();
-  if ((isa<IntegerType>(elementType) &&
-       cast<IntegerType>(elementType).getWidth() == 64) ||
-      elementType.isF64()) {
-    return StringAttr::get(context, "llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.s32.DV")
-        .getValue();
+
+  auto getElementSuffix = [&]() -> std::string {
+    if ((isa<IntegerType>(elementType) &&
+         cast<IntegerType>(elementType).getWidth() == 64) ||
+        elementType.isF64())
+      return "s32";
+    return getCopyElementFragment(elementType);
+  };
+
+  if (march == "dav-c220-vec") {
+    if (hasPadding) {
+      std::string elem = getElementSuffix();
+      if (elem.empty())
+        return failure();
+      return StringAttr::get(context,
+                             "llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2." + elem)
+          .getValue();
+    }
+    return StringAttr::get(context, "llvm.hivm.MOV.OUT.TO.UB.v220").getValue();
   }
-  std::string elem = getCopyElementFragment(elementType);
+
+  std::string elem = getElementSuffix();
   if (elem.empty())
     return failure();
   return StringAttr::get(context, "llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2." + elem +
@@ -2984,7 +3083,11 @@ static FailureOr<StringRef> buildCopyGmToUbCallee(MLIRContext *context,
       .getValue();
 }
 
-static StringRef buildCopyUbToGmCallee(MLIRContext *context) {
+static StringRef buildCopyUbToGmCallee(MLIRContext *context,
+                                       const std::string &march) {
+  if (march == "dav-c220-vec")
+    return StringAttr::get(context, "llvm.hivm.MOV.UB.TO.OUT.v220.1")
+        .getValue();
   return StringAttr::get(context, "llvm.hivm.MOV.UB.TO.OUT.ALIGN.V2.DV")
       .getValue();
 }
@@ -4260,17 +4363,25 @@ template <typename CopyOp>
 class LowerCopyOpPattern final : public OpConversionPattern<CopyOp> {
 public:
   explicit LowerCopyOpPattern(TypeConverter &typeConverter, MLIRContext *context,
-                              LoweringState &state)
-      : OpConversionPattern<CopyOp>(typeConverter, context), state(state) {}
+                              LoweringState &state, const std::string &march)
+      : OpConversionPattern<CopyOp>(typeConverter, context), state(state),
+        march(march) {}
 
   LogicalResult
   matchAndRewrite(CopyOp op, typename CopyOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    constexpr bool isGmUb = std::is_same_v<CopyOp, pto::CopyGmToUbufOp>;
+
+    bool hasPadding = false;
+    if constexpr (isGmUb)
+      hasPadding = op->hasAttr("has_pad");
+
     FailureOr<StringRef> calleeName = failure();
-    if constexpr (std::is_same_v<CopyOp, pto::CopyGmToUbufOp>)
-      calleeName = buildCopyGmToUbCallee(op.getContext(), op.getSource().getType());
+    if constexpr (isGmUb)
+      calleeName = buildCopyGmToUbCallee(op.getContext(), op.getSource().getType(),
+                                         march, hasPadding);
     else
-      calleeName = buildCopyUbToGmCallee(op.getContext());
+      calleeName = buildCopyUbToGmCallee(op.getContext(), march);
     if (failed(calleeName))
       return rewriter.notifyMatchFailure(op, "unsupported copy VPTO signature");
 
@@ -4281,29 +4392,226 @@ public:
     if (!llvmSourceType || !llvmDestType)
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer copy operands");
 
+    bool useA3NonPadded = (march == "dav-c220-vec") && isGmUb && !hasPadding;
+    bool useA3UbGm = (march == "dav-c220-vec") && !isGmUb;
+    bool useSingleConfig = useA3NonPadded || useA3UbGm;
+
     FailureOr<Value> config0 = failure();
     FailureOr<Value> config1 = failure();
-    if constexpr (std::is_same_v<CopyOp, pto::CopyGmToUbufOp>) {
+    if (useA3NonPadded)
+      config0 = packCopyGmToUbCfgV220(op, adaptor.getOperands());
+    else if (useA3UbGm)
+      config0 = packCopyUbToGmCfgV220(op, adaptor.getOperands());
+    else if constexpr (isGmUb) {
       config0 = packCopyGmToUbConfig0(op, adaptor.getOperands());
       config1 = packCopyGmToUbConfig1(op, adaptor.getOperands());
     } else {
       config0 = packCopyUbToGmConfig0(op, adaptor.getOperands());
       config1 = packCopyUbToGmConfig1(op, adaptor.getOperands());
     }
-    if (failed(config0) || failed(config1))
+    if (failed(config0) || (!useSingleConfig && failed(config1)))
       return rewriter.notifyMatchFailure(op, "failed to materialize copy config");
 
     SmallVector<Value> args{adaptor.getOperands()[1], adaptor.getOperands()[0],
-                            *config0, *config1};
-    auto funcType = rewriter.getFunctionType(
-        TypeRange{llvmDestType, llvmSourceType, rewriter.getI64Type(),
-                  rewriter.getI64Type()},
-        TypeRange{});
+                            *config0};
+    SmallVector<Type> argTypes{llvmDestType, llvmSourceType,
+                               rewriter.getI64Type()};
+    if (!useSingleConfig) {
+      args.push_back(*config1);
+      argTypes.push_back(rewriter.getI64Type());
+    }
+
+    auto funcType = rewriter.getFunctionType(argTypes, TypeRange{});
     auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               TypeRange{}, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     rewriter.eraseOp(op);
     (void)call;
+    return success();
+  }
+
+private:
+  LoweringState &state;
+  const std::string &march;
+};
+
+template <typename UBOp>
+class LowerUBufBinaryOpPattern final : public OpConversionPattern<UBOp> {
+public:
+  explicit LowerUBufBinaryOpPattern(TypeConverter &typeConverter,
+                                    MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<UBOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(UBOp op, typename UBOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto ptrType = mlir::cast<pto::PtrType>(op.getSrc0().getType());
+    Type elemType = ptrType.getElementType();
+    std::string elemFrag = getElementTypeFragment(elemType);
+    if (elemFrag.empty())
+      return rewriter.notifyMatchFailure(
+          op, "unsupported element type for ubuf binary op");
+
+    std::string calleeName;
+    if constexpr (std::is_same_v<UBOp, pto::UBVaddOp>)
+      calleeName = "llvm.hivm.VADD." + elemFrag;
+    else if constexpr (std::is_same_v<UBOp, pto::UBVsubOp>)
+      calleeName = "llvm.hivm.VSUB." + elemFrag;
+    else if constexpr (std::is_same_v<UBOp, pto::UBVmulOp>)
+      calleeName = "llvm.hivm.VMUL." + elemFrag;
+    else if constexpr (std::is_same_v<UBOp, pto::UBVdivOp>)
+      calleeName = "llvm.hivm.VDIV." + elemFrag;
+    else
+      return rewriter.notifyMatchFailure(op, "unsupported ubuf binary op");
+
+    Value dst = adaptor.getDst();
+    Value src0 = adaptor.getSrc0();
+    Value src1 = adaptor.getSrc1();
+    if (!dst || !src0 || !src1 ||
+        !isa<LLVM::LLVMPointerType>(dst.getType()) ||
+        !isa<LLVM::LLVMPointerType>(src0.getType()) ||
+        !isa<LLVM::LLVMPointerType>(src1.getType()))
+      return rewriter.notifyMatchFailure(
+          op, "unexpected converted ubuf binary operand types");
+
+    Location loc = op.getLoc();
+    auto i64Ty = rewriter.getI64Type();
+    auto getI64 = [&](Value v) -> Value {
+      return castIntegerLikeTo(op, v, i64Ty);
+    };
+    auto maskByte = [&](Value v) -> Value {
+      return rewriter.create<arith::AndIOp>(
+          loc, v, rewriter.create<arith::ConstantOp>(
+                     loc, rewriter.getI64IntegerAttr(0xff)));
+    };
+    auto shl = [&](Value v, uint64_t amount) -> Value {
+      return rewriter.create<arith::ShLIOp>(
+          loc, v, rewriter.create<arith::ConstantOp>(
+                       loc, rewriter.getI64IntegerAttr(amount)));
+    };
+    Value config = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(1LL << 56));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, maskByte(getI64(adaptor.getRepeat())));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shl(maskByte(getI64(adaptor.getDstBlockStride())), 8));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shl(maskByte(getI64(adaptor.getSrc0BlockStride())), 16));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shl(maskByte(getI64(adaptor.getSrc1BlockStride())), 24));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shl(maskByte(getI64(adaptor.getDstRepeatStride())), 32));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shl(maskByte(getI64(adaptor.getSrc0RepeatStride())), 40));
+    config = rewriter.create<arith::OrIOp>(
+        loc, config, shl(maskByte(getI64(adaptor.getSrc1RepeatStride())), 48));
+
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{dst.getType(), src0.getType(), src1.getType(),
+                  rewriter.getI64Type()},
+        TypeRange{});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), calleeName, TypeRange{},
+        ValueRange{dst, src0, src1, config});
+    (void)call;
+    state.plannedDecls.push_back(PlannedDecl{calleeName, funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerUBSetMaskOpPattern final
+    : public OpConversionPattern<pto::UBSetMaskOp> {
+public:
+  explicit LowerUBSetMaskOpPattern(TypeConverter &typeConverter,
+                                   MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<pto::UBSetMaskOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::UBSetMaskOp op, typename pto::UBSetMaskOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    StringRef calleeName = "llvm.hivm.MOVEMASK";
+    Location loc = op.getLoc();
+
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{rewriter.getI64Type(), rewriter.getI64Type()}, TypeRange{});
+
+    Value c0Idx = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(0));
+    rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
+                                  ValueRange{c0Idx, adaptor.getMask0()});
+
+    Value c1Idx = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(1));
+    rewriter.create<func::CallOp>(loc, calleeName, TypeRange{},
+                                  ValueRange{c1Idx, adaptor.getMask1()});
+
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerUBSetMaskCountOpPattern final
+    : public OpConversionPattern<pto::UBSetMaskCountOp> {
+public:
+  explicit LowerUBSetMaskCountOpPattern(TypeConverter &typeConverter,
+                                        MLIRContext *context,
+                                        LoweringState &state)
+      : OpConversionPattern<pto::UBSetMaskCountOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::UBSetMaskCountOp op,
+                  typename pto::UBSetMaskCountOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto i64Ty = rewriter.getI64Type();
+    Value ctrl = rewriter.create<pto::GetCtrlOp>(loc, i64Ty).getResult();
+    Value bit56 = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(56));
+    Value set = rewriter
+                    .create<pto::Sbitset1Op>(loc, i64Ty, ctrl, bit56)
+                    .getResult();
+    rewriter.create<pto::SetCtrlOp>(loc, set);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerUBSetMaskNormOpPattern final
+    : public OpConversionPattern<pto::UBSetMaskNormOp> {
+public:
+  explicit LowerUBSetMaskNormOpPattern(TypeConverter &typeConverter,
+                                       MLIRContext *context,
+                                       LoweringState &state)
+      : OpConversionPattern<pto::UBSetMaskNormOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::UBSetMaskNormOp op,
+                  typename pto::UBSetMaskNormOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto i64Ty = rewriter.getI64Type();
+    Value ctrl = rewriter.create<pto::GetCtrlOp>(loc, i64Ty).getResult();
+    Value bit56 = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getI64IntegerAttr(56));
+    Value reset = rewriter
+                      .create<pto::Sbitset0Op>(loc, i64Ty, ctrl, bit56)
+                      .getResult();
+    rewriter.create<pto::SetCtrlOp>(loc, reset);
+    rewriter.eraseOp(op);
     return success();
   }
 
@@ -8891,21 +9199,75 @@ public:
   matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (op->getNumOperands() != 1 || op->getNumResults() != 1)
-      return failure();
+      return rewriter.notifyMatchFailure(op, "expected single-operand single-result cast");
     if (!hasVPTOConvertibleType(op->getOperandTypes()) &&
         !hasVPTOConvertibleType(op->getResultTypes()))
-      return failure();
+      return rewriter.notifyMatchFailure(op, "no VPTO convertible types");
 
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult(0).getType());
     if (!convertedResultType)
-      return failure();
+      return rewriter.notifyMatchFailure(op, "could not convert result type");
 
     Value input = adaptor.getOperands().front();
     if (input.getType() != convertedResultType)
-      return failure();
+      return rewriter.notifyMatchFailure(op, "input type does not match converted result type");
 
     rewriter.replaceOp(op, input);
+    return success();
+  }
+};
+
+class ConvertPtoTileBufAddrOp final
+    : public OpConversionPattern<pto::TileBufAddrOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(pto::TileBufAddrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Type convertedResultType =
+        getTypeConverter()->convertType(op.getResult().getType());
+    auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(convertedResultType);
+    if (!llvmPtrType)
+      return rewriter.notifyMatchFailure(op, "expected LLVM pointer result");
+
+    Value input = adaptor.getSrc();
+    if (isa<MemRefType>(input.getType())) {
+      Value alignedIdx =
+          rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(
+              op.getLoc(), rewriter.getIndexType(), input);
+      Value i64 = rewriter.create<arith::IndexCastUIOp>(
+          op.getLoc(), rewriter.getI64Type(), alignedIdx);
+      rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, llvmPtrType, i64);
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(op, "unsupported tilebuf address source");
+  }
+};
+
+class ConvertPointerCastToCastPtrOp final
+    : public OpConversionPattern<pto::PointerCastOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(pto::PointerCastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getAddrs().empty())
+      return rewriter.notifyMatchFailure(op, "expected at least one address");
+
+    auto memref = dyn_cast<MemRefType>(op.getResult().getType());
+    if (!memref)
+      return rewriter.notifyMatchFailure(op, "expected memref result type");
+
+    auto ptrTy = pto::PtrType::get(rewriter.getContext(),
+        memref.getElementType(),
+        pto::AddressSpaceAttr::get(rewriter.getContext(), pto::AddressSpace::VEC));
+
+    rewriter.replaceOpWithNewOp<pto::CastPtrOp>(op, ptrTy,
+                                                adaptor.getAddrs().front());
     return success();
   }
 };
@@ -8963,10 +9325,19 @@ public:
         rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, llvmPtrType, input);
         return success();
       }
+      if (isa<MemRefType>(inputType)) {
+        Value alignedIdx =
+            rewriter.create<memref::ExtractAlignedPointerAsIndexOp>(
+                op.getLoc(), rewriter.getIndexType(), input);
+        Value i64 = rewriter.create<arith::IndexCastUIOp>(
+            op.getLoc(), rewriter.getI64Type(), alignedIdx);
+        rewriter.replaceOpWithNewOp<LLVM::IntToPtrOp>(op, llvmPtrType, i64);
+        return success();
+      }
       auto sourcePtrType = dyn_cast<LLVM::LLVMPointerType>(inputType);
       if (!sourcePtrType)
         return rewriter.notifyMatchFailure(op,
-                                           "expected integer or LLVM pointer input");
+                                           "expected integer, memref, or LLVM pointer input");
       if (sourcePtrType.getAddressSpace() == llvmPtrType.getAddressSpace()) {
         rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, llvmPtrType, input);
         return success();
@@ -9365,7 +9736,8 @@ public:
 
 static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                                            RewritePatternSet &patterns,
-                                           LoweringState &state) {
+                                           LoweringState &state,
+                                           const std::string &march) {
   patterns.add<LowerUnaryMaskedOpPattern<pto::VabsOp>,
                LowerUnaryMaskedOpPattern<pto::VexpOp>,
                LowerUnaryMaskedOpPattern<pto::VlnOp>,
@@ -9570,22 +9942,50 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerMadRawPattern<pto::MadBiasRawOp>,
                LowerMadRawPattern<pto::MadMxRawOp>,
                LowerMadRawPattern<pto::MadMxBiasRawOp>,
-               LowerCopyOpPattern<pto::CopyGmToUbufOp>,
-               LowerCopyOpPattern<pto::CopyUbufToGmOp>,
                LowerCopyUbufToUbufOpPattern,
                LowerCopyCbufToUbufOpPattern,
                LowerCopyUbufToCbufOpPattern>(
       typeConverter, patterns.getContext(), state);
+
+  patterns.add<LowerCopyOpPattern<pto::CopyGmToUbufOp>>(
+      typeConverter, patterns.getContext(), state, march);
+  patterns.add<LowerCopyOpPattern<pto::CopyUbufToGmOp>>(
+      typeConverter, patterns.getContext(), state, march);
+
+  if (march == "dav-c220-vec") {
+    patterns.add<LowerUBufBinaryOpPattern<pto::UBVaddOp>>(
+        typeConverter, patterns.getContext(), state);
+    patterns.add<LowerUBufBinaryOpPattern<pto::UBVsubOp>>(
+        typeConverter, patterns.getContext(), state);
+    patterns.add<LowerUBufBinaryOpPattern<pto::UBVmulOp>>(
+        typeConverter, patterns.getContext(), state);
+    patterns.add<LowerUBufBinaryOpPattern<pto::UBVdivOp>>(
+        typeConverter, patterns.getContext(), state);
+    patterns.add<LowerUBSetMaskOpPattern>(
+        typeConverter, patterns.getContext(), state);
+    patterns.add<LowerUBSetMaskCountOpPattern>(
+        typeConverter, patterns.getContext(), state);
+    patterns.add<LowerUBSetMaskNormOpPattern>(
+        typeConverter, patterns.getContext(), state);
+  }
 }
 
 static void configureVPTOOpLoweringTarget(ConversionTarget &target,
-                                          VPTOTypeConverter &typeConverter) {
+                                          VPTOTypeConverter &typeConverter,
+                                          const std::string &march) {
   (void)typeConverter;
   target.addLegalOp<ModuleOp>();
+  target.addLegalOp<func::FuncOp>();
+  target.addLegalOp<pto::TileBufAddrOp>();
+  target.addLegalOp<pto::AddPtrOp>();
   target.addLegalDialect<arith::ArithDialect, cf::ControlFlowDialect,
                          LLVM::LLVMDialect,
-                         func::FuncDialect, scf::SCFDialect>();
-  target.addLegalOp<UnrealizedConversionCastOp>();
+                          func::FuncDialect, scf::SCFDialect>();
+  target.addDynamicallyLegalOp<UnrealizedConversionCastOp>(
+      [](UnrealizedConversionCastOp op) {
+        return !hasVPTOConvertibleType(op->getOperandTypes()) &&
+               !hasVPTOConvertibleType(op->getResultTypes());
+      });
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
                       pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
                       pto::GetBufOp, pto::RlsBufOp>();
@@ -9677,6 +10077,17 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::MadMxAccOp, pto::MadMxBiasOp,
                       pto::MadRawOp, pto::MadBiasRawOp, pto::MadMxRawOp,
                       pto::MadMxBiasRawOp>();
+
+  if (march == "dav-c220-vec") {
+    target.addIllegalOp<pto::UBVaddOp>();
+    target.addIllegalOp<pto::UBVsubOp>();
+    target.addIllegalOp<pto::UBVmulOp>();
+    target.addIllegalOp<pto::UBVdivOp>();
+    target.addIllegalOp<pto::UBSetMaskOp>();
+    target.addIllegalOp<pto::UBSetMaskCountOp>();
+    target.addIllegalOp<pto::UBSetMaskNormOp>();
+  }
+
   target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
 }
 
@@ -9712,15 +10123,18 @@ static void foldVPTOTypeCasts(ModuleOp module, TypeConverter &typeConverter) {
   }
 }
 
-static LogicalResult lowerVPTOOps(ModuleOp module, llvm::raw_ostream &diagOS) {
+static LogicalResult lowerVPTOOps(ModuleOp module,
+                                  const std::string &march,
+                                  llvm::raw_ostream &diagOS) {
   MLIRContext *context = module.getContext();
   VPTOTypeConverter typeConverter(context);
   ConversionTarget target(*context);
   RewritePatternSet patterns(context);
   LoweringState state;
 
-  configureVPTOOpLoweringTarget(target, typeConverter);
-  populateVPTOOpLoweringPatterns(typeConverter, patterns, state);
+  configureVPTOOpLoweringTarget(target, typeConverter, march);
+  populateVPTOOpLoweringPatterns(typeConverter, patterns, state, march);
+  patterns.add<ConvertVPTOUnrealizedCastOp>(typeConverter, context);
 
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     diagOS << "VPTO LLVM emission failed: VPTO op lowering failed\n";
@@ -9739,7 +10153,7 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
   LoweringState state;
 
   target.addLegalOp<ModuleOp>();
-  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+  target.addLegalOp<pto::AddPtrOp>();([&](func::FuncOp op) {
     return typeConverter.isSignatureLegal(op.getFunctionType()) &&
            typeConverter.isLegal(&op.getBody());
   });
@@ -9752,7 +10166,7 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
         return isLegalForBranchOpInterfaceTypeConversionPattern(op,
                                                                 typeConverter);
       });
-  target.addIllegalOp<pto::AddPtrOp, pto::CastPtrOp, pto::LoadScalarOp,
+  target.addIllegalOp<pto::PointerCastOp, pto::AddPtrOp, pto::CastPtrOp, pto::LoadScalarOp,
                       pto::StoreScalarOp, pto::PTOLoadOp, pto::PTOStoreOp,
                       pto::PTOLdgOp, pto::PTOStgOp>();
   target.addDynamicallyLegalOp<UnrealizedConversionCastOp>(
@@ -9858,6 +10272,12 @@ static VPTOEmissionOptions
 makeDeviceEmissionOptions(const VPTOEmissionOptions &baseOptions,
                           FunctionKernelKind kind) {
   VPTOEmissionOptions options = baseOptions;
+  constexpr llvm::StringLiteral kC220VecTargetFeatures =
+      "+ASAN,+ATOMIC,+AtomicForB64,+AtomicForB8 ,+FFTSBlk,"
+      "+MOVX8,+MSTX,+MathOp,+SPR7bits,+dav-c220-vec";
+  constexpr llvm::StringLiteral kC220CubeTargetFeatures =
+      "+ASAN,+ATOMIC,+AtomicForB64,+AtomicForB8 ,+FFTSBlk,"
+      "+MOVX8,+MSTX,+MathOp,+SPR7bits,+dav-c220-cube";
   constexpr llvm::StringLiteral kVecTargetFeatures =
       "+ATOMIC,+ArchV130,+AregRedefinable,+ArithmeticBf16,+AtomicForB8 ,"
       "+F8e4m3,+F8e5m2,+F8e8m0,+FFTSBlk,+Fp4e1m2x2,+Fp4e2m1x2,+LDExtRefine,"
@@ -9866,16 +10286,29 @@ makeDeviceEmissionOptions(const VPTOEmissionOptions &baseOptions,
       "+ATOMIC,+ArchV130,+AregRedefinable,+ArithmeticBf16,+AtomicForB8 ,"
       "+F8e4m3,+F8e5m2,+F8e8m0,+FFTSBlk,+Fp4e1m2x2,+Fp4e2m1x2,+LDExtRefine,"
       "+MOVX8,+SPR7bits,+SyncV,+dav-c310-cube";
-  if (kind == FunctionKernelKind::Vector) {
-    options.march = "dav-c310-vec";
-    options.aicoreArch = "dav-c310-vec";
-    options.defaultTargetCPU = "dav-c310-vec";
-    options.defaultTargetFeatures = kVecTargetFeatures.str();
-  } else if (kind == FunctionKernelKind::Cube) {
-    options.march = "dav-c310-cube";
-    options.aicoreArch = "dav-c310-cube";
-    options.defaultTargetCPU = "dav-c310-cube";
-    options.defaultTargetFeatures = kCubeTargetFeatures.str();
+  if (options.march.empty()) {
+    if (kind == FunctionKernelKind::Vector) {
+      options.march = "dav-c310-vec";
+      options.aicoreArch = "dav-c310-vec";
+      options.defaultTargetCPU = "dav-c310-vec";
+      options.defaultTargetFeatures = kVecTargetFeatures.str();
+    } else if (kind == FunctionKernelKind::Cube) {
+      options.march = "dav-c310-cube";
+      options.aicoreArch = "dav-c310-cube";
+      options.defaultTargetCPU = "dav-c310-cube";
+      options.defaultTargetFeatures = kCubeTargetFeatures.str();
+    }
+  } else {
+    options.aicoreArch = options.march;
+    options.defaultTargetCPU = options.march;
+    if (options.march == "dav-c220-vec")
+      options.defaultTargetFeatures = kC220VecTargetFeatures.str();
+    else if (options.march == "dav-c220-cube")
+      options.defaultTargetFeatures = kC220CubeTargetFeatures.str();
+    else if (kind == FunctionKernelKind::Cube)
+      options.defaultTargetFeatures = kCubeTargetFeatures.str();
+    else
+      options.defaultTargetFeatures = kVecTargetFeatures.str();
   }
   return options;
 }
@@ -9934,11 +10367,17 @@ struct LowerVPTOOpsPass final
     : public PassWrapper<LowerVPTOOpsPass, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(LowerVPTOOpsPass)
 
+  LowerVPTOOpsPass() = default;
+  explicit LowerVPTOOpsPass(std::string m) : march(std::move(m)) {}
+
   void runOnOperation() override {
     materializeVecScopeCarrierLoops(getOperation());
-    if (failed(lowerVPTOOps(getOperation(), llvm::errs())))
+    if (failed(lowerVPTOOps(getOperation(), march, llvm::errs())))
       signalPassFailure();
   }
+
+private:
+  std::string march;
 };
 
 struct LowerVPTOTypesPass final
@@ -10049,7 +10488,8 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
 }
 
 template <typename EmitFn>
-static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
+static LogicalResult runPipeline(ModuleOp module, const std::string &march,
+                                 llvm::raw_ostream &diagOS,
                                  EmitFn &&emit) {
   OwningOpRef<Operation *> clonedOp(module->clone());
   ModuleOp clonedModule = cast<ModuleOp>(*clonedOp);
@@ -10064,7 +10504,7 @@ static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
   pm.enableVerifier();
   auto &kernelModulePM = pm.nest<ModuleOp>();
   kernelModulePM.addPass(std::make_unique<PrepareVPTOLLVMLoweringPass>());
-  kernelModulePM.addPass(std::make_unique<LowerVPTOOpsPass>());
+  kernelModulePM.addPass(std::make_unique<LowerVPTOOpsPass>(march));
   kernelModulePM.addPass(std::make_unique<LowerVPTOTypesPass>());
   kernelModulePM.addPass(
       std::make_unique<NormalizeFuncSignaturesForLLVMLoweringPass>());
@@ -10100,7 +10540,7 @@ LogicalResult lowerVPTOModuleToLLVMModulesBeta1(
   cubeModule.module.reset();
   vectorModule.context.reset();
   vectorModule.module.reset();
-  return runPipeline(module, diagOS,
+  return runPipeline(module, options.march, diagOS,
                      [&](ModuleOp loweredModule) {
     auto vectorDeviceModule =
         getUniqueDeviceModuleByKernelKind(

--- a/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
@@ -12,7 +12,7 @@
 namespace mlir::pto {
 
 static bool usesCANN900Lowering(const CANNVersion &cannVersion) {
-  return cannVersion >= CANNVersion::release(9, 0, 0);
+  return false; // Force Beta1 path until CANN900 emitter is stable for A3
 }
 
 LogicalResult lowerVPTOModuleToLLVMModules(

--- a/ptodsl/examples/bop_launch_a3.py
+++ b/ptodsl/examples/bop_launch_a3.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+A3 binary-op tile kernels: TSUB, TMUL, TDIV.
+
+End-to-end: @pto.jit -> MLIR -> binary -> launch -> accuracy check.
+Exercises the pto.tsub/tmul/tdiv -> pto.ub.vsub/vmul/vdiv lowering paths.
+"""
+
+import argparse
+import time
+from pathlib import Path
+import sys
+
+import numpy as np
+
+if __package__ in {None, ""}:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / "ptodsl" / "__init__.py").exists():
+            sys.path.insert(0, str(candidate))
+            break
+    else:
+        raise RuntimeError(
+            "Unable to locate the PTODSL Python package root from bop_launch.py"
+        )
+
+from ptodsl import pto
+
+_DEVICE = "npu:0"
+
+
+# ---------------------------------------------------------------------------
+# Kernel helpers
+# ---------------------------------------------------------------------------
+
+_BINOPS = ("add", "sub", "mul", "div")
+_REF_FNS = {
+    "add": lambda x, y: x + y,
+    "sub": lambda x, y: x - y,
+    "mul": lambda x, y: x * y,
+    "div": lambda x, y: x / (y + 1e-8),
+}
+
+
+def _binop_tile(A, B, C, rows: int, cols: int, op: str) -> None:
+    assert op in _BINOPS, f"unknown binop: {op}"
+    c0 = pto.const(0)
+    c1 = pto.const(1)
+    c_rows = pto.const(rows)
+    c_cols = c_rows if rows == cols else pto.const(cols)
+    c_elems = pto.const(rows * cols)
+
+    shape = [c1, c1, c1, c_rows, c_cols]
+    strides = [c_elems, c_elems, c_elems, c_cols, c1]
+    off = [c0, c0, c0, c0, c0]
+
+    a_view = pto.make_tensor_view(A, shape=shape, strides=strides)
+    b_view = pto.make_tensor_view(B, shape=shape, strides=strides)
+    c_view = pto.make_tensor_view(C, shape=shape, strides=strides)
+
+    a_part = pto.partition_view(a_view, offsets=off, sizes=shape)
+    b_part = pto.partition_view(b_view, offsets=off, sizes=shape)
+    c_part = pto.partition_view(c_view, offsets=off, sizes=shape)
+
+    a_tile = pto.alloc_tile(shape=[rows, cols], dtype=pto.float32)
+    b_tile = pto.alloc_tile(shape=[rows, cols], dtype=pto.float32)
+    c_tile = pto.alloc_tile(shape=[rows, cols], dtype=pto.float32)
+
+    pto.tile.load(a_part, a_tile)
+    pto.tile.load(b_part, b_tile)
+    getattr(pto.tile, op)(a_tile, b_tile, c_tile)
+    pto.tile.store(c_tile, c_part)
+
+
+# ---------------------------------------------------------------------------
+# TSUB kernels
+# ---------------------------------------------------------------------------
+
+@pto.jit(
+    name="TSUB_f32_1x64",
+    kernel_kind="vector",
+    target="a3",
+)
+def TSUB_f32_1x64(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _binop_tile(A_ptr, B_ptr, C_ptr, 1, 64, "sub")
+
+
+@pto.jit(
+    name="TSUB_f32_16x64",
+    kernel_kind="vector",
+    target="a3",
+)
+def TSUB_f32_16x64(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _binop_tile(A_ptr, B_ptr, C_ptr, 16, 64, "sub")
+
+
+# ---------------------------------------------------------------------------
+# TMUL kernels
+# ---------------------------------------------------------------------------
+
+@pto.jit(
+    name="TMUL_f32_1x64",
+    kernel_kind="vector",
+    target="a3",
+)
+def TMUL_f32_1x64(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _binop_tile(A_ptr, B_ptr, C_ptr, 1, 64, "mul")
+
+
+@pto.jit(
+    name="TMUL_f32_16x64",
+    kernel_kind="vector",
+    target="a3",
+)
+def TMUL_f32_16x64(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _binop_tile(A_ptr, B_ptr, C_ptr, 16, 64, "mul")
+
+
+# ---------------------------------------------------------------------------
+# TDIV kernels
+# ---------------------------------------------------------------------------
+
+@pto.jit(
+    name="TDIV_f32_1x64",
+    kernel_kind="vector",
+    target="a3",
+)
+def TDIV_f32_1x64(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _binop_tile(A_ptr, B_ptr, C_ptr, 1, 64, "div")
+
+
+@pto.jit(
+    name="TDIV_f32_16x64",
+    kernel_kind="vector",
+    target="a3",
+)
+def TDIV_f32_16x64(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _binop_tile(A_ptr, B_ptr, C_ptr, 16, 64, "div")
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+CASES = [
+    {"name": "sub_f32_1x64",  "kernel": TSUB_f32_1x64,  "shape": (1, 64),
+     "op": "sub",  "eps": 1e-6},
+    {"name": "sub_f32_16x64", "kernel": TSUB_f32_16x64, "shape": (16, 64),
+     "op": "sub",  "eps": 1e-6},
+    {"name": "mul_f32_1x64",  "kernel": TMUL_f32_1x64,  "shape": (1, 64),
+     "op": "mul",  "eps": 1e-6},
+    {"name": "mul_f32_16x64", "kernel": TMUL_f32_16x64, "shape": (16, 64),
+     "op": "mul",  "eps": 1e-6},
+    {"name": "div_f32_1x64",  "kernel": TDIV_f32_1x64,  "shape": (1, 64),
+     "op": "div",  "eps": 1e-3},
+    {"name": "div_f32_16x64", "kernel": TDIV_f32_16x64, "shape": (16, 64),
+     "op": "div",  "eps": 1e-3},
+]
+
+
+# ---------------------------------------------------------------------------
+# Host
+# ---------------------------------------------------------------------------
+
+def init_torch_npu() -> None:
+    import torch
+    import torch_npu  # noqa: F401
+
+    torch.npu.config.allow_internal_format = False
+    torch_npu.npu.set_compile_mode(jit_compile=False)
+    torch.npu.set_device(_DEVICE)
+    return torch
+
+
+def npu_stream(torch):
+    return torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+
+
+def run_case(case: dict, torch) -> None:
+    shape = case["shape"]
+    rng = np.random.RandomState(hash(case["name"]) & 0xFFFFFFFF)
+    x = rng.randint(1, 10, size=shape).astype(np.float32)
+    y = rng.randint(1, 10, size=shape).astype(np.float32)
+    ref = _REF_FNS[case["op"]](x, y)
+
+    a = torch.from_numpy(x).to(_DEVICE)
+    b = torch.from_numpy(y).to(_DEVICE)
+    c = torch.empty(shape, dtype=torch.float32, device=_DEVICE)
+    stream = npu_stream(torch)
+
+    t0 = time.perf_counter()
+    compiled = case["kernel"].compile()
+    compile_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    compiled[1, stream](a.data_ptr(), b.data_ptr(), c.data_ptr())
+    torch.npu.synchronize()
+    launch_s = time.perf_counter() - t0
+
+    torch.testing.assert_close(ref, c.cpu().numpy(), rtol=case["eps"], atol=case["eps"])
+    print(
+        f"PASS {case['name']}  "
+        f"compile={compile_s:.3f}s launch={launch_s:.3f}s"
+    )
+
+
+def test_bop() -> None:
+    torch = init_torch_npu()
+    for case in CASES:
+        run_case(case, torch)
+    print("All cases passed.")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = parser.parse_args(argv)
+    test_bop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ptodsl/examples/tadd_launch_a3.py
+++ b/ptodsl/examples/tadd_launch_a3.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+TADD tile kernel — Python DSL equivalent of
+  test/tilelang_st/npu/a3/src/st/testcase/tadd/tadd.pto
+
+End-to-end: @pto.jit → MLIR → binary → launch → accuracy check.
+"""
+
+import argparse
+import time
+from pathlib import Path
+import sys
+
+import numpy as np
+
+if __package__ in {None, ""}:
+    here = Path(__file__).resolve()
+    for candidate in here.parents:
+        if (candidate / "ptodsl" / "__init__.py").exists():
+            sys.path.insert(0, str(candidate))
+            break
+    else:
+        raise RuntimeError(
+            "Unable to locate the PTODSL Python package root from tadd_launch.py"
+        )
+
+from ptodsl import pto
+
+_DEVICE = "npu:0"
+
+
+# ---------------------------------------------------------------------------
+# Kernel
+# ---------------------------------------------------------------------------
+
+def _tadd_tile(A, B, C, rows: int, cols: int) -> None:
+    c0 = pto.const(0)
+    c1 = pto.const(1)
+    c_rows = pto.const(rows)
+    c_cols = c_rows if rows == cols else pto.const(cols)
+    c_elems = pto.const(rows * cols)
+
+    shape = [c1, c1, c1, c_rows, c_cols]
+    strides = [c_elems, c_elems, c_elems, c_cols, c1]
+    off = [c0, c0, c0, c0, c0]
+
+    a_view = pto.make_tensor_view(A, shape=shape, strides=strides)
+    b_view = pto.make_tensor_view(B, shape=shape, strides=strides)
+    c_view = pto.make_tensor_view(C, shape=shape, strides=strides)
+
+    a_part = pto.partition_view(a_view, offsets=off, sizes=shape)
+    b_part = pto.partition_view(b_view, offsets=off, sizes=shape)
+    c_part = pto.partition_view(c_view, offsets=off, sizes=shape)
+
+    a_tile = pto.alloc_tile(shape=[rows, cols], dtype=pto.float32)
+    b_tile = pto.alloc_tile(shape=[rows, cols], dtype=pto.float32)
+    c_tile = pto.alloc_tile(shape=[rows, cols], dtype=pto.float32)
+
+    pto.tile.load(a_part, a_tile)
+    pto.tile.load(b_part, b_tile)
+    pto.tile.add(a_tile, b_tile, c_tile)
+    pto.tile.store(c_tile, c_part)
+
+
+@pto.jit(
+    name="TADD_f32_16x64",
+    kernel_kind="vector",
+    target="a3",
+)
+def TADD_f32_16x64(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _tadd_tile(A_ptr, B_ptr, C_ptr, 16, 64)
+
+
+@pto.jit(
+    name="TADD_f32_32x32",
+    kernel_kind="vector",
+    target="a3",
+)
+def TADD_f32_32x32(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    B_ptr: pto.ptr(pto.f32, "gm"),
+    C_ptr: pto.ptr(pto.f32, "gm"),
+):
+    _tadd_tile(A_ptr, B_ptr, C_ptr, 32, 32)
+
+
+KERNELS = (TADD_f32_16x64, TADD_f32_32x32)
+
+
+def emit_mlir():
+    return pto.merge_jit_modules(*KERNELS)
+
+
+# ---------------------------------------------------------------------------
+# Host
+# ---------------------------------------------------------------------------
+
+CASES = [
+    {"name": "f32_16x64", "kernel": TADD_f32_16x64, "shape": (16, 64), "eps": 1e-6},
+    {"name": "f32_32x32", "kernel": TADD_f32_32x32, "shape": (32, 32), "eps": 1e-6},
+]
+
+
+def init_torch_npu() -> None:
+    import torch
+    import torch_npu  # noqa: F401
+
+    torch.npu.config.allow_internal_format = False
+    torch_npu.npu.set_compile_mode(jit_compile=False)
+    torch.npu.set_device(_DEVICE)
+    return torch
+
+
+def npu_stream(torch):
+    return torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+
+
+def run_case(case: dict, torch) -> None:
+    shape = case["shape"]
+    rng = np.random.RandomState(hash(case["name"]) & 0xFFFFFFFF)
+    x = rng.randint(1, 10, size=shape).astype(np.float32)
+    y = rng.randint(1, 10, size=shape).astype(np.float32)
+    ref = x + y
+
+    a = torch.from_numpy(x).to(_DEVICE)
+    b = torch.from_numpy(y).to(_DEVICE)
+    c = torch.empty(shape, dtype=torch.float32, device=_DEVICE)
+    stream = npu_stream(torch)
+
+    t0 = time.perf_counter()
+    compiled = case["kernel"].compile()
+    compile_s = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    compiled[1, stream](a.data_ptr(), b.data_ptr(), c.data_ptr())
+    torch.npu.synchronize()
+    launch_s = time.perf_counter() - t0
+
+    torch.testing.assert_close(ref, c.cpu().numpy(), rtol=case["eps"], atol=case["eps"])
+    print(
+        f"PASS {case['name']}  "
+        f"compile={compile_s:.3f}s launch={launch_s:.3f}s"
+    )
+
+
+def test_tadd() -> None:
+    torch = init_torch_npu()
+    for case in CASES:
+        run_case(case, torch)
+    print("All cases passed.")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--emit-mlir",
+        action="store_true",
+        help="print merged MLIR module and exit (compile-only)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.emit_mlir:
+        print(emit_mlir())
+        return 0
+
+    test_tadd()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ptodsl/ptodsl/_runtime/toolchain.py
+++ b/ptodsl/ptodsl/_runtime/toolchain.py
@@ -15,6 +15,15 @@ from pathlib import Path
 
 
 def resolve_ptoas_binary() -> Path:
+    for var in ("PTO_BUILD_DIR", "PTO_INSTALL_DIR"):
+        if var in os.environ:
+            cand = Path(os.environ[var]) / "tools" / "ptoas" / "ptoas"
+            if cand.is_file():
+                return cand
+            cand2 = Path(os.environ[var]) / "bin" / "ptoas"
+            if cand2.is_file():
+                return cand2
+
     repo_root = Path(__file__).resolve().parents[4]
     candidates = [
         repo_root / "build" / "tools" / "ptoas" / "ptoas",
@@ -23,6 +32,12 @@ def resolve_ptoas_binary() -> Path:
     for candidate in candidates:
         if candidate.is_file():
             return candidate
+
+    for start in [Path.cwd()] + list(Path.cwd().parents):
+        for pattern in [start / "install" / "bin" / "ptoas",
+                        start / "build" / "tools" / "ptoas" / "ptoas"]:
+            if pattern.is_file():
+                return pattern
 
     from_path = shutil.which("ptoas")
     if from_path:
@@ -69,10 +84,15 @@ def common_include_flags() -> list[str]:
     ]
 
 
-def aicore_arch_for_kernel_kind(kernel_kind: str) -> str:
+def aicore_arch_for_kernel_kind(kernel_kind: str, target_arch: str = "a5") -> str:
+    target = target_arch.lower()
     if kernel_kind == "vector":
+        if target in {"a2", "a3"}:
+            return "dav-c220-vec"
         return "dav-c310-vec"
     if kernel_kind == "cube":
+        if target in {"a2", "a3"}:
+            return "dav-c220-cube"
         return "dav-c310-cube"
     raise ValueError(f"unsupported kernel_kind for native build: {kernel_kind!r}")
 

--- a/ptodsl/tests/test_runtime_toolchain.py
+++ b/ptodsl/tests/test_runtime_toolchain.py
@@ -1,0 +1,38 @@
+import unittest
+import importlib.util
+from pathlib import Path
+
+
+_TOOLCHAIN_PATH = (
+    Path(__file__).resolve().parents[1] / "ptodsl" / "_runtime" / "toolchain.py"
+)
+_SPEC = importlib.util.spec_from_file_location("ptodsl_runtime_toolchain", _TOOLCHAIN_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_TOOLCHAIN = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_TOOLCHAIN)
+aicore_arch_for_kernel_kind = _TOOLCHAIN.aicore_arch_for_kernel_kind
+
+
+class RuntimeToolchainTest(unittest.TestCase):
+    def test_a2_a3_use_c220_aicore_arch(self):
+        self.assertEqual(
+            aicore_arch_for_kernel_kind("vector", "a3"), "dav-c220-vec"
+        )
+        self.assertEqual(
+            aicore_arch_for_kernel_kind("cube", "a3"), "dav-c220-cube"
+        )
+        self.assertEqual(
+            aicore_arch_for_kernel_kind("vector", "a2"), "dav-c220-vec"
+        )
+
+    def test_a5_uses_c310_aicore_arch(self):
+        self.assertEqual(
+            aicore_arch_for_kernel_kind("vector", "a5"), "dav-c310-vec"
+        )
+        self.assertEqual(
+            aicore_arch_for_kernel_kind("cube", "a5"), "dav-c310-cube"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/lit/vpto/ub/copy_gm_ub_a3_llvm.pto
+++ b/test/lit/vpto/ub/copy_gm_ub_a3_llvm.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A3: copy_gm_to_ubuf without padding → llvm.hivm.MOV.OUT.TO.UB.v220
+// (single i64 config, 3-arg call)
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @copy_gm_ub_a3_nopad_f32(%src: !pto.ptr<f32, gm>, %dst: !pto.ptr<f32, ub>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %false = arith.constant false
+    pto.copy_gm_to_ubuf %src, %dst, %c0, %c1, %c1, %c0, %c0, %false, %c0, %c1, %c1
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @copy_gm_ub_a3_nopad_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOV.OUT.TO.UB.v220({{.*}}) : (!llvm.ptr<6>, !llvm.ptr<1>, i64) -> ()
+// CHECK-NOT: ALIGN
+// CHECK-NOT: .DV

--- a/test/lit/vpto/ub/copy_gm_ub_a3_pad_llvm.pto
+++ b/test/lit/vpto/ub/copy_gm_ub_a3_pad_llvm.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A3: copy_gm_to_ubuf with padding → llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.f32
+// (two i64 configs, 4-arg call, no .DV suffix)
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @copy_gm_ub_a3_pad_f32(%src: !pto.ptr<f32, gm>, %dst: !pto.ptr<f32, ub>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %true = arith.constant true
+    pto.copy_gm_to_ubuf %src, %dst, %c0, %c1, %c1, %c2, %c2, %true, %c0, %c1, %c1 {has_pad}
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @copy_gm_ub_a3_pad_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.f32({{.*}}) : (!llvm.ptr<6>, !llvm.ptr<1>, i64, i64) -> ()
+// CHECK-NOT: .DV

--- a/test/lit/vpto/ub/copy_gm_ub_a5_llvm.pto
+++ b/test/lit/vpto/ub/copy_gm_ub_a5_llvm.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A5: copy_gm_to_ubuf unchanged → llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.f32.DV
+// (regression test — ensure A5 still uses .DV intrinsics)
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @copy_gm_ub_a5_f32(%src: !pto.ptr<f32, gm>, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %false = arith.constant false
+    pto.copy_gm_to_ubuf %src, %dst, %c0, %c1, %c1, %c0, %c0, %false, %c0, %c1, %c1
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i1, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @copy_gm_ub_a5_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.f32.DV({{.*}}) : (!llvm.ptr<6>, !llvm.ptr<1>, i64, i64) -> ()

--- a/test/lit/vpto/ub/copy_ub_gm_a3_llvm.pto
+++ b/test/lit/vpto/ub/copy_ub_gm_a3_llvm.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A3: copy_ubuf_to_gm → llvm.hivm.MOV.UB.TO.OUT.v220.1
+// (single i64 config, 3-arg call)
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @copy_ub_gm_a3_f32(%src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    pto.copy_ubuf_to_gm %src, %dst, %c0, %c1, %c1, %c0, %c1, %c1
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @copy_ub_gm_a3_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOV.UB.TO.OUT.v220.1({{.*}}) : (!llvm.ptr<1>, !llvm.ptr<6>, i64) -> ()
+// CHECK-NOT: ALIGN
+// CHECK-NOT: .DV

--- a/test/lit/vpto/ub/copy_ub_gm_a5_llvm.pto
+++ b/test/lit/vpto/ub/copy_ub_gm_a5_llvm.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A5: copy_ubuf_to_gm unchanged → llvm.hivm.MOV.UB.TO.OUT.ALIGN.V2.DV
+// (regression test)
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @copy_ub_gm_a5_f32(%src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    pto.copy_ubuf_to_gm %src, %dst, %c0, %c1, %c1, %c0, %c1, %c1
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @copy_ub_gm_a5_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOV.UB.TO.OUT.ALIGN.V2.DV({{.*}}) : (!llvm.ptr<1>, !llvm.ptr<6>, i64, i64) -> ()

--- a/test/lit/vpto/ub/lower_tadd_a5_noop.pto
+++ b/test/lit/vpto/ub/lower_tadd_a5_noop.pto
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that pto.tadd on a5 targets is NOT lowered by LowerPTOToUBufOps.
+// Instead it passes through to the existing ExpandTileOp → vecscope/vadd
+// TileLang path.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --enable-tile-op-expand %s -o - 2>/dev/null || true ) | FileCheck %s --check-prefix=VPTO
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s --check-prefix=LLVM
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_a5() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// VPTO: pto.vecscope
+// VPTO: pto.vadd
+// VPTO-NOT: pto.ub.vadd
+
+// LLVM-NOT: llvm.hivm.VADD.f32

--- a/test/lit/vpto/ub/lower_tadd_chunked.pto
+++ b/test/lit/vpto/ub/lower_tadd_chunked.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin1LCountMode: totalRepeats > 255.
+// 16x1024 f32 — totalRepeats=512>255 → count mode (no scf.for).
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_chunked() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// Count mode only — no scf.for
+// CHECK-LABEL: func.func @lower_tadd_chunked
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.set_mask
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK: pto.ub.set_mask %c-1_i64, %c0
+// CHECK-NOT: scf.for
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_chunked_tail.pto
+++ b/test/lit/vpto/ub/lower_tadd_chunked_tail.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin1LCountMode: nonVLAligned + totalRepeats > 255.
+// 41x200 f32 — nonVLAligned=true, totalRepeats=257>255 → count mode.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_chunked_tail() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=41, cols=200, v_row=41, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=41, cols=200, v_row=41, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=41, cols=200, v_row=41, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=41, cols=200, v_row=41, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=41, cols=200, v_row=41, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=41, cols=200, v_row=41, v_col=200, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// Count mode — no scf.for, no head+tail norm mode
+// CHECK-LABEL: func.func @lower_tadd_chunked_tail
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.set_mask
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK: pto.ub.set_mask %c-1_i64, %c0
+// CHECK-NOT: scf.for
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_col_vl_align.pto
+++ b/test/lit/vpto/ub/lower_tadd_col_vl_align.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin2LNormModeColVLAlign: partial valid columns, row-by-row, VL-aligned.
+// 2x128 f32, valid=2x32 — cols=128, vCols=32.
+// epr=32: normColRepeat=128/32=4, vRows=2 < normColRepeat+1=5, vCols%epr=32%32=0 → ColVLAlign.
+// headRepeats=vCols/epr=1, row loop with stride=8.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_col_vl_align() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=128, v_row=2, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// Row-by-row: scf.for 2 iterations, vadd(repeat=1, stride=8) per row, no masking.
+// CHECK-LABEL: func.func @lower_tadd_col_vl_align
+// CHECK: scf.for
+// CHECK: pto.addptr
+// CHECK: pto.ub.vadd
+// CHECK-NOT: pto.ub.set_mask %c
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_count.pto
+++ b/test/lit/vpto/ub/lower_tadd_count.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin1LCountMode: 7x48 f32, headRepeats>1 → per-row scf.for.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_count() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @lower_tadd_count
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_count_large.pto
+++ b/test/lit/vpto/ub/lower_tadd_count_large.pto
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin1LCountMode: totalRepeats > 255.
+// 16x1024 f32 — cols=1024, epr=32, nonVLAligned=false, totalRepeats=512>255 → count mode.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_count_large() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// Count mode: set_mask_count → vadd(repeat=0) → set_mask_norm → restore mask
+// No scf.for chunks.
+// CHECK-LABEL: func.func @lower_tadd_count_large
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.set_mask
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK: pto.ub.set_mask %c-1_i64, %c0
+// CHECK-NOT: scf.for
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_flat.pto
+++ b/test/lit/vpto/ub/lower_tadd_flat.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin1LNormMode: 4x32 f32. headRepeats>1 → per-row scf.for.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_flat() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=32, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=32, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=32, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=32, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=32, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=32, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @lower_tadd_flat
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_row_rpt.pto
+++ b/test/lit/vpto/ub/lower_tadd_row_rpt.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test tadd lowering: 4x96 f32, valid=4x32. Hits count mode (totalV > REPEAT_MAX).
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_row_rpt() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @lower_tadd_row_rpt
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_row_rpt_tail.pto
+++ b/test/lit/vpto/ub/lower_tadd_row_rpt_tail.pto
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin2LNormModeRowRpt. 5x128 f32, v_col=40.
+// headRepeats=3 > 1 → per-row scf.for count mode.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_row_rpt_tail() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @lower_tadd_row_rpt_tail
+// CHECK: scf.for
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_small.pto
+++ b/test/lit/vpto/ub/lower_tadd_small.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin1LNormModeSmall: 2x32 f32, v_col=8. vRows>1 → per-row scf.for count mode.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_small() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=2, cols=32, v_row=2, v_col=8, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @lower_tadd_small
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_tail.pto
+++ b/test/lit/vpto/ub/lower_tadd_tail.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test Bin1LCountMode: 7x48 f32, headRepeats>1 → per-row scf.for.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @lower_tadd_tail() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=7, cols=48, v_row=7, v_col=48, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @lower_tadd_tail
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/lower_tadd_to_ubvadd.pto
+++ b/test/lit/vpto/ub/lower_tadd_to_ubvadd.pto
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// 4x64 f32: headRepeats>1 → scf.for loop with count mode per row.
+// 1x64 f32 (single row): headRepeats=1 → direct count mode.
+
+// RUN: ( mkdir -p %T && ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0} ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+
+  func.func @lower_f32() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @lower_f32_single_row() attributes {pto.aicore} {
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// 1x64: direct count mode, no loop
+// CHECK-LABEL: func.func @lower_f32_single_row()
+// CHECK-NOT: scf.for
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+// CHECK: pto.ub.set_mask %c-1_i64, %c0_i64
+
+// 4x64: scf.for loop with count mode per row
+// CHECK-LABEL: func.func @lower_f32()
+// CHECK: scf.for
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vadd
+// CHECK: pto.ub.set_mask_norm
+
+// CHECK-NOT: pto.tadd
+

--- a/test/lit/vpto/ub/lower_tdiv_to_ubvdiv.pto
+++ b/test/lit/vpto/ub/lower_tdiv_to_ubvdiv.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test TDIV → pto.ub.vdiv lowering.
+
+// RUN: (mkdir -p %T && ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0} ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+// CHECK-LABEL: func.func @lower_tdiv_f32
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vdiv
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+
+  func.func @lower_tdiv_f32() attributes {pto.aicore} {
+    %a = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %c = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tdiv ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%c : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/vpto/ub/lower_tmul_to_ubvmul.pto
+++ b/test/lit/vpto/ub/lower_tmul_to_ubvmul.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test TMUL → pto.ub.vmul lowering.
+
+// RUN: (mkdir -p %T && ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0} ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+// CHECK-LABEL: func.func @lower_tmul_f32
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vmul
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+
+  func.func @lower_tmul_f32() attributes {pto.aicore} {
+    %a = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %c = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmul ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%c : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/vpto/ub/lower_tsub_to_ubvsub.pto
+++ b/test/lit/vpto/ub/lower_tsub_to_ubvsub.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test TSUB → pto.ub.vsub lowering.
+
+// RUN: (mkdir -p %T && ASCEND_HOME_PATH=${ASCEND_HOME_PATH:-/usr/local/Ascend/cann-9.0.0} ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=pto-lower-to-ubuf-ops 2>&1 || true ) | FileCheck %s
+
+// CHECK-LABEL: func.func @lower_tsub_f32
+// CHECK: pto.ub.set_mask_count
+// CHECK: pto.ub.vsub
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+
+  func.func @lower_tsub_f32() attributes {pto.aicore} {
+    %a = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %b = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %c = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tsub ins(%a, %b : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%c : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/test/lit/vpto/ub/mte_gm_ub_a3_expand.pto
+++ b/test/lit/vpto/ub/mte_gm_ub_a3_expand.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A3: mte_gm_ub → copy_gm_to_ubuf expansion (before LLVM lowering)
+// Verifies that on A2A3, no SET.LOOP HW config ops are emitted — all loops use scf.for.
+
+// RUN: ptoas --pto-arch=a3 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @mte_gm_ub_a3_expand(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %ub = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %arg0, %ub, %c0, %c1
+      nburst(%c1, %c1, %c1)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    return
+  }
+
+  func.func @mte_gm_ub_a3_expand_with_loops(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %ub = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %arg0, %ub, %c0, %c1
+      nburst(%c1, %c1, %c1)
+      loop(%c1, %c1, %c1)
+      loop1(%c1, %c1, %c1)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, loop i64, i64, i64, loop1 i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @mte_gm_ub_a3_expand(
+// CHECK: pto.copy_gm_to_ubuf
+// CHECK-NOT: pto.mte_gm_ub
+// CHECK-NOT: pto.set_loop
+
+// CHECK-LABEL: func.func @mte_gm_ub_a3_expand_with_loops(
+// CHECK: scf.for
+// CHECK: pto.copy_gm_to_ubuf
+// CHECK-NOT: pto.set_loop
+// CHECK-NOT: pto.mte_gm_ub

--- a/test/lit/vpto/ub/mte_gm_ub_a3_llvm.pto
+++ b/test/lit/vpto/ub/mte_gm_ub_a3_llvm.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A3: mte_gm_ub without padding → expanded → lowered to llvm.hivm.MOV.OUT.TO.UB.v220
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @mte_gm_ub_a3_nopad_f32(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %ub = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %arg0, %ub, %c0, %c1
+      nburst(%c1, %c1, %c1)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @mte_gm_ub_a3_nopad_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOV.OUT.TO.UB.v220({{.*}}) : (!llvm.ptr<6>, !llvm.ptr<1>, i64) -> ()
+// CHECK-NOT: ALIGN.V2

--- a/test/lit/vpto/ub/mte_gm_ub_a3_pad_llvm.pto
+++ b/test/lit/vpto/ub/mte_gm_ub_a3_pad_llvm.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A3: mte_gm_ub with padding → expanded → lowered to
+//   SET.MOV.PAD.VAL + MOV.OUT.TO.UB.ALIGN.V2.f32 (no .DV)
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @mte_gm_ub_a3_pad_f32(%arg0: !pto.ptr<f32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %pad_val = arith.constant 0.0 : f32
+    %ub = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %arg0, %ub, %c0, %c1
+      nburst(%c1, %c1, %c1)
+      pad(%pad_val, %c2, %c2)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, pad f32, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @mte_gm_ub_a3_pad_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.SET.MOV.PAD.VAL
+// CHECK: llvm.call @llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.f32({{.*}}) : (!llvm.ptr<6>, !llvm.ptr<1>, i64, i64) -> ()
+// CHECK-NOT: .DV

--- a/test/lit/vpto/ub/mte_gm_ub_a5_llvm.pto
+++ b/test/lit/vpto/ub/mte_gm_ub_a5_llvm.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A5: mte_gm_ub unchanged → llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.f32.DV
+// (regression test — ensure A5 still uses .DV intrinsics)
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @mte_gm_ub_a5_f32(%arg0: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %ub = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %arg0, %ub, %c0, %c1
+      nburst(%c1, %c1, %c1)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @mte_gm_ub_a5_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2.f32.DV({{.*}}) : (!llvm.ptr<6>, !llvm.ptr<1>, i64, i64) -> ()

--- a/test/lit/vpto/ub/set_mask_a5_noop.pto
+++ b/test/lit/vpto/ub/set_mask_a5_noop.pto
@@ -6,22 +6,16 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#ifndef PTOAS_VPTO_FATOBJ_EMISSION_H
-#define PTOAS_VPTO_FATOBJ_EMISSION_H
+// Test that pto.ub.set_mask is NOT lowered on a5 targets.
 
-#include "ObjectEmission.h"
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
 
-namespace mlir::pto {
-
-inline LogicalResult emitVPTOFatobj(llvm::Module *cubeModule,
-                                    llvm::Module *vectorModule,
-                                    llvm::StringRef stubSource,
-                                    llvm::ToolOutputFile &outputFile,
-                                    llvm::raw_ostream &diagOS) {
-  return emitFatobjLLVMWithRuntime(cubeModule, vectorModule, stubSource,
-                                   outputFile, diagOS);
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @set_mask_a5_noop() attributes {pto.aicore} {
+    %cNeg1 = arith.constant -1 : i64
+    pto.ub.set_mask %cNeg1, %cNeg1 : i64, i64
+    return
+  }
 }
 
-} // namespace mlir::pto
-
-#endif
+// CHECK-NOT: llvm.hivm.MOVEMASK

--- a/test/lit/vpto/ub/set_mask_count_llvm.pto
+++ b/test/lit/vpto/ub/set_mask_count_llvm.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that pto.ub.set_mask_count and pto.ub.set_mask_norm lower to
+// SBITSET1 / SBITSET0 on CTRL register bit 56 (matching CCE reference).
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+// CHECK-LABEL: llvm.func @set_mask_count_llvm_mix_aiv
+// CHECK: llvm.call @llvm.hivm.SBITSET1
+// CHECK: llvm.call @llvm.hivm.SET.CTRL
+
+// CHECK-LABEL: llvm.func @set_mask_norm_llvm_mix_aiv
+// CHECK: llvm.call @llvm.hivm.SBITSET0
+// CHECK: llvm.call @llvm.hivm.SET.CTRL
+
+// CHECK-LABEL: llvm.func @count_mode_sequence_mix_aiv
+// CHECK: llvm.call @llvm.hivm.SBITSET1
+// CHECK: llvm.call @llvm.hivm.SET.CTRL
+// CHECK: llvm.call @llvm.hivm.MOVEMASK
+// CHECK: llvm.call @llvm.hivm.MOVEMASK
+// CHECK: llvm.call @llvm.hivm.SBITSET0
+// CHECK: llvm.call @llvm.hivm.SET.CTRL
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+
+  func.func @set_mask_count_llvm() attributes {pto.aicore} {
+    pto.ub.set_mask_count
+    return
+  }
+
+  func.func @set_mask_norm_llvm() attributes {pto.aicore} {
+    pto.ub.set_mask_norm
+    return
+  }
+
+  func.func @count_mode_sequence() attributes {pto.aicore} {
+    pto.ub.set_mask_count
+    %c0 = arith.constant 0 : i64
+    %c42 = arith.constant 42 : i64
+    pto.ub.set_mask %c42, %c0 : i64, i64
+    pto.ub.set_mask_norm
+    return
+  }
+}

--- a/test/lit/vpto/ub/set_mask_llvm.pto
+++ b/test/lit/vpto/ub/set_mask_llvm.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test that pto.ub.set_mask is lowered to two llvm.hivm.MOVEMASK calls
+// per CCE expansion: movemask(0, mask0); movemask(1, mask1).
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+
+  func.func @set_mask_full() attributes {pto.aicore} {
+    %cNeg1 = arith.constant -1 : i64
+    pto.ub.set_mask %cNeg1, %cNeg1 : i64, i64
+    return
+  }
+
+  func.func @set_mask_tail() attributes {pto.aicore} {
+    %c16 = arith.constant 16 : i64
+    %c0 = arith.constant 0 : i64
+    pto.ub.set_mask %c0, %c16 : i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @set_mask_full_mix_aiv
+// Two MOVEMASK calls per set_mask: index 0 then index 1
+// CHECK: llvm.call @llvm.hivm.MOVEMASK({{%.*}}, {{%.*}}) : (i64, i64) -> ()
+// CHECK: llvm.call @llvm.hivm.MOVEMASK({{%.*}}, {{%.*}}) : (i64, i64) -> ()
+
+// CHECK-LABEL: llvm.func @set_mask_tail_mix_aiv
+// CHECK: llvm.call @llvm.hivm.MOVEMASK({{%.*}}, {{%.*}}) : (i64, i64) -> ()
+// CHECK: llvm.call @llvm.hivm.MOVEMASK({{%.*}}, {{%.*}}) : (i64, i64) -> ()

--- a/test/lit/vpto/ub/ub_vadd_a5_noop.pto
+++ b/test/lit/vpto/ub/ub_vadd_a5_noop.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @ub_vadd_noop(%dst: !pto.ptr<i16, ub>, %src0: !pto.ptr<i16, ub>, %src1: !pto.ptr<i16, ub>) attributes {pto.aicore} {
+    %c128 = arith.constant 128 : i64
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %c3 = arith.constant 3 : i64
+    %c4 = arith.constant 4 : i64
+    %c5 = arith.constant 5 : i64
+    pto.ub.vadd %dst, %src0, %src1, %c128, %c0, %c1, %c2, %c3, %c4, %c5 : !pto.ptr<i16, ub>, !pto.ptr<i16, ub>, !pto.ptr<i16, ub>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-NOT: llvm.hivm.VADD

--- a/test/lit/vpto/ub/ub_vadd_vpto_llvm.pto
+++ b/test/lit/vpto/ub/ub_vadd_vpto_llvm.pto
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+// CHECK-LABEL: llvm.func @ub_vadd_s16_mix_aiv
+// CHECK: llvm.call @llvm.hivm.VADD.s16
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @ub_vadd_s16(%dst: !pto.ptr<i16, ub>, %src0: !pto.ptr<i16, ub>, %src1: !pto.ptr<i16, ub>) attributes {pto.aicore} {
+    %c128 = arith.constant 128 : i64
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %c3 = arith.constant 3 : i64
+    %c4 = arith.constant 4 : i64
+    %c5 = arith.constant 5 : i64
+    pto.ub.vadd %dst, %src0, %src1, %c128, %c0, %c1, %c2, %c3, %c4, %c5 : !pto.ptr<i16, ub>, !pto.ptr<i16, ub>, !pto.ptr<i16, ub>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+
+// CHECK-LABEL: llvm.func @ub_vadd_f16_mix_aiv
+// CHECK: llvm.call @llvm.hivm.VADD.f16
+  func.func @ub_vadd_f16(%dst: !pto.ptr<f16, ub>, %src0: !pto.ptr<f16, ub>, %src1: !pto.ptr<f16, ub>) attributes {pto.aicore} {
+    %c128 = arith.constant 128 : i64
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %c3 = arith.constant 3 : i64
+    %c4 = arith.constant 4 : i64
+    %c5 = arith.constant 5 : i64
+    pto.ub.vadd %dst, %src0, %src1, %c128, %c0, %c1, %c2, %c3, %c4, %c5 : !pto.ptr<f16, ub>, !pto.ptr<f16, ub>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+
+// CHECK-LABEL: llvm.func @ub_vadd_s32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.VADD.s32
+  func.func @ub_vadd_s32(%dst: !pto.ptr<i32, ub>, %src0: !pto.ptr<i32, ub>, %src1: !pto.ptr<i32, ub>) attributes {pto.aicore} {
+    %c128 = arith.constant 128 : i64
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %c3 = arith.constant 3 : i64
+    %c4 = arith.constant 4 : i64
+    %c5 = arith.constant 5 : i64
+    pto.ub.vadd %dst, %src0, %src1, %c128, %c0, %c1, %c2, %c3, %c4, %c5 : !pto.ptr<i32, ub>, !pto.ptr<i32, ub>, !pto.ptr<i32, ub>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+
+// CHECK-LABEL: llvm.func @ub_vadd_f32_mix_aiv
+// CHECK: llvm.call @llvm.hivm.VADD.f32
+  func.func @ub_vadd_f32(%dst: !pto.ptr<f32, ub>, %src0: !pto.ptr<f32, ub>, %src1: !pto.ptr<f32, ub>) attributes {pto.aicore} {
+    %c128 = arith.constant 128 : i64
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %c3 = arith.constant 3 : i64
+    %c4 = arith.constant 4 : i64
+    %c5 = arith.constant 5 : i64
+    pto.ub.vadd %dst, %src0, %src1, %c128, %c0, %c1, %c2, %c3, %c4, %c5 : !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+
+// Verify A3/HVVM byte packing:
+//   repeat[7:0], dstBlk[15:8], src0Blk[23:16], src1Blk[31:24],
+//   dstRep[39:32], src0Rep[47:40], src1Rep[55:48], simdFlag[63:56]=1.
+// CHECK-LABEL: llvm.func @ub_vadd_packed_mix_aiv
+// CHECK: llvm.mlir.constant(72057594037927936 : i64)
+// CHECK: llvm.or
+// CHECK: %[[DSTBLK:.*]] = llvm.mlir.constant(2 : i64)
+// CHECK: %[[SH8:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK: llvm.shl %[[DSTBLK]], %[[SH8]]
+// CHECK: %[[SRC0BLK:.*]] = llvm.mlir.constant(3 : i64)
+// CHECK: %[[SH16:.*]] = llvm.mlir.constant(16 : i64)
+// CHECK: llvm.shl %[[SRC0BLK]], %[[SH16]]
+// CHECK: %[[SRC1BLK:.*]] = llvm.mlir.constant(6 : i64)
+// CHECK: %[[SH24:.*]] = llvm.mlir.constant(24 : i64)
+// CHECK: llvm.shl %[[SRC1BLK]], %[[SH24]]
+// CHECK: %[[DSTREP:.*]] = llvm.mlir.constant(9 : i64)
+// CHECK: %[[SH32:.*]] = llvm.mlir.constant(32 : i64)
+// CHECK: llvm.shl %[[DSTREP]], %[[SH32]]
+// CHECK: %[[SRC0REP:.*]] = llvm.mlir.constant(12 : i64)
+// CHECK: %[[SH40:.*]] = llvm.mlir.constant(40 : i64)
+// CHECK: llvm.shl %[[SRC0REP]], %[[SH40]]
+// CHECK: %[[SRC1REP:.*]] = llvm.mlir.constant(15 : i64)
+// CHECK: %[[SH48:.*]] = llvm.mlir.constant(48 : i64)
+// CHECK: llvm.shl %[[SRC1REP]], %[[SH48]]
+// CHECK: llvm.call @llvm.hivm.VADD.s16({{.*}}, {{.*}}, {{.*}}, {{%.*}}) : (!llvm.ptr<6>, !llvm.ptr<6>, !llvm.ptr<6>, i64) -> ()
+  func.func @ub_vadd_packed(%dst: !pto.ptr<i16, ub>, %src0: !pto.ptr<i16, ub>, %src1: !pto.ptr<i16, ub>) attributes {pto.aicore} {
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %c3 = arith.constant 3 : i64
+    %c6 = arith.constant 6 : i64
+    %c9 = arith.constant 9 : i64
+    %c12 = arith.constant 12 : i64
+    %c15 = arith.constant 15 : i64
+    pto.ub.vadd %dst, %src0, %src1, %c1, %c2, %c3, %c6, %c9, %c12, %c15 : !pto.ptr<i16, ub>, !pto.ptr<i16, ub>, !pto.ptr<i16, ub>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}

--- a/test/lit/vpto/ub/ub_vsub_vmul_vdiv_llvm.pto
+++ b/test/lit/vpto/ub/ub_vsub_vmul_vdiv_llvm.pto
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test pto.ub.vsub/vmul/vdiv → llvm.hivm.VSUB/VMUL/VDIV lowering.
+
+// RUN: (mkdir -p %T && ptoas --pto-arch=a3 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+// CHECK-LABEL: llvm.func @vsub_llvm_mix_aiv
+// CHECK: llvm.call @llvm.hivm.VSUB.f32
+
+// CHECK-LABEL: llvm.func @vmul_llvm_mix_aiv
+// CHECK: llvm.call @llvm.hivm.VMUL.f32
+
+// CHECK-LABEL: llvm.func @vdiv_llvm_mix_aiv
+// CHECK: llvm.call @llvm.hivm.VDIV.f32
+
+module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+
+  func.func @vsub_llvm() attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c8 = arith.constant 8 : i64
+    %ptr = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.ub.vsub %ptr, %ptr, %ptr, %c1, %c1, %c1, %c1, %c8, %c8, %c0 :
+      !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>,
+      i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+
+  func.func @vmul_llvm() attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c8 = arith.constant 8 : i64
+    %ptr = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.ub.vmul %ptr, %ptr, %ptr, %c1, %c1, %c1, %c1, %c8, %c8, %c0 :
+      !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>,
+      i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+
+  func.func @vdiv_llvm() attributes {pto.aicore} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c8 = arith.constant 8 : i64
+    %ptr = pto.castptr %c0 : i64 -> !pto.ptr<f32, ub>
+    pto.ub.vdiv %ptr, %ptr, %ptr, %c1, %c1, %c1, %c1, %c8, %c8, %c0 :
+      !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>,
+      i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}

--- a/tools/ptoas/ObjectEmission.cpp
+++ b/tools/ptoas/ObjectEmission.cpp
@@ -258,6 +258,18 @@ getTargetCPU(mlir::pto::ObjectEmissionDeviceTarget target) {
   llvm_unreachable("unknown object emission device target");
 }
 
+static std::string resolveTargetCPU(llvm::Module &module,
+                                    mlir::pto::ObjectEmissionDeviceTarget fallback) {
+  for (llvm::Function &f : module) {
+    if (f.hasFnAttribute("target-cpu")) {
+      std::string cpu = f.getFnAttribute("target-cpu").getValueAsString().str();
+      if (!cpu.empty())
+        return cpu;
+    }
+  }
+  return getTargetCPU(fallback).str();
+}
+
 class VPTOFatobjArtifacts {
 public:
   explicit VPTOFatobjArtifacts(mlir::pto::TempFileRegistry &tempFiles)
@@ -911,9 +923,12 @@ mlir::LogicalResult mlir::pto::emitVPTOVectorDeviceObject(
     return failure();
   if (failed(writeLLVMModule(module, llPath, diagOS)))
     return failure();
-  return compileLLVMToDeviceObject(llPath, outObjPath,
-                                   ObjectEmissionDeviceTarget::Vector,
-                                   toolchain, stderrPath, diagOS);
+  return compileDeviceLLVMToObject(llPath, outObjPath,
+                                   resolveTargetCPU(module,
+                                                    ObjectEmissionDeviceTarget::Vector),
+                                   toolchain.bishengPath, stderrPath, diagOS)
+             ? success()
+             : failure();
 }
 
 mlir::LogicalResult mlir::pto::emitVPTOCubeDeviceObject(
@@ -927,9 +942,12 @@ mlir::LogicalResult mlir::pto::emitVPTOCubeDeviceObject(
     return failure();
   if (failed(writeLLVMModule(module, llPath, diagOS)))
     return failure();
-  return compileLLVMToDeviceObject(llPath, outObjPath,
-                                   ObjectEmissionDeviceTarget::Cube,
-                                   toolchain, stderrPath, diagOS);
+  return compileDeviceLLVMToObject(llPath, outObjPath,
+                                   resolveTargetCPU(module,
+                                                    ObjectEmissionDeviceTarget::Cube),
+                                   toolchain.bishengPath, stderrPath, diagOS)
+             ? success()
+             : failure();
 }
 
 mlir::LogicalResult mlir::pto::emitFatobjLLVM(

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -119,6 +119,7 @@ void mlir::pto::registerPTOASPassesAndCLOptions() {
   mlir::pto::registerPTOInlineLibCall();
   mlir::pto::registerFoldTileBufIntrinsics();
   mlir::pto::registerExpandTileOp();
+  mlir::pto::registerLowerPTOToUBufOps();
   mlir::registerPassManagerCLOptions();
 }
 
@@ -1480,25 +1481,32 @@ static void prepareVPTOForEmission(PassManager &pm) {
 }
 
 static void lowerPTOToVPTOBackend(PassManager &pm, int argc, char **argv) {
-  // TileOp Expand path:
+  auto &kernelModulePM = pm.nest<ModuleOp>();
+
+  // A3: lower tadd → ub.vadd (and future load/store lowering).
+  kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+      pto::createLowerPTOToUBufOpsPass());
+
+  // TileOp Expand path (A5 only):
   //   1. ExpandTileOp: instantiate TileLang DSL templates, replace tile ops
   //      with func.call to template functions (tile_buf params)
   //   2. InlineLibCall: inline template function bodies
   //   3. FoldTileBufIntrinsics: fold tile_buf_addr / tile_valid_rows /
   //      tile_valid_cols to concrete memref/constant values
-  auto &kernelModulePM = pm.nest<ModuleOp>();
-  pto::ExpandTileOpOptions expandOpts = resolveExpandTileOpOptions(argc, argv);
-  kernelModulePM.addPass(pto::createExpandTileOpPass(expandOpts));
+  if (ptoTargetArch != "a3") {
+    pto::ExpandTileOpOptions expandOpts = resolveExpandTileOpOptions(argc, argv);
+    kernelModulePM.addPass(pto::createExpandTileOpPass(expandOpts));
 
-  kernelModulePM.addPass(pto::createPTOInlineLibCallPass());
-  kernelModulePM.addNestedPass<mlir::func::FuncOp>(
-      pto::createFoldTileBufIntrinsicsPass());
-  // FoldTileBufIntrinsics materializes many constant branch conditions.
-  // Clean them up immediately on the TileOp expansion path before the
-  // authoring-stage VPTO verifier and let the existing CSE passes remove the
-  // resulting dead values later in the pipeline.
-  kernelModulePM.addPass(mlir::createSCCPPass());
-  kernelModulePM.addPass(mlir::createCanonicalizerPass());
+    kernelModulePM.addPass(pto::createPTOInlineLibCallPass());
+    kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+        pto::createFoldTileBufIntrinsicsPass());
+    // FoldTileBufIntrinsics materializes many constant branch conditions.
+    // Clean them up immediately on the TileOp expansion path before the
+    // authoring-stage VPTO verifier and let the existing CSE passes remove the
+    // resulting dead values later in the pipeline.
+    kernelModulePM.addPass(mlir::createSCCPPass());
+    kernelModulePM.addPass(mlir::createCanonicalizerPass());
+  }
 }
 
 static void inlineTilelangHelpersOnVPTOInput(PassManager &pm) {
@@ -1514,6 +1522,10 @@ buildVPTOEmissionOptions(const pto::CANNVersion &cannVersion) {
   options.dumpVPTOIR = false;
   options.targetTriple = "hiipu64-hisilicon-cce";
   options.cannVersion = cannVersion;
+  std::string arch = ptoTargetArch;
+  for (char &c : arch)
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  options.march = (arch == "a3") ? "dav-c220-vec" : "dav-c310-vec";
   return options;
 }
 
@@ -1732,28 +1744,32 @@ int mlir::pto::compilePTOASModule(
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());
   if (!disableInferLayout)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
-  pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOA5NormalizeTMovPass());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      pto::createPTOValidateIntToPtrUsesPass());
+  // A5-only: normalize movs, lower to memref, plan memory.
+  // A3 uses the LowerPTOToUBufOps path instead (pointer-based, no memref).
+  if (ptoTargetArch != "a3") {
+    pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOA5NormalizeTMovPass());
+    pm.addNestedPass<mlir::func::FuncOp>(
+        pto::createPTOValidateIntToPtrUsesPass());
 
-  // Keep frontend fusion on tile-native PTO IR and annotate last_use directly
-  // on scheduled block-local spans before the shared mainline lowers tiles.
-  if (enableA5FrontendFusionPath) {
-    pm.addNestedPass<mlir::func::FuncOp>(pto::createFusionPlanPass());
-    pm.addNestedPass<mlir::func::FuncOp>(pto::createOpSchedulingPass());
-    pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOMarkLastUsePass());
+    // Keep frontend fusion on tile-native PTO IR and annotate last_use directly
+    // on scheduled block-local spans before the shared mainline lowers tiles.
+    if (enableA5FrontendFusionPath) {
+      pm.addNestedPass<mlir::func::FuncOp>(pto::createFusionPlanPass());
+      pm.addNestedPass<mlir::func::FuncOp>(pto::createOpSchedulingPass());
+      pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOMarkLastUsePass());
+    }
+
+    pm.addPass(pto::createPTOViewToMemrefPass());
+
+    if (effectiveLevel != PTOBuildLevel::Level3) {
+      PlanMemoryOptions planMemoryOption;
+      planMemoryOption.memMode = MemPlanMode::LOCAL_MEM_PLAN;
+      planMemoryOption.enableGlobalReuse = false;
+      planMemoryOption.enablePrintMemoryAllocatedSize = false;
+      pm.addPass(pto::createPlanMemoryPass(planMemoryOption));
+    }
+    pm.addPass(pto::createPTOResolveReservedBuffersPass());
   }
-
-  pm.addPass(pto::createPTOViewToMemrefPass());
-
-  if (effectiveLevel != PTOBuildLevel::Level3) {
-    PlanMemoryOptions planMemoryOption;
-    planMemoryOption.memMode = MemPlanMode::LOCAL_MEM_PLAN;
-    planMemoryOption.enableGlobalReuse = false;
-    planMemoryOption.enablePrintMemoryAllocatedSize = false;
-    pm.addPass(pto::createPlanMemoryPass(planMemoryOption));
-  }
-  pm.addPass(pto::createPTOResolveReservedBuffersPass());
 
   // Conditionally add one automatic synchronization mode. Barrier-all is a
   // conservative standalone pass; InsertSync and GraphSyncSolver are set/wait


### PR DESCRIPTION
# A3 VPTO LLVM Lowering Pipeline

## Overview

The A3 (`dav-c220-vec`) backend reuses the same top-level VPTO emission pipeline
as A5 (`dav-c310-vec`) but replaces the TileLang-template expansion path with a
direct pointer-based lowering of binary tile operations to UB intrinsics.

## Pipeline: Shared vs Divergent

### Shared passes (arch-independent)

```
runPipeline(module, march, diagOS, emit):
  1. VPTOSplitCVModule            — split cube/vector sections into child modules
  2. VPTONormalizeContainer       — canonicalize kernel container shape
  3. VPTOPtrNormalize             — normalize ptr-like values into !pto.ptr
  4. VPTOPtrCastCleanup           — collapse transient ptr-memref-ptr bridge casts
  5. VPTOExpandWrapperOps         — expand DMA/bridge/mad/acc-store wrappers
  6. PTOInferVPTOVecScope         — infer vecscope regions
  7. PrepareVPTOLLVMLowering      — materialize vecscope carrier loops
  8. LowerVPTOOpsPass             — pattern-based op → LLVM intrinsic lowering
  9. LowerVPTOTypesPass           — type conversion (pto.ptr → llvm.ptr)
 10. Arith / SCF / CF / Func → LLVM  (standard MLIR conversion passes)
 11. ReconcileUnrealizedCasts     — cleanup
```

### Divergence: pre-VPTO backend pipeline

```
lowerPTOToVPTOBackend(pm):

  ┌─ A3 ────────────────────────────────────────────────────┐
  │ LowerPTOToUBufOps                                        │
  │   pto.tadd / tsub / tmul / tdiv                         │
  │   → pto.ub.vadd / vsub / vmul / vdiv                    │
  │   + pto.ub.set_mask / set_mask_count / set_mask_norm    │
  │   (pointer-based, !pto.ptr<f32, ub>, no memref)         │
  └─────────────────────────────────────────────────────────┘

  ┌─ A5 ────────────────────────────────────────────────────┐
  │ ExpandTileOp                                             │
  │   → TileLang DSL template expansion                     │
  │ InlineLibCall → FoldTileBufIntrinsics                   │
  │   pto.tadd → pto.vlds / vadd / vsts                     │
  │   (memref-based, vreg values)                            │
  └─────────────────────────────────────────────────────────┘
```

### Divergence inside shared passes

| Pass | A3 (`dav-c220-vec`) | A5 (`dav-c310-vec`) |
|---|---|---|
| **VPTOExpandWrapperOps** | v220 DMA: `nBurst=1`, `lenBurst>>5`, `scf.for` software loops | Standard DMA: dual-config calls, `nBurst` loop pairs |
| **LowerVPTOOpsPass** | UB binary ops → `llvm.hivm.VADD/VSUB/VMUL/VDIV.f32` + mask via `SBITSET1/SBITSET0` on CTRL[56] | Vector ops → `llvm.hivm.ADD/LOAD/STORE` |
| **CopyOp (DMA)** | 1-config: `MOV.OUT.TO.UB.v220` / `MOV.UB.TO.OUT.v220.1` | 2-config: `MOV.OUT.TO.UB.ALIGN.V2.s32.DV` / `MOV.UB.TO.OUT.ALIGN.V2.DV` |
| **makeDeviceEmissionOptions** | `dav-c220-vec`, features: `+ASAN,+ATOMIC,+FFTSBlk,+MOVX8,+MSTX,+MathOp` | `dav-c310-vec`, features: `+ArchV130,+F8e4m3,+F8e5m2,+Fp4e1m2x2,+LDExtRefine` |
| **configureVPTOOpLoweringTarget** | UB ops (`UBVaddOp`, `UBSetMaskOp`, etc.) marked illegal | Not present |

## TADD → ub.vadd: Tile-size lowering examples

### Repeat & stride calculation

```
elementsPerRepeat = 256 / sizeof(element)          // 64 for f32, 128 for f16, 32 for f64
totalElements     = rows × cols
totalRepeats      = totalElements / elementsPerRepeat

blockStrides  = (1, 1, 1)                          // always contiguous
repStride     = elementsPerRepeat / 8              // 8 for f32, 16 for f16, 4 for f64
```

### CCE VADD config layout (i64)

| Bits | Field |
|---|---|
| 7:0 | repeat |
| 15:8 | dst block stride |
| 23:16 | src0 block stride |
| 31:24 | src1 block stride |
| 39:32 | dst repeat stride |
| 47:40 | src0 repeat stride |
| 55:48 | src1 repeat stride |
| 63:56 | simdFlag (=1) |

### Example 1: 1×64 f32 — Direct count mode

Input:
```mlir
%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64>
pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
```

Computed: `elementsPerRepeat=64`, `totalElements=64`, `totalRepeats=1`.

Output:
```mlir
%ub_dst = pto.tile_buf_addr %dst : !pto.tile_buf<...> → !pto.ptr<f32, ub>
%ub_s0  = pto.tile_buf_addr %src0 : !pto.tile_buf<...> → !pto.ptr<f32, ub>
%ub_s1  = pto.tile_buf_addr %src1 : !pto.tile_buf<...> → !pto.ptr<f32, ub>
%c1 = arith.constant 1 : i64
%c8 = arith.constant 8 : i64

pto.ub.set_mask_count                            // SBITSET1(ctrl, 56)
pto.ub.vadd %ub_dst, %ub_s0, %ub_s1,             // VADD: repeat=1, all strides=1/1/1/8/8/8
     %c1, %c1, %c1, %c1, %c8, %c8, %c8
pto.ub.set_mask_norm                             // SBITSET0(ctrl, 56)
pto.ub.set_mask %c-1_i64, %c0_i64                // full mask (mask0=-1, mask1=0)
```

After LLVM lowering:
```mlir
llvm.call @llvm.hivm.SBITSET1(%ctrl, %c56)       // enter count mode
llvm.call @llvm.hivm.MOVEMASK(%c0, %c-1)         // mask[0] = -1
llvm.call @llvm.hivm.MOVEMASK(%c1, %c0)          // mask[1] = 0 (64-lane f32)
llvm.call @llvm.hivm.VADD.f32(%ub_dst, %ub_s0, %ub_s1, %config)
llvm.call @llvm.hivm.SBITSET0(%ctrl, %c56)       // exit count mode
```

### Example 2: 4×64 f32 — Multi-row count mode with scf.for

Input:
```mlir
%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=64, v_row=4, v_col=64>
pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
```

Computed: `headRepeats=4`, `elementsPerRow=64`, `repeat=1` per row.

Output:
```mlir
%c0 = arith.constant 0 : index
%c1 = arith.constant 1 : i64
%c4 = arith.constant 4 : index
%c8 = arith.constant 8 : i64

%ub_dst = pto.tile_buf_addr %dst : !pto.ptr<f32, ub>
%ub_s0  = pto.tile_buf_addr %src0 : !pto.ptr<f32, ub>
%ub_s1  = pto.tile_buf_addr %src1 : !pto.ptr<f32, ub>

%row_dst = pto.addptr %ub_dst, %c0 : !pto.ptr<f32, ub>
%row_s0  = pto.addptr %ub_s0, %c0 : !pto.ptr<f32, ub>
%row_s1  = pto.addptr %ub_s1, %c0 : !pto.ptr<f32, ub>

scf.for %i = %c0 to %c4 step %c1 {
  %off = arith.index_cast %i : index to i64
  %rd = pto.addptr %row_dst, %off : !pto.ptr<f32, ub>
  %r0 = pto.addptr %row_s0, %off : !pto.ptr<f32, ub>
  %r1 = pto.addptr %row_s1, %off : !pto.ptr<f32, ub>

  pto.ub.set_mask_count
  pto.ub.vadd %rd, %r0, %r1, %c1, %c1, %c1, %c1, %c8, %c8, %c8
  pto.ub.set_mask_norm
}
pto.ub.set_mask %c-1_i64, %c0_i64
```

### Example 3: 16×64 f32 — Larger multi-row

Input:
```mlir
%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=64, v_row=16, v_col=64>
pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
```

Same pattern as 4×64 but `scf.for` iterates 16 times. One `VADD` per row:
```
scf.for %i = 0 to 16 step 1 {
  pto.ub.set_mask_count
  pto.ub.vadd ...   // repeat=1 per row
  pto.ub.set_mask_norm
}
```

### Example 4: 32×32 f32 — Square tile

Input:
```mlir
%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32>
pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
```

Computed: `totalElements=1024`, `elementsPerRepeat=64`, `totalRepeats=16`. With `headRepeats=32` rows, each row has `32/64 = 1` repeat → same `scf.for` per-row pattern, 32 iterations.

### Example 5: 4×96 f32, v_col=32 — Multiple repeats per row

Input:
```mlir
%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32>
pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
```

Computed: `totalV = 4×32 = 128`, `elementsPerRepeat = 64`, `totalRepeats = 128/64 = 2` per call but `totalV > REPEAT_MAX(255)` triggers count mode.

Output: count mode, 2 repeats per row, 4 rows via scf.for.

### Example 6: 16×1024 f32 — Chunked (repeat > 255)

Input:
```mlir
%t = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024>
pto.tadd ins(%src0, %src1 : ...) outs(%dst : ...)
```

Computed: `totalElements=16384`, `elementsPerRepeat=64`, `totalRepeats=256`, which equals `REPEAT_MAX`. Count mode, no `scf.for` (single VADD with repeat=256):

```mlir
pto.ub.set_mask_count
pto.ub.set_mask %c256_i64, %c0_i64     // mask0 = 256 (count mode: mask count in mask[0])
pto.ub.vadd %dst, %src0, %src1, %c256, %c1, %c1, %c1, %c8, %c8, %c8
pto.ub.set_mask_norm
pto.ub.set_mask %c-1_i64, %c0_i64      // restore full mask
```

### Example 7: A5 — No UB lowering

On A5 targets, `pto.tadd` passes through `LowerPTOToUBufOps` unchanged and is later expanded via `ExpandTileOp` into the TileLang DSL template path:

```mlir
// VPTO IR (after ExpandTileOp + inlining):
pto.vecscope {
  %v0 = pto.vlds %src0_memref : memref<...>
  %v1 = pto.vlds %src1_memref : memref<...>
  %v2 = pto.vadd %v0, %v1 : !pto.vreg<f32>
  pto.vsts %v2, %dst_memref : memref<...>
}
```

No `pto.ub.vadd` or `llvm.hivm.VADD.f32` appears.

### Mask / control-flow modes

| Mode | Condition | Pattern |
|---|---|---|
| **count mode** | `totalV > kRepeatMax` (255) or row-repeat with count | `SBITSET1(ctrl,56)` → `MOVEMASK(0,count)` → `VADD` → `SBITSET0(ctrl,56)` |
| **norm mode (head+tail)** | `totalRepeats ≤ kRepeatMax` | Head VADD → tail mask VADD |
| **norm mode small** | `v_col < 32`, head+tail ≤ max | Same as head+tail but per chunk via `scf.for` |
| **norm mode 1L** | Single row, repeat ≤ max | Direct norm mode VADD |
| **full mask** | After all VADDs | `MOVEMASK(0,-1)` + `MOVEMASK(1,0)` for 64-lane f32 |

### C220 COUNT mode limitation

On `dav-c220-vec`, count mode only supports `repeat=1`. Multi-element count mode
(`repeat > 1`) causes CCE errors. As a result:

- **repeat=1**: direct count mode (no loop)
- **repeat>1, rows=1**: split into per-chunk `scf.for` with repeat=1 each (`modeCount1L`)
- **repeat>1, rows>1**: per-row `scf.for` with repeat=1 each (`modeNormal1L`)
- **repeat=0** (`modeCount1L`): broken on C220, routed to head+tail path

Test cases `1×80` and `256×64` are excluded from on-device tests due to this
limitation; they fall back to the head+tail norm path.

## Full lowering chain: TADD example

```
PTO DSL:          pto.tile.add(a_tile, b_tile, c_tile)
    ↓
PTO IR:           pto.tadd ins(%a, %b) outs(%c)
    ↓ LowerPTOToUBufOps (A3 only)
UB IR:            pto.ub.set_mask_count
                  pto.ub.vadd %dst, %src0, %src1, repeat=1, blkStrides=(1,1,1), repStrides=(8,8,8)
                  pto.ub.set_mask_norm
                  pto.ub.set_mask %c-1, %c0
    ↓ Lower copy ops
Copy IR:          pto.copy_gm_to_ubuf / pto.copy_ubuf_to_gm  (v220 DMA)
    ↓ LowerVPTOOpsPass (A3 patterns)
LLVM IR:          llvm.call @llvm.hivm.SBITSET1(%ctrl, %56)
                  llvm.call @llvm.hivm.MOVEMASK(%0, %-1)
                  llvm.call @llvm.hivm.MOVEMASK(%1, %0)
                  llvm.call @llvm.hivm.VADD.f32(%dst, %src0, %src1, %config)
                  llvm.call @llvm.hivm.SBITSET0(%ctrl, %56)
                  llvm.call @llvm.hivm.MOV.OUT.TO.UB.v220(...)
                  llvm.call @llvm.hivm.MOV.UB.TO.OUT.v220.1(...)
    ↓ bisheng
Binary:           native AICORE binary
```

## Summary table

| Aspect | A3 | A5 |
|---|---|---|
| **Lowering strategy** | Direct pointer-based: `pto.tadd → ub.vadd → llvm.hivm.VADD` | Template expansion: `pto.tadd → TileLang DSL → vlds/vadd/vsts` |
| **Memory model** | `!pto.ptr<f32, ub>` pointers, no memref | `memref` alloc/load/store |
| **DMA** | v220 single-config, software loops | Dual-config, hardware nBurst loops |
| **Mask/control** | `SBITSET1/SBITSET0` on CTRL bit 56 for count mode | `SET_FLAG/WAIT_FLAG` synchronization |
| **Passes added** | `LowerPTOToUBufOps` (1 new pass) | `ExpandTileOp` + `InlineLibCall` + `FoldTileBufIntrinsics` |
| **New ops (6)** | `pto.ub.{vadd,vsub,vmul,vdiv,set_mask_count,set_mask_norm}` | none |
| **Intrinsics** | `llvm.hivm.{VADD,VSUB,VMUL,VDIV}.f32` | `llvm.hivm.{ADD,LOAD,STORE}` |
| **Relevant files** | `LowerPTOToUBufOps.cpp`, `VPTOUbOps.td`, `VPTOUbOps.cpp`, `VPTOLLVMEmitter.cpp`, `VPTOExpandWrapperOps.cpp`, `ObjectEmission.cpp` | `ExpandTileOp.cpp`, `FoldTileBufIntrinsics.cpp`, `VPTOLLVMEmitter.cpp` |
