### PR TITLE
Fix A5 validation host linking

### DIFF
--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -1981,6 +1981,11 @@ def generate_testcase(
             if runtime_rt_include
             else '#include "pto/npu/comm/async/sdma/sdma_workspace_manager.hpp"'
         )
+    cann_extra_link_dirs = """set(PTO_CANN_EXTRA_LINK_DIRS "")
+if(DEFINED ENV{PTO_CANN_EXTRA_LINK_DIRS} AND NOT "$ENV{PTO_CANN_EXTRA_LINK_DIRS}" STREQUAL "")
+    string(REPLACE ":" ";" PTO_CANN_EXTRA_LINK_DIRS "$ENV{PTO_CANN_EXTRA_LINK_DIRS}")
+endif()
+"""
     main_cpp = (
         template
         .replace("@RUNTIME_RT_INCLUDE@", runtime_rt_include)
@@ -2365,6 +2370,8 @@ include_directories(
     ${{ASCEND_DRIVER_PATH}}/kernel/inc
 )
 
+{cann_extra_link_dirs}
+
 	add_library({testcase}_kernel SHARED {testcase}_kernel.cpp launch.cpp)
 	target_compile_options({testcase}_kernel PRIVATE ${{CMAKE_CCE_COMPILE_OPTIONS}} --cce-aicore-arch={aicore_arch}{dav_defines} -D{mem_base_define} -std=c++17)
 	target_include_directories({testcase}_kernel PRIVATE
@@ -2383,12 +2390,25 @@ target_include_directories({testcase} PRIVATE
 
 target_link_directories({testcase} PUBLIC
     ${{ASCEND_HOME_PATH}}/lib64
+    ${{PTO_CANN_EXTRA_LINK_DIRS}}
 )
+
+find_library(PTO_NNOPBASE_LIB
+    NAMES nnopbase
+    HINTS ${{PTO_CANN_EXTRA_LINK_DIRS}} ${{ASCEND_HOME_PATH}}/lib64
+    NO_DEFAULT_PATH
+)
+if(NOT PTO_NNOPBASE_LIB)
+    find_library(PTO_NNOPBASE_LIB NAMES nnopbase)
+endif()
+if(NOT PTO_NNOPBASE_LIB)
+    message(FATAL_ERROR "Cannot find libnnopbase.so. Set PTO_CANN_EXTRA_LINK_DIRS or fix ASCEND_HOME_PATH.")
+endif()
 
 target_link_libraries({testcase} PRIVATE
     {testcase}_kernel
     runtime
-    stdc++ ascendcl m tiling_api platform c_sec dl nnopbase
+    stdc++ ascendcl m tiling_api platform c_sec dl ${{PTO_NNOPBASE_LIB}}
 )
 
 if(ENABLE_SIM_GOLDEN)
@@ -2401,6 +2421,7 @@ if(ENABLE_SIM_GOLDEN)
 {runtime_host_include_dirs})
     target_link_directories({testcase}_sim PUBLIC
         ${{ASCEND_HOME_PATH}}/lib64
+        ${{PTO_CANN_EXTRA_LINK_DIRS}}
         ${{ASCEND_HOME_PATH}}/aarch64-linux/simulator/${{SOC_VERSION}}/lib
         ${{ASCEND_HOME_PATH}}/x86_64-linux/simulator/${{SOC_VERSION}}/lib
         ${{ASCEND_HOME_PATH}}/simulator/${{SOC_VERSION}}/lib
@@ -2409,7 +2430,7 @@ if(ENABLE_SIM_GOLDEN)
     target_link_libraries({testcase}_sim PRIVATE
         {testcase}_kernel
         runtime_camodel
-        stdc++ ascendcl m tiling_api platform c_sec dl nnopbase
+        stdc++ ascendcl m tiling_api platform c_sec dl ${{PTO_NNOPBASE_LIB}}
     )
 endif()
 """

--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -2410,6 +2410,7 @@ target_link_libraries({testcase} PRIVATE
     runtime
     stdc++ ascendcl m tiling_api platform c_sec dl ${{PTO_NNOPBASE_LIB}}
 )
+target_link_options({testcase} PRIVATE -Wl,--allow-shlib-undefined)
 
 if(ENABLE_SIM_GOLDEN)
     # Simulator executable: used to generate golden outputs (Ascend camodel).
@@ -2432,6 +2433,7 @@ if(ENABLE_SIM_GOLDEN)
         runtime_camodel
         stdc++ ascendcl m tiling_api platform c_sec dl ${{PTO_NNOPBASE_LIB}}
     )
+    target_link_options({testcase}_sim PRIVATE -Wl,--allow-shlib-undefined)
 endif()
 """
     (output_dir / "CMakeLists.txt").write_text(cmake_content.strip() + "\n", encoding="utf-8")

--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -312,6 +312,7 @@ def _describe_kernel_source(text: str):
                 "analysis_texts": [func["text"]],
                 "writer_texts": [func["text"]],
                 "call_text": func["text"],
+                "needs_global_wrapper": False,
             }
 
     if len(functions) == 1:
@@ -323,6 +324,7 @@ def _describe_kernel_source(text: str):
             "analysis_texts": [func["text"]],
             "writer_texts": [func["text"]],
             "call_text": func["text"],
+            "needs_global_wrapper": not func["is_global"],
         }
 
     mixed_groups = {}
@@ -348,6 +350,7 @@ def _describe_kernel_source(text: str):
                 "aic_text": group["aic"]["text"],
                 "aiv_text": group["aiv"]["text"],
                 "call_text": group["aiv"]["text"],
+                "needs_global_wrapper": False,
             }
 
     return {
@@ -357,7 +360,37 @@ def _describe_kernel_source(text: str):
         "analysis_texts": [text],
         "writer_texts": [text],
         "call_text": text,
+        "needs_global_wrapper": False,
     }
