### PR TITLE
fix: resolve issue 839 mgather A3 sync and validation

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2871,62 +2871,7 @@ def MGatherOp : PTO_TOp<"mgather", [
 
   let extraClassDeclaration = [{
     static StringRef getIntrinsicName() { return "MGATHER"; }
-    ::mlir::pto::PIPE getPipe() {
-      // GM -> L1 gather: the destination is an L1 / cube (loc=mat) tile and the
-      // gather is issued as a GM -> L1 DMA load (copy_gm_to_cbuf / nd2nz) on the
-      // MTE2 pipe on every arch, mirroring pto.tload. The GM -> UB (VEC) path
-      // below keeps its A5 SIMT (PIPE_V) / A2A3 MTE2 selection.
-      //
-      // Resolve the dst address space from BOTH the tile_buf and the lowered
-      // memref form: PTOViewToMemref rewrites dst into a memref<...,mat> before
-      // InsertSync / GraphSyncSolver run, and both consume getPipe() through the
-      // OpPipeInterface. A tile-only check would fall through to PIPE_V on A5.
-      auto getAddressSpace =
-          [](::mlir::Type ty) -> std::optional<::mlir::pto::AddressSpace> {
-        if (auto tb = ::mlir::dyn_cast<::mlir::pto::TileBufType>(ty)) {
-          if (auto as = ::mlir::dyn_cast_or_null<::mlir::pto::AddressSpaceAttr>(
-                  tb.getMemorySpace()))
-            return as.getAddressSpace();
-          return std::nullopt;
-        }
-        if (auto mr = ::mlir::dyn_cast<::mlir::MemRefType>(ty)) {
-          if (auto ms = mr.getMemorySpace()) {
-            if (auto as =
-                    ::mlir::dyn_cast<::mlir::pto::AddressSpaceAttr>(ms))
-              return as.getAddressSpace();
-          }
-          return std::nullopt;
-        }
-        return std::nullopt;
-      };
-      if (auto as = getAddressSpace(getDst().getType());
-          as && *as == ::mlir::pto::AddressSpace::MAT)
-        return ::mlir::pto::PIPE::PIPE_MTE2;
-
-      auto isA5Target = [&]() -> bool {
-        auto moduleOp = getOperation()->getParentOfType<::mlir::ModuleOp>();
-        if (!moduleOp)
-          return false;
-
-        if (auto arch =
-                moduleOp->getAttrOfType<::mlir::StringAttr>("pto.target_arch")) {
-          if (arch.getValue().equals_insensitive("a5"))
-            return true;
-        }
-
-        if (auto spec =
-                moduleOp->getAttrOfType<::mlir::StringAttr>("pto.device-spec")) {
-          auto s = spec.getValue();
-          if (s.starts_with("Ascend950") || s.starts_with("Ascend910_95"))
-            return true;
-        }
-
-        return false;
-      };
-
-      return isA5Target() ? ::mlir::pto::PIPE::PIPE_V
-                          : ::mlir::pto::PIPE::PIPE_MTE2;
-    }
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
   }];
 }

