### PR TITLE
Keep CMake 4 FetchContent compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,37 @@ jobs:
             llvm-project/llvm/build-assert
           key: llvm-${{ runner.os }}-clang${{ env.PTOAS_CLANG_MAJOR }}-${{ env.LLVM_SOURCE_SHA }}-${{ env.LLVM_CACHE_FLAVOR }}
 
+      - name: Validate strict CMake 4 configure
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmake4_pkg="${RUNNER_TEMP:-${GITHUB_WORKSPACE}/.tmp}/cmake-4.1.3-pkg"
+          cmake4_build="${RUNNER_TEMP:-${GITHUB_WORKSPACE}/.tmp}/ptoas-cmake4-strict"
+          rm -rf "${cmake4_pkg}" "${cmake4_build}"
+          python3 -m pip install --target "${cmake4_pkg}" "cmake==4.1.3"
+          cmake4_bin="$(
+            PYTHONPATH="${cmake4_pkg}" python3 -c 'import cmake; from pathlib import Path; print(Path(cmake.__file__).resolve().parent / "data" / "bin" / "cmake")'
+          )"
+          "${cmake4_bin}" --version
+          "${cmake4_bin}" -C "${GITHUB_WORKSPACE}/cmake/LinuxHardeningCache.cmake" \
+            -G Ninja \
+            -S "${GITHUB_WORKSPACE}" \
+            -B "${cmake4_build}" \
+            -DLLVM_DIR="${LLVM_DIR}/lib/cmake/llvm" \
+            -DMLIR_DIR="${LLVM_DIR}/lib/cmake/mlir" \
+            -DPython3_EXECUTABLE="$(command -v python3)" \
+            -DPython3_FIND_STRATEGY=LOCATION \
+            -Dpybind11_DIR="$(python3 -m pybind11 --cmakedir)" \
+            -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+            -DMLIR_PYTHON_PACKAGE_DIR="${MLIR_PYTHONPATH}" \
+            -DPTO_ENABLE_PYTHON_BINDING=ON \
+            -DPTOAS_VALIDATE_CMAKE4_FETCHCONTENT_COMPAT=ON \
+            -DPTOAS_ENABLE_WERROR=OFF \
+            -DBUILD_TESTING=ON \
+            -DCMAKE_C_COMPILER="${PTOAS_CMAKE_C_COMPILER}" \
+            -DCMAKE_CXX_COMPILER="${PTOAS_CMAKE_CXX_COMPILER}" \
+            -Werror=dev
+
       - name: Build PTOAS
         run: |
           rm -rf "${PTO_BUILD_DIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,17 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 
 cmake_minimum_required(VERSION 3.20.0)
+
+# CANN/Ascend CMake packages used by downstream PTOAS builds may still use the
+# pre-CMake-3.30 FetchContent_Populate(<declared-name>) pattern. Keep that
+# compatibility path enabled so CMake 4.x developer warnings do not become
+# configure errors when users build with strict warning settings. The default
+# covers nested third-party directories that set their own cmake_minimum_required().
+if(POLICY CMP0169)
+  cmake_policy(SET CMP0169 OLD)
+  set(CMAKE_POLICY_DEFAULT_CMP0169 OLD)
+endif()
+
 project(ptoas VERSION 0.49)
 
 set(PTOAS_RELEASE_VERSION_OVERRIDE ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,28 @@ endif()
 
 project(ptoas VERSION 0.49)
 
+option(PTOAS_VALIDATE_CMAKE4_FETCHCONTENT_COMPAT
+       "Validate CMake 4 compatibility for legacy FetchContent users" OFF)
+if(PTOAS_VALIDATE_CMAKE4_FETCHCONTENT_COMPAT)
+  set(_ptoas_cmp0169_check_dir "${CMAKE_BINARY_DIR}/cmake-cmp0169-compat")
+  file(MAKE_DIRECTORY "${_ptoas_cmp0169_check_dir}/nested/cann-cmake")
+  file(WRITE "${_ptoas_cmp0169_check_dir}/nested/cann-cmake/CMakeLists.txt"
+       "cmake_minimum_required(VERSION 3.20)\n"
+       "project(ptoas_cmp0169_cann_cmake_fixture NONE)\n")
+  file(WRITE "${_ptoas_cmp0169_check_dir}/nested/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.20)
+project(ptoas_cmp0169_nested_fixture NONE)
+include(FetchContent)
+FetchContent_Declare(cann-cmake SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/cann-cmake")
+FetchContent_GetProperties(cann-cmake)
+if(NOT cann-cmake_POPULATED)
+  FetchContent_Populate(cann-cmake)
+endif()
+]=])
+  add_subdirectory("${_ptoas_cmp0169_check_dir}/nested"
+                   "${_ptoas_cmp0169_check_dir}/nested-build")
+endif()
+
 set(PTOAS_RELEASE_VERSION_OVERRIDE ""
     CACHE STRING "Override the version printed by ptoas --version")
 set(PTOAS_EXACT_GIT_TAG_VERSION "")


### PR DESCRIPTION
## Summary
- keep CMP0169 on the old compatibility path for PTOAS builds using CMake 3.30+
- set CMAKE_POLICY_DEFAULT_CMP0169 so nested third-party CMake directories inherit the same compatibility default
- avoid CMake 4.x strict developer-warning builds failing on legacy CANN/Ascend FetchContent_Populate(<declared-name>) usage

## Validation
- dev: installed isolated CMake 4.1.3 and reproduced the strict-warning failure with a minimal FetchContent_Populate(cann-cmake) fixture
- dev: verified the same fixture configures after applying the PTOAS policy snippet
- dev: configured PTOAS with CMake 4.1.3 and built `ninja -C build-cmake41 ptoas`; `ptoas --version` reported `ptoas 0.48`
- dev: configured PTOAS with CMake 3.20.2 and built `ninja -C build-cmake320 ptoas`; `ptoas --version` reported `ptoas 0.48`
- local macOS: configured PTOAS with CMake 4.x and `-Werror=dev`
