### PR TITLE
docs(ptodsl): clarify user guide operation contracts

### DIFF
--- a/ptodsl/README.md
+++ b/ptodsl/README.md
@@ -237,166 +237,32 @@ implementation.
 
 ---
 
-## DSL-style API quick reference
+## Public API map
 
-```python
-from ptodsl import pto, scalar
-s = scalar       # arith shorthand alias
-```
+The user guide under `ptodsl/docs/user_guide/` is the canonical PTODSL API
+reference. This README keeps only a compact map of the public surface:
 
-`pto` is the main DSL namespace. `scalar` is a separate top-level helper
-namespace for runtime scalar load/store, arithmetic helpers, and scalar math;
-it is intentionally not exported as `pto.scalar`.
+- `@pto.jit`: the only host-visible kernel entry
+- `@pto.cube`, `@pto.simd`, `@pto.simt`: hardware-unit sub-kernels
+- `pto.ptr(...)` + runtime PTO scalar annotations: public entry ABI
+- `pto.make_tensor_view(...)`, `pto.partition_view(...)`, `pto.alloc_tile(...)`:
+  core data-model builders
+- `pto.tile.*`, `pto.mte_*`, `pto.v*`, `scalar.*`: operational namespaces
+- default AST rewrite for Python `for` / `if`, plus explicit `pto.for_` /
+  `pto.if_`: control-flow surface
 
-### Kernel decorator
+Start here for the full reference:
 
