### PR TITLE
fix(sync): prune identity tmov before insert sync

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -77,6 +77,7 @@ std::unique_ptr<Pass> createPTOValidateIntToPtrUsesPass();
 std::unique_ptr<Pass> createPTOMaterializeTileHandlesPass();
 std::unique_ptr<Pass> createInferPTOLayoutPass();
 std::unique_ptr<Pass> createPTOA5NormalizeTMovPass();
+std::unique_ptr<Pass> createPTORemoveIdentityTMovPass();
 std::unique_ptr<Pass> createPreFusionAnalysisPass();
 std::unique_ptr<Pass> createPrintPreFusionAnalysisPass();
 std::unique_ptr<Pass> createFusionPlanPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -147,6 +147,23 @@ def PTOA5NormalizeTMov : Pass<"pto-a5-normalize-tmov", "func::FuncOp"> {
   let dependentDialects = ["pto::PTODialect", "func::FuncDialect"];
 }
 
+def PTORemoveIdentityTMov : Pass<"pto-remove-identity-tmov", "func::FuncOp"> {
+  let summary = "Remove plain PTO TMOV operations that copy a tile onto itself";
+  let description = [{
+    Removes side-effect-free `pto.tmov` operations whose source and destination
+    are proven to refer to the same physical tile address. This pass runs before
+    InsertSync so deleting the identity TMOV also prevents synchronization from
+    being generated only for that no-op copy.
+  }];
+  let constructor = "mlir::pto::createPTORemoveIdentityTMovPass()";
+  let dependentDialects = [
+    "pto::PTODialect",
+    "arith::ArithDialect",
+    "func::FuncDialect",
+    "memref::MemRefDialect"
+  ];
+}
+
 
 def InferPTOMemScope : Pass<"pto-infer-mem-scope"> {
   let summary = "Infer memory scope for PTO Ops";

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -151,13 +151,13 @@ def PTORemoveIdentityTMov : Pass<"pto-remove-identity-tmov", "func::FuncOp"> {
   let summary = "Remove plain PTO TMOV operations that copy a tile onto itself";
   let description = [{
     Removes side-effect-free `pto.tmov` operations whose source and destination
-    are proven to refer to the same physical tile address/range. The proof is
-    conservative: first check explicit address tokens (`tassign` /
-    `pointer_cast`), then fall back to InsertSync's `BaseMemInfo` exact-range
-    analysis for statically addressable values. Different-root same-address
-    copies are removed only when the TMOV destination/result is dead, so a live
-    copy cannot be the sole synchronization bridge between two InsertSync roots.
-    This pass runs before InsertSync so deleting the identity TMOV also prevents
+    are proven to refer to the same physical tile address/range. Except for
+    exact same-SSA self-copies, the proof goes through InsertSync's
+    `BaseMemInfo` exact-range analysis for statically addressable values.
+    Same-address copies are removed only when the TMOV destination/result is
+    dead and no later same-address alias use is visible, so a live copy cannot
+    be the sole synchronization bridge. This pass runs before InsertSync so
+    deleting the identity TMOV also prevents
     synchronization from being generated only for that no-op copy.
   }];
   let constructor = "mlir::pto::createPTORemoveIdentityTMovPass()";

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -151,9 +151,12 @@ def PTORemoveIdentityTMov : Pass<"pto-remove-identity-tmov", "func::FuncOp"> {
   let summary = "Remove plain PTO TMOV operations that copy a tile onto itself";
   let description = [{
     Removes side-effect-free `pto.tmov` operations whose source and destination
-    are proven to refer to the same physical tile address. This pass runs before
-    InsertSync so deleting the identity TMOV also prevents synchronization from
-    being generated only for that no-op copy.
+    are proven to refer to the same physical tile address/range. The proof is
+    conservative: first check explicit address tokens (`tassign` /
+    `pointer_cast`), then fall back to InsertSync's `BaseMemInfo` exact-range
+    analysis for statically addressable values. This pass runs before InsertSync
+    so deleting the identity TMOV also prevents synchronization from being
+    generated only for that no-op copy.
   }];
   let constructor = "mlir::pto::createPTORemoveIdentityTMovPass()";
   let dependentDialects = [

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -154,9 +154,11 @@ def PTORemoveIdentityTMov : Pass<"pto-remove-identity-tmov", "func::FuncOp"> {
     are proven to refer to the same physical tile address/range. The proof is
     conservative: first check explicit address tokens (`tassign` /
     `pointer_cast`), then fall back to InsertSync's `BaseMemInfo` exact-range
-    analysis for statically addressable values. This pass runs before InsertSync
-    so deleting the identity TMOV also prevents synchronization from being
-    generated only for that no-op copy.
+    analysis for statically addressable values. Different-root same-address
+    copies are removed only when the TMOV destination/result is dead, so a live
+    copy cannot be the sole synchronization bridge between two InsertSync roots.
+    This pass runs before InsertSync so deleting the identity TMOV also prevents
+    synchronization from being generated only for that no-op copy.
   }];
   let constructor = "mlir::pto::createPTORemoveIdentityTMovPass()";
   let dependentDialects = [

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -56,6 +56,7 @@ add_mlir_dialect_library(PTOTransforms
   PTORemoveRedundantBarrier.cpp
   InferPTOLayout.cpp
   PTOA5NormalizeTMovPass.cpp
+  PTORemoveIdentityTMov.cpp
   PTOCanonicalizeIR.cpp
   PTOMaterializeTileHandles.cpp
   BufferizableOpInterfaceImpl.cpp

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -36,11 +36,6 @@ using namespace mlir::pto;
 
 namespace {
 
-struct AddressToken {
-  Value value;
-  std::optional<int64_t> constant;
-};
-
 static std::optional<unsigned> getIntegerLikeBitWidth(Type type) {
   if (auto intTy = dyn_cast<IntegerType>(type))
     return intTy.getWidth();
@@ -110,43 +105,6 @@ static std::optional<int64_t> tryEvalI64Constant(Value value) {
   if (!apInt || apInt->getBitWidth() > 64)
     return std::nullopt;
   return apInt->getSExtValue();
-}
-
-static Value peelMetadata(Value value) {
-  while (true) {
-    if (auto bind = value.getDefiningOp<BindTileOp>()) {
-      value = bind.getSource();
-      continue;
-    }
-    if (auto cast = value.getDefiningOp<memref::CastOp>()) {
-      value = cast.getSource();
-      continue;
-    }
-    return value;
-  }
-}
-
-static std::optional<AddressToken> getExplicitAddressToken(Value value) {
-  value = peelMetadata(value);
-
-  if (auto tassign = value.getDefiningOp<TAssignOp>())
-    return AddressToken{tassign.getAddr(),
-                        tryEvalI64Constant(tassign.getAddr())};
-
-  auto pointerCast = value.getDefiningOp<PointerCastOp>();
-  if (!pointerCast || pointerCast.getAddrs().size() != 1)
-    return std::nullopt;
-
-  Value addr = pointerCast.getAddrs().front();
-  return AddressToken{addr, tryEvalI64Constant(addr)};
-}
-
-static bool sameAddressToken(const AddressToken &lhs, const AddressToken &rhs) {
-  if (lhs.value == rhs.value)
-    return true;
-  if (lhs.constant && rhs.constant)
-    return *lhs.constant == *rhs.constant;
-  return false;
 }
 
 static bool hasOnlyCurrentOpUses(Value value, Operation *currentOp) {
@@ -262,6 +220,56 @@ static bool hasExactSameAddressRange(const BaseMemInfo *srcInfo,
   return true;
 }
 
+static bool hasSameConcreteAddressRange(const BaseMemInfo *srcInfo,
+                                        const BaseMemInfo *dstInfo) {
+  if (!hasExactSameAddressRange(srcInfo, dstInfo))
+    return false;
+  if (srcInfo->rootBuffer == dstInfo->rootBuffer)
+    return true;
+  auto srcRootAddr = tryGetConcreteRootAddress(srcInfo);
+  auto dstRootAddr = tryGetConcreteRootAddress(dstInfo);
+  return srcRootAddr && dstRootAddr && *srcRootAddr == *dstRootAddr;
+}
+
+static Operation *getAncestorInBlock(Operation *op, Block *block) {
+  for (Operation *cur = op; cur; cur = cur->getParentOp()) {
+    if (cur->getBlock() == block)
+      return cur;
+  }
+  return nullptr;
+}
+
+static bool hasUseAfterOp(Value value, Operation *currentOp) {
+  Block *block = currentOp->getBlock();
+  for (OpOperand &use : value.getUses()) {
+    Operation *owner = use.getOwner();
+    if (owner == currentOp)
+      continue;
+    Operation *ancestor = getAncestorInBlock(owner, block);
+    if (!ancestor)
+      return true;
+    if (ancestor != currentOp && currentOp->isBeforeInBlock(ancestor))
+      return true;
+  }
+  return false;
+}
+
+static bool hasLaterUseOfSameAddressRange(
+    TMovOp op, const BaseMemInfo *dstInfo,
+    const Buffer2MemInfoMap &buffer2MemInfoMap) {
+  for (const auto &entry : buffer2MemInfoMap) {
+    // Later reads of the source itself do not make this no-op TMOV a bridge.
+    if (entry.first == op.getSrc())
+      continue;
+    bool sameRange = llvm::any_of(entry.second, [&](const auto &info) {
+      return hasSameConcreteAddressRange(info.get(), dstInfo);
+    });
+    if (sameRange && hasUseAfterOp(entry.first, op))
+      return true;
+  }
+  return false;
+}
+
 static bool hasPlainTMovSemantics(TMovOp op) {
   return !op.getFp() && !op.getPreQuantScalar() && !op.getAccToVecModeAttr() &&
          op.getReluPreMode() == ReluPreMode::NoRelu;
@@ -297,17 +305,6 @@ static bool touchesLowPrecisionElement(TMovOp op) {
   });
 }
 
-static bool isIdentityTMovByExplicitAddress(TMovOp op) {
-  if (op.getSrc() == op.getDst())
-    return true;
-
-  std::optional<AddressToken> src = getExplicitAddressToken(op.getSrc());
-  std::optional<AddressToken> dst = getExplicitAddressToken(op.getDst());
-  if (!src || !dst)
-    return false;
-  return sameAddressToken(*src, *dst) && isDeadDstTMov(op);
-}
-
 static bool
 isIdentityTMovByMemInfo(TMovOp op, const Buffer2MemInfoMap &buffer2MemInfoMap) {
   Value src = op.getSrc();
@@ -318,16 +315,11 @@ isIdentityTMovByMemInfo(TMovOp op, const Buffer2MemInfoMap &buffer2MemInfoMap) {
 
   const BaseMemInfo *srcInfo = getSingleMemInfo(buffer2MemInfoMap, src);
   const BaseMemInfo *dstInfo = getSingleMemInfo(buffer2MemInfoMap, dst);
-  if (!hasExactSameAddressRange(srcInfo, dstInfo))
+  if (!hasSameConcreteAddressRange(srcInfo, dstInfo))
     return false;
 
-  if (srcInfo->rootBuffer == dstInfo->rootBuffer)
-    return true;
-
-  auto srcRootAddr = tryGetConcreteRootAddress(srcInfo);
-  auto dstRootAddr = tryGetConcreteRootAddress(dstInfo);
-  return srcRootAddr && dstRootAddr && *srcRootAddr == *dstRootAddr &&
-         isDeadDstTMov(op);
+  return isDeadDstTMov(op) &&
+         !hasLaterUseOfSameAddressRange(op, dstInfo, buffer2MemInfoMap);
 }
 
 struct PTORemoveIdentityTMovPass
@@ -342,7 +334,7 @@ struct PTORemoveIdentityTMovPass
       if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op) ||
           touchesLowPrecisionElement(op))
         return;
-      if (isIdentityTMovByExplicitAddress(op)) {
+      if (op.getSrc() == op.getDst()) {
         identityMoves.push_back(op);
         return;
       }

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+//===- PTORemoveIdentityTMov.cpp -----------------------------------------===//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Pass/Pass.h"
+
+#include <optional>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOREMOVEIDENTITYTMOV
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::pto;
+
+namespace {
+
+struct AddressToken {
+  Value value;
+  std::optional<llvm::APInt> constant;
+};
+
+static Value peelMetadata(Value value) {
+  while (true) {
+    if (auto bind = value.getDefiningOp<BindTileOp>()) {
+      value = bind.getSource();
+      continue;
+    }
+    if (auto cast = value.getDefiningOp<memref::CastOp>()) {
+      value = cast.getSource();
+      continue;
+    }
+    return value;
+  }
+}
+
+static std::optional<AddressToken> getExplicitAddressToken(Value value) {
+  value = peelMetadata(value);
+
+  if (auto tassign = value.getDefiningOp<TAssignOp>())
+    return AddressToken{tassign.getAddr(), std::nullopt};
+
+  auto pointerCast = value.getDefiningOp<PointerCastOp>();
+  if (!pointerCast || pointerCast.getAddrs().size() != 1)
+    return std::nullopt;
+
+  Value addr = pointerCast.getAddrs().front();
+  llvm::APInt constant;
+  if (matchPattern(addr, m_ConstantInt(&constant)))
+    return AddressToken{addr, constant};
+  return AddressToken{addr, std::nullopt};
+}
+
+static bool sameAddressToken(const AddressToken &lhs, const AddressToken &rhs) {
+  if (lhs.value == rhs.value)
+    return true;
+  if (lhs.constant && rhs.constant)
+    return lhs.constant->getSExtValue() == rhs.constant->getSExtValue();
+  return false;
+}
+
+static bool hasPlainTMovSemantics(TMovOp op) {
+  return !op.getFp() && !op.getPreQuantScalar() && !op.getAccToVecModeAttr() &&
+         op.getReluPreMode() == ReluPreMode::NoRelu;
+}
+
+static bool hasCompatibleIdentityTypes(TMovOp op) {
+  if (op.getSrc().getType() != op.getDst().getType())
+    return false;
+  for (OpResult result : op->getResults()) {
+    if (result.getType() != op.getDst().getType())
+      return false;
+  }
+  return true;
+}
+
+static bool isIdentityTMov(TMovOp op) {
+  if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op))
+    return false;
+
+  if (op.getSrc() == op.getDst())
+    return true;
+
+  std::optional<AddressToken> src = getExplicitAddressToken(op.getSrc());
+  std::optional<AddressToken> dst = getExplicitAddressToken(op.getDst());
+  if (!src || !dst)
+    return false;
+  return sameAddressToken(*src, *dst);
+}
+
+struct PTORemoveIdentityTMovPass
+    : public mlir::pto::impl::PTORemoveIdentityTMovBase<
+          PTORemoveIdentityTMovPass> {
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+    SmallVector<TMovOp, 16> identityMoves;
+
+    func.walk([&](TMovOp op) {
+      if (isIdentityTMov(op))
+        identityMoves.push_back(op);
+    });
+
+    for (TMovOp op : identityMoves) {
+      for (OpResult result : op->getResults())
+        result.replaceAllUsesWith(op.getDst());
+      op.erase();
+    }
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTORemoveIdentityTMovPass() {
+  return std::make_unique<PTORemoveIdentityTMovPass>();
+}

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -1,12 +1,10 @@
 // Copyright (c) 2026 Huawei Technologies Co., Ltd.
-// This program is free software, you can redistribute it and/or modify it under
-// the terms and conditions of CANN Open Software License Agreement Version 2.0
-// (the "License"). Please refer to the License for details. You may not use
-// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
-// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
-// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
-// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
-// for the full text of the License.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
 
 //===- PTORemoveIdentityTMov.cpp -----------------------------------------===//
 //===----------------------------------------------------------------------===//

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "PTO/IR/PTO.h"
+#include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
 #include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
 #include "PTO/Transforms/InsertSync/SyncCommon.h"
@@ -214,6 +215,26 @@ static bool hasCompatibleIdentityTypes(TMovOp op) {
   return true;
 }
 
+static bool hasLowPrecisionElement(Value value) {
+  if (auto tileTy = dyn_cast<TileBufType>(value.getType()))
+    return isPTOLowPrecisionType(tileTy.getElementType());
+  if (auto memrefTy = dyn_cast<MemRefType>(value.getType()))
+    return isPTOLowPrecisionType(memrefTy.getElementType());
+  return false;
+}
+
+static bool touchesLowPrecisionElement(TMovOp op) {
+  if (hasLowPrecisionElement(op.getSrc()) || hasLowPrecisionElement(op.getDst()))
+    return true;
+  return llvm::any_of(op->getResults(), [](OpResult result) {
+    if (auto tileTy = dyn_cast<TileBufType>(result.getType()))
+      return isPTOLowPrecisionType(tileTy.getElementType());
+    if (auto memrefTy = dyn_cast<MemRefType>(result.getType()))
+      return isPTOLowPrecisionType(memrefTy.getElementType());
+    return false;
+  });
+}
+
 static bool isIdentityTMovByExplicitAddress(TMovOp op) {
   if (op.getSrc() == op.getDst())
     return true;
@@ -255,7 +276,8 @@ struct PTORemoveIdentityTMovPass
     SmallVector<TMovOp, 16> memInfoCandidates;
 
     func.walk([&](TMovOp op) {
-      if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op))
+      if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op) ||
+          touchesLowPrecisionElement(op))
         return;
       if (isIdentityTMovByExplicitAddress(op)) {
         identityMoves.push_back(op);

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -41,28 +41,75 @@ struct AddressToken {
   std::optional<int64_t> constant;
 };
 
-static std::optional<int64_t> tryEvalI64Constant(Value value) {
+static std::optional<unsigned> getIntegerLikeBitWidth(Type type) {
+  if (auto intTy = dyn_cast<IntegerType>(type))
+    return intTy.getWidth();
+  if (isa<IndexType>(type))
+    return 64;
+  return std::nullopt;
+}
+
+static std::optional<APInt> tryEvalIntegerLikeConstant(Value value);
+
+static std::optional<APInt> evalSignedCast(Value input, Type resultType) {
+  std::optional<APInt> inputValue = tryEvalIntegerLikeConstant(input);
+  std::optional<unsigned> resultWidth = getIntegerLikeBitWidth(resultType);
+  if (!inputValue || !resultWidth)
+    return std::nullopt;
+  return inputValue->sextOrTrunc(*resultWidth);
+}
+
+static std::optional<APInt> evalUnsignedCast(Value input, Type resultType) {
+  std::optional<APInt> inputValue = tryEvalIntegerLikeConstant(input);
+  std::optional<unsigned> resultWidth = getIntegerLikeBitWidth(resultType);
+  if (!inputValue || !resultWidth)
+    return std::nullopt;
+  return inputValue->zextOrTrunc(*resultWidth);
+}
+
+static std::optional<APInt> evalTruncCast(Value input, Type resultType) {
+  std::optional<APInt> inputValue = tryEvalIntegerLikeConstant(input);
+  std::optional<unsigned> resultWidth = getIntegerLikeBitWidth(resultType);
+  if (!inputValue || !resultWidth || *resultWidth > inputValue->getBitWidth())
+    return std::nullopt;
+  return inputValue->trunc(*resultWidth);
+}
+
+static std::optional<APInt> tryEvalIntegerLikeConstant(Value value) {
   if (!value)
     return std::nullopt;
 
   APInt apInt;
-  if (matchPattern(value, m_ConstantInt(&apInt)))
-    return apInt.getSExtValue();
+  if (matchPattern(value, m_ConstantInt(&apInt))) {
+    std::optional<unsigned> width = getIntegerLikeBitWidth(value.getType());
+    if (!width)
+      return std::nullopt;
+    return apInt.sextOrTrunc(*width);
+  }
 
   Operation *defOp = value.getDefiningOp();
   if (!defOp)
     return std::nullopt;
 
   if (auto castOp = dyn_cast<arith::IndexCastOp>(defOp))
-    return tryEvalI64Constant(castOp.getIn());
+    return evalSignedCast(castOp.getIn(), castOp.getType());
+  if (auto castOp = dyn_cast<arith::IndexCastUIOp>(defOp))
+    return evalUnsignedCast(castOp.getIn(), castOp.getType());
   if (auto castOp = dyn_cast<arith::ExtSIOp>(defOp))
-    return tryEvalI64Constant(castOp.getIn());
+    return evalSignedCast(castOp.getIn(), castOp.getType());
   if (auto castOp = dyn_cast<arith::ExtUIOp>(defOp))
-    return tryEvalI64Constant(castOp.getIn());
+    return evalUnsignedCast(castOp.getIn(), castOp.getType());
   if (auto castOp = dyn_cast<arith::TruncIOp>(defOp))
-    return tryEvalI64Constant(castOp.getIn());
+    return evalTruncCast(castOp.getIn(), castOp.getType());
 
   return std::nullopt;
+}
+
+static std::optional<int64_t> tryEvalI64Constant(Value value) {
+  std::optional<APInt> apInt = tryEvalIntegerLikeConstant(value);
+  if (!apInt || apInt->getBitWidth() > 64)
+    return std::nullopt;
+  return apInt->getSExtValue();
 }
 
 static Value peelMetadata(Value value) {

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -12,6 +12,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "PTO/IR/PTO.h"
+#include "PTO/Transforms/InsertSync/MemoryDependentAnalyzer.h"
+#include "PTO/Transforms/InsertSync/PTOIRTranslator.h"
+#include "PTO/Transforms/InsertSync/SyncCommon.h"
 #include "PTO/Transforms/Passes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -36,8 +39,32 @@ namespace {
 
 struct AddressToken {
   Value value;
-  std::optional<llvm::APInt> constant;
+  std::optional<int64_t> constant;
 };
+
+static std::optional<int64_t> tryEvalI64Constant(Value value) {
+  if (!value)
+    return std::nullopt;
+
+  APInt apInt;
+  if (matchPattern(value, m_ConstantInt(&apInt)))
+    return apInt.getSExtValue();
+
+  Operation *defOp = value.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  if (auto castOp = dyn_cast<arith::IndexCastOp>(defOp))
+    return tryEvalI64Constant(castOp.getIn());
+  if (auto castOp = dyn_cast<arith::ExtSIOp>(defOp))
+    return tryEvalI64Constant(castOp.getIn());
+  if (auto castOp = dyn_cast<arith::ExtUIOp>(defOp))
+    return tryEvalI64Constant(castOp.getIn());
+  if (auto castOp = dyn_cast<arith::TruncIOp>(defOp))
+    return tryEvalI64Constant(castOp.getIn());
+
+  return std::nullopt;
+}
 
 static Value peelMetadata(Value value) {
   while (true) {
@@ -57,25 +84,121 @@ static std::optional<AddressToken> getExplicitAddressToken(Value value) {
   value = peelMetadata(value);
 
   if (auto tassign = value.getDefiningOp<TAssignOp>())
-    return AddressToken{tassign.getAddr(), std::nullopt};
+    return AddressToken{tassign.getAddr(),
+                        tryEvalI64Constant(tassign.getAddr())};
 
   auto pointerCast = value.getDefiningOp<PointerCastOp>();
   if (!pointerCast || pointerCast.getAddrs().size() != 1)
     return std::nullopt;
 
   Value addr = pointerCast.getAddrs().front();
-  llvm::APInt constant;
-  if (matchPattern(addr, m_ConstantInt(&constant)))
-    return AddressToken{addr, constant};
-  return AddressToken{addr, std::nullopt};
+  return AddressToken{addr, tryEvalI64Constant(addr)};
 }
 
 static bool sameAddressToken(const AddressToken &lhs, const AddressToken &rhs) {
   if (lhs.value == rhs.value)
     return true;
   if (lhs.constant && rhs.constant)
-    return lhs.constant->getSExtValue() == rhs.constant->getSExtValue();
+    return *lhs.constant == *rhs.constant;
   return false;
+}
+
+static const BaseMemInfo *
+getSingleMemInfo(const Buffer2MemInfoMap &buffer2MemInfoMap, Value value) {
+  auto it = buffer2MemInfoMap.find(value);
+  if (it == buffer2MemInfoMap.end() || it->second.size() != 1)
+    return nullptr;
+  return it->second.front().get();
+}
+
+static std::optional<int64_t>
+tryGetConcreteRootAddress(const BaseMemInfo *info) {
+  if (!info)
+    return std::nullopt;
+
+  if (auto direct = tryEvalI64Constant(info->rootBuffer))
+    return direct;
+
+  Operation *defOp = info->rootBuffer.getDefiningOp();
+  if (!defOp)
+    return std::nullopt;
+
+  if (auto alloc = dyn_cast<pto::AllocTileOp>(defOp))
+    return tryEvalI64Constant(alloc.getAddr());
+
+  if (auto pointerCast = dyn_cast<pto::PointerCastOp>(defOp)) {
+    if (pointerCast.getAddrs().size() == 1)
+      return tryEvalI64Constant(pointerCast.getAddrs().front());
+  }
+
+  return std::nullopt;
+}
+
+static bool hasDynamicStaticList(ArrayRef<int64_t> values) {
+  return llvm::any_of(
+      values, [](int64_t value) { return value == ShapedType::kDynamic; });
+}
+
+static bool isStaticallyAddressableValue(Value value) {
+  int depth = 0;
+  constexpr int kMaxDepth = 32;
+  while (value && depth++ < kMaxDepth) {
+    Operation *defOp = value.getDefiningOp();
+    if (!defOp)
+      return false;
+
+    if (auto subView = dyn_cast<memref::SubViewOp>(defOp)) {
+      if (hasDynamicStaticList(subView.getStaticOffsets()) ||
+          hasDynamicStaticList(subView.getStaticSizes()) ||
+          hasDynamicStaticList(subView.getStaticStrides()))
+        return false;
+      value = subView.getSource();
+      continue;
+    }
+
+    if (isa<memref::ReinterpretCastOp>(defOp))
+      return false;
+
+    if (auto cast = dyn_cast<memref::CastOp>(defOp)) {
+      value = cast.getSource();
+      continue;
+    }
+    if (auto collapse = dyn_cast<memref::CollapseShapeOp>(defOp)) {
+      value = collapse.getSrc();
+      continue;
+    }
+    if (auto expand = dyn_cast<memref::ExpandShapeOp>(defOp)) {
+      value = expand.getSrc();
+      continue;
+    }
+    if (auto view = dyn_cast<memref::ViewOp>(defOp)) {
+      if (view.getByteShift())
+        return false;
+      value = view.getSource();
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+static bool hasExactSameAddressRange(const BaseMemInfo *srcInfo,
+                                     const BaseMemInfo *dstInfo) {
+  if (!srcInfo || !dstInfo)
+    return false;
+  if (srcInfo->scope != dstInfo->scope)
+    return false;
+  if (srcInfo->allocateSize == 0 || dstInfo->allocateSize == 0)
+    return false;
+  if (srcInfo->allocateSize != dstInfo->allocateSize)
+    return false;
+  if (srcInfo->baseAddresses.empty() || dstInfo->baseAddresses.empty())
+    return false;
+  if (srcInfo->baseAddresses != dstInfo->baseAddresses)
+    return false;
+  return true;
 }
 
 static bool hasPlainTMovSemantics(TMovOp op) {
@@ -93,10 +216,7 @@ static bool hasCompatibleIdentityTypes(TMovOp op) {
   return true;
 }
 
-static bool isIdentityTMov(TMovOp op) {
-  if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op))
-    return false;
-
+static bool isIdentityTMovByExplicitAddress(TMovOp op) {
   if (op.getSrc() == op.getDst())
     return true;
 
@@ -107,17 +227,58 @@ static bool isIdentityTMov(TMovOp op) {
   return sameAddressToken(*src, *dst);
 }
 
+static bool
+isIdentityTMovByMemInfo(TMovOp op, const Buffer2MemInfoMap &buffer2MemInfoMap) {
+  Value src = op.getSrc();
+  Value dst = op.getDst();
+
+  if (!isStaticallyAddressableValue(src) || !isStaticallyAddressableValue(dst))
+    return false;
+
+  const BaseMemInfo *srcInfo = getSingleMemInfo(buffer2MemInfoMap, src);
+  const BaseMemInfo *dstInfo = getSingleMemInfo(buffer2MemInfoMap, dst);
+  if (!hasExactSameAddressRange(srcInfo, dstInfo))
+    return false;
+
+  if (srcInfo->rootBuffer == dstInfo->rootBuffer)
+    return true;
+
+  auto srcRootAddr = tryGetConcreteRootAddress(srcInfo);
+  auto dstRootAddr = tryGetConcreteRootAddress(dstInfo);
+  return srcRootAddr && dstRootAddr && *srcRootAddr == *dstRootAddr;
+}
+
 struct PTORemoveIdentityTMovPass
     : public mlir::pto::impl::PTORemoveIdentityTMovBase<
           PTORemoveIdentityTMovPass> {
   void runOnOperation() override {
     func::FuncOp func = getOperation();
     SmallVector<TMovOp, 16> identityMoves;
+    SmallVector<TMovOp, 16> memInfoCandidates;
 
     func.walk([&](TMovOp op) {
-      if (isIdentityTMov(op))
+      if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op))
+        return;
+      if (isIdentityTMovByExplicitAddress(op)) {
         identityMoves.push_back(op);
+        return;
+      }
+      memInfoCandidates.push_back(op);
     });
+
+    if (!memInfoCandidates.empty()) {
+      MemoryDependentAnalyzer memAnalyzer;
+      SyncIRs syncIR;
+      Buffer2MemInfoMap buffer2MemInfoMap;
+      PTOIRTranslator translator(syncIR, memAnalyzer, buffer2MemInfoMap, func,
+                                 SyncAnalysisMode::NORMALSYNC);
+      translator.Build();
+
+      for (TMovOp op : memInfoCandidates) {
+        if (isIdentityTMovByMemInfo(op, buffer2MemInfoMap))
+          identityMoves.push_back(op);
+      }
+    }
 
     for (TMovOp op : identityMoves) {
       for (OpResult result : op->getResults())

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -149,6 +149,21 @@ static bool sameAddressToken(const AddressToken &lhs, const AddressToken &rhs) {
   return false;
 }
 
+static bool hasOnlyCurrentOpUses(Value value, Operation *currentOp) {
+  return llvm::all_of(value.getUses(), [currentOp](OpOperand &use) {
+    return use.getOwner() == currentOp;
+  });
+}
+
+static bool hasNoResultUses(Operation *op) {
+  return llvm::all_of(op->getResults(),
+                      [](OpResult result) { return result.use_empty(); });
+}
+
+static bool isDeadDstTMov(TMovOp op) {
+  return hasOnlyCurrentOpUses(op.getDst(), op) && hasNoResultUses(op);
+}
+
 static const BaseMemInfo *
 getSingleMemInfo(const Buffer2MemInfoMap &buffer2MemInfoMap, Value value) {
   auto it = buffer2MemInfoMap.find(value);
@@ -290,7 +305,7 @@ static bool isIdentityTMovByExplicitAddress(TMovOp op) {
   std::optional<AddressToken> dst = getExplicitAddressToken(op.getDst());
   if (!src || !dst)
     return false;
-  return sameAddressToken(*src, *dst);
+  return sameAddressToken(*src, *dst) && isDeadDstTMov(op);
 }
 
 static bool
@@ -311,7 +326,8 @@ isIdentityTMovByMemInfo(TMovOp op, const Buffer2MemInfoMap &buffer2MemInfoMap) {
 
   auto srcRootAddr = tryGetConcreteRootAddress(srcInfo);
   auto dstRootAddr = tryGetConcreteRootAddress(dstInfo);
-  return srcRootAddr && dstRootAddr && *srcRootAddr == *dstRootAddr;
+  return srcRootAddr && dstRootAddr && *srcRootAddr == *dstRootAddr &&
+         isDeadDstTMov(op);
 }
 
 struct PTORemoveIdentityTMovPass

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -91,9 +91,6 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
 // IR-NOT: pto.tmov
 // IR: return
 
-// IR-LABEL: func.func @non_identity_tmov_extui_negative_addr
-// IR: pto.tmov
-
 // IR-LABEL: func.func @non_identity_tmov_trunc_then_extsi_addr
 // IR: pto.tmov
 

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -1,0 +1,51 @@
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --emit-pto-ir --mlir-print-ir-after=pto-remove-identity-tmov %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=IR-ID
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --emit-pto-ir --mlir-print-ir-after=pto-remove-identity-tmov %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=IR-KEEP
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=CPP-ID
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=CPP-KEEP
+
+module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @identity_tmov_same_addr() {
+    %c0_i64 = arith.constant 0 : i64
+    %one = arith.constant 1.000000e+00 : f32
+    %src = pto.alloc_tile addr = %c0_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c0_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tadds ins(%src, %one
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+      outs(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmov ins(%src
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @non_identity_tmov_different_addr() {
+    %c0_i64 = arith.constant 0 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %src = pto.alloc_tile addr = %c0_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c64_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmov ins(%src
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// IR-ID-LABEL: func.func @identity_tmov_same_addr
+// IR-ID-NOT: pto.tmov
+// IR-ID: return
+
+// IR-KEEP-LABEL: func.func @non_identity_tmov_different_addr
+// IR-KEEP: pto.tmov
+
+// CPP-ID-LABEL: AICORE void identity_tmov_same_addr
+// CPP-ID-NOT: pipe_barrier(PIPE_V)
+// CPP-ID-NOT: TMOV(
+// CPP-ID: return;
+
+// CPP-KEEP-LABEL: AICORE void non_identity_tmov_different_addr
+// CPP-KEEP: TMOV(

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -43,6 +43,34 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
     return
   }
 
+  func.func @non_identity_tmov_extui_negative_addr() {
+    %cm1_i8 = arith.constant -1 : i8
+    %c255_i64 = arith.extui %cm1_i8 : i8 to i64
+    %cm1_i64 = arith.constant -1 : i64
+    %src = pto.alloc_tile addr = %c255_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %cm1_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmov ins(%src
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  func.func @non_identity_tmov_trunc_then_extsi_addr() {
+    %c255_i64 = arith.constant 255 : i64
+    %trunc_i8 = arith.trunci %c255_i64 : i64 to i8
+    %cm1_i64 = arith.extsi %trunc_i8 : i8 to i64
+    %src = pto.alloc_tile addr = %cm1_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c255_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tmov ins(%src
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
   func.func @non_identity_tmov_dynamic_addr(%addr0: i64, %addr1: i64) {
     %src = pto.pointer_cast(%addr0) : memref<1x16xf32, #pto.address_space<vec>>
     %dst = pto.pointer_cast(%addr1) : memref<1x16xf32, #pto.address_space<vec>>
@@ -63,6 +91,12 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
 // IR-NOT: pto.tmov
 // IR: return
 
+// IR-LABEL: func.func @non_identity_tmov_extui_negative_addr
+// IR: pto.tmov
+
+// IR-LABEL: func.func @non_identity_tmov_trunc_then_extsi_addr
+// IR: pto.tmov
+
 // IR-LABEL: func.func @non_identity_tmov_dynamic_addr
 // IR: pto.tmov
 
@@ -78,6 +112,12 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
 // CPP-NOT: pipe_barrier(PIPE_V)
 // CPP-NOT: TMOV(
 // CPP: return;
+
+// CPP-LABEL: AICORE void non_identity_tmov_extui_negative_addr
+// CPP: TMOV(
+
+// CPP-LABEL: AICORE void non_identity_tmov_trunc_then_extsi_addr
+// CPP: TMOV(
 
 // CPP-LABEL: AICORE void non_identity_tmov_dynamic_addr
 // CPP: TMOV(

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -1,7 +1,5 @@
-// RUN: ptoas --pto-arch=a3 --pto-level=level3 --emit-pto-ir --mlir-print-ir-after=pto-remove-identity-tmov %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=IR-ID
-// RUN: ptoas --pto-arch=a3 --pto-level=level3 --emit-pto-ir --mlir-print-ir-after=pto-remove-identity-tmov %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=IR-KEEP
-// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=CPP-ID
-// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=CPP-KEEP
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --emit-pto-ir --mlir-print-ir-after=pto-remove-identity-tmov %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=IR
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=CPP
 
 module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @identity_tmov_same_addr() {
@@ -33,19 +31,53 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
       outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     return
   }
+
+  func.func @identity_tmov_pointer_cast_same_addr_index_cast() {
+    %c0_i64 = arith.constant 0 : i64
+    %c0_idx = arith.constant 0 : index
+    %c0_alt = arith.index_cast %c0_idx : index to i64
+    %src = pto.pointer_cast(%c0_i64) : memref<1x16xf32, #pto.address_space<vec>>
+    %dst = pto.pointer_cast(%c0_alt) : memref<1x16xf32, #pto.address_space<vec>>
+    pto.tmov ins(%src : memref<1x16xf32, #pto.address_space<vec>>)
+      outs(%dst : memref<1x16xf32, #pto.address_space<vec>>)
+    return
+  }
+
+  func.func @non_identity_tmov_dynamic_addr(%addr0: i64, %addr1: i64) {
+    %src = pto.pointer_cast(%addr0) : memref<1x16xf32, #pto.address_space<vec>>
+    %dst = pto.pointer_cast(%addr1) : memref<1x16xf32, #pto.address_space<vec>>
+    pto.tmov ins(%src : memref<1x16xf32, #pto.address_space<vec>>)
+      outs(%dst : memref<1x16xf32, #pto.address_space<vec>>)
+    return
+  }
 }
 
-// IR-ID-LABEL: func.func @identity_tmov_same_addr
-// IR-ID-NOT: pto.tmov
-// IR-ID: return
+// IR-LABEL: func.func @identity_tmov_same_addr
+// IR-NOT: pto.tmov
+// IR: return
 
-// IR-KEEP-LABEL: func.func @non_identity_tmov_different_addr
-// IR-KEEP: pto.tmov
+// IR-LABEL: func.func @non_identity_tmov_different_addr
+// IR: pto.tmov
 
-// CPP-ID-LABEL: AICORE void identity_tmov_same_addr
-// CPP-ID-NOT: pipe_barrier(PIPE_V)
-// CPP-ID-NOT: TMOV(
-// CPP-ID: return;
+// IR-LABEL: func.func @identity_tmov_pointer_cast_same_addr_index_cast
+// IR-NOT: pto.tmov
+// IR: return
 
-// CPP-KEEP-LABEL: AICORE void non_identity_tmov_different_addr
-// CPP-KEEP: TMOV(
+// IR-LABEL: func.func @non_identity_tmov_dynamic_addr
+// IR: pto.tmov
+
+// CPP-LABEL: AICORE void identity_tmov_same_addr
+// CPP-NOT: pipe_barrier(PIPE_V)
+// CPP-NOT: TMOV(
+// CPP: return;
+
+// CPP-LABEL: AICORE void non_identity_tmov_different_addr
+// CPP: TMOV(
+
+// CPP-LABEL: AICORE void identity_tmov_pointer_cast_same_addr_index_cast
+// CPP-NOT: pipe_barrier(PIPE_V)
+// CPP-NOT: TMOV(
+// CPP: return;
+
+// CPP-LABEL: AICORE void non_identity_tmov_dynamic_addr
+// CPP: TMOV(

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -1,4 +1,3 @@
-// RUN: ptoas --pto-arch=a3 --pto-level=level3 --emit-pto-ir --mlir-print-ir-after=pto-remove-identity-tmov %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=IR
 // RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=CPP
 
 module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
@@ -79,23 +78,6 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
     return
   }
 }
-
-// IR-LABEL: func.func @identity_tmov_same_addr
-// IR-NOT: pto.tmov
-// IR: return
-
-// IR-LABEL: func.func @non_identity_tmov_different_addr
-// IR: pto.tmov
-
-// IR-LABEL: func.func @identity_tmov_pointer_cast_same_addr_index_cast
-// IR-NOT: pto.tmov
-// IR: return
-
-// IR-LABEL: func.func @non_identity_tmov_trunc_then_extsi_addr
-// IR: pto.tmov
-
-// IR-LABEL: func.func @non_identity_tmov_dynamic_addr
-// IR: pto.tmov
 
 // CPP-LABEL: AICORE void identity_tmov_same_addr
 // CPP-NOT: pipe_barrier(PIPE_V)

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -21,24 +21,15 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
   }
 
   func.func @live_dst_same_addr_keeps_tmov() {
-    %c0_src_i64 = arith.constant 0 : i64
-    %c0_dst_i32 = arith.constant 0 : i32
-    %c0_dst_i64 = arith.extsi %c0_dst_i32 : i32 to i64
-    %one = arith.constant 1.000000e+00 : f32
-    %src = pto.alloc_tile addr = %c0_src_i64
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile addr = %c0_dst_i64
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-
-    pto.tadds ins(%src, %one
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
-      outs(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tmov ins(%src
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
-    pto.tadds ins(%dst, %one
-      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
-      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %c0_i64 = arith.constant 0 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %src = pto.pointer_cast(%c0_i64) : memref<1x16xf32, #pto.address_space<vec>>
+    %dst = pto.pointer_cast(%c0_i64) : memref<1x16xf32, #pto.address_space<vec>>
+    %out = pto.pointer_cast(%c64_i64) : memref<1x16xf32, #pto.address_space<vec>>
+    pto.tmov ins(%src : memref<1x16xf32, #pto.address_space<vec>>)
+      outs(%dst : memref<1x16xf32, #pto.address_space<vec>>)
+    pto.tmov ins(%dst : memref<1x16xf32, #pto.address_space<vec>>)
+      outs(%out : memref<1x16xf32, #pto.address_space<vec>>)
     return
   }
 
@@ -109,7 +100,7 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
 // CPP: return;
 
 // CPP-LABEL: AICORE void live_dst_same_addr_keeps_tmov
-// CPP: TMOV(
+// CPP-COUNT-2: TMOV(
 
 // CPP-LABEL: AICORE void non_identity_tmov_different_addr
 // CPP: TMOV(

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -2,11 +2,13 @@
 
 module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @identity_tmov_same_addr() {
-    %c0_i64 = arith.constant 0 : i64
+    %c0_src_i64 = arith.constant 0 : i64
+    %c0_dst_i32 = arith.constant 0 : i32
+    %c0_dst_i64 = arith.extsi %c0_dst_i32 : i32 to i64
     %one = arith.constant 1.000000e+00 : f32
-    %src = pto.alloc_tile addr = %c0_i64
+    %src = pto.alloc_tile addr = %c0_src_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile addr = %c0_i64
+    %dst = pto.alloc_tile addr = %c0_dst_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tadds ins(%src, %one
@@ -19,11 +21,13 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
   }
 
   func.func @live_dst_same_addr_keeps_tmov() {
-    %c0_i64 = arith.constant 0 : i64
+    %c0_src_i64 = arith.constant 0 : i64
+    %c0_dst_i32 = arith.constant 0 : i32
+    %c0_dst_i64 = arith.extsi %c0_dst_i32 : i32 to i64
     %one = arith.constant 1.000000e+00 : f32
-    %src = pto.alloc_tile addr = %c0_i64
+    %src = pto.alloc_tile addr = %c0_src_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    %dst = pto.alloc_tile addr = %c0_i64
+    %dst = pto.alloc_tile addr = %c0_dst_i64
       : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
     pto.tadds ins(%src, %one

--- a/test/lit/pto/issue870_identity_tmov_pruning.pto
+++ b/test/lit/pto/issue870_identity_tmov_pruning.pto
@@ -18,6 +18,26 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
     return
   }
 
+  func.func @live_dst_same_addr_keeps_tmov() {
+    %c0_i64 = arith.constant 0 : i64
+    %one = arith.constant 1.000000e+00 : f32
+    %src = pto.alloc_tile addr = %c0_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile addr = %c0_i64
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tadds ins(%src, %one
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+      outs(%src : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmov ins(%src
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tadds ins(%dst, %one
+      : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+      outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
   func.func @non_identity_tmov_different_addr() {
     %c0_i64 = arith.constant 0 : i64
     %c64_i64 = arith.constant 64 : i64
@@ -83,6 +103,9 @@ module attributes {pto.target_arch = "a2a3", pto.kernel_kind = #pto.kernel_kind<
 // CPP-NOT: pipe_barrier(PIPE_V)
 // CPP-NOT: TMOV(
 // CPP: return;
+
+// CPP-LABEL: AICORE void live_dst_same_addr_keeps_tmov
+// CPP: TMOV(
 
 // CPP-LABEL: AICORE void non_identity_tmov_different_addr
 // CPP: TMOV(

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1870,6 +1870,7 @@ int mlir::pto::compilePTOASModule(
     pm.addPass(pto::createPlanMemoryPass(planMemoryOption));
   }
   pm.addPass(pto::createPTOResolveReservedBuffersPass());
+  pm.addNestedPass<mlir::func::FuncOp>(pto::createPTORemoveIdentityTMovPass());
 
   // Conditionally add one automatic synchronization mode. Barrier-all is a
   // conservative standalone pass; InsertSync and GraphSyncSolver are set/wait


### PR DESCRIPTION
Summary
- Add a pre-InsertSync `pto-remove-identity-tmov` cleanup pass.
- Remove plain `pto.tmov` when src/dst are proven to refer to the same physical tile address/range.
- Place the pass after reserved-buffer resolution and before automatic sync insertion so sync is not generated for the no-op TMOV.
- Add regression coverage that checks identity TMOV and its induced `pipe_barrier(PIPE_V)` disappear, while different-address and unproven-dynamic TMOV are preserved.

Motivation
- Fixes the first part of #870: dead identity TMOV self-copy and the redundant sync generated only because that no-op still reached InsertSync.
- Supersedes and absorbs the useful part of the earlier identity-TMOV cleanup attempts #419/#420:
  - #419 is closed and was not merged.
  - #420 is still open and was not merged into current `main`.
  - #420's useful exact-address-range proof is incorporated here, but without its broader PR scope/debug flag/unrelated diagnostic cases.
- This PR intentionally does not change generic same-pipe `PIPE_V` barrier policy; that will be handled separately.

Design
- The cleanup is conservative and only removes plain TMOV:
  - no `fp`
  - no `preQuantScalar`
  - no `accToVecMode`
  - `reluPreMode == NoRelu`
  - src/dst/result types match
- Address identity is proven in two tiers:
  - fast explicit address proof: direct same SSA, `pto.bind_tile` / `memref.cast` peeling, `pto.tassign`, and single-address `pto.pointer_cast`
  - fallback exact-range proof: lazily build InsertSync's `Buffer2MemInfoMap` and require same scope, same non-zero allocate size, identical base addresses, and either the same InsertSync root or a different-root same-concrete-address TMOV whose destination is dead after the TMOV
- Dynamic or ambiguous cases are kept. If exact identity cannot be proven, the TMOV remains. Different-root same-address TMOVs are also kept when the destination is live, because the TMOV may be the only bridge that lets InsertSync observe the src-root to dst-root dependency.

Performance Profiling / camodel-msprof
- Actual collection was performed on the A3 remote host through `task-submit + msprof op simulator`.
- Because the full Qwen `v_proj_vec_rs.cpp` artifact from #870 was not available in the current run environment, this measures a focused AIV/vector microbenchmark that reproduces the exact identity-TMOV pattern fixed by this PR.
- Microbenchmark shape:
  - common work in both variants: `TLOAD -> pipe_barrier(PIPE_ALL) -> TADD -> pipe_barrier(PIPE_ALL) -> TSTORE`
  - baseline-only redundant work: 320 iterations of `pipe_barrier(PIPE_V); TMOV(alias, acc)` where `alias` and `acc` are `TileType::Vec<f32, 32x32>` bound to the same UB address (`0x1000`)
  - candidate: same kernel with the identity-TMOV pattern removed
  - correctness check in both runs: `repeat=320 expected=2 first=2 max_abs_err=0`
- Environment:
  - CANN: `/usr/local/Ascend/cann-9.0.0`
  - simulator SOC: `dav_2201`
  - pto-isa headers: `/home/zhongxuan/pto-isa`
  - workdir: `/data/pyptouser/zhongxuan/ptoas_board_runs/issue870_identity_tmov_camodel`
- Collection command:
  ```bash
  task-submit --device auto --max-time 600 --timeout 60 --run     "bash /data/pyptouser/zhongxuan/ptoas_board_runs/issue870_identity_tmov_camodel/run_msprof_task.sh <baseline|candidate> 320"
  ```
- Results:

  | Variant | core0.veccore0 duration | core0.veccore0 running | Total tick | instr rows | redundant `BAR PIPE:VEC` | redundant `MOV_UB_TO_UB` | Verification |
  |---|---:|---:|---:|---:|---:|---:|---|
  | baseline | 3.56 us | 3.56 us | 8123 | 75 | 320 | 320 | pass |
  | candidate | 0.62 us | 0.62 us | 2672 | 60 | 0 | 0 | pass |

- Delta on this focused pattern:
  - veccore duration: `3.56us -> 0.62us`, `-2.94us` (`-82.6%`)
  - total simulator tick: `8123 -> 2672`, `-5451` (`-67.1%`)
- CSV evidence:
  - baseline `core0.veccore0_instr_exe.csv` contains `BAR, pipe=VECTOR, call_count=320, detail=PIPE:VEC` and `MOV_UB_TO_UB, call_count=320, Src:UB,Dst:UB,XD:X4=0x1000,XN:X4=0x1000`
  - candidate `core0.veccore0_instr_exe.csv` has neither redundant row
- Scope note: this is not a full Qwen decode end-to-end number. It directly validates the #870 identity-TMOV pattern removed by this PR and the induced `PIPE_V` barrier disappearing before InsertSync/codegen reaches profiling.

Testing
- Local license check:
  - `python3 .github/scripts/check_license_headers.py --repo hw-native-sys/PTOAS --event-name push --base-sha hw-native-sys/main --head-sha HEAD` OK
- Local targeted compile check:
  - `ninja -C build-llvm21 lib/PTO/Transforms/CMakeFiles/obj.PTOTransforms.dir/PTORemoveIdentityTMov.cpp.o` OK
- Follow-up guard after CI signal:
  - Low-precision `TMOV` operands/results (`hif8`/`fp4` family through `isPTOLowPrecisionType`) are explicitly preserved by the identity cleanup pass.
  - This keeps existing A5 low-precision EmitC coverage, including `tmov_low_precision_a5_emitc.pto` and `tmov_fp4_low_precision_a5_emitc.pto`, from being optimized away.
- P1 review follow-up:
  - Different-root same-address TMOVs are now pruned only when the destination has no uses outside the TMOV and all TMOV results are unused; live destination cases keep the TMOV to preserve the InsertSync bridge and avoid under-synchronization.
  - Regression coverage added for a live-dst same-address case that must keep `TMOV`.
  - Integer cast chains in explicit address proofs are now evaluated with exact `sext`/`zext`/`trunc` semantics instead of being stripped transparently.
  - Regression coverage added for `extui(i8 -1) -> i64` vs `i64 -1`, and `trunci(i64 255) -> i8` followed by `extsi -> i64` vs `i64 255`.
- Previous local LLVM21 validation worktree with the base patch:
  - `ninja -C build-llvm21 ptoas` OK
  - `llvm-lit -v build-llvm21/test/lit/pto/issue870_identity_tmov_pruning.pto` OK
  - `llvm-lit -v build-llvm21/test/lit/pto/issue454_nested_loop_same_pipe_pair_regression_gss.pto build-llvm21/test/lit/pto/syncfinder_zero_loop_if_probe_gss.pto build-llvm21/test/lit/pto/issue706_tgather_hidden_mte_sync.pto build-llvm21/test/lit/pto/issue706_tscatter_hidden_mte_sync.pto` OK
- Note: direct full rebuild of the fresh upstream-main worktree on this machine is currently blocked by a pre-existing local LLVM header/API mismatch in unrelated PTO IR files (`Type::isFloat8*`, `getStridesAndOffset`). The new pass object itself compiles cleanly in that environment.

Risk / Rollback
- Risk is low because the pass only erases TMOV when it can prove physical self-copy and the TMOV has no extra conversion/quant/relu semantics. Low-precision TMOV is excluded from cleanup and remains on the existing lowering path. Integer address casts are modeled exactly; unmodeled cast chains remain conservative and do not trigger deletion.
- Rollback: revert this PR; no public IR, CLI, or API changes are required.


