### PR TITLE
clear residual op in vpto emit

### DIFF
--- a/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
+++ b/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
@@ -394,6 +394,7 @@ struct FoldTileBufIntrinsicsPass
     SmallVector<pto::TensorViewAddrOp, 8> tvAddrOps;
     SmallVector<pto::GetTensorViewDimOp, 8> tvDimOps;
     SmallVector<pto::GetTensorViewStrideOp, 8> tvStrideOps;
+    SmallVector<pto::GetValidShapeOp, 8> getValidShapeOps;
 
     func.walk([&](Operation *op) {
       if (auto addr = dyn_cast<pto::TileBufAddrOp>(op))
@@ -408,9 +409,50 @@ struct FoldTileBufIntrinsicsPass
         tvDimOps.push_back(tvDim);
       else if (auto tvStride = dyn_cast<pto::GetTensorViewStrideOp>(op))
         tvStrideOps.push_back(tvStride);
+      else if (auto gvs = dyn_cast<pto::GetValidShapeOp>(op))
+        getValidShapeOps.push_back(gvs);
     });
 
     if (shouldFoldAddrFamily(*mode)) {
+      // Fold pto.get_validshape into the materialized tile handle
+      // valid_row / valid_col. This must precede tile_buf_addr and
+      // tile_valid_{rows,cols} folding: set_validshape operands are usually
+      // produced by get_validshape, so resolving them first lets
+      // resolveTileHandle observe the overridden valid shape carried by a
+      // treshape + set_validshape pair.
+      for (auto gvsOp : getValidShapeOps) {
+        if (!isa<pto::TileBufType>(gvsOp.getSource().getType()))
+          continue;
+
+        auto handleInfo = resolveTileHandle(gvsOp.getSource(), gvsOp);
+        if (!handleInfo)
+          return signalPassFailure();
+
+        builder.setInsertionPoint(gvsOp);
+        auto tileTy = cast<pto::TileBufType>(gvsOp.getSource().getType());
+        auto validShape = tileTy.getValidShape();
+
+        Value rowReplacement = handleInfo->validRow;
+        if (!validShape.empty() && validShape[0] != ShapedType::kDynamic)
+          rowReplacement =
+              builder.create<arith::ConstantIndexOp>(gvsOp.getLoc(), validShape[0]);
+
+        Value colReplacement = handleInfo->validCol;
+        if (validShape.size() >= 2 && validShape[1] != ShapedType::kDynamic)
+          colReplacement =
+              builder.create<arith::ConstantIndexOp>(gvsOp.getLoc(), validShape[1]);
+
+        if (!rowReplacement || !colReplacement) {
+          gvsOp.emitError("FoldTileBufIntrinsics: pto.get_validshape could not "
+                          "resolve a concrete valid_row / valid_col");
+          return signalPassFailure();
+        }
+
+        gvsOp.getValidRow().replaceAllUsesWith(rowReplacement);
+        gvsOp.getValidCol().replaceAllUsesWith(colReplacement);
+        gvsOp.erase();
+      }
+
       // Fold pto.tile_buf_addr by recovering the active materialized tile
       // handle contract:
       //   - pto.materialize_tile → use the source memref directly
@@ -712,6 +754,38 @@ struct FoldTileBufIntrinsicsPass
         break;
       for (auto *op : llvm::reverse(deadMemrefOps))
         op->erase();
+    }
+
+    // Erase pto.set_validshape ops. Every valid-shape reader
+    // (get_validshape / tile_valid_{rows,cols} / tile_buf_addr) has been
+    // folded above, so the runtime metadata writes have no remaining
+    // observer and have no LLVM lowering.
+    SmallVector<pto::SetValidShapeOp, 8> setValidShapeOps;
+    func.walk([&](pto::SetValidShapeOp op) { setValidShapeOps.push_back(op); });
+    for (auto op : llvm::reverse(setValidShapeOps))
+      op.erase();
+
+    // DCE tile-handle view / alloc ops left behind after valid-shape
+    // folding (treshape / materialize_tile / alloc_tile / bridging casts).
+    bool tileDceChanged = true;
+    while (tileDceChanged) {
+      tileDceChanged = false;
+      SmallVector<Operation *, 8> deadTileOps;
+      func.walk([&](Operation *op) {
+        if (!op->use_empty())
+          return;
+        if (isa<pto::TReshapeOp, pto::MaterializeTileOp, pto::AllocTileOp>(op))
+          deadTileOps.push_back(op);
+        else if (auto castOp = dyn_cast<UnrealizedConversionCastOp>(op)) {
+          if (castOp.getNumOperands() == 1 &&
+              isa<pto::TileBufType>(castOp.getResult(0).getType()))
+            deadTileOps.push_back(op);
+        }
+      });
+      for (auto *op : llvm::reverse(deadTileOps)) {
+        op->erase();
+        tileDceChanged = true;
+      }
     }
 
     eraseDeadAllocTileOps(func);


### PR DESCRIPTION

### 问题总结

VPTO lowering pipeline 完成后，module 中残留的 tile 元数据 op 阻塞了 LLVM 导出。这些 op 分为两类：

1. **语义已完成但未清理的死 op**：`pto.set_valid_shape`（始终无 user）、无 user 的 `pto.get_valid_shape`、无 user 的 `pto.treshape`、无 user 的 `pto.alloc_tile`、无 user 的 `UnrealizedConversionCastOp`。

2. **可被折叠的 cast 链**：`pto.get_valid_shape` → `UnrealizedConversionCastOp` → LLVM i64 的 cast 链，其等价的 LLVM i64 值已存在于原始 `pto.alloc_tile` 的 valid row/col 属性中，但未被复用。