-```python
-@pto.jit(name="MyKernel", kernel_kind="vector", target="a5")
-def MyKernel():
-    ...
-
-@pto.jit(name="Softmax", kernel_kind="vector", target="a5")
-def Softmax(
-    X_ptr: pto.ptr(pto.f32, "gm"),
-    O_ptr: pto.ptr(pto.f32, "gm"),
-    rows: pto.i32,
-    cols: pto.i32,
-    *,
-    BLOCK: pto.const_expr = 128,
-):
-    x_view = pto.make_tensor_view(X_ptr, shape=[rows, cols], strides=[cols, 1])
-    o_view = pto.make_tensor_view(O_ptr, shape=[rows, cols], strides=[cols, 1])
-    ...
-
-print(MyKernel)               # prints MLIR text
-mod = MyKernel.mlir_module()  # returns mlir.ir.Module
-```
-
-`@pto.jit` now emits a flat aicore launch-entry module by default. The traced
-entry function carries the `pto.aicore` attribute and lives directly under the
-top-level module, which matches the runtime-launch path and merged-MLIR example
-flow.
-
-PTODSL v1 keeps the public `@pto.jit` entry ABI intentionally narrow:
-
-- positional device buffers are explicit GM pointers declared with
-  `pto.ptr(..., "gm")`
-- shape, stride, and other launch-varying metadata travel as positional runtime
-  scalars such as `pto.i32`, `pto.f32`, and `pto.i1`
-- kernel bodies reconstruct tensor descriptors explicitly with
-  `pto.make_tensor_view(ptr, shape=..., strides=...)`
-- positional runtime scalars use PTO scalar annotations such as `pto.i32`,
-  `pto.f32`, and `pto.i1`, while launch-time values remain ordinary Python
-  scalars
-- keyword-only parameters annotated with `pto.const_expr` are compile-time
-  specialization knobs
-
-The host wrapper is responsible for extracting or deriving whatever runtime
-metadata the kernel needs and passing it explicitly at launch time. PTODSL no
-longer uses `pto.tensor_spec(...)` as the public `@pto.jit` entry contract.
-
-Additional layered kernel entry modes and shared compute decorators are also
-exported on the public surface: `@pto.jit(mode="auto")`,
-`@pto.jit(mode="explicit")`, `@pto.cube`, `@pto.simd`, and `@pto.simt`.
-
-### Type descriptors (lazy – safe to use in annotations)
-
-| Expression | MLIR type |
-|---|---|
-| `pto.float32` | `f32` |
-| `pto.int32` | `i32` |
-| `pto.int64` | `i64` |
-| `pto.index` | `index` |
-| `pto.ptr(pto.float32, "gm")` | `!pto.ptr<f32, gm>` |
-| `pto.ptr(pto.float32, "ub")` | `!pto.ptr<f32, ub>` |
-
-### Type constructors (eager – require active context)
-
-```python
-vf32     = pto.vreg_type(64, pto.float32)                       # !pto.vreg<64xf32>
-tile_col = pto.alloc_tile(shape=[8, 1], dtype=pto.float32, blayout="ColMajor")
-tile_w   = pto.alloc_tile(shape=[8, 128], dtype=pto.float32)
-```
-
-### Constants
-
-```python
-c0     = pto.const(0)               # index
-c1_i32 = pto.const(1, dtype=pto.int32)
-c64_i64= pto.const(64, dtype=pto.int64)
-```
-
-### Control flow
-
-```python
-with pto.simd():                    # pto.simd { … }
-    ...
-
-with pto.for_(c0, c16, step=c1) as i:     # simple scf.for
-    ...                                    # scf.yield inserted automatically
-
-loop = pto.for_(c0, c128, step=c64).carry(lhs=a, rhs=b)
-with loop:
-    x = loop.lhs
-    y = loop.rhs
-    ...
-    loop.update(lhs=nx, rhs=ny)
-fx = loop.final("lhs")
-fy = loop.final("rhs")
-
-with pto.if_(has_rows) as br:      # simple scf.if
-    with br.then_:
-        ...
-
-with pto.if_(has_chunk) as br:
-    with br.then_:
-        br.assign(x=merged_max, y=merged_sum)
-    with br.else_:
-        br.assign(x=running_max, y=running_sum)
-x = br.x
-y = br.y
-```
-
-### Scalar arithmetic (`s = scalar`)
-
-```python
-s.muli(a, b)                 # arith.muli
-s.addi(a, b)                 # arith.addi
-s.subi(a, b)                 # arith.subi
-s.index_cast(val)            # arith.index_cast → index
-s.index_cast(pto.int32, val) # arith.index_cast → i32
-(a > b)                      # scalar compare → pto.i1
-(a <= b)                     # scalar compare → pto.i1
-s.select(cond, t, f)         # arith.select
-```
-
-### PTO operations
-
-```python
-pto.castptr(addr, ptr_type)              # pto.castptr
-pto.addptr(ptr, offset)                  # pto.addptr
-pto.vlds(ptr, offset)                    # pto.vlds, result vreg inferred from ptr element type
-pto.vbr(scalar)                          # pto.vbr, scalar broadcast -> vreg
-pto.vsts(v, ptr, offset, mask)           # pto.vsts
-pto.plt_b32(scalar)                      # → (mask, scalar_out)
-pto.pset_b32("PAT_ALL")                  # pto.pset_b32 → mask
-pto.vbitcast(v, dtype)                   # pto.vbitcast
-pto.pbitcast(mask, mask_type)            # pto.pbitcast
-pto.vadd(a, b, mask)   # infers result type from a.type
-pto.vmul / vmax / vdiv / vcmax / vcadd / vdup / vexpdif  # similarly
-pto.make_tensor_view(ptr, shape=…, strides=…)    # type inferred
-pto.partition_view(tv, offsets=…, sizes=…)        # type inferred
-pto.alloc_tile(shape=…, dtype=…, memory_space=…, valid_shape=…, addr=…)  # authored surface
-pto.tile.load(part, tile)
-pto.tile.store(tile, part)
-pto.tile.load(tv, tile)                           # partition + tile.load, zero offsets, sizes inferred from tile
-pto.tile.store(tile, tv)                          # partition + tile.store, zero offsets, sizes inferred from tile
-tile.as_ptr() / view.as_ptr()
-pto.get_block_idx()           # → i64
-pto.set_flag("MTE2", "V", event_id=0)
-pto.wait_flag("MTE2", "V", event_id=0)
-pto.pipe_barrier(pto.Pipe.ALL)
-```
+- `ptodsl/docs/user_guide/01-introduction.md`
+- `ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md`
+- `ptodsl/docs/user_guide/04-type-system-and-buffer.md`
+- `ptodsl/docs/user_guide/05-control-flow.md`
+- `ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md`
+- `ptodsl/docs/user_guide/07-data-movement-ops.md`
+- `ptodsl/docs/user_guide/08-compute-operations.md`
+- `ptodsl/docs/user_guide/09-predicate-and-mask-ops.md`
+- `ptodsl/docs/user_guide/10-sync-ops.md`
+- `ptodsl/docs/user_guide/13-simt-micro-ops.md`
 
 ## How the IR check works
 

