### PR TITLE
ci: 修复A3板测问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ on:
         description: "pto-isa ref (commit/tag/branch; empty = repo-pinned weekly commit)"
         type: string
         # NOTE: Pin a known-good GitCode commit for deterministic runs.
-        default: 66c931430f08af80e598863fec68f55c39cbeb52
+        default: 5d979cde785f04ab76f17c26f17cb5fb13ad9a51
       remote_host:
         description: "SSH host/IP for the NPU machine"
         type: string
@@ -340,7 +340,7 @@ jobs:
           SKIP_CASES: ${{ github.event.inputs.skip_cases || '' }}
           RUN_ONLY_CASES: ${{ github.event.inputs.run_only_cases || '' }}
           PTO_ISA_REPO: ${{ github.event.inputs.pto_isa_repo || 'https://gitcode.com/cann/pto-isa.git' }}
-          PTO_ISA_COMMIT: ${{ github.event.inputs.pto_isa_commit || '66c931430f08af80e598863fec68f55c39cbeb52' }}
+          PTO_ISA_COMMIT: ${{ github.event.inputs.pto_isa_commit || '5d979cde785f04ab76f17c26f17cb5fb13ad9a51' }}
           REMOTE_HOST: ${{ github.event.inputs.remote_host || '101.245.68.6' }}
           REMOTE_USER: ${{ github.event.inputs.remote_user || 'zhongxuan' }}
           REMOTE_PORT: ${{ github.event.inputs.remote_port || '22' }}

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -8337,16 +8337,18 @@ pto.tmov.fp ins(%acc, %fp : !pto.tile_buf<...>, !pto.tile_buf<...>)
 dst[i, j] = Quantize(src[i, j]; fp, quant_type)
 ```
 
-- `INT8_SYM`: symmetric quantization; `dst` element type must be `i8`.
-- `INT8_ASYM`: asymmetric quantization; `dst` element type must be `ui8`.
+- `INT8_SYM`: symmetric quantization; `dst` element type must be `i8`; no `offset` operand is allowed.
+- `INT8_ASYM`: asymmetric quantization; `dst` element type must be `ui8`; an `offset` operand is required.
 
 **Arguments:**
 
 | Name | Type | Description |
 |------|------|-------------|
 | `src` | `pto.tile_buf` | Source tile (`f32`) |
-| `fp` | `pto.tile_buf` | Scaling parameter tile |
+| `fp` | `pto.tile_buf` | Scaling parameter tile (`f32`) |
+| `offset` | `pto.tile_buf` | Optional asymmetric offset tile (`f32`, required for `INT8_ASYM`) |
 | `dst` | `pto.tile_buf` | Destination tile (`i8` for SYM, `ui8` for ASYM) |
+| `tmp` | `pto.tile_buf` | Optional scratch tile. A2/A3 uses it for row-broadcast and fp32-to-s32 conversion scratch; PTOAS auto-synthesizes it when omitted. A5 accepts it as a placeholder but does not require it. |
 
 **Attributes:**
 
@@ -8359,9 +8361,12 @@ dst[i, j] = Quantize(src[i, j]; fp, quant_type)
 **Constraints & Verification:**
 
 - `src` element type must be `f32`.
+- `src` and `dst` must have the same valid shape.
 - `dst` element type must be `i8` (`INT8_SYM`) or `ui8` (`INT8_ASYM`).
 - `pto.tquant` only models the plain INT8 quantization forms. MX quantization uses `pto.tquant.mx`.
-- A2/A3: `src` and `dst` must use row-major layout.
+- A2/A3: `src`, `dst`, and explicit `tmp` must use row-major layout.
+- A2/A3: `fp` and `offset` must be per-row broadcast tiles: non-row-major layout, `valid_shape[0] == dst.valid_shape[0]`, and `valid_shape[1] == 1`.
+- A2/A3: explicit `tmp` must have the same element type, shape, and valid shape as `src`.
 
 **Hardware Mapping:**
 
@@ -8373,6 +8378,10 @@ dst[i, j] = Quantize(src[i, j]; fp, quant_type)
 pto.tquant ins(%src, %fp : !pto.tile_buf<...>, !pto.tile_buf<...>)
            outs(%dst : !pto.tile_buf<...>)
            {quant_type = #pto<quant_type INT8_SYM>}
+
+pto.tquant ins(%src, %fp, %offset : !pto.tile_buf<...>, !pto.tile_buf<...>, !pto.tile_buf<...>)
+           outs(%dst, %tmp : !pto.tile_buf<...>, !pto.tile_buf<...>)
+           {quant_type = #pto<quant_type INT8_ASYM>}
 ```
 
 ---

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -5349,6 +5349,7 @@ def TPReluOp: PTO_TOp<"tprelu", [
 //===----------------------------------------------------------------------===//
 
 def TQuantOp : PTO_TOp<"tquant", [
+  AttrSizedOperandSegments,
   PTO_DpsInitOpInterface,
   OpPipeInterface,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
@@ -5361,18 +5362,33 @@ def TQuantOp : PTO_TOp<"tquant", [
 
     For INT8_ASYM an additional offset tile must be supplied in ins.
 
+    The optional tmp tile is the scratch buffer used by the A2/A3
+    TQUANT_IMPL row-wise broadcast (the fp->s32 conversion reuses it). On
+    pto-isa builds where the 4-arg TQUANT overload routes through the fixed
+    TMP_UB_OFFSET scratch area, supplying tmp selects the tmp-aware 5-arg
+    overload and avoids the fixed-address collision. PTOAS auto-synthesizes
+    this scratch tile for A2/A3 only. On A5 the tmp operand is accepted as a
+    placeholder and does not add extra shape or memory-planning constraints.
+
     DPS form (INT8_SYM):
       pto.tquant ins(%src, %fp : <src_type>, <fp_type>)
                  outs(%dst : <dst_type>) {quant_type = #pto<quant_type INT8_SYM>}
+    DPS form (INT8_SYM, with tmp):
+      pto.tquant ins(%src, %fp : <src_type>, <fp_type>)
+                 outs(%dst, %tmp : <dst_type>, <tmp_type>) {quant_type = #pto<quant_type INT8_SYM>}
     DPS form (INT8_ASYM):
       pto.tquant ins(%src, %fp, %offset : <src_type>, <fp_type>, <offset_type>)
                  outs(%dst : <dst_type>) {quant_type = #pto<quant_type INT8_ASYM>}
+    DPS form (INT8_ASYM, with tmp):
+      pto.tquant ins(%src, %fp, %offset : <src_type>, <fp_type>, <offset_type>)
+                 outs(%dst, %tmp : <dst_type>, <tmp_type>) {quant_type = #pto<quant_type INT8_ASYM>}
   }];
 
   let arguments = (ins
     PTODpsType:$src,
     PTODpsType:$fp,
     Optional<PTODpsType>:$offset,
+    Optional<PTODpsType>:$tmp,
     PTODpsType:$dst,
     PTO_QuantTypeAttr:$quant_type
   );
@@ -5381,11 +5397,7 @@ def TQuantOp : PTO_TOp<"tquant", [
 
   let hasVerifier = 1;
 
-  let assemblyFormat = [{
-    `ins` `(` $src `,` $fp (`,` $offset^)? `:` qualified(type($src)) `,` qualified(type($fp)) (`,` qualified(type($offset))^)? `)`
-    `outs` `(` $dst `:` qualified(type($dst)) `)`
-    attr-dict
-  }];
+  let hasCustomAssemblyFormat = 1;
 
   let extraClassDeclaration = [{
     ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -9178,6 +9178,8 @@ mlir::LogicalResult mlir::pto::TQuantOp::verify() {
         failed(verifyTileBufCommon(*this, fpTy, "fp")) ||
         failed(verifyTileBufCommon(*this, dstTy, "dst")))
       return failure();
+    if (failed(verifyTileBufSameValidShape(*this, srcTy, dstTy, "src", "dst")))
+      return failure();
     // src must be f32 (ISA static_assert)
     if (!getElemTy(srcTy).isF32())
       return emitOpError() << "expects src to have element type f32";
@@ -9188,6 +9190,13 @@ mlir::LogicalResult mlir::pto::TQuantOp::verify() {
       if (!getElemTy(offsetTy).isF32())
         return emitOpError() << "expects offset to have element type f32";
     }
+    if (getTmp()) {
+      Type tmpTy = getTmp().getType();
+      if (failed(verifyTileBufCommon(*this, tmpTy, "tmp")))
+        return failure();
+      if (!getElemTy(tmpTy).isF32())
+        return emitOpError() << "expects tmp to have element type f32";
+    }
     return success();
   };
 
@@ -9195,9 +9204,49 @@ mlir::LogicalResult mlir::pto::TQuantOp::verify() {
     if (failed(verifyCommon()))
       return failure();
     Type srcTy = getSrc().getType();
+    Type fpTy = getFp().getType();
     Type dstTy = getDst().getType();
     if (!isRowMajorTileBuf(srcTy) || !isRowMajorTileBuf(dstTy))
       return emitOpError() << "expects A2/A3 src and dst to use row-major layout";
+    auto verifyA2A3Tmp = [&](Type tmpTy) -> LogicalResult {
+      if (failed(verifyTileBufSameElemType(*this, srcTy, tmpTy, "src", "tmp")))
+        return failure();
+      if (!isRowMajorTileBuf(tmpTy))
+        return emitOpError()
+               << "expects A2/A3 tmp to use row-major layout";
+      if (getShapeVec(srcTy) != getShapeVec(tmpTy))
+        return emitOpError()
+               << "expects A2/A3 tmp to have the same shape as src";
+      if (failed(verifyTileBufSameValidShape(*this, srcTy, tmpTy, "src",
+                                             "tmp")))
+        return failure();
+      return success();
+    };
+    if (getTmp() && failed(verifyA2A3Tmp(getTmp().getType())))
+      return failure();
+    auto verifyA2A3Param = [&](Type paramTy, StringRef paramName) -> LogicalResult {
+      if (isRowMajorTileBuf(paramTy))
+        return emitOpError() << "expects A2/A3 " << paramName
+                             << " to use non-row-major layout";
+      auto paramValid = getValidShapeVec(paramTy);
+      auto dstValid = getValidShapeVec(dstTy);
+      if (paramValid.size() != 2 || dstValid.size() != 2)
+        return emitOpError() << "expects A2/A3 " << paramName
+                             << " and dst to have rank-2 valid_shape";
+      if (paramValid[0] != ShapedType::kDynamic &&
+          dstValid[0] != ShapedType::kDynamic && paramValid[0] != dstValid[0])
+        return emitOpError() << "expects A2/A3 " << paramName
+                             << " valid_shape[0] to equal dst valid_shape[0]";
+      if (paramValid[1] != ShapedType::kDynamic && paramValid[1] != 1)
+        return emitOpError() << "expects A2/A3 " << paramName
+                             << " valid_shape[1] to be 1";
+      return success();
+    };
+    if (failed(verifyA2A3Param(fpTy, "fp")))
+      return failure();
+    if (getOffset() &&
+        failed(verifyA2A3Param(getOffset().getType(), "offset")))
+      return failure();
     return success();
   };
 
@@ -10252,6 +10301,102 @@ static void printTRowExpandBinaryLikeOp(OpAsmPrinter &p, Operation *op, Value sr
   }
   p << " outs(" << dst << " : " << dst.getType() << ")";
   p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"operandSegmentSizes"});
+}
+
+// TQuantOp: ins(src, fp [, offset] : types...) outs(dst [, tmp] : types...)
+// offset is optional (INT8_ASYM only); tmp is optional and placed in the outs
+// group to keep the ins group unambiguous (a 3-operand ins is always
+// src,fp,offset, never src,fp,tmp).
+static ParseResult parseTQuantOp(OpAsmParser &parser, OperationState &result) {
+  OpAsmParser::UnresolvedOperand src, fp, offset, dst, tmp;
+  Type srcTy, fpTy, offsetTy, dstTy, tmpTy;
+  bool hasOffset = false;
+  bool hasTmp = false;
+
+  if (parser.parseKeyword("ins") || parser.parseLParen() ||
+      parser.parseOperand(src) || parser.parseComma() || parser.parseOperand(fp))
+    return failure();
+  if (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseOperand(offset))
+      return failure();
+    hasOffset = true;
+  }
+  if (parser.parseColon())
+    return failure();
+  if (parser.parseType(srcTy) || parser.parseComma() || parser.parseType(fpTy))
+    return failure();
+  if (hasOffset) {
+    if (parser.parseComma() || parser.parseType(offsetTy))
+      return failure();
+  }
+  if (parser.parseRParen())
+    return failure();
+  if (parser.parseKeyword("outs") || parser.parseLParen() ||
+      parser.parseOperand(dst))
+    return failure();
+  if (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseOperand(tmp))
+      return failure();
+    hasTmp = true;
+  }
+  if (parser.parseColonType(dstTy))
+    return failure();
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy))
+      return failure();
+  }
+  if (parser.parseRParen())
+    return failure();
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+
+  if (parser.resolveOperand(src, srcTy, result.operands) ||
+      parser.resolveOperand(fp, fpTy, result.operands))
+    return failure();
+  if (hasOffset) {
+    if (parser.resolveOperand(offset, offsetTy, result.operands))
+      return failure();
+  }
+  if (hasTmp) {
+    if (parser.resolveOperand(tmp, tmpTy, result.operands))
+      return failure();
+  }
+  if (parser.resolveOperand(dst, dstTy, result.operands))
+    return failure();
+
+  // operand order: src, fp, offset?, tmp?, dst
+  result.addAttribute(
+      "operandSegmentSizes",
+      parser.getBuilder().getDenseI32ArrayAttr(
+          {1, 1, hasOffset ? 1 : 0, hasTmp ? 1 : 0, 1}));
+  return success();
+}
+
+static void printTQuantOp(OpAsmPrinter &p, Operation *op, Value src, Value fp,
+                          Value offset, Value tmp, Value dst) {
+  p << " ins(" << src << ", " << fp;
+  if (offset) {
+    p << ", " << offset << " : " << src.getType() << ", " << fp.getType()
+      << ", " << offset.getType() << ")";
+  } else {
+    p << " : " << src.getType() << ", " << fp.getType() << ")";
+  }
+  p << " outs(" << dst;
+  if (tmp) {
+    p << ", " << tmp << " : " << dst.getType() << ", " << tmp.getType() << ")";
+  } else {
+    p << " : " << dst.getType() << ")";
+  }
+  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"operandSegmentSizes"});
+}
+
+ParseResult mlir::pto::TQuantOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseTQuantOp(parser, result);
+}
+
+void mlir::pto::TQuantOp::print(OpAsmPrinter &p) {
+  printTQuantOp(p, getOperation(), getSrc(), getFp(), getOffset(), getTmp(),
+                getDst());
 }
 
 ParseResult mlir::pto::TRowExpandDivOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -12985,6 +13130,9 @@ void TQuantOp::getEffects(
   auto offsetRange = getOffsetMutable();
   if (!offsetRange.empty())
     PTO_ADD_READ(offsetRange[0]);
+  auto tmpRange = getTmpMutable();
+  if (!tmpRange.empty() && getTargetArch(getOperation()) != PTOArch::A5)
+    PTO_ADD_WRITE(tmpRange[0]);
   PTO_ADD_WRITE(getDstMutable());
 }
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -9609,8 +9609,6 @@ struct PTOQuantToEmitC : public OpConversionPattern<pto::TQuantOp> {
     Value fp  = peelUnrealized(adaptor.getFp());
 
     // Optional offset (INT8_ASYM only): pto::TQUANT expects TileDataPara*.
-    // Passing the tile value directly selects the tmp-aware overload and
-    // drops the actual offset argument.
     Value offsetPtr;
     if (op.getOffset()) {
       Value offset = peelUnrealized(adaptor.getOffset());
@@ -9623,7 +9621,15 @@ struct PTOQuantToEmitC : public OpConversionPattern<pto::TQuantOp> {
       }
     }
 
-    // TQUANT<QuantType, DstTile, SrcTile, FpTile>(dst, src, fp[, &offset])
+    // Optional tmp tile: when supplied it selects the tmp-aware 5-arg TQUANT
+    // overload (TQUANT<QuantType, Out, Src, Para>(dst, src, scale, tmp[,
+    // &offset])). Missing tmp operands are synthesized before memory planning
+    // so EmitC never hard-codes a backend scratch address.
+    Value tmp = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
+
+    // TQUANT<QuantType, DstTile, SrcTile, ParaTile>(dst, src, fp[, tmp][, &offset])
+    // (TileDataTmp is deduced from the tmp argument; not passed as a template
+    // argument, matching the pto-isa A5 sample tquant_kernel.cpp.)
     std::string quantTypeStr =
         op.getQuantType() == pto::QuantType::INT8_SYM
             ? "pto::QuantType::INT8_SYM"
@@ -9644,6 +9650,8 @@ struct PTOQuantToEmitC : public OpConversionPattern<pto::TQuantOp> {
     }
 
     SmallVector<Value> operands{dst, src, fp};
+    if (tmp)
+      operands.push_back(tmp);
     if (offsetPtr)
       operands.push_back(offsetPtr);
 

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -163,6 +163,11 @@ static mlir::pto::TileBufConfigAttr lookupConfig(Value v) {
 // Helper: Valid dims backtracking (v_row / v_col)
 // =============================================================================
 static void lookupValidDims(Value v, Value &vRow, Value &vCol) {
+  if (auto alloc = v.getDefiningOp<mlir::pto::AllocTileOp>()) {
+    vRow = alloc.getValidRow();
+    vCol = alloc.getValidCol();
+    return;
+  }
   if (auto bind = v.getDefiningOp<mlir::pto::BindTileOp>()) {
     vRow = bind.getValidRow();
     vCol = bind.getValidCol();
@@ -242,6 +247,58 @@ static Value resolveTileBufViewLikeSource(Value src) {
   }
 
   return Value();
+}
+
+static LogicalResult synthesizeMissingTQuantTmpOps(func::FuncOp func,
+                                                   MLIRContext *ctx) {
+  if (mlir::pto::getTargetArch(func.getOperation()) == mlir::pto::PTOArch::A5)
+    return success();
+
+  DefaultInlineVector<mlir::pto::TQuantOp> quantOps;
+  func.walk([&](mlir::pto::TQuantOp op) { quantOps.push_back(op); });
+
+  for (auto op : quantOps) {
+    if (op.getTmp())
+      continue;
+
+    auto srcTy = dyn_cast<mlir::pto::TileBufType>(op.getSrc().getType());
+    if (!srcTy)
+      continue;
+
+    if (srcTy.getRank() != static_cast<int64_t>(kTileRank2D)) {
+      op.emitError("expects rank-2 src tile to synthesize tquant tmp");
+      return failure();
+    }
+
+    IRRewriter rewriter(ctx);
+    rewriter.setInsertionPoint(op);
+    Location loc = op.getLoc();
+
+    SmallInlineVector<int64_t> shape(srcTy.getShape().begin(),
+                                     srcTy.getShape().end());
+    SmallInlineVector<int64_t> validShape(srcTy.getValidShape().begin(),
+                                          srcTy.getValidShape().end());
+    if (validShape.empty())
+      validShape.assign(shape.begin(), shape.end());
+
+    auto tmpTy = mlir::pto::TileBufType::get(
+        ctx, shape, srcTy.getElementType(), srcTy.getMemorySpace(), validShape,
+        mlir::pto::TileBufConfigAttr::getDefault(ctx));
+    Value validRow;
+    Value validCol;
+    lookupValidDims(op.getSrc(), validRow, validCol);
+    Value tmp = rewriter
+                    .create<mlir::pto::AllocTileOp>(loc, tmpTy, Value(),
+                                                    validRow, validCol)
+                    .getResult();
+
+    rewriter.create<mlir::pto::TQuantOp>(
+        loc, TypeRange{}, op.getSrc(), op.getFp(), op.getOffset(), tmp,
+        op.getDst(), op.getQuantTypeAttr());
+    rewriter.eraseOp(op);
+  }
+
+  return success();
 }
 
 // =============================================================================
@@ -1475,6 +1532,12 @@ struct PTOViewToMemrefPass
       // Stage 0: ensure inttoptr values remain scalar-load/store only.
       // ------------------------------------------------------------------
       if (failed(validateIntToPtrUses(func))) {
+        signalPassFailure();
+        return;
+      }
+
+      if (!func.isExternal() &&
+          failed(synthesizeMissingTQuantTmpOps(func, ctx))) {
         signalPassFailure();
         return;
       }
@@ -3449,6 +3512,7 @@ struct PTOViewToMemrefPass
         Value src = op.getSrc();
         Value fp = op.getFp();
         Value offset = op.getOffset();
+        Value tmp = op.getTmp();
         Value dst = op.getDst();
 
         auto srcTy = dyn_cast<MemRefType>(src.getType());
@@ -3464,6 +3528,21 @@ struct PTOViewToMemrefPass
           signalPassFailure();
           return;
         }
+        if (!tmp &&
+            mlir::pto::getTargetArch(op.getOperation()) !=
+                mlir::pto::PTOArch::A5) {
+          if (!srcTy.hasStaticShape()) {
+            op.emitError("cannot synthesize tquant tmp for dynamic memref src");
+            signalPassFailure();
+            return;
+          }
+          tmp = rewriter.create<memref::AllocOp>(op.getLoc(), srcTy).getResult();
+        }
+        if (tmp && !dyn_cast<MemRefType>(tmp.getType())) {
+          op.emitError("tmp is not memref yet");
+          signalPassFailure();
+          return;
+        }
 
         rewriter.replaceOpWithNewOp<pto::TQuantOp>(
             op,
@@ -3471,6 +3550,7 @@ struct PTOViewToMemrefPass
             src,
             fp,
             offset,
+            tmp,
             dst,
             op.getQuantTypeAttr());
       }

--- a/test/lit/pto/tquant.pto
+++ b/test/lit/pto/tquant.pto
@@ -1,30 +1,39 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 // RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
 // RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
 
 module attributes {"pto.device-spec" = "Ascend910B3"} {
   func.func @tquant_sym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %fp  = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %dst = memref.alloc() : memref<16x32xi8, #pto.address_space<vec>>
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tquant ins(%src, %fp : memref<16x32xf32, #pto.address_space<vec>>,
-                               memref<16x32xf32, #pto.address_space<vec>>)
-               outs(%dst : memref<16x32xi8, #pto.address_space<vec>>)
+    pto.tquant ins(%src, %fp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                {quant_type = #pto<quant_type INT8_SYM>}
 
     return
   }
 
   func.func @tquant_asym() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    %src    = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %fp     = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %offset = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-    %dst    = memref.alloc() : memref<16x32xui8, #pto.address_space<vec>>
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %offset = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tquant ins(%src, %fp, %offset : memref<16x32xf32, #pto.address_space<vec>>,
-                                        memref<16x32xf32, #pto.address_space<vec>>,
-                                        memref<16x32xf32, #pto.address_space<vec>>)
-               outs(%dst : memref<16x32xui8, #pto.address_space<vec>>)
+    pto.tquant ins(%src, %fp, %offset :
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                {quant_type = #pto<quant_type INT8_ASYM>}
 
     return

--- a/test/lit/pto/tquant_dynamic_tmp_valid_a3.pto
+++ b/test/lit/pto/tquant_dynamic_tmp_valid_a3.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s
+
+module {
+  func.func @tquant_dynamic_tmp_valid_a3(%valid_row: index, %valid_col: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile valid_row = %valid_row valid_col = %valid_col : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile valid_row = %valid_row valid_col = %valid_col : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    // CHECK-LABEL: func.func @tquant_dynamic_tmp_valid_a3
+    // CHECK-SAME: (%[[ROW:arg[0-9]+]]: index, %[[COL:arg[0-9]+]]: index)
+    // CHECK: pto.bind_tile %{{.*}}, %[[ROW]], %[[COL]] {{.*}} : memref<32x32xf32
+    // CHECK: pto.bind_tile %{{.*}} : memref<32x1xf32
+    // CHECK: pto.bind_tile %{{.*}}, %[[ROW]], %[[COL]] {{.*}} : memref<32x32xi8
+    // CHECK: %[[TMP:.*]] = pto.bind_tile %{{.*}}, %[[ROW]], %[[COL]] {{.*}} : memref<32x32xf32
+    // CHECK: pto.tquant
+    // CHECK-SAME: outs(%{{[^,]+}}, %[[TMP]] :
+    pto.tquant ins(%src, %fp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {quant_type = #pto<quant_type INT8_SYM>}
+    return
+  }
+}

--- a/test/lit/pto/tquant_e2e.pto
+++ b/test/lit/pto/tquant_e2e.pto
@@ -1,6 +1,15 @@
-// RUN: ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s --check-prefix=A3
-// RUN: ptoas --pto-arch=a5 %s -emit-pto-ir 2>&1 | FileCheck %s --check-prefix=A5
+// RUN: ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s --check-prefixes=IR,A3IR
+// RUN: ptoas --pto-arch=a5 %s -emit-pto-ir 2>&1 | FileCheck %s --check-prefixes=IR,A5IR
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=EMITC
+// RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=EMITC
 module attributes {"pto.device-spec" = "Ascend910B3"} {
+// IR-LABEL: func.func @tquant_sym_run
+// A3IR: pto.tquant ins({{.*}}) outs(%{{[^,]+}}, %{{[^ ]+}} :
+// A3IR-SAME: quant_type = #pto<quant_type INT8_SYM>
+// A5IR: pto.tquant ins({{.*}}) outs(%{{[^, :]+}} :
+// A5IR-SAME: quant_type = #pto<quant_type INT8_SYM>
+// EMITC-LABEL: AICORE void tquant_sym_run(
+// EMITC: TQUANT<pto::QuantType::INT8_SYM
   func.func @tquant_sym_run(%src_ptr: !pto.ptr<f32>, %fp_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<i8>)
       attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {
     %c0  = arith.constant 0 : index
@@ -8,22 +17,22 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
     %c32 = arith.constant 32 : index
 
     %src_view = pto.make_tensor_view %src_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
-    %fp_view  = pto.make_tensor_view %fp_ptr,  shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %fp_view  = pto.make_tensor_view %fp_ptr,  shape = [%c32, %c1],  strides = [%c1, %c1] {layout = #pto.layout<dn>} : !pto.tensor_view<?x?xf32>
     %dst_view = pto.make_tensor_view %dst_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xi8>
 
     %src_part = pto.partition_view %src_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
-    %fp_part  = pto.partition_view %fp_view,  offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x32xf32>
+    %fp_part  = pto.partition_view %fp_view,  offsets = [%c0, %c0], sizes = [%c32, %c1]  : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x1xf32>
     %dst_part = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xi8>  -> !pto.partition_tensor_view<32x32xi8>
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fp_tile  = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp_tile  = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8,  rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<32x32xf32>) outs(%src_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tload ins(%fp_part  : !pto.partition_tensor_view<32x32xf32>) outs(%fp_tile  : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%fp_part  : !pto.partition_tensor_view<32x1xf32>)  outs(%fp_tile  : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
 
     pto.tquant ins(%src_tile, %fp_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                                         !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+                                         !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
                outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                {quant_type = #pto<quant_type INT8_SYM>}
 
@@ -31,8 +40,12 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
 
     return
   }
-// A3-LABEL: func.func @tquant_asym_run({{.*}}) attributes {{.*}} {
-// A5-LABEL: func.func @tquant_asym_run({{.*}}) attributes {{.*}} {
+
+// IR-LABEL: func.func @tquant_asym_run
+// IR: pto.tquant ins({{.*}}) outs(%{{[^,]+}}, %{{[^ ]+}} :
+// IR-SAME: quant_type = #pto<quant_type INT8_ASYM>
+// EMITC-LABEL: AICORE void tquant_asym_run(
+// EMITC: TQUANT<pto::QuantType::INT8_ASYM
   func.func @tquant_asym_run(%src_ptr: !pto.ptr<f32>, %fp_ptr: !pto.ptr<f32>, %offset_ptr: !pto.ptr<f32>, %dst_ptr: !pto.ptr<ui8>)
       attributes {pto.entry, pto.kernel_kind = #pto.kernel_kind<vector>} {
     %c0  = arith.constant 0 : index
@@ -40,29 +53,32 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
     %c32 = arith.constant 32 : index
 
     %src_view    = pto.make_tensor_view %src_ptr,    shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
-    %fp_view     = pto.make_tensor_view %fp_ptr,     shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
-    %offset_view = pto.make_tensor_view %offset_ptr, shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xf32>
+    %fp_view     = pto.make_tensor_view %fp_ptr,     shape = [%c32, %c1],  strides = [%c1, %c1] {layout = #pto.layout<dn>} : !pto.tensor_view<?x?xf32>
+    %offset_view = pto.make_tensor_view %offset_ptr, shape = [%c32, %c1],  strides = [%c1, %c1] {layout = #pto.layout<dn>} : !pto.tensor_view<?x?xf32>
     %dst_view    = pto.make_tensor_view %dst_ptr,    shape = [%c32, %c32], strides = [%c32, %c1] : !pto.tensor_view<?x?xui8>
 
     %src_part    = pto.partition_view %src_view,    offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x32xf32>
-    %fp_part     = pto.partition_view %fp_view,     offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x32xf32>
-    %offset_part = pto.partition_view %offset_view, offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x32xf32>
+    %fp_part     = pto.partition_view %fp_view,     offsets = [%c0, %c0], sizes = [%c32, %c1]  : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x1xf32>
+    %offset_part = pto.partition_view %offset_view, offsets = [%c0, %c0], sizes = [%c32, %c1]  : !pto.tensor_view<?x?xf32>  -> !pto.partition_tensor_view<32x1xf32>
     %dst_part    = pto.partition_view %dst_view,    offsets = [%c0, %c0], sizes = [%c32, %c32] : !pto.tensor_view<?x?xui8>  -> !pto.partition_tensor_view<32x32xui8>
 
     %src_tile    = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %fp_tile     = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %offset_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp_tile     = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %offset_tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %tmp_tile    = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst_tile    = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tload ins(%src_part    : !pto.partition_tensor_view<32x32xf32>) outs(%src_tile    : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tload ins(%fp_part     : !pto.partition_tensor_view<32x32xf32>) outs(%fp_tile     : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tload ins(%offset_part : !pto.partition_tensor_view<32x32xf32>) outs(%offset_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%fp_part     : !pto.partition_tensor_view<32x1xf32>)  outs(%fp_tile     : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%offset_part : !pto.partition_tensor_view<32x1xf32>)  outs(%offset_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
 
     pto.tquant ins(%src_tile, %fp_tile, %offset_tile :
                      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
-                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst_tile, %tmp_tile :
+                     !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
                      !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-               outs(%dst_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                {quant_type = #pto<quant_type INT8_ASYM>}
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst_part : !pto.partition_tensor_view<32x32xui8>)

--- a/test/lit/pto/tquant_verify_invalid_a3_offset_layout.pto
+++ b/test/lit/pto/tquant_verify_invalid_a3_offset_layout.pto
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s
+
+module {
+  func.func @tquant_a3_invalid_offset_layout() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %offset = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    // CHECK: error: 'pto.tquant' op expects A2/A3 offset to use non-row-major layout
+    pto.tquant ins(%src, %fp, %offset :
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst, %tmp :
+                     !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {quant_type = #pto<quant_type INT8_ASYM>}
+    return
+  }
+}

--- a/test/lit/pto/tquant_verify_invalid_a3_param_layout.pto
+++ b/test/lit/pto/tquant_verify_invalid_a3_param_layout.pto
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s
+
+module {
+  func.func @tquant_a3_invalid_fp_layout() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    // CHECK: error: 'pto.tquant' op expects A2/A3 fp to use non-row-major layout
+    pto.tquant ins(%src, %fp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {quant_type = #pto<quant_type INT8_SYM>}
+    return
+  }
+}

--- a/test/lit/pto/tquant_verify_invalid_a3_tmp_shape.pto
+++ b/test/lit/pto/tquant_verify_invalid_a3_tmp_shape.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s
+
+module {
+  func.func @tquant_a3_invalid_tmp_shape() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    // CHECK: error: 'pto.tquant' op expects A2/A3 tmp to have the same shape as src
+    pto.tquant ins(%src, %fp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst, %tmp :
+                     !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {quant_type = #pto<quant_type INT8_SYM>}
+    return
+  }
+}

--- a/test/lit/pto/tquant_verify_invalid_int8_asym_no_offset.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_asym_no_offset.pto
@@ -12,13 +12,13 @@
 // CHECK: error: 'pto.tquant' op INT8_ASYM quantization requires an offset operand
 
 func.func @tquant_asym_no_offset() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x16xui8, #pto.address_space<vec>>
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-  pto.tquant ins(%src, %fp : memref<16x16xf32, #pto.address_space<vec>>,
-                             memref<16x16xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x16xui8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                             !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              {quant_type = #pto<quant_type INT8_ASYM>}
 
   return

--- a/test/lit/pto/tquant_verify_invalid_int8_asym_wrong_dst.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_asym_wrong_dst.pto
@@ -13,15 +13,16 @@
 // CHECK: AICORE void tquant_asym_wrong_dst()
 
 func.func @tquant_asym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %offset = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x32xi8, #pto.address_space<vec>>
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %offset = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-  pto.tquant ins(%src, %fp, %offset : memref<16x32xf32, #pto.address_space<vec>>,
-                                      memref<16x32xf32, #pto.address_space<vec>>,
-                                      memref<16x32xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x32xi8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp, %offset :
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>,
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              {quant_type = #pto<quant_type INT8_ASYM>}
 
   return

--- a/test/lit/pto/tquant_verify_invalid_int8_sym_with_offset.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_sym_with_offset.pto
@@ -12,15 +12,16 @@
 // CHECK: error: 'pto.tquant' op INT8_SYM quantization must not have an offset operand
 
 func.func @tquant_sym_with_offset() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %offset = memref.alloc() : memref<16x16xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x16xi8, #pto.address_space<vec>>
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %offset = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-  pto.tquant ins(%src, %fp, %offset : memref<16x16xf32, #pto.address_space<vec>>,
-                                      memref<16x16xf32, #pto.address_space<vec>>,
-                                      memref<16x16xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x16xi8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp, %offset :
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>,
+                   !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              {quant_type = #pto<quant_type INT8_SYM>}
 
   return

--- a/test/lit/pto/tquant_verify_invalid_int8_sym_wrong_dst.pto
+++ b/test/lit/pto/tquant_verify_invalid_int8_sym_wrong_dst.pto
@@ -13,13 +13,13 @@
 // CHECK: AICORE void tquant_sym_wrong_dst()
 
 func.func @tquant_sym_wrong_dst() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  %src = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %fp = memref.alloc() : memref<16x32xf32, #pto.address_space<vec>>
-  %dst = memref.alloc() : memref<16x32xui8, #pto.address_space<vec>>
+  %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+  %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+  %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-  pto.tquant ins(%src, %fp : memref<16x32xf32, #pto.address_space<vec>>,
-                             memref<16x32xf32, #pto.address_space<vec>>)
-             outs(%dst : memref<16x32xui8, #pto.address_space<vec>>)
+  pto.tquant ins(%src, %fp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                             !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=1, v_row=32, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=ui8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
              {quant_type = #pto<quant_type INT8_SYM>}
 
   return

--- a/test/lit/pto/tquant_verify_invalid_src_dst_valid_shape.pto
+++ b/test/lit/pto/tquant_verify_invalid_src_dst_valid_shape.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 %s -emit-pto-ir 2>&1 | FileCheck %s
+
+module {
+  func.func @tquant_a3_invalid_src_dst_valid_shape() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %fp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    // CHECK: error: 'pto.tquant' op expects src and dst to have the same valid_shape
+    pto.tquant ins(%src, %fp : !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                               !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1, v_row=16, v_col=1, blayout=col_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst, %tmp :
+                     !pto.tile_buf<loc=vec, dtype=i8, rows=32, cols=32, v_row=32, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+                     !pto.tile_buf<loc=vec, dtype=f32, rows=32, cols=32, v_row=16, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {quant_type = #pto<quant_type INT8_SYM>}
+    return
+  }
+}

--- a/test/npu_validation/scripts/generate_testcase.py
+++ b/test/npu_validation/scripts/generate_testcase.py
@@ -1039,7 +1039,10 @@ def _find_custom_case_asset(sample_root: Path, testcase: str, filename: str) -> 
 def _use_custom_golden_for_case(testcase: str, soc_version: str) -> bool:
     testcase_lc = testcase.lower()
     soc_lc = (soc_version or "").lower()
-    is_a3 = "910b" in soc_lc or os.environ.get("PTOAS_BOARD_IS_A3") == "1"
+    is_a3 = (
+        any(token in soc_lc for token in ("910a", "910proa", "910b"))
+        or os.environ.get("PTOAS_BOARD_IS_A3") == "1"
+    )
     if is_a3 and testcase_lc in UNSTABLE_A3_CUSTOM_GOLDEN_CASES:
         return False
     return True
@@ -1959,8 +1962,10 @@ def generate_testcase(
         param_decls_lines.append("    pto::comm::sdma::SdmaWorkspaceManager sdmaMgr;")
         param_decls_lines.append("    bool sdmaWorkspaceOk = false;")
         param_decls_lines.append('    const char *sdmaSocVersion = std::getenv("SOC_VERSION");')
+        param_decls_lines.append('    const char *ptoasBoardIsA3 = std::getenv("PTOAS_BOARD_IS_A3");')
         param_decls_lines.append(
             '    const bool skipSdmaWorkspaceInit = (std::getenv("PTO_DISABLE_SDMA_WORKSPACE_INIT") != nullptr) || '
+            '(ptoasBoardIsA3 != nullptr && std::strcmp(ptoasBoardIsA3, "1") == 0) || '
             '(sdmaSocVersion != nullptr && (std::strstr(sdmaSocVersion, "950") != nullptr || '
             'std::strstr(sdmaSocVersion, "A5") != nullptr || std::strstr(sdmaSocVersion, "a5") != nullptr));'
         )

--- a/test/npu_validation/scripts/run_remote_npu_validation.sh
+++ b/test/npu_validation/scripts/run_remote_npu_validation.sh
@@ -359,19 +359,29 @@ if [[ "${SIM_SOC_VERSION}" == "Ascend910" ]]; then
   fi
 fi
 
-# Detect A3 (Ascend910B) target for golden-script gating.
+# Detect A3 (Ascend910A/910B) target for golden-script gating.
 # This is separate from SOC_VERSION/SIM_SOC_VERSION used for compilation
 # to avoid changing the compiler arch (dav-c220 vs dav-c310). Simulator runs
-# must key off the selected SIM target, not the mere presence of 910B sim libs.
+# must key off the selected SIM target, not the mere presence of 910 sim libs.
 export PTOAS_BOARD_IS_A3=0
 if [[ "${RUN_MODE}" == "sim" ]]; then
-  if [[ "$(printf '%s' "${SIM_SOC_VERSION}" | tr '[:upper:]' '[:lower:]')" == *910b* ]]; then
+  sim_soc_lc="$(printf '%s' "${SIM_SOC_VERSION}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${sim_soc_lc}" == *910a* || "${sim_soc_lc}" == *910proa* || "${sim_soc_lc}" == *910b* ]]; then
     export PTOAS_BOARD_IS_A3=1
     log "Detected A3 target from SIM_SOC_VERSION=${SIM_SOC_VERSION}"
   fi
-elif [[ "$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')" == *910b* ]]; then
-  export PTOAS_BOARD_IS_A3=1
-  log "Detected A3 board from npu-smi chip name: ${_board_chip}"
+else
+  board_chip_lc="$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${board_chip_lc}" == *910a* || "${board_chip_lc}" == *910proa* || "${board_chip_lc}" == *910b* ]]; then
+    export PTOAS_BOARD_IS_A3=1
+    log "Detected A3 board from npu-smi chip name: ${_board_chip}"
+  elif [[ -z "${_board_chip}" ]]; then
+    sim_soc_lc="$(printf '%s' "${SIM_SOC_VERSION}" | tr '[:upper:]' '[:lower:]')"
+    if [[ "${sim_soc_lc}" == *910a* || "${sim_soc_lc}" == *910proa* || "${sim_soc_lc}" == *910b* ]]; then
+      export PTOAS_BOARD_IS_A3=1
+      log "Detected A3 board from SIM_SOC_VERSION=${SIM_SOC_VERSION}"
+    fi
+  fi
 fi
 log "SIM_SOC_VERSION=${SIM_SOC_VERSION}"
 log "PTOAS_BOARD_IS_A3=${PTOAS_BOARD_IS_A3}"
@@ -382,12 +392,13 @@ log "PTOAS_BOARD_IS_A3=${PTOAS_BOARD_IS_A3}"
 # getenv() unless exported here.
 export RUN_MODE
 export SOC_VERSION="${SIM_SOC_VERSION}"
-if [[ "${PTOAS_BOARD_IS_A3}" != "1" ]]; then
-  board_chip_lc="$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')"
-  if [[ "${board_chip_lc}" == *950* || "${board_chip_lc}" == *a5* || "${SOC_VERSION,,}" == *950* || "${SOC_VERSION,,}" == *a5* ]]; then
-    export PTO_DISABLE_SDMA_WORKSPACE_INIT=1
-    log "Export PTO_DISABLE_SDMA_WORKSPACE_INIT=1 for A5 TPREFETCH_ASYNC runtime fallback"
-  fi
+board_chip_lc="$(printf '%s' "${_board_chip}" | tr '[:upper:]' '[:lower:]')"
+if [[ "${PTOAS_BOARD_IS_A3}" == "1" ]]; then
+  export PTO_DISABLE_SDMA_WORKSPACE_INIT=1
+  log "Export PTO_DISABLE_SDMA_WORKSPACE_INIT=1 for A3 TPREFETCH_ASYNC runtime fallback"
+elif [[ "${board_chip_lc}" == *950* || "${board_chip_lc}" == *a5* || "${SOC_VERSION,,}" == *950* || "${SOC_VERSION,,}" == *a5* ]]; then
+  export PTO_DISABLE_SDMA_WORKSPACE_INIT=1
+  log "Export PTO_DISABLE_SDMA_WORKSPACE_INIT=1 for A5 TPREFETCH_ASYNC runtime fallback"
 fi
 
 LD_LIBRARY_PATH_NPU="${LD_LIBRARY_PATH}"


### PR DESCRIPTION
## Summary

Bump the pinned `pto-isa` commit from `66c93143` to `5d979cde` (current GitCode `main` HEAD) in `.github/workflows/ci.yml`.

## Context

The prior pin (`66c93143`, introduced via the #837 merge) regressed A3 board validation. Controlled comparison on the a3 runner (`101.245.68.6`):

| pto-isa pin | PTOAS source | a3 result |
| --- | --- | --- |
| `b65945bf` | main (pre-#837) | **0 failing** cases |
| `66c93143` | main (post-#837), same source otherwise | **69 failing** cases |

The 11 cases failing on PR #856's board run (`20260623_175013_manual_pr856`) are a strict subset of that 69-case regression set:

`partmin`, `quant`, `quant_asym`, `rope_kv_cache`, `rowexpanddiv`, `rowexpandmul`, `rowexpandsub`, `scatter`, `sels`, `tprefetch_async_binding`, `xor`

Since the board monitor reads the pin from the PR head's `ci.yml` (`monitor.py:1568`), this bump lets a single `/run a3` here measure **which of the 11 regressions upstream pto-isa has since fixed** vs. which still need a PTOAS-side adaptation.

This is a **measurement-first** bump. PTOAS-side fixes (e.g. the `PTOQuantToEmitC` TQuant overload that drops the offset argument, causing the `quant`/`quant_asym` compile errors) will be added in follow-up commits based on what this run surfaces.

## Changes
- `.github/workflows/ci.yml`: `PTO_ISA_COMMIT` default `66c93143` → `5d979cde` (two occurrences: the workflow input default and the env fallback).