### PR TITLE
fix(ci): scan all failed step logs in watchdog, not just Checkout/LLVM source

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -89,25 +89,13 @@ jobs:
 
           git_failure_pattern='(error: RPC failed|Operation timed out|Connection timed out|connection timeout|Failed to connect|Could not resolve host|early EOF|fetch-pack|remote end hung up|GnuTLS recv error|TLS connection|HTTP/2 stream)'
           log_file="failed.log"
-          step_log_file="failed-git-steps.log"
 
           echo "Downloading failed logs for workflow run ${RUN_ID}"
           gh run view "${RUN_ID}" --repo "${REPO}" --log-failed > "${log_file}"
 
-          awk -F'\t' '
-            $2 == "Checkout" || $2 ~ /^Prepare LLVM source/ {
-              print
-            }
-          ' "${log_file}" > "${step_log_file}"
-
-          if [[ ! -s "${step_log_file}" ]]; then
-            echo "No Checkout/Prepare LLVM source logs found in failed jobs; skip rerun."
-            exit 0
-          fi
-
-          if grep -Eiq "${git_failure_pattern}" "${step_log_file}"; then
-            echo "Git/network failure detected in self-hosted checkout/fetch stage; rerunning failed jobs."
+          if grep -Eiq "${git_failure_pattern}" "${log_file}"; then
+            echo "Git/network failure detected; rerunning failed jobs."
             gh api --method POST "repos/${REPO}/actions/runs/${RUN_ID}/rerun-failed-jobs"
           else
-            echo "Failed jobs did not fail in a recognized git/network stage; skip rerun."
+            echo "Failed jobs did not fail with a recognized git/network error; skip rerun."
           fi


### PR DESCRIPTION
## 背景

#807 只修复了步骤名匹配（精确→正则），但仍然只检查 `Checkout` 和 `Prepare LLVM source` 两个步骤。实际 `Checkout PyPTO`、`Checkout PTO-ISA` 等步骤同样可能因网络问题失败，但步骤名不在白名单里就不会触发重试。

## 修改

移除按步骤名过滤的白名单机制，改为扫描 **所有失败步骤** 的日志。`grep -Eiq` 命中 pattern 就直接触发重试，不管失败发生在哪个步骤。

同时不再有"步骤名改了 watchdog 就跟不上"的问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)