### PR TITLE
fix(ci): extend watchdog to non-PR events, simplify stale checks

### DIFF
--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -22,7 +22,6 @@ jobs:
   rerun-self-hosted-git-failure:
     if: >-
       ${{
-        github.event.workflow_run.event == 'pull_request' &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt <= 8
       }}
@@ -50,42 +49,35 @@ jobs:
           echo "Inspecting CI workflow run ${RUN_ID} in ${REPO}"
           run_head_sha="${RUN_HEAD_SHA}"
 
-          if [[ ! -f pr-context/pr-number || ! -f pr-context/pr-head-sha ]]; then
-            echo "No pr-context artifact found for workflow run ${RUN_ID}; skip rerun."
-            exit 0
-          fi
+          # ── PR: validate that the run is still current for an open PR ──
+          if [[ -f pr-context/pr-number && -f pr-context/pr-head-sha ]]; then
+            pr_number="$(< pr-context/pr-number)"
+            pr_head_sha="$(< pr-context/pr-head-sha)"
 
-          pr_number="$(< pr-context/pr-number)"
-          pr_head_sha="$(< pr-context/pr-head-sha)"
+            if [[ ! "${pr_number}" =~ ^[0-9]+$ ||
+                  ! "${pr_head_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "Invalid pr-context artifact for workflow run ${RUN_ID}; skip rerun."
+              exit 0
+            fi
 
-          if [[ ! "${pr_number}" =~ ^[0-9]+$ ||
-                ! "${pr_head_sha}" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            echo "Invalid pr-context artifact for workflow run ${RUN_ID}; skip rerun."
-            exit 0
-          fi
+            read -r pr_state current_head_sha < <(
+              gh api "repos/${REPO}/pulls/${pr_number}" \
+                --jq '[.state, .head.sha] | @tsv'
+            )
+            if [[ "${pr_state}" != "open" ]]; then
+              echo "PR #${pr_number} is ${pr_state}; skip rerun."
+              exit 0
+            fi
 
-          if [[ "${pr_head_sha}" != "${run_head_sha}" ]]; then
-            echo "Workflow run ${RUN_ID} does not match pr-context head sha; skip rerun."
-            echo "Run head SHA: ${run_head_sha}"
-            echo "PR context head SHA: ${pr_head_sha}"
-            exit 0
+            if [[ "${run_head_sha}" != "${current_head_sha}" ]]; then
+              echo "Workflow run ${RUN_ID} is stale for PR #${pr_number}; skip rerun."
+              echo "Run head SHA: ${run_head_sha}"
+              echo "Current PR head SHA: ${current_head_sha}"
+              exit 0
+            fi
           fi
-
-          read -r pr_state current_head_sha < <(
-            gh api "repos/${REPO}/pulls/${pr_number}" \
-              --jq '[.state, .head.sha] | @tsv'
-          )
-          if [[ "${pr_state}" != "open" ]]; then
-            echo "PR #${pr_number} is ${pr_state}; skip rerun."
-            exit 0
-          fi
-
-          if [[ "${run_head_sha}" != "${current_head_sha}" ]]; then
-            echo "Workflow run ${RUN_ID} is stale for PR #${pr_number}; skip rerun."
-            echo "Run head SHA: ${run_head_sha}"
-            echo "Current PR head SHA: ${current_head_sha}"
-            exit 0
-          fi
+          # ── schedule / workflow_dispatch: no pr-context artifact, the commit
+          #    is immutable.  run_attempt <= 8 prevents infinite retry loops.
 
           git_failure_pattern='(error: RPC failed|Operation timed out|Connection timed out|connection timeout|Failed to connect|Could not resolve host|early EOF|fetch-pack|remote end hung up|GnuTLS recv error|TLS connection|HTTP/2 stream)'
           log_file="failed.log"


### PR DESCRIPTION
## 背景

目前 watchdog 只对 `pull_request` 事件的失败做自动重试，`schedule` 和 `workflow_dispatch` 如果遇到网络问题不会重试。同时 PR 校验中存在多余的 SHA 比较。

## 修改

1. **去掉 `if` 条件中的事件类型限制** — ci-sim 本来只有 `pull_request`、`schedule`、`workflow_dispatch` 三种触发，不需要在 watchdog 里再过滤
2. **用 pr-context artifact 是否存在做分叉** — 存在走 PR 校验（open 状态 + SHA 是否 stale），不存在走非 PR 路径（直接日志扫描 + 重试）
3. **删除冗余的 `pr_head_sha != run_head_sha` 校验** — 两者都来自同一次 run，必定相等
4. **`pr-context` 不存在时改为 fall through** 而非直接 exit，让 schedule/dispatch 也能走到重试逻辑

## 行为变化

| 场景 | 之前 | 现在 |
|------|:---:|:---:|
| PR 网络失败 + 仍 open + SHA 匹配 | 重试 | 重试 |
| PR 网络失败 + PR 已 close | 不重试 | 不重试 |
| PR 网络失败 + 有新 commit 推送 | 不重试 | 不重试 |
| schedule 网络失败 | 不重试 | 重试 |
| workflow_dispatch 网络失败 | 不重试 | 重试 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)