### PR TITLE
Add VPTO dcci and dsb ops

### DIFF
--- a/docs/isa/micro-isa/01-pipeline-sync.md
+++ b/docs/isa/micro-isa/01-pipeline-sync.md
@@ -148,6 +148,63 @@ pto.mem_bar "VST_VLD"
 
 ---
 
+### `pto.dsb`
+
+- **syntax:** `pto.dsb "MEM_DOMAIN"`
+- **semantics:** Issues a data synchronization barrier for the selected memory domain. All prior memory effects covered by the domain must become complete before subsequent memory effects proceed.
+
+**Memory domains:**
+
+| Domain | Meaning |
+|--------|---------|
+| `ALL` | Wait for all memory-access classes covered by the target |
+| `DDR` | Wait for DDR/GM memory-access effects |
+| `UB` | Wait for UB memory-access effects |
+| `SEQ` | Wait for sequencer-visible memory-access effects |
+
+**Example:** Ensure prior GM stores are complete before publishing a scalar signal:
+
+```mlir
+pto.dsb "DDR"
+```
+
+---
+
+### `pto.dcci`
+
+- **syntax:** `pto.dcci %ptr "CACHE_SCOPE" : !pto.ptr<T, gm|ub>`
+- **syntax:** `pto.dcci %ptr "CACHE_SCOPE", "CACHE_DST" : !pto.ptr<T, gm|ub>`
+- **semantics:** Performs data-cache clean/invalidate maintenance for the selected cache scope. The pointer address space selects whether the operation applies to GM or UB-backed cache state. The optional destination domain further restricts which cache-line class is affected.
+
+**Cache scopes:**
+
+| Scope | Meaning |
+|-------|---------|
+| `SINGLE_CACHE_LINE` | Apply maintenance to the cache line containing `%ptr` |
+| `ENTIRE_DATA_CACHE` | Apply maintenance to the entire data cache; `%ptr` is still required by the IR form |
+
+**Destination domains:**
+
+| Destination | Meaning |
+|-------------|---------|
+| `CACHELINE_ALL` | All supported cache-line domains |
+| `CACHELINE_UB` | UB cache-line domain |
+| `CACHELINE_OUT` | Output/GM-visible cache-line domain |
+| `CACHELINE_ATOMIC` | Atomic cache-line domain |
+
+**Constraints:**
+- `%ptr` must be a PTO pointer or buffer-like value in GM or UB address space.
+- Omitting `CACHE_DST` uses the target's default destination-domain form.
+
+**Example:** Flush GM-visible cache state after scalar GM stores:
+
+```mlir
+pto.dcci %gm "ENTIRE_DATA_CACHE", "CACHELINE_OUT" : !pto.ptr<i8, gm>
+pto.dsb "ALL"
+```
+
+---
+
 ## Why `get_buf` / `rls_buf` is More Programmer-Friendly
 
 The buffer-based synchronization (`get_buf`/`rls_buf`) provides the **same functional capability** as `set_flag`/`wait_flag` for maintaining correct ordering of RAW/WAR/WAW dependencies across pipelines, but with significant usability advantages:

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -294,6 +294,8 @@ Within the vector execution scope, the hardware does not track UB address aliasi
 pto.mem_bar "VV_ALL"      // All prior vector ops complete before subsequent
 pto.mem_bar "VST_VLD"     // All prior vector stores visible before subsequent loads
 pto.mem_bar "VLD_VST"     // All prior vector loads complete before subsequent stores