+
+
+def _append_single_kernel_global_wrapper(
+    kernel_text: str,
+    kernel_name: str,
+    raw_params: list[str],
+) -> str:
+    impl_name = f"__ptoas_{kernel_name}_impl"
+    pattern = re.compile(
+        rf"(?P<prefix>extern\s+\"C\"\s+)?AICORE\s+void\s+{re.escape(kernel_name)}\s*\((?P<params>[^)]*)\)\s*\{{",
+        re.S,
+    )
+
+    def _replace_entry(match):
+        params = match.group("params").strip()
+        return f"static AICORE inline void {impl_name}({params}) {{"
+
+    rewritten, count = pattern.subn(_replace_entry, kernel_text, count=1)
+    if count == 0:
+        return kernel_text
+
+    call_args = ", ".join(_extract_cpp_name(param) for param in raw_params)
+    wrapper = (
+        "\n\n"
+        f"extern \"C\" __global__ AICORE void {kernel_name}({', '.join(raw_params)}) {{\n"
+        f"  {impl_name}({call_args});\n"
+        "}\n"
+    )
+    return rewritten.rstrip() + wrapper
 
 
 def _append_mixed_kernel_wrapper(
@@ -2217,6 +2250,13 @@ endif()
                     cols=cols,
                     logical_elem_count=logical_elem_count,
                 )
