### PR TITLE
refactor(ptodsl): share scalar adaptation coercion

### DIFF
--- a/docs/designs/ptodsl-scalar-adaptation-coercion.md
+++ b/docs/designs/ptodsl-scalar-adaptation-coercion.md
@@ -1,0 +1,212 @@
+# PTODSL Scalar Adaptation and Coercion Design
+
+## Background
+
+PTODSL has several frontend paths that accept authored scalar values and lower
+them to MLIR scalar operands:
+
+- runtime scalar arithmetic and comparisons;
+- runtime scalar bitwise operators;
+- loop bounds and loop steps;
+- sync event IDs;
+- pointer and tile offsets;
+- scalar load/store values.
+
+These paths all need the same basic decisions: identify whether an authored
+value is an `index`, integer, or floating-point scalar; materialize Python
+literals; convert integer values to `index` where the target semantic is an
+index; and adapt fixed-width integer values without losing signedness metadata.
+
+Today those rules are duplicated across multiple modules:
+
+- `ptodsl/_runtime_scalar_ops.py`
+- `ptodsl/_scalar_coercion.py`
+- `ptodsl/_runtime_index_ops.py`
+- `ptodsl/_ops.py`
+
+Issue #794 tracks the need to make the rules shared rather than fixing each
+new `index` / integer mixed case at the individual operation emitter.
+
+## Goals
+
+- Introduce one common scalar adaptation module for PTODSL frontend lowering.
+- Preserve current user-visible behavior while moving common code.
+- Make mixed `index` / integer behavior explicit by semantic target:
+  - "prefer index" for loop bounds, event IDs, pointer offsets, and authored
+    operations whose result stays in the index domain;
+  - "prefer wider integer" for fixed-width integer arithmetic;
+  - "explicit target type" for scalar stores and API parameters with a known
+    result type.
+- Keep operation-specific emitters focused on operation lowering, not type
+  reconciliation details.
+- Avoid backend changes. This is a PTODSL frontend refactor.
+
+## Non-Goals
+
+- Do not change PTO IR operation definitions or verifier behavior.
+- Do not redesign signed/unsigned semantics.
+- Do not introduce a public user-facing API.
+- Do not change AST rewrite behavior.
+- Do not merge tile-template tracing's private `_Value(type_text)` prototype
+  model into this helper. That path does not operate on the authored
+  surface/MLIR scalar values addressed by issue #794, and sharing this module
+  there would require a separate tile-template tracing design change.
+
+## Proposed Module
+
+Add:
+
+```text
+ptodsl/ptodsl/_scalar_adaptation.py
+```
+
+The module operates on Python literals or already-unwrapped MLIR SSA values. It
+must not import `_surface_values`, because `_surface_values` imports runtime
+scalar operators and would otherwise create a cycle.
+
+Initial helpers:
+
+```python
+classify_runtime_scalar_type(type_obj) -> "index" | "integer" | "float"
+is_mlir_value(value) -> bool
+materialize_scalar_literal(value, target_type, *, context)
+coerce_scalar_value_to_type(value, target_type, *, context)
+coerce_runtime_index_value(value, *, context)
+coerce_runtime_integer_value(value, target_type, *, context)
+coerce_runtime_i1_value(value, *, context)
+normalize_runtime_binary_operands(lhs, rhs)
+coerce_integer_like(value, target_type)
+```
+
+The names intentionally match existing internal vocabulary so migration stays
+mechanical and reviewable.
+
+## Semantics
+
+### Explicit Target Type
+
+APIs such as scalar store know their destination element type. They should call
+`coerce_scalar_value_to_type(value, target_type, context=...)`.
+
+Rules:
+
+- Python literals materialize directly as the target type.
+- `integer -> index` uses `arith.index_cast`.
+- `index -> integer` uses `arith.index_cast` to the signless target and then
+  restores authored integer signedness where needed.
+- `integer -> integer` extends, truncates, or strips/restores signedness using
+  the existing width rules.
+- `float -> float` extends or truncates.
+- `float -> index/integer` and `index/integer -> float` remain invalid unless a
+  future API explicitly asks for such a conversion.
+
+### Prefer Index
+
+Loop bounds, pointer offsets, tile offsets, and dynamic sync event IDs are
+semantically index values. They should call `coerce_runtime_index_value(...)`.
+
+Rules:
+
+- Python `int` materializes as `index`.
+- runtime `index` is kept as-is.
+- runtime integer is cast to `index`.
+- Python `bool`, floating-point literals, and runtime floating-point scalars
+  are rejected.
+- Surface index expression helpers normalize intermediate operands before
+  emitting `arith.addi` or `arith.muli`, so expressions such as tile slices with
+  integer runtime offsets are converted to the index domain before arithmetic.
+
+### Fixed-Width Integer Targets
+
+Micro-op parameters such as mask scalar operands, DMA burst sizes, MAD
+dimensions, and other hardware integer operands have a fixed integer target
+type. Their local wrappers keep operation-specific diagnostics and names, but
+delegate integer/index/literal adaptation to
+`coerce_runtime_integer_value(value, target_type, context=...)`.
+
+Rules:
+
+- Python `int` materializes directly as the target integer type.
+- Python `bool` is rejected for normal integer operands.
+- runtime `index` casts to the target integer type with `arith.index_cast`.
+- runtime integer values extend, truncate, or strip/restore signedness using
+  the shared integer adaptation helper.
+- runtime floating-point values are rejected.
+- `i1` operands use `coerce_runtime_i1_value(...)`, preserving the historical
+  special case that Python `bool` and Python `0`/`1` are accepted.
+
+### Runtime Binary Operators
+
+Runtime scalar binary operators should call
+`normalize_runtime_binary_operands(lhs, rhs)`.
+
+Rules:
+
+- At least one operand must be a traced runtime scalar.
+- Python literals materialize against the other operand's type.
+- matching operand types stay unchanged.
+- `index` mixed with integer casts the integer operand to `index`.
+- integer mixed with integer adapts both sides to the wider integer type.
+- floating-point mixed with floating-point requires matching type for now.
+- unsupported mixed categories raise a context-rich `TypeError`.
+
+Bitwise operators benefit from the same normalization. After issue #484,
+`index & 1` lowers directly to `arith.andi : index`, not through a fixed-width
+integer cast.
+
+## Migration Plan
+
+1. Add `_scalar_adaptation.py` and move common logic from
+   `_runtime_scalar_ops.py` into it.
+2. Update `_runtime_scalar_ops.py` to import:
+   - `classify_runtime_scalar_type`
+   - `normalize_runtime_binary_operands`
+   - `coerce_integer_like`
+3. Update `_scalar_coercion.py` to become a thin surface-aware wrapper:
+   - unwrap authored values;
+   - delegate to `coerce_scalar_value_to_type`;
+   - re-export `materialize_scalar_literal`.
+4. Update `_runtime_index_ops.py` to delegate to
+   `coerce_runtime_index_value`.
+5. Update `_ops.py`:
+   - import `classify_runtime_scalar_type` from `_scalar_adaptation`;
+   - make `_coerce_index(...)` delegate to `coerce_runtime_index_value`;
+   - make `_coerce_i16`, `_coerce_i32`, `_coerce_i64`, and `_coerce_i1`
+     delegate to shared fixed-width integer coercion helpers.
+6. Update `_surface_values.py`:
+   - normalize surface index expression inputs through
+     `coerce_runtime_index_value`;
+   - keep static Python integer expression folding unchanged.
+
+This keeps operation-specific wrapper names stable while moving duplicated
+runtime scalar rules into one place.
+
+## Testing Strategy
+
+Use behavior tests rather than only helper tests:
+
+- `test_jit_compile.py`
+  - runtime scalar arithmetic remains unchanged;
+  - `index` / integer mixed bitwise from issue #484 still lowers to dynamic
+    sync event IDs;
+  - loop bounds and pointer offsets still accept integer runtime scalars.
+  - fixed-width integer parameters accept runtime index values through shared
+    adaptation.
+  - surface tile slice indices accept runtime integer values through shared
+    index adaptation.
+- `test_jit_diagnostics.py`
+  - bool values remain rejected for runtime scalar operators and index-like
+    contexts;
+  - floating-point values remain rejected for index-like contexts;
+  - floating-point bitwise remains rejected.
+- `test_docs_as_test.py`
+  - user guide examples continue to compile.
+- `test_ptoas_frontend_verify.py`
+  - generated MLIR continues to pass PTOAS frontend verification.
+
+## Rollout
+
+This change should land after issue #484 is merged, because #484 adds the
+concrete user-facing `index` bitwise behavior and tests. The scalar adaptation
+refactor should be reviewed as a separate PR so that behavior changes and
+mechanical code movement are easy to distinguish.

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -25,7 +25,7 @@ This chapter covers every type you can use in a PTODSL kernel, plus the operatio
 | `pto.bf16` | Brain float 16 | 16 |
 | `pto.f32` | Single-precision float | 32 |
 