+pto.dcci %gm "ENTIRE_DATA_CACHE", "CACHELINE_OUT" : !pto.ptr<i8, gm>
+pto.dsb "ALL"
 ```
 
 Without proper barriers, loads may see stale data or stores may be reordered incorrectly.
@@ -1449,6 +1451,7 @@ This section provides a categorized overview of all PTO micro Instruction operat
 |-----------|-------|-------------|
 | Intra-core Sync | 1 | `pto.set_flag`, `pto.wait_flag` |
 | Pipeline Buffer Sync | 1 | `pto.get_buf`, `pto.rls_buf` |
+| Memory Barrier / Cache Maintenance | 1 | `pto.mem_bar`, `pto.dsb`, `pto.dcci` |
 
 ### Scalar & Control Operations
 

--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -303,6 +303,69 @@ def PTO_MemBarAttr : PTO_Attr<"MemBar", "membar"> {
 }
 
 //===----------------------------------------------------------------------===//
+// DCCI / DSB
+//===----------------------------------------------------------------------===//
+
+def PTO_DSB_MEM_ALL : I32EnumAttrCase<"ALL", 0>;
+def PTO_DSB_MEM_DDR : I32EnumAttrCase<"DDR", 1>;
+def PTO_DSB_MEM_UB  : I32EnumAttrCase<"UB", 2>;
+def PTO_DSB_MEM_SEQ : I32EnumAttrCase<"SEQ", 3>;
+
+def PTO_DsbMemEnum : PTO_I32Enum<
+  "DsbMem", "PTO DSB memory domain", [
+    PTO_DSB_MEM_ALL,
+    PTO_DSB_MEM_DDR,
+    PTO_DSB_MEM_UB,
+    PTO_DSB_MEM_SEQ
+  ]>;
+
+def PTO_DsbMemAttr : PTO_Attr<"DsbMem", "dsb_mem"> {
+  let parameters = (ins EnumParameter<PTO_DsbMemEnum>:$kind);
+  let assemblyFormat = "`<` params `>`";
+  let description = [{
+    Memory domain for VPTO `pto.dsb`.
+  }];
+}
+
+def PTO_DCCI_CACHE_SINGLE : I32EnumAttrCase<"SINGLE_CACHE_LINE", 0>;
+def PTO_DCCI_CACHE_ENTIRE : I32EnumAttrCase<"ENTIRE_DATA_CACHE", 1>;
+
+def PTO_DcciCacheLineEnum : PTO_I32Enum<
+  "DcciCacheLine", "PTO DCCI cache-line selection", [
+    PTO_DCCI_CACHE_SINGLE,
+    PTO_DCCI_CACHE_ENTIRE
+  ]>;
+
+def PTO_DcciCacheLineAttr : PTO_Attr<"DcciCacheLine", "dcci_cache_line"> {
+  let parameters = (ins EnumParameter<PTO_DcciCacheLineEnum>:$kind);
+  let assemblyFormat = "`<` params `>`";
+  let description = [{
+    Cache-line selection for VPTO `pto.dcci`.
+  }];
+}
+
+def PTO_DCCI_DST_ALL    : I32EnumAttrCase<"CACHELINE_ALL", 0>;
+def PTO_DCCI_DST_UB     : I32EnumAttrCase<"CACHELINE_UB", 1>;
+def PTO_DCCI_DST_OUT    : I32EnumAttrCase<"CACHELINE_OUT", 2>;
+def PTO_DCCI_DST_ATOMIC : I32EnumAttrCase<"CACHELINE_ATOMIC", 3>;
+
+def PTO_DcciDstEnum : PTO_I32Enum<
+  "DcciDst", "PTO DCCI destination cache-line domain", [
+    PTO_DCCI_DST_ALL,
+    PTO_DCCI_DST_UB,
+    PTO_DCCI_DST_OUT,
+    PTO_DCCI_DST_ATOMIC
+  ]>;
+
+def PTO_DcciDstAttr : PTO_Attr<"DcciDst", "dcci_dst"> {
+  let parameters = (ins EnumParameter<PTO_DcciDstEnum>:$kind);
+  let assemblyFormat = "`<` params `>`";
+  let description = [{
+    Optional destination cache-line domain for VPTO `pto.dcci`.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Sync Op Type (High Level Abstraction)
 //===----------------------------------------------------------------------===//
 

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -287,6 +287,44 @@ def PTO_MemBarOp : PTO_Op<"mem_bar"> {
   let hasCustomAssemblyFormat = 1;
 }
 
+def DsbOp : PTO_Op<"dsb"> {
+  let summary = "Issue a low-level DSB memory barrier";
+  let description = [{
+    Lowers to `llvm.hivm.DSB(i64)`. The memory domain maps directly to the CCE
+    `mem_dsb_t` enum values: `ALL`, `DDR`, `UB`, and `SEQ`.
+  }];
+
+  let arguments = (ins PTO_DsbMemAttr:$mem);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    custom<LegacyOrAttrDsbMem>($mem) attr-dict
+  }];
+}
+
+def DcciOp : PTO_Op<"dcci"> {
+  let summary = "Issue a low-level DCCI cache maintenance operation";
+  let description = [{
+    Lowers to the `llvm.hivm.DCCI*` intrinsic family. The pointer address space
+    selects the intrinsic variant: GM pointers use `DCCI` / `DCCI.DST`; UB
+    pointers use `DCCI.UB` / `DCCI.DST.UB`.
+  }];
+
+  let arguments = (ins
+    PTO_BufferType:$ptr,
+    PTO_DcciCacheLineAttr:$cache,
+    OptionalAttr<PTO_DcciDstAttr>:$dst
+  );
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    $ptr custom<LegacyOrAttrDcciCacheLine>($cache)
+    custom<OptionalDcciDst>($dst) attr-dict `:` type($ptr)
+  }];
+}
+
 
 class PTO_BinaryI64ConfigOp<string mnemonic> : PTO_Op<mnemonic> {
   let arguments = (ins

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3946,6 +3946,8 @@ static std::optional<uint64_t> getStaticByteSize(Type ty) {
 }
 
 static std::optional<pto::AddressSpace> getPTOMemorySpaceEnum(Type ty) {
+  if (auto ptr = dyn_cast<pto::PtrType>(ty))
+    return ptr.getMemorySpace().getAddressSpace();
   if (auto tb = dyn_cast<pto::TileBufType>(ty)) {
     if (auto as = dyn_cast_or_null<pto::AddressSpaceAttr>(tb.getMemorySpace()))
       return as.getAddressSpace();
@@ -8022,6 +8024,105 @@ static void printLegacyOrAttrMemBar(OpAsmPrinter &p, MemBarAttr kind,
                                     ArrayRef<NamedAttribute> attrs) {
   p << ' ' << '"' << stringifyMemBarKind(kind.getKind()) << '"';
   p.printOptionalAttrDict(attrs, {"kind"});
+}
+
+static ParseResult parseLegacyOrAttrDsbMem(OpAsmParser &parser,
+                                           DsbMemAttr &attr) {
+  auto loc = parser.getCurrentLocation();
+  std::string token;
+  if (succeeded(parser.parseOptionalString(&token))) {
+    auto kind = symbolizeDsbMem(token);
+    if (!kind)
+      return parser.emitError(loc) << "invalid dsb memory token: " << token;
+    attr = DsbMemAttr::get(parser.getContext(), *kind);
+    return success();
+  }
+
+  Attribute parsed;
+  if (failed(parser.parseAttribute(parsed)))
+    return failure();
+  auto dsbMemAttr = dyn_cast<DsbMemAttr>(parsed);
+  if (!dsbMemAttr)
+    return parser.emitError(loc, "expected dsb_mem attribute");
+  attr = dsbMemAttr;
+  return success();
+}
+
+static void printLegacyOrAttrDsbMem(OpAsmPrinter &printer, Operation *op,
+                                    DsbMemAttr mem) {
+  (void)op;
+  printer << ' ' << '"' << stringifyDsbMem(mem.getKind()) << '"';
+}
+
+static ParseResult parseLegacyOrAttrDcciCacheLine(OpAsmParser &parser,
+                                                  DcciCacheLineAttr &attr) {
+  auto loc = parser.getCurrentLocation();
+  std::string token;
+  if (succeeded(parser.parseOptionalString(&token))) {
+    auto kind = symbolizeDcciCacheLine(token);
+    if (!kind)
+      return parser.emitError(loc) << "invalid dcci cache token: " << token;
+    attr = DcciCacheLineAttr::get(parser.getContext(), *kind);
+    return success();
+  }
+
+  Attribute parsed;
+  if (failed(parser.parseAttribute(parsed)))
+    return failure();
+  auto cacheAttr = dyn_cast<DcciCacheLineAttr>(parsed);
+  if (!cacheAttr)
+    return parser.emitError(loc, "expected dcci_cache_line attribute");
+  attr = cacheAttr;
+  return success();
+}
+
+static void printLegacyOrAttrDcciCacheLine(OpAsmPrinter &printer, Operation *op,
+                                           DcciCacheLineAttr cache) {
+  (void)op;
+  printer << ' ' << '"' << stringifyDcciCacheLine(cache.getKind()) << '"';
+}
+
+static ParseResult parseOptionalDcciDst(OpAsmParser &parser,
+                                        DcciDstAttr &attr) {
+  if (failed(parser.parseOptionalComma()))
+    return success();
+
+  auto loc = parser.getCurrentLocation();
+  std::string token;
+  if (succeeded(parser.parseOptionalString(&token))) {
+    auto kind = symbolizeDcciDst(token);
+    if (!kind)
+      return parser.emitError(loc) << "invalid dcci dst token: " << token;
+    attr = DcciDstAttr::get(parser.getContext(), *kind);
+    return success();
+  }
+
+  Attribute parsed;
+  if (failed(parser.parseAttribute(parsed)))
+    return failure();
+  auto dstAttr = dyn_cast<DcciDstAttr>(parsed);
+  if (!dstAttr)
+    return parser.emitError(loc, "expected dcci_dst attribute");
+  attr = dstAttr;
+  return success();
+}
+
+static void printOptionalDcciDst(OpAsmPrinter &printer, Operation *op,
+                                 DcciDstAttr dst) {
+  (void)op;
+  if (!dst)
+    return;
+  printer << ", \"" << stringifyDcciDst(dst.getKind()) << '"';
+}
+
+LogicalResult DcciOp::verify() {
+  auto space = getPTOMemorySpaceEnum(getPtr().getType());
+  if (!space)
+    return emitOpError("expects ptr to have a PTO memory space");
+  if (*space != pto::AddressSpace::GM && *space != pto::AddressSpace::VEC)
+    return emitOpError("expects ptr memory space to be gm or ub/vec");
+
+  return success();
 }
 
 static ParseResult parseLegacyOrAttrPipe(OpAsmParser &parser, PipeAttr &attr) {

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -4034,6 +4034,33 @@ static StringRef buildMemBarCallee(MemBarKind kind, MLIRContext *context) {
   llvm_unreachable("unexpected membar kind");
 }
 
+static uint64_t getDsbMemImmediate(DsbMem kind) {
+  return static_cast<uint64_t>(kind);
+}
+
+static uint64_t getDcciCacheLineImmediate(DcciCacheLine kind) {
+  return static_cast<uint64_t>(kind);
+}
+
+static uint64_t getDcciDstImmediate(DcciDst kind) {
+  return static_cast<uint64_t>(kind);
+}
+
+static StringRef buildDcciCallee(unsigned addressSpace, bool hasDst,
+                                 MLIRContext *context) {
+  if (addressSpace == static_cast<unsigned>(pto::AddressSpace::GM)) {
+    return StringAttr::get(context, hasDst ? "llvm.hivm.DCCI.DST"
+                                           : "llvm.hivm.DCCI")
+        .getValue();
+  }
+  if (addressSpace == static_cast<unsigned>(pto::AddressSpace::VEC)) {
+    return StringAttr::get(context, hasDst ? "llvm.hivm.DCCI.DST.UB"
+                                           : "llvm.hivm.DCCI.UB")
+        .getValue();
+  }
+  llvm_unreachable("unexpected dcci address space");
+}
+
 template <>
 StringRef buildSyncCallee<pto::GetBufOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.GET.BUFI.mode").getValue();
@@ -8589,6 +8616,74 @@ private:
   LoweringState &state;
 };
 
+class LowerDsbOpPattern final : public OpConversionPattern<pto::DsbOp> {
+public:
+  explicit LowerDsbOpPattern(TypeConverter &typeConverter, MLIRContext *context,
+                             LoweringState &state)
+      : OpConversionPattern<pto::DsbOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::DsbOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    StringRef calleeName =
+        StringAttr::get(op.getContext(), "llvm.hivm.DSB").getValue();
+    Type i64Ty = rewriter.getI64Type();
+    auto funcType = rewriter.getFunctionType(TypeRange{i64Ty}, TypeRange{});
+    Value mem =
+        getI64Constant(rewriter, op.getLoc(),
+                       getDsbMemImmediate(op.getMem().getKind()));
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
+                                  ValueRange{mem});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerDcciOpPattern final : public OpConversionPattern<pto::DcciOp> {
+public:
+  explicit LowerDcciOpPattern(TypeConverter &typeConverter, MLIRContext *context,
+                              LoweringState &state)
+      : OpConversionPattern<pto::DcciOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::DcciOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto ptrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
+    if (!ptrType)
+      return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+
+    bool hasDst = static_cast<bool>(op.getDstAttr());
+    StringRef calleeName =
+        buildDcciCallee(ptrType.getAddressSpace(), hasDst, op.getContext());
+
+    Type i64Ty = rewriter.getI64Type();
+    SmallVector<Type> argTypes{ptrType, i64Ty};
+    SmallVector<Value> args{
+        adaptor.getPtr(),
+        getI64Constant(rewriter, op.getLoc(),
+                       getDcciCacheLineImmediate(op.getCache().getKind()))};
+    if (auto dst = op.getDstAttr()) {
+      argTypes.push_back(i64Ty);
+      args.push_back(getI64Constant(rewriter, op.getLoc(),
+                                    getDcciDstImmediate(dst.getKind())));
+    }
+
+    auto funcType = rewriter.getFunctionType(argTypes, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{}, args);
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 template <typename BufSyncOp>
 class LowerBufSyncOpPattern final : public OpConversionPattern<BufSyncOp> {
 public:
@@ -9988,7 +10083,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerPipeEventSyncOpPattern<pto::WaitFlagOp>,
                LowerPipeEventDynSyncOpPattern<pto::SetFlagDynOp>,
                LowerPipeEventDynSyncOpPattern<pto::WaitFlagDynOp>,
-               LowerBarrierOpPattern, LowerMemBarOpPattern,
+               LowerBarrierOpPattern, LowerMemBarOpPattern, LowerDsbOpPattern,
+               LowerDcciOpPattern,
                LowerBufSyncOpPattern<pto::GetBufOp>,
                LowerBufSyncOpPattern<pto::RlsBufOp>,
                LowerRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
@@ -10050,6 +10146,7 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
   target.addLegalOp<UnrealizedConversionCastOp>();
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
                       pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
+                      pto::DsbOp, pto::DcciOp,
                       pto::GetBufOp, pto::RlsBufOp>();
   target.addIllegalOp<pto::GetBlockIdxOp, pto::GetSubBlockIdxOp,
                       pto::GetBlockNumOp, pto::GetSubBlockNumOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -3976,6 +3976,33 @@ static StringRef buildMemBarCallee(MemBarKind kind, MLIRContext *context) {
   llvm_unreachable("unexpected membar kind");
 }
 
+static uint64_t getDsbMemImmediate(DsbMem kind) {
+  return static_cast<uint64_t>(kind);
+}
+
+static uint64_t getDcciCacheLineImmediate(DcciCacheLine kind) {
+  return static_cast<uint64_t>(kind);
+}
+
+static uint64_t getDcciDstImmediate(DcciDst kind) {
+  return static_cast<uint64_t>(kind);
+}
+
+static StringRef buildDcciCallee(unsigned addressSpace, bool hasDst,
+                                 MLIRContext *context) {
+  if (addressSpace == static_cast<unsigned>(pto::AddressSpace::GM)) {
+    return StringAttr::get(context, hasDst ? "llvm.hivm.DCCI.DST"
+                                           : "llvm.hivm.DCCI")
+        .getValue();
+  }
+  if (addressSpace == static_cast<unsigned>(pto::AddressSpace::VEC)) {
+    return StringAttr::get(context, hasDst ? "llvm.hivm.DCCI.DST.UB"
+                                           : "llvm.hivm.DCCI.UB")
+        .getValue();
+  }
+  llvm_unreachable("unexpected dcci address space");
+}
+
 template <>
 StringRef buildSyncCallee<pto::GetBufOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.GET.BUFI.mode").getValue();
@@ -8533,6 +8560,74 @@ private:
   LoweringState &state;
 };
 
+class LowerDsbOpPattern final : public OpConversionPattern<pto::DsbOp> {
+public:
+  explicit LowerDsbOpPattern(TypeConverter &typeConverter, MLIRContext *context,
+                             LoweringState &state)
+      : OpConversionPattern<pto::DsbOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::DsbOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    StringRef calleeName =
+        StringAttr::get(op.getContext(), "llvm.hivm.DSB").getValue();
+    Type i64Ty = rewriter.getI64Type();
+    auto funcType = rewriter.getFunctionType(TypeRange{i64Ty}, TypeRange{});
+    Value mem =
+        getI64Constant(rewriter, op.getLoc(),
+                       getDsbMemImmediate(op.getMem().getKind()));
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
+                                  ValueRange{mem});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+class LowerDcciOpPattern final : public OpConversionPattern<pto::DcciOp> {
+public:
+  explicit LowerDcciOpPattern(TypeConverter &typeConverter, MLIRContext *context,
+                              LoweringState &state)
+      : OpConversionPattern<pto::DcciOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(pto::DcciOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto ptrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
+    if (!ptrType)
+      return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+
+    bool hasDst = static_cast<bool>(op.getDstAttr());
+    StringRef calleeName =
+        buildDcciCallee(ptrType.getAddressSpace(), hasDst, op.getContext());
+
+    Type i64Ty = rewriter.getI64Type();
+    SmallVector<Type> argTypes{ptrType, i64Ty};
+    SmallVector<Value> args{
+        adaptor.getPtr(),
+        getI64Constant(rewriter, op.getLoc(),
+                       getDcciCacheLineImmediate(op.getCache().getKind()))};
+    if (auto dst = op.getDstAttr()) {
+      argTypes.push_back(i64Ty);
+      args.push_back(getI64Constant(rewriter, op.getLoc(),
+                                    getDcciDstImmediate(dst.getKind())));
+    }
+
+    auto funcType = rewriter.getFunctionType(argTypes, TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{}, args);
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 template <typename BufSyncOp>
 class LowerBufSyncOpPattern final : public OpConversionPattern<BufSyncOp> {
 public:
@@ -9934,7 +10029,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerPipeEventSyncOpPattern<pto::WaitFlagOp>,
                LowerPipeEventDynSyncOpPattern<pto::SetFlagDynOp>,
                LowerPipeEventDynSyncOpPattern<pto::WaitFlagDynOp>,
-               LowerBarrierOpPattern, LowerMemBarOpPattern,
+               LowerBarrierOpPattern, LowerMemBarOpPattern, LowerDsbOpPattern,
+               LowerDcciOpPattern,
                LowerBufSyncOpPattern<pto::GetBufOp>,
                LowerBufSyncOpPattern<pto::RlsBufOp>,
                LowerRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
@@ -9996,6 +10092,7 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
   target.addLegalOp<UnrealizedConversionCastOp>();
   target.addIllegalOp<pto::SetFlagOp, pto::WaitFlagOp, pto::SetFlagDynOp, pto::WaitFlagDynOp, pto::SyncSetOp,
                       pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
+                      pto::DsbOp, pto::DcciOp,
                       pto::GetBufOp, pto::RlsBufOp>();
   target.addIllegalOp<pto::GetBlockIdxOp, pto::GetSubBlockIdxOp,
                       pto::GetBlockNumOp, pto::GetSubBlockNumOp,

--- a/test/lit/vpto/dcci_dsb_vpto_llvm.pto
+++ b/test/lit/vpto/dcci_dsb_vpto_llvm.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s --check-prefix=LLVM
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @dcci_dsb_kernel(%gm: !pto.ptr<i8, gm>, %ub: !pto.ptr<i8, ub>) attributes {pto.kernel} {
+    pto.dcci %gm "SINGLE_CACHE_LINE" : !pto.ptr<i8, gm>
+    pto.dcci %gm "ENTIRE_DATA_CACHE", "CACHELINE_OUT" : !pto.ptr<i8, gm>
+    pto.dcci %ub "SINGLE_CACHE_LINE" : !pto.ptr<i8, ub>
+    pto.dcci %ub "SINGLE_CACHE_LINE", "CACHELINE_UB" : !pto.ptr<i8, ub>
+    pto.dsb "ALL"
+    pto.dsb "DDR"
+    pto.dsb "UB"
+    pto.dsb "SEQ"
+    return
+  }
+}
+
+// ROUNDTRIP: pto.dcci {{.*}} "SINGLE_CACHE_LINE" : !pto.ptr<i8, gm>
+// ROUNDTRIP: pto.dcci {{.*}} "ENTIRE_DATA_CACHE" {{,}} "CACHELINE_OUT" : !pto.ptr<i8, gm>
+// ROUNDTRIP: pto.dcci {{.*}} "SINGLE_CACHE_LINE" : !pto.ptr<i8, ub>
+// ROUNDTRIP: pto.dcci {{.*}} "SINGLE_CACHE_LINE" {{,}} "CACHELINE_UB" : !pto.ptr<i8, ub>
+// ROUNDTRIP: pto.dsb "ALL"
+// ROUNDTRIP: pto.dsb "DDR"
+// ROUNDTRIP: pto.dsb "UB"
+// ROUNDTRIP: pto.dsb "SEQ"
+
+// LLVM-LABEL: llvm.func @dcci_dsb_kernel_mix_aiv
+// LLVM-DAG: llvm.call @llvm.hivm.DCCI(
+// LLVM-DAG: llvm.call @llvm.hivm.DCCI.DST(
+// LLVM-DAG: llvm.call @llvm.hivm.DCCI.UB(
+// LLVM-DAG: llvm.call @llvm.hivm.DCCI.DST.UB(
+// LLVM-DAG: llvm.call @llvm.hivm.DSB(

--- a/test/vpto/cases/micro-op/scalar-load-store/load-store-scalar-ub/kernel.pto
+++ b/test/vpto/cases/micro-op/scalar-load-store/load-store-scalar-ub/kernel.pto
@@ -46,6 +46,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       nburst(%c1_i64, %c64_i64, %c64_i64)
       : !pto.ptr<i16, ub>, !pto.ptr<i16, gm>, i64, i64, i64, i64
     pto.barrier #pto.pipe<PIPE_ALL>
+    pto.dcci %arg1 "ENTIRE_DATA_CACHE", "CACHELINE_OUT" : !pto.ptr<i16, gm>
+    pto.dcci %ub_out "SINGLE_CACHE_LINE", "CACHELINE_UB" : !pto.ptr<i16, ub>
+    pto.dsb "ALL"
     return
   }
 }


### PR DESCRIPTION
## Summary
- add VPTO `pto.dcci` and `pto.dsb` ops with attrs, parser/printer, verifier, and LLVM lowering
- document DCCI/DSB semantics and VPTO syntax
- add lit coverage and insert DCCI/DSB into an existing SIM runtime case

## Validation
- `cmake --build build-main-llvm21 -j64 --target ptoas`
- `PATH=/home/mouliangyu/projects/github.com/mouliangyu/PTOAS-2/.work/llvm-build-feature-vpto-llvm21/bin:$PATH /home/mouliangyu/projects/github.com/mouliangyu/PTOAS-2/.work/llvm-build-feature-vpto-llvm21/bin/llvm-lit -v build-main-llvm21/test/lit --filter dcci_dsb_vpto_llvm`
- `WORK_SPACE=$PWD/.work/vpto-dcci-dsb-sim CASE_NAME=micro-op/scalar-load-store/load-store-scalar-ub DEVICE=SIM PTOAS_BIN=$PWD/build-main-llvm21/tools/ptoas/ptoas test/vpto/scripts/run_host_vpto_validation.sh`