### PR TITLE
fix(npv): match __global__/static/inline in kernel decl regex

### DIFF
--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -371,7 +371,8 @@ def _append_single_kernel_global_wrapper(
 ) -> str:
     impl_name = f"__ptoas_{kernel_name}_impl"
     pattern = re.compile(
-        rf"(?P<prefix>extern\s+\"C\"\s+)?AICORE\s+void\s+{re.escape(kernel_name)}\s*\((?P<params>[^)]*)\)\s*\{{",
+        rf"(?P<prefix>extern\s+\"C\"\s+)?(?P<global>__global__\s+)?(?P<static>static\s+)?"
+        rf"AICORE\s+(?P<inline>inline\s+)?void\s+{re.escape(kernel_name)}\s*\((?P<params>[^)]*)\)\s*\{{",
         re.S,
     )
 


### PR DESCRIPTION
## Summary

Extracts the `generate_testcase.py` change from #747 into a standalone PR, so it can land independently of the larger PTO op-overload work.

In `_append_single_kernel_global_wrapper`, the wrapper-rewrite regex only matched a bare `AICORE void <kernel>(...)` declaration. Kernels emitted with `__global__`, `static`, or `inline` modifiers were not rewritten into the per-kernel `__ptoas_<kernel>_impl` wrapper, leaving the global-wrapper step silently skipped for those kernels.

This PR adds optional capture groups for those three modifiers so the regex accepts all of the declaration forms currently produced, while leaving the rest of the regex behavior untouched.

## Changes

- `test/npu_validation/scripts/generate_testcase.py`: extend the optional capture groups to match `__global__`, `static`, and `inline` (each independently optional) before `void`.

## Validation

Regex smoke-tested against the declaration forms the compiler emits:

| Declaration form | Matched |
| --- | --- |
| `extern "C" AICORE void k(...)` | yes |
| `AICORE void k(...)` | yes |
| `extern "C" __global__ AICORE void k(...)` | yes |
| `static AICORE inline void k(...)` | yes |
| `__global__ static AICORE inline void k(...)` | yes |
| `static void notAKernel(...)` | no |

## Relation to #747

This is the `generate_testcase.py` portion of #747, isolated so it can be reviewed/merged on its own. The remaining op-overload changes stay in #747.