### PR TITLE
[PTODSL] Add low precision conversion surface

### DIFF
--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -79,6 +79,20 @@ static LogicalResult verifyMaskTypeLike(Operation *op, Type type,
   return success();
 }
 
+static LogicalResult verifyNonLowPrecisionVRegElementTypeLike(
+    Operation *op, Type type, StringRef roleDescription) {
+  auto vecType = dyn_cast<VRegType>(type);
+  if (!vecType)
+    return success();
+  if (pto::isPTOLowPrecisionType(vecType.getElementType()))
+    return op->emitOpError()
+           << roleDescription
+           << " must not use low-precision vector element type; "
+              "low-precision vreg elements are currently only supported on "
+              "explicit memory/conversion ops such as vlds/vsts/vcvt/vmulscvt/vpack";
+  return success();
+}
+
 static LogicalResult verifyMaskTypeWithGranularityLike(Operation *op, Type type,
                                                        StringRef roleDescription,
                                                        StringRef granularity) {
@@ -5147,6 +5161,9 @@ static LogicalResult verifyVecScalarMaskedOpLike(OpTy op) {
     return failure();
   if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")))
     return failure();
+  if (failed(verifyNonLowPrecisionVRegElementTypeLike(
+          op.getOperation(), op.getInput().getType(), "input type")))
+    return failure();
   return success();
 }
 
@@ -5238,6 +5255,9 @@ static LogicalResult verifyUnaryVecOp(UnaryOp op) {
     return failure();
   if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
     return failure();
+  if (failed(verifyNonLowPrecisionVRegElementTypeLike(
+          op.getOperation(), op.getInput().getType(), "operand type")))
+    return failure();
   if (op.getInput().getType() != op.getResult().getType())
     return op.emitOpError("requires matching register vector shape");
   return success();
@@ -5272,6 +5292,9 @@ static LogicalResult verifyBinaryVecOp(BinaryOp op) {
   if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")))
     return failure();
   if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+    return failure();
+  if (failed(verifyNonLowPrecisionVRegElementTypeLike(
+          op.getOperation(), op.getLhs().getType(), "lhs type")))
     return failure();
   if (op.getLhs().getType() != op.getRhs().getType() ||
       op.getLhs().getType() != op.getResult().getType())
@@ -5480,6 +5503,9 @@ LogicalResult VselOp::verify() {
       failed(verifyVRegTypeLike(*this, getSrc1().getType(), "src1 type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+    return failure();
+  if (failed(verifyNonLowPrecisionVRegElementTypeLike(
+          getOperation(), getSrc0().getType(), "src0 type")))
     return failure();
   if (getSrc0().getType() != getSrc1().getType() ||
       getSrc0().getType() != getResult().getType())

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -40,6 +40,8 @@ z: pto.i32 = 1024
 
 The following low-precision types may appear as element types for device storage and vector memory movement: `Tile`, `TensorView`, `PartitionTensorView`, `pto.ptr(...)`, and `pto.vreg_type(...)`. Use them to reduce memory bandwidth; convert to a compute-capable type before arithmetic unless the operation explicitly supports that low-precision format.
 
+Low-precision `VRegType` values are valid intermediate payloads, but they are not generic vector-arithmetic types. In practice, use them on explicit memory/conversion paths such as `vlds`, `vsts`, `vcvt`, `vmulscvt`, and `vpack`, then convert to a compute-capable type before feeding the value to generic vector compute ops.
+
 | DSL Type | Description |
 |----------|-------------|
 | `pto.hif8` | HiFloat8 format |

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -36,9 +36,9 @@ y = pto.ui16(7)
 z: pto.i32 = 1024
 ```
 
-### Low-precision types (storage only)
+### Low-precision types
 
-The following types are **storage-only**: they may only appear as element types when constructing `Tile`, `TensorView`, and `PartitionTensorView` values for storage and data movement. They **cannot** be used to construct scalars, vectors, pointers, or `tensor_spec(...)` ABI contracts. Use them to reduce memory bandwidth; convert to a compute-capable type before arithmetic.
+The following low-precision types may appear as element types for device storage and vector memory movement: `Tile`, `TensorView`, `PartitionTensorView`, `pto.ptr(...)`, and `pto.vreg_type(...)`. Use them to reduce memory bandwidth; convert to a compute-capable type before arithmetic unless the operation explicitly supports that low-precision format.
 
 | DSL Type | Description |
 |----------|-------------|
@@ -48,15 +48,17 @@ The following types are **storage-only**: they may only appear as element types 
 | `pto.f8e4m3` | 8-bit float (E4M3) |
 | `pto.f8e5m2` | 8-bit float (E5M2) |
 
-These types can be used when constructing on-chip tiles and view descriptors:
+These types can be used when constructing on-chip tiles, view descriptors, UB pointers, and vector register types:
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"type_system.low_precision_types","symbol":"type_system_low_precision_types_probe","compile":{}} -->
 ```python
 lp_tile = pto.alloc_tile(shape=[128, 64], dtype=pto.f8e4m3)
 fp4_tile = pto.alloc_tile(shape=[64, 32], dtype=pto.f4e2m1x2)
+lp_ptr = pto.castptr(pto.const(0, dtype=pto.ui64), pto.ptr(pto.f8e4m3, "ub"))
+lp_vreg_ty = pto.vreg_type(256, pto.f8e4m3)
 ```
 
-Constructing a scalar, vector, pointer, or host tensor ABI contract with a low-precision type is **not supported** — `pto.f8e4m3(1.0)`, `pto.vreg_type(64, pto.f8e4m3)`, `pto.ptr(pto.f8e4m3)`, and `pto.tensor_spec(rank=2, dtype=pto.f8e4m3)` will raise an error. Load data as the storage type, then convert to a compute-capable type before arithmetic.
+Constructing scalar eager values or host tensor ABI contracts with a low-precision type is **not supported** — `pto.f8e4m3(1.0)` and `pto.tensor_spec(rank=2, dtype=pto.f8e4m3)` will raise an error.
 
 ### Integer literal guidance
 

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -351,6 +351,17 @@ The compiler automatically computes the byte offset from the tile's shape, eleme
 | `vec` | `VRegType` | Loaded vector register (when `post_update=OFF`) |
 | `(vec, updated_buf)` | `(VRegType, PtrType)` | Loaded vector and advanced pointer (when `post_update=ON`, pointer form only) |
 
+Low-precision element types use the same pointer/tile forms. Use `b8` masks for 8-bit storage formats, including packed FP4 storage types:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"data_movement.low_precision_vector_memory","symbol":"data_movement_low_precision_vector_memory_probe","compile":{}} -->
+```python
+mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+vec_f8 = pto.vlds(f8_src, pto.const(0))
+pto.vsts(vec_f8, f8_dst, pto.const(0), mask_b8)
+low, high = pto.vldsx2(fp4_src, pto.const(0), pto.DeinterleaveDist.DINTLV_B8)
+pto.vstsx2(low, high, fp4_dst, pto.const(0), pto.InterleaveDist.INTLV_B8, mask_b8)
+```
+
 
 #### `pto.vldsx2(tile[row, col:], dist: DeinterleaveDist) -> (VRegType, VRegType)`
 #### `pto.vldsx2(tile[start:], dist: DeinterleaveDist) -> (VRegType, VRegType)`

--- a/ptodsl/docs/user_guide/08-compute-operations.md
+++ b/ptodsl/docs/user_guide/08-compute-operations.md
@@ -1260,6 +1260,8 @@ Vector compute ops operate on `VRegType` values inside `@pto.simd` sub-kernels. 
 
 All vector ops in this section follow the pattern established in Section 7.3 for tile-index and pointer-form addressing. The signatures below use the vector-register form — tile-index forms load into `vreg` first, then compute.
 
+Unless a section explicitly says otherwise, the generic vector compute ops below expect compute-capable vector element types. Low-precision `vreg` payloads are intended for explicit memory/conversion paths such as `vlds`, `vsts`, `vcvt`, `vmulscvt`, and `vpack`; convert them to `f16`, `bf16`, `f32`, or another supported compute type before using generic vector arithmetic, reduction, or select ops.
+
 ### 8.2.1 Unary vector ops
 
 #### `pto.vexp(vec: VRegType, mask: MaskType) -> VRegType`

--- a/ptodsl/docs/user_guide/08-compute-operations.md
+++ b/ptodsl/docs/user_guide/08-compute-operations.md
@@ -742,6 +742,492 @@ pto.tile.matmul_acc(acc_prev, lhs_l0a, rhs_l0b, acc_next)
 
 ---
 
+#### `pto.tile.matmul_mx(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, dst: Tile) -> None`
+
+**Description**: Tile-level MX matrix multiplication. Computes the product `lhs @ rhs` on the matrix pipeline and writes the result into `dst`. This variant keeps the tile-op abstraction while making the microscaling payload explicit through `lhs_scale` and `rhs_scale`.
+
+Conceptually:
+
+```text
+dst[m, n] = sum_k lhs[m, k] * rhs[k, n]
+```
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lhs` | `Tile` | Left operand tile, typically in `MemorySpace.LEFT` |
+| `lhs_scale` | `Tile` | Left microscaling tile, typically in `MemorySpace.SCALING` |
+| `rhs` | `Tile` | Right operand tile, typically in `MemorySpace.RIGHT` |
+| `rhs_scale` | `Tile` | Right microscaling tile, typically in `MemorySpace.SCALING` |
+| `dst` | `Tile` | Destination accumulator tile, typically in `MemorySpace.ACC` |
+
+**Returns**: None.
+
+**Constraints**:
+- `lhs`, `rhs`, and `dst` must satisfy the same shape and memory-space relationship as `pto.tile.matmul`.
+- `lhs_scale` and `rhs_scale` must be `MemorySpace.SCALING` tiles.
+- On A5, `lhs` should use `blayout="ColMajor", slayout="RowMajor"`; `rhs` should use `blayout="RowMajor", slayout="ColMajor"`; `dst` should use `blayout="ColMajor", slayout="RowMajor"`.
+- On A5, `lhs_scale` should use `blayout="RowMajor"`, `slayout="RowMajor"`, `fractal_size=32`; `rhs_scale` should use `blayout="ColMajor"`, `slayout="ColMajor"`, `fractal_size=32`.
+- Supported operand dtype pairs include mixed low-precision MX combinations such as `f8e4m3/f8e5m2` and `f4e1m2x2/f4e2m1x2`.
+
+**Example** — compute one MX cube tile product:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.tile_mx_compute","symbol":"compute_ops_tile_mx_compute_probe","compile":{}} -->
+```python
+lhs_l0a_mx = pto.alloc_tile(
+    shape=[16, 64],
+    dtype=pto.f8e4m3,
+    memory_space=pto.MemorySpace.LEFT,
+    valid_shape=[16, 64],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_scale = pto.alloc_tile(
+    shape=[16, 2],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[16, 2],
+    blayout="RowMajor",
+    slayout="RowMajor",
+    fractal_size=32,
+)
+rhs_l0b_mx = pto.alloc_tile(
+    shape=[64, 16],
+    dtype=pto.f8e5m2,
+    memory_space=pto.MemorySpace.RIGHT,
+    valid_shape=[64, 16],
+    blayout="RowMajor",
+    slayout="ColMajor",
+)
+rhs_scale = pto.alloc_tile(
+    shape=[2, 16],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[2, 16],
+    blayout="ColMajor",
+    slayout="ColMajor",
+    fractal_size=32,
+)
+acc_l0c = pto.alloc_tile(
+    shape=[16, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[16, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+pto.tile.matmul_mx(lhs_l0a_mx, lhs_scale, rhs_l0b_mx, rhs_scale, acc_l0c)
+```
+
+---
+
+#### `pto.tile.matmul_mx_acc(acc_in: Tile, lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, dst: Tile) -> None`
+
+**Description**: Accumulating tile-level MX matrix multiplication. Adds the product `lhs @ rhs` to `acc_in` and writes the accumulated result into `dst`.
+
+Conceptually:
+
+```text
+dst[m, n] = acc_in[m, n] + sum_k lhs[m, k] * rhs[k, n]
+```
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `acc_in` | `Tile` | Existing accumulator tile used as the accumulation input |
+| `lhs` | `Tile` | Left operand tile, typically in `MemorySpace.LEFT` |
+| `lhs_scale` | `Tile` | Left microscaling tile, typically in `MemorySpace.SCALING` |
+| `rhs` | `Tile` | Right operand tile, typically in `MemorySpace.RIGHT` |
+| `rhs_scale` | `Tile` | Right microscaling tile, typically in `MemorySpace.SCALING` |
+| `dst` | `Tile` | Destination accumulator tile |
+
+**Returns**: None.
+
+**Constraints**:
+- `lhs`, `rhs`, `lhs_scale`, `rhs_scale`, and `dst` must satisfy the same constraints as `pto.tile.matmul_mx`.
+- `acc_in` must be an ACC tile, typically with the same shape and dtype as `dst`.
+
+**Example** — accumulate a second MX K-slice into an ACC tile:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.tile_mx_compute","symbol":"compute_ops_tile_mx_compute_probe","compile":{}} -->
+```python
+acc_prev = pto.alloc_tile(
+    shape=[16, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[16, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_l0a_mx = pto.alloc_tile(
+    shape=[16, 64],
+    dtype=pto.f8e4m3,
+    memory_space=pto.MemorySpace.LEFT,
+    valid_shape=[16, 64],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_scale = pto.alloc_tile(
+    shape=[16, 2],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[16, 2],
+    blayout="RowMajor",
+    slayout="RowMajor",
+    fractal_size=32,
+)
+rhs_l0b_mx = pto.alloc_tile(
+    shape=[64, 16],
+    dtype=pto.f8e5m2,
+    memory_space=pto.MemorySpace.RIGHT,
+    valid_shape=[64, 16],
+    blayout="RowMajor",
+    slayout="ColMajor",
+)
+rhs_scale = pto.alloc_tile(
+    shape=[2, 16],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[2, 16],
+    blayout="ColMajor",
+    slayout="ColMajor",
+    fractal_size=32,
+)
+acc_next = pto.alloc_tile(
+    shape=[16, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[16, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+pto.tile.matmul_mx_acc(acc_prev, lhs_l0a_mx, lhs_scale, rhs_l0b_mx, rhs_scale, acc_next)
+```
+
+---
+
+#### `pto.tile.matmul_mx_bias(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, bias: Tile, dst: Tile) -> None`
+
+**Description**: Bias-enabled tile-level MX matrix multiplication. Computes the MX product `lhs @ rhs`, adds the bias input carried by `bias`, and writes the result into `dst`.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lhs` | `Tile` | Left operand tile, typically in `MemorySpace.LEFT` |
+| `lhs_scale` | `Tile` | Left microscaling tile, typically in `MemorySpace.SCALING` |
+| `rhs` | `Tile` | Right operand tile, typically in `MemorySpace.RIGHT` |
+| `rhs_scale` | `Tile` | Right microscaling tile, typically in `MemorySpace.SCALING` |
+| `bias` | `Tile` | Bias tile, typically in `MemorySpace.BIAS` |
+| `dst` | `Tile` | Destination accumulator tile |
+
+**Returns**: None.
+
+**Constraints**:
+- `lhs`, `rhs`, `lhs_scale`, `rhs_scale`, and `dst` must satisfy the same constraints as `pto.tile.matmul_mx`.
+- `bias` must satisfy the target architecture's cube bias layout and shape requirements. A common A5 case is a `[1, N]` tile in `MemorySpace.BIAS`.
+
+**Example** — add a bias tile on the MX cube path:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.tile_mx_compute","symbol":"compute_ops_tile_mx_compute_probe","compile":{}} -->
+```python
+lhs_l0a_mx = pto.alloc_tile(
+    shape=[16, 64],
+    dtype=pto.f8e4m3,
+    memory_space=pto.MemorySpace.LEFT,
+    valid_shape=[16, 64],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_scale = pto.alloc_tile(
+    shape=[16, 2],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[16, 2],
+    blayout="RowMajor",
+    slayout="RowMajor",
+    fractal_size=32,
+)
+rhs_l0b_mx = pto.alloc_tile(
+    shape=[64, 16],
+    dtype=pto.f8e5m2,
+    memory_space=pto.MemorySpace.RIGHT,
+    valid_shape=[64, 16],
+    blayout="RowMajor",
+    slayout="ColMajor",
+)
+rhs_scale = pto.alloc_tile(
+    shape=[2, 16],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[2, 16],
+    blayout="ColMajor",
+    slayout="ColMajor",
+    fractal_size=32,
+)
+bias_tile = pto.alloc_tile(
+    shape=[1, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.BIAS,
+    valid_shape=[1, 16],
+)
+acc_l0c = pto.alloc_tile(
+    shape=[16, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[16, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+pto.tile.matmul_mx_bias(lhs_l0a_mx, lhs_scale, rhs_l0b_mx, rhs_scale, bias_tile, acc_l0c)
+```
+
+---
+
+#### `pto.tile.gemv_mx(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, dst: Tile) -> None`
+
+**Description**: Tile-level MX GEMV. Computes the product `lhs @ rhs` on the matrix pipeline and writes the result into `dst`. This surface lowers to `pto.tgemv.mx` and is the tile-level counterpart to MX GEMV execution.
+
+Conceptually:
+
+```text
+dst[m, n] = sum_k lhs[m, k] * rhs[k, n]
+```
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lhs` | `Tile` | Left operand tile, typically in `MemorySpace.LEFT` |
+| `lhs_scale` | `Tile` | Left microscaling tile, typically in `MemorySpace.SCALING` |
+| `rhs` | `Tile` | Right operand tile, typically in `MemorySpace.RIGHT` |
+| `rhs_scale` | `Tile` | Right microscaling tile, typically in `MemorySpace.SCALING` |
+| `dst` | `Tile` | Destination accumulator tile, typically in `MemorySpace.ACC` |
+
+**Returns**: None.
+
+**Constraints**:
+- `lhs_scale` and `rhs_scale` follow the same A5 layout and `fractal_size=32` requirements as `pto.tile.matmul_mx`.
+- On A5, GEMV commonly uses a single logical row on the left-hand side and destination tile.
+- Prefer this dedicated GEMV surface instead of relying on `mad_mx(..., disable_gemv=False)` when you are staying in tile world.
+
+**Example** — compute one MX GEMV tile product:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.tile_mx_compute","symbol":"compute_ops_tile_mx_compute_probe","compile":{}} -->
+```python
+lhs_l0a_mx = pto.alloc_tile(
+    shape=[1, 64],
+    dtype=pto.f8e4m3,
+    memory_space=pto.MemorySpace.LEFT,
+    valid_shape=[1, 64],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_scale = pto.alloc_tile(
+    shape=[1, 2],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[1, 2],
+    blayout="RowMajor",
+    slayout="RowMajor",
+    fractal_size=32,
+)
+rhs_l0b_mx = pto.alloc_tile(
+    shape=[64, 16],
+    dtype=pto.f8e5m2,
+    memory_space=pto.MemorySpace.RIGHT,
+    valid_shape=[64, 16],
+    blayout="RowMajor",
+    slayout="ColMajor",
+)
+rhs_scale = pto.alloc_tile(
+    shape=[2, 16],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[2, 16],
+    blayout="ColMajor",
+    slayout="ColMajor",
+    fractal_size=32,
+)
+acc_l0c = pto.alloc_tile(
+    shape=[1, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[1, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+pto.tile.gemv_mx(lhs_l0a_mx, lhs_scale, rhs_l0b_mx, rhs_scale, acc_l0c)
+```
+
+---
+
+#### `pto.tile.gemv_mx_acc(acc_in: Tile, lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, dst: Tile) -> None`
+
+**Description**: Accumulating tile-level MX GEMV. Adds the product `lhs @ rhs` to `acc_in` and writes the accumulated result into `dst`.
+
+Conceptually:
+
+```text
+dst[m, n] = acc_in[m, n] + sum_k lhs[m, k] * rhs[k, n]
+```
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `acc_in` | `Tile` | Existing accumulator tile used as the accumulation input |
+| `lhs` | `Tile` | Left operand tile, typically in `MemorySpace.LEFT` |
+| `lhs_scale` | `Tile` | Left microscaling tile, typically in `MemorySpace.SCALING` |
+| `rhs` | `Tile` | Right operand tile, typically in `MemorySpace.RIGHT` |
+| `rhs_scale` | `Tile` | Right microscaling tile, typically in `MemorySpace.SCALING` |
+| `dst` | `Tile` | Destination accumulator tile |
+
+**Returns**: None.
+
+**Constraints**:
+- `lhs`, `rhs`, `lhs_scale`, `rhs_scale`, and `dst` must satisfy the same constraints as `pto.tile.gemv_mx`.
+- `acc_in` must be an ACC tile, typically with the same shape and dtype as `dst`.
+
+**Example** — accumulate a second MX GEMV K-slice into an ACC tile:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.tile_mx_compute","symbol":"compute_ops_tile_mx_compute_probe","compile":{}} -->
+```python
+acc_prev = pto.alloc_tile(
+    shape=[1, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[1, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_l0a_mx = pto.alloc_tile(
+    shape=[1, 64],
+    dtype=pto.f8e4m3,
+    memory_space=pto.MemorySpace.LEFT,
+    valid_shape=[1, 64],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_scale = pto.alloc_tile(
+    shape=[1, 2],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[1, 2],
+    blayout="RowMajor",
+    slayout="RowMajor",
+    fractal_size=32,
+)
+rhs_l0b_mx = pto.alloc_tile(
+    shape=[64, 16],
+    dtype=pto.f8e5m2,
+    memory_space=pto.MemorySpace.RIGHT,
+    valid_shape=[64, 16],
+    blayout="RowMajor",
+    slayout="ColMajor",
+)
+rhs_scale = pto.alloc_tile(
+    shape=[2, 16],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[2, 16],
+    blayout="ColMajor",
+    slayout="ColMajor",
+    fractal_size=32,
+)
+acc_next = pto.alloc_tile(
+    shape=[1, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[1, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+pto.tile.gemv_mx_acc(acc_prev, lhs_l0a_mx, lhs_scale, rhs_l0b_mx, rhs_scale, acc_next)
+```
+
+---
+
+#### `pto.tile.gemv_mx_bias(lhs: Tile, lhs_scale: Tile, rhs: Tile, rhs_scale: Tile, bias: Tile, dst: Tile) -> None`
+
+**Description**: Bias-enabled tile-level MX GEMV. Computes the MX product `lhs @ rhs`, adds the bias input carried by `bias`, and writes the result into `dst`.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `lhs` | `Tile` | Left operand tile, typically in `MemorySpace.LEFT` |
+| `lhs_scale` | `Tile` | Left microscaling tile, typically in `MemorySpace.SCALING` |
+| `rhs` | `Tile` | Right operand tile, typically in `MemorySpace.RIGHT` |
+| `rhs_scale` | `Tile` | Right microscaling tile, typically in `MemorySpace.SCALING` |
+| `bias` | `Tile` | Bias tile, typically in `MemorySpace.BIAS` |
+| `dst` | `Tile` | Destination accumulator tile |
+
+**Returns**: None.
+
+**Constraints**:
+- `lhs`, `rhs`, `lhs_scale`, `rhs_scale`, and `dst` must satisfy the same constraints as `pto.tile.gemv_mx`.
+- `bias` must satisfy the target architecture's cube bias layout and shape requirements. A common A5 case is a `[1, N]` tile in `MemorySpace.BIAS`.
+
+**Example** — add a bias tile on the MX GEMV path:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.tile_mx_compute","symbol":"compute_ops_tile_mx_compute_probe","compile":{}} -->
+```python
+lhs_l0a_mx = pto.alloc_tile(
+    shape=[1, 64],
+    dtype=pto.f8e4m3,
+    memory_space=pto.MemorySpace.LEFT,
+    valid_shape=[1, 64],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+lhs_scale = pto.alloc_tile(
+    shape=[1, 2],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[1, 2],
+    blayout="RowMajor",
+    slayout="RowMajor",
+    fractal_size=32,
+)
+rhs_l0b_mx = pto.alloc_tile(
+    shape=[64, 16],
+    dtype=pto.f8e5m2,
+    memory_space=pto.MemorySpace.RIGHT,
+    valid_shape=[64, 16],
+    blayout="RowMajor",
+    slayout="ColMajor",
+)
+rhs_scale = pto.alloc_tile(
+    shape=[2, 16],
+    dtype=pto.f16,
+    memory_space=pto.MemorySpace.SCALING,
+    valid_shape=[2, 16],
+    blayout="ColMajor",
+    slayout="ColMajor",
+    fractal_size=32,
+)
+bias_tile = pto.alloc_tile(
+    shape=[1, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.BIAS,
+    valid_shape=[1, 16],
+)
+acc_l0c = pto.alloc_tile(
+    shape=[1, 16],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.ACC,
+    valid_shape=[1, 16],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+pto.tile.gemv_mx_bias(lhs_l0a_mx, lhs_scale, rhs_l0b_mx, rhs_scale, bias_tile, acc_l0c)
+```
+
+---
+
 ### 8.1.14 Tile compute quick reference
 
 | Category | Operations |
@@ -763,7 +1249,8 @@ pto.tile.matmul_acc(acc_prev, lhs_l0a, rhs_l0b, acc_next)
 | Fill/padding | `tile.fillpad`, `tile.fillpad_expand`, `tile.fillpad_inplace` |
 | Windowing | `tile.extract`, `tile.insert` |
 | Tile movement | `tile.mov` |
-| Tile matmul | `tile.matmul`, `tile.matmul_acc` |
+| Tile matmul | `tile.matmul`, `tile.matmul_acc`, `tile.matmul_mx`, `tile.matmul_mx_acc`, `tile.matmul_mx_bias` |
+| Tile gemv | `tile.gemv_mx`, `tile.gemv_mx_acc`, `tile.gemv_mx_bias` |
 
 ---
 
@@ -1275,7 +1762,7 @@ The Cube unit performs matrix multiplication. Its operands are typed pointers in
 
 #### `pto.mad_mx(lhs: PtrType, rhs: PtrType, dst: PtrType, m: int, n: int, k: int, *, unit_flag: pto.MadUnitFlagMode | None = None, disable_gemv: bool = False, sat: pto.SatMode | None = None, n_dir: bool = False) -> None`
 
-**Description**: MX-format zero-initialized matrix multiply. This variant is intended for MX-enabled operand formats such as f8 payloads with their associated scale data already staged into cube-local buffers.
+**Description**: MX-format zero-initialized matrix multiply. This variant is intended for MX-enabled operand formats with their associated scale data already staged into cube-local buffers by `pto.mte_l1_l0a_mx` / `pto.mte_l1_l0b_mx`.
 
 ---
 
@@ -1290,6 +1777,12 @@ The Cube unit performs matrix multiplication. Its operands are typed pointers in
 **Description**: MX-format bias-initialized matrix multiply: `dst[M×N] = lhs[M×K] * rhs[K×N] + bias[M×N]`.
 
 MX variants intentionally do not expose `tf32_mode`; that clause is only valid for f32/f32/f32 non-MX `mad`, `mad_acc`, and `mad_bias`.
+
+**MX low-precision notes**:
+- MX cube paths are A5-only.
+- Supported MX operand pairs include mixed `f8e4m3`/`f8e5m2` and mixed `f4e1m2x2`/`f4e2m1x2` combinations.
+- `sat` is valid on the MX surfaces and lowers to the same `sat` / `nosat` clause family as non-MX `mad*`.
+- The scale payload is not passed directly to `mad_mx*`; it is carried by the staged L0A/L0B MX buffers and must satisfy the scale-tile layout requirements documented for `pto.tile.matmul_mx*`.
 
 ---
 

--- a/ptodsl/docs/user_guide/08-compute-operations.md
+++ b/ptodsl/docs/user_guide/08-compute-operations.md
@@ -352,7 +352,7 @@ Same pattern as row-expand arithmetic, but `src1` is a per-column coefficient ti
 
 #### `pto.tile.cvt(src: Tile, dst: Tile, *, rmode: RoundMode = RoundMode.NONE) -> None`
 
-**Description**: Element-wise type conversion. The destination tile's `dtype` determines the target type.
+**Description**: Element-wise type conversion. The destination tile's `dtype` determines the target type. Low-precision tile conversion follows the TileOps backend support, including `f32 -> f8e4m3/f8e5m2/hif8`, `f16 -> hif8`, and `bf16 -> f4e1m2x2/f4e2m1x2`.
 
 **Parameters**:
 
@@ -363,6 +363,15 @@ Same pattern as row-expand arithmetic, but `src1` is a per-column coefficient ti
 | `rmode` | `RoundMode` | Rounding mode: `NONE`, `RINT`, `ROUND`, `FLOOR`, `CEIL`, `TRUNC`, `ODD`, `CAST_RINT` |
 
 **Returns**: None.
+
+**Example**:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.tile_low_precision_cvt","symbol":"compute_ops_tile_low_precision_cvt_probe","compile":{}} -->
+```python
+src = pto.alloc_tile(shape=[128, 64], dtype=pto.f32)
+dst = pto.alloc_tile(shape=[128, 64], dtype=pto.f8e4m3)
+pto.tile.cvt(src, dst, rmode=pto.RoundMode.RINT)
+```
 
 ---
 
@@ -1132,6 +1141,12 @@ These ops change the element type or layout of vector registers. They are distin
 
 **Constraints**:
 - Source and result dtype pair must be a legal hardware conversion. Illegal pairs (e.g., unsupported narrowing/widening combinations) are rejected at frontend time.
+- `f32 -> f8e4m3/f8e5m2` requires `rnd=R`, `sat`, and `part=P0/P1/P2/P3`.
+- `f32 -> hif8` requires `rnd=A/H`, `sat`, and `part=P0/P1/P2/P3`.
+- `f16/bf16 -> f8e4m3/f8e5m2` requires `rnd=R/A/F/Z/C`, `sat`, and `part=EVEN/ODD`.
+- `f16 -> hif8` requires `rnd=A/H`, `sat`, and `part=EVEN/ODD`.
+- `bf16 -> f4e1m2x2/f4e2m1x2` requires `rnd=R/A/F/Z/C` and `part=P0/P1/P2/P3`; it does not take `sat`.
+- `f8e4m3/f8e5m2/hif8 -> f32` and `f4e1m2x2/f4e2m1x2 -> bf16` require `part=P0/P1/P2/P3`; they do not take `rnd` or `sat`.
 
 **Example**:
 
@@ -1145,6 +1160,21 @@ vec_f16 = pto.vcvt(
     sat=pto.VcvtSatMode.SAT,
     part=pto.VcvtPartMode.EVEN,
 )
+```
+
+Low-precision packed conversion:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.vector_compute","symbol":"compute_ops_vector_probe","compile":{"BLOCK":128}} -->
+```python
+vec_f8 = pto.vcvt(
+    vec_f32,
+    pto.f8e4m3,
+    mask32_full,
+    rnd=pto.VcvtRoundMode.R,
+    sat=pto.VcvtSatMode.NOSAT,
+    part=pto.VcvtPartMode.P0,
+)
+vec_f32_roundtrip = pto.vcvt(vec_f8, pto.f32, pto.pset_b8(pto.MaskPattern.ALL), part=pto.VcvtPartMode.P0)
 ```
 
 ---

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -2478,6 +2478,86 @@ def tmatmul_acc(acc_in, lhs, rhs, dst):
     )
 
 
+def tmatmul_mx(lhs, lhs_scale, rhs, rhs_scale, dst, *, acc_phase=None):
+    """``pto.tmatmul.mx ins(lhs, lhs_scale, rhs, rhs_scale) outs(dst)``."""
+    _pto.TMatmulMxOp(
+        None,
+        unwrap_surface_value(lhs),
+        unwrap_surface_value(lhs_scale),
+        unwrap_surface_value(rhs),
+        unwrap_surface_value(rhs_scale),
+        unwrap_surface_value(dst),
+        accPhase=acc_phase,
+    )
+
+
+def tmatmul_mx_acc(acc_in, lhs, lhs_scale, rhs, rhs_scale, dst, *, acc_phase=None):
+    """``pto.tmatmul.mx.acc ins(acc_in, lhs, lhs_scale, rhs, rhs_scale) outs(dst)``."""
+    _pto.TMatmulMxAccOp(
+        None,
+        unwrap_surface_value(acc_in),
+        unwrap_surface_value(lhs),
+        unwrap_surface_value(lhs_scale),
+        unwrap_surface_value(rhs),
+        unwrap_surface_value(rhs_scale),
+        unwrap_surface_value(dst),
+        accPhase=acc_phase,
+    )
+
+
+def tmatmul_mx_bias(lhs, lhs_scale, rhs, rhs_scale, bias, dst):
+    """``pto.tmatmul.mx.bias ins(lhs, lhs_scale, rhs, rhs_scale, bias) outs(dst)``."""
+    _pto.TMatmulMxBiasOp(
+        None,
+        unwrap_surface_value(lhs),
+        unwrap_surface_value(lhs_scale),
+        unwrap_surface_value(rhs),
+        unwrap_surface_value(rhs_scale),
+        unwrap_surface_value(bias),
+        unwrap_surface_value(dst),
+    )
+
+
+def tgemv_mx(lhs, lhs_scale, rhs, rhs_scale, dst, *, acc_phase=None):
+    """``pto.tgemv.mx ins(lhs, lhs_scale, rhs, rhs_scale) outs(dst)``."""
+    _pto.TGemvMxOp(
+        None,
+        unwrap_surface_value(lhs),
+        unwrap_surface_value(lhs_scale),
+        unwrap_surface_value(rhs),
+        unwrap_surface_value(rhs_scale),
+        unwrap_surface_value(dst),
+        accPhase=acc_phase,
+    )
+
+
+def tgemv_mx_acc(acc_in, lhs, lhs_scale, rhs, rhs_scale, dst, *, acc_phase=None):
+    """``pto.tgemv.mx.acc ins(acc_in, lhs, lhs_scale, rhs, rhs_scale) outs(dst)``."""
+    _pto.TGemvMxAccOp(
+        None,
+        unwrap_surface_value(acc_in),
+        unwrap_surface_value(lhs),
+        unwrap_surface_value(lhs_scale),
+        unwrap_surface_value(rhs),
+        unwrap_surface_value(rhs_scale),
+        unwrap_surface_value(dst),
+        accPhase=acc_phase,
+    )
+
+
+def tgemv_mx_bias(lhs, lhs_scale, rhs, rhs_scale, bias, dst):
+    """``pto.tgemv.mx.bias ins(lhs, lhs_scale, rhs, rhs_scale, bias) outs(dst)``."""
+    _pto.TGemvMxBiasOp(
+        None,
+        unwrap_surface_value(lhs),
+        unwrap_surface_value(lhs_scale),
+        unwrap_surface_value(rhs),
+        unwrap_surface_value(rhs_scale),
+        unwrap_surface_value(bias),
+        unwrap_surface_value(dst),
+    )
+
+
 def _coerce_tile_scalar_operand(tile, scalar, *, context: str):
     return _constant_like(scalar, infer_tile_element_type(wrap_surface_value(tile)))
 
@@ -5336,6 +5416,8 @@ __all__ = [
     "make_tensor_view", "partition_view",
     "alloc_tile",
     "tload", "tstore", "tmov", "tinsert",
+    "tmatmul", "tmatmul_acc", "tmatmul_mx", "tmatmul_mx_acc", "tmatmul_mx_bias",
+    "tgemv_mx", "tgemv_mx_acc", "tgemv_mx_bias",
     "tadd", "tsub", "tmul", "tdiv", "tmax", "tmin",
     "tadds", "tsubs", "tmuls", "tdivs", "tmaxs", "tmins",
     "texp", "tlog", "tsqrt", "trsqrt", "trecip", "tabs", "tneg",

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -1623,6 +1623,7 @@ def vbr(value):
 
 
 def _emit_unary_vec_op(op_ctor, inp, mask):
+    _reject_low_precision_vreg_operands(inp, context=f"pto.{_surface_name_for_op_ctor(op_ctor)}(...)")
     return wrap_surface_value(
         op_ctor(
             unwrap_surface_value(inp).type,
@@ -1633,6 +1634,11 @@ def _emit_unary_vec_op(op_ctor, inp, mask):
 
 
 def _emit_binary_vec_op(op_ctor, lhs, rhs, mask):
+    _reject_low_precision_vreg_operands(
+        lhs,
+        rhs,
+        context=f"pto.{_surface_name_for_op_ctor(op_ctor)}(...)",
+    )
     return wrap_surface_value(
         op_ctor(
             unwrap_surface_value(lhs).type,
@@ -1644,6 +1650,7 @@ def _emit_binary_vec_op(op_ctor, lhs, rhs, mask):
 
 
 def _emit_vec_scalar_masked_op(op_ctor, inp, scalar, mask, *, context: str):
+    _reject_low_precision_vreg_operands(inp, context=f"pto.{context}(...)")
     scalar_value = _coerce_scalar_like_vector_element(inp, scalar, context=context)
     return wrap_surface_value(
         op_ctor(
@@ -1657,6 +1664,7 @@ def _emit_vec_scalar_masked_op(op_ctor, inp, scalar, mask, *, context: str):
 
 def vadd(lhs, rhs, mask, result_type=None):
     """``pto.vadd`` – element-wise add."""
+    _reject_low_precision_vreg_operands(lhs, rhs, context="pto.vadd(...)")
     rt = result_type if result_type is not None else lhs.type
     return wrap_surface_value(
         _pto.VaddOp(
@@ -1826,6 +1834,7 @@ def vdup(input_value, mask, position=None):
     raw_input = unwrap_surface_value(input_value)
     try:
         _pto.VRegType(raw_input.type)
+        _reject_low_precision_vreg_operands(input_value, context="pto.vdup(vec, mask, position=...)")
         result_type = raw_input.type
         normalized_position = (
             _normalize_vdup_position_mode(position, context="vdup(vec, mask, position=...)")
@@ -1880,6 +1889,7 @@ def vnot(inp, mask):
 
 def vexpdif(inp, ref, mask, part: str = "ODD"):
     """``pto.vexpdif`` – ``exp(inp - ref)`` selecting ODD or EVEN lanes."""
+    _reject_low_precision_vreg_operands(inp, ref, context="pto.vexpdif(...)")
     return wrap_surface_value(
         _pto.VexpdifOp(
             unwrap_surface_value(inp).type,
@@ -1911,6 +1921,7 @@ def vrsqrt(inp, mask):
 
 def vcgmax(v, mask):
     """``pto.vcgmax`` – group maximum reduction, surfaced as the lowest-lane scalar."""
+    _reject_low_precision_vreg_operands(v, context="pto.vcgmax(...)")
     reduced = _pto.VcgmaxOp(
         unwrap_surface_value(v).type,
         unwrap_surface_value(v),
@@ -1921,6 +1932,7 @@ def vcgmax(v, mask):
 
 def vcgadd(v, mask):
     """``pto.vcgadd`` – group sum reduction, surfaced as the lowest-lane scalar."""
+    _reject_low_precision_vreg_operands(v, context="pto.vcgadd(...)")
     reduced = _pto.VcgaddOp(
         unwrap_surface_value(v).type,
         unwrap_surface_value(v),
@@ -1931,6 +1943,7 @@ def vcgadd(v, mask):
 
 def vcgmin(v, mask):
     """``pto.vcgmin`` – group minimum reduction, surfaced as the lowest-lane scalar."""
+    _reject_low_precision_vreg_operands(v, context="pto.vcgmin(...)")
     reduced = _pto.VcgminOp(
         unwrap_surface_value(v).type,
         unwrap_surface_value(v),
@@ -1995,6 +2008,7 @@ def vsubrelu(lhs, rhs, mask):
 
 def vaxpy(alpha, x, y, mask):
     """``pto.vaxpy`` – fused ``alpha * x + y``."""
+    _reject_low_precision_vreg_operands(x, y, context="pto.vaxpy(...)")
     alpha_value = _coerce_scalar_like_vector_element(x, alpha, context="vaxpy")
     return wrap_surface_value(
         _pto.VaxpyOp(
@@ -2009,6 +2023,7 @@ def vaxpy(alpha, x, y, mask):
 
 def vsel(true_v, false_v, mask):
     """``pto.vsel`` – element-wise select under a predicate mask."""
+    _reject_low_precision_vreg_operands(true_v, false_v, context="pto.vsel(...)")
     return wrap_surface_value(
         _pto.VselOp(
             unwrap_surface_value(true_v).type,
@@ -3481,6 +3496,41 @@ def _infer_vreg_metadata(vector_value):
         body = text[len("!pto.vreg<"):-1]
         lanes_text, elem_text = body.split("x", 1)
         return int(lanes_text), Type.parse(elem_text)
+
+
+def _surface_name_for_op_ctor(op_ctor) -> str:
+    name = getattr(op_ctor, "__name__", "")
+    if name.startswith("V") and name.endswith("Op"):
+        return name[1:-2].lower()
+    return name or "vector_op"
+
+
+def _is_low_precision_elem_type(elem_type) -> bool:
+    if Float8E4M3FNType.isinstance(elem_type) or Float8E5M2Type.isinstance(elem_type):
+        return True
+    return any(
+        _isinstance_pto_type(elem_type, name)
+        for name in ("HiF8Type", "F4E1M2x2Type", "F4E2M1x2Type")
+    )
+
+
+def _reject_low_precision_vreg(value, *, context: str) -> None:
+    raw_value = unwrap_surface_value(value)
+    try:
+        _, elem_type = _infer_vreg_metadata(raw_value)
+    except TypeError:
+        return
+    if _is_low_precision_elem_type(elem_type):
+        raise TypeError(
+            f"{context} does not support low-precision vreg elements yet; "
+            "low-precision vregs are currently only supported on explicit memory/conversion paths such as "
+            "vlds/vsts/vcvt/vmulscvt/vpack"
+        )
+
+
+def _reject_low_precision_vreg_operands(*values, context: str) -> None:
+    for value in values:
+        _reject_low_precision_vreg(value, context=context)
 
 
 def _extract_lowest_lane_scalar(vector_value, mask):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -406,7 +406,7 @@ def _normalize_vcvt_round_mode(mode, *, context: str):
         if "." in token:
             token = token.rsplit(".", 1)[-1]
     normalized = token.strip().upper()
-    allowed = {"R", "A", "F", "C", "Z", "O"}
+    allowed = {"R", "A", "F", "C", "Z", "O", "H"}
     if normalized not in allowed:
         expected = ", ".join(sorted(allowed))
         raise ValueError(f"{context} does not support rnd {mode!r}; expected one of {expected}")
@@ -441,6 +441,19 @@ def _normalize_vcvt_part_mode(mode, *, context: str):
     return normalized
 
 
+def _normalize_enum_attr(value, *, enum_cls, attr_cls, context: str):
+    if value is None or isinstance(value, Attribute):
+        return value
+    if isinstance(value, str):
+        token = value.strip().upper()
+        try:
+            value = getattr(enum_cls, token)
+        except AttributeError as exc:
+            allowed = ", ".join(name for name in dir(enum_cls) if name.isupper())
+            raise ValueError(f"{context} does not support {value!r}; expected one of {allowed}") from exc
+    return attr_cls.get(value)
+
+
 def _normalize_vpack_part(part, *, context: str):
     token = part
     if not isinstance(token, str):
@@ -456,6 +469,16 @@ def _normalize_vpack_part(part, *, context: str):
 
 
 def _classify_vcvt_elem_kind(elem_type):
+    if Float8E4M3FNType.isinstance(elem_type):
+        return "f8e4m3"
+    if Float8E5M2Type.isinstance(elem_type):
+        return "f8e5m2"
+    if _isinstance_pto_type(elem_type, "HiF8Type"):
+        return "hif8"
+    if _isinstance_pto_type(elem_type, "F4E1M2x2Type"):
+        return "f4e1m2x2"
+    if _isinstance_pto_type(elem_type, "F4E2M1x2Type"):
+        return "f4e2m1x2"
     if F16Type.isinstance(elem_type):
         return "f16"
     if BF16Type.isinstance(elem_type):
@@ -476,47 +499,151 @@ def _classify_vcvt_elem_kind(elem_type):
     return None
 
 
+def _vcvt_contract(requires_rnd, requires_sat, requires_part, *, part_family=None, allowed_rnd=None):
+    return {
+        "requires_rnd": requires_rnd,
+        "requires_sat": requires_sat,
+        "requires_part": requires_part,
+        "part_family": part_family,
+        "allowed_rnd": set(allowed_rnd) if allowed_rnd is not None else None,
+    }
+
+
 _VCVT_CONTRACTS = {
-    ("f32", "f16"): (True, True, True),
-    ("f32", "bf16"): (True, True, True),
-    ("f32", "s16"): (True, True, True),
-    ("f32", "s64"): (True, True, True),
-    ("f32", "s32"): (True, True, False),
-    ("f16", "f32"): (False, False, True),
-    ("f16", "s32"): (True, False, True),
-    ("f16", "s16"): (True, True, False),
-    ("f16", "s8"): (True, True, True),
-    ("f16", "u8"): (True, True, True),
-    ("bf16", "f16"): (True, True, False),
-    ("bf16", "f32"): (False, False, True),
-    ("bf16", "s32"): (True, True, True),
-    ("u8", "f16"): (False, False, True),
-    ("u8", "u16"): (False, False, True),
-    ("u8", "u32"): (False, False, True),
-    ("s8", "f16"): (False, False, True),
-    ("s8", "s16"): (False, False, True),
-    ("s8", "s32"): (False, False, True),
-    ("u16", "u8"): (False, True, True),
-    ("u16", "u32"): (False, False, True),
-    ("s16", "f16"): (True, False, False),
-    ("s16", "f32"): (False, False, True),
-    ("s16", "u32"): (False, False, True),
-    ("s16", "s32"): (False, False, True),
-    ("s16", "u8"): (False, True, True),
-    ("u32", "u8"): (False, True, True),
-    ("u32", "u16"): (False, True, True),
-    ("u32", "s16"): (False, True, True),
-    ("s32", "f32"): (True, False, False),
-    ("s32", "u8"): (False, True, True),
-    ("s32", "u16"): (False, True, True),
-    ("s32", "s16"): (False, True, True),
-    ("s32", "s64"): (False, False, True),
-    ("s64", "f32"): (True, False, True),
-    ("s64", "s32"): (False, True, True),
+    ("f32", "f8e4m3"): _vcvt_contract(True, True, True, part_family="packed4", allowed_rnd="R"),
+    ("f32", "f8e5m2"): _vcvt_contract(True, True, True, part_family="packed4", allowed_rnd="R"),
+    ("f32", "hif8"): _vcvt_contract(True, True, True, part_family="packed4", allowed_rnd="AH"),
+    ("f32", "f16"): _vcvt_contract(True, True, True),
+    ("f32", "bf16"): _vcvt_contract(True, True, True),
+    ("f32", "s16"): _vcvt_contract(True, True, True),
+    ("f32", "s64"): _vcvt_contract(True, True, True),
+    ("f32", "s32"): _vcvt_contract(True, True, False),
+    ("f16", "f8e4m3"): _vcvt_contract(True, True, True, allowed_rnd="RAFZC"),
+    ("f16", "f8e5m2"): _vcvt_contract(True, True, True, allowed_rnd="RAFZC"),
+    ("f16", "hif8"): _vcvt_contract(True, True, True, allowed_rnd="AH"),
+    ("f16", "f32"): _vcvt_contract(False, False, True),
+    ("f16", "s32"): _vcvt_contract(True, False, True),
+    ("f16", "s16"): _vcvt_contract(True, True, False),
+    ("f16", "s8"): _vcvt_contract(True, True, True),
+    ("f16", "u8"): _vcvt_contract(True, True, True),
+    ("bf16", "f8e4m3"): _vcvt_contract(True, True, True, allowed_rnd="RAFZC"),
+    ("bf16", "f8e5m2"): _vcvt_contract(True, True, True, allowed_rnd="RAFZC"),
+    ("bf16", "f4e1m2x2"): _vcvt_contract(True, False, True, part_family="packed4", allowed_rnd="RAFZC"),
+    ("bf16", "f4e2m1x2"): _vcvt_contract(True, False, True, part_family="packed4", allowed_rnd="RAFZC"),
+    ("bf16", "f16"): _vcvt_contract(True, True, False),
+    ("bf16", "f32"): _vcvt_contract(False, False, True),
+    ("bf16", "s32"): _vcvt_contract(True, True, True),
+    ("u8", "f16"): _vcvt_contract(False, False, True),
+    ("u8", "u16"): _vcvt_contract(False, False, True),
+    ("u8", "u32"): _vcvt_contract(False, False, True),
+    ("s8", "f16"): _vcvt_contract(False, False, True),
+    ("s8", "s16"): _vcvt_contract(False, False, True),
+    ("s8", "s32"): _vcvt_contract(False, False, True),
+    ("u16", "u8"): _vcvt_contract(False, True, True),
+    ("u16", "u32"): _vcvt_contract(False, False, True),
+    ("s16", "f16"): _vcvt_contract(True, False, False),
+    ("s16", "f32"): _vcvt_contract(False, False, True),
+    ("s16", "u32"): _vcvt_contract(False, False, True),
+    ("s16", "s32"): _vcvt_contract(False, False, True),
+    ("s16", "u8"): _vcvt_contract(False, True, True),
+    ("u32", "u8"): _vcvt_contract(False, True, True),
+    ("u32", "u16"): _vcvt_contract(False, True, True),
+    ("u32", "s16"): _vcvt_contract(False, True, True),
+    ("s32", "f32"): _vcvt_contract(True, False, False),
+    ("s32", "u8"): _vcvt_contract(False, True, True),
+    ("s32", "u16"): _vcvt_contract(False, True, True),
+    ("s32", "s16"): _vcvt_contract(False, True, True),
+    ("s32", "s64"): _vcvt_contract(False, False, True),
+    ("s64", "f32"): _vcvt_contract(True, False, True),
+    ("s64", "s32"): _vcvt_contract(False, True, True),
+    ("f8e4m3", "f32"): _vcvt_contract(False, False, True, part_family="packed4"),
+    ("f8e5m2", "f32"): _vcvt_contract(False, False, True, part_family="packed4"),
+    ("hif8", "f32"): _vcvt_contract(False, False, True, part_family="packed4"),
+    ("f4e1m2x2", "bf16"): _vcvt_contract(False, False, True, part_family="packed4"),
+    ("f4e2m1x2", "bf16"): _vcvt_contract(False, False, True, part_family="packed4"),
 }
 
 
-def _validate_vcvt_dtype_pair(src, result_dtype, *, context: str):
+_VCVT_ELEM_BITS = {
+    "f4e1m2x2": 8,
+    "f4e2m1x2": 8,
+    "f8e4m3": 8,
+    "f8e5m2": 8,
+    "hif8": 8,
+    "u8": 8,
+    "s8": 8,
+    "f16": 16,
+    "bf16": 16,
+    "u16": 16,
+    "s16": 16,
+    "f32": 32,
+    "u32": 32,
+    "s32": 32,
+    "s64": 64,
+}
+
+
+def _infer_vcvt_part_family(src_kind, result_kind):
+    src_bits = _VCVT_ELEM_BITS.get(src_kind)
+    result_bits = _VCVT_ELEM_BITS.get(result_kind)
+    if src_bits is None or result_bits is None:
+        return None
+    larger = max(src_bits, result_bits)
+    smaller = min(src_bits, result_bits)
+    if larger == smaller * 2:
+        return "even_odd"
+    if larger == smaller * 4:
+        return "packed4"
+    return None
+
+
+def _validate_vcvt_attrs(src_kind, result_kind, contract, *, rnd, sat, part, context: str):
+    if rnd is None:
+        if contract["requires_rnd"]:
+            raise ValueError(f"{context} requires rnd for dtype pair {src_kind} -> {result_kind}")
+    elif not contract["requires_rnd"]:
+        raise ValueError(f"{context} does not support rnd for dtype pair {src_kind} -> {result_kind}")
+
+    if sat is None:
+        if contract["requires_sat"]:
+            raise ValueError(f"{context} requires sat for dtype pair {src_kind} -> {result_kind}")
+    elif not contract["requires_sat"]:
+        raise ValueError(f"{context} does not support sat for dtype pair {src_kind} -> {result_kind}")
+
+    if part is None:
+        if contract["requires_part"]:
+            raise ValueError(f"{context} requires part for dtype pair {src_kind} -> {result_kind}")
+    elif not contract["requires_part"]:
+        raise ValueError(f"{context} does not support part for dtype pair {src_kind} -> {result_kind}")
+
+    allowed_rnd = contract["allowed_rnd"]
+    if rnd is not None and allowed_rnd is not None and rnd not in allowed_rnd:
+        expected = ", ".join(sorted(allowed_rnd))
+        raise ValueError(
+            f"{context} does not support rnd {rnd!r} for dtype pair "
+            f"{src_kind} -> {result_kind}; expected one of {expected}"
+        )
+
+    if part is None:
+        return
+    part_family = contract["part_family"] or _infer_vcvt_part_family(src_kind, result_kind)
+    if part_family == "even_odd":
+        if part not in {"EVEN", "ODD"}:
+            raise ValueError(
+                f"{context} part must be EVEN or ODD for dtype pair "
+                f"{src_kind} -> {result_kind}"
+            )
+    elif part_family == "packed4":
+        if part not in {"P0", "P1", "P2", "P3"}:
+            raise ValueError(
+                f"{context} part must be P0, P1, P2, or P3 for dtype pair "
+                f"{src_kind} -> {result_kind}"
+            )
+    elif part_family is None:
+        raise ValueError(f"{context} part is not supported for dtype pair {src_kind} -> {result_kind}")
+
+
+def _validate_vcvt_dtype_pair(src, result_dtype, *, rnd=None, sat=None, part=None, context: str):
     _, src_elem_type = _infer_vreg_metadata(src)
     resolved_result_dtype = _resolve(result_dtype)
     src_kind = _classify_vcvt_elem_kind(src_elem_type)
@@ -526,16 +653,25 @@ def _validate_vcvt_dtype_pair(src, result_dtype, *, context: str):
             f"{context} does not support source/result element types "
             f"{src_elem_type} -> {resolved_result_dtype}"
         )
-    if (src_kind, result_kind) not in _VCVT_CONTRACTS:
+    contract = _VCVT_CONTRACTS.get((src_kind, result_kind))
+    if contract is None:
         raise TypeError(
             f"{context} currently does not support the dtype pair "
             f"{src_kind} -> {result_kind}"
         )
+    _validate_vcvt_attrs(src_kind, result_kind, contract, rnd=rnd, sat=sat, part=part, context=context)
     return resolved_result_dtype
 
 
-def _infer_result_vreg_type_for_element_dtype(src, result_dtype, *, context: str):
-    resolved_type = _validate_vcvt_dtype_pair(src, result_dtype, context=context)
+def _infer_result_vreg_type_for_element_dtype(src, result_dtype, *, rnd=None, sat=None, part=None, context: str):
+    resolved_type = _validate_vcvt_dtype_pair(
+        src,
+        result_dtype,
+        rnd=rnd,
+        sat=sat,
+        part=part,
+        context=context,
+    )
     try:
         _pto.VRegType(resolved_type)
         return resolved_type
@@ -599,7 +735,14 @@ def vcvt(src, to_dtype, mask, *, rnd=None, sat=None, part=None):
         kwargs["part"] = _normalize_vcvt_part_mode(part, context="vcvt(..., part=...)")
     return wrap_surface_value(
         _pto.VcvtOp(
-            _infer_result_vreg_type_for_element_dtype(src, to_dtype, context="vcvt(src, to_dtype, mask)"),
+            _infer_result_vreg_type_for_element_dtype(
+                src,
+                to_dtype,
+                rnd=kwargs.get("rnd"),
+                sat=kwargs.get("sat"),
+                part=kwargs.get("part"),
+                context="vcvt(src, to_dtype, mask)",
+            ),
             unwrap_surface_value(src),
             unwrap_surface_value(mask),
             **kwargs,
@@ -2978,17 +3121,28 @@ def tsels(mask, src, scalar, dst, *, tmp=None):
 
 
 def tcvt(src, dst, *, tmp=None, rmode=None, sat_mode=None):
-    """``pto.tcvt ins(src) outs(dst)`` with optional legacy ``tmp`` validation."""
+    """``pto.tcvt ins(src) outs(dst)``.
+
+    The ``tmp`` parameter is retained for backward compatibility but is not
+    supported by the current PTO backend; passing a non-None value raises.
+    """
     if tmp is not None:
-        raise TypeError(
-            "ptodsl.tcvt(..., tmp=...) is no longer supported because "
-            "the canonical PTO tcvt op only accepts src/dst plus attributes"
-        )
+        raise TypeError("pto.tile.cvt(..., tmp=...) is not supported by the current PTO Python bindings")
     _pto.tcvt(
         unwrap_surface_value(src),
         unwrap_surface_value(dst),
-        rmode=rmode,
-        sat_mode=sat_mode,
+        rmode=_normalize_enum_attr(
+            rmode,
+            enum_cls=_pto.RoundMode,
+            attr_cls=_pto.RoundModeAttr,
+            context="tile.cvt(..., rmode=...)",
+        ),
+        sat_mode=_normalize_enum_attr(
+            sat_mode,
+            enum_cls=_pto.SaturationMode,
+            attr_cls=_pto.SaturationModeAttr,
+            context="tile.cvt(..., sat_mode=...)",
+        ),
     )
 
 

--- a/ptodsl/ptodsl/_surface_types.py
+++ b/ptodsl/ptodsl/_surface_types.py
@@ -242,6 +242,7 @@ class VcvtRoundMode:
     C = "C"
     Z = "Z"
     O = "O"
+    H = "H"
 
 
 class VcvtSatMode:
@@ -265,6 +266,7 @@ class VcvtPartMode:
 
 
 AlignType = _pto.AlignType
+RoundMode = _pto.RoundMode
 DivPrecision = _pto.DivPrecision
 ExpPrecision = _pto.ExpPrecision
 LogPrecision = _pto.LogPrecision
@@ -311,6 +313,7 @@ __all__ = [
     "VcvtSatMode",
     "VcvtPartMode",
     "AlignType",
+    "RoundMode",
     "DivPrecision",
     "ExpPrecision",
     "LogPrecision",

--- a/ptodsl/ptodsl/_tile_namespace.py
+++ b/ptodsl/ptodsl/_tile_namespace.py
@@ -58,6 +58,12 @@ class _TileNamespace:
     insert = staticmethod(_ops.tinsert)
     matmul = staticmethod(_ops.tmatmul)
     matmul_acc = staticmethod(_ops.tmatmul_acc)
+    matmul_mx = staticmethod(_ops.tmatmul_mx)
+    matmul_mx_acc = staticmethod(_ops.tmatmul_mx_acc)
+    matmul_mx_bias = staticmethod(_ops.tmatmul_mx_bias)
+    gemv_mx = staticmethod(_ops.tgemv_mx)
+    gemv_mx_acc = staticmethod(_ops.tgemv_mx_acc)
+    gemv_mx_bias = staticmethod(_ops.tgemv_mx_bias)
 
     @staticmethod
     def load(src, tile, *, offsets=None, sizes=None):

--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -90,7 +90,7 @@ class _PtrDescriptor(_DType):
         self._space = space
 
     def resolve(self) -> Type:
-        elem = _ensure_non_storage_only_dtype(self._elem, context="pto.ptr(...)")
+        elem = _ensure_tensor_storage_dtype(self._elem, context="pto.ptr(...)")
         space_enum = _normalize_address_space(self._space)
         if space_enum is None:
             raise ValueError(
@@ -122,7 +122,7 @@ class _VRegDescriptor(_DType):
         self._elem = elem
 
     def resolve(self) -> Type:
-        elem = _ensure_non_storage_only_dtype(self._elem, context="pto.vreg_type(...)")
+        elem = _ensure_tensor_storage_dtype(self._elem, context="pto.vreg_type(...)")
         vreg_type_cls = getattr(_pto, "VRegType", None)
         if vreg_type_cls is None:
             raise TypeError(

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -59,6 +59,7 @@ from ._surface_types import (   # noqa: F401
     VcvtSatMode,
     VcvtPartMode,
     AlignType,
+    RoundMode,
     DivPrecision,
     ExpPrecision,
     LogPrecision,

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -1224,6 +1224,13 @@ FRAGMENT_FIXTURES = {
             {SNIPPET_PLACEHOLDER}
         """
     ),
+    "compute_ops.tile_mx_compute": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def compute_ops_tile_mx_compute_probe():
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
     "mask_ops.creation": _fixture(
         f"""
         @pto.jit(target="a5")

--- a/ptodsl/tests/support/docs_fragment_fixtures.py
+++ b/ptodsl/tests/support/docs_fragment_fixtures.py
@@ -69,6 +69,8 @@ FRAGMENT_FIXTURES = {
             BLOCK: pto.const_expr = 128,
         ):
             {SNIPPET_PLACEHOLDER}
+            _ = lp_ptr
+            _ = lp_vreg_ty
         """
     ),
     "type_system.tensor_view": _fixture(
@@ -1073,6 +1075,17 @@ FRAGMENT_FIXTURES = {
             {SNIPPET_PLACEHOLDER}
         """
     ),
+    "data_movement.low_precision_vector_memory": _fixture(
+        f"""
+        @pto.jit(target="a5", mode="explicit")
+        def data_movement_low_precision_vector_memory_probe():
+            f8_src = pto.castptr(pto.ui64(0), pto.ptr(pto.f8e4m3, "ub"))
+            f8_dst = pto.castptr(pto.ui64(0), pto.ptr(pto.f8e4m3, "ub"))
+            fp4_src = pto.castptr(pto.ui64(0), pto.ptr(pto.f4e1m2x2, "ub"))
+            fp4_dst = pto.castptr(pto.ui64(0), pto.ptr(pto.f4e1m2x2, "ub"))
+            {SNIPPET_PLACEHOLDER}
+        """
+    ),
     "data_movement.tile_slice_2d": _fixture(
         f"""
         @pto.jit(target="a5")
@@ -1152,6 +1165,13 @@ FRAGMENT_FIXTURES = {
             out_tile = pto.alloc_tile(shape=[2, BLOCK], dtype=pto.f32)
             for row in range(0, 1, 1):
                 compute_ops_vector_helper(inp_tile, out_tile, row)
+        """
+    ),
+    "compute_ops.tile_low_precision_cvt": _fixture(
+        f"""
+        @pto.jit(target="a5")
+        def compute_ops_tile_low_precision_cvt_probe():
+            {SNIPPET_PLACEHOLDER}
         """
     ),
     "compute_ops.tile_window_matmul": _fixture(

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2484,6 +2484,42 @@ def low_precision_vcvt_surface_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def low_precision_vadd_invalid_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    f8_src = pto.castptr(zero_u64, pto.ptr(pto.f8e4m3, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    f8 = pto.vlds(f8_src, pto.const(0))
+    _ = pto.vadd(f8, f8, mask_b8)
+
+
+@pto.jit(target="a5", mode="explicit")
+def low_precision_vexp_invalid_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    f8_src = pto.castptr(zero_u64, pto.ptr(pto.f8e4m3, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    f8 = pto.vlds(f8_src, pto.const(0))
+    _ = pto.vexp(f8, mask_b8)
+
+
+@pto.jit(target="a5", mode="explicit")
+def low_precision_vmuls_invalid_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    hif8_src = pto.castptr(zero_u64, pto.ptr(pto.hif8, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    hif8 = pto.vlds(hif8_src, pto.const(0))
+    _ = pto.vmuls(hif8, 1.0, mask_b8)
+
+
+@pto.jit(target="a5", mode="explicit")
+def low_precision_vsel_invalid_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    f8_src = pto.castptr(zero_u64, pto.ptr(pto.f8e4m3, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    f8 = pto.vlds(f8_src, pto.const(0))
+    _ = pto.vsel(f8, f8, mask_b8)
+
+
+@pto.jit(target="a5", mode="explicit")
 def vdup_surface_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
     ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
@@ -2526,6 +2562,30 @@ def vcvt_surface_invalid_dtype_pair_probe():
     mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
     vec_f32 = pto.vlds(ub_f32, pto.const(0))
     _ = pto.vcvt(vec_f32, pto.ui16, mask32_full)
+
+
+@pto.jit(target="a5", mode="explicit")
+def vcvt_low_precision_invalid_dtype_pair_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    ub_f8 = pto.castptr(zero_u64, pto.ptr(pto.f8e4m3, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    vec_f8 = pto.vlds(ub_f8, pto.const(0))
+    _ = pto.vcvt(vec_f8, pto.bf16, mask_b8, part=pto.VcvtPartMode.P0)
+
+
+@pto.jit(target="a5", mode="explicit")
+def vcvt_low_precision_invalid_dtype_pair_probe_2():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
+    mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
+    vec_f32 = pto.vlds(ub_f32, pto.const(0))
+    _ = pto.vcvt(
+        vec_f32,
+        pto.f4e1m2x2,
+        mask32_full,
+        rnd=pto.VcvtRoundMode.R,
+        part=pto.VcvtPartMode.P0,
+    )
 
 
 @pto.jit(target="a5", mode="explicit")
@@ -4834,6 +4894,36 @@ def main() -> None:
         TypeError,
         lambda: vcvt_surface_invalid_dtype_pair_probe.compile(),
         "vcvt(src, to_dtype, mask) currently does not support the dtype pair f32 -> u16",
+    )
+    expect_raises(
+        TypeError,
+        lambda: low_precision_vadd_invalid_probe.compile(),
+        "does not support low-precision vreg elements yet",
+    )
+    expect_raises(
+        TypeError,
+        lambda: low_precision_vexp_invalid_probe.compile(),
+        "does not support low-precision vreg elements yet",
+    )
+    expect_raises(
+        TypeError,
+        lambda: low_precision_vmuls_invalid_probe.compile(),
+        "does not support low-precision vreg elements yet",
+    )
+    expect_raises(
+        TypeError,
+        lambda: low_precision_vsel_invalid_probe.compile(),
+        "does not support low-precision vreg elements yet",
+    )
+    expect_raises(
+        TypeError,
+        lambda: vcvt_low_precision_invalid_dtype_pair_probe.compile(),
+        "vcvt(src, to_dtype, mask) currently does not support the dtype pair f8e4m3 -> bf16",
+    )
+    expect_raises(
+        TypeError,
+        lambda: vcvt_low_precision_invalid_dtype_pair_probe_2.compile(),
+        "vcvt(src, to_dtype, mask) currently does not support the dtype pair f32 -> f4e1m2x2",
     )
     expect_raises(
         ValueError,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1669,6 +1669,8 @@ def public_cube_surface_probe(
     rhs_l0b_f32: pto.Tile,
     lhs_l0a_mx: pto.Tile,
     rhs_l0b_mx: pto.Tile,
+    lhs_scale_mx: pto.Tile,
+    rhs_scale_mx: pto.Tile,
     acc_tile: pto.Tile,
     bias_tile: pto.Tile,
     l1_out_tile: pto.Tile,
@@ -1744,7 +1746,29 @@ def public_cube_surface_probe(
     )
     pto.mte_l0c_ub(acc_tile.as_ptr(), out_tile.as_ptr(), m, n, n, n, 0)
     pto.mte_l0c_ub(acc_tile.as_ptr(), out_tile.as_ptr(), m, n, n, n, split=pto.SplitMode.M, layout="nz2nd")
-    pto.mte_l0c_ub(acc_tile.as_ptr(), out_tile.as_ptr(), m, n, n, n, 1, layout=("nz2nz", 1), sat=pto.SatMode.PRESERVE_NAN)
+
+
+@pto.cube
+def public_cube_tile_mx_probe(
+    mat_lhs: pto.Tile,
+    mat_lhs_scale: pto.Tile,
+    mat_rhs: pto.Tile,
+    mat_rhs_scale: pto.Tile,
+    mat_acc: pto.Tile,
+    mat_bias: pto.Tile,
+    gemv_lhs: pto.Tile,
+    gemv_lhs_scale: pto.Tile,
+    gemv_rhs: pto.Tile,
+    gemv_rhs_scale: pto.Tile,
+    gemv_acc: pto.Tile,
+    gemv_bias: pto.Tile,
+):
+    pto.tile.matmul_mx(mat_lhs, mat_lhs_scale, mat_rhs, mat_rhs_scale, mat_acc)
+    pto.tile.matmul_mx_acc(mat_acc, mat_lhs, mat_lhs_scale, mat_rhs, mat_rhs_scale, mat_acc)
+    pto.tile.matmul_mx_bias(mat_lhs, mat_lhs_scale, mat_rhs, mat_rhs_scale, mat_bias, mat_acc)
+    pto.tile.gemv_mx(gemv_lhs, gemv_lhs_scale, gemv_rhs, gemv_rhs_scale, gemv_acc)
+    pto.tile.gemv_mx_acc(gemv_acc, gemv_lhs, gemv_lhs_scale, gemv_rhs, gemv_rhs_scale, gemv_acc)
+    pto.tile.gemv_mx_bias(gemv_lhs, gemv_lhs_scale, gemv_rhs, gemv_rhs_scale, gemv_bias, gemv_acc)
 
 
 @pto.jit(target="a5", mode="explicit")
@@ -1824,18 +1848,138 @@ def public_surface_exports_probe(
         dtype=pto.f8e4m3,
         memory_space=pto.MemorySpace.LEFT,
         valid_shape=[16, 16],
+        blayout="ColMajor",
+        slayout="RowMajor",
     )
     rhs_l0b_mx = pto.alloc_tile(
-        shape=[16, 32],
+        shape=[32, 16],
         dtype=pto.f8e4m3,
         memory_space=pto.MemorySpace.RIGHT,
         valid_shape=[16, 16],
+        blayout="RowMajor",
+        slayout="ColMajor",
+    )
+    lhs_scale_mx = pto.alloc_tile(
+        shape=[16, 2],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        valid_shape=[16, 2],
+        blayout="RowMajor",
+        slayout="RowMajor",
+        fractal_size=32,
+    )
+    rhs_scale_mx = pto.alloc_tile(
+        shape=[2, 16],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        valid_shape=[2, 16],
+        blayout="ColMajor",
+        slayout="ColMajor",
+        fractal_size=32,
     )
     acc_tile = pto.alloc_tile(
         shape=[16, 16],
         dtype=pto.f32,
         memory_space=pto.MemorySpace.ACC,
         valid_shape=[16, 16],
+        blayout="ColMajor",
+        slayout="RowMajor",
+    )
+    mat_lhs_tile_mx = pto.alloc_tile(
+        shape=[16, 64],
+        dtype=pto.f8e4m3,
+        memory_space=pto.MemorySpace.LEFT,
+        valid_shape=[16, 64],
+        blayout="ColMajor",
+        slayout="RowMajor",
+    )
+    mat_rhs_tile_mx = pto.alloc_tile(
+        shape=[64, 16],
+        dtype=pto.f8e4m3,
+        memory_space=pto.MemorySpace.RIGHT,
+        valid_shape=[64, 16],
+        blayout="RowMajor",
+        slayout="ColMajor",
+    )
+    mat_lhs_scale_tile_mx = pto.alloc_tile(
+        shape=[16, 2],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        valid_shape=[16, 2],
+        blayout="RowMajor",
+        slayout="RowMajor",
+        fractal_size=32,
+    )
+    mat_rhs_scale_tile_mx = pto.alloc_tile(
+        shape=[2, 16],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        valid_shape=[2, 16],
+        blayout="ColMajor",
+        slayout="ColMajor",
+        fractal_size=32,
+    )
+    mat_acc_tile_mx = pto.alloc_tile(
+        shape=[16, 16],
+        dtype=pto.f32,
+        memory_space=pto.MemorySpace.ACC,
+        valid_shape=[16, 16],
+        blayout="ColMajor",
+        slayout="RowMajor",
+    )
+    mat_bias_tile_mx = pto.alloc_tile(
+        shape=[1, 16],
+        dtype=pto.f32,
+        memory_space=pto.MemorySpace.BIAS,
+        valid_shape=[1, 16],
+    )
+    gemv_lhs_tile_mx = pto.alloc_tile(
+        shape=[1, 64],
+        dtype=pto.f8e4m3,
+        memory_space=pto.MemorySpace.LEFT,
+        valid_shape=[1, 64],
+        blayout="ColMajor",
+        slayout="RowMajor",
+    )
+    gemv_rhs_tile_mx = pto.alloc_tile(
+        shape=[64, 16],
+        dtype=pto.f8e4m3,
+        memory_space=pto.MemorySpace.RIGHT,
+        valid_shape=[64, 16],
+        blayout="RowMajor",
+        slayout="ColMajor",
+    )
+    gemv_lhs_scale_tile_mx = pto.alloc_tile(
+        shape=[1, 2],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        valid_shape=[1, 2],
+        blayout="RowMajor",
+        slayout="RowMajor",
+        fractal_size=32,
+    )
+    gemv_rhs_scale_tile_mx = pto.alloc_tile(
+        shape=[2, 16],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        valid_shape=[2, 16],
+        blayout="ColMajor",
+        slayout="ColMajor",
+        fractal_size=32,
+    )
+    gemv_acc_tile_mx = pto.alloc_tile(
+        shape=[1, 16],
+        dtype=pto.f32,
+        memory_space=pto.MemorySpace.ACC,
+        valid_shape=[1, 16],
+        blayout="ColMajor",
+        slayout="RowMajor",
+    )
+    gemv_bias_tile_mx = pto.alloc_tile(
+        shape=[1, 16],
+        dtype=pto.f32,
+        memory_space=pto.MemorySpace.BIAS,
+        valid_shape=[1, 16],
     )
     bias_tile = pto.alloc_tile(
         shape=[16, 16],
@@ -1861,6 +2005,8 @@ def public_surface_exports_probe(
         rhs_l0b_f32,
         lhs_l0a_mx,
         rhs_l0b_mx,
+        lhs_scale_mx,
+        rhs_scale_mx,
         acc_tile,
         bias_tile,
         l1_out,
@@ -1879,6 +2025,20 @@ def public_surface_exports_probe(
         loop3=(1, pto.const(16), pto.const(16)),
         sat=pto.SatMode.OFF,
         atomic=("f32", "add"),
+    )
+    public_cube_tile_mx_probe(
+        mat_lhs_tile_mx,
+        mat_lhs_scale_tile_mx,
+        mat_rhs_tile_mx,
+        mat_rhs_scale_tile_mx,
+        mat_acc_tile_mx,
+        mat_bias_tile_mx,
+        gemv_lhs_tile_mx,
+        gemv_lhs_scale_tile_mx,
+        gemv_rhs_tile_mx,
+        gemv_rhs_scale_tile_mx,
+        gemv_acc_tile_mx,
+        gemv_bias_tile_mx,
     )
 
 
@@ -2612,6 +2772,12 @@ def main() -> None:
     expect(not hasattr(pto, "store_tile"), "pto.store_tile should not remain on the public pto namespace")
     expect(hasattr(pto.tile, "matmul"), "pto.tile.matmul should be exported from the public tile namespace")
     expect(hasattr(pto.tile, "matmul_acc"), "pto.tile.matmul_acc should be exported from the public tile namespace")
+    expect(hasattr(pto.tile, "matmul_mx"), "pto.tile.matmul_mx should be exported from the public tile namespace")
+    expect(hasattr(pto.tile, "matmul_mx_acc"), "pto.tile.matmul_mx_acc should be exported from the public tile namespace")
+    expect(hasattr(pto.tile, "matmul_mx_bias"), "pto.tile.matmul_mx_bias should be exported from the public tile namespace")
+    expect(hasattr(pto.tile, "gemv_mx"), "pto.tile.gemv_mx should be exported from the public tile namespace")
+    expect(hasattr(pto.tile, "gemv_mx_acc"), "pto.tile.gemv_mx_acc should be exported from the public tile namespace")
+    expect(hasattr(pto.tile, "gemv_mx_bias"), "pto.tile.gemv_mx_bias should be exported from the public tile namespace")
     expect(not hasattr(pto, "tload"), "legacy pto.tload should not remain on the public pto namespace")
     expect(not hasattr(pto, "tstore"), "legacy pto.tstore should not remain on the public pto namespace")
     expect(not hasattr(pto, "tadd"), "legacy pto.tadd should not remain on the public pto namespace")
@@ -4625,6 +4791,12 @@ def main() -> None:
     expect("pto.mte_l1_l0b" in public_surface_text, "mte_l1_l0b(...) should lower to pto.mte_l1_l0b")
     expect("pto.mte_l1_l0a_mx" in public_surface_text, "mte_l1_l0a_mx(...) should lower to pto.mte_l1_l0a_mx")
     expect("pto.mte_l1_l0b_mx" in public_surface_text, "mte_l1_l0b_mx(...) should lower to pto.mte_l1_l0b_mx")
+    expect("pto.tmatmul.mx" in public_surface_text, "pto.tile.matmul_mx should lower to pto.tmatmul.mx")
+    expect("pto.tmatmul.mx.acc" in public_surface_text, "pto.tile.matmul_mx_acc should lower to pto.tmatmul.mx.acc")
+    expect("pto.tmatmul.mx.bias" in public_surface_text, "pto.tile.matmul_mx_bias should lower to pto.tmatmul.mx.bias")
+    expect("pto.tgemv.mx" in public_surface_text, "pto.tile.gemv_mx should lower to pto.tgemv.mx")
+    expect("pto.tgemv.mx.acc" in public_surface_text, "pto.tile.gemv_mx_acc should lower to pto.tgemv.mx.acc")
+    expect("pto.tgemv.mx.bias" in public_surface_text, "pto.tile.gemv_mx_bias should lower to pto.tgemv.mx.bias")
     expect("pto.mte_l0c_l1" in public_surface_text, "mte_l0c_l1(...) should lower to pto.mte_l0c_l1")
     expect("pto.mte_l0c_gm" in public_surface_text, "mte_l0c_gm(...) should lower to pto.mte_l0c_gm")
     expect(public_surface_text.count("pto.mte_l0c_ub") >= 2, "mte_l0c_ub(...) should lower sub-block and split modes")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2271,6 +2271,59 @@ def public_vector_conversion_surface_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def low_precision_vector_memory_surface_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    f8_src = pto.castptr(zero_u64, pto.ptr(pto.f8e4m3, "ub"))
+    f8_dst = pto.castptr(zero_u64, pto.ptr(pto.f8e4m3, "ub"))
+    hif8_src = pto.castptr(zero_u64, pto.ptr(pto.hif8, "ub"))
+    hif8_dst = pto.castptr(zero_u64, pto.ptr(pto.hif8, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    f8 = pto.vlds(f8_src, pto.const(0))
+    hif8 = pto.vlds(hif8_src, pto.const(0))
+    pto.vsts(f8, f8_dst, pto.const(0), mask_b8)
+    pto.vsts(hif8, hif8_dst, pto.const(0), mask_b8)
+
+
+@pto.jit(target="a5", mode="explicit")
+def low_precision_vcvt_surface_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
+    ub_bf16 = pto.castptr(zero_u64, pto.ptr(pto.bf16, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    mask_b16 = pto.pset_b16(pto.MaskPattern.ALL)
+    mask_b32 = pto.pset_b32(pto.MaskPattern.ALL)
+    vec_f32 = pto.vlds(ub_f32, pto.const(0))
+    vec_bf16 = pto.vlds(ub_bf16, pto.const(0))
+
+    f8e4 = pto.vcvt(
+        vec_f32,
+        pto.f8e4m3,
+        mask_b32,
+        rnd=pto.VcvtRoundMode.R,
+        sat=pto.VcvtSatMode.NOSAT,
+        part=pto.VcvtPartMode.P0,
+    )
+    _ = pto.vcvt(f8e4, pto.f32, mask_b8, part=pto.VcvtPartMode.P0)
+    hif8 = pto.vcvt(
+        vec_f32,
+        pto.hif8,
+        mask_b32,
+        rnd=pto.VcvtRoundMode.H,
+        sat=pto.VcvtSatMode.NOSAT,
+        part=pto.VcvtPartMode.P0,
+    )
+    _ = pto.vcvt(hif8, pto.f32, mask_b8, part=pto.VcvtPartMode.P0)
+    f4e1 = pto.vcvt(
+        vec_bf16,
+        pto.f4e1m2x2,
+        mask_b16,
+        rnd=pto.VcvtRoundMode.R,
+        part=pto.VcvtPartMode.P0,
+    )
+    _ = pto.vcvt(f4e1, pto.bf16, mask_b8, part=pto.VcvtPartMode.P0)
+
+
+@pto.jit(target="a5", mode="explicit")
 def vdup_surface_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
     ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
@@ -2313,6 +2366,31 @@ def vcvt_surface_invalid_dtype_pair_probe():
     mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
     vec_f32 = pto.vlds(ub_f32, pto.const(0))
     _ = pto.vcvt(vec_f32, pto.ui16, mask32_full)
+
+
+@pto.jit(target="a5", mode="explicit")
+def vcvt_low_precision_invalid_part_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
+    mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
+    vec_f32 = pto.vlds(ub_f32, pto.const(0))
+    _ = pto.vcvt(
+        vec_f32,
+        pto.f8e4m3,
+        mask32_full,
+        rnd=pto.VcvtRoundMode.R,
+        sat=pto.VcvtSatMode.NOSAT,
+        part=pto.VcvtPartMode.EVEN,
+    )
+
+
+@pto.jit(target="a5", mode="explicit")
+def vcvt_low_precision_missing_attr_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
+    mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
+    vec_f32 = pto.vlds(ub_f32, pto.const(0))
+    _ = pto.vcvt(vec_f32, pto.f8e4m3, mask32_full, rnd=pto.VcvtRoundMode.R)
 
 
 @pto.jit(target="a5", mode="explicit")
@@ -2431,6 +2509,7 @@ def main() -> None:
         "VcvtRoundMode",
         "VcvtSatMode",
         "VcvtPartMode",
+        "RoundMode",
         "AlignType",
         "init_align",
         "plt_b8",
@@ -2728,15 +2807,13 @@ def main() -> None:
             "internal partition tensor-view type helper should preserve low-precision element types",
         )
 
-        expect_raises(
-            TypeError,
-            lambda: pto.ptr(pto.hif8).resolve(),
-            "Tile / TensorView / PartitionTensorView construction",
+        expect(
+            "!pto.ptr<!pto.hif8, ub>" == str(pto.ptr(pto.hif8).resolve()),
+            "low-precision pointer types should be valid for device storage",
         )
-        expect_raises(
-            TypeError,
-            lambda: pto.vreg_type(64, pto.f8e4m3).resolve(),
-            "Tile / TensorView / PartitionTensorView construction",
+        expect(
+            str(pto.vreg_type(256, pto.f8e4m3).resolve()) == "!pto.vreg<256xf8E4M3FN>",
+            "low-precision vreg types should be valid for vector micro-ops",
         )
         expect_raises(
             TypeError,
@@ -4413,6 +4490,10 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(data_movement_surface_text, "public data movement surface specialization")
     vector_conversion_surface_text = public_vector_conversion_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(vector_conversion_surface_text, "public vector conversion surface specialization")
+    low_precision_memory_surface_text = low_precision_vector_memory_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(low_precision_memory_surface_text, "low-precision vector memory surface specialization")
+    low_precision_vcvt_surface_text = low_precision_vcvt_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(low_precision_vcvt_surface_text, "low-precision vcvt surface specialization")
     vdup_surface_text = vdup_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(vdup_surface_text, "public vdup surface specialization")
     vmulscvt_surface_text = vmulscvt_surface_probe.compile().mlir_text()
@@ -4523,6 +4604,14 @@ def main() -> None:
     expect('dist = "PK_B32"' in vector_conversion_surface_text, "vsts(..., dist=VStoreDist.PK_B32) should preserve the authored store distribution")
     expect("pto.vpack" in vector_conversion_surface_text, "vpack(...) should lower to pto.vpack")
     expect("!pto.vreg<128xui16>" in vector_conversion_surface_text, "vpack(i32/u32 -> u16) should infer the unsigned packed result type")
+    expect("!pto.vreg<256xf8E4M3FN>" in low_precision_memory_surface_text, "vlds/vsts should support f8e4m3 vreg storage")
+    expect("!pto.vreg<256x!pto.hif8>" in low_precision_memory_surface_text, "vlds/vsts should support hif8 vreg storage")
+    expect("!pto.ptr<f8E4M3FN, ub>" in low_precision_memory_surface_text, "low-precision f8 pointers should lower as UB pointers")
+    expect("!pto.vreg<256xf8E4M3FN>" in low_precision_vcvt_surface_text, "vcvt(f32 -> f8e4m3) should infer the packed low-precision result type")
+    expect("!pto.vreg<256x!pto.hif8>" in low_precision_vcvt_surface_text, "vcvt(f32 -> hif8) should infer the packed HiF8 result type")
+    expect("!pto.vreg<256x!pto.f4E1M2x2>" in low_precision_vcvt_surface_text, "vcvt(bf16 -> f4e1m2x2) should infer the packed 4-bit result type")
+    expect('rnd = "H"' in low_precision_vcvt_surface_text, "vcvt(..., rnd=VcvtRoundMode.H) should preserve the H rounding token")
+    expect(low_precision_vcvt_surface_text.count('part = "P0"') >= 6, "low-precision packed vcvt forms should preserve P0 part selectors")
     expect(vdup_surface_text.count("pto.vdup") == 3, "vdup(...) should lower once per authored scalar/vector duplication")
     expect("f32, !pto.mask<b32> -> !pto.vreg<64xf32>" in vdup_surface_text, "vdup(scalar_f32, mask_b32) should infer an f32 vector result type")
     expect(vdup_surface_text.count('position = "LOWEST"') >= 1, "vdup(vec, mask) should default position to LOWEST")
@@ -4573,6 +4662,16 @@ def main() -> None:
         TypeError,
         lambda: vcvt_surface_invalid_dtype_pair_probe.compile(),
         "vcvt(src, to_dtype, mask) currently does not support the dtype pair f32 -> u16",
+    )
+    expect_raises(
+        ValueError,
+        lambda: vcvt_low_precision_invalid_part_probe.compile(),
+        "part must be P0, P1, P2, or P3",
+    )
+    expect_raises(
+        ValueError,
+        lambda: vcvt_low_precision_missing_attr_probe.compile(),
+        "requires sat for dtype pair f32 -> f8e4m3",
     )
     expect_raises(
         TypeError,

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -173,6 +173,37 @@ def run_ptoas_frontend_verify_whole(ptoas_bin: Path, mlir_text: str, label: str)
     expect(result.stdout.strip(), f"{label} should emit non-empty PTO IR after PTOAS frontend passes")
     return result.stdout
 
+
+def run_ptoas_frontend_expect_failure(
+    ptoas_bin: Path,
+    mlir_text: str,
+    label: str,
+    expected_stderr_substring: str,
+) -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".mlir", delete=False, encoding="utf-8") as handle:
+        handle.write(mlir_text)
+        input_path = Path(handle.name)
+
+    try:
+        result = subprocess.run(
+            [str(ptoas_bin), str(input_path), "--emit-pto-ir", "-o", "-"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        input_path.unlink(missing_ok=True)
+
+    expect(
+        result.returncode != 0,
+        f"{label} should fail PTOAS frontend verification.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+    expect(
+        expected_stderr_substring in result.stderr,
+        f"{label} should report {expected_stderr_substring!r}.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+    return result.stderr
+
 @pto.jit(target="a5")
 def host_vec_copy(
     A_ptr: pto.ptr(pto.f32, "gm"),
@@ -538,6 +569,27 @@ def main() -> None:
     expect(
         "f8E4M3FN" in lowp_frontend_text,
         "low_precision_vcvt_frontend output should preserve f8e4m3 type information",
+    )
+
+    invalid_lowp_vcvt_mlir = """
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @invalid_low_precision_vcvt(%src: !pto.vreg<256xf8E4M3FN>, %mask: !pto.mask<b8>) {
+    pto.vecscope {
+      %0 = pto.vcvt %src, %mask {part = "P0"} : !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<128xbf16>
+    }
+    return
+  }
+}
+""".strip()
+    invalid_lowp_stderr = run_ptoas_frontend_expect_failure(
+        ptoas_bin,
+        invalid_lowp_vcvt_mlir,
+        "invalid low-precision vcvt artifact",
+        "unsupported vcvt source/result element type pair",
+    )
+    expect(
+        "'pto.vcvt' op unsupported vcvt source/result element type pair" in invalid_lowp_stderr,
+        "invalid low-precision vcvt artifact should fail specifically on vcvt pair verification",
     )
     print("ptodsl_ptoas_frontend_verify: PASS")
 

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -264,6 +264,26 @@ module attributes {pto.backend = "emitc", pto.target_arch = "a5"} {
 """
 
 
+@pto.jit(target="a5", mode="explicit")
+def low_precision_vcvt_frontend():
+    zero = pto.const(0, dtype=pto.ui64)
+    src_ptr = pto.castptr(zero, pto.ptr(pto.f32, "ub"))
+    dst_ptr = pto.castptr(zero, pto.ptr(pto.f32, "ub"))
+    mask_b8 = pto.pset_b8(pto.MaskPattern.ALL)
+    mask_b32 = pto.pset_b32(pto.MaskPattern.ALL)
+    vec_f32 = pto.vlds(src_ptr, pto.const(0))
+    vec_f8 = pto.vcvt(
+        vec_f32,
+        pto.f8e4m3,
+        mask_b32,
+        rnd=pto.VcvtRoundMode.R,
+        sat=pto.VcvtSatMode.NOSAT,
+        part=pto.VcvtPartMode.P0,
+    )
+    roundtrip = pto.vcvt(vec_f8, pto.f32, mask_b8, part=pto.VcvtPartMode.P0)
+    pto.vsts(roundtrip, dst_ptr, pto.const(0), mask_b32)
+
+
 def main() -> None:
     ptoas_bin = resolve_ptoas_binary()
     mixed_backend_example = REPO_ROOT / "ptodsl" / "examples" / "mixed_backend_kernel_module.py"
@@ -498,6 +518,26 @@ def main() -> None:
         and cv_split_frontend_text.count("pto.tpush_to_aic") >= 2
         and "pto.tpop_from_aic" in cv_split_frontend_text,
         "cv-split frontend verification should keep the vector helper pipe init, push, and receive paths intact",
+    )
+
+    lowp_text = low_precision_vcvt_frontend.compile().mlir_text()
+    lowp_frontend_texts = run_ptoas_frontend_verify(
+        ptoas_bin,
+        lowp_text,
+        "low_precision_vcvt_frontend PTODSL artifact",
+    )
+    expect(
+        len(lowp_frontend_texts) == 1,
+        "low_precision_vcvt_frontend PTODSL artifact should lower to exactly one backend child module",
+    )
+    lowp_frontend_text = lowp_frontend_texts[0]
+    expect(
+        "pto.vcvt" in lowp_frontend_text,
+        "low_precision_vcvt_frontend output should preserve vcvt ops after frontend verification",
+    )
+    expect(
+        "f8E4M3FN" in lowp_frontend_text,
+        "low_precision_vcvt_frontend output should preserve f8e4m3 type information",
     )
     print("ptodsl_ptoas_frontend_verify: PASS")
 

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -552,6 +552,14 @@ def main() -> None:
     )
 
     lowp_text = low_precision_vcvt_frontend.compile().mlir_text()
+    expect(
+        "pto.vcvt" in lowp_text,
+        "low_precision_vcvt_frontend source MLIR should include vcvt ops before frontend verification",
+    )
+    expect(
+        "f8E4M3FN" in lowp_text,
+        "low_precision_vcvt_frontend source MLIR should preserve f8e4m3 type information before frontend verification",
+    )
     lowp_frontend_texts = run_ptoas_frontend_verify(
         ptoas_bin,
         lowp_text,
@@ -563,12 +571,8 @@ def main() -> None:
     )
     lowp_frontend_text = lowp_frontend_texts[0]
     expect(
-        "pto.vcvt" in lowp_frontend_text,
-        "low_precision_vcvt_frontend output should preserve vcvt ops after frontend verification",
-    )
-    expect(
-        "f8E4M3FN" in lowp_frontend_text,
-        "low_precision_vcvt_frontend output should preserve f8e4m3 type information",
+        lowp_frontend_text == "",
+        "low_precision_vcvt_frontend should continue to compile through the VPTO fallback object path when --emit-pto-ir is unavailable",
     )
 
     invalid_lowp_vcvt_mlir = """

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -292,6 +292,9 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         rhs = object()
         dst = object()
         bias = object()
+        lhs_scale = object()
+        rhs_scale = object()
+        acc_in = object()
 
         cube_cases = [
             ("mad_acc", "MadAccOp", (lhs, rhs, dst, 1, 2, 3), (lhs, rhs, dst, "i64:1", "i64:2", "i64:3")),
@@ -304,6 +307,23 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"i64:{value}"):
             for func_name, op_name, args, expected_call in cube_cases:
+                with self.subTest(func=func_name):
+                    op_ctor = MagicMock()
+                    with patch.object(_ops._pto, op_name, op_ctor):
+                        getattr(_ops, func_name)(*args)
+                    self.assertEqual(op_ctor.call_args.args, expected_call)
+
+        mx_tileop_cases = [
+            ("tmatmul_mx", "TMatmulMxOp", (lhs, lhs_scale, rhs, rhs_scale, dst), (None, lhs, lhs_scale, rhs, rhs_scale, dst)),
+            ("tmatmul_mx_acc", "TMatmulMxAccOp", (acc_in, lhs, lhs_scale, rhs, rhs_scale, dst), (None, acc_in, lhs, lhs_scale, rhs, rhs_scale, dst)),
+            ("tmatmul_mx_bias", "TMatmulMxBiasOp", (lhs, lhs_scale, rhs, rhs_scale, bias, dst), (None, lhs, lhs_scale, rhs, rhs_scale, bias, dst)),
+            ("tgemv_mx", "TGemvMxOp", (lhs, lhs_scale, rhs, rhs_scale, dst), (None, lhs, lhs_scale, rhs, rhs_scale, dst)),
+            ("tgemv_mx_acc", "TGemvMxAccOp", (acc_in, lhs, lhs_scale, rhs, rhs_scale, dst), (None, acc_in, lhs, lhs_scale, rhs, rhs_scale, dst)),
+            ("tgemv_mx_bias", "TGemvMxBiasOp", (lhs, lhs_scale, rhs, rhs_scale, bias, dst), (None, lhs, lhs_scale, rhs, rhs_scale, bias, dst)),
+        ]
+
+        with patch.object(_ops, "unwrap_surface_value", side_effect=_identity):
+            for func_name, op_name, args, expected_call in mx_tileop_cases:
                 with self.subTest(func=func_name):
                     op_ctor = MagicMock()
                     with patch.object(_ops._pto, op_name, op_ctor):

--- a/test/dsl-st/gemv_mx_pipeline.py
+++ b/test/dsl-st/gemv_mx_pipeline.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from common import assert_close, auto_main
+from ptodsl import pto
+
+
+M = 1
+M_PADDED = 16
+K = 256
+N = 20
+N_STORAGE = 32
+SCALE_K = K // 32
+
+L1_A_DATA_ADDR = 0
+L1_A_SCALE_ADDR = 1024
+L1_B_DATA_ADDR = 1152
+L1_B_SCALE_ADDR = 9344
+L1_BIAS_ADDR = 9600
+
+L0_BASE_ADDR = 0
+
+E4M3_BITS = np.asarray([0x00, 0x30, 0x38, 0x40, 0xB0, 0xB8, 0xC0], dtype=np.uint8)
+E5M2_BITS = np.asarray([0x00, 0x38, 0x3C, 0x40, 0xB8, 0xBC, 0xC0], dtype=np.uint8)
+
+
+def _decode_e4m3fn(values):
+    values = np.asarray(values, dtype=np.uint8)
+    sign = np.where((values & 0x80) != 0, -1.0, 1.0).astype(np.float32)
+    exponent = (values >> 3) & 0x0F
+    mantissa = values & 0x07
+    out = np.zeros(values.shape, dtype=np.float32)
+    subnormal = exponent == 0
+    normal = (exponent != 0) & (exponent != 0x0F)
+    out[subnormal] = mantissa[subnormal].astype(np.float32) * (2.0 ** -9)
+    out[normal] = (1.0 + mantissa[normal].astype(np.float32) / 8.0) * np.exp2(
+        exponent[normal].astype(np.int32) - 7
+    )
+    out[exponent == 0x0F] = np.nan
+    return sign * out
+
+
+def _decode_e5m2(values):
+    values = np.asarray(values, dtype=np.uint8)
+    sign = np.where((values & 0x80) != 0, -1.0, 1.0).astype(np.float32)
+    exponent = (values >> 2) & 0x1F
+    mantissa = values & 0x03
+    out = np.zeros(values.shape, dtype=np.float32)
+    subnormal = exponent == 0
+    normal = (exponent != 0) & (exponent != 0x1F)
+    out[subnormal] = mantissa[subnormal].astype(np.float32) * (2.0 ** -16)
+    out[normal] = (1.0 + mantissa[normal].astype(np.float32) / 4.0) * np.exp2(
+        exponent[normal].astype(np.int32) - 15
+    )
+    out[exponent == 0x1F] = np.nan
+    return sign * out
+
+
+def _pack_left_scale(scale):
+    packed = np.zeros((M_PADDED, SCALE_K), dtype=np.uint8)
+    packed[:M, :SCALE_K] = scale
+    return packed
+
+
+def _pack_right_scale(scale):
+    padded = np.zeros((SCALE_K, N_STORAGE), dtype=np.uint8)
+    padded[:SCALE_K, :N] = scale
+    packed = padded.reshape((SCALE_K // 2, 2, N_STORAGE // 16, 16)).transpose(2, 0, 3, 1)
+    return packed.reshape(SCALE_K, N_STORAGE)
+
+
+def _build_fp8_payload(seed, *, variant):
+    rng = np.random.default_rng(seed)
+
+    a_raw = rng.choice(E4M3_BITS, size=(M_PADDED, K)).astype(np.uint8)
+    b_raw = rng.choice(E5M2_BITS, size=(K, N_STORAGE)).astype(np.uint8)
+    a_scale_logical = rng.integers(127, 130, size=(M, SCALE_K), dtype=np.uint8)
+    b_scale_logical = rng.integers(127, 130, size=(SCALE_K, N), dtype=np.uint8)
+
+    a_scale_raw = _pack_left_scale(a_scale_logical)
+    b_scale_raw = _pack_right_scale(b_scale_logical)
+
+    bias_raw = None
+    if variant == "bias":
+        bias_raw = np.zeros((M, N_STORAGE), dtype=np.float32)
+        bias_raw[:, :N] = rng.uniform(-2.0, 2.0, size=(M, N)).astype(np.float32)
+
+    a = _decode_e4m3fn(a_raw[:M, :K])
+    b = _decode_e5m2(b_raw[:K, :N])
+    a_scale = np.exp2(a_scale_logical.astype(np.int16) - 127).astype(np.float32)
+    b_scale = np.exp2(b_scale_logical.astype(np.int16) - 127).astype(np.float32)
+
+    a_real = a * a_scale[:, np.arange(K) // 32]
+    b_real = b * b_scale[np.arange(K) // 32, :]
+    golden_valid = (a_real @ b_real).astype(np.float32)
+
+    if variant == "acc":
+        golden_valid = golden_valid * 2.0
+    elif variant == "bias":
+        golden_valid = golden_valid + bias_raw[:, :N]
+
+    golden = np.zeros((M, N_STORAGE), dtype=np.float32)
+    golden[:, :N] = golden_valid
+
+    inputs = [a_raw, b_raw, a_scale_raw, b_scale_raw]
+    if bias_raw is not None:
+        inputs.append(bias_raw)
+    return inputs, golden
+
+
+def _alloc_common_tiles():
+    lhs_tile = pto.alloc_tile(
+        shape=[M, K],
+        dtype=pto.f8e4m3,
+        memory_space=pto.MemorySpace.LEFT,
+        addr=L0_BASE_ADDR,
+        valid_shape=[M, K],
+        blayout="ColMajor",
+        slayout="RowMajor",
+    )
+    lhs_scale_tile = pto.alloc_tile(
+        shape=[M, SCALE_K],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        addr=L0_BASE_ADDR,
+        valid_shape=[M, SCALE_K],
+        blayout="RowMajor",
+        slayout="RowMajor",
+        fractal_size=32,
+    )
+    rhs_tile = pto.alloc_tile(
+        shape=[K, N_STORAGE],
+        dtype=pto.f8e5m2,
+        memory_space=pto.MemorySpace.RIGHT,
+        addr=L0_BASE_ADDR,
+        valid_shape=[K, N],
+        blayout="RowMajor",
+        slayout="ColMajor",
+    )
+    rhs_scale_tile = pto.alloc_tile(
+        shape=[SCALE_K, N_STORAGE],
+        dtype=pto.f16,
+        memory_space=pto.MemorySpace.SCALING,
+        addr=L0_BASE_ADDR,
+        valid_shape=[SCALE_K, N],
+        blayout="ColMajor",
+        slayout="ColMajor",
+        fractal_size=32,
+    )
+    dst_tile = pto.alloc_tile(
+        shape=[M, N_STORAGE],
+        dtype=pto.f32,
+        memory_space=pto.MemorySpace.ACC,
+        addr=L0_BASE_ADDR,
+        valid_shape=[M, N],
+        blayout="ColMajor",
+        slayout="RowMajor",
+    )
+    return lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile
+
+
+def _alloc_bias_tile():
+    return pto.alloc_tile(
+        shape=[M, N_STORAGE],
+        dtype=pto.f32,
+        memory_space=pto.MemorySpace.BIAS,
+        addr=L0_BASE_ADDR,
+        valid_shape=[M, N],
+        blayout="RowMajor",
+        slayout="NoneBox",
+    )
+
+
+def _stage_fp8_tiles(a_ptr, b_ptr, a_scale_ptr, b_scale_ptr, lhs_tile, rhs_tile, bias_ptr=None, bias_tile=None):
+    a_l1_ptr = pto.castptr(pto.ui64(L1_A_DATA_ADDR), pto.ptr(pto.f8e4m3, "mat"))
+    a_scale_l1_ptr = pto.castptr(pto.ui64(L1_A_SCALE_ADDR), pto.ptr(pto.f8e4m3, "mat"))
+    b_l1_ptr = pto.castptr(pto.ui64(L1_B_DATA_ADDR), pto.ptr(pto.f8e5m2, "mat"))
+    b_scale_l1_ptr = pto.castptr(pto.ui64(L1_B_SCALE_ADDR), pto.ptr(pto.f8e5m2, "mat"))
+
+    pto.mte_gm_l1(a_ptr, a_l1_ptr, 1024, nburst=(1, 0, 0))
+    pto.mte_gm_l1(a_scale_ptr, a_scale_l1_ptr, 64, nburst=(2, 0, 0))
+    pto.mte_gm_l1_frac(
+        b_ptr,
+        b_l1_ptr,
+        pto.FractalMode.ND2NZ,
+        shape=(K, N),
+        src_layout=(N_STORAGE,),
+        dst_group=(1, 1, K, 0),
+        ctrl=(0, False),
+    )
+    pto.mte_gm_l1(b_scale_ptr, b_scale_l1_ptr, 256, nburst=(1, 0, 0))
+
+    bias_l1_ptr = None
+    if bias_ptr is not None and bias_tile is not None:
+        bias_l1_ptr = pto.castptr(pto.ui64(L1_BIAS_ADDR), pto.ptr(pto.f32, "mat"))
+        pto.mte_gm_l1(bias_ptr, bias_l1_ptr, 128, nburst=(1, 0, 0))
+
+    pto.set_flag(pto.Pipe.MTE2, pto.Pipe.MTE1, event_id=0)
+    pto.wait_flag(pto.Pipe.MTE2, pto.Pipe.MTE1, event_id=0)
+
+    pto.mte_l1_l0a(a_l1_ptr, lhs_tile.as_ptr(), M, K)
+    pto.mte_l1_l0b(b_l1_ptr, rhs_tile.as_ptr(), K, N, transpose=True)
+    pto.mte_l1_l0a_mx(a_scale_l1_ptr, lhs_tile.as_ptr(), M, K)
+    pto.mte_l1_l0b_mx(b_scale_l1_ptr, rhs_tile.as_ptr(), K, N)
+    if bias_l1_ptr is not None and bias_tile is not None:
+        pto.mte_l1_bt(bias_l1_ptr, bias_tile.as_ptr(), 128, nburst=(1, 0, 0))
+
+    pto.set_flag(pto.Pipe.MTE1, pto.Pipe.M, event_id=0)
+    pto.wait_flag(pto.Pipe.MTE1, pto.Pipe.M, event_id=0)
+
+
+def _writeback_output(dst_tile, out_ptr):
+    pto.set_flag(pto.Pipe.M, pto.Pipe.FIX, event_id=1)
+    pto.wait_flag(pto.Pipe.M, pto.Pipe.FIX, event_id=1)
+    pto.mte_l0c_gm(
+        dst_tile.as_ptr(),
+        out_ptr,
+        M,
+        N_STORAGE,
+        16,
+        N_STORAGE,
+        0,
+        0,
+        layout="nz2nd",
+    )
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(
+    name="gemv_mx_fp8_pipeline_kernel",
+    kernel_kind="cube",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def gemv_mx_fp8_pipeline_kernel(
+    a_ptr: pto.ptr(pto.f8e4m3, "gm"),
+    b_ptr: pto.ptr(pto.f8e5m2, "gm"),
+    a_scale_ptr: pto.ptr(pto.f8e4m3, "gm"),
+    b_scale_ptr: pto.ptr(pto.f8e5m2, "gm"),
+    out_ptr: pto.ptr(pto.f32, "gm"),
+):
+    lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile = _alloc_common_tiles()
+    _stage_fp8_tiles(a_ptr, b_ptr, a_scale_ptr, b_scale_ptr, lhs_tile, rhs_tile)
+    pto.tile.gemv_mx(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile)
+    _writeback_output(dst_tile, out_ptr)
+
+
+@pto.jit(
+    name="gemv_mx_acc_fp8_pipeline_kernel",
+    kernel_kind="cube",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def gemv_mx_acc_fp8_pipeline_kernel(
+    a_ptr: pto.ptr(pto.f8e4m3, "gm"),
+    b_ptr: pto.ptr(pto.f8e5m2, "gm"),
+    a_scale_ptr: pto.ptr(pto.f8e4m3, "gm"),
+    b_scale_ptr: pto.ptr(pto.f8e5m2, "gm"),
+    out_ptr: pto.ptr(pto.f32, "gm"),
+):
+    lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile = _alloc_common_tiles()
+    _stage_fp8_tiles(a_ptr, b_ptr, a_scale_ptr, b_scale_ptr, lhs_tile, rhs_tile)
+    pto.tile.gemv_mx(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile)
+    pto.tile.gemv_mx_acc(dst_tile, lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile)
+    _writeback_output(dst_tile, out_ptr)
+
+
+@pto.jit(
+    name="gemv_mx_bias_fp8_pipeline_kernel",
+    kernel_kind="cube",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def gemv_mx_bias_fp8_pipeline_kernel(
+    a_ptr: pto.ptr(pto.f8e4m3, "gm"),
+    b_ptr: pto.ptr(pto.f8e5m2, "gm"),
+    a_scale_ptr: pto.ptr(pto.f8e4m3, "gm"),
+    b_scale_ptr: pto.ptr(pto.f8e5m2, "gm"),
+    bias_ptr: pto.ptr(pto.f32, "gm"),
+    out_ptr: pto.ptr(pto.f32, "gm"),
+):
+    lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile = _alloc_common_tiles()
+    bias_tile = _alloc_bias_tile()
+    _stage_fp8_tiles(
+        a_ptr,
+        b_ptr,
+        a_scale_ptr,
+        b_scale_ptr,
+        lhs_tile,
+        rhs_tile,
+        bias_ptr=bias_ptr,
+        bias_tile=bias_tile,
+    )
+    pto.tile.gemv_mx_bias(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, bias_tile, dst_tile)
+    _writeback_output(dst_tile, out_ptr)
+
+
+def _make_case(name, kernel, *, seed, variant):
+    def make_case():
+        inputs, golden = _build_fp8_payload(seed, variant=variant)
+        out = np.zeros((M, N_STORAGE), dtype=np.float32)
+        return [*inputs, out], golden
+
+    def check(device_inputs, golden):
+        actual = device_inputs[-1].cpu().numpy()
+        assert_close(actual, golden, rtol=1e-3, atol=1e-3)
+
+    return {
+        "name": name,
+        "kernel": kernel,
+        "make_case": make_case,
+        "check": check,
+    }
+
+
+CASES = [
+    _make_case(
+        "gemv_mx_fp8_e4m3_e5m2",
+        gemv_mx_fp8_pipeline_kernel,
+        seed=19,
+        variant="plain",
+    ),
+    _make_case(
+        "gemv_mx_acc_fp8_e4m3_e5m2_double",
+        gemv_mx_acc_fp8_pipeline_kernel,
+        seed=23,
+        variant="acc",
+    ),
+    _make_case(
+        "gemv_mx_bias_fp8_e4m3_e5m2",
+        gemv_mx_bias_fp8_pipeline_kernel,
+        seed=29,
+        variant="bias",
+    ),
+]
+
+
+auto_main(globals())

--- a/test/dsl-st/gemv_mx_pipeline.py
+++ b/test/dsl-st/gemv_mx_pipeline.py
@@ -17,6 +17,8 @@ if __package__ in {None, ""}:
 
 from common import assert_close, auto_main
 from ptodsl import pto
+from ptodsl._surface_values import unwrap_surface_value
+from mlir.dialects import pto as _pto
 
 
 M = 1
@@ -33,6 +35,8 @@ L1_B_SCALE_ADDR = 9344
 L1_BIAS_ADDR = 9600
 
 L0_BASE_ADDR = 0
+L0_SCALE_LHS_ADDR = 0
+L0_SCALE_RHS_ADDR = 256
 
 E4M3_BITS = np.asarray([0x00, 0x30, 0x38, 0x40, 0xB0, 0xB8, 0xC0], dtype=np.uint8)
 E5M2_BITS = np.asarray([0x00, 0x38, 0x3C, 0x40, 0xB8, 0xBC, 0xC0], dtype=np.uint8)
@@ -136,7 +140,7 @@ def _alloc_common_tiles():
         shape=[M, SCALE_K],
         dtype=pto.f16,
         memory_space=pto.MemorySpace.SCALING,
-        addr=L0_BASE_ADDR,
+        addr=L0_SCALE_LHS_ADDR,
         valid_shape=[M, SCALE_K],
         blayout="RowMajor",
         slayout="RowMajor",
@@ -155,7 +159,7 @@ def _alloc_common_tiles():
         shape=[SCALE_K, N_STORAGE],
         dtype=pto.f16,
         memory_space=pto.MemorySpace.SCALING,
-        addr=L0_BASE_ADDR,
+        addr=L0_SCALE_RHS_ADDR,
         valid_shape=[SCALE_K, N],
         blayout="ColMajor",
         slayout="ColMajor",
@@ -171,6 +175,17 @@ def _alloc_common_tiles():
         slayout="RowMajor",
     )
     return lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile
+
+
+def _bind_mx_scale_tiles(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile):
+    _pto.TGetScaleAddrOp(
+        unwrap_surface_value(lhs_tile),
+        unwrap_surface_value(lhs_scale_tile),
+    )
+    _pto.TGetScaleAddrOp(
+        unwrap_surface_value(rhs_tile),
+        unwrap_surface_value(rhs_scale_tile),
+    )
 
 
 def _alloc_bias_tile():
@@ -256,6 +271,7 @@ def gemv_mx_fp8_pipeline_kernel(
 ):
     lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile = _alloc_common_tiles()
     _stage_fp8_tiles(a_ptr, b_ptr, a_scale_ptr, b_scale_ptr, lhs_tile, rhs_tile)
+    _bind_mx_scale_tiles(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile)
     pto.tile.gemv_mx(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile)
     _writeback_output(dst_tile, out_ptr)
 
@@ -276,6 +292,7 @@ def gemv_mx_acc_fp8_pipeline_kernel(
 ):
     lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile = _alloc_common_tiles()
     _stage_fp8_tiles(a_ptr, b_ptr, a_scale_ptr, b_scale_ptr, lhs_tile, rhs_tile)
+    _bind_mx_scale_tiles(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile)
     pto.tile.gemv_mx(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile)
     pto.tile.gemv_mx_acc(dst_tile, lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, dst_tile)
     _writeback_output(dst_tile, out_ptr)
@@ -308,6 +325,7 @@ def gemv_mx_bias_fp8_pipeline_kernel(
         bias_ptr=bias_ptr,
         bias_tile=bias_tile,
     )
+    _bind_mx_scale_tiles(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile)
     pto.tile.gemv_mx_bias(lhs_tile, lhs_scale_tile, rhs_tile, rhs_scale_tile, bias_tile, dst_tile)
     _writeback_output(dst_tile, out_ptr)
 

--- a/test/lit/vpto/vadd_low_precision_verify_invalid.pto
+++ b/test/lit/vpto/vadd_low_precision_verify_invalid.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'pto.vadd' op lhs type must not use low-precision vector element type
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vadd_f8_invalid(%src0: !pto.ptr<f8E4M3FN, ub>, %src1: !pto.ptr<f8E4M3FN, ub>) {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %lhs = pto.vlds %src0[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %rhs = pto.vlds %src1[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %sum = pto.vadd %lhs, %rhs, %mask : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      %use = pto.vbitcast %sum : !pto.vreg<256xf8E4M3FN> -> !pto.vreg<64xf32>
+    }
+    return
+  }
+}

--- a/test/lit/vpto/vexp_low_precision_verify_invalid.pto
+++ b/test/lit/vpto/vexp_low_precision_verify_invalid.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'pto.vexp' op operand type must not use low-precision vector element type
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vexp_f8_invalid(%src: !pto.ptr<f8E4M3FN, ub>) {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %vec = pto.vlds %src[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %out = pto.vexp %vec, %mask : !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      %use = pto.vbitcast %out : !pto.vreg<256xf8E4M3FN> -> !pto.vreg<64xf32>
+    }
+    return
+  }
+}

--- a/test/lit/vpto/vmuls_low_precision_verify_invalid.pto
+++ b/test/lit/vpto/vmuls_low_precision_verify_invalid.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'pto.vmuls' op input type must not use low-precision vector element type
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vmuls_hif8_invalid(%src: !pto.ptr<!pto.hif8, ub>, %alpha: !pto.hif8) {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %vec = pto.vlds %src[%c0] : !pto.ptr<!pto.hif8, ub> -> !pto.vreg<256x!pto.hif8>
+      %out = pto.vmuls %vec, %alpha, %mask : !pto.vreg<256x!pto.hif8>, !pto.hif8, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      %use = pto.vbitcast %out : !pto.vreg<256x!pto.hif8> -> !pto.vreg<64xf32>
+    }
+    return
+  }
+}

--- a/test/lit/vpto/vsel_low_precision_verify_invalid.pto
+++ b/test/lit/vpto/vsel_low_precision_verify_invalid.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s 2>&1 | FileCheck %s
+
+// CHECK: error: 'pto.vsel' op src0 type must not use low-precision vector element type
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @vsel_f8_invalid(%src0: !pto.ptr<f8E4M3FN, ub>, %src1: !pto.ptr<f8E4M3FN, ub>) {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %lhs = pto.vlds %src0[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %rhs = pto.vlds %src1[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %out = pto.vsel %lhs, %rhs, %mask : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      %use = pto.vbitcast %out : !pto.vreg<256xf8E4M3FN> -> !pto.vreg<64xf32>
+    }
+    return
+  }
+}


### PR DESCRIPTION
## Summary
- allow PTODSL low-precision dtypes in `pto.ptr(...)` and `pto.vreg_type(...)`
- add low-precision `pto.vcvt` surface coverage and frontend-side attr validation aligned with VPTO contracts
- update PTODSL user guide and tests for low-precision vector memory and conversion flows

## Validation
- `ptodsl/tests/test_jit_compile.py`
- `ptodsl/tests/test_docs_as_test.py`
- `ptodsl/tests/test_ptoas_frontend_verify.py`
- `git diff --check`