-Python literals are automatically typed by the tracer: `bool` → `pto.i1`, `int` → context-dependent (typically `pto.i32` or `pto.i64`), `float` → `pto.f32`.
+Python literals are typed by the tracer in contexts that accept them: `bool` → `pto.i1`, `int` → context-dependent (typically `pto.i32`, `pto.i64`, or `index`), `float` → a floating-point type. This does not mean every literal is accepted everywhere; for example, float literals are rejected in index-like and integer-only contexts.
 
 For explicit typing, use type constructors:
 

--- a/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
+++ b/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
@@ -101,6 +101,53 @@ scalar.store(value, tile[row, col])
 scalar.store(value, ptr, offset)
 ```
 
+### Scalar value adaptation
+
+`scalar.store` adapts the authored `value` to the destination element type.
+Use this for normal scalar stores instead of manually materializing constants
+with a particular MLIR type.
+
+The adaptation rules are intentionally narrow:
+
+| Destination element type | Accepted values |
+|--------------------------|-----------------|
+| `index` | Python `int`, runtime `index`, runtime integer |
+| Integer types | Python `int`, runtime integer, runtime `index` |
+| Floating-point types | Python `int`/`float`, runtime float of the same format or a different width |
+
+Integer and `index` values are converted with `index_cast` where needed.
+Integer width changes use the destination type's signedness. Floating-point
+width changes use `extf` or `truncf`.
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"scalar_ops.value_adaptation","symbol":"scalar_ops_value_adaptation_probe","compile":{}} -->
+```python
+int_ptr = int_tile.as_ptr()
+row = pto.const(0, dtype=pto.index)
+wide_count = pto.const(4, dtype=pto.i64)
+
+scalar.store(row, int_ptr + 0)          # runtime index -> i32 destination
+scalar.store(wide_count, int_ptr + 1)   # i64 -> i32 destination
+scalar.store(3, int_ptr + 2)            # Python int -> i32 destination
+
+half_value = scalar.load(f16_tile[0, 0])
+scalar.store(1.0, f32_tile[0, 0])       # Python float -> f32 destination
+scalar.store(half_value, f32_tile[0, 1]) # f16 -> f32 destination
+```
+
+The following conversions are not implicit:
+
+- Python `bool` is not accepted as a normal integer or index value.
+- A Python `float` literal is rejected for `index` and integer destinations.
+- Runtime floating-point values are rejected for `index` and integer
+  destinations.
+- Runtime `index` and integer values are rejected for floating-point
+  destinations.
+- `f16` and `bf16` are different formats even though both are 16-bit; PTODSL
+  does not silently reinterpret one as the other.
+
+Use an explicit conversion operation when you need a semantic numeric
+conversion, or a bitcast operation when you need bit reinterpretation.
+
 ---
 
 ### Typical SIMT usage
@@ -165,6 +212,12 @@ step = (N + BLOCK - 1) // BLOCK               # Python int arithmetic (trace-tim
 ```
 
 When both operands are PTO scalars (loaded from device memory or produced by another device-side op), `+`, `-`, `*`, `/` produce device-side arithmetic instructions. When one operand is a Python scalar (trace-time constant), the tracer embeds it as an immediate.
+
+Runtime scalar binary operators materialize Python literals against the other
+operand's type. `index` mixed with an integer runtime scalar stays in the
+`index` domain. Integer mixed with integer uses the wider integer type. Float
+operators require floating-point operands; Python float literals are not
+accepted in runtime `index` or integer expressions.
 
 ### Bitwise operators
 
