### PR TITLE
[IR] Verify explicit local tile address alignment

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1526,6 +1526,10 @@ def PointerCastOp : PTO_Op<"pointer_cast", [AttrSizedOperandSegments, Pure]> {
         $_builder.getDenseI32ArrayAttr({addrsSize, vRowSize, vColSize}));
     }]>
   ];
+
+  let extraClassDeclaration = [{
+    ::mlir::LogicalResult verify();
+  }];
 }
 
 def SlotMarkerOp : PTO_Op<"slot_marker", [

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2835,10 +2835,75 @@ void mlir::pto::annotatePTOEntryFunctions(ModuleOp module) {
   return success();
 }
 
+static std::optional<uint64_t>
+getLocalAddressAlignmentBytes(Attribute memorySpace) {
+  auto addrSpace = dyn_cast_or_null<AddressSpaceAttr>(memorySpace);
+  if (!addrSpace)
+    return std::nullopt;
+
+  // Keep this verifier as a conservative front-line guard for explicit local
+  // tile addresses. PTO-ISA's buffer_limits.hpp defines the baseline
+  // TASSIGN<Addr> alignment as 32 bytes for local tile memories. For L0 tile
+  // bases, PTOAS level3/manual IR historically uses a 4096-bit (512-byte)
+  // granularity; fuller per-arch/per-layout bounds checks belong in PTO-ISA.
+  switch (addrSpace.getAddressSpace()) {
+  case AddressSpace::VEC:
+  case AddressSpace::MAT:
+  case AddressSpace::BIAS:
+  case AddressSpace::SCALING:
+    return 32;
+  case AddressSpace::LEFT:
+  case AddressSpace::RIGHT:
+  case AddressSpace::ACC:
+    return 512;
+  case AddressSpace::GM:
+  case AddressSpace::Zero:
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+static LogicalResult verifyConstantLocalAddress(Operation *op, Value addr,
+                                                Attribute memorySpace,
+                                                int addrIndex = -1) {
+  std::optional<uint64_t> alignment =
+      getLocalAddressAlignmentBytes(memorySpace);
+  if (!alignment || *alignment == 0)
+    return success();
+
+  std::optional<int64_t> constantAddr = mlir::getConstantIntValue(addr);
+  if (!constantAddr)
+    return success();
+
+  auto emitAddrError = [&]() {
+    InFlightDiagnostic diag = op->emitOpError();
+    if (addrIndex >= 0)
+      diag << "addr[" << addrIndex << "]";
+    else
+      diag << "addr";
+    return diag;
+  };
+
+  if (*constantAddr < 0)
+    return emitAddrError() << " must be non-negative, got " << *constantAddr;
+
+  uint64_t unsignedAddr = static_cast<uint64_t>(*constantAddr);
+  if ((unsignedAddr % *alignment) != 0)
+    return emitAddrError()
+           << " must be aligned to " << *alignment
+           << " bytes for local tile memory space, got " << unsignedAddr;
+
+  return success();
+}
+
 LogicalResult AllocTileOp::verify() {
   auto ty = getResult().getType(); // TileBufType
 
   if (failed(verifyTileBufLayoutConstraints(*this, ty, "result")))
+    return failure();
+
+  if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
+                                        ty.getMemorySpace())))
     return failure();
 
   // op 上有没有传 operands
@@ -2969,6 +3034,21 @@ LogicalResult MultiTileGetOp::verify() {
   return success();
 }
 
+LogicalResult PointerCastOp::verify() {
+  auto memRefTy = dyn_cast<BaseMemRefType>(getResult().getType());
+  if (!memRefTy)
+    return emitOpError("result must be a memref type");
+
+  for (auto [idx, addr] : llvm::enumerate(getAddrs())) {
+    if (failed(verifyConstantLocalAddress(getOperation(), addr,
+                                          memRefTy.getMemorySpace(),
+                                          static_cast<int>(idx))))
+      return failure();
+  }
+
+  return success();
+}
+
 LogicalResult MaterializeTileOp::verify() {
   auto sourceTy = cast<MemRefType>(getSource().getType());
   auto resultTy = cast<TileBufType>(getResult().getType());
@@ -3016,6 +3096,18 @@ LogicalResult TAssignOp::verify() {
   if (getTile().getType() != getResult().getType()) {
     return emitOpError("result type must match tile operand type");
   }
+
+  Type tileType = getTile().getType();
+  if (auto tileTy = dyn_cast<TileBufType>(tileType)) {
+    if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
+                                          tileTy.getMemorySpace())))
+      return failure();
+  } else if (auto memRefTy = dyn_cast<BaseMemRefType>(tileType)) {
+    if (failed(verifyConstantLocalAddress(getOperation(), getAddr(),
+                                          memRefTy.getMemorySpace())))
+      return failure();
+  }
+
   return success();
 }
 

