### PR TITLE
Support low-precision VPTO vlogic lowering

### DIFF
--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -5283,7 +5283,8 @@ LogicalResult VreluOp::verify() {
 LogicalResult VnotOp::verify() { return verifyUnaryVecOp(*this); }
 
 template <typename BinaryOp>
-static LogicalResult verifyBinaryVecOp(BinaryOp op) {
+static LogicalResult verifyBinaryVecOp(BinaryOp op,
+                                       bool allowLowPrecision = false) {
   if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")))
     return failure();
   if (failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")))
@@ -5292,7 +5293,8 @@ static LogicalResult verifyBinaryVecOp(BinaryOp op) {
     return failure();
   if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
     return failure();
-  if (failed(verifyNonLowPrecisionVRegElementTypeLike(
+  if (!allowLowPrecision &&
+      failed(verifyNonLowPrecisionVRegElementTypeLike(
           op.getOperation(), op.getLhs().getType(), "lhs type")))
     return failure();
   if (op.getLhs().getType() != op.getRhs().getType() ||
@@ -5305,9 +5307,15 @@ LogicalResult VaddOp::verify() { return verifyBinaryVecOp(*this); }
 LogicalResult VsubOp::verify() { return verifyBinaryVecOp(*this); }
 LogicalResult VmulOp::verify() { return verifyBinaryVecOp(*this); }
 LogicalResult VdivOp::verify() { return verifyBinaryVecOp(*this); }
-LogicalResult VandOp::verify() { return verifyBinaryVecOp(*this); }
-LogicalResult VorOp::verify() { return verifyBinaryVecOp(*this); }
-LogicalResult VxorOp::verify() { return verifyBinaryVecOp(*this); }
+LogicalResult VandOp::verify() {
+  return verifyBinaryVecOp(*this, /*allowLowPrecision=*/true);
+}
+LogicalResult VorOp::verify() {
+  return verifyBinaryVecOp(*this, /*allowLowPrecision=*/true);
+}
+LogicalResult VxorOp::verify() {
+  return verifyBinaryVecOp(*this, /*allowLowPrecision=*/true);
+}
 
 template <typename TernaryOp>
 static LogicalResult verifyTernaryVecOp(TernaryOp op) {

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -552,6 +552,43 @@ getLowpPayloadABI(Type elementType, MLIRContext *context) {
   return LowpPayloadABI{IntegerType::get(context, 8), "u8"};
 }
 
+static std::string getDirectLowpVLogicElementFragment(Type type) {
+  if (pto::isPTOFloat8E4M3LikeType(type))
+    return "fp8e4m3";
+  if (pto::isPTOFloat8E5M2LikeType(type))
+    return "fp8e5m2";
+  return {};
+}
+
+static FailureOr<StringRef>
+buildDirectLowpVLogicCallee(MLIRContext *context, Type vectorType,
+                            StringRef stem, StringRef mode) {
+  Type elementType = getElementTypeFromVectorLike(vectorType);
+  auto lanes = getElementCountFromVectorLike(vectorType);
+  std::string elem = getDirectLowpVLogicElementFragment(elementType);
+  if (elem.empty() || !lanes)
+    return failure();
+  return StringAttr::get(context, "llvm.hivm." + stem.str() + "." +
+                                      mode.str() + ".v" +
+                                      std::to_string(*lanes) + elem)
+      .getValue();
+}
+
+static FailureOr<StringRef>
+buildLowpPayloadVLogicCallee(MLIRContext *context, Type vectorType,
+                             StringRef stem, StringRef mode) {
+  Type elementType = getElementTypeFromVectorLike(vectorType);
+  auto lanes = getElementCountFromVectorLike(vectorType);
+  std::optional<LowpPayloadABI> abi = getLowpPayloadABI(elementType, context);
+  if (!abi || !lanes)
+    return failure();
+  return StringAttr::get(context, "llvm.hivm." + stem.str() + "." +
+                                      mode.str() + ".v" +
+                                      std::to_string(*lanes) +
+                                      abi->intrinsicElementFragment.str())
+      .getValue();
+}
+
 static Type getLowpPayloadCarrierType(Type vectorLikeType,
                                       MLIRContext *context) {
   Type elementType = getElementTypeFromVectorLike(vectorLikeType);
@@ -4322,15 +4359,6 @@ public:
   matchAndRewrite(BinaryOp op, typename BinaryOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     StringRef stem = getBinaryMaskedStem<BinaryOp>();
-    FailureOr<StringRef> calleeName =
-        usesSignedBinaryCANN900Callee<BinaryOp>()
-            ? buildCANN900SignedModeTypedCallee(
-                  op.getContext(), op.getResult().getType(), stem, "x")
-            : buildCANN900ModeTypedCallee(op.getContext(),
-                                          op.getResult().getType(), stem, "x");
-    if (failed(calleeName))
-      return rewriter.notifyMatchFailure(op, "unsupported binary VPTO signature");
-
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
@@ -4348,12 +4376,51 @@ public:
           op, "unexpected converted binary VPTO operand types");
     }
 
+    Type callResultType = resultType;
+    Value callLhs = lhs;
+    Value callRhs = rhs;
+    FailureOr<StringRef> calleeName =
+        usesSignedBinaryCANN900Callee<BinaryOp>()
+            ? buildCANN900SignedModeTypedCallee(
+                  op.getContext(), op.getResult().getType(), stem, "x")
+            : buildCANN900ModeTypedCallee(op.getContext(),
+                                          op.getResult().getType(), stem, "x");
+
+    if constexpr (std::is_same_v<BinaryOp, pto::VandOp> ||
+                  std::is_same_v<BinaryOp, pto::VorOp> ||
+                  std::is_same_v<BinaryOp, pto::VxorOp>) {
+      Type elementType = getElementTypeFromVectorLike(op.getResult().getType());
+      if (elementType && pto::isPTOLowPrecisionType(elementType)) {
+        calleeName = buildDirectLowpVLogicCallee(
+            op.getContext(), op.getResult().getType(), stem, "x");
+        if (failed(calleeName)) {
+          Type carrierType = getLowpPayloadCarrierType(
+              op.getResult().getType(), rewriter.getContext());
+          if (!carrierType)
+            return rewriter.notifyMatchFailure(
+                op, "unsupported low-precision binary payload ABI");
+          callResultType = carrierType;
+          callLhs = castToPayloadABI(op.getLoc(), lhs,
+                                     op.getResult().getType(), rewriter);
+          callRhs = castToPayloadABI(op.getLoc(), rhs,
+                                     op.getResult().getType(), rewriter);
+          calleeName = buildLowpPayloadVLogicCallee(
+              op.getContext(), op.getResult().getType(), stem, "x");
+        }
+      }
+    }
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported binary VPTO signature");
+
     auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
-                                              TypeRange{resultType},
-                                              ValueRange{lhs, rhs, mask});
+                                              TypeRange{callResultType},
+                                              ValueRange{callLhs, callRhs, mask});
     state.plannedDecls.push_back(
         PlannedDecl{calleeName->str(), call.getCalleeType()});
-    rewriter.replaceOp(op, call.getResults());
+    Value result = castFromPayloadABI(op.getLoc(), call.getResult(0),
+                                      op.getResult().getType(), resultType,
+                                      rewriter);
+    rewriter.replaceOp(op, result);
     return success();
   }
 

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -507,6 +507,43 @@ getLowpPayloadABI(Type elementType, MLIRContext *context) {
   return LowpPayloadABI{IntegerType::get(context, 8), "u8"};
 }
 
+static std::string getDirectLowpVLogicElementFragment(Type type) {
+  if (pto::isPTOFloat8E4M3LikeType(type))
+    return "fp8e4m3";
+  if (pto::isPTOFloat8E5M2LikeType(type))
+    return "fp8e5m2";
+  return {};
+}
+
+static FailureOr<StringRef>
+buildDirectLowpVLogicCallee(MLIRContext *context, Type vectorType,
+                            StringRef stem, StringRef mode) {
+  Type elementType = getElementTypeFromVectorLike(vectorType);
+  auto lanes = getElementCountFromVectorLike(vectorType);
+  std::string elem = getDirectLowpVLogicElementFragment(elementType);
+  if (elem.empty() || !lanes)
+    return failure();
+  return StringAttr::get(context, "llvm.hivm." + stem.str() + "." +
+                                      mode.str() + ".v" +
+                                      std::to_string(*lanes) + elem)
+      .getValue();
+}
+
+static FailureOr<StringRef>
+buildLowpPayloadVLogicCallee(MLIRContext *context, Type vectorType,
+                             StringRef stem, StringRef mode) {
+  Type elementType = getElementTypeFromVectorLike(vectorType);
+  auto lanes = getElementCountFromVectorLike(vectorType);
+  std::optional<LowpPayloadABI> abi = getLowpPayloadABI(elementType, context);
+  if (!abi || !lanes)
+    return failure();
+  return StringAttr::get(context, "llvm.hivm." + stem.str() + ".v" +
+                                      std::to_string(*lanes) +
+                                      abi->intrinsicElementFragment.str() +
+                                      "." + mode.str())
+      .getValue();
+}
+
 static Type getLowpPayloadCarrierType(Type vectorLikeType,
                                       MLIRContext *context) {
   Type elementType = getElementTypeFromVectorLike(vectorLikeType);
@@ -4264,11 +4301,6 @@ public:
   matchAndRewrite(BinaryOp op, typename BinaryOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     StringRef stem = getBinaryMaskedStem<BinaryOp>();
-    FailureOr<StringRef> calleeName =
-        buildLaneTypedCallee(op.getContext(), op.getResult().getType(), stem, ".x");
-    if (failed(calleeName))
-      return rewriter.notifyMatchFailure(op, "unsupported binary VPTO signature");
-
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
@@ -4286,12 +4318,47 @@ public:
           op, "unexpected converted binary VPTO operand types");
     }
 
+    Type callResultType = resultType;
+    Value callLhs = lhs;
+    Value callRhs = rhs;
+    FailureOr<StringRef> calleeName =
+        buildLaneTypedCallee(op.getContext(), op.getResult().getType(), stem, ".x");
+
+    if constexpr (std::is_same_v<BinaryOp, pto::VandOp> ||
+                  std::is_same_v<BinaryOp, pto::VorOp> ||
+                  std::is_same_v<BinaryOp, pto::VxorOp>) {
+      Type elementType = getElementTypeFromVectorLike(op.getResult().getType());
+      if (elementType && pto::isPTOLowPrecisionType(elementType)) {
+        calleeName = buildDirectLowpVLogicCallee(
+            op.getContext(), op.getResult().getType(), stem, "x");
+        if (failed(calleeName)) {
+          Type carrierType = getLowpPayloadCarrierType(
+              op.getResult().getType(), rewriter.getContext());
+          if (!carrierType)
+            return rewriter.notifyMatchFailure(
+                op, "unsupported low-precision binary payload ABI");
+          callResultType = carrierType;
+          callLhs = castToPayloadABI(op.getLoc(), lhs,
+                                     op.getResult().getType(), rewriter);
+          callRhs = castToPayloadABI(op.getLoc(), rhs,
+                                     op.getResult().getType(), rewriter);
+          calleeName = buildLowpPayloadVLogicCallee(
+              op.getContext(), op.getResult().getType(), stem, "x");
+        }
+      }
+    }
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported binary VPTO signature");
+
     auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
-                                              TypeRange{resultType},
-                                              ValueRange{lhs, rhs, mask});
+                                              TypeRange{callResultType},
+                                              ValueRange{callLhs, callRhs, mask});
     state.plannedDecls.push_back(
         PlannedDecl{calleeName->str(), call.getCalleeType()});
-    rewriter.replaceOp(op, call.getResults());
+    Value result = castFromPayloadABI(op.getLoc(), call.getResult(0),
+                                      op.getResult().getType(), resultType,
+                                      rewriter);
+    rewriter.replaceOp(op, result);
     return success();
   }
 

--- a/test/lit/vpto/vlogic_low_precision_vpto_llvm.pto
+++ b/test/lit/vpto/vlogic_low_precision_vpto_llvm.pto
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vand_lowp_direct(%lhs_ptr: !pto.ptr<f8E4M3FN, ub>,
+                              %rhs_ptr: !pto.ptr<f8E4M3FN, ub>,
+                              %dst_ptr: !pto.ptr<f8E4M3FN, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %lhs = pto.vlds %lhs_ptr[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %rhs = pto.vlds %rhs_ptr[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %out = pto.vand %lhs, %rhs, %mask : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      pto.vsts %out, %dst_ptr[%c0], %mask : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
+    }
+    return
+  }
+
+  func.func @vor_lowp_direct(%lhs_ptr: !pto.ptr<f8E4M3FN, ub>,
+                             %rhs_ptr: !pto.ptr<f8E4M3FN, ub>,
+                             %dst_ptr: !pto.ptr<f8E4M3FN, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %lhs = pto.vlds %lhs_ptr[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %rhs = pto.vlds %rhs_ptr[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %out = pto.vor %lhs, %rhs, %mask : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      pto.vsts %out, %dst_ptr[%c0], %mask : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
+    }
+    return
+  }
+
+  func.func @vxor_lowp_direct(%lhs_ptr: !pto.ptr<f8E4M3FN, ub>,
+                              %rhs_ptr: !pto.ptr<f8E4M3FN, ub>,
+                              %dst_ptr: !pto.ptr<f8E4M3FN, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %lhs = pto.vlds %lhs_ptr[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %rhs = pto.vlds %rhs_ptr[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %out = pto.vxor %lhs, %rhs, %mask : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      pto.vsts %out, %dst_ptr[%c0], %mask : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
+    }
+    return
+  }
+
+  func.func @vlogic_lowp_payload(%lhs_ptr: !pto.ptr<!pto.hif8, ub>,
+                                 %rhs_ptr: !pto.ptr<!pto.hif8, ub>,
+                                 %dst_ptr: !pto.ptr<!pto.hif8, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %lhs = pto.vlds %lhs_ptr[%c0] : !pto.ptr<!pto.hif8, ub> -> !pto.vreg<256x!pto.hif8>
+      %rhs = pto.vlds %rhs_ptr[%c0] : !pto.ptr<!pto.hif8, ub> -> !pto.vreg<256x!pto.hif8>
+      %and = pto.vand %lhs, %rhs, %mask : !pto.vreg<256x!pto.hif8>, !pto.vreg<256x!pto.hif8>, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      %or = pto.vor %and, %rhs, %mask : !pto.vreg<256x!pto.hif8>, !pto.vreg<256x!pto.hif8>, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      %xor = pto.vxor %or, %lhs, %mask : !pto.vreg<256x!pto.hif8>, !pto.vreg<256x!pto.hif8>, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      pto.vsts %xor, %dst_ptr[%c0], %mask : !pto.vreg<256x!pto.hif8>, !pto.ptr<!pto.hif8, ub>, !pto.mask<b8>
+    }
+    return
+  }
+}
+
+// CHECK-DAG: declare <256 x float8e4m3> @llvm.hivm.vand.x.v256fp8e4m3(<256 x float8e4m3>, <256 x float8e4m3>, <256 x i1>)
+// CHECK-DAG: declare <256 x float8e4m3> @llvm.hivm.vor.x.v256fp8e4m3(<256 x float8e4m3>, <256 x float8e4m3>, <256 x i1>)
+// CHECK-DAG: declare <256 x float8e4m3> @llvm.hivm.vxor.x.v256fp8e4m3(<256 x float8e4m3>, <256 x float8e4m3>, <256 x i1>)
+// CHECK-DAG: declare <256 x i8> @llvm.hivm.vand.v256u8.x(<256 x i8>, <256 x i8>, <256 x i1>)
+// CHECK-DAG: declare <256 x i8> @llvm.hivm.vor.v256u8.x(<256 x i8>, <256 x i8>, <256 x i1>)
+// CHECK-DAG: declare <256 x i8> @llvm.hivm.vxor.v256u8.x(<256 x i8>, <256 x i8>, <256 x i1>)
+// CHECK-LABEL: define void @vand_lowp_direct_mix_aiv
+// CHECK: call <256 x float8e4m3> @llvm.hivm.vand.x.v256fp8e4m3
+// CHECK-LABEL: define void @vor_lowp_direct_mix_aiv
+// CHECK: call <256 x float8e4m3> @llvm.hivm.vor.x.v256fp8e4m3
+// CHECK-LABEL: define void @vxor_lowp_direct_mix_aiv
+// CHECK: call <256 x float8e4m3> @llvm.hivm.vxor.x.v256fp8e4m3
+// CHECK-LABEL: define void @vlogic_lowp_payload_mix_aiv
+// CHECK: call <256 x i8> @llvm.hivm.vand.v256u8.x
+// CHECK: call <256 x i8> @llvm.hivm.vor.v256u8.x
+// CHECK: call <256 x i8> @llvm.hivm.vxor.v256u8.x
+// CHECK: bitcast <256 x i8> {{.*}} to <256 x hifloat8>

--- a/test/vpto/cases/micro-op/binary-vector/vand/compare.py
+++ b/test/vpto/cases/micro-op/binary-vector/vand/compare.py
@@ -38,11 +38,41 @@ def main():
         print('[ERROR] compare failed: mask_edge')
     else:
         print('[INFO] mask_edge: passed')
+    if not (_cmpeq("golden_v3_f8_and.bin","v3_f8_and.bin",np.uint8)):
+        failed.append('f8_and')
+        print('[ERROR] compare failed: f8_and')
+    else:
+        print('[INFO] f8_and: passed')
+    if not (_cmpeq("golden_v4_f8_xor.bin","v4_f8_xor.bin",np.uint8)):
+        failed.append('f8_xor')
+        print('[ERROR] compare failed: f8_xor')
+    else:
+        print('[INFO] f8_xor: passed')
+    if not (_cmpeq("golden_v5_f8_or.bin","v5_f8_or.bin",np.uint8)):
+        failed.append('f8_or')
+        print('[ERROR] compare failed: f8_or')
+    else:
+        print('[INFO] f8_or: passed')
+    if not (_cmpeq("golden_v3_hif8_and.bin","v3_hif8_and.bin",np.uint8)):
+        failed.append('hif8_and')
+        print('[ERROR] compare failed: hif8_and')
+    else:
+        print('[INFO] hif8_and: passed')
+    if not (_cmpeq("golden_v4_hif8_xor.bin","v4_hif8_xor.bin",np.uint8)):
+        failed.append('hif8_xor')
+        print('[ERROR] compare failed: hif8_xor')
+    else:
+        print('[INFO] hif8_xor: passed')
+    if not (_cmpeq("golden_v5_hif8_or.bin","v5_hif8_or.bin",np.uint8)):
+        failed.append('hif8_or')
+        print('[ERROR] compare failed: hif8_or')
+    else:
+        print('[INFO] hif8_or: passed')
     if failed:
         if strict: print(f"[ERROR] {len(failed)} variant(s) failed"); sys.exit(2)
         print(f"[WARN] {len(failed)} variant(s) failed (non-gating)")
         return
-    print("[INFO] compare passed (all 2 variants)")
+    print("[INFO] compare passed (all 8 variants)")
 
 if __name__=="__main__":
     main()

--- a/test/vpto/cases/micro-op/binary-vector/vand/golden.py
+++ b/test/vpto/cases/micro-op/binary-vector/vand/golden.py
@@ -49,9 +49,34 @@ def gen_mask_edge(out, rng):
     v3.reshape(-1).tofile(out/"v3_mask_edge.bin")
     g.reshape(-1).tofile(out/"golden_v3_mask_edge.bin")
 
+# ---- lowp ----
+def gen_lowp(out, rng):
+    f8_v1=rng.integers(0,256,size=256,dtype=np.uint8)
+    f8_v2=rng.integers(0,256,size=256,dtype=np.uint8)
+    hif8_v1=rng.integers(0,256,size=256,dtype=np.uint8)
+    hif8_v2=rng.integers(0,256,size=256,dtype=np.uint8)
+    zeros=np.zeros(256,dtype=np.uint8)
+    f8_v1.tofile(out/"v1_f8.bin")
+    f8_v2.tofile(out/"v2_f8.bin")
+    zeros.tofile(out/"v3_f8_and.bin")
+    zeros.tofile(out/"v4_f8_xor.bin")
+    zeros.tofile(out/"v5_f8_or.bin")
+    hif8_v1.tofile(out/"v1_hif8.bin")
+    hif8_v2.tofile(out/"v2_hif8.bin")
+    zeros.tofile(out/"v3_hif8_and.bin")
+    zeros.tofile(out/"v4_hif8_xor.bin")
+    zeros.tofile(out/"v5_hif8_or.bin")
+    np.bitwise_and(f8_v1,f8_v2).tofile(out/"golden_v3_f8_and.bin")
+    np.bitwise_xor(f8_v1,f8_v2).tofile(out/"golden_v4_f8_xor.bin")
+    np.bitwise_or(f8_v1,f8_v2).tofile(out/"golden_v5_f8_or.bin")
+    np.bitwise_and(hif8_v1,hif8_v2).tofile(out/"golden_v3_hif8_and.bin")
+    np.bitwise_xor(hif8_v1,hif8_v2).tofile(out/"golden_v4_hif8_xor.bin")
+    np.bitwise_or(hif8_v1,hif8_v2).tofile(out/"golden_v5_hif8_or.bin")
+
 GENERATORS = [
     gen_f32,
     gen_mask_edge,
+    gen_lowp,
 ]
 
 def main():

--- a/test/vpto/cases/micro-op/binary-vector/vand/kernel.pto
+++ b/test/vpto/cases/micro-op/binary-vector/vand/kernel.pto
@@ -1,5 +1,5 @@
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-    func.func @vand_deep_merged_kernel(%arg0: !pto.ptr<ui16, gm>, %arg1: !pto.ptr<ui16, gm>, %arg2: !pto.ptr<ui16, gm>, %arg3: !pto.ptr<ui16, gm>, %arg4: !pto.ptr<ui16, gm>, %arg5: !pto.ptr<ui16, gm>) attributes {pto.kernel} {
+    func.func @vand_deep_merged_kernel(%arg0: !pto.ptr<ui16, gm>, %arg1: !pto.ptr<ui16, gm>, %arg2: !pto.ptr<ui16, gm>, %arg3: !pto.ptr<ui16, gm>, %arg4: !pto.ptr<ui16, gm>, %arg5: !pto.ptr<ui16, gm>, %arg6: !pto.ptr<f8E4M3FN, gm>, %arg7: !pto.ptr<f8E4M3FN, gm>, %arg8: !pto.ptr<f8E4M3FN, gm>, %arg9: !pto.ptr<f8E4M3FN, gm>, %arg10: !pto.ptr<f8E4M3FN, gm>, %arg11: !pto.ptr<!pto.hif8, gm>, %arg12: !pto.ptr<!pto.hif8, gm>, %arg13: !pto.ptr<!pto.hif8, gm>, %arg14: !pto.ptr<!pto.hif8, gm>, %arg15: !pto.ptr<!pto.hif8, gm>) attributes {pto.kernel} {
     // merged from vand_i16_unsigned_kernel via LaunchVand_i16_unsigned_kernel
 
     %c0_m0 = arith.constant 0 : index
@@ -15,6 +15,27 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %ub_lhs_m0 = pto.castptr %c0_i64_m0 : i64 -> !pto.ptr<ui16, ub>
     %ub_rhs_m0 = pto.castptr %c2048_i64_m0 : i64 -> !pto.ptr<ui16, ub>
     %ub_out_m0 = pto.castptr %c4096_i64_m0 : i64 -> !pto.ptr<ui16, ub>
+    %c6144_i64_lowp = arith.constant 6144 : i64
+    %c6400_i64_lowp = arith.constant 6400 : i64
+    %c6656_i64_lowp = arith.constant 6656 : i64
+    %c6912_i64_lowp = arith.constant 6912 : i64
+    %c7168_i64_lowp = arith.constant 7168 : i64
+    %c7424_i64_lowp = arith.constant 7424 : i64
+    %c7680_i64_lowp = arith.constant 7680 : i64
+    %c7936_i64_lowp = arith.constant 7936 : i64
+    %c8192_i64_lowp = arith.constant 8192 : i64
+    %c8448_i64_lowp = arith.constant 8448 : i64
+    %c4_i64_lowp = arith.constant 4 : i64
+    %f8_lhs_lowp = pto.castptr %c6144_i64_lowp : i64 -> !pto.ptr<f8E4M3FN, ub>
+    %f8_rhs_lowp = pto.castptr %c6400_i64_lowp : i64 -> !pto.ptr<f8E4M3FN, ub>
+    %f8_and_lowp = pto.castptr %c6656_i64_lowp : i64 -> !pto.ptr<f8E4M3FN, ub>
+    %f8_or_lowp = pto.castptr %c6912_i64_lowp : i64 -> !pto.ptr<f8E4M3FN, ub>
+    %f8_xor_lowp = pto.castptr %c7168_i64_lowp : i64 -> !pto.ptr<f8E4M3FN, ub>
+    %hif8_lhs_lowp = pto.castptr %c7424_i64_lowp : i64 -> !pto.ptr<!pto.hif8, ub>
+    %hif8_rhs_lowp = pto.castptr %c7680_i64_lowp : i64 -> !pto.ptr<!pto.hif8, ub>
+    %hif8_and_lowp = pto.castptr %c7936_i64_lowp : i64 -> !pto.ptr<!pto.hif8, ub>
+    %hif8_or_lowp = pto.castptr %c8192_i64_lowp : i64 -> !pto.ptr<!pto.hif8, ub>
+    %hif8_xor_lowp = pto.castptr %c8448_i64_lowp : i64 -> !pto.ptr<!pto.hif8, ub>
 
     %false_m0 = arith.constant false
     pto.mte_gm_ub %arg0, %ub_lhs_m0, %c0_i64_m0, %c64_i64_m0
@@ -23,6 +44,18 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.mte_gm_ub %arg1, %ub_rhs_m0, %c0_i64_m0, %c64_i64_m0
       nburst(%c32_i64_m0, %c64_i64_m0, %c64_i64_m0)
       : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg6, %f8_lhs_lowp, %c0_i64_m0, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<f8E4M3FN, gm>, !pto.ptr<f8E4M3FN, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg7, %f8_rhs_lowp, %c0_i64_m0, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<f8E4M3FN, gm>, !pto.ptr<f8E4M3FN, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg11, %hif8_lhs_lowp, %c0_i64_m0, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<!pto.hif8, gm>, !pto.ptr<!pto.hif8, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg12, %hif8_rhs_lowp, %c0_i64_m0, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<!pto.hif8, gm>, !pto.ptr<!pto.hif8, ub>, i64, i64, i64, i64, i64
 
     pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
     pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
@@ -35,6 +68,24 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %out_m0 = pto.vand %lhs_m0, %rhs_m0, %mask_m0 : !pto.vreg<128xui16>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
         pto.vsts %out_m0, %ub_out_m0[%offset_m0], %mask_m0 : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
       }
+      %mask_lowp = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %f8_lhs_val = pto.vlds %f8_lhs_lowp[%c0_m0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %f8_rhs_val = pto.vlds %f8_rhs_lowp[%c0_m0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
+      %f8_and_val = pto.vand %f8_lhs_val, %f8_rhs_val, %mask_lowp : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      %f8_or_val = pto.vor %f8_lhs_val, %f8_rhs_val, %mask_lowp : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      %f8_xor_val = pto.vxor %f8_lhs_val, %f8_rhs_val, %mask_lowp : !pto.vreg<256xf8E4M3FN>, !pto.vreg<256xf8E4M3FN>, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      pto.vsts %f8_and_val, %f8_and_lowp[%c0_m0], %mask_lowp : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
+      pto.vsts %f8_or_val, %f8_or_lowp[%c0_m0], %mask_lowp : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
+      pto.vsts %f8_xor_val, %f8_xor_lowp[%c0_m0], %mask_lowp : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
+
+      %hif8_lhs_val = pto.vlds %hif8_lhs_lowp[%c0_m0] : !pto.ptr<!pto.hif8, ub> -> !pto.vreg<256x!pto.hif8>
+      %hif8_rhs_val = pto.vlds %hif8_rhs_lowp[%c0_m0] : !pto.ptr<!pto.hif8, ub> -> !pto.vreg<256x!pto.hif8>
+      %hif8_and_val = pto.vand %hif8_lhs_val, %hif8_rhs_val, %mask_lowp : !pto.vreg<256x!pto.hif8>, !pto.vreg<256x!pto.hif8>, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      %hif8_or_val = pto.vor %hif8_lhs_val, %hif8_rhs_val, %mask_lowp : !pto.vreg<256x!pto.hif8>, !pto.vreg<256x!pto.hif8>, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      %hif8_xor_val = pto.vxor %hif8_lhs_val, %hif8_rhs_val, %mask_lowp : !pto.vreg<256x!pto.hif8>, !pto.vreg<256x!pto.hif8>, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      pto.vsts %hif8_and_val, %hif8_and_lowp[%c0_m0], %mask_lowp : !pto.vreg<256x!pto.hif8>, !pto.ptr<!pto.hif8, ub>, !pto.mask<b8>
+      pto.vsts %hif8_or_val, %hif8_or_lowp[%c0_m0], %mask_lowp : !pto.vreg<256x!pto.hif8>, !pto.ptr<!pto.hif8, ub>, !pto.mask<b8>
+      pto.vsts %hif8_xor_val, %hif8_xor_lowp[%c0_m0], %mask_lowp : !pto.vreg<256x!pto.hif8>, !pto.ptr<!pto.hif8, ub>, !pto.mask<b8>
     }
 
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
@@ -42,6 +93,24 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.mte_ub_gm %ub_out_m0, %arg2, %c64_i64_m0
       nburst(%c32_i64_m0, %c64_i64_m0, %c64_i64_m0)
       : !pto.ptr<ui16, ub>, !pto.ptr<ui16, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %f8_and_lowp, %arg8, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<f8E4M3FN, ub>, !pto.ptr<f8E4M3FN, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %f8_xor_lowp, %arg9, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<f8E4M3FN, ub>, !pto.ptr<f8E4M3FN, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %f8_or_lowp, %arg10, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<f8E4M3FN, ub>, !pto.ptr<f8E4M3FN, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %hif8_and_lowp, %arg13, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<!pto.hif8, ub>, !pto.ptr<!pto.hif8, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %hif8_xor_lowp, %arg14, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<!pto.hif8, ub>, !pto.ptr<!pto.hif8, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %hif8_or_lowp, %arg15, %c64_i64_m0
+      nburst(%c4_i64_lowp, %c64_i64_m0, %c64_i64_m0)
+      : !pto.ptr<!pto.hif8, ub>, !pto.ptr<!pto.hif8, gm>, i64, i64, i64, i64
     pto.barrier #pto.pipe<PIPE_ALL>
 
     // merged from vand_mask_edge_kernel via LaunchVand_mask_edge_kernel

--- a/test/vpto/cases/micro-op/binary-vector/vand/launch.cpp
+++ b/test/vpto/cases/micro-op/binary-vector/vand/launch.cpp
@@ -38,14 +38,34 @@ extern "C" __global__ [aicore] void vand_deep_merged_kernel(
     __gm__ uint16_t * arg2,
     __gm__ uint16_t * arg3,
     __gm__ uint16_t * arg4,
-    __gm__ uint16_t * arg5);
+    __gm__ uint16_t * arg5,
+    __gm__ float8_e4m3_t * arg6,
+    __gm__ float8_e4m3_t * arg7,
+    __gm__ float8_e4m3_t * arg8,
+    __gm__ float8_e4m3_t * arg9,
+    __gm__ float8_e4m3_t * arg10,
+    __gm__ hifloat8_t * arg11,
+    __gm__ hifloat8_t * arg12,
+    __gm__ hifloat8_t * arg13,
+    __gm__ hifloat8_t * arg14,
+    __gm__ hifloat8_t * arg15);
 
-void LaunchVandDeepMerged(uint16_t * p0, uint16_t * p1, uint16_t * p2, uint16_t * p3, uint16_t * p4, uint16_t * p5, void *stream) {
+void LaunchVandDeepMerged(uint16_t * p0, uint16_t * p1, uint16_t * p2, uint16_t * p3, uint16_t * p4, uint16_t * p5, uint8_t * p6, uint8_t * p7, uint8_t * p8, uint8_t * p9, uint8_t * p10, uint8_t * p11, uint8_t * p12, uint8_t * p13, uint8_t * p14, uint8_t * p15, void *stream) {
   vand_deep_merged_kernel<<<1, nullptr, stream>>>(
       (__gm__ uint16_t *)p0,
       (__gm__ uint16_t *)p1,
       (__gm__ uint16_t *)p2,
       (__gm__ uint16_t *)p3,
       (__gm__ uint16_t *)p4,
-      (__gm__ uint16_t *)p5);
+      (__gm__ uint16_t *)p5,
+      (__gm__ float8_e4m3_t *)p6,
+      (__gm__ float8_e4m3_t *)p7,
+      (__gm__ float8_e4m3_t *)p8,
+      (__gm__ float8_e4m3_t *)p9,
+      (__gm__ float8_e4m3_t *)p10,
+      (__gm__ hifloat8_t *)p11,
+      (__gm__ hifloat8_t *)p12,
+      (__gm__ hifloat8_t *)p13,
+      (__gm__ hifloat8_t *)p14,
+      (__gm__ hifloat8_t *)p15);
 }

--- a/test/vpto/cases/micro-op/binary-vector/vand/main.cpp
+++ b/test/vpto/cases/micro-op/binary-vector/vand/main.cpp
@@ -20,10 +20,11 @@ using namespace PtoTestCommon;
 
 
 
-void LaunchVandDeepMerged(uint16_t * p0, uint16_t * p1, uint16_t * p2, uint16_t * p3, uint16_t * p4, uint16_t * p5, void *stream);
+void LaunchVandDeepMerged(uint16_t * p0, uint16_t * p1, uint16_t * p2, uint16_t * p3, uint16_t * p4, uint16_t * p5, uint8_t * p6, uint8_t * p7, uint8_t * p8, uint8_t * p9, uint8_t * p10, uint8_t * p11, uint8_t * p12, uint8_t * p13, uint8_t * p14, uint8_t * p15, void *stream);
 int main() {
   constexpr size_t SZ_f32 = 2048;
   constexpr size_t SZ_mask_edge = 2048;
+  constexpr size_t SZ_lowp = 256;
 
   uint16_t *h_f32_v1=nullptr, *d_f32_v1=nullptr;
   uint16_t *h_f32_v2=nullptr, *d_f32_v2=nullptr;
@@ -31,6 +32,16 @@ int main() {
   uint16_t *h_mask_edge_v1=nullptr, *d_mask_edge_v1=nullptr;
   uint16_t *h_mask_edge_v2=nullptr, *d_mask_edge_v2=nullptr;
   uint16_t *h_mask_edge_v3=nullptr, *d_mask_edge_v3=nullptr;
+  uint8_t *h_f8_v1=nullptr, *d_f8_v1=nullptr;
+  uint8_t *h_f8_v2=nullptr, *d_f8_v2=nullptr;
+  uint8_t *h_f8_and=nullptr, *d_f8_and=nullptr;
+  uint8_t *h_f8_xor=nullptr, *d_f8_xor=nullptr;
+  uint8_t *h_f8_or=nullptr, *d_f8_or=nullptr;
+  uint8_t *h_hif8_v1=nullptr, *d_hif8_v1=nullptr;
+  uint8_t *h_hif8_v2=nullptr, *d_hif8_v2=nullptr;
+  uint8_t *h_hif8_and=nullptr, *d_hif8_and=nullptr;
+  uint8_t *h_hif8_xor=nullptr, *d_hif8_xor=nullptr;
+  uint8_t *h_hif8_or=nullptr, *d_hif8_or=nullptr;
   int rc=0; bool aclInited=false,deviceSet=false; int deviceId=0; aclrtStream stream=nullptr; size_t fsz=0;
   ACL_CHECK(aclInit(nullptr)); aclInited=true;
   if(const char*e=std::getenv("ACL_DEVICE_ID")) deviceId=std::atoi(e);
@@ -42,24 +53,64 @@ int main() {
   ACL_CHECK(aclrtMallocHost((void**)&h_mask_edge_v1,SZ_mask_edge));
   ACL_CHECK(aclrtMallocHost((void**)&h_mask_edge_v2,SZ_mask_edge));
   ACL_CHECK(aclrtMallocHost((void**)&h_mask_edge_v3,SZ_mask_edge));
+  ACL_CHECK(aclrtMallocHost((void**)&h_f8_v1,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_f8_v2,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_f8_and,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_f8_xor,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_f8_or,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_hif8_v1,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_hif8_v2,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_hif8_and,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_hif8_xor,SZ_lowp));
+  ACL_CHECK(aclrtMallocHost((void**)&h_hif8_or,SZ_lowp));
   ACL_CHECK(aclrtMalloc((void**)&d_f32_v1,SZ_f32,ACL_MEM_MALLOC_HUGE_FIRST));
   ACL_CHECK(aclrtMalloc((void**)&d_f32_v2,SZ_f32,ACL_MEM_MALLOC_HUGE_FIRST));
   ACL_CHECK(aclrtMalloc((void**)&d_f32_v3,SZ_f32,ACL_MEM_MALLOC_HUGE_FIRST));
   ACL_CHECK(aclrtMalloc((void**)&d_mask_edge_v1,SZ_mask_edge,ACL_MEM_MALLOC_HUGE_FIRST));
   ACL_CHECK(aclrtMalloc((void**)&d_mask_edge_v2,SZ_mask_edge,ACL_MEM_MALLOC_HUGE_FIRST));
   ACL_CHECK(aclrtMalloc((void**)&d_mask_edge_v3,SZ_mask_edge,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_f8_v1,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_f8_v2,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_f8_and,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_f8_xor,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_f8_or,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_hif8_v1,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_hif8_v2,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_hif8_and,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_hif8_xor,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void**)&d_hif8_or,SZ_lowp,ACL_MEM_MALLOC_HUGE_FIRST));
   fsz=SZ_f32; FCK(ReadFile("v1.bin",fsz,h_f32_v1,SZ_f32)&&fsz==SZ_f32,"v1.bin");
   fsz=SZ_f32; FCK(ReadFile("v2.bin",fsz,h_f32_v2,SZ_f32)&&fsz==SZ_f32,"v2.bin");
   fsz=SZ_f32; FCK(ReadFile("v3.bin",fsz,h_f32_v3,SZ_f32)&&fsz==SZ_f32,"v3.bin");
   fsz=SZ_mask_edge; FCK(ReadFile("v1_mask_edge.bin",fsz,h_mask_edge_v1,SZ_mask_edge)&&fsz==SZ_mask_edge,"v1_mask_edge.bin");
   fsz=SZ_mask_edge; FCK(ReadFile("v2_mask_edge.bin",fsz,h_mask_edge_v2,SZ_mask_edge)&&fsz==SZ_mask_edge,"v2_mask_edge.bin");
   fsz=SZ_mask_edge; FCK(ReadFile("v3_mask_edge.bin",fsz,h_mask_edge_v3,SZ_mask_edge)&&fsz==SZ_mask_edge,"v3_mask_edge.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v1_f8.bin",fsz,h_f8_v1,SZ_lowp)&&fsz==SZ_lowp,"v1_f8.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v2_f8.bin",fsz,h_f8_v2,SZ_lowp)&&fsz==SZ_lowp,"v2_f8.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v3_f8_and.bin",fsz,h_f8_and,SZ_lowp)&&fsz==SZ_lowp,"v3_f8_and.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v4_f8_xor.bin",fsz,h_f8_xor,SZ_lowp)&&fsz==SZ_lowp,"v4_f8_xor.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v5_f8_or.bin",fsz,h_f8_or,SZ_lowp)&&fsz==SZ_lowp,"v5_f8_or.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v1_hif8.bin",fsz,h_hif8_v1,SZ_lowp)&&fsz==SZ_lowp,"v1_hif8.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v2_hif8.bin",fsz,h_hif8_v2,SZ_lowp)&&fsz==SZ_lowp,"v2_hif8.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v3_hif8_and.bin",fsz,h_hif8_and,SZ_lowp)&&fsz==SZ_lowp,"v3_hif8_and.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v4_hif8_xor.bin",fsz,h_hif8_xor,SZ_lowp)&&fsz==SZ_lowp,"v4_hif8_xor.bin");