+
+    if kernel_info.get("needs_global_wrapper"):
+        kernel_text_out = _append_single_kernel_global_wrapper(
+            kernel_text_out,
+            kernel_name,
+            raw_params,
+        )
 
     if is_mixed_kernel:
         kernel_text_out = _append_mixed_kernel_wrapper(

--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -108,7 +108,7 @@ discover_cann_host_link_dirs() {
   fi
 
   if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
-    log "ASCEND_HOME_PATH=${ASCEND_HOME_PATH} is missing libnnopbase.so under standard host lib dirs; probing fallback CANN roots."
+    log "ASCEND_HOME_PATH=${ASCEND_HOME_PATH} is missing libnnopbase.so under standard host lib dirs; probing fallback CANN roots." >&2
   fi
 
   for root in \

--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -31,6 +31,121 @@ fi
 
 log() { echo "[$(date +'%F %T')] $*"; }
 
+append_unique_colon_item() {
+  local list="$1"
+  local item="$2"
+  [[ -n "${item}" && -d "${item}" ]] || {
+    echo "${list}"
+    return 0
+  }
+  if [[ -z "${list}" ]]; then
+    echo "${item}"
+    return 0
+  fi
+  case ":${list}:" in
+    *":${item}:"*) echo "${list}" ;;
+    *) echo "${list}:${item}" ;;
+  esac
+}
+
+list_contains_file() {
+  local list="$1"
+  local file_name="$2"
+  local dir
+  IFS=':' read -r -a _pto_list_dirs <<< "${list}"
+  for dir in "${_pto_list_dirs[@]}"; do
+    [[ -n "${dir}" && -e "${dir}/${file_name}" ]] && return 0
+  done
+  return 1
+}
+
+host_lib_arch() {
+  case "$(uname -m)" in
+    aarch64 | arm64) echo "aarch64" ;;
+    x86_64 | amd64) echo "x86_64" ;;
+    *) uname -m ;;
+  esac
+}
+
+collect_cann_host_link_dirs_for_root() {
+  local root="$1"
+  local arch="$2"
+  local dirs="$3"
+  local dir=""
+  for dir in \
+    "${root}/lib64" \
+    "${root}/${arch}-linux/lib64" \
+    "${root}/runtime/lib64" \
+    "${root}/fwkacllib/lib64" \
+    "${root}/${arch}-linux/devlib" \
+    "${root}/${arch}-linux/devlib/linux/${arch}"; do
+    [[ -d "${dir}" ]] || continue
+    if [[ -e "${dir}/libnnopbase.so" || -e "${dir}/libascendcl.so" \
+       || -e "${dir}/libplatform.so" || -e "${dir}/libtiling_api.a" \
+       || -e "${dir}/libtiling_api.so" ]]; then
+      dirs="$(append_unique_colon_item "${dirs}" "${dir}")"
+    fi
+  done
+  echo "${dirs}"
+}
+
+discover_cann_host_link_dirs() {
+  local arch="$1"
+  local dirs=""
+  local root=""
+  local current_base=""
+  local -a candidate_roots=()
+  shopt -s nullglob
+
+  if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
+    dirs="$(collect_cann_host_link_dirs_for_root "${ASCEND_HOME_PATH}" "${arch}" "${dirs}")"
+    current_base="$(basename "${ASCEND_HOME_PATH}")"
+  fi
+  if list_contains_file "${dirs}" "libnnopbase.so"; then
+    shopt -u nullglob
+    echo "${dirs}"
+    return 0
+  fi
+
+  if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
+    log "ASCEND_HOME_PATH=${ASCEND_HOME_PATH} is missing libnnopbase.so under standard host lib dirs; probing fallback CANN roots."
+  fi
+
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ -n "${current_base}" && "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    if [[ -n "${current_base}" && "${root}" == *"/${current_base}" ]]; then
+      candidate_roots+=("${root}")
+    fi
+  done
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    candidate_roots+=("${root}")
+  done
+  shopt -u nullglob
+
+  for root in "${candidate_roots[@]}"; do
+    dirs="$(collect_cann_host_link_dirs_for_root "${root}" "${arch}" "${dirs}")"
+    if list_contains_file "${dirs}" "libnnopbase.so"; then
+      break
+    fi
+  done
+  echo "${dirs}"
+}
+
 log "=== Remote NPU Validation ==="
 log "STAGE=${STAGE} RUN_MODE=${RUN_MODE} SOC_VERSION=${SOC_VERSION}"
 log "GOLDEN_MODE=${GOLDEN_MODE}"
@@ -138,7 +253,16 @@ if ! command -v bisheng >/dev/null 2>&1; then
   fi
 fi
 
