### PR TITLE
feat(pass):add PTOUnrollSIMTForPass

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -84,6 +84,7 @@ std::unique_ptr<Pass> createPTOFusionRegionGenPass();
 
 LogicalResult validateIntToPtrUses(func::FuncOp func);
 
+std::unique_ptr<Pass> createPTOUnrollSIMTForPass();
 std::unique_ptr<Pass> createPTOInferVPTOVecScopePass();
 std::unique_ptr<Pass> createVPTOExpandWrapperOpsPass();
 std::unique_ptr<Pass> createPTOVPTOPtrBoundaryPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -565,6 +565,39 @@ def PTOMaterializeTileHandles : Pass<"pto-materialize-tile-handles", "ModuleOp">
   ];
 }
 
+def PTOUnrollSIMTFor : Pass<"pto-unroll-simt-for", "func::FuncOp"> {
+  let summary =
+      "Unroll small constant-trip-count scf.for loops in pto.simt_entry functions";
+  let description = [{
+    Walks functions with `pto.simt_entry` attribute and fully unrolls `scf.for`
+    loops that meet one of these criteria:
+
+    1. The loop carries the `{pto.unroll = "full"}` attribute.
+    2. The loop has constant lower bound, upper bound, and step, and the trip
+       count does not exceed the configurable `max-trip-count` threshold (default 64).
+
+    Full unrolling enables subsequent canonicalize/sccp/cse to constant-fold
+    induction-variable-dependent conditionals (e.g. `scf.if i < 10`), eliminating
+    divergent branches that can cause the AICore backend to emit predicated END
+    instructions inside SIMTVF kernels.
+
+    This pass must run before `createConvertSCFToCFPass` (i.e. before LLVM
+    lowering) so that the unrolled structured control flow can be canonicalized.
+  }];
+  let constructor = "mlir::pto::createPTOUnrollSIMTForPass()";
+  let dependentDialects = [
+    "mlir::func::FuncDialect",
+    "mlir::scf::SCFDialect",
+    "mlir::pto::PTODialect",
+    "mlir::arith::ArithDialect"
+  ];
+  let options = [
+    Option<"maxTripCount", "max-trip-count", "int64_t", "64",
+           "Maximum constant trip count to auto-unroll (default: 64). "
+           "Loops exceeding this are left unchanged.">
+  ];
+}
+
 def PTOInferVPTOVecScope
     : Pass<"pto-infer-vpto-vecscope", "func::FuncOp"> {
   let summary =

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ add_mlir_dialect_library(PTOTransforms
   PTOVPTOPtrBoundary.cpp
   VPTOBufferMaterialization.cpp
   PTOValidateVPTOIR.cpp
+  PTOUnrollSIMTForPass.cpp
   PTOInferVPTOVecScope.cpp
 
   InsertSync/PTOInsertSync.cpp

--- a/lib/PTO/Transforms/PTOUnrollSIMTForPass.cpp
+++ b/lib/PTO/Transforms/PTOUnrollSIMTForPass.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- PTOUnrollSIMTForPass.cpp -------------------------------------------===//
+//
+// Unroll small constant-trip-count scf.for loops inside pto.simt_entry
+// functions to eliminate divergent control flow before LLVM lowering.
+//
+// Workaround for: https://github.com/mouliangyu/PTOAS/issues/485
+//
+// When a SIMTVF kernel contains scf.for + scf.if with a constant-condition
+// branch (e.g. for i in 0..16: if i < 10: store), the AICore backend may
+// emit a predicated END instruction.  By fully unrolling the loop and
+// letting canonicalize/sccp constant-fold the induction-variable-dependent
+// conditions, we obtain straight-line code without branches, which avoids
+// the bug.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOUNROLLSIMTFOR
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+#define DEBUG_TYPE "pto-unroll-simt-for"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Name of the unroll annotation placed on scf::ForOp by users.
+static constexpr llvm::StringLiteral kUnrollAttrName = "pto.unroll";
+static constexpr llvm::StringLiteral kUnrollFullValue = "full";
+
+/// Try to compute a constant trip count for an scf::ForOp.
+/// Returns std::nullopt if any bound or step is non-constant.
+static std::optional<int64_t> computeConstantTripCount(scf::ForOp forOp) {
+  std::optional<int64_t> lb = getConstantIntValue(forOp.getLowerBound());
+  std::optional<int64_t> ub = getConstantIntValue(forOp.getUpperBound());
+  std::optional<int64_t> step = getConstantIntValue(forOp.getStep());
+  if (!lb || !ub || !step || *step <= 0)
+    return std::nullopt;
+  if (*ub <= *lb)
+    return 0;
+  return (*ub - *lb + *step - 1) / *step; // ceil division
+}
+
+/// Check whether the loop has the explicit "full unroll" annotation.
+static bool hasUnrollFullAttr(scf::ForOp forOp) {
+  if (auto attr = forOp->getAttrOfType<StringAttr>(kUnrollAttrName))
+    return attr.getValue() == kUnrollFullValue;
+  return false;
+}
+
+/// Check whether this function is a SIMT entry.
+static bool isSIMTEntry(func::FuncOp func) {
+  return func->hasAttr(pto::kPTOSimtEntryAttrName);
+}
+
+// ---------------------------------------------------------------------------
+// Rewrite pattern
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct UnrollSIMTForPattern : public OpRewritePattern<scf::ForOp> {
+  UnrollSIMTForPattern(MLIRContext *ctx, int64_t maxTripCount)
+      : OpRewritePattern(ctx), maxTripCount(maxTripCount) {}
+
+  LogicalResult matchAndRewrite(scf::ForOp forOp,
+                                PatternRewriter &rewriter) const override {
+    // Only apply inside SIMT entry functions.
+    auto func = forOp->getParentOfType<func::FuncOp>();
+    if (!func || !isSIMTEntry(func))
+      return failure();
+
+    // Check explicit annotation first.
+    if (hasUnrollFullAttr(forOp)) {
+      return unrollFull(forOp, rewriter, /*isAnnotated=*/true);
+    }
+
+    // Auto-detect: constant bounds and small trip count.
+    auto tripCount = computeConstantTripCount(forOp);
+    if (!tripCount || *tripCount > maxTripCount)
+      return failure();
+
+    return unrollFull(forOp, rewriter, /*isAnnotated=*/false);
+  }
+
+private:
+  LogicalResult unrollFull(scf::ForOp forOp, PatternRewriter &rewriter,
+                           bool isAnnotated) const {
+    auto tripCount = computeConstantTripCount(forOp);
+    if (!tripCount || *tripCount <= 0)
+      return failure();
+
+    LLVM_DEBUG(llvm::dbgs()
+               << "PTOUnrollSIMTFor: unrolling scf.for "
+               << (isAnnotated ? "(annotated)" : "(auto)") << " tripCount="
+               << *tripCount << " at " << forOp.getLoc() << "\n");
+
+    // loopUnrollByFactor returns failure if the loop carries iteration
+    // arguments that have uses outside the loop (live-out values).  In that
+    // case we cannot unroll.
+    if (failed(loopUnrollByFactor(forOp, static_cast<uint64_t>(*tripCount))))
+      return failure();
+
+    return success();
+  }
+
+  int64_t maxTripCount;
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Pass definition
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct PTOUnrollSIMTFor : public pto::impl::PTOUnrollSIMTForBase<PTOUnrollSIMTFor> {
+  using pto::impl::PTOUnrollSIMTForBase<
+      PTOUnrollSIMTFor>::PTOUnrollSIMTForBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    if (!isSIMTEntry(func))
+      return;
+
+    MLIRContext *ctx = &getContext();
+    RewritePatternSet patterns(ctx);
+    patterns.add<UnrollSIMTForPattern>(ctx, maxTripCount);
+
+    GreedyRewriteConfig config;
+    config.maxIterations = 10; // loops may nest
+    config.strictMode = GreedyRewriteStrictness::ExistingOps;
+
+    if (failed(applyPatternsAndFoldGreedily(func, std::move(patterns), config)))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Pass constructor
+// ---------------------------------------------------------------------------
+
+std::unique_ptr<Pass> mlir::pto::createPTOUnrollSIMTForPass() {
+  return std::make_unique<PTOUnrollSIMTFor>();
+}

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1464,6 +1464,12 @@ static bool shouldDeclareVariablesAtTop(ModuleOp module) {
 
 static void prepareVPTOForEmission(PassManager &pm) {
   auto &kernelModulePM = pm.nest<ModuleOp>();
+  // Issue #485 workaround: unroll small constant-trip-count scf.for loops
+  // inside pto.simt_entry functions, then constant-fold the induction-variable
+  // dependent scf.if branches so subsequent canonicalize/cse eliminate them.
+  kernelModulePM.addNestedPass<func::FuncOp>(
+      pto::createPTOUnrollSIMTForPass());
+  kernelModulePM.addPass(createSCCPPass());
   kernelModulePM.addPass(createCanonicalizerPass());
   kernelModulePM.addPass(createCSEPass());
   kernelModulePM.addPass(pto::createVPTOPtrNormalizePass());


### PR DESCRIPTION
  新增 `PTOUnrollSIMTFor` pass，规避 ：SIMTVF kernel 中 `scf.for` + `scf.if` 常量分支导致 AICore 后端生成带谓词的 `END @!P0`。

  ## 根因

  SCF→CF→LLVM lowering 后 `ret` 自然在 `cond_br` 可达的 block 中，IR 本身正确。Bisheng AICore 后端未正确处理 `SimtEntry` calling convention，给 `END` 加上了谓词。

  ## 方案

  将 `pto.simt_entry` 函数内常量 `scf.for` 完全展开，由下游 SCCP + canonicalize 自动消除 `scf.if` 分支，生成无分支直线代码。

  - 显式标注 `{pto.unroll = "full"}`：无条件展开
  - 自动检测：常量 bounds 且 trip count ≤ 64（可通过 `--max-trip-count` 调整）

  ## 涉及文件

  - `lib/PTO/Transforms/PTOUnrollSIMTForPass.cpp` — pass 实现（新增）
  - `include/PTO/Transforms/Passes.td` — 定义
  - `include/PTO/Transforms/Passes.h` — 声明
  - `lib/PTO/Transforms/CMakeLists.txt` — 注册
  - `tools/ptoas/ptoas.cpp` — 接入 `prepareVPTOForEmission`