--- a/test/lit/pto/issue839_mgather_pipe_selection.pto
+++ b/test/lit/pto/issue839_mgather_pipe_selection.pto
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-level=level3 --pto-arch=a3 --enable-insert-sync %s | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @mgather_elem_pipe_selection(%mem: !pto.ptr<f32>,
+                                         %idx: !pto.ptr<i32>,
+                                         %out: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c256 = arith.constant 256 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+
+    %mem_view = pto.make_tensor_view %mem,
+                shape = [%c256], strides = [%c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?xf32>
+    %idx_view = pto.make_tensor_view %idx,
+                shape = [%c8, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %out,
+                shape = [%c8, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xf32>
+
+    %idx_tile = pto.alloc_tile addr = %c0_i64
+              : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile addr = %c0_i64
+              : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %idx_part = pto.partition_view %idx_view,
+                offsets = [%c0, %c0], sizes = [%c8, %c32]
+              : !pto.tensor_view<?x?xi32>
+                -> !pto.partition_tensor_view<8x32xi32>
+    %mem_part = pto.partition_view %mem_view,
+                offsets = [%c0], sizes = [%c256]
+              : !pto.tensor_view<?xf32>
+                -> !pto.partition_tensor_view<256xf32>
+    %out_part = pto.partition_view %out_view,
+                offsets = [%c0, %c0], sizes = [%c8, %c32]
+              : !pto.tensor_view<?x?xf32>
+                -> !pto.partition_tensor_view<8x32xf32>
+
+    pto.tload ins(%idx_part : !pto.partition_tensor_view<8x32xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.mgather ins(%mem_part, %idx_tile
+        : !pto.partition_tensor_view<256xf32>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst_tile
+        : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      {coalesce = #pto<coalesce elem>}
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%out_part : !pto.partition_tensor_view<8x32xf32>)
+    return
+  }
+
+  func.func @mgather_row_pipe_selection(%mem: !pto.ptr<f16>,
+                                        %idx: !pto.ptr<i32>,
+                                        %out: !pto.ptr<f16>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c64 = arith.constant 64 : index
+    %c32 = arith.constant 32 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c0 = arith.constant 0 : index
+
+    %mem_view = pto.make_tensor_view %mem,
+                shape = [%c64, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xf16>
+    %idx_view = pto.make_tensor_view %idx,
+                shape = [%c1, %c16], strides = [%c16, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %out,
+                shape = [%c16, %c32], strides = [%c32, %c1]
+                {layout = #pto.layout<nd>}
+              : !pto.tensor_view<?x?xf16>
+
+    %idx_tile = pto.alloc_tile addr = %c0_i64
+              : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst_tile = pto.alloc_tile addr = %c64_i64
+              : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    %idx_part = pto.partition_view %idx_view,
+                offsets = [%c0, %c0], sizes = [%c1, %c16]
+              : !pto.tensor_view<?x?xi32>
+                -> !pto.partition_tensor_view<1x16xi32>
+    %mem_part = pto.partition_view %mem_view,
+                offsets = [%c0, %c0], sizes = [%c64, %c32]
+              : !pto.tensor_view<?x?xf16>
+                -> !pto.partition_tensor_view<64x32xf16>
+    %out_part = pto.partition_view %out_view,
+                offsets = [%c0, %c0], sizes = [%c16, %c32]
+              : !pto.tensor_view<?x?xf16>
+                -> !pto.partition_tensor_view<16x32xf16>
+
+    pto.tload ins(%idx_part : !pto.partition_tensor_view<1x16xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.mgather ins(%mem_part, %idx_tile
+        : !pto.partition_tensor_view<64x32xf16>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst_tile
+        : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%out_part : !pto.partition_tensor_view<16x32xf16>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void mgather_elem_pipe_selection(
+// CHECK: TLOAD(
+// CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK-NOT: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK: MGATHER<pto::Coalesce::Elem>(
+// CHECK: set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+// CHECK: wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+//
+// CHECK-LABEL: AICORE void mgather_row_pipe_selection(
+// CHECK: TLOAD(
+// CHECK: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK-NOT: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+// CHECK: MGATHER<pto::Coalesce::Row>(
+// CHECK: set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+// CHECK: wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);

--- a/test/lit/pto/mgather_gm2l1_sync_a5.pto
+++ b/test/lit/pto/mgather_gm2l1_sync_a5.pto
@@ -6,13 +6,9 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Regression for the A5 GM->L1 mgather pipe. PTOViewToMemref rewrites the mat
-// destination into a memref<...,mat> before InsertSync / GraphSyncSolver run, so
-// MGatherOp::getPipe() must resolve the MAT address space from the lowered
-// memref form too. If it only matched a TileBufType, A5 would fall through to
-// PIPE_V and the GM->L1 DMA would be mis-synced as a vector op. Here the gathered
-// L1 tile feeds a TMOV (mat -> left, PIPE_MTE1); the producer side of the sync
-// must be PIPE_MTE2 (the GM->L1 DMA pipe), not PIPE_V.
+// Regression for the A5 GM->L1 mgather sync chain. A5 MGATHER now runs on
+// PIPE_V, so when its MAT/L1 result feeds TMOV (mat -> left, PIPE_MTE1) the
+// producer side of the inserted sync must be PIPE_V rather than PIPE_MTE2.
 
 // RUN: ptoas --pto-arch=a5 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
 
@@ -46,6 +42,6 @@ module {
 }
 
 // CHECK: MGATHER<pto::Coalesce::Row>
-// CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_MTE1
-// CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_MTE1
+// CHECK-NEXT: set_flag(PIPE_V, PIPE_MTE1
+// CHECK-NEXT: wait_flag(PIPE_V, PIPE_MTE1
 // CHECK-NEXT: TMOV

--- a/test/samples/Mgather/issue839_mgather_elem.pto
+++ b/test/samples/Mgather/issue839_mgather_elem.pto
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {"pto.device-spec" = "Ascend910B1"} {
+  func.func @mgather_kernel(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>, %arg2: !pto.ptr<f32>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c256_index = arith.constant 256 : index
+    %c1_index = arith.constant 1 : index
+    %c8_index = arith.constant 8 : index
+    %c32_index = arith.constant 32 : index
+    %c0_index = arith.constant 0 : index
+    %mem_tensor__ssa_v0_view = pto.make_tensor_view %arg0, shape = [%c256_index], strides = [%c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?xf32>
+    %idx_tensor__ssa_v0_view = pto.make_tensor_view %arg1, shape = [%c8_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xi32>
+    %output__ssa_v0_view = pto.make_tensor_view %arg2, shape = [%c8_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_tile__ssa_v0 = pto.alloc_tile valid_row = %c8_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_tensor__ssa_v0_pview = pto.partition_view %idx_tensor__ssa_v0_view, offsets = [%c0_index, %c0_index], sizes = [%c8_index, %c32_index] : !pto.tensor_view<?x?xi32> -> !pto.partition_tensor_view<8x32xi32>
+    pto.tload ins(%idx_tensor__ssa_v0_pview : !pto.partition_tensor_view<8x32xi32>) outs(%idx_tile__ssa_v0 : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %dst__ssa_v0 = pto.alloc_tile valid_row = %c8_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_tensor__ssa_v0_pview = pto.partition_view %mem_tensor__ssa_v0_view, offsets = [%c0_index], sizes = [%c256_index] : !pto.tensor_view<?xf32> -> !pto.partition_tensor_view<256xf32>
+    pto.mgather ins(%mem_tensor__ssa_v0_pview, %idx_tile__ssa_v0 : !pto.partition_tensor_view<256xf32>, !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst__ssa_v0 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {coalesce = #pto<coalesce elem>}
+    %output__ssa_v0_pview = pto.partition_view %output__ssa_v0_view, offsets = [%c0_index, %c0_index], sizes = [%c8_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<8x32xf32>
+    pto.tstore ins(%dst__ssa_v0 : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%output__ssa_v0_pview : !pto.partition_tensor_view<8x32xf32>)
+    return
+  }
+}

--- a/test/samples/Mgather/issue839_mgather_row.pto
+++ b/test/samples/Mgather/issue839_mgather_row.pto
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module attributes {"pto.device-spec" = "Ascend910B1"} {
+  func.func @mgather_kernel(%arg0: !pto.ptr<f16>, %arg1: !pto.ptr<i32>, %arg2: !pto.ptr<f16>) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c64_index = arith.constant 64 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c16_index = arith.constant 16 : index
+    %c0_index = arith.constant 0 : index
+    %mem_tensor__ssa_v0_view = pto.make_tensor_view %arg0, shape = [%c64_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf16>
+    %idx_tensor__ssa_v0_view = pto.make_tensor_view %arg1, shape = [%c1_index, %c16_index], strides = [%c16_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xi32>
+    %output__ssa_v0_view = pto.make_tensor_view %arg2, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf16>
+    %idx_tile__ssa_v0 = pto.alloc_tile valid_row = %c1_index valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_tensor__ssa_v0_pview = pto.partition_view %idx_tensor__ssa_v0_view, offsets = [%c0_index, %c0_index], sizes = [%c1_index, %c16_index] : !pto.tensor_view<?x?xi32> -> !pto.partition_tensor_view<1x16xi32>
+    pto.tload ins(%idx_tensor__ssa_v0_pview : !pto.partition_tensor_view<1x16xi32>) outs(%idx_tile__ssa_v0 : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %dst__ssa_v0 = pto.alloc_tile valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_tensor__ssa_v0_pview = pto.partition_view %mem_tensor__ssa_v0_view, offsets = [%c0_index, %c0_index], sizes = [%c64_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<64x32xf16>
+    pto.mgather ins(%mem_tensor__ssa_v0_pview, %idx_tile__ssa_v0 : !pto.partition_tensor_view<64x32xf16>, !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst__ssa_v0 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %output__ssa_v0_pview = pto.partition_view %output__ssa_v0_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<16x32xf16>
+    pto.tstore ins(%dst__ssa_v0 : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%output__ssa_v0_pview : !pto.partition_tensor_view<16x32xf16>)
+    return
+  }
+}

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -20,7 +20,7 @@ PTOAS_OUT_DIR="${PTOAS_OUT_DIR:-}"
 PTO_BUILD_DIR="${PTO_BUILD_DIR:-}"
 PTOAS_ENABLE_INSERT_SYNC="${PTOAS_ENABLE_INSERT_SYNC:-1}"
 PTOAS_FLAGS="${PTOAS_FLAGS:-}"
-PTO_PTO_DIRS="${PTO_PTO_DIRS:-Sync Qwen3DecodeA3 Qwen3DecodeA5 DeepseekV4DecodeA3 DeepseekV4DecodeA5 CommSync Prelu Rem Rems Gemvmx MatmulMxLowPrecision}"
+PTO_PTO_DIRS="${PTO_PTO_DIRS:-Sync Qwen3DecodeA3 Qwen3DecodeA5 DeepseekV4DecodeA3 DeepseekV4DecodeA5 CommSync Prelu Rem Rems Gemvmx MatmulMxLowPrecision Mgather}"
 ENABLE_BC=0
 
 usage() {


### PR DESCRIPTION
## Summary
- classify `pto.mgather` as `PIPE_V` so A3 insert-sync emits the correct `PIPE_MTE2 -> PIPE_V -> PIPE_MTE3` dependency chain
- add a focused lit regression for both `coalesce elem` and row/default `mgather` issue839 reproductions
- fix `test/npu_validation` testcase generation so PTOAS kernels keep an exported launch entry and row-mgather indices stay within the source table row range

## Validation
- regenerate issue839 PTO repro kernels with `build/tools/ptoas/ptoas --enable-insert-sync --pto-level=level3 --pto-arch=a3`
- A3 board validation passed for `issue839_elem`: `task_20260622_144351_383590314696`
- A3 board validation passed for `issue839_row`: `task_20260622_144351_383587416890`

Closes #839
