### PR TITLE
refactor: switch PTOUnrollSIMTFor to annotation-only unrolling

### DIFF
--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -669,19 +669,18 @@ def PTOMaterializeTileHandles : Pass<"pto-materialize-tile-handles", "ModuleOp">
 
 def PTOUnrollSIMTFor : Pass<"pto-unroll-simt-for", "func::FuncOp"> {
   let summary =
-      "Unroll small constant-trip-count scf.for loops in pto.simt_entry functions";
+      "Unroll explicitly annotated scf.for loops in pto.simt_entry functions";
   let description = [{
     Walks functions with `pto.simt_entry` attribute and fully unrolls `scf.for`
-    loops that meet one of these criteria:
+    loops that carry the `{pto.unroll = "full"}` attribute.
 
-    1. The loop carries the `{pto.unroll = "full"}` attribute.
-    2. The loop has constant lower bound, upper bound, and step, and the trip
-       count does not exceed the configurable `max-trip-count` threshold (default 64).
+    Only loops with constant lower bound, upper bound, and positive step are
+    unrolled.  The annotation is opt-in: loops without the attribute are
+    left unchanged regardless of trip count.
 
     Full unrolling enables subsequent canonicalize/sccp/cse to constant-fold
     induction-variable-dependent conditionals (e.g. `scf.if i < 10`), eliminating
-    divergent branches that can cause the AICore backend to emit predicated END
-    instructions inside SIMTVF kernels.
+    divergent branches inside SIMTVF kernels.
 
     This pass must run before `createConvertSCFToCFPass` (i.e. before LLVM
     lowering) so that the unrolled structured control flow can be canonicalized.
@@ -692,11 +691,6 @@ def PTOUnrollSIMTFor : Pass<"pto-unroll-simt-for", "func::FuncOp"> {
     "mlir::scf::SCFDialect",
     "mlir::pto::PTODialect",
     "mlir::arith::ArithDialect"
-  ];
-  let options = [
-    Option<"maxTripCount", "max-trip-count", "int64_t", "64",
-           "Maximum constant trip count to auto-unroll (default: 64). "
-           "Loops exceeding this are left unchanged.">
   ];
 }
 

--- a/lib/PTO/Transforms/PTOUnrollSIMTForPass.cpp
+++ b/lib/PTO/Transforms/PTOUnrollSIMTForPass.cpp
@@ -8,17 +8,12 @@
 
 //===- PTOUnrollSIMTForPass.cpp -------------------------------------------===//
 //
-// Unroll small constant-trip-count scf.for loops inside pto.simt_entry
+// Unroll explicitly annotated scf.for loops inside pto.simt_entry
 // functions to eliminate divergent control flow before LLVM lowering.
 //
-// Workaround for: https://github.com/mouliangyu/PTOAS/issues/485
-//
-// When a SIMTVF kernel contains scf.for + scf.if with a constant-condition
-// branch (e.g. for i in 0..16: if i < 10: store), the AICore backend may
-// emit a predicated END instruction.  By fully unrolling the loop and
-// letting canonicalize/sccp constant-fold the induction-variable-dependent
-// conditions, we obtain straight-line code without branches, which avoids
-// the bug.
+// Only loops carrying the `{pto.unroll = "full"}` attribute are unrolled.
+// The pass is gated to pto.simt_entry functions so it does not affect
+// general-purpose loops.
 //
 //===----------------------------------------------------------------------===//
 
@@ -61,19 +56,6 @@ using namespace mlir;
 static constexpr llvm::StringLiteral kUnrollAttrName = "pto.unroll";
 static constexpr llvm::StringLiteral kUnrollFullValue = "full";
 
-/// Try to compute a constant trip count for an scf::ForOp.
-/// Returns std::nullopt if any bound or step is non-constant.
-static std::optional<int64_t> computeConstantTripCount(scf::ForOp forOp) {
-  std::optional<int64_t> lb = getConstantIntValue(forOp.getLowerBound());
-  std::optional<int64_t> ub = getConstantIntValue(forOp.getUpperBound());
-  std::optional<int64_t> step = getConstantIntValue(forOp.getStep());
-  if (!lb || !ub || !step || *step <= 0)
-    return std::nullopt;
-  if (*ub <= *lb)
-    return 0;
-  return (*ub - *lb + *step - 1) / *step; // ceil division
-}
-
 /// Check whether the loop has the explicit "full unroll" annotation.
 static bool hasUnrollFullAttr(scf::ForOp forOp) {
   if (auto attr = forOp->getAttrOfType<StringAttr>(kUnrollAttrName))
@@ -93,8 +75,7 @@ static bool isSIMTEntry(func::FuncOp func) {
 namespace {
 
 struct UnrollSIMTForPattern : public OpRewritePattern<scf::ForOp> {
-  UnrollSIMTForPattern(MLIRContext *ctx, int64_t maxTripCount)
-      : OpRewritePattern(ctx), maxTripCount(maxTripCount) {}
+  using OpRewritePattern<scf::ForOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(scf::ForOp forOp,
                                 PatternRewriter &rewriter) const override {
@@ -103,41 +84,32 @@ struct UnrollSIMTForPattern : public OpRewritePattern<scf::ForOp> {
     if (!func || !isSIMTEntry(func))
       return failure();
 
-    // Check explicit annotation first.
-    if (hasUnrollFullAttr(forOp)) {
-      return unrollFull(forOp, rewriter, /*isAnnotated=*/true);
-    }
-
-    // Auto-detect: constant bounds and small trip count.
-    auto tripCount = computeConstantTripCount(forOp);
-    if (!tripCount || *tripCount > maxTripCount)
+    // Only unroll loops with explicit {pto.unroll = "full"} annotation.
+    if (!hasUnrollFullAttr(forOp))
       return failure();
 
-    return unrollFull(forOp, rewriter, /*isAnnotated=*/false);
-  }
+    std::optional<int64_t> lb = getConstantIntValue(forOp.getLowerBound());
+    std::optional<int64_t> ub = getConstantIntValue(forOp.getUpperBound());
+    std::optional<int64_t> step = getConstantIntValue(forOp.getStep());
+    if (!lb || !ub || !step || *step <= 0 || *ub <= *lb)
+      return failure();
 
-private:
-  LogicalResult unrollFull(scf::ForOp forOp, PatternRewriter &rewriter,
-                           bool isAnnotated) const {
-    auto tripCount = computeConstantTripCount(forOp);
-    if (!tripCount || *tripCount <= 0)
+    int64_t tripCount = (*ub - *lb + *step - 1) / *step;
+    if (tripCount <= 0)
       return failure();
 
     LLVM_DEBUG(llvm::dbgs()
-               << "PTOUnrollSIMTFor: unrolling scf.for "
-               << (isAnnotated ? "(annotated)" : "(auto)") << " tripCount="
-               << *tripCount << " at " << forOp.getLoc() << "\n");
+               << "PTOUnrollSIMTFor: unrolling annotated scf.for tripCount="
+               << tripCount << " at " << forOp.getLoc() << "\n");
 
     // loopUnrollByFactor returns failure if the loop carries iteration
     // arguments that have uses outside the loop (live-out values).  In that
     // case we cannot unroll.
-    if (failed(loopUnrollByFactor(forOp, static_cast<uint64_t>(*tripCount))))
+    if (failed(loopUnrollByFactor(forOp, static_cast<uint64_t>(tripCount))))
       return failure();
 
     return success();
   }
-
-  int64_t maxTripCount;
 };
 
 } // namespace
@@ -159,7 +131,7 @@ struct PTOUnrollSIMTFor : public pto::impl::PTOUnrollSIMTForBase<PTOUnrollSIMTFo
 
     MLIRContext *ctx = &getContext();
     RewritePatternSet patterns(ctx);
-    patterns.add<UnrollSIMTForPattern>(ctx, maxTripCount);
+    patterns.add<UnrollSIMTForPattern>(ctx);
 
     GreedyRewriteConfig config;
     config.maxIterations = 10; // loops may nest

--- a/test/test_unroll_annotation.mlir
+++ b/test/test_unroll_annotation.mlir
@@ -1,0 +1,55 @@
+// Test PTOUnrollSIMTFor pass: annotation-only unrolling behavior.
+//
+// Verifies three cases:
+//   1. simt_entry + pto.unroll="full"  -> fully unrolled (no scf.for)
+//   2. simt_entry + no annotation       -> loop NOT unrolled
+//   3. annotation + not simt_entry      -> loop NOT unrolled
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto %s -o /dev/null --mlir-print-ir-after=pto-unroll-simt-for 2>&1 | FileCheck %s
+
+// There should be exactly 2 scf.for in the output (from case 2 and 3).
+// CHECK-COUNT-2: scf.for
+// CHECK-NOT:     scf.for
+
+module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  // Case 1: simt_entry + pto.unroll="full" -> unrolled (no scf.for)
+  func.func @annotated_unrolled() attributes {pto.simt_entry} {
+    %buf = memref.alloc() : memref<1xindex>
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    "scf.for"(%c0, %c4, %c1) ({
+    ^bb0(%i: index):
+      %val = arith.addi %i, %i : index
+      memref.store %val, %buf[%c0] : memref<1xindex>
+      scf.yield
+    }) {"pto.unroll" = "full"} : (index, index, index) -> ()
+    return
+  }
+
+  // Case 2: simt_entry but NO annotation -> loop survives
+  func.func @not_annotated_skipped() attributes {pto.simt_entry} {
+    %buf = memref.alloc() : memref<1xindex>
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c4 step %c1 {
+      %val = arith.addi %i, %i : index
+      memref.store %val, %buf[%c0] : memref<1xindex>
+    }
+    return
+  }
+
+  // Case 3: annotation but NOT simt_entry -> loop survives
+  func.func @not_simt_entry_skipped() {
+    %buf = memref.alloc() : memref<1xindex>
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    scf.for %i = %c0 to %c4 step %c1 {
+      %val = arith.addi %i, %i : index
+      memref.store %val, %buf[%c0] : memref<1xindex>
+    }
+    return
+  }
+}

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1528,9 +1528,6 @@ static bool shouldDeclareVariablesAtTop(ModuleOp module) {
 
 static void prepareVPTOForEmission(PassManager &pm) {
   auto &kernelModulePM = pm.nest<ModuleOp>();
-  // Issue #485 workaround: unroll small constant-trip-count scf.for loops
-  // inside pto.simt_entry functions, then constant-fold the induction-variable
-  // dependent scf.if branches so subsequent canonicalize/cse eliminate them.
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTOUnrollSIMTForPass());
   kernelModulePM.addPass(createSCCPPass());


### PR DESCRIPTION
Remove auto-detection of constant-bound loops (issue #485 workaround). Only loops with explicit {pto.unroll = "full"} attribute are now unrolled. Drop the --max-trip-count option.