### PR TITLE
feat(tcvt): add optional tmp operand and lower to pto-isa tmp overload

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -7905,7 +7905,7 @@ idx = permutation indices for the sort
 |------|------|-------------|
 | `src` | `pto.tile_buf` | Input value tile |
 | `idx` | `pto.tile_buf` | Input index tile permuted together with `src` |
-| `tmp` | `Optional<pto.tile_buf>` | Optional scratch tile for the tmp-taking DPS overload |
+| `tmp` | `pto.tile_buf` | Scratch tile |
 | `dst` | `pto.tile_buf` | Output tile storing sorted value-index pairs |
 
 **Results:** None. Writes into `dst` via DPS pattern.
@@ -7913,7 +7913,7 @@ idx = permutation indices for the sort
 **Assembly Format:**
 
 ```
-pto.tsort32 ins(<src>, <idx>[, <tmp>] : <src_type>, <idx_type>[, <tmp_type>])
+pto.tsort32 ins(<src>, <idx>, <tmp> : <src_type>, <idx_type>, <tmp_type>)
            outs(<dst> : <dst_type>)
 ```
 
@@ -7923,7 +7923,7 @@ pto.tsort32 ins(<src>, <idx>[, <tmp>] : <src_type>, <idx_type>[, <tmp_type>])
 - `src` element type must match `dst` element type.
 - `idx` element type must be `u32`.
 - `src`, `dst`, and `idx` must all use `loc=vec` and `blayout=row_major`.
-- If the 4-operand form is used, `tmp` only needs to be a `loc=vec` tile.
+- `tmp` must be a `loc=vec` tile.
 - PTO IR does not impose a same-shape or rounded-tail tmp formula in the verifier.
 
 **Hardware Mapping:**
@@ -7933,10 +7933,6 @@ pto.tsort32 ins(<src>, <idx>[, <tmp>] : <src_type>, <idx_type>[, <tmp_type>])
 **Basic Example:**
 
 ```mlir
-pto.tsort32 ins(%src, %idx : !pto.tile_buf<...>, !pto.tile_buf<...>)
-           outs(%dst : !pto.tile_buf<...>)
-
-# Optional scratch form:
 pto.tsort32 ins(%src, %idx, %tmp : !pto.tile_buf<...>, !pto.tile_buf<...>, !pto.tile_buf<...>)
            outs(%dst : !pto.tile_buf<...>)
 ```

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -8063,6 +8063,7 @@ dst[i, j] = saturate(cast(src[i, j], rmode), satmode)
 | Name | Type | Description |
 |------|------|-------------|
 | `src` | `pto.tile_buf` | Source tile |
+| `tmp` | `pto.tile_buf` (optional) | Optional scratch tile forwarded to the `pto-isa` tmp-buffer overload of `TCVT` |
 | `dst` | `pto.tile_buf` | Destination tile (different element type) |
 | `rmode` | `RoundModeAttr` (default: `CAST_RINT`) | Rounding mode |
 | `satmode` | `SaturationModeAttr` (default: `OFF`) | Saturation mode |
@@ -8073,6 +8074,7 @@ dst[i, j] = saturate(cast(src[i, j], rmode), satmode)
 
 - `dst` and `src` must be compatible in shape/valid region as required by the implementation.
 - `satmode = ON` requests destination-range clamping after rounding; `OFF` preserves the target's non-saturating conversion path.
+- When `tmp` is provided it is forwarded to the `pto-isa` `TCVT` overload that takes a `TmpTileData` scratch tile — `TCVT(dst, src, tmp, mode, satMode)`; on A2/A3 `tmp` is consumed as a Unified-Buffer `int32` scratch, on A5 it is accepted for interface compatibility and ignored. Omitting `tmp` selects the non-tmp `TCVT(dst, src, mode, satMode)` overload.
 - **A2/A3 and A5 notes:**
   - A2/A3 reject all low-precision `tcvt` operands.
   - A5 only accepts the following low-precision pairs: 
@@ -8097,6 +8099,10 @@ dst[i, j] = saturate(cast(src[i, j], rmode), satmode)
 
 ```mlir
 pto.tcvt ins(%src {rmode = #pto<round_mode FLOOR>, satmode = #pto<saturation_mode ON>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+         outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+// with optional tmp scratch tile (selects the pto-isa TCVT tmp-buffer overload)
+pto.tcvt ins(%src, %tmp {rmode = #pto<round_mode FLOOR>, satmode = #pto<saturation_mode ON>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
          outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 ```
 

--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -8125,7 +8125,7 @@ dst[i, j] = S + linear_index(i, j)   // or descending if requested
 | Name | Type | Description |
 |------|------|-------------|
 | `S` | `Integer` | Starting value |
-| `tmp` | `pto.tile_buf` (optional) | Optional scratch tile forwarded to the `pto-isa` tmp-buffer overload |
+| `tmp` | `pto.tile_buf` | Scratch tile forwarded to the `pto-isa` tmp-buffer overload of `TCI` (required) |
 | `dst` | `pto.tile_buf` | Destination tile |
 | `descending` | `BoolAttr` (default: false) | Generate descending sequence |
 
@@ -8133,6 +8133,7 @@ dst[i, j] = S + linear_index(i, j)   // or descending if requested
 
 **Constraints & Verification:**
 
+- `tmp` is **required**. It is forwarded to the `pto-isa` `TCI(dst, start, tmp)` tmp-buffer overload; on A2/A3 `tmp` is consumed as a Unified-Buffer `float` scratch (the vectorized fast path), on A5 it is accepted for interface compatibility and ignored.
 - **Implementation checks (A2/A3/A5)**
   - Tile element type must be exactly the same type as the `S`.
   - `dst/scalar` element types must be identical, and must be one of: `i16`, `ui16`, `i32`, `ui32`.
@@ -8140,12 +8141,11 @@ dst[i, j] = S + linear_index(i, j)   // or descending if requested
 
 **Hardware Mapping:**
 
