### PR TITLE
Fix mgather sync insertion macro inference

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7426,13 +7426,13 @@ backends that provide it, including A2/A3 and A5.
 
 ##### `pto.mgather` - Gather-Load from Global Memory
 
-**Summary:** Loads elements from a global table into a VEC tile using per-element indices. Supports optional `coalesce` and `gatherOob` attributes that lower to the corresponding `MGATHER<...>` template overload.
+**Summary:** Loads elements from a global table into a VEC tile using per-element indices. Requires an explicit `coalesce` attribute and supports an optional `gatherOob` attribute; these lower to the corresponding `MGATHER<...>` template overload.
 
 **Semantics:**
 
 ```
-row mode (default): dst[r, j] = mem[idx[r], j]
-elem mode:          dst[i, j] = mem[idx[i, j]]
+row mode:  dst[r, j] = mem[idx[r], j]
+elem mode: dst[i, j] = mem[idx[i, j]]
 ```
 
 **Arguments:**
@@ -7442,7 +7442,7 @@ elem mode:          dst[i, j] = mem[idx[i, j]]
 | `mem` | `!pto.partition_tensor_view<...>` / GM memref | `NA` | Global source table |
 | `idx` | `pto.tile_buf` | `NA` | Index tile |
 | `dst` | `pto.tile_buf` | `NA` | Destination VEC tile |
-| `coalesce` | `#pto<coalesce ...>` | inferred | Explicit coalesce mode (`row` / `elem`) |
+| `coalesce` | `#pto<coalesce ...>` | required | Explicit coalesce mode (`row` / `elem`) |
 | `gatherOob` | `#pto<gather_oob ...>` | `undefined` | Out-of-bounds mode (`undefined/clamp/wrap/zero`) |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -7469,8 +7469,8 @@ elem mode:          dst[i, j] = mem[idx[i, j]]
   - Default `gatherOob = undefined` lowers to the default `MGATHER(dst, mem, idx)` overload.
   - Non-default `gatherOob` values lower to `MGATHER<Coalesce, GatherOOB::...>(dst, mem, idx)`.
 - **Coalesce mode**
-  - If `coalesce` is omitted, PTOAS preserves the existing inference from the `idx` tile shape/layout.
-  - If `coalesce` is specified, the `idx` tile shape/layout must match that mode.
+  - `coalesce` must be specified explicitly; PTOAS does not infer Row or Elem from the `idx` tile shape/layout.
+  - The `idx` tile shape/layout must match the specified mode.
   - `coalesce = #pto<coalesce row>` lowers to `MGATHER<pto::Coalesce::Row, ...>`.
   - `coalesce = #pto<coalesce elem>` lowers to `MGATHER<pto::Coalesce::Elem, ...>`.
 
@@ -7483,6 +7483,7 @@ elem mode:          dst[i, j] = mem[idx[i, j]]
 ```mlir
 pto.mgather ins(%mem, %idx : memref<...>, !pto.tile_buf<...>)
            outs(%dst : !pto.tile_buf<...>)
+           {coalesce = #pto<coalesce row>}
 
 pto.mgather ins(%mem, %idx : memref<...>, !pto.tile_buf<...>)
            outs(%dst : !pto.tile_buf<...>)
@@ -7490,7 +7491,7 @@ pto.mgather ins(%mem, %idx : memref<...>, !pto.tile_buf<...>)
 
 pto.mgather ins(%mem, %idx : memref<...>, !pto.tile_buf<...>)
            outs(%dst : !pto.tile_buf<...>)
-           {gatherOob = #pto<gather_oob zero>}
+           {coalesce = #pto<coalesce row>, gatherOob = #pto<gather_oob zero>}
 ```
 
 **GM → L1 (cube `loc=mat`) destination:**

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2855,7 +2855,7 @@ def MGatherOp : PTO_TOp<"mgather", [
     PTODpsType:$idx,
     PTODpsType:$dst,
     Optional<PTODpsType>:$scratch,
-    OptionalAttr<PTO_CoalesceAttr>:$coalesce,
+    PTO_CoalesceAttr:$coalesce,
     DefaultValuedAttr<PTO_GatherOOBAttr, "::mlir::pto::GatherOOB::Undefined">:$gatherOob);
 
   let results = (outs);

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -8499,12 +8499,14 @@ LogicalResult MGatherOp::verify() {
                                              "dst")))
     return failure();
 
-  std::optional<pto::Coalesce> explicitCoalesce;
-  if (auto coalesceAttr = getCoalesceAttr())
-    explicitCoalesce = coalesceAttr.getValue();
+  auto coalesceAttr = getCoalesceAttr();
+  if (!coalesceAttr)
+    return emitOpError(
+        "expects mgather to specify an explicit coalesce attribute (row or "
+        "elem)");
 
   if (failed(verifyMGatherMScatterTileShape(getOperation(), dstTy, idxTy, "dst",
-                                            explicitCoalesce)))
+                                            coalesceAttr.getValue())))
     return failure();
 
   return success();

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -266,38 +266,6 @@ static std::optional<SmallVector<Value, 2>> lookupMGatherValidDims(Value value) 
   return std::nullopt;
 }
 
