### PR TITLE
fix(tci): document unsigned scalar support

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -8129,7 +8129,7 @@ dst[i, j] = S + linear_index(i, j)   // or descending if requested
 
 - **Implementation checks (A2/A3/A5)**
   - Tile element type must be exactly the same type as the `S`.
-  - `dst/scalar` element types must be identical, and must be one of: `i32`, `i16`.
+  - `dst/scalar` element types must be identical, and must be one of: `i16`, `ui16`, `i32`, `ui32`.
   - `dst.cols != 1`.
 
 **Hardware Mapping:**

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -5454,7 +5454,7 @@ LogicalResult pto::TCIOp::verify() {
 
   unsigned bw = elemTy.getWidth();
   if (bw != 16 && bw != 32)
-    return emitOpError("expects dst element type to be i16/i32");
+    return emitOpError("expects dst element type to be i16/ui16/i32/ui32");
 
   auto sTy = mlir::dyn_cast<IntegerType>(getOperand(0).getType());
   if (!sTy)

--- a/test/lit/pto/tci_ui16_emitc.pto
+++ b/test/lit/pto/tci_ui16_emitc.pto
@@ -1,0 +1,19 @@
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=A3
+
+module {
+  func.func @tci_ui16_kernel(%dst: memref<16xui16, #pto.address_space<gm>>) {
+    %c7_i16 = arith.constant 7 : i16
+    %c7_ui16 = builtin.unrealized_conversion_cast %c7_i16 : i16 to ui16
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %src = memref.reinterpret_cast %dst to offset: [%c0], sizes: [%c1, %c16], strides: [%c16, %c1] {layout = #pto.layout<nd>} : memref<16xui16, #pto.address_space<gm>> to memref<1x16xui16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>
+    %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tci ins(%c7_ui16 : ui16) outs(%tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%src : memref<1x16xui16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
+    return
+  }
+}
+
+// A3: TCI<{{.*}}, uint16_t, 0>(
+// A3-NOT: TCI<{{.*}}, int16_t, 0>(


### PR DESCRIPTION
## Summary
- update `pto.tci` verifier messaging to include `ui16` and `ui32`
- align the PTO IR manual with `pto-isa` unsigned scalar support for `TCI`
- add a `ui16` EmitC regression that checks `TCI<..., uint16_t, 0>` emission

## Validation
- `/Users/jimmychou/work/ptoas/PTOAS-main-latest/build-local-vpto/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tci_ui16_emitc.pto | FileCheck ... --check-prefix=A3`
- `/Users/jimmychou/work/ptoas/PTOAS-main-latest/build-local-vpto/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tci_i16_emitc.pto | FileCheck ... --check-prefix=A3`
- `/Users/jimmychou/work/ptoas/PTOAS-main-latest/build-local-vpto/tools/ptoas/ptoas --pto-arch=a3 test/lit/pto/tci_ui32_emitc.pto | FileCheck ... --check-prefix=A3`

## Notes
- this change aligns `pto.tci`'s documented/type-checked support with `pto-isa`
- issue #878's exact Python repro still needs a frontend unsigned-constant construction fix (`arith.constant` requires signless integer types)

Refs #878
