### PR TITLE
clear residual tile op for llvm export

### DIFF
--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -9747,6 +9747,129 @@ static void foldVPTOTypeCasts(ModuleOp module, TypeConverter &typeConverter) {
   }
 }
 
+static Value peelSingleResultCast(Value value) {
+  while (auto castOp = value.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp->getNumOperands() != 1 || castOp->getNumResults() != 1)
+      break;
+    value = castOp.getOperand(0);
+  }
+  return value;
+}
+
+static Value findLLVMIndexValue(Value value) {
+  value = peelSingleResultCast(value);
+  if (!value)
+    return {};
+  if (value.getType().isInteger(64))
+    return value;
+  for (Operation *user : llvm::make_early_inc_range(value.getUsers())) {
+    auto castOp = dyn_cast<UnrealizedConversionCastOp>(user);
+    if (!castOp || castOp->getNumOperands() != 1 || castOp->getNumResults() != 1)
+      continue;
+    Value result = castOp.getResult(0);
+    if (result.getType().isInteger(64))
+      return result;
+  }
+  return {};
+}
+
+static void eraseDeadTileMetadataOps(ModuleOp module) {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    SmallVector<Operation *> opsToErase;
+    module.walk([&](pto::SetValidShapeOp op) {
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](pto::GetValidShapeOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](pto::TReshapeOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](pto::AllocTileOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](UnrealizedConversionCastOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+  }
+}
+
+static void cleanupResidualTileMetadataForLLVMExport(ModuleOp module) {
+  SmallVector<pto::GetValidShapeOp> getValidShapeOps;
+  module.walk([&](pto::GetValidShapeOp op) { getValidShapeOps.push_back(op); });
+
+  for (pto::GetValidShapeOp op : getValidShapeOps) {
+    Value source = peelSingleResultCast(op.getSource());
+    auto alloc = source ? source.getDefiningOp<pto::AllocTileOp>() : nullptr;
+    if (!alloc)
+      continue;
+
+    Value row = alloc.getValidRow();
+    Value col = alloc.getValidCol();
+    if (!row || !col)
+      continue;
+
+    if (Value llvmRow = findLLVMIndexValue(row)) {
+      for (Operation *user :
+           llvm::make_early_inc_range(op.getValidRow().getUsers())) {
+        auto castOp = dyn_cast<UnrealizedConversionCastOp>(user);
+        if (castOp && castOp->getNumResults() == 1 &&
+            castOp.getResult(0).getType().isInteger(64))
+          castOp.getResult(0).replaceAllUsesWith(llvmRow);
+      }
+    }
+    if (Value llvmCol = findLLVMIndexValue(col)) {
+      for (Operation *user :
+           llvm::make_early_inc_range(op.getValidCol().getUsers())) {
+        auto castOp = dyn_cast<UnrealizedConversionCastOp>(user);
+        if (castOp && castOp->getNumResults() == 1 &&
+            castOp.getResult(0).getType().isInteger(64))
+          castOp.getResult(0).replaceAllUsesWith(llvmCol);
+      }
+    }
+  }
+
+  eraseDeadTileMetadataOps(module);
+}
+
 static LogicalResult lowerVPTOOps(ModuleOp module, llvm::raw_ostream &diagOS) {
   MLIRContext *context = module.getContext();
   VPTOTypeConverter typeConverter(context);
@@ -10111,6 +10234,7 @@ static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
     diagOS << "VPTO LLVM emission failed: official lowering pipeline failed\n";
     return failure();
   }
+  cleanupResidualTileMetadataForLLVMExport(clonedModule);
   return emit(clonedModule);
 }
 

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -9777,6 +9777,129 @@ static void foldVPTOTypeCasts(ModuleOp module, TypeConverter &typeConverter) {
   }
 }
 