-static std::optional<pto::TileBufConfigAttr>
-lookupMGatherTileConfig(Value value) {
-  if (auto bind = value.getDefiningOp<pto::BindTileOp>())
-    return bind.getConfig();
-  if (auto pc = value.getDefiningOp<pto::PointerCastOp>()) {
-    if (auto config = pc.getConfig())
-      return *config;
-    return std::nullopt;
-  }
-  if (auto subview = value.getDefiningOp<memref::SubViewOp>())
-    return lookupMGatherTileConfig(subview.getSource());
-  if (auto cast = value.getDefiningOp<memref::ReinterpretCastOp>())
-    return lookupMGatherTileConfig(cast.getSource());
-  if (auto cast = value.getDefiningOp<memref::CastOp>())
-    return lookupMGatherTileConfig(cast.getSource());
-
-  if (auto regionResult = dyn_cast<OpResult>(value)) {
-    if (auto fusionRegion = dyn_cast<pto::FusionRegionOp>(regionResult.getOwner())) {
-      auto yieldOp =
-          dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
-      if (!yieldOp)
-        return std::nullopt;
-      unsigned resultIndex = regionResult.getResultNumber();
-      if (resultIndex >= yieldOp.getNumOperands())
-        return std::nullopt;
-      return lookupMGatherTileConfig(yieldOp.getOperand(resultIndex));
-    }
-  }
-
-  return std::nullopt;
-}
-
 static std::optional<SmallVector<int64_t>>
 getMGatherOperandShape(Value value, bool useValidShape = true) {
   auto shape = getMGatherOperandShapeFromType(value.getType(), useValidShape);
@@ -323,84 +291,6 @@ getMGatherOperandShape(Value value, bool useValidShape = true) {
   return shape;
 }
 
-struct MGatherShapeLayoutInfo {
-  SmallVector<int64_t, 2> shape;
-  bool rowMajor = false;
-  bool colMajor = false;
-};
-
-static std::optional<MGatherShapeLayoutInfo>
-getMGatherShapeLayoutInfo(Value value) {
-  auto shape = getMGatherOperandShape(value);
-  if (!shape || shape->size() != 2)
-    return std::nullopt;
-
-  MGatherShapeLayoutInfo info;
-  info.shape.assign(shape->begin(), shape->end());
-
-  if (auto tileTy = dyn_cast<pto::TileBufType>(value.getType())) {
-    int32_t blayout = tileTy.getBLayoutValueI32();
-    info.rowMajor = blayout == static_cast<int32_t>(pto::BLayout::RowMajor);
-    info.colMajor = blayout == static_cast<int32_t>(pto::BLayout::ColMajor);
-  }
-
-  if (auto config = lookupMGatherTileConfig(value)) {
-    auto blayoutAttr = dyn_cast<pto::BLayoutAttr>(config->getBLayout());
-    if (!blayoutAttr)
-      return info;
-    info.rowMajor = blayoutAttr.getValue() == pto::BLayout::RowMajor;
-    info.colMajor = blayoutAttr.getValue() == pto::BLayout::ColMajor;
-    return info;
-  }
-
-  if (auto memRefTy = dyn_cast<MemRefType>(value.getType())) {
-    SmallVector<int64_t, 4> strides;
-    int64_t offset = ShapedType::kDynamic;
-    if (failed(getStridesAndOffset(memRefTy, strides, offset)) ||
-        strides.size() != 2)
-      return std::nullopt;
-    info.rowMajor = strides[1] == 1;
-    info.colMajor = strides[0] == 1;
-  }
-
-  return info;
-}
-
-// Infer the effective Coalesce when the attribute is absent. Mirrors the
-// isRowCoalescedMGatherIndexType heuristic from PTOToEmitC: row gather has a
-// unit-extent index (valid [1,R] row-major or [R,1] col-major), otherwise Elem.
-// InsertSync runs after PTOViewToMemref / buffer materialization, where tile
-// valid_shape + layout metadata may live on pto.bind_tile/pointer_cast rather
-// than on the bare memref type. Recover that value-chain metadata first, and
-// only fall back to memref physical shape/strides when no PTO tile metadata is
-// available.
-static pto::Coalesce inferMGatherCoalesce(pto::MGatherOp op) {
-  if (auto coalesceAttr = op.getCoalesceAttr())
-    return coalesceAttr.getValue();
-
-  auto dataInfo = getMGatherShapeLayoutInfo(op.getDst());
-  auto idxInfo = getMGatherShapeLayoutInfo(op.getIdx());
-  if (!dataInfo || !idxInfo)
-    return pto::Coalesce::Elem;
-
-  auto isUnit = [](int64_t d) {
-    return d == 0 || d == 1;
-  };
-  auto compat = [](int64_t a, int64_t b) {
-    return a != ::mlir::ShapedType::kDynamic &&
-           b != ::mlir::ShapedType::kDynamic && a == b;
-  };
-
-  const bool rowCoalesce1xR =
-      idxInfo->rowMajor && isUnit(idxInfo->shape[0]) &&
-      compat(idxInfo->shape[1], dataInfo->shape[0]);
-  const bool rowCoalesceRx1 =
-      idxInfo->colMajor && compat(idxInfo->shape[0], dataInfo->shape[0]) &&
-      isUnit(idxInfo->shape[1]);
-  return (rowCoalesce1xR || rowCoalesceRx1) ? pto::Coalesce::Row
-                                            : pto::Coalesce::Elem;
-}
-
 // MGather is a macro-like library call whose internal pipe usage depends on the
 // destination address space, the coalesce mode, and the target arch. Model each
 // reachable lowering path as SyncMacroPhases so InsertSyncAnalysis can derive the
@@ -418,8 +308,12 @@ std::optional<SyncMacroModel> getMGatherSyncMacroModel(pto::MGatherOp op) {
   auto dstSpace = getMGatherOperandAddressSpace(op.getDst().getType());
   const bool isGm2L1 = dstSpace && *dstSpace == pto::AddressSpace::MAT;
 
+  auto coalesceAttr = op.getCoalesceAttr();
+  if (!coalesceAttr)
+    return std::nullopt;
+
   const PTOArch arch = getTargetArch(op.getOperation());
-  const pto::Coalesce coalesce = inferMGatherCoalesce(op);
+  const pto::Coalesce coalesce = coalesceAttr.getValue();
 
   SyncMacroModel model;
 

--- a/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncMacroModel.cpp
@@ -8,6 +8,8 @@
 
 #include "PTO/Transforms/InsertSync/SyncMacroModel.h"
 #include "PTO/IR/PTO.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Matchers.h"
 
 using namespace mlir;
 using namespace mlir::pto;
@@ -193,6 +195,326 @@ std::optional<SyncMacroModel> getTGatherSyncMacroModel(pto::TGatherOp op) {
   return model;
 }
 
+// Resolve the PTO address space of an MGatherOp operand type. Mirrors the
+// getAddressSpace helper used by MGatherOp::getPipe() so the model matches the
+// post-PTOViewToMemref (memref<...,mat>) form that InsertSync actually sees.
+static std::optional<pto::AddressSpace>
+getMGatherOperandAddressSpace(::mlir::Type ty) {
+  if (auto tb = ::mlir::dyn_cast<::mlir::pto::TileBufType>(ty)) {
+    if (auto as = ::mlir::dyn_cast_or_null<::mlir::pto::AddressSpaceAttr>(
+            tb.getMemorySpace()))
+      return as.getAddressSpace();
+    return std::nullopt;
+  }
+  if (auto mr = ::mlir::dyn_cast<::mlir::MemRefType>(ty)) {
+    if (auto ms = mr.getMemorySpace()) {
+      if (auto as = ::mlir::dyn_cast<::mlir::pto::AddressSpaceAttr>(ms))
+        return as.getAddressSpace();
+    }
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+static std::optional<SmallVector<int64_t>>
+getMGatherOperandShapeFromType(::mlir::Type ty, bool useValidShape = true) {
+  if (auto tb = ::mlir::dyn_cast<::mlir::pto::TileBufType>(ty)) {
+    ArrayRef<int64_t> shape =
+        useValidShape ? tb.getValidShape() : tb.getShape();
+    return SmallVector<int64_t>(shape.begin(), shape.end());
+  }
+  if (auto mr = ::mlir::dyn_cast<::mlir::MemRefType>(ty))
+    return SmallVector<int64_t>(mr.getShape().begin(), mr.getShape().end());
+  return std::nullopt;
+}
+
+static std::optional<int64_t> getConstantIndex(Value value) {
+  if (!value)
+    return std::nullopt;
+
+  APInt intValue;
+  if (!matchPattern(value, m_ConstantInt(&intValue)))
+    return std::nullopt;
+  return intValue.getSExtValue();
+}
+
+static std::optional<SmallVector<Value, 2>> lookupMGatherValidDims(Value value) {
+  if (auto bind = value.getDefiningOp<pto::BindTileOp>())
+    return SmallVector<Value, 2>{bind.getValidRow(), bind.getValidCol()};
+  if (auto pc = value.getDefiningOp<pto::PointerCastOp>())
+    return SmallVector<Value, 2>{pc.getValidRow(), pc.getValidCol()};
+  if (auto subview = value.getDefiningOp<memref::SubViewOp>())
+    return lookupMGatherValidDims(subview.getSource());
+  if (auto cast = value.getDefiningOp<memref::ReinterpretCastOp>())
+    return lookupMGatherValidDims(cast.getSource());
+  if (auto cast = value.getDefiningOp<memref::CastOp>())
+    return lookupMGatherValidDims(cast.getSource());
+
+  if (auto regionResult = dyn_cast<OpResult>(value)) {
+    if (auto fusionRegion = dyn_cast<pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp =
+          dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp)
+        return std::nullopt;
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands())
+        return std::nullopt;
+      return lookupMGatherValidDims(yieldOp.getOperand(resultIndex));
+    }
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<pto::TileBufConfigAttr>
+lookupMGatherTileConfig(Value value) {
+  if (auto bind = value.getDefiningOp<pto::BindTileOp>())
+    return bind.getConfig();
+  if (auto pc = value.getDefiningOp<pto::PointerCastOp>()) {
+    if (auto config = pc.getConfig())
+      return *config;
+    return std::nullopt;
+  }
+  if (auto subview = value.getDefiningOp<memref::SubViewOp>())
+    return lookupMGatherTileConfig(subview.getSource());
+  if (auto cast = value.getDefiningOp<memref::ReinterpretCastOp>())
+    return lookupMGatherTileConfig(cast.getSource());
+  if (auto cast = value.getDefiningOp<memref::CastOp>())
+    return lookupMGatherTileConfig(cast.getSource());
+
+  if (auto regionResult = dyn_cast<OpResult>(value)) {
+    if (auto fusionRegion = dyn_cast<pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp =
+          dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp)
+        return std::nullopt;
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands())
+        return std::nullopt;
+      return lookupMGatherTileConfig(yieldOp.getOperand(resultIndex));
+    }
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<SmallVector<int64_t>>
+getMGatherOperandShape(Value value, bool useValidShape = true) {
+  auto shape = getMGatherOperandShapeFromType(value.getType(), useValidShape);
+  if (!shape || !useValidShape)
+    return shape;
+
+  auto validDims = lookupMGatherValidDims(value);
+  if (!validDims || validDims->size() != 2)
+    return shape;
+
+  if (shape->size() >= 1) {
+    if (auto validRow = getConstantIndex((*validDims)[0]))
+      (*shape)[0] = *validRow;
+    else if ((*validDims)[0])
+      (*shape)[0] = ShapedType::kDynamic;
+  }
+  if (shape->size() >= 2) {
+    if (auto validCol = getConstantIndex((*validDims)[1]))
+      (*shape)[1] = *validCol;
+    else if ((*validDims)[1])
+      (*shape)[1] = ShapedType::kDynamic;
+  }
+  return shape;
+}
+
+struct MGatherShapeLayoutInfo {
+  SmallVector<int64_t, 2> shape;
+  bool rowMajor = false;
+  bool colMajor = false;
+};
+
+static std::optional<MGatherShapeLayoutInfo>
+getMGatherShapeLayoutInfo(Value value) {
+  auto shape = getMGatherOperandShape(value);
+  if (!shape || shape->size() != 2)
+    return std::nullopt;
+
+  MGatherShapeLayoutInfo info;
+  info.shape.assign(shape->begin(), shape->end());
+
+  if (auto tileTy = dyn_cast<pto::TileBufType>(value.getType())) {
+    int32_t blayout = tileTy.getBLayoutValueI32();
+    info.rowMajor = blayout == static_cast<int32_t>(pto::BLayout::RowMajor);
+    info.colMajor = blayout == static_cast<int32_t>(pto::BLayout::ColMajor);
+  }
+
+  if (auto config = lookupMGatherTileConfig(value)) {
+    auto blayoutAttr = dyn_cast<pto::BLayoutAttr>(config->getBLayout());
+    if (!blayoutAttr)
+      return info;
+    info.rowMajor = blayoutAttr.getValue() == pto::BLayout::RowMajor;
+    info.colMajor = blayoutAttr.getValue() == pto::BLayout::ColMajor;
+    return info;
+  }
+
+  if (auto memRefTy = dyn_cast<MemRefType>(value.getType())) {
+    SmallVector<int64_t, 4> strides;
+    int64_t offset = ShapedType::kDynamic;
+    if (failed(getStridesAndOffset(memRefTy, strides, offset)) ||
+        strides.size() != 2)
+      return std::nullopt;
+    info.rowMajor = strides[1] == 1;
+    info.colMajor = strides[0] == 1;
+  }
+
+  return info;
+}
+
+// Infer the effective Coalesce when the attribute is absent. Mirrors the
+// isRowCoalescedMGatherIndexType heuristic from PTOToEmitC: row gather has a
+// unit-extent index (valid [1,R] row-major or [R,1] col-major), otherwise Elem.
+// InsertSync runs after PTOViewToMemref / buffer materialization, where tile
+// valid_shape + layout metadata may live on pto.bind_tile/pointer_cast rather
+// than on the bare memref type. Recover that value-chain metadata first, and
+// only fall back to memref physical shape/strides when no PTO tile metadata is
+// available.
+static pto::Coalesce inferMGatherCoalesce(pto::MGatherOp op) {
+  if (auto coalesceAttr = op.getCoalesceAttr())
+    return coalesceAttr.getValue();
+
+  auto dataInfo = getMGatherShapeLayoutInfo(op.getDst());
+  auto idxInfo = getMGatherShapeLayoutInfo(op.getIdx());
+  if (!dataInfo || !idxInfo)
+    return pto::Coalesce::Elem;
+
+  auto isUnit = [](int64_t d) {
+    return d == 0 || d == 1;
+  };
+  auto compat = [](int64_t a, int64_t b) {
+    return a != ::mlir::ShapedType::kDynamic &&
+           b != ::mlir::ShapedType::kDynamic && a == b;
+  };
+
+  const bool rowCoalesce1xR =
+      idxInfo->rowMajor && isUnit(idxInfo->shape[0]) &&
+      compat(idxInfo->shape[1], dataInfo->shape[0]);
+  const bool rowCoalesceRx1 =
+      idxInfo->colMajor && compat(idxInfo->shape[0], dataInfo->shape[0]) &&
+      isUnit(idxInfo->shape[1]);
+  return (rowCoalesce1xR || rowCoalesceRx1) ? pto::Coalesce::Row
+                                            : pto::Coalesce::Elem;
+}
+
+// MGather is a macro-like library call whose internal pipe usage depends on the
+// destination address space, the coalesce mode, and the target arch. Model each
+// reachable lowering path as SyncMacroPhases so InsertSyncAnalysis can derive the
+// real cross-pipe sync (notably the MTE2->S wait for the scalar index read that
+// MGatherOp::getPipe() hides by reporting a single pipe).
+//
+// Also reserve pto-isa's fixed internal event ids through hiddenEvents so
+// compiler-generated sync around the macro does not reuse EVENT_ID0 on pipe
+// pairs already consumed inside the library implementation.
+std::optional<SyncMacroModel> getMGatherSyncMacroModel(pto::MGatherOp op) {
+  // GM -> L1 (dst is an L1 / cube MAT tile). A5/A2A3 share the same data flow:
+  // the scalar pipe reads the GM index to compute src rows, then MTE2 issues the
+  // GM -> L1 nd2nz DMA. pto-isa currently keeps an internal fixed EVENT_ID0 on
+  // S -> MTE2, so reserve that pair here.
+  auto dstSpace = getMGatherOperandAddressSpace(op.getDst().getType());
+  const bool isGm2L1 = dstSpace && *dstSpace == pto::AddressSpace::MAT;
+
+  const PTOArch arch = getTargetArch(op.getOperation());
+  const pto::Coalesce coalesce = inferMGatherCoalesce(op);
+
+  SyncMacroModel model;
+
+  if (isGm2L1) {
+    // P1/P2: GM -> L1 (Row + Elem). S reads GM idx; MTE2 DMAs GM -> L1 into dst.
+    // Elem additionally writes the GM scratch (owned by S in the template) before
+    // the MTE2 bulk copy reads it, so model scratch as a S def / MTE2 use.
+    SmallVector<Value> sDefs;
+    if (coalesce == pto::Coalesce::Elem && op.getScratch())
+      sDefs.push_back(op.getScratch());
+    addPhase(model, PipelineType::PIPE_S, ValueRange(sDefs),
+             ValueRange{op.getIdx()});
+    if (coalesce == pto::Coalesce::Elem && op.getScratch()) {
+      SmallVector<Value> mte2Uses;
+      mte2Uses.push_back(op.getMem());
+      mte2Uses.push_back(op.getScratch());
+      addPhase(model, PipelineType::PIPE_MTE2,
+               ValueRange{op.getDst()}, ValueRange(mte2Uses));
+    } else {
+      addPhase(model, PipelineType::PIPE_MTE2,
+               ValueRange{op.getDst()}, ValueRange{op.getMem()});
+    }
+    addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_MTE2,
+                   ArrayRef<unsigned>{0});
+    return model;
+  }
+
+  // GM -> UB (dst is a VEC tile).
+  if (arch == PTOArch::A5) {
+    // P3/P4: A5 lowers GM -> UB through a SIMT kernel on the vector pipe (no
+    // scalar index loop). The 1x1 scalar overload (P5) reads idx on V then does
+    // a scalar GM load + dst write on S.
+    auto dstShape = getMGatherOperandShape(op.getDst());
+    const bool isElem1x1 =
+        coalesce == pto::Coalesce::Elem && dstShape && dstShape->size() == 2 &&
+        (*dstShape)[0] == 1 && (*dstShape)[1] == 1;
+    if (isElem1x1) {
+      addPhase(model, PipelineType::PIPE_V, ValueRange{},
+               ValueRange{op.getIdx()});
+      addPhase(model, PipelineType::PIPE_S, ValueRange{op.getDst()},
+               ValueRange{op.getMem()});
+      addBidirectionalHiddenEvent(model, PipelineType::PIPE_V,
+                                  PipelineType::PIPE_S,
+                                  ArrayRef<unsigned>{0});
+    } else {
+      addPhase(model, PipelineType::PIPE_V, ValueRange{op.getDst()},
+               ValueRange{op.getMem(), op.getIdx()});
+    }
+    return model;
+  }
+
+  // A2/A3 GM -> UB. Row (P6): S reads the UB index tile to compute GM addresses,
+  // then MTE2 DMAs each gathered row GM -> UB. Elem (P7): the whole gather runs
+  // on the scalar pipe (scalar GM loads + scalar UB dst writes), single phase.
+  if (coalesce == pto::Coalesce::Row) {
+    addPhase(model, PipelineType::PIPE_S, ValueRange{},
+             ValueRange{op.getIdx()});
+    addPhase(model, PipelineType::PIPE_MTE2, ValueRange{op.getDst()},
+             ValueRange{op.getMem()});
+    addHiddenEvent(model, PipelineType::PIPE_V, PipelineType::PIPE_S,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_MTE3, PipelineType::PIPE_S,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_MTE2,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_MTE2, PipelineType::PIPE_V,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_MTE2, PipelineType::PIPE_MTE3,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_V,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_MTE3,
+                   ArrayRef<unsigned>{0});
+  } else {
+    SmallVector<Value> sUses;
+    sUses.push_back(op.getIdx());
+    sUses.push_back(op.getMem());
+    addPhase(model, PipelineType::PIPE_S, ValueRange{op.getDst()},
+             ValueRange(sUses));
+    addHiddenEvent(model, PipelineType::PIPE_V, PipelineType::PIPE_S,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_MTE3, PipelineType::PIPE_S,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_MTE2, PipelineType::PIPE_S,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_V,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_MTE2,
+                   ArrayRef<unsigned>{0});
+    addHiddenEvent(model, PipelineType::PIPE_S, PipelineType::PIPE_MTE3,
+                   ArrayRef<unsigned>{0});
+  }
+  return model;
+}
+
 } // namespace
 
 std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
@@ -204,5 +526,7 @@ std::optional<SyncMacroModel> mlir::pto::getSyncMacroModel(Operation *op) {
     return getTScatterSyncMacroModel(tscatter);
   if (auto tgather = dyn_cast<pto::TGatherOp>(op))
     return getTGatherSyncMacroModel(tgather);
+  if (auto mgather = dyn_cast<pto::MGatherOp>(op))
+    return getMGatherSyncMacroModel(mgather);
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -3268,17 +3268,15 @@ struct PTOMGatherToMGATHER : public OpConversionPattern<pto::MGatherOp> {
       llvm_unreachable("unknown Coalesce");
     };
 
+    auto coalesceAttr = op.getCoalesceAttr();
+    if (!coalesceAttr)
+      return op.emitError(
+          "expects mgather to specify an explicit coalesce attribute (row or "
+          "elem)");
+
     SmallVector<Attribute, 2> templateArgVec;
-    pto::Coalesce coalesce = pto::Coalesce::Elem;
-    if (auto coalesceAttr = op.getCoalesceAttr()) {
-      coalesce = coalesceAttr.getValue();
-    } else {
-      const bool rowCoalesce =
-          isRowCoalescedMGatherIndex(op.getDst(), op.getIdx());
-      coalesce = rowCoalesce ? pto::Coalesce::Row : pto::Coalesce::Elem;
-    }
     templateArgVec.push_back(
-        emitc::OpaqueAttr::get(ctx, coalesceTok(coalesce)));
+        emitc::OpaqueAttr::get(ctx, coalesceTok(coalesceAttr.getValue())));
     if (op.getGatherOob() != pto::GatherOOB::Undefined) {
       templateArgVec.push_back(
           emitc::OpaqueAttr::get(ctx, gatherOobTok(op.getGatherOob())));

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -380,12 +380,12 @@ static Value maybeWrapGlobalMemrefAsGlobalTensor(
     Type originalType, Operation *anchor, StringRef tag = {});
 
 static bool hasCompatibleKnownExtentForMGather(int64_t lhs, int64_t rhs) {
-  return lhs == ShapedType::kDynamic || rhs == ShapedType::kDynamic ||
+  return lhs != ShapedType::kDynamic && rhs != ShapedType::kDynamic &&
          lhs == rhs;
 }
 
 static bool isKnownUnitExtentForMGather(int64_t value) {
-  return value == ShapedType::kDynamic || value == 1;
+  return value == 0 || value == 1;
 }
 
 struct GatherScatterShapeLayoutInfo {
@@ -394,8 +394,80 @@ struct GatherScatterShapeLayoutInfo {
   bool colMajor = false;
 };
 
+static std::optional<int64_t> getGatherScatterConstantIndex(Value value) {
+  if (!value)
+    return std::nullopt;
+  if (auto cst = value.getDefiningOp<arith::ConstantIndexOp>())
+    return cst.value();
+  if (auto cst = value.getDefiningOp<arith::ConstantIntOp>())
+    return cst.value();
+  return std::nullopt;
+}
+
+static std::optional<SmallVector<Value, 2>>
+lookupGatherScatterValidDims(Value value) {
+  if (auto bind = value.getDefiningOp<pto::BindTileOp>())
+    return SmallVector<Value, 2>{bind.getValidRow(), bind.getValidCol()};
+  if (auto cast = value.getDefiningOp<pto::PointerCastOp>())
+    return SmallVector<Value, 2>{cast.getValidRow(), cast.getValidCol()};
+  if (auto subview = value.getDefiningOp<memref::SubViewOp>())
+    return lookupGatherScatterValidDims(subview.getSource());
+  if (auto cast = value.getDefiningOp<memref::ReinterpretCastOp>())
+    return lookupGatherScatterValidDims(cast.getSource());
+  if (auto cast = value.getDefiningOp<memref::CastOp>())
+    return lookupGatherScatterValidDims(cast.getSource());
+
+  if (auto regionResult = dyn_cast<OpResult>(value)) {
+    if (auto fusionRegion = dyn_cast<pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp =
+          dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp)
+        return std::nullopt;
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands())
+        return std::nullopt;
+      return lookupGatherScatterValidDims(yieldOp.getOperand(resultIndex));
+    }
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<pto::TileBufConfigAttr>
+lookupGatherScatterTileConfig(Value value) {
+  if (auto bind = value.getDefiningOp<pto::BindTileOp>())
+    return bind.getConfig();
+  if (auto cast = value.getDefiningOp<pto::PointerCastOp>()) {
+    if (auto config = cast.getConfig())
+      return *config;
+    return std::nullopt;
+  }
+  if (auto subview = value.getDefiningOp<memref::SubViewOp>())
+    return lookupGatherScatterTileConfig(subview.getSource());
+  if (auto cast = value.getDefiningOp<memref::ReinterpretCastOp>())
+    return lookupGatherScatterTileConfig(cast.getSource());
+  if (auto cast = value.getDefiningOp<memref::CastOp>())
+    return lookupGatherScatterTileConfig(cast.getSource());
+
+  if (auto regionResult = dyn_cast<OpResult>(value)) {
+    if (auto fusionRegion = dyn_cast<pto::FusionRegionOp>(regionResult.getOwner())) {
+      auto yieldOp =
+          dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
+      if (!yieldOp)
+        return std::nullopt;
+      unsigned resultIndex = regionResult.getResultNumber();
+      if (resultIndex >= yieldOp.getNumOperands())
+        return std::nullopt;
+      return lookupGatherScatterTileConfig(yieldOp.getOperand(resultIndex));
+    }
+  }
+
+  return std::nullopt;
+}
+
 static std::optional<GatherScatterShapeLayoutInfo>
-getGatherScatterShapeLayoutInfo(Type ty) {
+getGatherScatterShapeLayoutInfo(Value value) {
+  Type ty = value.getType();
   if (auto tileTy = dyn_cast<pto::TileBufType>(ty)) {
     ArrayRef<int64_t> validShape = tileTy.getValidShape();
     if (validShape.size() != 2)
@@ -421,14 +493,34 @@ getGatherScatterShapeLayoutInfo(Type ty) {
 
   GatherScatterShapeLayoutInfo info;
   info.shape.assign(memRefTy.getShape().begin(), memRefTy.getShape().end());
+  if (auto validDims = lookupGatherScatterValidDims(value)) {
+    if (auto validRow = getGatherScatterConstantIndex((*validDims)[0]))
+      info.shape[0] = *validRow;
+    else if ((*validDims)[0])
+      info.shape[0] = ShapedType::kDynamic;
+    if (auto validCol = getGatherScatterConstantIndex((*validDims)[1]))
+      info.shape[1] = *validCol;
+    else if ((*validDims)[1])
+      info.shape[1] = ShapedType::kDynamic;
+  }
+
+  if (auto config = lookupGatherScatterTileConfig(value)) {
+    auto blayoutAttr = dyn_cast<pto::BLayoutAttr>(config->getBLayout());
+    if (blayoutAttr) {
+      info.rowMajor = blayoutAttr.getValue() == pto::BLayout::RowMajor;
+      info.colMajor = blayoutAttr.getValue() == pto::BLayout::ColMajor;
+      return info;
+    }
+  }
+
   info.rowMajor = strides[1] == 1;
   info.colMajor = strides[0] == 1;
   return info;
 }
 
-static bool isRowCoalescedMGatherIndexType(Type dataTy, Type idxTy) {
-  auto dataInfo = getGatherScatterShapeLayoutInfo(dataTy);
-  auto idxInfo = getGatherScatterShapeLayoutInfo(idxTy);
+static bool isRowCoalescedMGatherIndex(Value data, Value idx) {
+  auto dataInfo = getGatherScatterShapeLayoutInfo(data);
+  auto idxInfo = getGatherScatterShapeLayoutInfo(idx);
   if (!dataInfo || !idxInfo)
     return false;
 
@@ -3182,7 +3274,7 @@ struct PTOMGatherToMGATHER : public OpConversionPattern<pto::MGatherOp> {
       coalesce = coalesceAttr.getValue();
     } else {
       const bool rowCoalesce =
-          isRowCoalescedMGatherIndexType(op.getDst().getType(), op.getIdx().getType());
+          isRowCoalescedMGatherIndex(op.getDst(), op.getIdx());
       coalesce = rowCoalesce ? pto::Coalesce::Row : pto::Coalesce::Elem;
     }
     templateArgVec.push_back(
@@ -6237,7 +6329,7 @@ struct PTOMScatterToMSCATTER : public OpConversionPattern<pto::MScatterOp> {
       coalesce = coalesceAttr.getValue();
     } else {
       const bool rowCoalesce =
-          isRowCoalescedMGatherIndexType(op.getSrc().getType(), op.getIdx().getType());
+          isRowCoalescedMGatherIndex(op.getSrc(), op.getIdx());
       coalesce = rowCoalesce ? pto::Coalesce::Row : pto::Coalesce::Elem;
     }
     templateArgVec.push_back(

--- a/test/lit/pto/mgather_default_coalesce_static_only.pto
+++ b/test/lit/pto/mgather_default_coalesce_static_only.pto
@@ -6,14 +6,14 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Default MGather Row inference is a static codegen choice. It should accept
-// verifier-compatible zero-valid unit extents, but must not treat dynamic
-// valid_shape as proof of Row.
+// MGather requires an explicit coalesce mode. Row and Elem are not conservative
+// fallbacks for each other, so PTOAS must not infer or silently default the mode
+// when the attribute is omitted.
 //
-// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+// RUN: not ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
 
 module attributes {pto.target_arch = "a2a3"} {
-  func.func @zero_valid_row_is_row(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>)
+  func.func @missing_coalesce_is_invalid(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>)
       attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
     %c0_i64 = arith.constant 0 : i64
     %c4096_i64 = arith.constant 4096 : i64
@@ -22,37 +22,15 @@ module attributes {pto.target_arch = "a2a3"} {
     %c1_index = arith.constant 1 : index
     %c0_index = arith.constant 0 : index
     %mem_view = pto.make_tensor_view %arg0, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
-    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c0_index valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1_index valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst = pto.alloc_tile addr = %c4096_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
     pto.mgather ins(%mem_pview, %idx_tile
         : !pto.partition_tensor_view<16x32xf32>,
-          !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    return
-  }
-
-  func.func @dynamic_valid_row_is_elem(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>, %dyn: index)
-      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-    %c0_i64 = arith.constant 0 : i64
-    %c4096_i64 = arith.constant 4096 : i64
-    %c16_index = arith.constant 16 : index
-    %c32_index = arith.constant 32 : index
-    %c1_index = arith.constant 1 : index
-    %c0_index = arith.constant 0 : index
-    %mem_view = pto.make_tensor_view %arg0, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
-    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %dyn valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile addr = %c4096_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
-    pto.mgather ins(%mem_pview, %idx_tile
-        : !pto.partition_tensor_view<16x32xf32>,
-          !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+          !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
 }
 
-// CHECK-LABEL: AICORE void zero_valid_row_is_row
-// CHECK:      MGATHER<pto::Coalesce::Row>
-// CHECK-LABEL: AICORE void dynamic_valid_row_is_elem
-// CHECK:      MGATHER<pto::Coalesce::Elem>
+// CHECK: error: 'pto.mgather' op expects mgather to specify an explicit coalesce attribute (row or elem)

--- a/test/lit/pto/mgather_default_coalesce_static_only.pto
+++ b/test/lit/pto/mgather_default_coalesce_static_only.pto
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Default MGather Row inference is a static codegen choice. It should accept
+// verifier-compatible zero-valid unit extents, but must not treat dynamic
+// valid_shape as proof of Row.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @zero_valid_row_is_row(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c16_index = arith.constant 16 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c0_index = arith.constant 0 : index
+    %mem_view = pto.make_tensor_view %arg0, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c0_index valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c4096_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
+    pto.mgather ins(%mem_pview, %idx_tile
+        : !pto.partition_tensor_view<16x32xf32>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @dynamic_valid_row_is_elem(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>, %dyn: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c16_index = arith.constant 16 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c0_index = arith.constant 0 : index
+    %mem_view = pto.make_tensor_view %arg0, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %dyn valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c4096_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
+    pto.mgather ins(%mem_pview, %idx_tile
+        : !pto.partition_tensor_view<16x32xf32>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void zero_valid_row_is_row
+// CHECK:      MGATHER<pto::Coalesce::Row>
+// CHECK-LABEL: AICORE void dynamic_valid_row_is_elem
+// CHECK:      MGATHER<pto::Coalesce::Elem>

--- a/test/lit/pto/mgather_default_coalesce_static_only.pto
+++ b/test/lit/pto/mgather_default_coalesce_static_only.pto
@@ -33,4 +33,4 @@ module attributes {pto.target_arch = "a2a3"} {
   }
 }
 
-// CHECK: error: 'pto.mgather' op expects mgather to specify an explicit coalesce attribute (row or elem)
+// CHECK: error: 'pto.mgather' op requires attribute 'coalesce'

--- a/test/lit/pto/mgather_gm2l1_elem_scratch_reuse_sync_a5.pto
+++ b/test/lit/pto/mgather_gm2l1_elem_scratch_reuse_sync_a5.pto
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// GM->L1 elem mgather writes the GM scratch in its scalar phase before the
+// MTE2 phase reads it. Reusing the same scratch in a following mgather must
+// preserve both sides of that dependency.
+//
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @mgather_gm2l1_elem_scratch_reuse(
+      %mem: memref<1x1x1x64x32xf16, #pto.address_space<gm>>,
+      %idx: memref<1x1x1x32x32xi32, #pto.address_space<gm>>,
+      %scratch: memref<1x1x1x32x32xf16, #pto.address_space<gm>>) {
+    pto.section.cube {
+      %m0 = pto.alloc_tile
+        : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=col_major, slayout=row_major, fractal=512, pad=0>
+      %m1 = pto.alloc_tile
+        : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=col_major, slayout=row_major, fractal=512, pad=0>
+      pto.mgather ins(%mem, %idx, %scratch
+          : memref<1x1x1x64x32xf16, #pto.address_space<gm>>,
+            memref<1x1x1x32x32xi32, #pto.address_space<gm>>,
+            memref<1x1x1x32x32xf16, #pto.address_space<gm>>)
+        outs(%m0
+          : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+        {coalesce = #pto<coalesce elem>}
+      pto.mgather ins(%mem, %idx, %scratch
+          : memref<1x1x1x64x32xf16, #pto.address_space<gm>>,
+            memref<1x1x1x32x32xi32, #pto.address_space<gm>>,
+            memref<1x1x1x32x32xf16, #pto.address_space<gm>>)
+        outs(%m1
+          : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+        {coalesce = #pto<coalesce elem>}
+    }
+    return
+  }
+}
+
+// CHECK:      MGATHER<pto::Coalesce::Elem>
+// CHECK-NEXT: set_flag(PIPE_S, PIPE_MTE2
+// CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_S
+// CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_S
+// CHECK-NEXT: wait_flag(PIPE_S, PIPE_MTE2
+// CHECK:      MGATHER<pto::Coalesce::Elem>

--- a/test/lit/pto/mgather_gm2l1_elem_sync_a5.pto
+++ b/test/lit/pto/mgather_gm2l1_elem_sync_a5.pto
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A5 GM->L1 elem mgather uses a hidden MTE2 phase even though the source-side
+// index walk and scratch staging happen inside the macro. A downstream TMOV
+// must still wait on PIPE_MTE2, not PIPE_V.
+//
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @mgather_gm2l1_elem_sync(
+      %mem: memref<1x1x1x64x32xf16, #pto.address_space<gm>>,
+      %idx: memref<1x1x1x32x32xi32, #pto.address_space<gm>>,
+      %scratch: memref<1x1x1x32x32xf16, #pto.address_space<gm>>) {
+    pto.section.cube {
+      %m = pto.alloc_tile
+        : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=col_major, slayout=row_major, fractal=512, pad=0>
+      %l = pto.alloc_tile
+        : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                        blayout=row_major, slayout=row_major, fractal=512, pad=0>
+      pto.mgather ins(%mem, %idx, %scratch
+          : memref<1x1x1x64x32xf16, #pto.address_space<gm>>,
+            memref<1x1x1x32x32xi32, #pto.address_space<gm>>,
+            memref<1x1x1x32x32xf16, #pto.address_space<gm>>)
+        outs(%m
+          : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+        {coalesce = #pto<coalesce elem>}
+      pto.tmov ins(%m
+          : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+        outs(%l
+          : !pto.tile_buf<loc=left, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                          blayout=row_major, slayout=row_major, fractal=512, pad=0>)
+    }
+    return
+  }
+}
+
+// CHECK: MGATHER<pto::Coalesce::Elem>
+// CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_MTE1
+// CHECK-NEXT: wait_flag(PIPE_MTE2, PIPE_MTE1
+// CHECK-NEXT: TMOV

--- a/test/lit/pto/mgather_gm2ub_a2a3_elem_sync.pto
+++ b/test/lit/pto/mgather_gm2ub_a2a3_elem_sync.pto
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Elem-coalesced A2/A3 GM->UB mgather is a single scalar-pipe macro phase. It
+// still needs the MTE2->S wait for the preceding idx TLOAD, but the dst handed
+// to TSTORE is produced by the scalar phase itself.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @mgather_elem(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>, %arg2: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c256_index = arith.constant 256 : index
+    %c1_index = arith.constant 1 : index
+    %c8_index = arith.constant 8 : index
+    %c32_index = arith.constant 32 : index
+    %c0_index = arith.constant 0 : index
+    %mem_view = pto.make_tensor_view %arg0, shape = [%c256_index], strides = [%c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?xf32>
+    %idx_view = pto.make_tensor_view %arg1, shape = [%c8_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %arg2, shape = [%c8_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c8_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_pview = pto.partition_view %idx_view, offsets = [%c0_index, %c0_index], sizes = [%c8_index, %c32_index] : !pto.tensor_view<?x?xi32> -> !pto.partition_tensor_view<8x32xi32>
+    pto.tload ins(%idx_pview : !pto.partition_tensor_view<8x32xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %dst = pto.alloc_tile addr = %c0_i64 valid_row = %c8_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index], sizes = [%c256_index] : !pto.tensor_view<?xf32> -> !pto.partition_tensor_view<256xf32>
+    pto.mgather ins(%mem_pview, %idx_tile
+        : !pto.partition_tensor_view<256xf32>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      {coalesce = #pto<coalesce elem>}
+    %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c8_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<8x32xf32>
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%out_pview : !pto.partition_tensor_view<8x32xf32>)
+    return
+  }
+}
+
+// CHECK: TLOAD(
+// CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_S, EVENT_ID1);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_S, EVENT_ID1);
+// CHECK-NEXT: MGATHER<pto::Coalesce::Elem>(
+// CHECK-NEXT: set_flag(PIPE_S, PIPE_MTE3, EVENT_ID1);
+// CHECK: wait_flag(PIPE_S, PIPE_MTE3, EVENT_ID1);
+// CHECK-NEXT: TSTORE(

--- a/test/lit/pto/mgather_gm2ub_a2a3_row_macro_sync_model.pto
+++ b/test/lit/pto/mgather_gm2ub_a2a3_row_macro_sync_model.pto
@@ -6,10 +6,10 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// The default A2/A3 row-form mgather should expand into two macro phases even
+// Explicit A2/A3 row-form mgather should expand into two macro phases even
 // after the index tile is lowered to a memref: phase 0 on PIPE_S (read idx),
-// phase 1 on PIPE_MTE2 (GM->UB row DMA). This debug test guards the lowered
-// coalesce inference used by InsertSync.
+// phase 1 on PIPE_MTE2 (GM->UB row DMA). This debug test guards InsertSync
+// macro modeling without relying on coalesce inference.
 //
 // RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
 
@@ -36,6 +36,7 @@ module attributes {pto.target_arch = "a2a3"} {
         : !pto.partition_tensor_view<64x32xf16>,
           !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      {coalesce = #pto<coalesce row>}
     %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<16x32xf16>
     pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                outs(%out_pview : !pto.partition_tensor_view<16x32xf16>)

--- a/test/lit/pto/mgather_gm2ub_a2a3_row_macro_sync_model.pto
+++ b/test/lit/pto/mgather_gm2ub_a2a3_row_macro_sync_model.pto
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// The default A2/A3 row-form mgather should expand into two macro phases even
+// after the index tile is lowered to a memref: phase 0 on PIPE_S (read idx),
+// phase 1 on PIPE_MTE2 (GM->UB row DMA). This debug test guards the lowered
+// coalesce inference used by InsertSync.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @mgather_row_macro_model(%arg0: !pto.ptr<f16>, %arg1: !pto.ptr<i32>, %arg2: !pto.ptr<f16>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c64_index = arith.constant 64 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c16_index = arith.constant 16 : index
+    %c0_index = arith.constant 0 : index
+    %mem_view = pto.make_tensor_view %arg0, shape = [%c64_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf16>
+    %idx_view = pto.make_tensor_view %arg1, shape = [%c1_index, %c16_index], strides = [%c16_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %arg2, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf16>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1_index valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_pview = pto.partition_view %idx_view, offsets = [%c0_index, %c0_index], sizes = [%c1_index, %c16_index] : !pto.tensor_view<?x?xi32> -> !pto.partition_tensor_view<1x16xi32>
+    pto.tload ins(%idx_pview : !pto.partition_tensor_view<1x16xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %dst = pto.alloc_tile addr = %c64_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c64_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<64x32xf16>
+    pto.mgather ins(%mem_pview, %idx_tile
+        : !pto.partition_tensor_view<64x32xf16>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<16x32xf16>
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%out_pview : !pto.partition_tensor_view<16x32xf16>)
+    return
+  }
+}
+
+// CHECK-LABEL: After Translator
+// CHECK:      COMPOUND pto.tload [PIPE_MTE2]
+// CHECK-NEXT: COMPOUND pto.mgather [PIPE_S]
+// CHECK-NEXT: COMPOUND pto.mgather [PIPE_MTE2]
+// CHECK-NEXT: COMPOUND pto.tstore [PIPE_MTE3]
+// CHECK:      set_flag <PIPE_MTE2 -> PIPE_S>
+// CHECK:      wait_flag <PIPE_MTE2 -> PIPE_S>
+// CHECK:      set_flag <PIPE_MTE2 -> PIPE_MTE3>
+// CHECK:      wait_flag <PIPE_MTE2 -> PIPE_MTE3>

--- a/test/lit/pto/mgather_gm2ub_a2a3_row_sync.pto
+++ b/test/lit/pto/mgather_gm2ub_a2a3_row_sync.pto
@@ -6,9 +6,8 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Regression for PTOAS#861 on A2/A3 row-coalesced GM->UB mgather. The default
-// row form omits the coalesce attribute, so InsertSync sees the post-lowering
-// memref index shape (1xR) and must still model mgather as two hidden phases:
+// Regression for PTOAS#861 on A2/A3 row-coalesced GM->UB mgather. The
+// explicitly row-coalesced form must be modeled as two hidden phases:
 // scalar pipe reads the UB index, then MTE2 performs the GM->UB row DMA.
 //
 // RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
@@ -36,6 +35,7 @@ module attributes {pto.target_arch = "a2a3"} {
         : !pto.partition_tensor_view<64x32xf16>,
           !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      {coalesce = #pto<coalesce row>}
     %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<16x32xf16>
     pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                outs(%out_pview : !pto.partition_tensor_view<16x32xf16>)

--- a/test/lit/pto/mgather_gm2ub_a2a3_row_sync.pto
+++ b/test/lit/pto/mgather_gm2ub_a2a3_row_sync.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression for PTOAS#861 on A2/A3 row-coalesced GM->UB mgather. The default
+// row form omits the coalesce attribute, so InsertSync sees the post-lowering
+// memref index shape (1xR) and must still model mgather as two hidden phases:
+// scalar pipe reads the UB index, then MTE2 performs the GM->UB row DMA.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @mgather_row(%arg0: !pto.ptr<f16>, %arg1: !pto.ptr<i32>, %arg2: !pto.ptr<f16>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c64_index = arith.constant 64 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c16_index = arith.constant 16 : index
+    %c0_index = arith.constant 0 : index
+    %mem_view = pto.make_tensor_view %arg0, shape = [%c64_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf16>
+    %idx_view = pto.make_tensor_view %arg1, shape = [%c1_index, %c16_index], strides = [%c16_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %arg2, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf16>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1_index valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_pview = pto.partition_view %idx_view, offsets = [%c0_index, %c0_index], sizes = [%c1_index, %c16_index] : !pto.tensor_view<?x?xi32> -> !pto.partition_tensor_view<1x16xi32>
+    pto.tload ins(%idx_pview : !pto.partition_tensor_view<1x16xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %dst = pto.alloc_tile addr = %c64_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c64_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<64x32xf16>
+    pto.mgather ins(%mem_pview, %idx_tile
+        : !pto.partition_tensor_view<64x32xf16>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf16> -> !pto.partition_tensor_view<16x32xf16>
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%out_pview : !pto.partition_tensor_view<16x32xf16>)
+    return
+  }
+}
+
+// CHECK: TLOAD(
+// CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_S, EVENT_ID0);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_S, EVENT_ID0);
+// CHECK-NEXT: MGATHER<pto::Coalesce::Row>(
+// CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID1);
+// CHECK-NEXT: TSTORE(

--- a/test/lit/pto/mgather_gm2ub_a5_elem_1x1_memref_macro_sync_model.pto
+++ b/test/lit/pto/mgather_gm2ub_a5_elem_1x1_memref_macro_sync_model.pto
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A5 elem-coalesced 1x1 GM->UB mgather lowers to the scalar overload even when
+// InsertSync sees the dst after PTOViewToMemref lowering. The macro model must
+// recover the 1x1 shape from MemRefType instead of requiring TileBufType.
+//
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync --pto-insert-sync-debug=2 %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @mgather_elem_1x1_memref_model(
+      %mem: memref<1xf32, #pto.address_space<gm>>,
+      %idx: memref<1x1xi32, #pto.address_space<vec>>) {
+    %dst = memref.alloc() : memref<1x1xf32, #pto.address_space<vec>>
+    pto.mgather ins(%mem, %idx
+        : memref<1xf32, #pto.address_space<gm>>,
+          memref<1x1xi32, #pto.address_space<vec>>)
+      outs(%dst : memref<1x1xf32, #pto.address_space<vec>>)
+      {coalesce = #pto<coalesce elem>}
+    return
+  }
+}
+
+// CHECK-LABEL: After Sync Motion
+// CHECK:      COMPOUND pto.mgather [PIPE_V]
+// CHECK-NEXT: COMPOUND pto.mgather [PIPE_S]

--- a/test/lit/pto/mgather_mscatter_low_precision_a5_emitc.pto
+++ b/test/lit/pto/mgather_mscatter_low_precision_a5_emitc.pto
@@ -10,6 +10,7 @@ module {
 
     pto.mgather ins(%mem_in, %idx : memref<1x1x1x8x32x!pto.hif8, #pto.address_space<gm>>, !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                outs(%dst : !pto.tile_buf<loc=vec, dtype=!pto.hif8, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               {coalesce = #pto<coalesce elem>}
     pto.mscatter ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=!pto.hif8, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=32, v_row=8, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                  outs(%mem_out : memref<1x1x1x8x32x!pto.hif8, #pto.address_space<gm>>)
     return

--- a/test/lit/pto/mgather_padded_valid_shape_coalesce_sync.pto
+++ b/test/lit/pto/mgather_padded_valid_shape_coalesce_sync.pto
@@ -6,12 +6,10 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// InsertSync must infer default MGather<Row/Elem> from bind_tile valid_shape +
-// layout after tile buffers are lowered to memrefs. The first kernel has a
-// padded physical index tile (8x16) but valid_shape=1x16 row-major, so A2/A3
-// must model the Row path as PIPE_S + PIPE_MTE2. The second kernel is
-// valid_shape=16x1 row-major, which remains Elem and must not be mistaken for
-// the col-major Rx1 Row form.
+// InsertSync must honor explicit MGather<Row/Elem> after tile buffers are
+// lowered to memrefs. The first kernel has a padded physical index tile (8x16)
+// but valid_shape=1x16 row-major and explicit Row, so A2/A3 must model the Row
+// path as PIPE_S + PIPE_MTE2. The second kernel is explicit Elem.
 //
 // RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
 
@@ -37,6 +35,7 @@ module attributes {pto.target_arch = "a2a3"} {
         : !pto.partition_tensor_view<16x32xf32>,
           !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      {coalesce = #pto<coalesce row>}
     %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
     pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                outs(%out_pview : !pto.partition_tensor_view<16x32xf32>)
@@ -64,6 +63,7 @@ module attributes {pto.target_arch = "a2a3"} {
         : !pto.partition_tensor_view<16x32xf32>,
           !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      {coalesce = #pto<coalesce elem>}
     %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
     pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
                outs(%out_pview : !pto.partition_tensor_view<16x32xf32>)

--- a/test/lit/pto/mgather_padded_valid_shape_coalesce_sync.pto
+++ b/test/lit/pto/mgather_padded_valid_shape_coalesce_sync.pto
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// InsertSync must infer default MGather<Row/Elem> from bind_tile valid_shape +
+// layout after tile buffers are lowered to memrefs. The first kernel has a
+// padded physical index tile (8x16) but valid_shape=1x16 row-major, so A2/A3
+// must model the Row path as PIPE_S + PIPE_MTE2. The second kernel is
+// valid_shape=16x1 row-major, which remains Elem and must not be mistaken for
+// the col-major Rx1 Row form.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @row_major_valid_1xr_is_row(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>, %arg2: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c16_index = arith.constant 16 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c0_index = arith.constant 0 : index
+    %mem_view = pto.make_tensor_view %arg0, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_view = pto.make_tensor_view %arg1, shape = [%c1_index, %c16_index], strides = [%c16_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %arg2, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c1_index valid_col = %c16_index : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_pview = pto.partition_view %idx_view, offsets = [%c0_index, %c0_index], sizes = [%c1_index, %c16_index] : !pto.tensor_view<?x?xi32> -> !pto.partition_tensor_view<1x16xi32>
+    pto.tload ins(%idx_pview : !pto.partition_tensor_view<1x16xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %dst = pto.alloc_tile addr = %c4096_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
+    pto.mgather ins(%mem_pview, %idx_tile
+        : !pto.partition_tensor_view<16x32xf32>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=8, cols=16, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%out_pview : !pto.partition_tensor_view<16x32xf32>)
+    return
+  }
+
+  func.func @row_major_valid_rx1_is_elem(%arg0: !pto.ptr<f32>, %arg1: !pto.ptr<i32>, %arg2: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0_i64 = arith.constant 0 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c16_index = arith.constant 16 : index
+    %c32_index = arith.constant 32 : index
+    %c1_index = arith.constant 1 : index
+    %c0_index = arith.constant 0 : index
+    %mem_view = pto.make_tensor_view %arg0, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_view = pto.make_tensor_view %arg1, shape = [%c16_index, %c1_index], strides = [%c1_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xi32>
+    %out_view = pto.make_tensor_view %arg2, shape = [%c16_index, %c32_index], strides = [%c32_index, %c1_index] {layout = #pto.layout<nd>}: !pto.tensor_view<?x?xf32>
+    %idx_tile = pto.alloc_tile addr = %c0_i64 valid_row = %c16_index valid_col = %c1_index : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %idx_pview = pto.partition_view %idx_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c1_index] : !pto.tensor_view<?x?xi32> -> !pto.partition_tensor_view<16x1xi32>
+    pto.tload ins(%idx_pview : !pto.partition_tensor_view<16x1xi32>)
+              outs(%idx_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %dst = pto.alloc_tile addr = %c4096_i64 valid_row = %c16_index valid_col = %c32_index : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %mem_pview = pto.partition_view %mem_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
+    pto.mgather ins(%mem_pview, %idx_tile
+        : !pto.partition_tensor_view<16x32xf32>,
+          !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=8, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %out_pview = pto.partition_view %out_view, offsets = [%c0_index, %c0_index], sizes = [%c16_index, %c32_index] : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<16x32xf32>
+    pto.tstore ins(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=32, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%out_pview : !pto.partition_tensor_view<16x32xf32>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void row_major_valid_1xr_is_row
+// CHECK:      set_flag(PIPE_MTE2, PIPE_S
+// CHECK:      wait_flag(PIPE_MTE2, PIPE_S
+// CHECK-NEXT: MGATHER<pto::Coalesce::Row>
+// CHECK-NEXT: set_flag(PIPE_MTE2, PIPE_MTE3
+// CHECK:      wait_flag(PIPE_MTE2, PIPE_MTE3
+// CHECK-LABEL: AICORE void row_major_valid_rx1_is_elem
+// CHECK:      set_flag(PIPE_MTE2, PIPE_S
+// CHECK:      wait_flag(PIPE_MTE2, PIPE_S
+// CHECK-NEXT: MGATHER<pto::Coalesce::Elem>
+// CHECK-NEXT: set_flag(PIPE_S, PIPE_MTE3
+// CHECK:      wait_flag(PIPE_S, PIPE_MTE3

--- a/test/samples/Mgather/mgather.py
+++ b/test/samples/Mgather/mgather.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from mlir.ir import Context, Location, Module, InsertionPoint, StringAttr, UnitAttr
+from mlir.ir import Attribute, Context, Location, Module, InsertionPoint, StringAttr, UnitAttr
 from mlir.dialects import func, arith, pto
 from mlir.ir import IndexType, IntegerType
 
@@ -59,7 +59,9 @@ def build():
                 tb2 = pto.AllocTileOp(tile_buf_data_i32).result
 
                 pto.TLoadOp(None, sv1, tb1)
-                pto.MGatherOp(sv0, tb1, tb2)
+                pto.MGatherOp(
+                    sv0, tb1, tb2,
+                    coalesce=Attribute.parse("#pto<coalesce row>"))
 
                 sv2 = pto.PartitionViewOp(tile_view_32, tv2, offsets=[c0, c0], sizes=[c32, c32]).result
                 pto.TStoreOp(None, tb2, sv2)


### PR DESCRIPTION
主要变更：
为 pto.mgather 建立更精确的 macro sync model，覆盖 A2/A3、A5、GM->UB、GM->L1、Row/Elem 等路径。
修复 A2/A3 MGATHER<Row> 实际走 PIPE_S + PIPE_MTE2，但 InsertSync 漏建模导致缺少 MTE2 -> S 同步的问题。
从 bind_tile / pointer_cast 恢复 lowered memref 上丢失的 valid_shape + layout 元数据，避免 Row/Elem coalesce 推断错误。
同步修复 EmitC 默认 coalesce 推断，确保生成的 MGATHER<Row/Elem> 与 InsertSync pipe model 一致。