+  fsz=SZ_lowp; FCK(ReadFile("v5_hif8_or.bin",fsz,h_hif8_or,SZ_lowp)&&fsz==SZ_lowp,"v5_hif8_or.bin");
   ACL_CHECK(aclrtMemcpy(d_f32_v1,SZ_f32,h_f32_v1,SZ_f32,ACL_MEMCPY_HOST_TO_DEVICE));
   ACL_CHECK(aclrtMemcpy(d_f32_v2,SZ_f32,h_f32_v2,SZ_f32,ACL_MEMCPY_HOST_TO_DEVICE));
   ACL_CHECK(aclrtMemcpy(d_f32_v3,SZ_f32,h_f32_v3,SZ_f32,ACL_MEMCPY_HOST_TO_DEVICE));
   ACL_CHECK(aclrtMemcpy(d_mask_edge_v1,SZ_mask_edge,h_mask_edge_v1,SZ_mask_edge,ACL_MEMCPY_HOST_TO_DEVICE));
   ACL_CHECK(aclrtMemcpy(d_mask_edge_v2,SZ_mask_edge,h_mask_edge_v2,SZ_mask_edge,ACL_MEMCPY_HOST_TO_DEVICE));
   ACL_CHECK(aclrtMemcpy(d_mask_edge_v3,SZ_mask_edge,h_mask_edge_v3,SZ_mask_edge,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_f8_v1,SZ_lowp,h_f8_v1,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_f8_v2,SZ_lowp,h_f8_v2,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_f8_and,SZ_lowp,h_f8_and,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_f8_xor,SZ_lowp,h_f8_xor,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_f8_or,SZ_lowp,h_f8_or,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_hif8_v1,SZ_lowp,h_hif8_v1,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_hif8_v2,SZ_lowp,h_hif8_v2,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_hif8_and,SZ_lowp,h_hif8_and,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_hif8_xor,SZ_lowp,h_hif8_xor,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(d_hif8_or,SZ_lowp,h_hif8_or,SZ_lowp,ACL_MEMCPY_HOST_TO_DEVICE));
     LaunchVandDeepMerged(
       d_f32_v1,
       d_f32_v2,
@@ -67,13 +118,35 @@ int main() {
       d_mask_edge_v1,
       d_mask_edge_v2,
       d_mask_edge_v3,
+      d_f8_v1,
+      d_f8_v2,
+      d_f8_and,
+      d_f8_xor,
+      d_f8_or,
+      d_hif8_v1,
+      d_hif8_v2,
+      d_hif8_and,
+      d_hif8_xor,
+      d_hif8_or,
       stream
   );
   ACL_CHECK(aclrtSynchronizeStream(stream));
   ACL_CHECK(aclrtMemcpy(h_f32_v3,SZ_f32,d_f32_v3,SZ_f32,ACL_MEMCPY_DEVICE_TO_HOST));
   ACL_CHECK(aclrtMemcpy(h_mask_edge_v3,SZ_mask_edge,d_mask_edge_v3,SZ_mask_edge,ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(h_f8_and,SZ_lowp,d_f8_and,SZ_lowp,ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(h_f8_xor,SZ_lowp,d_f8_xor,SZ_lowp,ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(h_f8_or,SZ_lowp,d_f8_or,SZ_lowp,ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(h_hif8_and,SZ_lowp,d_hif8_and,SZ_lowp,ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(h_hif8_xor,SZ_lowp,d_hif8_xor,SZ_lowp,ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(h_hif8_or,SZ_lowp,d_hif8_or,SZ_lowp,ACL_MEMCPY_DEVICE_TO_HOST));
   FCK(WriteFile("v3.bin",h_f32_v3,SZ_f32),"v3.bin");
   FCK(WriteFile("v3_mask_edge.bin",h_mask_edge_v3,SZ_mask_edge),"v3_mask_edge.bin");
+  FCK(WriteFile("v3_f8_and.bin",h_f8_and,SZ_lowp),"v3_f8_and.bin");
+  FCK(WriteFile("v4_f8_xor.bin",h_f8_xor,SZ_lowp),"v4_f8_xor.bin");
+  FCK(WriteFile("v5_f8_or.bin",h_f8_or,SZ_lowp),"v5_f8_or.bin");
+  FCK(WriteFile("v3_hif8_and.bin",h_hif8_and,SZ_lowp),"v3_hif8_and.bin");
+  FCK(WriteFile("v4_hif8_xor.bin",h_hif8_xor,SZ_lowp),"v4_hif8_xor.bin");
+  FCK(WriteFile("v5_hif8_or.bin",h_hif8_or,SZ_lowp),"v5_hif8_or.bin");
 
 cleanup:
   aclrtFree(d_f32_v1);
@@ -82,12 +155,32 @@ cleanup:
   aclrtFree(d_mask_edge_v1);
   aclrtFree(d_mask_edge_v2);
   aclrtFree(d_mask_edge_v3);
+  aclrtFree(d_f8_v1);
+  aclrtFree(d_f8_v2);
+  aclrtFree(d_f8_and);
+  aclrtFree(d_f8_xor);
+  aclrtFree(d_f8_or);
+  aclrtFree(d_hif8_v1);
+  aclrtFree(d_hif8_v2);
+  aclrtFree(d_hif8_and);
+  aclrtFree(d_hif8_xor);
+  aclrtFree(d_hif8_or);
   aclrtFreeHost(h_f32_v1);
   aclrtFreeHost(h_f32_v2);
   aclrtFreeHost(h_f32_v3);
   aclrtFreeHost(h_mask_edge_v1);
   aclrtFreeHost(h_mask_edge_v2);
   aclrtFreeHost(h_mask_edge_v3);
+  aclrtFreeHost(h_f8_v1);
+  aclrtFreeHost(h_f8_v2);
+  aclrtFreeHost(h_f8_and);
+  aclrtFreeHost(h_f8_xor);
+  aclrtFreeHost(h_f8_or);
+  aclrtFreeHost(h_hif8_v1);
+  aclrtFreeHost(h_hif8_v2);
+  aclrtFreeHost(h_hif8_and);
+  aclrtFreeHost(h_hif8_xor);
+  aclrtFreeHost(h_hif8_or);
   if(stream) aclrtDestroyStream(stream);
   if(deviceSet) aclrtResetDevice(deviceId);
   if(aclInited) aclFinalize();


### PR DESCRIPTION
## Summary
- allow low-precision VPTO vreg types for vand/vor/vxor verification
- lower low-precision vand/vor/vxor through direct fp8 intrinsics when available
- fall back to u8 payload carrier lowering for other low-precision types such as hif8
- add pure VPTO LLVM lowering coverage for fp8 direct and hif8 payload paths

## Validation
- cmake --build build-main-llvm21 --target ptoas pto-opt -j64
- llvm-lit -q build-main-llvm21/test/lit/vpto/vlogic_low_precision_vpto_llvm.pto
- llvm-lit -q build-main-llvm21/test/lit/vpto