+static Value peelSingleResultCast(Value value) {
+  while (auto castOp = value.getDefiningOp<UnrealizedConversionCastOp>()) {
+    if (castOp->getNumOperands() != 1 || castOp->getNumResults() != 1)
+      break;
+    value = castOp.getOperand(0);
+  }
+  return value;
+}
+
+static Value findLLVMIndexValue(Value value) {
+  value = peelSingleResultCast(value);
+  if (!value)
+    return {};
+  if (value.getType().isInteger(64))
+    return value;
+  for (Operation *user : llvm::make_early_inc_range(value.getUsers())) {
+    auto castOp = dyn_cast<UnrealizedConversionCastOp>(user);
+    if (!castOp || castOp->getNumOperands() != 1 || castOp->getNumResults() != 1)
+      continue;
+    Value result = castOp.getResult(0);
+    if (result.getType().isInteger(64))
+      return result;
+  }
+  return {};
+}
+
+static void eraseDeadTileMetadataOps(ModuleOp module) {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    SmallVector<Operation *> opsToErase;
+    module.walk([&](pto::SetValidShapeOp op) {
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](pto::GetValidShapeOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](pto::TReshapeOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](pto::AllocTileOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+
+    opsToErase.clear();
+    module.walk([&](UnrealizedConversionCastOp op) {
+      if (!op->use_empty())
+        return;
+      opsToErase.push_back(op);
+    });
+    for (Operation *op : llvm::reverse(opsToErase)) {
+      op->erase();
+      changed = true;
+    }
+  }
+}
+
+static void cleanupResidualTileMetadataForLLVMExport(ModuleOp module) {
+  SmallVector<pto::GetValidShapeOp> getValidShapeOps;
+  module.walk([&](pto::GetValidShapeOp op) { getValidShapeOps.push_back(op); });
+
+  for (pto::GetValidShapeOp op : getValidShapeOps) {
+    Value source = peelSingleResultCast(op.getSource());
+    auto alloc = source ? source.getDefiningOp<pto::AllocTileOp>() : nullptr;
+    if (!alloc)
+      continue;
+
+    Value row = alloc.getValidRow();
+    Value col = alloc.getValidCol();
+    if (!row || !col)
+      continue;
+
+    if (Value llvmRow = findLLVMIndexValue(row)) {
+      for (Operation *user :
+           llvm::make_early_inc_range(op.getValidRow().getUsers())) {
+        auto castOp = dyn_cast<UnrealizedConversionCastOp>(user);
+        if (castOp && castOp->getNumResults() == 1 &&
+            castOp.getResult(0).getType().isInteger(64))
+          castOp.getResult(0).replaceAllUsesWith(llvmRow);
+      }
+    }
+    if (Value llvmCol = findLLVMIndexValue(col)) {
+      for (Operation *user :
+           llvm::make_early_inc_range(op.getValidCol().getUsers())) {
+        auto castOp = dyn_cast<UnrealizedConversionCastOp>(user);
+        if (castOp && castOp->getNumResults() == 1 &&
+            castOp.getResult(0).getType().isInteger(64))
+          castOp.getResult(0).replaceAllUsesWith(llvmCol);
+      }
+    }
+  }
+
+  eraseDeadTileMetadataOps(module);
+}
+
 static LogicalResult lowerVPTOOps(ModuleOp module, llvm::raw_ostream &diagOS) {
   MLIRContext *context = module.getContext();
   VPTOTypeConverter typeConverter(context);
@@ -10150,6 +10273,7 @@ static LogicalResult runPipeline(ModuleOp module, llvm::raw_ostream &diagOS,
     diagOS << "VPTO LLVM emission failed: official lowering pipeline failed\n";
     return failure();
   }
+  cleanupResidualTileMetadataForLLVMExport(clonedModule);
   return emit(clonedModule);
 }
 


### PR DESCRIPTION
### 问题总结

VPTO lowering pipeline 完成后，module 中残留的 tile 元数据 op 阻塞了 LLVM 导出。这些 op 分为两类：

1. **语义已完成但未清理的死 op**：`pto.set_valid_shape`（始终无 user）、无 user 的 `pto.get_valid_shape`、无 user 的 `pto.treshape`、无 user 的 `pto.alloc_tile`、无 user 的 `UnrealizedConversionCastOp`。

2. **可被折叠的 cast 链**：`pto.get_valid_shape` → `UnrealizedConversionCastOp` → LLVM i64 的 cast 链，其等价的 LLVM i64 值已存在于原始 `pto.alloc_tile` 的 valid row/col 属性中，但未被复用。

### 修改方案

在 `runPipeline()` 中，于 LLVM emit 之前插入 `cleanupResidualTileMetadataForLLVMExport()` 调用。该函数分两步执行清理：

#### 第一步：Rewire get_valid_shape → 直达 LLVM index 值

`cleanupResidualTileMetadataForLLVMExport()` 遍历所有 `pto.get_valid_shape` op：

1. 通过 `peelSingleResultCast()` 穿透 `UnrealizedConversionCastOp` 找到其 source（期望为 `pto.alloc_tile`）。
2. 从 `alloc_tile` 中取出原始的 valid row/col value。
3. 通过 `findLLVMIndexValue()` 查找该 value 对应的 LLVM i64 值（穿透 cast 链查找或在其 user 中匹配 i64 类型的 cast 结果）。
4. 将 `get_valid_shape` 下游的 `UnrealizedConversionCastOp` 的 i64 result 替换为找到的 LLVM i64 值，消除中间 cast 链。

辅助函数：

- `peelSingleResultCast(Value)`: 递归穿透单输入单输出的 `UnrealizedConversionCastOp`，返回最内层非 cast 的源头 value。
- `findLLVMIndexValue(Value)`: 在 value 及其 user cast chain 中查找 i64 类型的 LLVM 值。

#### 第二步：迭代删除所有死 tile 元数据 op

`eraseDeadTileMetadataOps()` 使用固定点迭代删除以下 op：

| 删除顺序 | Op | 条件 |
| --- | --- | --- |
| 1 | `pto.set_valid_shape` | 无条件删除（纯 metadata，始终无 user） |
| 2 | `pto.get_valid_shape` | 无 user（第一步 rewire 后变为死代码） |
| 3 | `pto.treshape` | 无 user |
| 4 | `pto.alloc_tile` | 无 user |
| 5 | `UnrealizedConversionCastOp` | 无 user |

采用 while-changed 循环确保级联删除（例如删除 `get_valid_shape` 后，其下游 cast 变为无 user，下一轮被删除）。每轮按上述顺序依次收集并删除符合条件的 op。

#### 3. 涉及文件

| 文件 | 变更内容 |
| --- | --- |
| `lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp` | 新增 `peelSingleResultCast`、`findLLVMIndexValue`、`eraseDeadTileMetadataOps`、`cleanupResidualTileMetadataForLLVMExport` 四个静态函数；在 `runPipeline` 的 LLVM emit 前调用 `cleanupResidualTileMetadataForLLVMExport` |
| `lib/PTO/Transforms/VPTOLLVMEmitter.cpp` | 同上（两个 emitter 的清理逻辑完全一致） |

#### 注意事项

- 此修改为 `tmp fix`，当前清理逻辑仅覆盖已知的残留 op 类型。如果后续新增其他 tile metadata op 或更复杂的 cast 拓扑结构，可能需要扩展清理范围。
- 第一步 rewire 依赖于 `get_valid_shape` → `alloc_tile` 的 def-use 链未被打断（即 lowering 过程中未插入额外的隔离 op），若未来 lowering 策略变化导致该链断裂，需调整 `peelSingleResultCast` 逻辑。
- 两个 LLVM emitter 文件的实现完全相同，存在代码重复。后续可考虑将清理逻辑提取到公共工具文件中。
