### PR TITLE
Fix tcmps ST packed dst layout

### DIFF
--- a/test/tilelang_st/npu/a5/src/st/testcase/tcmps/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcmps/cases.py
@@ -9,13 +9,7 @@
 
 # coding=utf-8
 
-"""Single source of truth for tcmps ST test cases.
-
-tcmps: packed mask of (src < scalar), dst stores packed predicate mask.
-Supports 32-bit source types: f32, i32. Output dtype is uint8.
-
-Cases reference testcase/tcmps with various shapes and valid regions.
-"""
+"""Single source of truth for tcmps ST test cases."""
 
 import numpy as np
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tcmps/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcmps/main.cpp
@@ -47,6 +47,18 @@ struct TestCase {
     size_t      dstElemSize; // bytes per destination element
 };
 
+static size_t GetDstElemCount(const TestCase &tc) {
+    if (tc.srcElemSize == sizeof(float) || tc.srcElemSize == sizeof(int32_t)) {
+        const size_t logicalElems = tc.validRows * tc.validCols;
+        const size_t repeatElm = 256 / tc.srcElemSize;
+        const size_t repeatTimes = (logicalElems + repeatElm - 1) / repeatElm + 1;
+        return (repeatTimes / 2) * 16;
+    }
+    const size_t repeatElm = 256 / tc.srcElemSize;
+    const size_t repeatTimes = (tc.validCols + repeatElm - 1) / repeatElm;
+    return tc.validRows * repeatTimes * 16;
+}
+
 static const TestCase kCases[] = {
     {"f32_1x64",              (void (*)(void*,void*,void*))LaunchTCMP_f32_1x64,              1,   64,   1,   64,  sizeof(float),    sizeof(uint8_t)},
     {"f32_4x64",              (void (*)(void*,void*,void*))LaunchTCMP_f32_4x64,              4,   64,   4,   64,  sizeof(float),    sizeof(uint8_t)},
@@ -67,7 +79,7 @@ static constexpr size_t kNumCases = sizeof(kCases) / sizeof(kCases[0]);
 static int RunCase(const TestCase &tc, int deviceId, aclrtStream stream) {
     int rc = 0;
     const size_t srcElemCount = tc.rows * tc.cols;
-    const size_t dstElemCount = tc.rows * tc.cols;
+    const size_t dstElemCount = GetDstElemCount(tc);
     const size_t srcFileSize  = srcElemCount * tc.srcElemSize;
     const size_t dstFileSize  = dstElemCount * tc.dstElemSize;
 

--- a/test/tilelang_st/npu/a5/src/st/testcase/tcmps/main.cpp
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcmps/main.cpp
@@ -56,7 +56,8 @@ static size_t GetDstElemCount(const TestCase &tc) {
     }
     const size_t repeatElm = 256 / tc.srcElemSize;
     const size_t repeatTimes = (tc.validCols + repeatElm - 1) / repeatElm;
-    return tc.validRows * repeatTimes * 16;
+    const size_t bytesPerIter = (tc.srcElemSize == sizeof(uint8_t)) ? 32 : 16;
+    return tc.validRows * repeatTimes * bytesPerIter;
 }
 
 static const TestCase kCases[] = {

--- a/test/tilelang_st/npu/a5/src/st/testcase/tcmps/tcmps.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tcmps/tcmps.pto
@@ -377,16 +377,18 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %c1    = arith.constant 1    : index
     %c256  = arith.constant 256  : index
     %c16   = arith.constant 16   : index
+    %c32   = arith.constant 32   : index
     %c4096 = arith.constant 4096 : index
+    %c8192 = arith.constant 8192 : index
 
     %src_view = pto.make_tensor_view %src_ptr,
       shape = [%c1, %c1, %c1, %c256, %c16],
       strides = [%c4096, %c4096, %c4096, %c16, %c1]
       : !pto.tensor_view<1x1x1x256x16xf32>
     %dst_view = pto.make_tensor_view %dst_ptr,
-      shape = [%c1, %c1, %c1, %c256, %c16],
-      strides = [%c4096, %c4096, %c4096, %c16, %c1]
-      : !pto.tensor_view<1x1x1x256x16xui8>
+      shape = [%c1, %c1, %c1, %c256, %c32],
+      strides = [%c8192, %c8192, %c8192, %c32, %c1]
+      : !pto.tensor_view<1x1x1x256x32xui8>
 
     %src_part = pto.partition_view %src_view,
       offsets = [%c0, %c0, %c0, %c0, %c0],
@@ -394,20 +396,20 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       : !pto.tensor_view<1x1x1x256x16xf32> -> !pto.partition_tensor_view<1x1x1x256x16xf32>
     %dst_part = pto.partition_view %dst_view,
       offsets = [%c0, %c0, %c0, %c0, %c0],
-      sizes = [%c1, %c1, %c1, %c256, %c16]
-      : !pto.tensor_view<1x1x1x256x16xui8> -> !pto.partition_tensor_view<1x1x1x256x16xui8>
+      sizes = [%c1, %c1, %c1, %c256, %c32]
+      : !pto.tensor_view<1x1x1x256x32xui8> -> !pto.partition_tensor_view<1x1x1x256x32xui8>
 
     %src = pto.alloc_tile
       : !pto.tile_buf<vec, 256x16xf32>
     %dst = pto.alloc_tile
-      : !pto.tile_buf<vec, 256x32xui8, valid=256x16>
+      : !pto.tile_buf<vec, 256x32xui8>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x256x16xf32>)
               outs(%src : !pto.tile_buf<vec, 256x16xf32>)
     pto.tcmps ins(%src, %scalar {cmpMode = #pto<cmp lt>} : !pto.tile_buf<vec, 256x16xf32>, f32)
-              outs(%dst : !pto.tile_buf<vec, 256x32xui8, valid=256x16>)
-    pto.tstore ins(%dst : !pto.tile_buf<vec, 256x32xui8, valid=256x16>)
-               outs(%dst_part : !pto.partition_tensor_view<1x1x1x256x16xui8>)
+              outs(%dst : !pto.tile_buf<vec, 256x32xui8>)
+    pto.tstore ins(%dst : !pto.tile_buf<vec, 256x32xui8>)
+               outs(%dst_part : !pto.partition_tensor_view<1x1x1x256x32xui8>)
     return
   }
 


### PR DESCRIPTION
## Summary
- fix the TileLang ST `tcmps` host-side dst buffer sizing for packed predicate outputs
- correct the `f32_256x16` ST kernel dst tensor view/tstore layout to match the allocated `256x32xui8` tile
- drop the incomplete `cases.py` metadata experiment so the testcase stays aligned with the actual harness behavior

## Root cause
`f32_256x16` allocated a `256x32xui8` dst tile, but its GM dst view and `tstore` path still used `256x16`. That truncated the packed predicate output during store, so the compare failed from byte 256 onward.

## Validation
- `python3 test/tilelang_st/script/run_st.py -r sim -v a5 -t tcmps -p "$PWD/build/tools/ptoas/ptoas"`
