### PR TITLE
fix(emitc): preserve private helper static linkage

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -3296,6 +3296,9 @@ struct FuncToEmitC : public OpConversionPattern<func::FuncOp> {
     if (pto::isPTOEntryFunction(op)) {
       emitcFunc.setSpecifiersAttr(
           rewriter.getStrArrayAttr({"extern \"C\"", "__global__ AICORE"}));
+    } else if (op.isPrivate()) {
+      emitcFunc.setSpecifiersAttr(
+          rewriter.getStrArrayAttr({"static", "AICORE"}));
     } else if (pto::hasExternalArtifactVisibility(op)) {
       emitcFunc.setSpecifiersAttr(
           rewriter.getStrArrayAttr({"extern \"C\"", "AICORE"}));

--- a/test/lit/pto/emitc_private_helper_static_linkage.pto
+++ b/test/lit/pto/emitc_private_helper_static_linkage.pto
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas %s --enable-insert-sync --pto-level=level3 --pto-arch a3 | FileCheck %s
+// Guards issue #884: MLIR private function visibility must lower to C++ static
+// linkage, otherwise same-named private helpers collide across object files.
+
+module {
+  func.func @k(%arg0: !pto.ptr<i64>, %arg1: index) attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %0 = func.call @my_helper(%arg1) : (index) -> index
+    func.return
+  }
+
+  func.func private @my_helper(%x: index) -> index {
+    %c = arith.constant 1 : index
+    %r = arith.addi %x, %c : index
+    return %r : index
+  }
+}
+
+// CHECK-LABEL: static AICORE int64_t my_helper(
+// CHECK-LABEL: AICORE void k(
+// CHECK: my_helper(


### PR DESCRIPTION
## Summary
- restore `static AICORE` emission for `func.func private` helpers in EmitC lowering
- add a regression test for issue #884 covering private helper static linkage
- keep explicit `pto.visibility = "external"` handling for public helper C linkage unchanged

## Validation
- `build/tools/ptoas/ptoas test/lit/pto/emitc_private_helper_static_linkage.pto --enable-insert-sync --pto-level=level3 --pto-arch a3 | /home/zhangzhendong/ptoas-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/emitc_private_helper_static_linkage.pto`
- `build/tools/ptoas/ptoas test/lit/pto/emitc_public_helper_c_linkage.pto | /home/zhangzhendong/ptoas-workspace/llvm-project/build-shared/bin/FileCheck test/lit/pto/emitc_public_helper_c_linkage.pto`

Closes #884