--- a/test/lit/pto/alloc_tile_addr_alignment_invalid.pto
+++ b/test/lit/pto/alloc_tile_addr_alignment_invalid.pto
@@ -1,0 +1,11 @@
+// RUN: not ptoas --pto-level=level3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @unaligned_alloc_tile_addr() {
+    %bad = arith.constant 70660 : i64
+    // CHECK: pto.alloc_tile
+    // CHECK: addr must be aligned to 32 bytes for local tile memory space, got 70660
+    %tile = pto.alloc_tile addr = %bad : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}

--- a/test/lit/pto/alloc_tile_addr_alignment_valid.pto
+++ b/test/lit/pto/alloc_tile_addr_alignment_valid.pto
@@ -1,0 +1,9 @@
+// RUN: ptoas --pto-level=level3 %s >/dev/null
+
+module {
+  func.func @aligned_alloc_tile_addr() {
+    %ok = arith.constant 71232 : i64
+    %tile = pto.alloc_tile addr = %ok : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -57,13 +57,13 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
     return
   }
 
-  func.func @non_identity_tmov_extui_negative_addr() {
-    %cm1_i8 = arith.constant -1 : i8
-    %c255_i64 = arith.extui %cm1_i8 : i8 to i64
-    %cm1_i64 = arith.constant -1 : i64
-    %src = pto.alloc_tile addr = %c255_i64
+  func.func @non_identity_tmov_extui_addr() {
+    %c32_i8 = arith.constant 32 : i8
+    %c32_i64 = arith.extui %c32_i8 : i8 to i64
+    %c64_i64 = arith.constant 64 : i64
+    %src = pto.alloc_tile addr = %c32_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile addr = %cm1_i64
+    %dst = pto.alloc_tile addr = %c64_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tmov ins(%src
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
@@ -72,12 +72,13 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
   }
 
   func.func @non_identity_tmov_trunc_then_extsi_addr() {
-    %c255_i64 = arith.constant 255 : i64
-    %trunc_i8 = arith.trunci %c255_i64 : i64 to i8
-    %cm1_i64 = arith.extsi %trunc_i8 : i8 to i64
-    %src = pto.alloc_tile addr = %cm1_i64
+    %c32_i64 = arith.constant 32 : i64
+    %trunc_i8 = arith.trunci %c32_i64 : i64 to i8
+    %c32_alt_i64 = arith.extsi %trunc_i8 : i8 to i64
+    %c64_i64 = arith.constant 64 : i64
+    %src = pto.alloc_tile addr = %c32_alt_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile addr = %c255_i64
+    %dst = pto.alloc_tile addr = %c64_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     pto.tmov ins(%src
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
@@ -110,7 +111,7 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
 // CPP-NOT: TMOV(
 // CPP: return;
 
-// CPP-LABEL: AICORE void non_identity_tmov_extui_negative_addr
+// CPP-LABEL: AICORE void non_identity_tmov_extui_addr
 // CPP: TMOV(
 
 // CPP-LABEL: AICORE void non_identity_tmov_trunc_then_extsi_addr

--- a/test/lit/pto/pointer_cast_addr_alignment_gm_ignored.pto
+++ b/test/lit/pto/pointer_cast_addr_alignment_gm_ignored.pto
@@ -1,0 +1,9 @@
+// RUN: ptoas --pto-level=level3 %s >/dev/null
+
+module {
+  func.func @gm_pointer_cast_addr_is_ignored() {
+    %neg = arith.constant -1 : i64
+    %buf = pto.pointer_cast(%neg) : memref<32x64xf16, #pto.address_space<gm>>
+    return
+  }
+}

--- a/test/lit/pto/pointer_cast_addr_alignment_invalid.pto
+++ b/test/lit/pto/pointer_cast_addr_alignment_invalid.pto
@@ -1,0 +1,11 @@
+// RUN: not ptoas --pto-level=level3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @unaligned_pointer_cast_addr() {
+    %bad = arith.constant 70660 : i64
+    // CHECK: pto.pointer_cast
+    // CHECK: addr[0] must be aligned to 32 bytes for local tile memory space, got 70660
+    %buf = pto.pointer_cast(%bad) : memref<32x64xf16, #pto.address_space<vec>>
+    return
+  }
+}

--- a/test/lit/pto/tassign_addr_alignment_invalid.pto
+++ b/test/lit/pto/tassign_addr_alignment_invalid.pto
@@ -1,0 +1,16 @@
+// RUN: not ptoas --pto-level=level3 %s 2>&1 | FileCheck %s
+
+module {
+  func.func @unaligned_tassign_addr() attributes {pto.entry} {
+    %base = arith.constant 0 : i64
+    %bad = arith.constant 70660 : i64
+    %tile = pto.alloc_tile addr = %base
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    // CHECK: pto.tassign
+    // CHECK: addr must be aligned to 32 bytes for local tile memory space, got 70660
+    %rebased = pto.tassign %tile, %bad
+      : !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+     -> !pto.tile_buf<loc=vec, dtype=f16, rows=32, cols=64, v_row=32, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    return
+  }
+}


### PR DESCRIPTION
Summary
- Add IR verifier checks for constant explicit local tile addresses.
- Reject negative or misaligned constant `pto.alloc_tile addr` and `pto.pointer_cast(addrs=...)` operands.
- Add regressions for the 70660 unaligned UB address pattern and a 71232 aligned control case.

Motivation
- The issue-1789 reduction shows that `TASSIGN(tile, 70660)` can hang on A3 even without explicit sync/TPipe complexity.
- PTOAS currently lowers constant explicit tile addresses through runtime `TASSIGN(tile, addr)`, so PTO-ISA's `TASSIGN<Addr>` static checks are not triggered.
- Catching constant illegal addresses in PTOAS IR gives an early diagnostic instead of a board-side timeout.

Design
- VEC/MAT/BIAS/SCALING local spaces require 32-byte alignment.
- LEFT/RIGHT/ACC local spaces require 512-byte alignment.
- GM/default spaces are ignored by this local tile address verifier.
- Dynamic addresses are left unchanged because verifier cannot prove their alignment.

Testing
- Local compatible worktree: `ninja -C PTOAS/build pto-opt`
- Local compatible worktree: `ptoas --pto-level=level3 test/basic/alloc_tile_addr_alignment_invalid.mlir` exits 1 and FileCheck passes.
- Local compatible worktree: `ptoas --pto-level=level3 test/basic/pointer_cast_addr_alignment_invalid.mlir` exits 1 and FileCheck passes.
- Local compatible worktree: `ptoas --pto-level=level3 test/basic/alloc_tile_addr_alignment_valid.mlir` exits 0.
- Clean main worktree: `ninja -C build-pr PTOIR` passes.

Note
- A full `ptoas` build from current `hw-native-sys/main` on this Mac is blocked by unrelated local LLVM/VPTO API mismatch (`LLVMHiFloat8Type` / `CallingConv::SimtEntry` missing). The changed IR target itself builds in the clean main worktree.