### PR TITLE
fix: detect single AICORE kernel entry in testcase generator

### DIFF
--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -314,6 +314,17 @@ def _describe_kernel_source(text: str):
                 "call_text": func["text"],
             }
 
+    if len(functions) == 1:
+        func = functions[0]
+        return {
+            "kind": "global",
+            "kernel_name": func["name"],
+            "raw_params": func["raw_params"],
+            "analysis_texts": [func["text"]],
+            "writer_texts": [func["text"]],
+            "call_text": func["text"],
+        }
+
     mixed_groups = {}
     for func in functions:
         name = func["name"]


### PR DESCRIPTION
## Summary
- treat a single bare `AICORE void <name>(...)` function as the testcase entry kernel
- avoid falling back to the synthetic `kernel` symbol when the source contains exactly one non-`__global__` AICORE kernel

## Background
A5 board validation can generate device sources where the entry appears as a single bare `AICORE void kernel_add(...)` function. The existing testcase generator only recognized:
- `__global__ AICORE void ...`
- paired `_aic` / `_aiv` mixed kernels

In the single-function case it fell back to `kernel`, which later produced link/runtime failures such as `undefined symbol: kernel`.

## Validation
- `python3 -m py_compile test/npu_validation/scripts/generate_testcase.py`
- direct `_describe_kernel_source(...)` check with a single bare `AICORE void kernel_add(...)` input now returns `kernel_add` instead of `kernel`