--- a/ptodsl/docs/user_guide/01-introduction.md
+++ b/ptodsl/docs/user_guide/01-introduction.md
@@ -243,4 +243,3 @@ Chapter 11 walks through this example in full detail.
 | 11 | Flash attention walkthrough |
 | 12 | Additional examples |
 | 13 | SIMT micro-ops |
-| 14 | Common errors and compatibility notes |

--- a/ptodsl/docs/user_guide/01-introduction.md
+++ b/ptodsl/docs/user_guide/01-introduction.md
@@ -154,6 +154,12 @@ the same kernel.
 
 The SPMD launch contract is also owned here: the runtime grid (e.g., `batch * heads` blocks) is declared at the call site, and block/subblock indices are queried via `pto.get_block_idx()` and friends.
 
+PTODSL does not expose a second public "module" decorator alongside
+`@pto.jit`. For ordinary code organization, write plain Python helper
+functions that are called from the entry body. Use `@pto.cube`,
+`@pto.simd`, and `@pto.simt` only when the helper must execute on a
+specific hardware unit.
+
 ### Sub-kernels — `@pto.cube` / `@pto.simd` / `@pto.simt`
 
 These are hardware-bound compute sub-kernels, each mapped to a specific NPU compute unit:
@@ -221,7 +227,6 @@ Chapter 11 walks through this example in full detail.
 | If you are... | Start with... |
 |---------------|---------------|
 | New to PTODSL | Chapter 2 (Quick Start), then Chapter 3 (Kernel Entries) |
-
 | Writing your first kernel | Chapter 2 → Chapter 4 (Type System) → Chapter 5 (Control Flow) |
 | Looking up a specific operation | Chapters 6–10 and Chapter 13 (organized by topic) |
 | Understanding the flash attention reference | Chapter 11 |