-export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+PTO_CANN_EXTRA_LINK_DIRS="$(discover_cann_host_link_dirs "$(host_lib_arch)")"
+if [[ -n "${PTO_CANN_EXTRA_LINK_DIRS}" ]]; then
+  export PTO_CANN_EXTRA_LINK_DIRS
+  export LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+  export LD_LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  log "PTO_CANN_EXTRA_LINK_DIRS=${PTO_CANN_EXTRA_LINK_DIRS}"
+else
+  export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+  log "WARN: no usable CANN host link dirs detected; falling back to ${ASCEND_HOME_PATH}/lib64"
+fi
 
 # Some CANN installs do not provide a simulator directory named exactly
 # "Ascend910". Map it to a real directory so we can link/run camodel.
@@ -170,19 +294,6 @@ if [[ "${RUN_MODE}" == "sim" ]]; then
 elif [[ "$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')" == *910b* ]]; then
   export PTOAS_BOARD_IS_A3=1
   log "Detected A3 board from npu-smi chip name: ${_board_chip}"
-else
-  for _sim_dir in "${ASCEND_HOME_PATH}/aarch64-linux/simulator" \
-                  "${ASCEND_HOME_PATH}/x86_64-linux/simulator" \
-                  "${ASCEND_HOME_PATH}/simulator" \
-                  "${ASCEND_HOME_PATH}/tools/simulator"; do
-    for _d in "${_sim_dir}"/Ascend910B*/lib; do
-      if [[ -d "$_d" ]]; then
-        export PTOAS_BOARD_IS_A3=1
-        log "Detected A3 board from simulator dir fallback: $_d"
-        break 2
-      fi
-    done
-  done
 fi
 log "SIM_SOC_VERSION=${SIM_SOC_VERSION}"
 log "PTOAS_BOARD_IS_A3=${PTOAS_BOARD_IS_A3}"

--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -146,6 +146,74 @@ discover_cann_host_link_dirs() {
   echo "${dirs}"
 }
 
+collect_cann_host_include_dirs_for_root() {
+  local root="$1"
+  local arch="$2"
+  local dirs="$3"
+  local dir=""
+  for dir in \
+    "${root}/include" \
+    "${root}/${arch}-linux/include" \
+    "${root}/runtime/include" \
+    "${root}/fwkacllib/include" \
+    "${root}/${arch}-linux/pkg_inc" \
+    "${root}/pkg_inc"; do
+    [[ -d "${dir}" ]] || continue
+    if [[ -e "${dir}/pto/npu/comm/async/sdma/sdma_workspace_manager.hpp" \
+       || -e "${dir}/ccelib/common/runtime.h" \
+       || -e "${dir}/runtime/rt.h" \
+       || -e "${dir}/acl/acl.h" ]]; then
+      dirs="$(append_unique_colon_item "${dirs}" "${dir}")"
+    fi
+  done
+  echo "${dirs}"
+}
+
+discover_cann_host_include_dirs() {
+  local arch="$1"
+  local dirs=""
+  local root=""
+  local current_base=""
+  local -a candidate_roots=()
+  shopt -s nullglob
+
+  if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
+    dirs="$(collect_cann_host_include_dirs_for_root "${ASCEND_HOME_PATH}" "${arch}" "${dirs}")"
+    current_base="$(basename "${ASCEND_HOME_PATH}")"
+  fi
+
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ -n "${current_base}" && "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    if [[ -n "${current_base}" && "${root}" == *"/${current_base}" ]]; then
+      candidate_roots+=("${root}")
+    fi
+  done
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    candidate_roots+=("${root}")
+  done
+  shopt -u nullglob
+
+  for root in "${candidate_roots[@]}"; do
+    dirs="$(collect_cann_host_include_dirs_for_root "${root}" "${arch}" "${dirs}")"
+  done
+  echo "${dirs}"
+}
+
 log "=== Remote NPU Validation ==="
 log "STAGE=${STAGE} RUN_MODE=${RUN_MODE} SOC_VERSION=${SOC_VERSION}"
 log "GOLDEN_MODE=${GOLDEN_MODE}"
@@ -254,14 +322,24 @@ if ! command -v bisheng >/dev/null 2>&1; then
 fi
 
 PTO_CANN_EXTRA_LINK_DIRS="$(discover_cann_host_link_dirs "$(host_lib_arch)")"