-- Executes on the **Vector pipeline** (`PIPE_V`)
+- Executes on the **Scalar pipeline** (`PIPE_S`)
 
 **Basic Example:**
 
 ```mlir
-pto.tci ins(%start : i32) outs(%dst : !pto.tile_buf<...>)
 pto.tci ins(%start, %tmp : i32, !pto.tile_buf<...>) outs(%dst : !pto.tile_buf<...>)
 ```
 

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3970,6 +3970,7 @@ def TCvtOp : PTO_TOp<"tcvt", [
 
   let arguments = (ins
     PTODpsType:$src,
+    Optional<PTODpsType>:$tmp,
     PTODpsType:$dst,
     DefaultValuedAttr<PTO_RoundModeAttr, "::mlir::pto::RoundMode::CAST_RINT">:$rmode,
     DefaultValuedAttr<PTO_SaturationModeAttr, "::mlir::pto::SaturationMode::OFF">:$sat_mode

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3446,7 +3446,7 @@ def TCIOp : PTO_TOp<"tci", [
 
   let arguments = (ins
     AnyInteger:$S,
-    Optional<PTODpsType>:$tmp,
+    PTODpsType:$tmp,
     PTODpsType:$dst,
     DefaultValuedAttr<BoolAttr, "false">:$descending
   );

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -6384,15 +6384,16 @@ def TSort32Op: PTO_TOp<"tsort32", [
 ]> {
   let summary = "TSORT32: Sort fixed-size 32-element blocks using explicit input indices.";
   let description = [{
-    DPS form matching pto-isa overloads: (dst, src, idx) or (dst, src, idx, tmp).
-    In PTO IR, `idx` is modeled as an input operand in `ins(...)`, while `dst`
-    remains the sole DPS init/output buffer in `outs(...)`.
+    DPS form: `idx` is modeled as an input operand in `ins(...)`, while `dst`
+    remains the sole DPS init/output buffer in `outs(...)`. The `tmp` operand is
+    required scratch storage, so lowering always targets the tmp-taking TSORT32
+    backend interface.
   }];
 
   let arguments = (ins
     PTODpsType:$src,
     PTODpsType:$idx,
-    Optional<PTODpsType>:$tmp,
+    PTODpsType:$tmp,
     PTODpsType:$dst
   );
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -5388,47 +5388,28 @@ static ParseResult parseTCILikeOp(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand s, tmp, dst;
   Type sTy, tmpTy, dstTy;
 
-  if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(s))
+  // ins(%s, %tmp : ty_s, ty_tmp) outs(%dst : ty_dst)
+  if (parser.parseKeyword("ins") || parser.parseLParen() ||
+      parser.parseOperand(s) || parser.parseComma() || parser.parseOperand(tmp) ||
+      parser.parseColonType(sTy) || parser.parseComma() || parser.parseType(tmpTy) ||
+      parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen() ||
+      parser.parseOperand(dst) || parser.parseColonType(dstTy) ||
+      parser.parseRParen() || parser.parseOptionalAttrDict(result.attributes))
     return failure();
 
-  bool hasTmp = succeeded(parser.parseOptionalComma());
-  if (hasTmp && parser.parseOperand(tmp))
+  if (parser.resolveOperand(s, sTy, result.operands) ||
+      parser.resolveOperand(tmp, tmpTy, result.operands) ||
+      parser.resolveOperand(dst, dstTy, result.operands))
     return failure();
 
-  if (parser.parseColonType(sTy))
-    return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
-  }
-  if (parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen() ||
-      parser.parseOperand(dst) || parser.parseColonType(dstTy) || parser.parseRParen() ||
-      parser.parseOptionalAttrDict(result.attributes))
-    return failure();
-
-  if (parser.resolveOperand(s, sTy, result.operands))
-    return failure();
-  if (hasTmp && parser.resolveOperand(tmp, tmpTy, result.operands))
-    return failure();
-  if (parser.resolveOperand(dst, dstTy, result.operands))
-    return failure();
-
-  result.addAttribute(
-      "operandSegmentSizes",
-      parser.getBuilder().getDenseI32ArrayAttr({1, hasTmp ? 1 : 0, 1}));
   return success();
 }
 
 static void printTCILikeOp(OpAsmPrinter &p, Operation *op, Value s, Value tmp,
                            Value dst) {
-  p << " ins(" << s;
-  if (tmp)
-    p << ", " << tmp;
-  p << " : " << s.getType();
-  if (tmp)
-    p << ", " << tmp.getType();
-  p << ") outs(" << dst << " : " << dst.getType() << ")";
-  p.printOptionalAttrDict(op->getAttrs(), /*elidedAttrs=*/{"operandSegmentSizes"});
+  p << " ins(" << s << ", " << tmp << " : " << s.getType() << ", "
+    << tmp.getType() << ") outs(" << dst << " : " << dst.getType() << ")";
+  p.printOptionalAttrDict(op->getAttrs());
 }
 
 ParseResult mlir::pto::TCIOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -5445,7 +5426,7 @@ LogicalResult pto::TCIOp::verify() {
   Type dstTy = getDst().getType();
   if (failed(verifyTileBufCommon(*this, dstTy, "dst")))
     return failure();
-  if (getTmp() && failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp")))
+  if (failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp")))
     return failure();
 
   auto elemTy = mlir::dyn_cast<IntegerType>(getElemTy(dstTy));
@@ -13198,9 +13179,11 @@ PTO_DEFINE_BINARY_EFFECTS(TConcatOp, getSrc0Mutable(), getSrc1Mutable(), getDstM
 PTO_DEFINE_QUATERNARY_EFFECTS(TConcatidxOp, getSrc0Mutable(), getSrc1Mutable(), getSrc0IdxMutable(), getSrc1IdxMutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TAndSOp, getSrcMutable(), getDstMutable())
 
-// TCI: Write(dst) (generates sequence)
+// TCI: Read/Write(tmp scratch), Write(dst) (generates sequence)
 void TCIOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
+  PTO_ADD_READ(getTmpMutable());
+  PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -10242,28 +10242,15 @@ mlir::LogicalResult mlir::pto::TRowExpandOp::verify() {
 ParseResult mlir::pto::TSort32Op::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand src, idx, tmp, dst;
   Type srcTy, dstTy, idxTy, tmpTy;
-  bool hasTmp = false;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
     return failure();
-  if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(idx))
-      return failure();
-    if (succeeded(parser.parseOptionalComma())) {
-      if (parser.parseOperand(tmp))
-        return failure();
-      hasTmp = true;
-    }
-  } else {
+  if (parser.parseComma() || parser.parseOperand(idx) ||
+      parser.parseComma() || parser.parseOperand(tmp))
     return failure();
-  }
-  if (parser.parseColonType(srcTy) || parser.parseComma() || parser.parseType(idxTy))
-    return failure();
-  if (hasTmp) {
-    if (parser.parseComma() || parser.parseType(tmpTy))
-      return failure();
-  }
-  if (parser.parseRParen())
+  if (parser.parseColonType(srcTy) || parser.parseComma() ||
+      parser.parseType(idxTy) || parser.parseComma() ||
+      parser.parseType(tmpTy) || parser.parseRParen())
     return failure();
 
   if (parser.parseKeyword("outs") || parser.parseLParen() ||
@@ -10274,32 +10261,20 @@ ParseResult mlir::pto::TSort32Op::parse(OpAsmParser &parser, OperationState &res
     return failure();
 
   if (parser.resolveOperand(src, srcTy, result.operands) ||
-      parser.resolveOperand(idx, idxTy, result.operands))
+      parser.resolveOperand(idx, idxTy, result.operands) ||
+      parser.resolveOperand(tmp, tmpTy, result.operands))
     return failure();
-  if (hasTmp) {
-    if (parser.resolveOperand(tmp, tmpTy, result.operands))
-      return failure();
-  }
   if (parser.resolveOperand(dst, dstTy, result.operands))
     return failure();
-
-  result.addAttribute(
-      "operandSegmentSizes",
-      parser.getBuilder().getDenseI32ArrayAttr({1, 1, hasTmp ? 1 : 0, 1}));
   return success();
 }
 
 void mlir::pto::TSort32Op::print(OpAsmPrinter &p) {
-  p << " ins(" << getSrc() << ", " << getIdx();
-  if (getTmp()) {
-    p << ", " << getTmp();
-    p << " : " << getSrc().getType() << ", " << getIdx().getType()
-      << ", " << getTmp().getType() << ")";
-  } else {
-    p << " : " << getSrc().getType() << ", " << getIdx().getType() << ")";
-  }
+  p << " ins(" << getSrc() << ", " << getIdx() << ", " << getTmp();
+  p << " : " << getSrc().getType() << ", " << getIdx().getType()
+    << ", " << getTmp().getType() << ")";
   p << " outs(" << getDst() << " : " << getDst().getType() << ")";
-  p.printOptionalAttrDict((*this)->getAttrs(), /*elidedAttrs=*/{"operandSegmentSizes"});
+  p.printOptionalAttrDict((*this)->getAttrs());
 }
 
 ParseResult mlir::pto::TRsqrtOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -13625,14 +13600,12 @@ PTO_DEFINE_BINARY_EFFECTS(TShrOp, getSrc0Mutable(), getSrc1Mutable(), getDstMuta
 PTO_DEFINE_UNARY_EFFECTS(TShlSOp, getSrcMutable(), getDstMutable())
 PTO_DEFINE_UNARY_EFFECTS(TShrSOp, getSrcMutable(), getDstMutable())
 
-// TSORT32: Read(src, idx) -> Write(dst [, tmp])
+// TSORT32: Read(src, idx) -> Write(dst, tmp)
 void TSort32Op::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
   PTO_ADD_READ(getIdxMutable());
-  auto tmp = getTmpMutable();
-  if (!tmp.empty())
-    PTO_ADD_WRITE(tmp[0]);
+  PTO_ADD_WRITE(getTmpMutable());
   PTO_ADD_WRITE(getDstMutable());
 }
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -5988,6 +5988,9 @@ llvm::LogicalResult mlir::pto::TCvtOp::verify() {
   if (failed(verifyTileBufCommon(*this, srcTy, "src", /*allowLowPrecision=*/true)) ||
       failed(verifyTileBufCommon(*this, dstTy, "dst", /*allowLowPrecision=*/true)))
     return failure();
+  if (getTmp() && failed(verifyTileBufCommon(*this, getTmp().getType(), "tmp",
+                                              /*allowLowPrecision=*/true)))
+    return failure();
   if (failed(verifyTileBufSameLogicalExtent(*this, srcTy, dstTy, "src", "dst",
                                             /*compareValidShape=*/false)))
     return failure();
@@ -8511,30 +8514,53 @@ LogicalResult MGatherOp::verify() {
 }
 
 void mlir::pto::TCvtOp::print(OpAsmPrinter &p) {
-  p << " ins(" << getSrc();
   Builder builder(getContext());
   NamedAttrList attrs;
   for (auto attr : (*this)->getAttrs()) {
+    if (attr.getName() == "operandSegmentSizes")
+      continue;
     if (attr.getName() == "sat_mode") {
       attrs.set(builder.getStringAttr("satmode"), attr.getValue());
       continue;
     }
     attrs.set(attr.getName(), attr.getValue());
   }
+
+  // ins(%src {attr...} : ty_src) | ins(%src, %tmp {attr...} : ty_src, ty_tmp)
+  p << " ins(" << getSrc();
+  if (getTmp())
+    p << ", " << getTmp();
   p.printOptionalAttrDict(attrs.getAttrs());
   p << " : " << getSrc().getType();
+  if (getTmp())
+    p << ", " << getTmp().getType();
   p << ") outs(" << getDst() << " : " << getDst().getType() << ")";
 }
 
 ParseResult mlir::pto::TCvtOp::parse(OpAsmParser &parser, OperationState &result) {
-  OpAsmParser::UnresolvedOperand src, dst;
-  Type srcTy, dstTy;
+  OpAsmParser::UnresolvedOperand src, dst, tmp;
+  Type srcTy, dstTy, tmpTy;
+  bool hasTmp = false;
 
   if (parser.parseKeyword("ins") || parser.parseLParen() || parser.parseOperand(src))
     return failure();
+
+  // Check for optional tmp operand: ins(%src, %tmp {attr...} : ty_src, ty_tmp)
+  if (succeeded(parser.parseOptionalComma())) {
+    if (parser.parseOperand(tmp))
+      return failure();
+    hasTmp = true;
+  }
+
   NamedAttrList attrs;
-  if (parser.parseOptionalAttrDict(attrs) || parser.parseColonType(srcTy))
+  if (parser.parseOptionalAttrDict(attrs))
     return failure();
+  if (parser.parseColonType(srcTy))
+    return failure();
+  if (hasTmp) {
+    if (parser.parseComma() || parser.parseType(tmpTy))
+      return failure();
+  }
   if (auto satmode = attrs.get("satmode")) {
     attrs.erase("satmode");
     if (attrs.get("sat_mode"))
@@ -8543,12 +8569,18 @@ ParseResult mlir::pto::TCvtOp::parse(OpAsmParser &parser, OperationState &result
     attrs.set("sat_mode", satmode);
   }
   result.attributes = attrs;
+
   if (parser.parseRParen() || parser.parseKeyword("outs") || parser.parseLParen() ||
       parser.parseOperand(dst) || parser.parseColonType(dstTy) || parser.parseRParen())
     return failure();
 
-  if (parser.resolveOperand(src, srcTy, result.operands) ||
-      parser.resolveOperand(dst, dstTy, result.operands))
+  if (parser.resolveOperand(src, srcTy, result.operands))
+    return failure();
+  if (hasTmp) {
+    if (parser.resolveOperand(tmp, tmpTy, result.operands))
+      return failure();
+  }
+  if (parser.resolveOperand(dst, dstTy, result.operands))
     return failure();
   return success();
 }
@@ -13222,6 +13254,11 @@ void TColSumOp::getEffects(
 void TCvtOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>> &effects) {
   PTO_ADD_READ(getSrcMutable());
+  auto tmp = getTmpMutable();
+  if (!tmp.empty()) {
+    PTO_ADD_READ(tmp[0]);
+    PTO_ADD_WRITE(tmp[0]);
+  }
   PTO_ADD_WRITE(getDstMutable());
 }
 void TRandomOp::getEffects(

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -11404,7 +11404,7 @@ struct PTOShrSConstToEmitC : public OpConversionPattern<pto::TShrSOp> {
 };
 
 //===----------------------------------------------------------------------===//
-// PTOConvert.cpp  (TSORT32 DPS/memref op: ins(src, idx[, tmp]) outs(dst))
+// PTOConvert.cpp  (TSORT32 DPS/memref op: ins(src, idx, tmp) outs(dst))
 //===----------------------------------------------------------------------===//
 
 struct PTOSORT32SToEmitC : public OpConversionPattern<pto::TSort32Op> {
@@ -11417,17 +11417,14 @@ struct PTOSORT32SToEmitC : public OpConversionPattern<pto::TSort32Op> {
     Value src = peelUnrealized(adaptor.getSrc());
     Value dst = peelUnrealized(adaptor.getDst());
     Value idx = peelUnrealized(adaptor.getIdx());
-    Value tmp = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
+    if (!op.getTmp())
+      return op.emitOpError("requires tmp before EmitC lowering");
+    Value tmp = peelUnrealized(adaptor.getTmp());
 
-    SmallVector<Value, 4> operands;
-    if (tmp)
-      operands.assign({dst, src, idx, tmp});
-    else
-      operands.assign({dst, src, idx});
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TSORT32",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
-        /*operands=*/operands);
+        /*operands=*/ValueRange{dst, src, idx, tmp});
 
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -8316,7 +8316,7 @@ struct PTOTCIToEmitC : public OpConversionPattern<pto::TCIOp> {
 
     Value dst = peelUnrealized(adaptor.getDst());
     Value S = peelUnrealized(adaptor.getOperands()[0]);
-    Value tmp = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
+    Value tmp = peelUnrealized(adaptor.getTmp());
 
     // The TCI scalar template parameter should follow the original PTO IR
     // scalar type, not the converted EmitC value type.
@@ -8332,29 +8332,24 @@ struct PTOTCIToEmitC : public OpConversionPattern<pto::TCIOp> {
     // descending -> "0"/"1"
     std::string descTok = op.getDescending() ? "1" : "0";
 
+    // Always lower to the pto-isa tmp-buffer overload TCI(dst, start, tmp).
     ArrayAttr targs;
     if (auto ot = mlir::dyn_cast<emitc::OpaqueType>(dst.getType())) {
-      SmallVector<Attribute, 4> templateArgVec;
-      templateArgVec.push_back(
-          emitc::OpaqueAttr::get(ctx, ot.getValue().str()));
-      if (tmp) {
-        auto tmpOt = mlir::dyn_cast<emitc::OpaqueType>(tmp.getType());
-        if (!tmpOt)
-          return rewriter.notifyMatchFailure(
-              op, "expected tmp tile to lower to emitc::OpaqueType");
-        templateArgVec.push_back(
-            emitc::OpaqueAttr::get(ctx, tmpOt.getValue().str()));
-      }
-      templateArgVec.push_back(emitc::OpaqueAttr::get(ctx, scalarTok));
-      templateArgVec.push_back(emitc::OpaqueAttr::get(ctx, descTok));
-      targs = rewriter.getArrayAttr(templateArgVec);
+      auto tmpOt = mlir::dyn_cast<emitc::OpaqueType>(tmp.getType());
+      if (!tmpOt)
+        return rewriter.notifyMatchFailure(
+            op, "expected tmp tile to lower to emitc::OpaqueType");
+      targs = rewriter.getArrayAttr({
+          emitc::OpaqueAttr::get(ctx, ot.getValue().str()),
+          emitc::OpaqueAttr::get(ctx, tmpOt.getValue().str()),
+          emitc::OpaqueAttr::get(ctx, scalarTok),
+          emitc::OpaqueAttr::get(ctx, descTok),
+      });
     } else {
       targs = rewriter.getArrayAttr({});
     }
 
-    SmallVector<Value, 3> operands{dst, S};
-    if (tmp)
-      operands.push_back(tmp);
+    SmallVector<Value, 3> operands{dst, S, tmp};
 
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TCI",

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -8854,13 +8854,28 @@ struct PTOCvtToEmitC : public OpConversionPattern<pto::TCvtOp> {
     Value satModeVal = rewriter.create<emitc::ConstantOp>(
         loc, satModeTy, emitc::OpaqueAttr::get(ctx, satTok));
 
-    SmallVector<Value, 4> operands{dst, src, rmodeVal, satModeVal};
+    // TCVT has four pto-isa overloads:
+    //   TCVT(dst, src, tmp, mode, satMode) | TCVT(dst, src, tmp, mode)
+    //   TCVT(dst, src, mode, satMode)      | TCVT(dst, src, mode)
+    // The satMode is always emitted (defaulting to OFF), so the tmp overload
+    // selected here is TCVT(dst, src, tmp, mode, satMode) and the non-tmp one
+    // is TCVT(dst, src, mode, satMode).
+    SmallVector<unsigned, 3> tileSlotOrder;
+    tileSlotOrder.push_back(op.getDstMutable().getOperandNumber());
+    tileSlotOrder.push_back(op.getSrcMutable().getOperandNumber());
 
-    rewriter.create<emitc::CallOpaqueOp>(
-        loc, TypeRange{}, "TCVT",
-        /*args=*/ArrayAttr{},
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/operands);
+    SmallVector<Value, 5> operands{dst, src};
+    if (op.getTmp()) {
+      Value tmp = peelUnrealized(adaptor.getTmp());
+      operands.push_back(tmp);
+      tileSlotOrder.push_back(op.getTmpMutable().begin()->getOperandNumber());
+    }
+    operands.push_back(rmodeVal);
+    operands.push_back(satModeVal);
+
+    createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
+                                 "TCVT", ValueRange{operands}, ArrayAttr{},
+                                 ArrayAttr{}, tileSlotOrder);
 
     rewriter.eraseOp(op);
     return success();

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -2990,6 +2990,7 @@ struct PTOViewToMemrefPass
 
         Value src = op.getSrc();
         Value dst = op.getDst();
+        Value tmp = op.getTmp();
 
         auto srcTy = dyn_cast<MemRefType>(src.getType());
         auto dstTy = dyn_cast<MemRefType>(dst.getType());
@@ -2997,6 +2998,14 @@ struct PTOViewToMemrefPass
           op.emitError("ins/outs are not memref yet");
           signalPassFailure();
           return;
+        }
+        if (tmp) {
+          auto tmpTy = dyn_cast<MemRefType>(tmp.getType());
+          if (!tmpTy) {
+            op.emitError("tmp is not memref yet");
+            signalPassFailure();
+            return;
+          }
         }
 
         auto rmodeAttr = op.getRmodeAttr(); // PTO_RoundModeAttr
@@ -3006,6 +3015,7 @@ struct PTOViewToMemrefPass
             op.getLoc(),
             TypeRange{},
             src,
+            tmp,
             dst,
             rmodeAttr,
             satModeAttr);

--- a/lib/PTO/Transforms/PTOViewToMemref.cpp
+++ b/lib/PTO/Transforms/PTOViewToMemref.cpp
@@ -2668,8 +2668,8 @@ struct PTOViewToMemrefPass
 
         auto sTy = dyn_cast<IntegerType>(s.getType());
         auto dstTy = dyn_cast<MemRefType>(dst.getType());
-        auto tmpTy = tmp ? dyn_cast<MemRefType>(tmp.getType()) : MemRefType{};
-        if (!sTy || !dstTy || (tmp && !tmpTy)) {
+        auto tmpTy = dyn_cast<MemRefType>(tmp.getType());
+        if (!sTy || !dstTy || !tmpTy) {
           op.emitError("ins/outs are not memref yet");
           signalPassFailure();
           return;

--- a/lib/TileOps/tsort32_template.py
+++ b/lib/TileOps/tsort32_template.py
@@ -28,7 +28,7 @@ def _constraint_aligned(
     idx_config=None,
     dst_config=None,
 ) -> bool:
-    """Constraint for Format1: valid_cols % 32 == 0 (aligned, no tmp needed)."""
+    """Constraint for Format1: valid_cols % 32 == 0."""
     if len(src_valid_shape) != 2:
         return False
     valid_cols = src_valid_shape[1]
@@ -62,14 +62,11 @@ def _constraint_unaligned(
     op="pto.tsort32",
     constraints=[_constraint_aligned]
 )
-def template_tsort32(src: pto.Tile, idx: pto.Tile, dst: pto.Tile):
+def template_tsort32_aligned_with_tmp(src: pto.Tile, idx: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
     """
-    TSort32 Format1: Bitonic sort for aligned cols (valid_cols % 32 == 0).
-    
-    Semantics (matching pto-isa TSort32.hpp Format1):
-    - Sorts src values into dst, generating indices in idx
-    - Direct sort without tmp buffer when src.valid_cols % 32 == 0
-    - No padding needed
+    TSort32 Format1 with explicit tmp operand: Bitonic sort for aligned cols
+    (valid_cols % 32 == 0). The tmp tile is part of the public IR signature but
+    is not used by the aligned algorithm.
     """
     dtype = dst.element_type
     valid_rows = dst.valid_shape[0]
@@ -108,7 +105,7 @@ def template_tsort32(src: pto.Tile, idx: pto.Tile, dst: pto.Tile):
                 repeat_num = REPEAT_MAX
                 if j == loop_num - 1:
                     repeat_num = tail_repeat_num
-                    
+
                 pto.vbitsort(
                     pto.addptr(dst_ptr, i * dst_stride + j * REPEAT_MAX * BLOCK_SIZE * type_coef),
                     pto.addptr(src_ptr, i * src_stride + j * REPEAT_MAX * BLOCK_SIZE),
@@ -126,11 +123,11 @@ def template_tsort32(src: pto.Tile, idx: pto.Tile, dst: pto.Tile):
 )
 def template_tsort32_with_tmp(src: pto.Tile, idx: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
     """
-    TSort32 Format2: Bitonic sort with tmp buffer for unaligned cols.
+    TSort32 with explicit tmp buffer.
     
     Semantics (matching pto-isa TSort32.hpp Format2):
     - Sorts src values into dst, generating indices in idx
-    - Uses tmp buffer when src.valid_cols % 32 != 0 (padding needed)
+    - Uses tmp buffer for unaligned cols that need padding
     - Pads unaligned tail with NaN to ensure correct sorting
     """
     dtype = dst.element_type

--- a/test/lit/pto/issue735_tci_pipe_s_sync.pto
+++ b/test/lit/pto/issue735_tci_pipe_s_sync.pto
@@ -5,8 +5,9 @@ module {
     %start = arith.constant 0 : i32
     %scale = arith.constant 2 : i32
     %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
 
-    pto.tci ins(%start : i32)
+    pto.tci ins(%start, %tmp : i32, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
             outs(%tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tmuls ins(%tile, %scale : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, i32)
               outs(%tile : !pto.tile_buf<loc=vec, dtype=i32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)

--- a/test/lit/pto/tci_i16_emitc.pto
+++ b/test/lit/pto/tci_i16_emitc.pto
@@ -8,11 +8,12 @@ module {
     %c16 = arith.constant 16 : index
     %src = memref.reinterpret_cast %dst to offset: [%c0], sizes: [%c1, %c16], strides: [%c16, %c1] {layout = #pto.layout<nd>} : memref<16xi16, #pto.address_space<gm>> to memref<1x16xi16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>
     %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=1>
-    pto.tci ins(%c0_i16 : i16) outs(%tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tci ins(%c0_i16, %tmp : i16, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=1>)
     pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=1>) outs(%src : memref<1x16xi16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
     return
   }
 }
 
-// A3: TCI<Tile<TileType::Vec, int16_t, 1, 16, BLayout::RowMajor, 1, 16, SLayout::NoneBox, 512, PadValue::Zero, CompactMode::Null>, int16_t, 0>(
-// A3-NOT: TCI<Tile<TileType::Vec, int16_t, 1, 16, BLayout::RowMajor, 1, 16, SLayout::NoneBox, 512, PadValue::Zero, CompactMode::Null>, int32_t, 0>(
+// A3: TCI<{{.*}}, {{.*}}, int16_t, 0>(
+// A3-NOT: TCI<{{.*}}, {{.*}}, int32_t, 0>(

--- a/test/lit/pto/tci_ui16_emitc.pto
+++ b/test/lit/pto/tci_ui16_emitc.pto
@@ -9,11 +9,12 @@ module {
     %c16 = arith.constant 16 : index
     %src = memref.reinterpret_cast %dst to offset: [%c0], sizes: [%c1, %c16], strides: [%c16, %c1] {layout = #pto.layout<nd>} : memref<16xui16, #pto.address_space<gm>> to memref<1x16xui16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>
     %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tci ins(%c7_ui16 : ui16) outs(%tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tci ins(%c7_ui16, %tmp : ui16, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=ui16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%src : memref<1x16xui16, strided<[16, 1], offset: ?>, #pto.address_space<gm>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
     return
   }
 }
 
-// A3: TCI<{{.*}}, uint16_t, 0>(
-// A3-NOT: TCI<{{.*}}, int16_t, 0>(
+// A3: TCI<{{.*}}, {{.*}}, uint16_t, 0>(
+// A3-NOT: TCI<{{.*}}, {{.*}}, int16_t, 0>(

--- a/test/lit/pto/tci_ui32_emitc.pto
+++ b/test/lit/pto/tci_ui32_emitc.pto
@@ -9,11 +9,12 @@ module {
     %c32 = arith.constant 32 : index
     %src = memref.reinterpret_cast %dst to offset: [%c0], sizes: [%c1, %c32], strides: [%c32, %c1] {layout = #pto.layout<nd>} : memref<32xui32, #pto.address_space<gm>> to memref<1x32xui32, strided<[32, 1], offset: ?>, #pto.address_space<gm>>
     %tile = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tci ins(%c5_ui32 : ui32) outs(%tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tci ins(%c5_ui32, %tmp : ui32, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     pto.tstore ins(%tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%src : memref<1x32xui32, strided<[32, 1], offset: ?>, #pto.address_space<gm>>) {layout = #pto.layout<nd>, pto.inferred_layout = true}
     return
   }
 }
 
-// A3: TCI<{{.*}}, uint32_t, 0>(
-// A3-NOT: TCI<{{.*}}, int32_t, 0>(
+// A3: TCI<{{.*}}, {{.*}}, uint32_t, 0>(
+// A3-NOT: TCI<{{.*}}, {{.*}}, int32_t, 0>(

--- a/test/lit/pto/tcvt_emitc.pto
+++ b/test/lit/pto/tcvt_emitc.pto
@@ -70,6 +70,21 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
     return
   }
 
+  // -----------------------------------------------------------------------
+  // f32 -> f16 with an explicit tmp scratch tile (selects the pto-isa
+  // TCVT(dst, src, tmp, mode, satMode) tmp-buffer overload)
+  // -----------------------------------------------------------------------
+  func.func @tcvt_f32_to_f16_tmp() attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tcvt ins(%src, %tmp {rmode = #pto<round_mode FLOOR>, satmode = #pto<saturation_mode ON>} : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=vec, dtype=f16, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+
+    return
+  }
+
 }
 
 // A3-LABEL: AICORE void tcvt_f32_to_f16(
@@ -90,6 +105,12 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
 // A3:       RoundMode::CAST_ROUND
 // A3:       TCVT(
 
+// A3-LABEL: AICORE void tcvt_f32_to_f16_tmp(
+// A3:       SaturationMode::ON
+// A3:       RoundMode::CAST_FLOOR
+// A3:       Tile<TileType::Vec, int32_t
+// A3:       TCVT({{[^)]*}}, {{[^)]*}}, {{[^)]*}}, {{[^)]*}}, {{[^)]*}})
+
 // A5-LABEL: AICORE void tcvt_f32_to_f16(
 // A5:       RoundMode::CAST_RINT
 // A5:       TCVT(
@@ -107,3 +128,9 @@ module attributes {"pto.device-spec" = "Ascend910B3"} {
 // A5:       SaturationMode::ON
 // A5:       RoundMode::CAST_ROUND
 // A5:       TCVT(
+
+// A5-LABEL: AICORE void tcvt_f32_to_f16_tmp(
+// A5:       SaturationMode::ON
+// A5:       RoundMode::CAST_FLOOR
+// A5:       Tile<TileType::Vec, int32_t
+// A5:       TCVT({{[^)]*}}, {{[^)]*}}, {{[^)]*}}, {{[^)]*}}, {{[^)]*}})

--- a/test/lit/pto/tsort32_emitc.pto
+++ b/test/lit/pto/tsort32_emitc.pto
@@ -12,8 +12,9 @@ module {
   func.func @tsort32_forms() {
     %src = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %idx = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tmp0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tsort32 ins(%src, %idx : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst0 : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tsort32 ins(%src, %idx, %tmp0 : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=ui32, rows=1, cols=32, v_row=1, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst0 : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     %tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %dst1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f16, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
@@ -22,9 +23,9 @@ module {
   }
 }
 
-// A3: pto.tsort32 ins([[SRC:%.*]], [[IDX:%.*]] : memref<1x32xf16
+// A3: pto.tsort32 ins([[SRC:%.*]], [[IDX:%.*]], [[TMP0:%.*]] : memref<1x32xf16{{.*}}memref<1x32xui32{{.*}}memref<1x64xf16
 // A3: outs([[DST0:%.*]] : memref<1x64xf16
 // A3: pto.tsort32 ins([[SRC]], [[IDX]], [[TMP:%.*]] : memref<1x32xf16{{.*}}memref<1x32xui32{{.*}}memref<1x64xf16
 // A3: outs([[DST1:%.*]] : memref<1x64xf16
-// A3: TSORT32([[VDST0:v[0-9]+]], [[VSRC:v[0-9]+]], [[VIDX:v[0-9]+]]);
+// A3: TSORT32([[VDST0:v[0-9]+]], [[VSRC:v[0-9]+]], [[VIDX:v[0-9]+]], [[VTMP0:v[0-9]+]]);
 // A3: TSORT32([[VDST1:v[0-9]+]], [[VSRC]], [[VIDX]], [[VTMP:v[0-9]+]]);

--- a/test/lit/vpto/expand_tile_op_tilelang_tsort32.pto
+++ b/test/lit/vpto/expand_tile_op_tilelang_tsort32.pto
@@ -16,7 +16,7 @@
 
 // After the full tile-op-expand path on the VPTO backend, the original
 // pto.tsort32 should be lowered to vector-style VPTO IR.
-// CHECK-LABEL: func.func @TSORT32_no_tmp
+// CHECK-LABEL: func.func @TSORT32_aligned_with_tmp
 // CHECK-NOT: pto.tsort32 ins
 // CHECK: pto.vbitsort
 
@@ -25,19 +25,21 @@
 // CHECK: pto.vbitsort
 
 module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
-  // Case 1: aligned cols (valid_cols % 32 == 0), no tmp needed
-  func.func @TSORT32_no_tmp() {
+  // Case 1: aligned cols (valid_cols % 32 == 0), tmp operand is still required
+  func.func @TSORT32_aligned_with_tmp() {
     %src = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf16>
     %idx = pto.alloc_tile : !pto.tile_buf<vec, 1x32xui32>
+    %tmp = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf16>
     %dst = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf16>
 
-    pto.tsort32 ins(%src, %idx : !pto.tile_buf<vec, 1x32xf16>,
-                            !pto.tile_buf<vec, 1x32xui32>)
+    pto.tsort32 ins(%src, %idx, %tmp : !pto.tile_buf<vec, 1x32xf16>,
+                            !pto.tile_buf<vec, 1x32xui32>,
+                            !pto.tile_buf<vec, 1x64xf16>)
                outs(%dst : !pto.tile_buf<vec, 1x64xf16>)
     return
   }
 
-  // Case 2: unaligned cols (valid_cols % 32 != 0), tmp needed
+  // Case 2: unaligned cols (valid_cols % 32 != 0)
   func.func @TSORT32_with_tmp() {
     %src = pto.alloc_tile : !pto.tile_buf<vec, 1x48xf16>
     %idx = pto.alloc_tile : !pto.tile_buf<vec, 1x48xui32>

--- a/test/samples/Ci/ci.py
+++ b/test/samples/Ci/ci.py
@@ -8,7 +8,7 @@
 
 from mlir.ir import Context, Location, Module, InsertionPoint, UnitAttr
 from mlir.dialects import func, arith, pto
-from mlir.ir import IntegerType, IndexType, IntegerAttr, BoolAttr
+from mlir.ir import IntegerType, IndexType, IntegerAttr, BoolAttr, F32Type
 
 
 def build():
@@ -32,6 +32,9 @@ def build():
             cfg = pto.TileBufConfigAttr.get(bl, sl, fractal_ab_size, pd, ctx)
             # TCI only initializes a 1xC row (see pto-isa: TCI loops `i < validCol`).
             tile_buf_1x32 = pto.TileBufType.get([1, 32], i32, vec, [1, 32], cfg, ctx)
+            # TCI requires a scratch tmp tile (Unified-Buffer float on A2/A3).
+            f32 = F32Type.get(ctx)
+            tile_buf_1x128_f32 = pto.TileBufType.get([1, 128], f32, vec, [1, 128], cfg, ctx)
 
             fn_ty = func.FunctionType.get([ptr_i32, i32], [])
             with InsertionPoint(m.body):
@@ -50,8 +53,9 @@ def build():
                 # Output is (1 x 32).
                 tv_dst = pto.MakeTensorViewOp(tv2_i32, arg0, [c1, c32], [c32, c1]).result
                 tb_dst = pto.AllocTileOp(tile_buf_1x32).result
+                tb_tmp = pto.AllocTileOp(tile_buf_1x128_f32).result
 
-                pto.TCIOp(arg1, tb_dst, descending=descending_attr)
+                pto.TCIOp(arg1, tb_tmp, tb_dst, descending=descending_attr)
 
                 sv_dst = pto.PartitionViewOp(tile_view_1x32, tv_dst, offsets=[c0, c0], sizes=[c1, c32]).result
                 pto.TStoreOp(None, tb_dst, sv_dst)

--- a/test/samples/Sort32/sort32.py
+++ b/test/samples/Sort32/sort32.py
@@ -69,9 +69,9 @@ def build():
                 pto.TLoadOp(None, sv0, tb_src)
                 pto.TLoadOp(None, sv2, tb_idx)
 
-                # Exercise the no-tmp form first.
-                pto.TSort32Op(src=tb_src, idx=tb_idx, dst=tb_stage0)
-                # Then exercise the tmp-taking form using the first result as input.
+                # TSORT32 requires explicit scratch.
+                pto.TSort32Op(src=tb_src, idx=tb_idx, dst=tb_stage0, tmp=tb_tmp)
+                # Then exercise the same form using the first result as input.
                 pto.TSort32Op(src=tb_stage0, idx=tb_idx, dst=tb_dst, tmp=tb_tmp)
 
                 pto.TStoreOp(None, tb_dst, sv1)

--- a/test/tilelang_st/npu/a5/src/st/smoke/testcase/tsort32/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/smoke/testcase/tsort32/cases.py
@@ -16,9 +16,7 @@ Each case defines:
   - dtype:       numpy dtype (e.g. np.float32).
   - src_shape:   (rows, cols) — allocated source tile dimensions.
   - idx_shape:   (rows, cols) — allocated index tile dimensions (can be 1 x cols for shared idx).
-  - tmp_shape:   (rows, cols) — allocated tmp tile dimensions (optional, only for unaligned cases).
-                 None for aligned cases (valid_cols % 32 == 0).
-                 For unaligned cases: tmp_rows = 1, tmp_cols = ceil(valid_cols, 32).
+  - tmp_shape:   (rows, cols) — allocated tmp tile dimensions.
   - dst_shape:   (rows, cols) — allocated destination tile dimensions.
                  For f32: dst_cols = src_cols * 4 (buffer allocation, but valid region is src_cols * 2).
                  For f16: dst_cols = src_cols * 2.
@@ -43,13 +41,13 @@ gen_data.py and compare.py both import this list to avoid redundant definitions.
 import numpy as np
 
 CASES = [
-    # f32 cases - basic shapes (aligned, no tmp needed)
+    # f32 cases - basic aligned shapes
     {
         "name": "f32_1x32",
         "dtype": np.float32,
         "src_shape": (1, 32),
         "idx_shape": (1, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (1, 128),      # buffer allocation (src_cols * 4)
         "valid_shape": (1, 32),
         "idx_vshape": (1, 32),
@@ -61,20 +59,20 @@ CASES = [
         "dtype": np.float32,
         "src_shape": (1, 64),
         "idx_shape": (1, 64),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (1, 256),      # buffer allocation (src_cols * 4)
         "valid_shape": (1, 64),
         "idx_vshape": (1, 64),
         "dst_vshape": (1, 128),     # actual valid output: src_cols * stride_coef = 64 * 2
         "eps": 1e-6,
     },
-    # f32 cases - multiple rows (aligned, no tmp needed)
+    # f32 cases - multiple aligned rows
     {
         "name": "f32_2x32",
         "dtype": np.float32,
         "src_shape": (2, 32),
         "idx_shape": (2, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (2, 128),      # buffer allocation (src_cols * 4)
         "valid_shape": (2, 32),
         "idx_vshape": (2, 32),
@@ -86,20 +84,20 @@ CASES = [
         "dtype": np.float32,
         "src_shape": (16, 32),
         "idx_shape": (16, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (16, 128),     # buffer allocation (src_cols * 4)
         "valid_shape": (16, 32),
         "idx_vshape": (16, 32),
         "dst_vshape": (16, 64),     # actual valid output: src_cols * stride_coef = 32 * 2
         "eps": 1e-6,
     },
-    # f32 cases - shared idx (aligned, no tmp needed)
+    # f32 cases - aligned shared idx
     {
         "name": "f32_2x64_shared_idx",
         "dtype": np.float32,
         "src_shape": (2, 64),
         "idx_shape": (1, 64),       # shared idx for all rows
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (2, 256),      # buffer allocation (src_cols * 4)
         "valid_shape": (2, 64),
         "idx_vshape": (1, 64),      # idx_valid_rows = 1 means shared idx
@@ -111,20 +109,20 @@ CASES = [
         "dtype": np.float32,
         "src_shape": (16, 64),
         "idx_shape": (1, 64),       # shared idx for all rows
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (16, 256),     # buffer allocation (src_cols * 4)
         "valid_shape": (16, 64),
         "idx_vshape": (1, 64),      # idx_valid_rows = 1 means shared idx
         "dst_vshape": (16, 128),    # actual valid output: src_cols * stride_coef = 64 * 2
         "eps": 1e-6,
     },
-    # f32 cases - large shape (multiple vbitsort calls, aligned, no tmp needed)
+    # f32 cases - large aligned shape (multiple vbitsort calls)
     {
         "name": "f32_1x8192",
         "dtype": np.float32,
         "src_shape": (1, 8192),     # 256 * 32, requires loop_num > 1
         "idx_shape": (1, 8192),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 8192),
         "dst_shape": (1, 32768),    # buffer allocation (src_cols * 4)
         "valid_shape": (1, 8192),
         "idx_vshape": (1, 8192),
@@ -171,13 +169,13 @@ CASES = [
         "dst_vshape": (2, 4168),       # VALID_C * stride_coef = 2084 * 2
         "eps": 1e-6,
     },
-    # f16 cases - basic shapes (aligned, no tmp needed)
+    # f16 cases - basic aligned shapes
     {
         "name": "f16_1x32",
         "dtype": np.float16,
         "src_shape": (1, 32),
         "idx_shape": (1, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (1, 128),      # buffer allocation (src_cols * 4 for f16)
         "valid_shape": (1, 32),
         "idx_vshape": (1, 32),
@@ -189,7 +187,7 @@ CASES = [
         "dtype": np.float16,
         "src_shape": (4, 64),
         "idx_shape": (4, 64),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (4, 256),      # buffer allocation (src_cols * 4 for f16)
         "valid_shape": (4, 64),
         "idx_vshape": (4, 64),
@@ -197,6 +195,7 @@ CASES = [
         "eps": 1e-3,
     },
 ]
+
 
 _SMOKE_CASE_NAMES = ['f32_2x13', 'f16_1x32']
 _SMOKE_CASE_NAME_SET = set(_SMOKE_CASE_NAMES)

--- a/test/tilelang_st/npu/a5/src/st/smoke/testcase/tsort32/tsort32.pto
+++ b/test/tilelang_st/npu/a5/src/st/smoke/testcase/tsort32/tsort32.pto
@@ -107,6 +107,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf16>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf16>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x128xf16>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x1x32xf16>)
@@ -114,8 +115,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x1x32xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 1x32xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 1x32xf16>,
-                          !pto.tile_buf<vec, 1x32xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 1x32xf16>,
+                          !pto.tile_buf<vec, 1x32xui32>,
+                          !pto.tile_buf<vec, 1x32xf16>)
              outs(%dst_tile : !pto.tile_buf<vec, 1x128xf16>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 1x128xf16>)

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsort32/cases.py
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsort32/cases.py
@@ -16,9 +16,7 @@ Each case defines:
   - dtype:       numpy dtype (e.g. np.float32).
   - src_shape:   (rows, cols) — allocated source tile dimensions.
   - idx_shape:   (rows, cols) — allocated index tile dimensions (can be 1 x cols for shared idx).
-  - tmp_shape:   (rows, cols) — allocated tmp tile dimensions (optional, only for unaligned cases).
-                 None for aligned cases (valid_cols % 32 == 0).
-                 For unaligned cases: tmp_rows = 1, tmp_cols = ceil(valid_cols, 32).
+  - tmp_shape:   (rows, cols) — allocated tmp tile dimensions.
   - dst_shape:   (rows, cols) — allocated destination tile dimensions.
                  For f32: dst_cols = src_cols * 4 (buffer allocation, but valid region is src_cols * 2).
                  For f16: dst_cols = src_cols * 2.
@@ -43,13 +41,13 @@ gen_data.py and compare.py both import this list to avoid redundant definitions.
 import numpy as np
 
 CASES = [
-    # f32 cases - basic shapes (aligned, no tmp needed)
+    # f32 cases - basic aligned shapes
     {
         "name": "f32_1x32",
         "dtype": np.float32,
         "src_shape": (1, 32),
         "idx_shape": (1, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (1, 128),      # buffer allocation (src_cols * 4)
         "valid_shape": (1, 32),
         "idx_vshape": (1, 32),
@@ -61,20 +59,20 @@ CASES = [
         "dtype": np.float32,
         "src_shape": (1, 64),
         "idx_shape": (1, 64),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (1, 256),      # buffer allocation (src_cols * 4)
         "valid_shape": (1, 64),
         "idx_vshape": (1, 64),
         "dst_vshape": (1, 128),     # actual valid output: src_cols * stride_coef = 64 * 2
         "eps": 1e-6,
     },
-    # f32 cases - multiple rows (aligned, no tmp needed)
+    # f32 cases - multiple aligned rows
     {
         "name": "f32_2x32",
         "dtype": np.float32,
         "src_shape": (2, 32),
         "idx_shape": (2, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (2, 128),      # buffer allocation (src_cols * 4)
         "valid_shape": (2, 32),
         "idx_vshape": (2, 32),
@@ -86,20 +84,20 @@ CASES = [
         "dtype": np.float32,
         "src_shape": (16, 32),
         "idx_shape": (16, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (16, 128),     # buffer allocation (src_cols * 4)
         "valid_shape": (16, 32),
         "idx_vshape": (16, 32),
         "dst_vshape": (16, 64),     # actual valid output: src_cols * stride_coef = 32 * 2
         "eps": 1e-6,
     },
-    # f32 cases - shared idx (aligned, no tmp needed)
+    # f32 cases - aligned shared idx
     {
         "name": "f32_2x64_shared_idx",
         "dtype": np.float32,
         "src_shape": (2, 64),
         "idx_shape": (1, 64),       # shared idx for all rows
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (2, 256),      # buffer allocation (src_cols * 4)
         "valid_shape": (2, 64),
         "idx_vshape": (1, 64),      # idx_valid_rows = 1 means shared idx
@@ -111,20 +109,20 @@ CASES = [
         "dtype": np.float32,
         "src_shape": (16, 64),
         "idx_shape": (1, 64),       # shared idx for all rows
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (16, 256),     # buffer allocation (src_cols * 4)
         "valid_shape": (16, 64),
         "idx_vshape": (1, 64),      # idx_valid_rows = 1 means shared idx
         "dst_vshape": (16, 128),    # actual valid output: src_cols * stride_coef = 64 * 2
         "eps": 1e-6,
     },
-    # f32 cases - large shape (multiple vbitsort calls, aligned, no tmp needed)
+    # f32 cases - large aligned shape (multiple vbitsort calls)
     {
         "name": "f32_1x8192",
         "dtype": np.float32,
         "src_shape": (1, 8192),     # 256 * 32, requires loop_num > 1
         "idx_shape": (1, 8192),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 8192),
         "dst_shape": (1, 32768),    # buffer allocation (src_cols * 4)
         "valid_shape": (1, 8192),
         "idx_vshape": (1, 8192),
@@ -171,13 +169,13 @@ CASES = [
         "dst_vshape": (2, 4168),       # VALID_C * stride_coef = 2084 * 2
         "eps": 1e-6,
     },
-    # f16 cases - basic shapes (aligned, no tmp needed)
+    # f16 cases - basic aligned shapes
     {
         "name": "f16_1x32",
         "dtype": np.float16,
         "src_shape": (1, 32),
         "idx_shape": (1, 32),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 32),
         "dst_shape": (1, 128),      # buffer allocation (src_cols * 4 for f16)
         "valid_shape": (1, 32),
         "idx_vshape": (1, 32),
@@ -189,7 +187,7 @@ CASES = [
         "dtype": np.float16,
         "src_shape": (4, 64),
         "idx_shape": (4, 64),
-        "tmp_shape": None,          # aligned: valid_cols % 32 == 0, no tmp
+        "tmp_shape": (1, 64),
         "dst_shape": (4, 256),      # buffer allocation (src_cols * 4 for f16)
         "valid_shape": (4, 64),
         "idx_vshape": (4, 64),

--- a/test/tilelang_st/npu/a5/src/st/testcase/tsort32/tsort32.pto
+++ b/test/tilelang_st/npu/a5/src/st/testcase/tsort32/tsort32.pto
@@ -47,6 +47,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf32>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf32>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x128xf32>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x1x32xf32>)
@@ -54,8 +55,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x1x32xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 1x32xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 1x32xf32>,
-                          !pto.tile_buf<vec, 1x32xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 1x32xf32>,
+                          !pto.tile_buf<vec, 1x32xui32>,
+                          !pto.tile_buf<vec, 1x32xf32>)
              outs(%dst_tile : !pto.tile_buf<vec, 1x128xf32>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 1x128xf32>)
@@ -98,6 +100,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x256xf32>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x1x64xf32>)
@@ -105,8 +108,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x1x64xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 1x64xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 1x64xf32>,
-                          !pto.tile_buf<vec, 1x64xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 1x64xf32>,
+                          !pto.tile_buf<vec, 1x64xui32>,
+                          !pto.tile_buf<vec, 1x64xf32>)
              outs(%dst_tile : !pto.tile_buf<vec, 1x256xf32>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 1x256xf32>)
@@ -152,6 +156,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 16x32xf32>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 16x32xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf32>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 16x128xf32>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x32xf32>)
@@ -159,8 +164,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x16x32xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 16x32xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 16x32xf32>,
-                          !pto.tile_buf<vec, 16x32xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 16x32xf32>,
+                          !pto.tile_buf<vec, 16x32xui32>,
+                          !pto.tile_buf<vec, 1x32xf32>)
              outs(%dst_tile : !pto.tile_buf<vec, 16x128xf32>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 16x128xf32>)
@@ -206,6 +212,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 16x64xf32>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 16x256xf32>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x16x64xf32>)
@@ -213,8 +220,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x1x64xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 1x64xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 16x64xf32>,
-                          !pto.tile_buf<vec, 1x64xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 16x64xf32>,
+                          !pto.tile_buf<vec, 1x64xui32>,
+                          !pto.tile_buf<vec, 1x64xf32>)
              outs(%dst_tile : !pto.tile_buf<vec, 16x256xf32>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 16x256xf32>)
@@ -260,6 +268,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 2x32xf32>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 2x32xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf32>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 2x128xf32>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x2x32xf32>)
@@ -267,8 +276,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x2x32xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 2x32xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 2x32xf32>,
-                          !pto.tile_buf<vec, 2x32xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 2x32xf32>,
+                          !pto.tile_buf<vec, 2x32xui32>,
+                          !pto.tile_buf<vec, 1x32xf32>)
              outs(%dst_tile : !pto.tile_buf<vec, 2x128xf32>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 2x128xf32>)
@@ -314,6 +324,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 2x64xf32>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf32>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 2x256xf32>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x2x64xf32>)
@@ -321,8 +332,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x1x64xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 1x64xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 2x64xf32>,
-                          !pto.tile_buf<vec, 1x64xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 2x64xf32>,
+                          !pto.tile_buf<vec, 1x64xui32>,
+                          !pto.tile_buf<vec, 1x64xf32>)
              outs(%dst_tile : !pto.tile_buf<vec, 2x256xf32>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 2x256xf32>)
@@ -365,6 +377,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x8192xf32>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x8192xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x8192xf32>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32768xf32>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x1x8192xf32>)
@@ -372,8 +385,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x1x8192xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 1x8192xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 1x8192xf32>,
-                          !pto.tile_buf<vec, 1x8192xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 1x8192xf32>,
+                          !pto.tile_buf<vec, 1x8192xui32>,
+                          !pto.tile_buf<vec, 1x8192xf32>)
              outs(%dst_tile : !pto.tile_buf<vec, 1x32768xf32>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 1x32768xf32>)
@@ -416,6 +430,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf16>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x32xf16>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x128xf16>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x1x32xf16>)
@@ -423,8 +438,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x1x32xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 1x32xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 1x32xf16>,
-                          !pto.tile_buf<vec, 1x32xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 1x32xf16>,
+                          !pto.tile_buf<vec, 1x32xui32>,
+                          !pto.tile_buf<vec, 1x32xf16>)
              outs(%dst_tile : !pto.tile_buf<vec, 1x128xf16>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 1x128xf16>)
@@ -469,6 +485,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     %src_tile = pto.alloc_tile : !pto.tile_buf<vec, 4x64xf16>
     %idx_tile = pto.alloc_tile : !pto.tile_buf<vec, 4x64xui32>
+    %tmp_tile = pto.alloc_tile : !pto.tile_buf<vec, 1x64xf16>
     %dst_tile = pto.alloc_tile : !pto.tile_buf<vec, 4x256xf16>
 
     pto.tload ins(%src_part : !pto.partition_tensor_view<1x1x1x4x64xf16>)
@@ -476,8 +493,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.tload ins(%idx_part : !pto.partition_tensor_view<1x1x1x4x64xui32>)
               outs(%idx_tile : !pto.tile_buf<vec, 4x64xui32>)
 
-    pto.tsort32 ins(%src_tile, %idx_tile : !pto.tile_buf<vec, 4x64xf16>,
-                          !pto.tile_buf<vec, 4x64xui32>)
+    pto.tsort32 ins(%src_tile, %idx_tile, %tmp_tile : !pto.tile_buf<vec, 4x64xf16>,
+                          !pto.tile_buf<vec, 4x64xui32>,
+                          !pto.tile_buf<vec, 1x64xf16>)
              outs(%dst_tile : !pto.tile_buf<vec, 4x256xf16>)
 
     pto.tstore ins(%dst_tile : !pto.tile_buf<vec, 4x256xf16>)

--- a/tools/ptobc/src/mlir_encode.cpp
+++ b/tools/ptobc/src/mlir_encode.cpp
@@ -70,6 +70,8 @@ static bool shouldEncodeViaGenericV0CompatibilityShim(mlir::Operation &op) {
   // pto.tci / pto.trowexpandadd forms without tmp. Newer tmp-operand forms
   // must not reuse those schemas or older .ptobc files would become
   // undecodable, so serialize the new forms through the generic v0 opcode.
+  // pto.tci's tmp operand is now mandatory, so every TCI routes here; the
+  // legacy 0x100D 2-operand schema is only kept for decoding old .ptobc files.
   if (auto tci = llvm::dyn_cast<mlir::pto::TCIOp>(&op))
     return static_cast<bool>(tci.getTmp());
   if (auto trowexpandadd = llvm::dyn_cast<mlir::pto::TRowExpandAddOp>(&op))


### PR DESCRIPTION
Add an optional `tmp` scratch operand to `pto.tcvt` and lower it to the pto-isa `TCVT(dst, src, tmp, mode, satMode)` tmp-buffer overload, instead of only the non-tmp `TCVT(dst, src, mode, satMode)`. The tmp constraints mirror pto-isa: on A2/A3 it is consumed as a Unified-Buffer int32 scratch, on A5 it is accepted for interface compatibility and ignored. Omitting tmp keeps the existing non-tmp overload (backward compatible).

- PTOOps.td: add `Optional<PTODpsType>:$tmp` to TCvtOp (between src and dst)
- PTO.cpp: tmp-aware print/parse, verify (verifyTileBufCommon), and read+write memory effects for tmp
- PTOToEmitC.cpp: two-way dispatch via createLastUseAwareOpaqueCall, with operands {dst, src, tmp, rmode, satMode} when tmp is present
- PTOViewToMemref.cpp: forward optional tmp in the view->memref build site
- PTO_IR_manual.md: document the tmp operand, constraints, and example
- tcvt_emitc.pto: add A3/A5 tmp test case verifying the 5-arg TCVT call