### PR TITLE
fix(ci): match Prepare LLVM source step by prefix in watchdog

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -95,7 +95,7 @@ jobs:
           gh run view "${RUN_ID}" --repo "${REPO}" --log-failed > "${log_file}"
 
           awk -F'\t' '
-            $2 == "Checkout" || $2 == "Prepare LLVM source (no rebuild)" {
+            $2 == "Checkout" || $2 ~ /^Prepare LLVM source/ {
               print
             }
           ' "${log_file}" > "${step_log_file}"


### PR DESCRIPTION
## 背景

ci-sim workflow 的步骤名从 `Prepare LLVM source (no rebuild)` 改成了 `Prepare LLVM source`，但 watchdog 的 awk 过滤器仍是精确字符串匹配 `==`，导致网络故障时匹配不上，不会触发自动重试。

## 修改

把 awk 的 `==` 精确匹配改成 `/^Prepare LLVM source/` 前缀正则，新旧名都能命中。

🤖 Generated with [Claude Code](https://claude.com/claude-code)