+PTO_CANN_EXTRA_INCLUDE_DIRS="$(discover_cann_host_include_dirs "$(host_lib_arch)")"
 if [[ -n "${PTO_CANN_EXTRA_LINK_DIRS}" ]]; then
   export PTO_CANN_EXTRA_LINK_DIRS
-  export LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LIBRARY_PATH:+:${LIBRARY_PATH}}"
-  export LD_LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  export LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+  export LIBRARY_PATH="${LIBRARY_PATH}:${PTO_CANN_EXTRA_LINK_DIRS}"
+  export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${PTO_CANN_EXTRA_LINK_DIRS}"
   log "PTO_CANN_EXTRA_LINK_DIRS=${PTO_CANN_EXTRA_LINK_DIRS}"
 else
-  export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+  export LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+  export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
   log "WARN: no usable CANN host link dirs detected; falling back to ${ASCEND_HOME_PATH}/lib64"
+fi
+if [[ -n "${PTO_CANN_EXTRA_INCLUDE_DIRS}" ]]; then
+  export PTO_CANN_EXTRA_INCLUDE_DIRS
+  export CPATH="${PTO_CANN_EXTRA_INCLUDE_DIRS}${CPATH:+:${CPATH}}"
+  export CPLUS_INCLUDE_PATH="${PTO_CANN_EXTRA_INCLUDE_DIRS}${CPLUS_INCLUDE_PATH:+:${CPLUS_INCLUDE_PATH}}"
+  log "PTO_CANN_EXTRA_INCLUDE_DIRS=${PTO_CANN_EXTRA_INCLUDE_DIRS}"
 fi
 
 # Some CANN installs do not provide a simulator directory named exactly

--- a/test/npu_validation/templates/run_sh_template.sh
+++ b/test/npu_validation/templates/run_sh_template.sh
@@ -18,6 +18,117 @@ BUILD_DIR="${BUILD_DIR:-build}"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+append_unique_colon_item() {
+  local list="$1"
+  local item="$2"
+  [[ -n "${item}" && -d "${item}" ]] || {
+    echo "${list}"
+    return 0
+  }
+  if [[ -z "${list}" ]]; then
+    echo "${item}"
+    return 0
+  fi
+  case ":${list}:" in
+    *":${item}:"*) echo "${list}" ;;
+    *) echo "${list}:${item}" ;;
+  esac
+}
+
+list_contains_file() {
+  local list="$1"
+  local file_name="$2"
+  local dir
+  IFS=':' read -r -a _pto_list_dirs <<< "${list}"
+  for dir in "${_pto_list_dirs[@]}"; do
+    [[ -n "${dir}" && -e "${dir}/${file_name}" ]] && return 0
+  done
+  return 1
+}
+
+host_lib_arch() {
+  case "$(uname -m)" in
+    aarch64 | arm64) echo "aarch64" ;;
+    x86_64 | amd64) echo "x86_64" ;;
+    *) uname -m ;;
+  esac
+}
+
+collect_cann_host_link_dirs_for_root() {
+  local root="$1"
+  local arch="$2"
+  local dirs="$3"
+  local dir=""
+  for dir in \
+    "${root}/lib64" \
+    "${root}/${arch}-linux/lib64" \
+    "${root}/runtime/lib64" \
+    "${root}/fwkacllib/lib64" \
+    "${root}/${arch}-linux/devlib" \
+    "${root}/${arch}-linux/devlib/linux/${arch}"; do
+    [[ -d "${dir}" ]] || continue
+    if [[ -e "${dir}/libnnopbase.so" || -e "${dir}/libascendcl.so" \
+       || -e "${dir}/libplatform.so" || -e "${dir}/libtiling_api.a" \
+       || -e "${dir}/libtiling_api.so" ]]; then
+      dirs="$(append_unique_colon_item "${dirs}" "${dir}")"
+    fi
+  done
+  echo "${dirs}"
+}
+
+discover_cann_host_link_dirs() {
+  local arch="$1"
+  local dirs=""
+  local root=""
+  local current_base=""
+  local -a candidate_roots=()
+  shopt -s nullglob
+
+  if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
+    dirs="$(collect_cann_host_link_dirs_for_root "${ASCEND_HOME_PATH}" "${arch}" "${dirs}")"
+    current_base="$(basename "${ASCEND_HOME_PATH}")"
+  fi
+  if list_contains_file "${dirs}" "libnnopbase.so"; then
+    shopt -u nullglob
+    echo "${dirs}"
+    return 0
+  fi
+
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ -n "${current_base}" && "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    if [[ -n "${current_base}" && "${root}" == *"/${current_base}" ]]; then
+      candidate_roots+=("${root}")
+    fi
+  done
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    candidate_roots+=("${root}")
+  done
+  shopt -u nullglob
+
+  for root in "${candidate_roots[@]}"; do
+    dirs="$(collect_cann_host_link_dirs_for_root "${root}" "$(host_lib_arch)" "${dirs}")"
+    if list_contains_file "${dirs}" "libnnopbase.so"; then
+      break
+    fi
+  done
+  echo "${dirs}"
+}
+
 cd "${ROOT_DIR}"
 python3 "${ROOT_DIR}/golden.py"
 