--- a/ptodsl/docs/user_guide/02-quick-start.md
+++ b/ptodsl/docs/user_guide/02-quick-start.md
@@ -24,9 +24,8 @@ def tile_copy(
     a_view = pto.make_tensor_view(A_ptr, shape=[rows, cols], strides=[cols, 1])
     o_view = pto.make_tensor_view(O_ptr, shape=[rows, cols], strides=[cols, 1])
 
-    # Allocate UB tiles for one row-strip block.
+    # Allocate a UB tile for one row-strip block.
     a_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
-    o_tile = pto.alloc_tile(shape=[1, BLOCK], dtype=pto.f32)
 
     # Partition the GM views to cover the current logical slice.
     a_part = pto.partition_view(a_view, offsets=[0, 0], sizes=[rows, cols])
@@ -34,7 +33,7 @@ def tile_copy(
 
     # Load from GM into UB, then store back out.
     pto.tile.load(a_part, a_tile)
-    pto.tile.store(o_tile, o_part)
+    pto.tile.store(a_tile, o_part)
 ```
 
 Let us step through each piece.
@@ -43,7 +42,14 @@ Let us step through each piece.
 
 ```python
 @pto.jit(target="a5")
-def tile_copy(A, O, *, BLOCK: pto.const_expr = 128):
+def tile_copy(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    O_ptr: pto.ptr(pto.f32, "gm"),
+    rows: pto.i32,
+    cols: pto.i32,
+    *,
+    BLOCK: pto.const_expr = 128,
+):
 ```
 
 `@pto.jit` marks this function as a launchable PTO kernel. The positional parameters `A_ptr` and `O_ptr` are explicit GM pointers, while `rows` and `cols` are runtime scalar metadata passed at launch time. The keyword-only argument `BLOCK` is a compile-time constant declared with `pto.const_expr`; the compiler specializes the kernel for each tile width.
@@ -76,7 +82,7 @@ a_part = pto.partition_view(a_view, offsets=[0, 0], sizes=[rows, cols])
 
 ```python
 pto.tile.load(a_part, a_tile)   # GM → UB
-pto.tile.store(o_tile, o_part)  # UB → GM
+pto.tile.store(a_tile, o_part)  # UB → GM
 ```
 
 `tile.load` copies a block of data from GM (described by a partition) into a UB tile. `tile.store` copies a UB tile back to GM. These are **Tile Ops** — they operate on entire tile buffers at once.
@@ -85,7 +91,7 @@ pto.tile.store(o_tile, o_part)  # UB → GM
 
 ```python
 pto.tile.load(a_part, a_tile)
-pto.tile.store(o_tile, o_part)
+pto.tile.store(a_tile, o_part)
 ```
 
 A copy kernel strips the example down to the essential PTODSL boundary objects:

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -306,6 +306,30 @@ def my_kernel(
         pto.tile.store(o_tile, o_part)
 ```
 
+### Plain helpers vs sub-kernels
+
+PTODSL exposes one public launch boundary: `@pto.jit`. Inside that entry,
+there are two kinds of helpers:
+
+- **Plain Python helpers** for code organization, repeated index math,
+  partition construction, and orchestration that should stay in the caller's
+  context.
+- **Sub-kernels** (`@pto.cube`, `@pto.simd`, `@pto.simt`) when the helper must
+  run on a specific hardware unit or use unit-local value categories such as
+  `vreg` or cube-local scratch.
+
+Use a plain helper when the code should not introduce a new hardware-unit
+boundary. Plain helpers do not define a separate ABI, target, mode, or
+backend. They are traced as part of the enclosing `@pto.jit` specialization
+and therefore inherit the caller's context.
+
+Use a sub-kernel when the helper's semantics belong to a specific unit:
+vector register math on SIMD, matrix instructions on Cube, or scalar-thread
+work on SIMT. Sub-kernels are the only public way to express that boundary.
+
+Named sub-kernels and plain nested helpers both use the same default AST
+rewrite behavior when they are traced from a compiled specialization.
+
 Sub-kernels are the mechanism for custom compute in PTODSL — when Tile Ops
 cover your needs, you don't need one; when they don't, a sub-kernel gives you
 direct access to the hardware unit. In auto mode, a sub-kernel's parameters
@@ -727,6 +751,7 @@ pointers:
 | Host → `@pto.jit` | explicit GM pointers + runtime scalars |
 | `@pto.jit(mode="auto")` → sub-kernel | `Tile`, PTO scalars (compiler handles staging + sync) |
 | `@pto.jit(mode="explicit")` → sub-kernel | `Tile`, `PartitionTensorView`, `pto.ptr`, PTO scalars |
+| `@pto.jit` → plain helper | same values as the caller; no new PTODSL boundary is introduced |
 | `@pto.jit` → `with pto.{cube,simd,simt}:` | `Tile` captured from enclosing scope |
 | Sub-kernel → sub-kernel | Not allowed (go through UB tiles via the caller) |
 | `@pto.simd` → caller | Only via `vsts`/`psts` to UB tiles; `vreg` cannot escape |
@@ -738,6 +763,10 @@ pointers:
 constant. The compiler specializes the kernel for each combination of constexpr
 values, and the compiled artifact is cached by specialization key together with
 the kernel's entry annotation contract.
+
+`pto.const_expr` is the public API name. In prose, this manual sometimes uses
+"constexpr" as shorthand for "compile-time constant"; it does not refer to a
+second PTODSL symbol.
 
 <!-- ptodsl-doc-test: {"mode":"compile","symbol":"kernel","compile":{}} -->
 ```python

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -245,6 +245,11 @@ For packed types (`pto.f4e1m2x2`, `pto.f4e2m1x2`), `shape` dimensions refer to t
 | `memory_space` | `MemorySpace` | Where the tile lives (UB, LEFT, RIGHT, ACC, BIAS) |
 | `valid_shape` | `tuple[int, ...]` | Logical data region, ≤ `shape` in each dimension |
 
+`valid_shape` is mutable. PTODSL uses this to describe runtime tails without
+changing the physical tile allocation. A common pattern is to allocate one
+full-size tile per block shape, then update `tile.valid_shape = [...]` before
+each sub-kernel or Tile Op call so the live region matches the current tail.
+
 ### Tile methods
 
 | Method | Description |
@@ -264,6 +269,10 @@ tail_tile.valid_shape = [rows]
 
 meta_ptr = meta_tile.as_ptr()
 ```
+
+When the live region is compile-time known, direct Python integers and
+`pto.const(...)` both work. When the live region depends on runtime metadata,
+assign PTO scalar values directly with `tile.valid_shape = [rows, cols]`.
 
 ## 4.8 Tile Reinterpretation
 

--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -214,7 +214,7 @@ This surface avoids explicit result-type declarations and explicit
 
 ## 5.4 `pto.const_expr` and tracing
 
-`pto.const_expr` parameters (Section 3.8) are compile-time constants. They are fixed at `.compile()` time and cannot change between launches of the same compiled kernel. Because their values are known during tracing, they interact naturally with Python control flow:
+`pto.const_expr` parameters (Section 3.6) are compile-time constants. They are fixed at `.compile()` time and cannot change between launches of the same compiled kernel. Because their values are known during tracing, they interact naturally with Python control flow:
 
 ```python
 @pto.jit(target="a5")

--- a/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
+++ b/ptodsl/docs/user_guide/06-scalar-and-pointer-ops.md
@@ -234,6 +234,11 @@ For fixed-width bit manipulation where the exact integer width matters, cast to 
 
 Non-trivial scalar math functions live under the top-level `scalar` namespace (imported as `from ptodsl import scalar`). They are intentionally separate from the `pto.*` namespace:
 
+Use the `scalar.*` helpers for device-side runtime math. Python built-ins such
+as `max(...)`, `min(...)`, and `abs(...)` run at trace time and are only
+correct for plain Python values. When the operands are PTO runtime scalars,
+write `scalar.max(a, b)`, `scalar.min(a, b)`, and `scalar.abs(x)` explicitly.
+
 #### `scalar.max(a: ScalarType, b: ScalarType) -> ScalarType`
 
 **Description**: Returns the maximum of two scalars.

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -84,6 +84,13 @@ Inside explicit-mode orchestration, data movement between memory spaces is expre
 
 All four share a common structure: a required innermost `nburst(...)` group that defines the repeated burst transfer, plus optional outer `loop(...)` groups for multi-level repetition. `pto.mte_gm_ub` additionally supports `pad(...)` for UB row padding.
 
+For day-to-day explicit-mode authoring, PTODSL also exposes the shorthand
+wrappers `pto.mte_load(...)` and `pto.mte_store(...)`. They are ptr-based
+aliases for the canonical `pto.mte_gm_ub(...)` and `pto.mte_ub_gm(...)`
+surfaces and accept the same grouped-DMA shape arguments. Later walkthroughs
+use the shorthand names because they read more naturally in orchestration code;
+this chapter documents the underlying canonical operations.
+
 ### 7.2.1 GM → UB: `pto.mte_gm_ub`
 
 #### `pto.mte_gm_ub(gm_src: PtrType, ub_dst: PtrType, l2_cache_ctl: int, len_burst: int, *, nburst: tuple[int, int, int], loops: list[tuple[int, int, int]] | None = None, pad: tuple[ScalarType, int, int] | tuple[ScalarType] | None = None) -> None`
@@ -96,7 +103,7 @@ All four share a common structure: a required innermost `nburst(...)` group that
 |-----------|------|-------------|
 | `gm_src` | `PtrType` (gm) | GM source pointer |
 | `ub_dst` | `PtrType` (ub) | UB destination pointer (must be 32B-aligned) |
-| `l2_cache_ctl` | `int` | L2 cache allocate control (2 bits) |
+| `l2_cache_ctl` | `int` | L2 cache allocate control (2 bits). PTODSL forwards the integer verbatim; most kernels should pass `0` unless they are matching a backend-specific cache policy |
 | `len_burst` | `int` | Contiguous bytes transferred per burst row |
 | `nburst` | `tuple[int, int, int]` | `(n_burst, src_stride, dst_stride)` — innermost burst group (required) |
 | `loops` | `list[tuple[int, int, int]]` or `None` | Optional outer loop groups, each `(count, src_stride, dst_stride)`. Ordered inner to outer |

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -4,6 +4,10 @@ This chapter covers every operation that moves data between memory spaces in PTO
 
 ## 7.1 Tile-level movement: tile.load and tile.store
 
+Section 7.6 on pipe communication is an advanced topic. Most kernels can skip
+it on a first read and come back only when they need explicit cube/vector FIFO
+coordination.
+
 Tile ops move entire blocks between Global Memory and the Unified Buffer in a single call. They are the primary data movement interface inside `@pto.jit`.
 
 #### `pto.tile.load(partition: PartitionTensorView, tile: Tile) -> None`

--- a/ptodsl/docs/user_guide/08-compute-operations.md
+++ b/ptodsl/docs/user_guide/08-compute-operations.md
@@ -84,6 +84,41 @@ Element-wise operations between a tile and a scalar.
 
 ---
 
+### 8.1.2a Tile movement between domains
+
+#### `pto.tile.mov(src: Tile, dst: Tile, *, mode=None) -> None`
+
+**Description**: Moves data between compatible tile domains without going
+through GM. This is the tile-domain transfer surface used when a workflow needs
+to stage data from one tile contract into another, for example UB → MAT before
+a cube sub-kernel consumes the result.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `src` | `Tile` | Source tile |
+| `dst` | `Tile` | Destination tile |
+| `mode` | implementation-defined or `None` | Optional transfer mode used only for specialized backend paths |
+
+**Returns**: None.
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"flash_attention.l1_tiles","symbol":"flash_attention_l1_tiles_probe","compile":{"BLOCK_Q":128,"BLOCK_KV":128,"HEAD_DIM":128}} -->
+```python
+p_tile = pto.alloc_tile(shape=[Br, Bc], dtype=pto.f32, valid_shape=[full_br, full_bc])
+p_mat = pto.alloc_tile(
+    shape=[Br, Bc],
+    dtype=pto.f32,
+    memory_space=pto.MemorySpace.MAT,
+    valid_shape=[full_br, full_bc],
+    blayout="ColMajor",
+    slayout="RowMajor",
+)
+pto.tile.mov(p_tile, p_mat)
+```
+
+---
+
 ### 8.1.3 Unary math
 
 Single-source element-wise math functions.
@@ -677,6 +712,7 @@ pto.tile.matmul_acc(acc_prev, lhs_l0a, rhs_l0b, acc_next)
 | Partial elementwise | `tile.partadd`, `tile.partmul`, `tile.partmax`, `tile.partmin` |
 | Fill/padding | `tile.fillpad`, `tile.fillpad_expand`, `tile.fillpad_inplace` |
 | Windowing | `tile.extract`, `tile.insert` |
+| Tile movement | `tile.mov` |
 | Tile matmul | `tile.matmul`, `tile.matmul_acc` |
 
 ---

--- a/ptodsl/docs/user_guide/11-flash-attention-walkthrough.md
+++ b/ptodsl/docs/user_guide/11-flash-attention-walkthrough.md
@@ -214,22 +214,10 @@ beta_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, o
 
 The walkthrough keeps Q/K/V/P on the MAT path so the cube sub-kernels consume the same tile objects that the top-level kernel owns. Runtime tails still live in `valid_shape`; the physical tile shapes stay static.
 
-**UB-resident state and scratch tiles** — the online-softmax state plus intermediate outputs:
-
-```python
-o_prev_tile = pto.alloc_tile(shape=[Br, D], dtype=pto.f32, valid_shape=[full_br, dim])
-o_next_tile = pto.alloc_tile(shape=[Br, D], dtype=pto.f32, valid_shape=[full_br, dim])
-m_prev_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
-m_next_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
-l_prev_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
-l_next_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
-
-s_tile = pto.alloc_tile(shape=[Br, Bc], dtype=pto.f32, valid_shape=[full_br, full_bc])
-p_tile = pto.alloc_tile(shape=[Br, Bc], dtype=pto.f32, valid_shape=[full_br, full_bc])
-pv_tile = pto.alloc_tile(shape=[Br, D], dtype=pto.f32, valid_shape=[full_br, dim])
-alpha_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
-beta_tile = pto.alloc_tile(shape=[Br, 1], dtype=pto.f32, valid_shape=[full_br, one], blayout="ColMajor")
-```
+**UB-resident state and scratch tiles** — among the allocations above, the
+online-softmax state lives in `o_prev_tile` / `o_next_tile`, `m_prev_tile` /
+`m_next_tile`, `l_prev_tile` / `l_next_tile`, plus the scratch tiles
+`s_tile`, `p_tile`, `pv_tile`, `alpha_tile`, and `beta_tile`.
 
 The online-softmax algorithm requires **ping-pong state tiles**: `m_prev`/`m_next`, `l_prev`/`l_next`, `o_prev`/`o_next`. After each KV block, `next` becomes `prev` for the following iteration.
 

--- a/ptodsl/docs/user_guide/11-flash-attention-walkthrough.md
+++ b/ptodsl/docs/user_guide/11-flash-attention-walkthrough.md
@@ -595,7 +595,12 @@ This is a scalar element-wise blend over the tile domain:
 O_next[row, col] = alpha[row] * O_prev[row, col] + beta[row] * PV[row, col]
 ```
 
-The SIMT kernel walks the tile element by element with nested `pto.for_` loops. Each iteration loads two scalars (`o_prev` and `pv_val`), computes the weighted sum, and stores the result. The `alpha`/`beta` coefficients are per-row (loaded once per row), while the blend is per-element.
+The SIMT kernel walks the tile element by element with nested Python
+`for range(...)` loops. Under the default AST rewrite path these become
+device-side runtime loops. Each iteration loads two scalars (`o_prev` and
+`pv_val`), computes the weighted sum, and stores the result. The `alpha` /
+`beta` coefficients are per-row (loaded once per row), while the blend is
+per-element.
 
 **Why SIMT instead of SIMD?** The intent is to contrast with `online_softmax_rows`: softmax is dominated by row-wise vector reductions and exponentials — natural SIMD work. The final blend is a simple linear combination with per-row coefficients — expressing it as explicit scalar work-items makes the per-element access pattern explicit and leaves the compiler free to vectorize or fuse as it sees fit.
 

--- a/ptodsl/docs/user_guide/12-additional-examples.md
+++ b/ptodsl/docs/user_guide/12-additional-examples.md
@@ -269,7 +269,16 @@ This pattern extends directly to batch-GEMM: pass a grid of `batch` and use `pto
 
 ### 12.3.4 Comparison with explicit-mode orchestration
 
-For reference, the same GEMM could be written in `mode="explicit"` when the kernel needs micro-instruction control. The direct-call path used above is recommended for most users; explicit mode is for cases that need hand-authored instruction scheduling and ordering.
+This example keeps `mode="explicit"` because the named Cube helper directly
+authors explicit-only surfaces such as `mte_l1_l0a`, `mte_l1_l0b`, and
+`mte_l0c_ub`. Even though the top-level `@pto.jit` body itself stays fairly
+tile-centric, the enclosing kernel still has to opt into explicit mode so that
+the called sub-kernel is legal.
+
+For most users, the direct-call structure shown above is still the recommended
+pattern: keep the orchestration simple, let the named Cube helper own the
+micro-instruction sequence, and only add more top-level explicit scheduling
+when you truly need hand-authored DMA ordering or phase control.
 
 ## 12.4 Online normalization with loop-carried state
 

--- a/ptodsl/docs/user_guide/12-additional-examples.md
+++ b/ptodsl/docs/user_guide/12-additional-examples.md
@@ -48,7 +48,9 @@ def mat_add(
 
 **Key points**:
 
-- Nested `pto.for_` loops produce a 2D block traversal. Both loops are recorded as device-side control flow — they adapt to the runtime shape `M`.
+- Nested Python `for range(...)` loops produce a 2D block traversal. Under the
+  default AST rewrite path they are recorded as device-side control flow, so
+  they adapt to the runtime shapes `M` and `N_`.
 - Tile shape `[BLOCK_M, BLOCK_N]` is 2D; all three tiles use the same shape so `tile.add` is elementwise.
 - `partition_view` takes 2D offsets and sizes.
 - `BLOCK_M` and `BLOCK_N` are `constexpr` — the compiler specializes the kernel per tile shape.


### PR DESCRIPTION
## Summary

This PR addresses a set of PTODSL user-guide issues from https://github.com/hw-native-sys/PTOAS/issues/800 that still reproduce on current .

The changes focus on documentation correctness and contract clarity:
- remove an outdated Chapter 14 reference in the introduction
- clarify that  is mutable and document the common runtime-tail update pattern
- fix the  control-flow cross-reference in Chapter 5
- explain the boundary between Python built-ins and  runtime helpers
- document  /  as explicit-mode shorthand wrappers for the canonical DMA surfaces
- add guidance for  default usage
- add formal  documentation and include it in the tile-op quick reference
- remove the duplicated UB state allocation block in the flash-attention walkthrough
- clarify why the Chapter 12 GEMM example legitimately stays in 

## Validation

Local checks on this branch:
- 
- 
- 

All passed locally.
Related to #800 