@@ -290,6 +343,11 @@ ptr = pto.addptr(base_ptr, 1024)
 ```
 
 The `+` shorthand on pointers also counts in elements, not bytes.
+
+Pointer offsets are index-like. They accept Python `int`, runtime `index`, and
+runtime integer scalar values. Runtime integer offsets are converted to
+`index` before pointer arithmetic. Python `bool`, Python `float`, and runtime
+floating-point values are rejected.
 
 ---
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -32,7 +32,13 @@ from ._diagnostics import (
 )
 from ._host_tensors import resolve_tensor_data_entry
 from ._scalar_coercion import coerce_scalar_to_type, materialize_scalar_literal
-from ._runtime_scalar_ops import classify_runtime_scalar_type, emit_runtime_binary_op
+from ._scalar_adaptation import (
+    classify_runtime_scalar_type,
+    coerce_runtime_i1_value,
+    coerce_runtime_index_value,
+    coerce_runtime_integer_value,
+)
+from ._runtime_scalar_ops import emit_runtime_binary_op
 from ._surface_values import (
     MaskResultValue,
     PartitionTensorViewValue,
@@ -52,11 +58,9 @@ from ._surface_values import (
 )
 from ._types import (
     _isinstance_pto_type,
-    _integer_signedness,
     _materialize_integer_literal,
     _normalize_address_space,
     _resolve,
-    _strip_integer_signedness,
     mask_type,
     part_tensor_view_type,
     part_tensor_view_type_from_dims,
@@ -124,6 +128,8 @@ def _canonical_pipe_token(pipe):
 
 
 def _validate_static_event_id(event_id, *, context: str):
+    if isinstance(event_id, bool):
+        raise TypeError(f"{context} does not accept bool values")
     if isinstance(event_id, int) and not 0 <= event_id <= 7:
         raise ValueError(f"{context} expects static event_id in [0, 7], got {event_id}")
 
@@ -795,27 +801,7 @@ def vscatter(value, destination, offsets, mask):
 
 def _coerce_i16(value, *, context: str):
     raw_value = unwrap_surface_value(value)
-    i16_type = IntegerType.get_signless(16)
-    if isinstance(raw_value, bool):
-        raise TypeError(f"{context} does not accept bool values")
-    if isinstance(raw_value, int):
-        return _materialize_integer_literal(i16_type, raw_value)
-    kind = classify_runtime_scalar_type(raw_value.type)
-    if kind == "float":
-        raise TypeError(f"{context} expects an integer-like scalar, got {raw_value.type}")
-    if kind == "index":
-        return arith.IndexCastOp(i16_type, raw_value).result
-    signless_value = _strip_integer_signedness(raw_value)
-    if signless_value.type == i16_type:
-        return signless_value
-    width = IntegerType(raw_value.type).width
-    if width < 16:
-        if _integer_signedness(raw_value.type) == "unsigned":
-            return arith.ExtUIOp(i16_type, signless_value).result
-        return arith.ExtSIOp(i16_type, signless_value).result
-    if width > 16:
-        return arith.TruncIOp(i16_type, signless_value).result
-    return signless_value
+    return coerce_runtime_integer_value(raw_value, IntegerType.get_signless(16), context=context)
 
 
 def vsldb(source, block_stride, repeat_stride, mask):
@@ -1000,19 +986,12 @@ def _pointer_element_type(ptr_value, *, context: str):
 
 def _coerce_index(value, *, context: str):
     raw_value = unwrap_surface_value(value)
-    index_type = IndexType.get()
-    if isinstance(raw_value, bool):
-        raise TypeError(f"{context} does not accept bool values")
-    if isinstance(raw_value, int):
-        return arith.ConstantOp(index_type, raw_value).result
-    kind = classify_runtime_scalar_type(raw_value.type)
-    if kind == "float":
-        raise TypeError(f"{context} expects an index-like scalar, got {raw_value.type}")
-    if IndexType.isinstance(raw_value.type):
-        return raw_value
-    if IntegerType.isinstance(raw_value.type):
-        return arith.IndexCastOp(index_type, _strip_integer_signedness(raw_value)).result
-    raise TypeError(f"{context} expects an index-like scalar, got {raw_value.type}")
+    try:
+        return coerce_runtime_index_value(raw_value, context=context)
+    except TypeError as exc:
+        if hasattr(raw_value, "type"):
+            raise TypeError(f"{context} expects an index-like scalar, got {raw_value.type}") from exc
+        raise
 
 
 def init_align():
@@ -3219,79 +3198,17 @@ def _plt_op_for_mask_bits(mask_bits: int):
 
 def _coerce_i32(value, *, context: str):
     raw_value = unwrap_surface_value(value)
-    i32_type = IntegerType.get_signless(32)
-    if isinstance(raw_value, bool):
-        raise TypeError(f"{context} does not accept bool values")
-    if isinstance(raw_value, int):
-        return _materialize_integer_literal(i32_type, raw_value)
-    kind = classify_runtime_scalar_type(raw_value.type)
-    if kind == "float":
-        raise TypeError(f"{context} expects an integer-like scalar, got {raw_value.type}")
-    if kind == "index":
-        return arith.IndexCastOp(i32_type, raw_value).result
-    signless_value = _strip_integer_signedness(raw_value)
-    if signless_value.type == i32_type:
-        return signless_value
-    width = IntegerType(raw_value.type).width
-    if width < 32:
-        if _integer_signedness(raw_value.type) == "unsigned":
-            return arith.ExtUIOp(i32_type, signless_value).result
-        return arith.ExtSIOp(i32_type, signless_value).result
-    if width > 32:
-        return arith.TruncIOp(i32_type, signless_value).result
-    return signless_value
+    return coerce_runtime_integer_value(raw_value, IntegerType.get_signless(32), context=context)
 
 
 def _coerce_i64(value, *, context: str):
     raw_value = unwrap_surface_value(value)
-    i64_type = IntegerType.get_signless(64)
-    if isinstance(raw_value, bool):
-        raise TypeError(f"{context} does not accept bool values")
-    if isinstance(raw_value, int):
-        return _materialize_integer_literal(i64_type, raw_value)
-    kind = classify_runtime_scalar_type(raw_value.type)
-    if kind == "float":
-        raise TypeError(f"{context} expects an integer-like scalar, got {raw_value.type}")
-    if kind == "index":
-        return arith.IndexCastOp(i64_type, raw_value).result
-    signless_value = _strip_integer_signedness(raw_value)
-    if signless_value.type == i64_type:
-        return signless_value
-    width = IntegerType(raw_value.type).width
-    if width < 64:
-        if _integer_signedness(raw_value.type) == "unsigned":
-            return arith.ExtUIOp(i64_type, signless_value).result
-        return arith.ExtSIOp(i64_type, signless_value).result
-    if width > 64:
-        return arith.TruncIOp(i64_type, signless_value).result
-    return signless_value
+    return coerce_runtime_integer_value(raw_value, IntegerType.get_signless(64), context=context)
 
 
 def _coerce_i1(value, *, context: str):
     raw_value = unwrap_surface_value(value)
-    i1_type = IntegerType.get_signless(1)
-    if isinstance(raw_value, bool):
-        return _materialize_integer_literal(i1_type, int(raw_value))
-    if isinstance(raw_value, int):
-        if raw_value not in (0, 1):
-            raise ValueError(f"{context} expects a bool or 0/1 integer, got {raw_value}")
-        return _materialize_integer_literal(i1_type, raw_value)
-    kind = classify_runtime_scalar_type(raw_value.type)
-    if kind == "float":
-        raise TypeError(f"{context} expects a bool or integer-like scalar, got {raw_value.type}")
-    if kind == "index":
-        return arith.IndexCastOp(i1_type, raw_value).result
-    signless_value = _strip_integer_signedness(raw_value)
-    if signless_value.type == i1_type:
-        return signless_value
-    width = IntegerType(raw_value.type).width
-    if width < 1:
-        if _integer_signedness(raw_value.type) == "unsigned":
-            return arith.ExtUIOp(i1_type, signless_value).result
-        return arith.ExtSIOp(i1_type, signless_value).result
-    if width > 1:
-        return arith.TruncIOp(i1_type, signless_value).result
-    return signless_value
+    return coerce_runtime_i1_value(raw_value, context=context)
 
 
 def _i64_zero():

--- a/ptodsl/ptodsl/_runtime_index_ops.py
+++ b/ptodsl/ptodsl/_runtime_index_ops.py
@@ -9,33 +9,12 @@
 
 from __future__ import annotations
 
-from mlir.dialects import arith
-from mlir.ir import IndexType, IntegerType
+from ._scalar_adaptation import coerce_runtime_index_value
 
 
 def coerce_runtime_index(value, *, context: str):
     """Normalize one authored loop/slice bound to an MLIR index SSA value."""
-    if isinstance(value, bool):
-        raise TypeError(f"{context} does not accept bool values")
-
-    if isinstance(value, int):
-        return arith.ConstantOp(IndexType.get(), value).result
-
-    if not hasattr(value, "type"):
-        raise TypeError(
-            f"{context} expects a Python int, an index value, or an integer runtime scalar; "
-            f"got {value!r}"
-        )
-
-    value_type = value.type
-    if IndexType.isinstance(value_type):
-        return value
-    if IntegerType.isinstance(value_type):
-        return arith.IndexCastOp(IndexType.get(), value).result
-
-    raise TypeError(
-        f"{context} expects an index or integer runtime scalar, got {value_type}"
-    )
+    return coerce_runtime_index_value(value, context=context)
 
 
 __all__ = [

--- a/ptodsl/ptodsl/_runtime_scalar_ops.py
+++ b/ptodsl/ptodsl/_runtime_scalar_ops.py
@@ -9,16 +9,18 @@
 
 from __future__ import annotations
 
+from ._scalar_adaptation import (
+    classify_runtime_scalar_type,
+    normalize_runtime_binary_operands,
+)
 from ._types import (
     _integer_signedness,
-    _materialize_integer_literal,
     _restore_integer_signedness,
-    _signless_integer_type,
     _strip_integer_signedness,
 )
 
 from mlir.dialects import arith, math
-from mlir.ir import BF16Type, F16Type, F32Type, FloatAttr, IndexType, IntegerType
+from mlir.ir import IndexType, IntegerType
 
 
 _FLOAT_BINARY_OPS = {
@@ -90,109 +92,6 @@ def emit_runtime_min(lhs, rhs):
         cond = arith.CmpIOp(arith.CmpIPredicate.sle, lhs, rhs).result
         return arith.SelectOp(cond, lhs, rhs).result
     raise TypeError(f"unsupported runtime scalar operand category '{kind}'")
-
-
-def normalize_runtime_binary_operands(lhs, rhs):
-    lhs_is_value = _is_mlir_value(lhs)
-    rhs_is_value = _is_mlir_value(rhs)
-
-    if not lhs_is_value and not rhs_is_value:
-        raise TypeError("runtime scalar operators require at least one traced runtime operand")
-
-    if lhs_is_value and rhs_is_value:
-        return _reconcile_typed_operands(lhs, rhs)
-
-    anchor_type = lhs.type if lhs_is_value else rhs.type
-    lhs = lhs if lhs_is_value else _materialize_literal(lhs, anchor_type)
-    rhs = rhs if rhs_is_value else _materialize_literal(rhs, anchor_type)
-    return _reconcile_typed_operands(lhs, rhs)
-
-
-def _reconcile_typed_operands(lhs, rhs):
-    lhs_type = lhs.type
-    rhs_type = rhs.type
-
-    if lhs_type == rhs_type:
-        return lhs, rhs, classify_runtime_scalar_type(lhs_type)
-
-    if IndexType.isinstance(lhs_type) and IntegerType.isinstance(rhs_type):
-        rhs = arith.IndexCastOp(IndexType.get(), _strip_integer_signedness(rhs)).result
-        return lhs, rhs, "index"
-
-    if IntegerType.isinstance(lhs_type) and IndexType.isinstance(rhs_type):
-        lhs = arith.IndexCastOp(IndexType.get(), _strip_integer_signedness(lhs)).result
-        return lhs, rhs, "index"
-
-    if IntegerType.isinstance(lhs_type) and IntegerType.isinstance(rhs_type):
-        lhs_width = IntegerType(lhs_type).width
-        rhs_width = IntegerType(rhs_type).width
-        target_type = lhs_type if lhs_width >= rhs_width else rhs_type
-        lhs = _coerce_runtime_integer_like(lhs, target_type)
-        rhs = _coerce_runtime_integer_like(rhs, target_type)
-        return lhs, rhs, "integer"
-
-    raise TypeError(
-        "runtime scalar operators require matching scalar types or an index/integer pair; "
-        f"got {lhs_type} and {rhs_type}"
-    )
-
-
-def _materialize_literal(value, anchor_type):
-    if isinstance(value, bool):
-        raise TypeError("runtime scalar operators do not accept bool literals")
-
-    kind = classify_runtime_scalar_type(anchor_type)
-    if kind == "float":
-        return arith.ConstantOp(anchor_type, FloatAttr.get(anchor_type, float(value))).result
-    if kind == "index":
-        return arith.ConstantOp(anchor_type, int(value)).result
-
-    if isinstance(value, float):
-        raise TypeError(
-            "runtime scalar operators cannot materialize a floating-point literal "
-            f"against non-floating operand type {anchor_type}"
-        )
-
-    return _materialize_integer_literal(anchor_type, value)
-
-
-def _coerce_runtime_integer_like(raw_value, target_type):
-    if IndexType.isinstance(raw_value.type):
-        signless_target = _signless_integer_type(target_type)
-        adapted = arith.IndexCastOp(signless_target, raw_value).result
-        return _restore_integer_signedness(adapted, target_type)
-
-    source_type = raw_value.type
-    source_width = IntegerType(source_type).width
-    target_width = IntegerType(target_type).width
-    signless_source = _strip_integer_signedness(raw_value)
-    signless_target = _signless_integer_type(target_type)
-
-    if source_width < target_width:
-        source_signedness = _integer_signedness(source_type)
-        if source_signedness == "unsigned":
-            widened = arith.ExtUIOp(signless_target, signless_source).result
-        else:
-            widened = arith.ExtSIOp(signless_target, signless_source).result
-        return _restore_integer_signedness(widened, target_type)
-    if source_width > target_width:
-        truncated = arith.TruncIOp(signless_target, signless_source).result
-        return _restore_integer_signedness(truncated, target_type)
-    return _restore_integer_signedness(signless_source, target_type)
-
-
-def classify_runtime_scalar_type(type_obj):
-    if IndexType.isinstance(type_obj):
-        return "index"
-    if IntegerType.isinstance(type_obj):
-        return "integer"
-    if any(cls.isinstance(type_obj) for cls in (BF16Type, F16Type, F32Type)):
-        return "float"
-    raise TypeError(f"runtime scalar operators only support index/int/float values, got {type_obj}")
-
-
-def _is_mlir_value(value) -> bool:
-    return not isinstance(value, (bool, int, float)) and hasattr(value, "type")
 
 
 def _restore_runtime_integer_result(result, authored_type):

--- a/ptodsl/ptodsl/_scalar_adaptation.py
+++ b/ptodsl/ptodsl/_scalar_adaptation.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+"""Shared scalar adaptation helpers for PTODSL frontend lowering."""
+
+from __future__ import annotations
+
+from ._types import (
+    _integer_signedness,
+    _materialize_integer_literal,
+    _restore_integer_signedness,
+    _signless_integer_type,
+    _strip_integer_signedness,
+)
+
+from mlir.dialects import arith
+from mlir.ir import BF16Type, F16Type, F32Type, FloatAttr, IndexType, IntegerType
+
+
+def classify_runtime_scalar_type(type_obj):
+    if IndexType.isinstance(type_obj):
+        return "index"
+    if IntegerType.isinstance(type_obj):
+        return "integer"
+    if any(cls.isinstance(type_obj) for cls in (BF16Type, F16Type, F32Type)):
+        return "float"
+    raise TypeError(f"runtime scalar operators only support index/int/float values, got {type_obj}")
+
+
+def is_mlir_value(value) -> bool:
+    return not isinstance(value, (bool, int, float)) and hasattr(value, "type")
+
+
+def materialize_scalar_literal(value, target_type, *, context: str):
+    """Materialize one Python literal as an MLIR scalar constant of *target_type*."""
+    if isinstance(value, bool):
+        raise TypeError(f"{context} does not accept bool literals")
+
+    target_kind = classify_runtime_scalar_type(target_type)
+    if isinstance(value, float) and target_kind != "float":
+        raise TypeError(
+            f"{context} cannot materialize a floating-point literal against non-floating "
+            f"target type {target_type}"
+        )
+
+    if target_kind == "float":
+        return arith.ConstantOp(target_type, FloatAttr.get(target_type, float(value))).result
+    if target_kind == "index":
+        return arith.ConstantOp(target_type, int(value)).result
+
+    return _materialize_integer_literal(target_type, value)
+
+
+def coerce_scalar_value_to_type(value, target_type, *, context: str):
+    """Normalize one already-unwrapped authored scalar value/literal to *target_type*."""
+    if not hasattr(value, "type"):
+        return materialize_scalar_literal(value, target_type, context=context)
+
+    if value.type == target_type:
+        return value
+
+    source_kind = classify_runtime_scalar_type(value.type)
+    target_kind = classify_runtime_scalar_type(target_type)
+
+    if source_kind == "index" and target_kind == "integer":
+        return coerce_integer_like(value, target_type)
+    if source_kind == "integer" and target_kind == "index":
+        return arith.IndexCastOp(target_type, _strip_integer_signedness(value)).result
+    if source_kind == "integer" and target_kind == "integer":
+        return coerce_integer_like(value, target_type)
+    if source_kind == "float" and target_kind == "float":
+        return _coerce_float_like(value, target_type)
+
+    raise TypeError(
+        f"{context} cannot coerce the authored value to the expected scalar type: "
+        f"got {value.type}, expected {target_type}"
+    )
+
+
+def coerce_runtime_index_value(value, *, context: str):
+    """Normalize one already-unwrapped authored value/literal to an MLIR index value."""
+    if isinstance(value, bool):
+        raise TypeError(f"{context} does not accept bool values")
+    if isinstance(value, int):
+        return arith.ConstantOp(IndexType.get(), value).result
+    if not hasattr(value, "type"):
+        raise TypeError(
+            f"{context} expects a Python int, an index value, or an integer runtime scalar; "
+            f"got {value!r}"
+        )
+
+    value_type = value.type
+    if IndexType.isinstance(value_type):
+        return value
+    if IntegerType.isinstance(value_type):
+        return arith.IndexCastOp(IndexType.get(), _strip_integer_signedness(value)).result
+
+    raise TypeError(f"{context} expects an index or integer runtime scalar, got {value_type}")
+
+
+def coerce_runtime_integer_value(value, target_type, *, context: str):
+    """Normalize one authored integer-like value/literal to *target_type*."""
+    if isinstance(value, bool):
+        raise TypeError(f"{context} does not accept bool values")
+    if isinstance(value, int):
+        return _materialize_integer_literal(target_type, value)
+    if not hasattr(value, "type"):
+        raise TypeError(f"{context} expects an integer-like scalar, got {value!r}")
+
+    kind = classify_runtime_scalar_type(value.type)
+    if kind == "float":
+        raise TypeError(f"{context} expects an integer-like scalar, got {value.type}")
+    return coerce_integer_like(value, target_type)
+
+
+def coerce_runtime_i1_value(value, *, context: str):
+    """Normalize one authored bool/integer-like value/literal to signless i1."""
+    i1_type = IntegerType.get_signless(1)
+    if isinstance(value, bool):
+        return _materialize_integer_literal(i1_type, int(value))
+    if isinstance(value, int):
+        if value not in (0, 1):
+            raise ValueError(f"{context} expects a bool or 0/1 integer, got {value}")
+        return _materialize_integer_literal(i1_type, value)
+    if not hasattr(value, "type"):
+        raise TypeError(f"{context} expects a bool or integer-like scalar, got {value!r}")
+
+    kind = classify_runtime_scalar_type(value.type)
+    if kind == "float":
+        raise TypeError(f"{context} expects a bool or integer-like scalar, got {value.type}")
+    return coerce_integer_like(value, i1_type)
+
+
+def normalize_runtime_binary_operands(lhs, rhs):
+    lhs_is_value = is_mlir_value(lhs)
+    rhs_is_value = is_mlir_value(rhs)
+
+    if not lhs_is_value and not rhs_is_value:
+        raise TypeError("runtime scalar operators require at least one traced runtime operand")
+
+    if lhs_is_value and rhs_is_value:
+        return reconcile_typed_runtime_binary_operands(lhs, rhs)
+
+    anchor_type = lhs.type if lhs_is_value else rhs.type
+    lhs = lhs if lhs_is_value else _materialize_runtime_literal(lhs, anchor_type)
+    rhs = rhs if rhs_is_value else _materialize_runtime_literal(rhs, anchor_type)
+    return reconcile_typed_runtime_binary_operands(lhs, rhs)
+
+
+def reconcile_typed_runtime_binary_operands(lhs, rhs):
+    lhs_type = lhs.type
+    rhs_type = rhs.type
+
+    if lhs_type == rhs_type:
+        return lhs, rhs, classify_runtime_scalar_type(lhs_type)
+
+    if IndexType.isinstance(lhs_type) and IntegerType.isinstance(rhs_type):
+        rhs = arith.IndexCastOp(IndexType.get(), _strip_integer_signedness(rhs)).result
+        return lhs, rhs, "index"
+
+    if IntegerType.isinstance(lhs_type) and IndexType.isinstance(rhs_type):
+        lhs = arith.IndexCastOp(IndexType.get(), _strip_integer_signedness(lhs)).result
+        return lhs, rhs, "index"
+
+    if IntegerType.isinstance(lhs_type) and IntegerType.isinstance(rhs_type):
+        lhs_width = IntegerType(lhs_type).width
+        rhs_width = IntegerType(rhs_type).width
+        target_type = lhs_type if lhs_width >= rhs_width else rhs_type
+        lhs = coerce_integer_like(lhs, target_type)
+        rhs = coerce_integer_like(rhs, target_type)
+        return lhs, rhs, "integer"
+
+    raise TypeError(
+        "runtime scalar operators require matching scalar types or an index/integer pair; "
+        f"got {lhs_type} and {rhs_type}"
+    )
+
+
+def coerce_integer_like(value, target_type):
+    if IndexType.isinstance(value.type):
+        signless_target = _signless_integer_type(target_type)
+        adapted = arith.IndexCastOp(signless_target, value).result
+        return _restore_integer_signedness(adapted, target_type)
+
+    source_type = value.type
+    source_width = IntegerType(source_type).width
+    target_width = IntegerType(target_type).width
+    signless_source = _strip_integer_signedness(value)
+    signless_target = _signless_integer_type(target_type)
+
+    if source_width < target_width:
+        source_signedness = _integer_signedness(source_type)
+        if source_signedness == "unsigned":
+            widened = arith.ExtUIOp(signless_target, signless_source).result
+        else:
+            widened = arith.ExtSIOp(signless_target, signless_source).result
+        return _restore_integer_signedness(widened, target_type)
+    if source_width > target_width:
+        truncated = arith.TruncIOp(signless_target, signless_source).result
+        return _restore_integer_signedness(truncated, target_type)
+    return _restore_integer_signedness(signless_source, target_type)
+
+
+def _materialize_runtime_literal(value, anchor_type):
+    if isinstance(value, bool):
+        raise TypeError("runtime scalar operators do not accept bool literals")
+
+    kind = classify_runtime_scalar_type(anchor_type)
+    if isinstance(value, float) and kind != "float":
+        raise TypeError(
+            "runtime scalar operators cannot materialize a floating-point literal "
+            f"against non-floating operand type {anchor_type}"
+        )
+
+    if kind == "float":
+        return arith.ConstantOp(anchor_type, FloatAttr.get(anchor_type, float(value))).result
+    if kind == "index":
+        return arith.ConstantOp(anchor_type, int(value)).result
+
+    return _materialize_integer_literal(anchor_type, value)
+
+
+def _coerce_float_like(value, target_type):
+    if value.type == target_type:
+        return value
+
+    source_width = _float_bytewidth(value.type)
+    target_width = _float_bytewidth(target_type)
+    if source_width < target_width:
+        return arith.ExtFOp(target_type, value).result
+    if source_width > target_width:
+        return arith.TruncFOp(target_type, value).result
+    raise TypeError(
+        "cannot coerce between different floating-point types of the same width: "
+        f"{value.type} and {target_type}"
+    )
+
+
+def _float_bytewidth(type_obj):
+    if BF16Type.isinstance(type_obj) or F16Type.isinstance(type_obj):
+        return 2
+    if F32Type.isinstance(type_obj):
+        return 4
+    raise TypeError(f"unsupported floating-point type {type_obj}")
+
+
+__all__ = [
+    "classify_runtime_scalar_type",
+    "coerce_integer_like",
+    "coerce_runtime_i1_value",
+    "coerce_runtime_index_value",
+    "coerce_runtime_integer_value",
+    "coerce_scalar_value_to_type",
+    "is_mlir_value",
+    "materialize_scalar_literal",
+    "normalize_runtime_binary_operands",
+    "reconcile_typed_runtime_binary_operands",
+]

--- a/ptodsl/ptodsl/_scalar_coercion.py
+++ b/ptodsl/ptodsl/_scalar_coercion.py
@@ -9,108 +9,17 @@
 
 from __future__ import annotations
 
-from ._runtime_scalar_ops import classify_runtime_scalar_type
-from ._surface_values import unwrap_surface_value
-from ._types import (
-    _integer_signedness,
-    _materialize_integer_literal,
-    _restore_integer_signedness,
-    _signless_integer_type,
-    _strip_integer_signedness,
+from ._scalar_adaptation import (
+    coerce_scalar_value_to_type,
+    materialize_scalar_literal,
 )
-
-from mlir.dialects import arith
-from mlir.ir import BF16Type, F16Type, F32Type, FloatAttr, IndexType, IntegerType
+from ._surface_values import unwrap_surface_value
 
 
 def coerce_scalar_to_type(value, target_type, *, context: str):
     """Normalize one authored scalar value/literal to *target_type*."""
     raw_value = unwrap_surface_value(value)
-    if not hasattr(raw_value, "type"):
-        return materialize_scalar_literal(raw_value, target_type, context=context)
-
-    if raw_value.type == target_type:
-        return raw_value
-
-    source_kind = classify_runtime_scalar_type(raw_value.type)
-    target_kind = classify_runtime_scalar_type(target_type)
-
-    if source_kind == "index" and target_kind == "integer":
-        return _coerce_integer_like(raw_value, target_type)
-    if source_kind == "integer" and target_kind == "index":
-        return arith.IndexCastOp(target_type, _strip_integer_signedness(raw_value)).result
-    if source_kind == "integer" and target_kind == "integer":
-        return _coerce_integer_like(raw_value, target_type)
-    if source_kind == "float" and target_kind == "float":
-        return _coerce_float_like(raw_value, target_type)
-
-    raise TypeError(
-        f"{context} cannot coerce the authored value to the expected scalar type: "
-        f"got {raw_value.type}, expected {target_type}"
-    )
-
-
-def materialize_scalar_literal(value, target_type, *, context: str):
-    """Materialize one Python literal as an MLIR scalar constant of *target_type*."""
-    if isinstance(value, bool):
-        raise TypeError(f"{context} does not accept bool literals")
-
-    target_kind = classify_runtime_scalar_type(target_type)
-    if target_kind == "float":
-        return arith.ConstantOp(target_type, FloatAttr.get(target_type, float(value))).result
-    if target_kind == "index":
-        return arith.ConstantOp(target_type, int(value)).result
-
-    if isinstance(value, float):
-        raise TypeError(
-            f"{context} cannot materialize a floating-point literal against non-floating "
-            f"target type {target_type}"
-        )
-
-    return _materialize_integer_literal(target_type, value)
-
-
-def _coerce_integer_like(raw_value, target_type):
-    if IndexType.isinstance(raw_value.type):
-        signless_target = _signless_integer_type(target_type)
-        adapted = arith.IndexCastOp(signless_target, raw_value).result
-        return _restore_integer_signedness(adapted, target_type)
-
-    source_type = raw_value.type
-    source_width = IntegerType(source_type).width
-    target_width = IntegerType(target_type).width
-    signless_source = _strip_integer_signedness(raw_value)
-    signless_target = _signless_integer_type(target_type)
-
-    if source_width < target_width:
-        source_signedness = _integer_signedness(source_type)
-        if source_signedness == "unsigned":
-            widened = arith.ExtUIOp(signless_target, signless_source).result
-        else:
-            widened = arith.ExtSIOp(signless_target, signless_source).result
-        return _restore_integer_signedness(widened, target_type)
-    if source_width > target_width:
-        truncated = arith.TruncIOp(signless_target, signless_source).result
-        return _restore_integer_signedness(truncated, target_type)
-    return _restore_integer_signedness(signless_source, target_type)
-
-
-def _coerce_float_like(raw_value, target_type):
-    source_width = _float_bytewidth(raw_value.type)
-    target_width = _float_bytewidth(target_type)
-    if source_width < target_width:
-        return arith.ExtFOp(target_type, raw_value).result
-    if source_width > target_width:
-        return arith.TruncFOp(target_type, raw_value).result
-    return raw_value
-
-
-def _float_bytewidth(type_obj):
-    if BF16Type.isinstance(type_obj) or F16Type.isinstance(type_obj):
-        return 2
-    if F32Type.isinstance(type_obj):
-        return 4
-    raise TypeError(f"unsupported floating-point type {type_obj}")
+    return coerce_scalar_value_to_type(raw_value, target_type, context=context)
 
 
 __all__ = [

--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -14,13 +14,14 @@ from dataclasses import dataclass
 
 from ._diagnostics import native_python_control_flow_error
 from ._runtime_scalar_ops import emit_runtime_binary_op, emit_runtime_bitwise_op, emit_runtime_compare
+from ._scalar_adaptation import coerce_runtime_index_value
 from ._surface_types import PartitionTensorView, TensorView, Tile
 from ._types import _normalize_address_space, _resolve, ptr
 
 from mlir.dialects import arith
 from mlir.dialects import memref
 from mlir.dialects import pto as _pto
-from mlir.ir import IndexType, IntegerAttr, IntegerType, MemRefType, ShapedType, StridedLayoutAttr, Type
+from mlir.ir import IndexType, IntegerAttr, MemRefType, ShapedType, StridedLayoutAttr, Type
 
 
 def unwrap_surface_value(value):
@@ -28,21 +29,33 @@ def unwrap_surface_value(value):
     return value.value if isinstance(value, _SurfaceValue) else value
 
 
+def _is_python_index_literal(value) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def _unwrap_sequence(values):
     normalized = []
     interned_ints = {}
     for value in values:
-        if isinstance(value, int):
+        if _is_python_index_literal(value):
             if value not in interned_ints:
                 interned_ints[value] = _index_const(value)
             normalized.append(interned_ints[value])
         else:
-            normalized.append(unwrap_surface_value(value))
+            normalized.append(_coerce_index_value(value))
     return normalized
 
 
 def _normalize_index(value):
-    return unwrap_surface_value(value)
+    raw_value = unwrap_surface_value(value)
+    if _is_python_index_literal(raw_value):
+        return raw_value
+    try:
+        return coerce_runtime_index_value(raw_value, context="surface index value")
+    except TypeError as exc:
+        if hasattr(raw_value, "type"):
+            raise TypeError(f"expected an index-like value, got {raw_value.type}") from exc
+        raise
 
 
 def _index_const(value: int):
@@ -50,24 +63,24 @@ def _index_const(value: int):
 
 
 def _add_index(lhs, rhs):
-    if isinstance(lhs, int) and lhs == 0:
+    if _is_python_index_literal(lhs) and lhs == 0:
         return _normalize_index(rhs)
-    if isinstance(rhs, int) and rhs == 0:
+    if _is_python_index_literal(rhs) and rhs == 0:
         return _normalize_index(lhs)
     lhs = _normalize_index(lhs)
     rhs = _normalize_index(rhs)
-    if isinstance(lhs, int) and isinstance(rhs, int):
+    if _is_python_index_literal(lhs) and _is_python_index_literal(rhs):
         return lhs + rhs
-    if isinstance(lhs, int):
+    if _is_python_index_literal(lhs):
         lhs = _index_const(lhs)
-    if isinstance(rhs, int):
+    if _is_python_index_literal(rhs):
         rhs = _index_const(rhs)
     return arith.AddIOp(lhs, rhs).result
 
 
 def _try_get_constant_index(value) -> int | None:
     """Return a compile-time index when *value* is a Python int or ``arith.constant``."""
-    if isinstance(value, int):
+    if _is_python_index_literal(value):
         return value
     raw = unwrap_surface_value(value)
     owner = getattr(raw, "owner", None)
@@ -388,7 +401,7 @@ class _TileValidShapeView:
         if self._tile.static_valid_shape is not None:
             dim = self._tile.static_valid_shape[index]
             if dim is not None:
-                value = _index_const(dim) if isinstance(dim, int) else unwrap_surface_value(dim)
+                value = _index_const(dim) if _is_python_index_literal(dim) else unwrap_surface_value(dim)
                 value = wrap_surface_value(value)
                 self._cache[index] = value
                 return value
@@ -881,24 +894,24 @@ def _emit_tile_memref(tile: TileValue):
 
 
 def _dynamic_extent(static_dim, start):
-    if isinstance(start, int):
+    if _is_python_index_literal(start):
         return static_dim - start
     return arith.SubIOp(_index_const(static_dim), _coerce_index_value(start)).result
 
 
 def _static_extent_if_known(extent):
-    return extent if isinstance(extent, int) else ShapedType.get_dynamic_size()
+    return extent if _is_python_index_literal(extent) else ShapedType.get_dynamic_size()
 
 
 def _static_index_attr(value):
-    return value if isinstance(value, int) else ShapedType.get_dynamic_size()
+    return value if _is_python_index_literal(value) else ShapedType.get_dynamic_size()
 
 
 def _split_dynamic_index_operands(values):
     operands = []
     static_attrs = []
     for value in values:
-        if isinstance(value, int):
+        if _is_python_index_literal(value):
             static_attrs.append(value)
         else:
             operands.append(_coerce_index_value(value))
@@ -931,7 +944,7 @@ def _compose_static_subview_offset(base_offset, base_strides, raw_offsets):
 
     linear_offset = base_offset
     for stride, authored_offset in zip(base_strides, raw_offsets):
-        if not isinstance(authored_offset, int):
+        if not _is_python_index_literal(authored_offset):
             return ShapedType.get_dynamic_size()
         linear_offset += stride * authored_offset
     return linear_offset
@@ -940,24 +953,20 @@ def _compose_static_subview_offset(base_offset, base_strides, raw_offsets):
 def _mul_index(lhs, rhs):
     lhs = _normalize_index(lhs)
     rhs = _normalize_index(rhs)
-    if isinstance(lhs, int) and isinstance(rhs, int):
+    if _is_python_index_literal(lhs) and _is_python_index_literal(rhs):
         return lhs * rhs
-    if isinstance(lhs, int):
+    if _is_python_index_literal(lhs):
         lhs = _index_const(lhs)
-    if isinstance(rhs, int):
+    if _is_python_index_literal(rhs):
         rhs = _index_const(rhs)
     return arith.MulIOp(lhs, rhs).result
 
 
 def _coerce_index_value(value):
     value = _normalize_index(value)
-    if isinstance(value, int):
+    if _is_python_index_literal(value):
         return _index_const(value)
-    if IndexType.isinstance(value.type):
-        return value
-    if IntegerType.isinstance(value.type):
-        return arith.IndexCastOp(IndexType.get(), value).result
-    raise TypeError(f"expected an index-like value, got {value.type}")
+    return value
 
 
 __all__ = [

--- a/ptodsl/ptodsl/scalar.py
+++ b/ptodsl/ptodsl/scalar.py
@@ -17,8 +17,8 @@ address views such as `tile[row, col]` and `tile.as_ptr() + offset`.
 
 from ._bootstrap import make_context  # ensure MLIR is on sys.path  # noqa: F401
 from ._scalar_coercion import coerce_scalar_to_type
+from ._scalar_adaptation import classify_runtime_scalar_type
 from ._runtime_scalar_ops import (
-    classify_runtime_scalar_type,
     emit_runtime_abs,
     emit_runtime_binary_op,
     emit_runtime_max,

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -857,6 +857,16 @@ FRAGMENT_FIXTURES = {
             {SNIPPET_PLACEHOLDER}
         """
     ),
+    "scalar_ops.value_adaptation": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def scalar_ops_value_adaptation_probe():
+            int_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32, valid_shape=[1, 4])
+            f16_tile = pto.alloc_tile(shape=[1, 16], dtype=pto.f16, valid_shape=[1, 1])
+            f32_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.f32, valid_shape=[1, 2])
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
     "scalar_ops.pointer_sources": _fixture(
         f"""
         @pto.jit(target="a5")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1206,6 +1206,13 @@ def carry_static_pyint_init_probe():
         col_loop.update(remained=remained_after_pack)
 
 
+def fixed_integer_index_coercion_probe():
+    count = pto.const(4)
+    mask, remained = pto.make_mask(pto.f32, count)
+    _ = mask
+    _ = remained
+
+
 @pto.jit(target="a5")
 def integer_loop_bound_probe(*, BLOCK: pto.const_expr = 8):
     row_start = pto.const(0, dtype=pto.i32)
@@ -1300,6 +1307,18 @@ def scalar_store_element_coercion_probe():
     scalar.store(row_stop, meta_ptr + 1)
     scalar.store(pto.const(2, dtype=pto.i64), meta_ptr + 2)
     scalar.store(3, meta_ptr + 3)
+
+
+@pto.jit(target="a5")
+def shared_index_coercion_probe():
+    limit = pto.const(4, dtype=pto.i32)
+    step = pto.const(1, dtype=pto.i32)
+    meta_tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32, valid_shape=[1, 4])
+    meta_ptr = meta_tile.as_ptr()
+    with pto.for_(0, limit, step=step) as i:
+        ptr = pto.addptr(meta_ptr, limit)
+        scalar.store(i, ptr)
+        pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=limit)
 
 
 @pto.simd
@@ -1842,6 +1861,49 @@ def public_data_movement_surface_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def fixed_width_integer_specialization_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    gm_src = pto.castptr(zero_u64, pto.ptr(pto.f16, "gm"))
+    ub_src = pto.castptr(zero_u64, pto.ptr(pto.f16, "ub"))
+    ub_dst = pto.castptr(zero_u64, pto.ptr(pto.f16, "ub"))
+    l1_dst = pto.castptr(zero_u64, pto.ptr(pto.f16, "mat"))
+
+    mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
+    index_stride = pto.const(32)
+    index_zero = pto.const(0)
+    blocked = pto.vsldb(ub_src, index_stride, index_zero, mask32_full)
+    pto.vsstb(blocked, ub_dst, index_stride, index_zero, mask32_full)
+
+    pto.mte_gm_l1_frac(
+        gm_src,
+        l1_dst,
+        pto.FractalMode.ND2NZ,
+        shape=(16, 4),
+        src_layout=(16, 256),
+        dst_group=(1, 0, 0, 0),
+        ctrl=(0, True),
+    )
+    pto.mte_gm_l1_frac(
+        gm_src,
+        l1_dst,
+        pto.FractalMode.ND2NZ,
+        shape=(16, 4),
+        src_layout=(16, 256),
+        dst_group=(1, 0, 0, 0),
+        ctrl=(0, 0),
+    )
+    pto.mte_gm_l1_frac(
+        gm_src,
+        l1_dst,
+        pto.FractalMode.ND2NZ,
+        shape=(16, 4),
+        src_layout=(16, 256),
+        dst_group=(1, 0, 0, 0),
+        ctrl=(0, 1),
+    )
+
+
+@pto.jit(target="a5", mode="explicit")
 def public_vector_conversion_surface_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
     ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
@@ -2218,11 +2280,13 @@ def main() -> None:
     tile_valid_shape_update_probe.verify()
     tile_valid_shape_update_1d_probe.verify()
     make_mask_index_roundtrip_probe.verify()
+    fixed_integer_index_coercion_probe.verify()
     integer_loop_bound_probe.verify()
     scalar_pointer_offset_probe.verify()
     addptr_surface_probe.verify()
     simt_pointer_offset_probe.verify()
     scalar_store_element_coercion_probe.verify()
+    shared_index_coercion_probe.verify()
     public_surface_exports_probe.verify()
     compile_time_query_probe.verify()
     eager_scalar_constructor_probe.verify()
@@ -2236,6 +2300,7 @@ def main() -> None:
     explicit_runtime_index_integer_bitwise_event_probe.verify()
     ast_runtime_index_bitwise_event_probe.verify()
     public_data_movement_surface_probe.verify()
+    fixed_width_integer_specialization_probe.verify()
     public_vector_conversion_surface_probe.verify()
     vdup_surface_probe.verify()
     vmulscvt_surface_probe.verify()
@@ -2658,6 +2723,20 @@ def main() -> None:
     expect(
         "pto.plt_b32" in carry_static_pyint_init_text,
         "a carried Python int should remain compatible with make_mask(...) without manual pto.const(...) wrapping",
+    )
+
+    fixed_integer_index_coercion_text = fixed_integer_index_coercion_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(fixed_integer_index_coercion_text, "fixed integer index coercion specialization")
+    expect(
+        re.search(
+            r"arith\.index_cast %[a-zA-Z0-9_]+ : index to i32",
+            fixed_integer_index_coercion_text,
+        ) is not None,
+        "fixed-width integer parameters should coerce runtime index values through shared scalar adaptation",
+    )
+    expect(
+        "pto.plt_b32" in fixed_integer_index_coercion_text,
+        "make_mask(...) should still lower runtime index counts to the predicate-load scalar path",
     )
 
     SUBKERNEL_OBSERVATIONS.clear()
@@ -3454,6 +3533,23 @@ def main() -> None:
         scalar_store_coercion_text.count("pto.store") == 4,
         "scalar.store(...) coercion probe should still lower to four pto.store operations",
     )
+    expect(
+        re.search(r"pto\.store %\w+, %\d+\[%c0(?:_\d+)?\]", scalar_store_coercion_text) is not None,
+        "scalar.store(index, i32_ptr) should preserve explicit target coercion at offset 0",
+    )
+
+    shared_index_coercion_text = shared_index_coercion_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(shared_index_coercion_text, "shared index coercion specialization")
+    expect(
+        shared_index_coercion_text.count("arith.index_cast") >= 3,
+        "shared index coercion should cast one i32 value through loop bound, step, addptr, and event id paths",
+    )
+    expect("scf.for" in shared_index_coercion_text, "shared index coercion should lower i32 loop bounds to scf.for")
+    expect("pto.addptr" in shared_index_coercion_text, "shared index coercion should lower i32 pointer offsets")
+    expect(
+        "pto.wait_flag_dyn" in shared_index_coercion_text,
+        "shared index coercion should lower i32 event ids to dynamic wait_flag",
+    )
 
     public_surface_text = public_surface_exports_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(public_surface_text, "public surface export specialization")
@@ -3498,6 +3594,8 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(vmulscvt_surface_text, "public vmulscvt surface specialization")
     vsstb_post_update_surface_text = vsstb_post_update_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(vsstb_post_update_surface_text, "vsstb post-update surface specialization")
+    fixed_width_integer_text = fixed_width_integer_specialization_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(fixed_width_integer_text, "fixed-width integer specialization")
     expect("pto.mte_gm_ub" in public_surface_text, "mte_load(...) should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in public_surface_text, "mte_store(...) should lower to pto.mte_ub_gm")
     expect(public_surface_text.count("pto.mem_bar") >= 1, "mem_bar(...) should still lower explicit memory barriers")
@@ -3575,6 +3673,18 @@ def main() -> None:
     expect("pto.vscatter" in data_movement_surface_text, "vscatter(...) should lower to pto.vscatter")
     expect("pto.vsldb" in data_movement_surface_text, "vsldb(...) should lower to pto.vsldb")
     expect("pto.vsstb" in data_movement_surface_text, "vsstb(...) should lower to pto.vsstb")
+    expect(
+        re.search(r"arith\.index_cast %[a-zA-Z0-9_]+ : index to i16", fixed_width_integer_text) is not None,
+        "vsldb/vsstb i16 operands should accept runtime index values through shared scalar adaptation",
+    )
+    expect(
+        fixed_width_integer_text.count("pto.mte_gm_l1_frac") == 3,
+        "mte_gm_l1_frac ctrl[1] should preserve bool, 0, and 1 i1 coercion cases",
+    )
+    expect(
+        fixed_width_integer_text.count("i1") >= 3,
+        "mte_gm_l1_frac ctrl[1] should materialize bool/0/1 as i1 values",
+    )
     expect("pto.vstar" in data_movement_surface_text, "vstar(...) should lower to pto.vstar")
     expect("pto.vstas" in data_movement_surface_text, "vstas(...) should lower to pto.vstas")
     expect("pto.vlds" in vector_conversion_surface_text, "vlds(..., post_update=ON) should lower through pto.vlds on the current VPTO Python surface")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1206,6 +1206,7 @@ def carry_static_pyint_init_probe():
         col_loop.update(remained=remained_after_pack)
 
 
+@pto.jit(target="a5")
 def fixed_integer_index_coercion_probe():
     count = pto.const(4)
     mask, remained = pto.make_mask(pto.f32, count)

--- a/ptodsl/tests/test_jit_diagnostics.py
+++ b/ptodsl/tests/test_jit_diagnostics.py
@@ -65,6 +65,64 @@ def float_bitwise_probe():
     _ = value & 1
 
 
+def float_literal_index_store_probe(ptr: pto.ptr(pto.index, "gm")):
+    scalar.store(1.5, ptr)
+
+
+@pto.jit(target="a5")
+def float_literal_index_binary_probe():
+    index_value = pto.const(1, dtype=pto.index)
+    _ = index_value + 1.5
+
+
+@pto.jit(target="a5")
+def same_width_float_store_probe():
+    f16_tile = pto.alloc_tile(shape=[1, 16], dtype=pto.f16, valid_shape=[1, 1])
+    bf16_tile = pto.alloc_tile(shape=[1, 16], dtype=pto.bf16, valid_shape=[1, 1])
+    f16_value = scalar.load(f16_tile[0, 0])
+    scalar.store(f16_value, bf16_tile[0, 0])
+
+
+@pto.jit(target="a5")
+def bool_loop_bound_probe():
+    with pto.for_(0, True, step=1):
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def bool_addptr_offset_probe():
+    tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32, valid_shape=[1, 4])
+    _ = pto.addptr(tile.as_ptr(), True)
+
+
+@pto.jit(target="a5")
+def bool_event_id_probe():
+    pto.wait_flag(pto.Pipe.V, pto.Pipe.MTE2, event_id=True)
+
+
+@pto.jit(target="a5")
+def bool_fixed_integer_probe():
+    _ = pto.make_mask(pto.f32, True)
+
+
+@pto.jit(target="a5")
+def bool_tile_element_probe():
+    tile = pto.alloc_tile(shape=[2, 8], dtype=pto.i32, valid_shape=[2, 4])
+    _ = scalar.load(tile[True, 0])
+
+
+@pto.jit(target="a5")
+def bool_address_sugar_probe():
+    tile = pto.alloc_tile(shape=[1, 8], dtype=pto.i32, valid_shape=[1, 4])
+    _ = scalar.load(tile.as_ptr() + True)
+
+
+@pto.jit(target="a5")
+def bool_tile_slice_probe():
+    tile = pto.alloc_tile(shape=[8], dtype=pto.i32, valid_shape=[4])
+    _ = tile[True:]
+
+
 @pto.jit(target="a5")
 def carry_update_mismatch_probe(*, BLOCK: pto.const_expr = 8):
     acc = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
@@ -387,6 +445,68 @@ def main() -> None:
         TypeError,
         "runtime scalar bitwise operator",
         "expects integer-like operands",
+    )
+    expect_raises(
+        float_literal_index_store_probe.compile,
+        TypeError,
+        "scalar.store(...)",
+        "cannot materialize a floating-point literal against non-floating",
+        "index",
+    )
+    expect_raises(
+        float_literal_index_binary_probe.compile,
+        TypeError,
+        "runtime scalar operators cannot materialize a floating-point literal",
+        "index",
+    )
+    expect_raises(
+        same_width_float_store_probe.compile,
+        TypeError,
+        "cannot coerce between different floating-point types of the same width",
+        "f16",
+        "bf16",
+    )
+    expect_raises(
+        bool_loop_bound_probe.compile,
+        TypeError,
+        "pto.for_(...) loop bound",
+        "does not accept bool values",
+    )
+    expect_raises(
+        bool_addptr_offset_probe.compile,
+        TypeError,
+        "addptr(ptr, offset)",
+        "does not accept bool values",
+    )
+    expect_raises(
+        bool_event_id_probe.compile,
+        TypeError,
+        "wait_flag(..., event_id=...)",
+        "does not accept bool values",
+    )
+    expect_raises(
+        bool_fixed_integer_probe.compile,
+        TypeError,
+        "make_mask(..., value)",
+        "does not accept bool values",
+    )
+    expect_raises(
+        bool_tile_element_probe.compile,
+        TypeError,
+        "surface index value",
+        "does not accept bool values",
+    )
+    expect_raises(
+        bool_address_sugar_probe.compile,
+        TypeError,
+        "surface index value",
+        "does not accept bool values",
+    )
+    expect_raises(
+        bool_tile_slice_probe.compile,
+        TypeError,
+        "surface index value",
+        "does not accept bool values",
     )
     expect_raises(
         carry_update_mismatch_probe.compile,

--- a/ptodsl/tests/test_jit_diagnostics.py
+++ b/ptodsl/tests/test_jit_diagnostics.py
@@ -65,6 +65,7 @@ def float_bitwise_probe():
     _ = value & 1
 
 
+@pto.jit(target="a5")
 def float_literal_index_store_probe(ptr: pto.ptr(pto.index, "gm")):
     scalar.store(1.5, ptr)
 


### PR DESCRIPTION
## Summary
- add a shared PTODSL scalar adaptation helper for index/integer/float classification, literal materialization, runtime index coercion, fixed-width integer coercion, and runtime binary operand normalization
- route runtime scalar ops, scalar store coercion, runtime index coercion, fixed-width micro-op operands, and surface index expressions through the shared helper
- reject Python bool consistently in index-like contexts while preserving the existing i1-specific bool/0/1 behavior
- document the design and the tile-template tracing non-goal

## Tests
- python3 -m py_compile ptodsl/ptodsl/_scalar_adaptation.py ptodsl/ptodsl/_ops.py ptodsl/ptodsl/_surface_values.py ptodsl/tests/test_jit_compile.py ptodsl/tests/test_jit_diagnostics.py
- git diff --check

Full frontend validation was run before the rebase with the same test set: ptodsl/tests/test_jit_compile.py, ptodsl/tests/test_jit_diagnostics.py, ptodsl/tests/test_docs_as_test.py, ptodsl/tests/test_ptoas_frontend_verify.py. Rebased validation is pending because the remote validation shell is currently not responding.

Related to #794 