@@ -60,7 +171,16 @@ fi
 
 # Improve runtime linking robustness.
 if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
-  export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+  if [[ -z "${PTO_CANN_EXTRA_LINK_DIRS:-}" ]]; then
+    PTO_CANN_EXTRA_LINK_DIRS="$(discover_cann_host_link_dirs "$(host_lib_arch)")"
+  fi
+  if [[ -n "${PTO_CANN_EXTRA_LINK_DIRS:-}" ]]; then
+    export PTO_CANN_EXTRA_LINK_DIRS
+    export LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+    export LD_LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  else
+    export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+  fi
 fi
 
 LD_LIBRARY_PATH_NPU="${LD_LIBRARY_PATH:-}"

--- a/test/npu_validation/templates/run_sh_template.sh
+++ b/test/npu_validation/templates/run_sh_template.sh
@@ -129,6 +129,74 @@ discover_cann_host_link_dirs() {
   echo "${dirs}"
 }
 
+collect_cann_host_include_dirs_for_root() {
+  local root="$1"
+  local arch="$2"
+  local dirs="$3"
+  local dir=""
+  for dir in \
+    "${root}/include" \
+    "${root}/${arch}-linux/include" \
+    "${root}/runtime/include" \
+    "${root}/fwkacllib/include" \
+    "${root}/${arch}-linux/pkg_inc" \
+    "${root}/pkg_inc"; do
+    [[ -d "${dir}" ]] || continue
+    if [[ -e "${dir}/pto/npu/comm/async/sdma/sdma_workspace_manager.hpp" \
+       || -e "${dir}/ccelib/common/runtime.h" \
+       || -e "${dir}/runtime/rt.h" \
+       || -e "${dir}/acl/acl.h" ]]; then
+      dirs="$(append_unique_colon_item "${dirs}" "${dir}")"
+    fi
+  done
+  echo "${dirs}"
+}
+
+discover_cann_host_include_dirs() {
+  local arch="$1"
+  local dirs=""
+  local root=""
+  local current_base=""
+  local -a candidate_roots=()
+  shopt -s nullglob
+
+  if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
+    dirs="$(collect_cann_host_include_dirs_for_root "${ASCEND_HOME_PATH}" "${arch}" "${dirs}")"
+    current_base="$(basename "${ASCEND_HOME_PATH}")"
+  fi
+
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ -n "${current_base}" && "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    if [[ -n "${current_base}" && "${root}" == *"/${current_base}" ]]; then
+      candidate_roots+=("${root}")
+    fi
+  done
+  for root in \
+    /usr/local/Ascend/cann \
+    /usr/local/Ascend/cann-* \
+    /usr/local/Ascend/ascend-toolkit/latest \
+    /home/*/cann*/cann-* \
+    /home/*/*/cann-* \
+    /home/*/Ascend/*/cann-*; do
+    [[ -d "${root}" ]] || continue
+    [[ "${root}" == "${ASCEND_HOME_PATH:-}" ]] && continue
+    candidate_roots+=("${root}")
+  done
+  shopt -u nullglob
+
+  for root in "${candidate_roots[@]}"; do
+    dirs="$(collect_cann_host_include_dirs_for_root "${root}" "${arch}" "${dirs}")"
+  done
+  echo "${dirs}"
+}
+
 cd "${ROOT_DIR}"
 python3 "${ROOT_DIR}/golden.py"
 
