### PR TITLE
fix(sync): detect local physical alias for reused alloc tiles

### DIFF
--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -104,6 +104,10 @@ static Value GetRealRoot(Value v) {
   }
   return v;
 }
+
+static bool hasKnownPhysicalRange(const BaseMemInfo *info) {
+  return info && !info->baseAddresses.empty() && info->allocateSize != 0;
+}
  
 bool MemoryDependentAnalyzer::DepBetween(
     const SmallVector<const BaseMemInfo *> &a,
@@ -154,7 +158,15 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   }
  
   // 2. Local Memory (UB/L1)
-  
+  if (hasKnownPhysicalRange(a) && hasKnownPhysicalRange(b)) {
+    bool overlap = isBufferAddressRangeOverlap(a, b);
+    if (isTraceEnabled())
+      llvm::errs() << "    -> Known local physical ranges "
+                   << (overlap ? "overlap. True.\n"
+                               : "do not overlap. False.\n");
+    return overlap;
+  }
+
   if (a->rootBuffer == b->rootBuffer) {
     if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true;
     if (a->allocateSize == 0 || b->allocateSize == 0) return true;

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -152,7 +152,7 @@ getMemrefSubViewBaseAddresses(memref::SubViewOp op, MemRefType sourceType,
 
   SmallVector<int64_t> strides;
   int64_t baseOffset = ShapedType::kDynamic;
-  if (failed(mlir::getStridesAndOffset(sourceType, strides, baseOffset)) ||
+  if (failed(sourceType.getStridesAndOffset(strides, baseOffset)) ||
       strides.size() != 2 ||
       llvm::is_contained(strides, ShapedType::kDynamic))
     return std::nullopt;
@@ -215,7 +215,7 @@ static std::pair<int64_t, int64_t> getStaticOffsetAndSize(Operation *op, Value s
   if (auto subView = dyn_cast<memref::SubViewOp>(op)) {
     int64_t baseOffset;
     StrideVector strides;
-    if (failed(mlir::getStridesAndOffset(srcType, strides, baseOffset))) {
+    if (failed(srcType.getStridesAndOffset(strides, baseOffset))) {
         return {-1, -1};
     }
 
@@ -387,16 +387,15 @@ LogicalResult PTOIRTranslator::UpdateAllocTileOpMemInfo(pto::AllocTileOp op) {
 
   auto tileType = dyn_cast<pto::TileBufType>(res.getType());
   uint64_t sizeInBytes = 0;
-  uint64_t baseAddr = 0;
+  SmallVector<uint64_t> baseAddresses;
 
   // If alloc_tile carries an explicit address, record it when it's a constant.
   if (Value addr = op.getAddr()) {
     llvm::APInt apIntValue;
     if (matchPattern(addr, m_ConstantInt(&apIntValue))) {
-        // 将 APInt 转换为 int64_t，再转为 uint64_t
-        int64_t c = apIntValue.getSExtValue();  // 有符号扩展转换
-        // 如果确定是无符号值，也可以用：apIntValue.getZExtValue()
-        baseAddr = static_cast<uint64_t>(c);
+      int64_t c = apIntValue.getSExtValue();
+      if (c >= 0)
+        baseAddresses.push_back(static_cast<uint64_t>(c));
     }
   }
 
@@ -440,7 +439,7 @@ LogicalResult PTOIRTranslator::UpdateAllocTileOpMemInfo(pto::AllocTileOp op) {
       res,
       res,
       space, // 使用解析出的 space
-      SmallVector<uint64_t>{baseAddr},
+      std::move(baseAddresses),
       sizeInBytes
   );
 
@@ -865,7 +864,7 @@ void PTOIRTranslator::UpdateMemrefSubViewAliasBufferInfo(memref::SubViewOp op) {
 
   SmallVector<int64_t> strides;
   int64_t baseOffset = ShapedType::kDynamic;
-  if (failed(mlir::getStridesAndOffset(sourceType, strides, baseOffset)) ||
+  if (failed(sourceType.getStridesAndOffset(strides, baseOffset)) ||
       strides.size() != 2) {
     UpdateConservativeAliasBufferInfo(result, source);
     return;

--- a/test/lit/pto/issue844_local_physical_disjoint_no_sync.pto
+++ b/test/lit/pto/issue844_local_physical_disjoint_no_sync.pto
@@ -1,0 +1,26 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @local_physical_disjoint_no_war(%dst: memref<1x32xf32, #pto.address_space<gm>>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %cst = arith.constant 1.000000e+00 : f32
+    %old = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %new = pto.alloc_tile addr = %c1024_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.texpands ins(%cst : f32)
+      outs(%old : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%old : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : memref<1x32xf32, #pto.address_space<gm>>)
+    pto.texpands ins(%cst : f32)
+      outs(%new : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: After Sync Motion
+// CHECK: COMPOUND pto.tstore [PIPE_MTE3]
+// CHECK-NOT: <PIPE_MTE3 -> PIPE_V>
+// CHECK: COMPOUND pto.texpands [PIPE_V]
+// CHECK-NOT: <PIPE_MTE3 -> PIPE_V>
+// CHECK-LABEL: After Remove Redundant Sync

--- a/test/lit/pto/issue844_local_physical_reuse_sync.pto
+++ b/test/lit/pto/issue844_local_physical_reuse_sync.pto
@@ -1,0 +1,24 @@
+// RUN: ptoas --pto-level=level3 --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @local_physical_overlap_war(%dst: memref<1x32xf32, #pto.address_space<gm>>) {
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 1.000000e+00 : f32
+    %old = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %new = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.texpands ins(%cst : f32)
+      outs(%old : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%old : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : memref<1x32xf32, #pto.address_space<gm>>)
+    pto.texpands ins(%cst : f32)
+      outs(%new : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: After Sync Motion
+// CHECK:      COMPOUND pto.tstore [PIPE_MTE3]
+// CHECK:        POST: set_flag <PIPE_MTE3 -> PIPE_V>
+// CHECK-NEXT: COMPOUND pto.texpands [PIPE_V]
+// CHECK-NEXT:   PRE : wait_flag <PIPE_MTE3 -> PIPE_V>


### PR DESCRIPTION
Summary
- Detect local-memory physical alias when two different `pto.alloc_tile` roots carry known constant address ranges that overlap.
- Keep address-unknown / dynamic cases on the existing root-based fallback path, so this does not turn all root-different unknown buffers into may-alias and does not broadly increase redundant sync.
- Add issue #844 regressions for the missing `PIPE_MTE3 -> PIPE_V` WAR sync and for the disjoint-address no-extra-sync case.

Motivation
- Fixes #844.
- PyPTO MemoryReuse can share storage for logical tiles whose sequential IR lifetimes do not overlap, then emit distinct `pto.alloc_tile` roots with the same or overlapping physical `addr`.
- PTOAS InsertSync previously treated different `rootBuffer`s as non-alias unless they shared a view/root chain, so it could miss WAR/WAW dependencies introduced by physical local-memory reuse.

Design
- `PTOIRTranslator::UpdateAllocTileOpMemInfo` now records `baseAddresses` only when `alloc_tile addr` is a constant. Missing or non-static addresses remain unknown instead of being recorded as address 0.
- `MemoryDependentAnalyzer::MemAlias` now gives local physical ranges priority when both sides have known address and size: overlap means alias, disjoint means no-alias, regardless of different logical roots.
- GM aliasing and unknown-address fallback behavior are intentionally unchanged.

Concern / Future Alignment
- If PTOAS treated every root-different + address-unknown case as may-alias, InsertSync would likely add a large number of redundant syncs.
- For future dynamic-address reuse, PyPTO should pass storage identity metadata such as `storageId` / `reuseGroup` to identify logical tiles sharing one physical storage object.
- PTOAS should then evolve from a root-only model to a unified model of `logical root + physical range + storage identity`, using symbolic range analysis only inside the same storage group.
- This keeps correctness for dynamic reuse without making unrelated unknown-address buffers all alias each other.

Testing
- `git diff --check`
- `ninja -C build-codex lib/PTO/Transforms/CMakeFiles/obj.PTOTransforms.dir/InsertSync/PTOIRTranslator.cpp.o lib/PTO/Transforms/CMakeFiles/obj.PTOTransforms.dir/InsertSync/MemoryDependentAnalyzer.cpp.o`
- `ptoas --pto-level=level3 --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 test/lit/pto/issue844_local_physical_reuse_sync.pto -o - | FileCheck test/lit/pto/issue844_local_physical_reuse_sync.pto`
- `ptoas --pto-level=level3 --pto-arch=a3 --enable-insert-sync --pto-insert-sync-debug=2 test/lit/pto/issue844_local_physical_disjoint_no_sync.pto -o - | FileCheck test/lit/pto/issue844_local_physical_disjoint_no_sync.pto`

Local build note
- Full `ninja -C build-codex ptoas` is blocked in this local checkout by pre-existing LLVM API mismatches unrelated to this patch (`Type::isFloat8*` calls and other current main/LLVM21 compatibility issues). The touched InsertSync objects compile successfully.