@@ -174,12 +242,20 @@ if [[ -n "${ASCEND_HOME_PATH:-}" ]]; then
   if [[ -z "${PTO_CANN_EXTRA_LINK_DIRS:-}" ]]; then
     PTO_CANN_EXTRA_LINK_DIRS="$(discover_cann_host_link_dirs "$(host_lib_arch)")"
   fi
+  if [[ -z "${PTO_CANN_EXTRA_INCLUDE_DIRS:-}" ]]; then
+    PTO_CANN_EXTRA_INCLUDE_DIRS="$(discover_cann_host_include_dirs "$(host_lib_arch)")"
+  fi
+  export LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+  export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
   if [[ -n "${PTO_CANN_EXTRA_LINK_DIRS:-}" ]]; then
     export PTO_CANN_EXTRA_LINK_DIRS
-    export LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LIBRARY_PATH:+:${LIBRARY_PATH}}"
-    export LD_LIBRARY_PATH="${PTO_CANN_EXTRA_LINK_DIRS}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-  else
-    export LD_LIBRARY_PATH="${ASCEND_HOME_PATH}/lib64:${LD_LIBRARY_PATH:-}"
+    export LIBRARY_PATH="${LIBRARY_PATH}:${PTO_CANN_EXTRA_LINK_DIRS}"
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${PTO_CANN_EXTRA_LINK_DIRS}"
+  fi
+  if [[ -n "${PTO_CANN_EXTRA_INCLUDE_DIRS:-}" ]]; then
+    export PTO_CANN_EXTRA_INCLUDE_DIRS
+    export CPATH="${PTO_CANN_EXTRA_INCLUDE_DIRS}${CPATH:+:${CPATH}}"
+    export CPLUS_INCLUDE_PATH="${PTO_CANN_EXTRA_INCLUDE_DIRS}${CPLUS_INCLUDE_PATH:+:${CPLUS_INCLUDE_PATH}}"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- keep CANN host link directory discovery stdout clean when it is captured into `PTO_CANN_EXTRA_LINK_DIRS`
- resolve `libnnopbase.so` from fallback CANN installs when `ASCEND_HOME_PATH` points at an incomplete host lib layout
- add `-Wl,--allow-shlib-undefined` to generated host validation executables so linking does not fail on unresolved AICORE kernel symbols left in `{case}_kernel.so`
- apply the same host link option to simulator-golden executables

## Context
A5 manual validation for PR #836 (`20260622_103708_manual_pr836`, source `f4c15bb812ca`) reported `OK=151 FAIL=74 SKIP=1`. The target MX cases from that PR, `matmul_mx_low_precision` and `gemvmx`, passed. Most failures were validation harness link failures like:

```text
ld.lld: error: undefined reference due to --no-allow-shlib-undefined: <kernel>
```

Those cases did not reach board execution. The run log also showed `PTO_CANN_EXTRA_LINK_DIRS` being polluted by a diagnostic log line emitted from `discover_cann_host_link_dirs()` while its stdout was captured.

## Validation
- `python3 -m py_compile test/npu_validation/scripts/generate_testcase.py`
- `bash -n test/npu_validation/scripts/run_remote_npu_validation.sh`
- `bash -n test/npu_validation/templates/run_sh_template.sh`
- generated a temporary `Prelu/prelu_gencheck` validation project and confirmed the generated `CMakeLists.txt` contains `-Wl,--allow-shlib-undefined` for both host executables

## Notes
This PR is intended to remove broad harness-side link noise in A5 board validation. It does not claim to fix the remaining numerical mismatches or runtime crashes reported by that run.
