### PR TITLE
Feature/add dynamic buf_id support for pto.get_buf / pto.rls_buf

### DIFF
--- a/docs/isa/micro-isa/01-pipeline-sync.md
+++ b/docs/isa/micro-isa/01-pipeline-sync.md
@@ -113,6 +113,32 @@ The `mode` parameter controls how `get_buf` and `rls_buf` interact with pipeline
 
 ---
 
+### `pto.get_buf_dyn` / `pto.rls_buf_dyn`
+
+Dynamic variants of `get_buf`/`rls_buf` where `buf_id` is provided as an SSA value instead of a static integer attribute. This enables runtime-computed buf_id patterns such as SIMT ping-pong buffering.
+
+- **syntax:**
+  - String shorthand: `pto.get_buf_dyn "PIPE_MTE2", %buf_id, 0`
+  - Bracket form: `pto.get_buf_dyn [TLOAD, %buf_id, 0]`
+- **semantics:** Same as `get_buf`/`rls_buf`, but the buffer-id is an `index`-typed SSA value resolved at runtime.
+- **inputs:**
+  - `op_type`: same pipe-like attribute as the static form
+  - `buf_id`: an SSA value of `index` type (e.g. `iter & 1` for ping-pong)
+  - `mode`: same mode parameter (default `0`)
+- **constraints and limitations:** The BufidSync auto-insertion pass only uses the static form (`get_buf`/`rls_buf`). Use the dynamic form (`get_buf_dyn`/`rls_buf_dyn`) when buf_id must be computed at runtime.
+
+Example (SIMT double-buffering with `iter & 1`):
+
+```mlir
+  %c1 = arith.constant 1 : index
+  %buf_id = arith.andi %iter, %c1 : index
+  pto.get_buf_dyn [TLOAD, %buf_id, 0]
+  // ... tload to ubuf slot %buf_id ...
+  pto.rls_buf_dyn [TLOAD, %buf_id, 0]
+```
+
+---
+
 ### `pto.mem_bar`
 
 - **syntax:** `pto.mem_bar "BARRIER_TYPE"`

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -973,6 +973,64 @@ func.func @body(%ub: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
 }
 ```
 
+**Memory ordering contract:** `pto.syncthreads` provides **acquire+release** semantics on
+global and shared memory visible to all workitems in the SIMT entry. Any store
+executed by a workitem before `syncthreads` is visible to every workitem after
+`syncthreads`. This is a full workitem barrier, not a pipeline drain — use
+`pto.barrier` (see below) when a hardware pipe must be drained.
+
+### `pto.barrier` (Pipe Barrier)
+
+- **syntax:** `pto.barrier $pipe attr-dict`
+- **semantics:** Drains all outstanding operations on the specified hardware pipe.
+  Does **not** synchronize across SIMT workitems. In SIMT kernels, a common pattern
+  is to pair `pto.barrier` with `pto.syncthreads`: use `barrier` before
+  `syncthreads` to ensure DMA/MTE transfers have completed, then `syncthreads`
+  to make the results visible across workitems.
+- **pipe values:** `PIPE_MTE2`, `PIPE_V`, `PIPE_MTE3`, `PIPE_ALL`, etc.
+- **constraints:** `pto.barrier` can appear in both SIMT-entry and non-SIMT
+  functions. It drains at the hardware level; the workitems' view of memory may
+  not be consistent until a subsequent `syncthreads`.
+
+Example combining barrier and syncthreads:
+
+```mlir
+  pto.mte_ub_gm %ub, %gm, %len ... : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64
+  pto.barrier #pto.pipe<PIPE_MTE3>
+  pto.syncthreads
+  // Safe to load MTE result from UB
+```
+
+### Buffer-ID Synchronization (`pto.get_buf` / `pto.rls_buf`)
+
+- **syntax:**
+  - Static: `pto.get_buf "TLOAD", 3, 0`
+  - Dynamic: `pto.get_buf [TLOAD, %buf_id, 0]` or `pto.get_buf "TLOAD", %buf_id, 0`
+- **semantics:** Acquires (`get_buf`) or releases (`rls_buf`) a buffer-ID token
+  for the given operation type. Operations mapped to the same pipe and guarded by
+  the same buffer-id execute in program order relative to other mapped pipes using
+  the same buffer-id. This enables double-buffering and multi-buffering patterns.
+- **inputs:**
+  - `op_type`: a pipe-like attribute (`PIPE_*`, `sync_op_type`, or `pipe_event_type`)
+  - `buf_id`: either a **static** integer attribute (range `[0, 31]`) or a
+    **dynamic** SSA value of `index` type (e.g., `iter & 1` for ping-pong)
+  - `mode`: optional mode attribute (default `0`)
+- **constraints and limitations:** Exactly one of static `buf_id` attribute or
+  dynamic `buf_id` operand must be provided. The BufidSync auto-insertion pass
+  uses the static form. Dynamic `buf_id` enables SIMT patterns such as staged
+  double-buffering with `(iter & 1)`.
+
+Example (dynamic double-buffering):
+
+```mlir
+  %c1 = arith.constant 1 : index
+  %buf_id = arith.andi %iter, %c1 : index
+  pto.get_buf "TLOAD", %buf_id, 0
+  // ... tload to ubuf slot %buf_id ...
+  pto.rls_buf "TLOAD", %buf_id, 0
+  pto.syncthreads
+```
+
 ### `pto.threadfence` / `pto.threadfence_block`
 
 - **syntax:** `pto.threadfence attr-dict` or `pto.threadfence_block attr-dict`

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -1001,35 +1001,10 @@ Example combining barrier and syncthreads:
   // Safe to load MTE result from UB
 ```
 
-### Buffer-ID Synchronization (`pto.get_buf` / `pto.rls_buf`)
-
-- **syntax:**
-  - Static: `pto.get_buf "TLOAD", 3, 0`
-  - Dynamic: `pto.get_buf [TLOAD, %buf_id, 0]` or `pto.get_buf "TLOAD", %buf_id, 0`
-- **semantics:** Acquires (`get_buf`) or releases (`rls_buf`) a buffer-ID token
-  for the given operation type. Operations mapped to the same pipe and guarded by
-  the same buffer-id execute in program order relative to other mapped pipes using
-  the same buffer-id. This enables double-buffering and multi-buffering patterns.
-- **inputs:**
-  - `op_type`: a pipe-like attribute (`PIPE_*`, `sync_op_type`, or `pipe_event_type`)
-  - `buf_id`: either a **static** integer attribute (range `[0, 31]`) or a
-    **dynamic** SSA value of `index` type (e.g., `iter & 1` for ping-pong)
-  - `mode`: optional mode attribute (default `0`)
-- **constraints and limitations:** Exactly one of static `buf_id` attribute or
-  dynamic `buf_id` operand must be provided. The BufidSync auto-insertion pass
-  uses the static form. Dynamic `buf_id` enables SIMT patterns such as staged
-  double-buffering with `(iter & 1)`.
-
-Example (dynamic double-buffering):
-
-```mlir
-  %c1 = arith.constant 1 : index
-  %buf_id = arith.andi %iter, %c1 : index
-  pto.get_buf "TLOAD", %buf_id, 0
-  // ... tload to ubuf slot %buf_id ...
-  pto.rls_buf "TLOAD", %buf_id, 0
-  pto.syncthreads
-```
+> **Note:** For buffer-based synchronization (`get_buf`/`rls_buf` and their dynamic
+> variants `get_buf_dyn`/`rls_buf_dyn`), see [1. Pipeline Synchronization](01-pipeline-sync.md).
+> The dynamic variants are particularly useful for SIMT double-buffering patterns
+> (e.g. `iter & 1` for ping-pong).
 
 ### `pto.threadfence` / `pto.threadfence_block`
 

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -973,39 +973,6 @@ func.func @body(%ub: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
 }
 ```
 
-**Memory ordering contract:** `pto.syncthreads` provides **acquire+release** semantics on
-global and shared memory visible to all workitems in the SIMT entry. Any store
-executed by a workitem before `syncthreads` is visible to every workitem after
-`syncthreads`. This is a full workitem barrier, not a pipeline drain — use
-`pto.barrier` (see below) when a hardware pipe must be drained.
-
-### `pto.barrier` (Pipe Barrier)
-
-- **syntax:** `pto.barrier $pipe attr-dict`
-- **semantics:** Drains all outstanding operations on the specified hardware pipe.
-  Does **not** synchronize across SIMT workitems. In SIMT kernels, a common pattern
-  is to pair `pto.barrier` with `pto.syncthreads`: use `barrier` before
-  `syncthreads` to ensure DMA/MTE transfers have completed, then `syncthreads`
-  to make the results visible across workitems.
-- **pipe values:** `PIPE_MTE2`, `PIPE_V`, `PIPE_MTE3`, `PIPE_ALL`, etc.
-- **constraints:** `pto.barrier` can appear in both SIMT-entry and non-SIMT
-  functions. It drains at the hardware level; the workitems' view of memory may
-  not be consistent until a subsequent `syncthreads`.
-
-Example combining barrier and syncthreads:
-
-```mlir
-  pto.mte_ub_gm %ub, %gm, %len ... : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64
-  pto.barrier #pto.pipe<PIPE_MTE3>
-  pto.syncthreads
-  // Safe to load MTE result from UB
-```
-
-> **Note:** For buffer-based synchronization (`get_buf`/`rls_buf` and their dynamic
-> variants `get_buf_dyn`/`rls_buf_dyn`), see [1. Pipeline Synchronization](01-pipeline-sync.md).
-> The dynamic variants are particularly useful for SIMT double-buffering patterns
-> (e.g. `iter & 1` for ping-pong).
-
 ### `pto.threadfence` / `pto.threadfence_block`
 
 - **syntax:** `pto.threadfence attr-dict` or `pto.threadfence_block attr-dict`

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2812,19 +2812,15 @@ def GetBufOp : PTO_Op<"get_buf"> {
 
   let arguments = (ins
     PTO_PipeLikeAttr:$op_type,
-    I32Attr:$buf_id,
-    DefaultValuedAttr<I32Attr, "0">:$mode
+    OptionalAttr<I32Attr>:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode,
+    Optional<Index>:$buf_id_dyn
   );
 
   let results = (outs);
 
   let hasVerifier = 1;
-
-  let extraClassDeclaration = [{
-    void print(::mlir::OpAsmPrinter &p);
-    static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser,
-                                     ::mlir::OperationState &result);
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def RlsBufOp : PTO_Op<"rls_buf"> {
@@ -2838,19 +2834,15 @@ def RlsBufOp : PTO_Op<"rls_buf"> {
 
   let arguments = (ins
     PTO_PipeLikeAttr:$op_type,
-    I32Attr:$buf_id,
-    DefaultValuedAttr<I32Attr, "0">:$mode
+    OptionalAttr<I32Attr>:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode,
+    Optional<Index>:$buf_id_dyn
   );
 
   let results = (outs);
 
   let hasVerifier = 1;
-
-  let extraClassDeclaration = [{
-    void print(::mlir::OpAsmPrinter &p);
-    static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser,
-                                     ::mlir::OperationState &result);
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def SyncSetOp : PTO_Op<"sync.set"> {

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -2812,9 +2812,34 @@ def GetBufOp : PTO_Op<"get_buf"> {
 
   let arguments = (ins
     PTO_PipeLikeAttr:$op_type,
-    OptionalAttr<I32Attr>:$buf_id,
-    DefaultValuedAttr<I32Attr, "0">:$mode,
-    Optional<Index>:$buf_id_dyn
+    I32Attr:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    void print(::mlir::OpAsmPrinter &p);
+    static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser,
+                                     ::mlir::OperationState &result);
+  }];
+}
+
+def GetBufDynOp : PTO_Op<"get_buf_dyn"> {
+  let summary = "Acquire a buffer-id token (dynamic buf-id)";
+  let description = [{
+    Dynamic variant of `pto.get_buf` where the buffer-id is provided as an
+    SSA value (index) instead of a static integer attribute. This enables
+    runtime-computed buf_id patterns such as SIMT ping-pong buffering
+    (e.g. `iter & 1`).
+  }];
+
+  let arguments = (ins
+    PTO_PipeLikeAttr:$op_type,
+    Index:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode
   );
 
   let results = (outs);
@@ -2834,9 +2859,32 @@ def RlsBufOp : PTO_Op<"rls_buf"> {
 
   let arguments = (ins
     PTO_PipeLikeAttr:$op_type,
-    OptionalAttr<I32Attr>:$buf_id,
-    DefaultValuedAttr<I32Attr, "0">:$mode,
-    Optional<Index>:$buf_id_dyn
+    I32Attr:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode
+  );
+
+  let results = (outs);
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    void print(::mlir::OpAsmPrinter &p);
+    static ::mlir::ParseResult parse(::mlir::OpAsmParser &parser,
+                                     ::mlir::OperationState &result);
+  }];
+}
+
+def RlsBufDynOp : PTO_Op<"rls_buf_dyn"> {
+  let summary = "Release a buffer-id token (dynamic buf-id)";
+  let description = [{
+    Dynamic variant of `pto.rls_buf` where the buffer-id is provided as an
+    SSA value (index) instead of a static integer attribute.
+  }];
+
+  let arguments = (ins
+    PTO_PipeLikeAttr:$op_type,
+    Index:$buf_id,
+    DefaultValuedAttr<I32Attr, "0">:$mode
   );
 
   let results = (outs);

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -8149,7 +8149,8 @@ LogicalResult CmoCacheInvalidOp::verify() {
 
 // ---- GetBufOp / RlsBufOp ----
 static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
-                                     IntegerAttr bufIdAttr, IntegerAttr modeAttr) {
+                                     IntegerAttr bufIdAttr, Value bufIdDyn,
+                                     IntegerAttr modeAttr) {
   if (!opTypeAttr)
     return op->emitOpError("expects 'op_type' attribute");
 
@@ -8169,11 +8170,18 @@ static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
   if (!isConcreteSyncPipe(pipe))
     return op->emitOpError("expects 'op_type' to map to a concrete pipe, not PIPE_ALL/PIPE_UNASSIGNED");
 
-  if (!bufIdAttr)
-    return op->emitOpError("expects 'buf_id' attribute");
-  int64_t bufId = bufIdAttr.getInt();
-  if (bufId < 0 || bufId > 31)
-    return op->emitOpError("expects 'buf_id' in range [0, 31]");
+  bool hasStatic = (bufIdAttr != nullptr);
+  bool hasDynamic = static_cast<bool>(bufIdDyn);
+  if (hasStatic == hasDynamic)
+    return op->emitOpError()
+           << "expects exactly one buf-id form: static attribute or dynamic "
+              "index operand";
+
+  if (hasStatic) {
+    int64_t bufId = bufIdAttr.getInt();
+    if (bufId < 0 || bufId > 31)
+      return op->emitOpError("expects 'buf_id' in range [0, 31]");
+  }
 
   if (modeAttr) {
     int64_t mode = modeAttr.getInt();
@@ -8186,12 +8194,12 @@ static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
 
 LogicalResult GetBufOp::verify() {
   return verifyBufSyncOp(getOperation(), getOpTypeAttr(), getBufIdAttr(),
-                         getModeAttr());
+                         getBufIdDyn(), getModeAttr());
 }
 
 LogicalResult RlsBufOp::verify() {
   return verifyBufSyncOp(getOperation(), getOpTypeAttr(), getBufIdAttr(),
-                         getModeAttr());
+                         getBufIdDyn(), getModeAttr());
 }
 
 static ParseResult parseLegacyOrAttrMemBar(OpAsmParser &parser,
@@ -8466,7 +8474,6 @@ void MemBarOp::print(OpAsmPrinter &p) {
 
 static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
   Attribute opTypeAttr;
-  IntegerAttr bufIdAttr;
   IntegerAttr modeAttr;
 
   auto loc = parser.getCurrentLocation();
@@ -8479,8 +8486,26 @@ static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
     else
       return parser.emitError(loc) << "invalid get_buf/rls_buf token: " << token;
 
-    if (parser.parseComma() || parseI32LiteralAttr(parser, bufIdAttr))
+    if (parser.parseComma())
       return failure();
+
+    OpAsmParser::UnresolvedOperand bufOperand;
+    OptionalParseResult parseBufOperand =
+        parser.parseOptionalOperand(bufOperand);
+    if (parseBufOperand.has_value()) {
+      if (failed(*parseBufOperand))
+        return failure();
+      if (parser.resolveOperand(bufOperand,
+                                parser.getBuilder().getIndexType(),
+                                result.operands))
+        return failure();
+    } else {
+      IntegerAttr bufIdAttr;
+      if (parseI32LiteralAttr(parser, bufIdAttr))
+        return failure();
+      result.addAttribute("buf_id", bufIdAttr);
+    }
+
     if (succeeded(parser.parseOptionalComma())) {
       if (parseI32LiteralAttr(parser, modeAttr))
         return failure();
@@ -8488,9 +8513,26 @@ static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
       modeAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), 0);
     }
   } else if (succeeded(parser.parseOptionalLSquare())) {
-    if (parser.parseAttribute(opTypeAttr) || parser.parseComma() ||
-        parseI32LiteralAttr(parser, bufIdAttr))
+    if (parser.parseAttribute(opTypeAttr) || parser.parseComma())
       return failure();
+
+    OpAsmParser::UnresolvedOperand bufOperand;
+    OptionalParseResult parseBufOperand =
+        parser.parseOptionalOperand(bufOperand);
+    if (parseBufOperand.has_value()) {
+      if (failed(*parseBufOperand))
+        return failure();
+      if (parser.resolveOperand(bufOperand,
+                                parser.getBuilder().getIndexType(),
+                                result.operands))
+        return failure();
+    } else {
+      IntegerAttr bufIdAttr;
+      if (parseI32LiteralAttr(parser, bufIdAttr))
+        return failure();
+      result.addAttribute("buf_id", bufIdAttr);
+    }
+
     if (succeeded(parser.parseOptionalComma())) {
       if (parseI32LiteralAttr(parser, modeAttr))
         return failure();
@@ -8506,26 +8548,42 @@ static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
   if (parser.parseOptionalAttrDict(result.attributes))
     return failure();
   result.addAttribute("op_type", opTypeAttr);
-  result.addAttribute("buf_id", bufIdAttr);
   result.addAttribute("mode", modeAttr);
   return success();
 }
 
 static void printBufSyncOp(OpAsmPrinter &p, Attribute opTypeAttr,
-                           IntegerAttr bufIdAttr, IntegerAttr modeAttr,
+                           IntegerAttr bufIdAttr, Value bufIdDyn,
+                           IntegerAttr modeAttr,
                            ArrayRef<NamedAttribute> attrs) {
   if (auto pipeAttr = dyn_cast<PipeAttr>(opTypeAttr)) {
-    p << " \"" << stringifyPIPE(pipeAttr.getPipe()) << "\", "
-      << bufIdAttr.getInt() << ", " << modeAttr.getInt();
+    p << " \"" << stringifyPIPE(pipeAttr.getPipe()) << "\", ";
+    if (bufIdAttr)
+      p << bufIdAttr.getInt();
+    else
+      p << bufIdDyn;
+    p << ", " << modeAttr.getInt();
   } else if (auto pipeEventType = dyn_cast<PipeEventTypeAttr>(opTypeAttr)) {
-    p << "[" << opTypeAttr << ", " << bufIdAttr.getInt() << ", "
-      << modeAttr.getInt() << "]";
+    p << "[" << opTypeAttr << ", ";
+    if (bufIdAttr)
+      p << bufIdAttr.getInt();
+    else
+      p << bufIdDyn;
+    p << ", " << modeAttr.getInt() << "]";
   } else if (auto syncOpType = dyn_cast<SyncOpTypeAttr>(opTypeAttr)) {
-    p << "[" << opTypeAttr << ", " << bufIdAttr.getInt() << ", "
-      << modeAttr.getInt() << "]";
+    p << "[" << opTypeAttr << ", ";
+    if (bufIdAttr)
+      p << bufIdAttr.getInt();
+    else
+      p << bufIdDyn;
+    p << ", " << modeAttr.getInt() << "]";
   } else {
-    p << "[" << opTypeAttr << ", " << bufIdAttr.getInt() << ", "
-      << modeAttr.getInt() << "]";
+    p << "[" << opTypeAttr << ", ";
+    if (bufIdAttr)
+      p << bufIdAttr.getInt();
+    else
+      p << bufIdDyn;
+    p << ", " << modeAttr.getInt() << "]";
   }
   p.printOptionalAttrDict(attrs, {"op_type", "buf_id", "mode"});
 }
@@ -8535,8 +8593,8 @@ ParseResult GetBufOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void GetBufOp::print(OpAsmPrinter &p) {
-  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getModeAttr(),
-                 (*this)->getAttrs());
+  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getBufIdDyn(),
+                 getModeAttr(), (*this)->getAttrs());
 }
 
 ParseResult RlsBufOp::parse(OpAsmParser &parser, OperationState &result) {
@@ -8544,8 +8602,8 @@ ParseResult RlsBufOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void RlsBufOp::print(OpAsmPrinter &p) {
-  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getModeAttr(),
-                 (*this)->getAttrs());
+  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getBufIdDyn(),
+                 getModeAttr(), (*this)->getAttrs());
 }
 // ---- TOp ----
 LogicalResult TGemvBiasOp::verify() {

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -8149,7 +8149,7 @@ LogicalResult CmoCacheInvalidOp::verify() {
 
 // ---- GetBufOp / RlsBufOp ----
 static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
-                                     IntegerAttr bufIdAttr, Value bufIdDyn,
+                                     IntegerAttr bufIdAttr,
                                      IntegerAttr modeAttr) {
   if (!opTypeAttr)
     return op->emitOpError("expects 'op_type' attribute");
@@ -8170,18 +8170,11 @@ static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
   if (!isConcreteSyncPipe(pipe))
     return op->emitOpError("expects 'op_type' to map to a concrete pipe, not PIPE_ALL/PIPE_UNASSIGNED");
 
-  bool hasStatic = (bufIdAttr != nullptr);
-  bool hasDynamic = static_cast<bool>(bufIdDyn);
-  if (hasStatic == hasDynamic)
-    return op->emitOpError()
-           << "expects exactly one buf-id form: static attribute or dynamic "
-              "index operand";
-
-  if (hasStatic) {
-    int64_t bufId = bufIdAttr.getInt();
-    if (bufId < 0 || bufId > 31)
-      return op->emitOpError("expects 'buf_id' in range [0, 31]");
-  }
+  if (!bufIdAttr)
+    return op->emitOpError("expects 'buf_id' attribute");
+  int64_t bufId = bufIdAttr.getInt();
+  if (bufId < 0 || bufId > 31)
+    return op->emitOpError("expects 'buf_id' in range [0, 31]");
 
   if (modeAttr) {
     int64_t mode = modeAttr.getInt();
@@ -8194,12 +8187,56 @@ static LogicalResult verifyBufSyncOp(Operation *op, Attribute opTypeAttr,
 
 LogicalResult GetBufOp::verify() {
   return verifyBufSyncOp(getOperation(), getOpTypeAttr(), getBufIdAttr(),
-                         getBufIdDyn(), getModeAttr());
+                         getModeAttr());
 }
 
 LogicalResult RlsBufOp::verify() {
   return verifyBufSyncOp(getOperation(), getOpTypeAttr(), getBufIdAttr(),
-                         getBufIdDyn(), getModeAttr());
+                         getModeAttr());
+}
+
+// ---- GetBufDynOp / RlsBufDynOp ----
+static LogicalResult verifyBufDynSyncOp(Operation *op, Attribute opTypeAttr,
+                                        Value bufId, IntegerAttr modeAttr) {
+  if (!opTypeAttr)
+    return op->emitOpError("expects 'op_type' attribute");
+
+  pto::PIPE pipe = pto::PIPE::PIPE_UNASSIGNED;
+  if (auto pipeAttr = dyn_cast<PipeAttr>(opTypeAttr)) {
+    pipe = pipeAttr.getPipe();
+  } else {
+    auto opTypeOr = parseSyncOpTypeLikeAttr(opTypeAttr);
+    if (failed(opTypeOr)) {
+      auto diag = op->emitOpError(
+          "expects 'op_type' to be pipe_event_type/sync_op_type/pipe, got ");
+      diag << opTypeAttr;
+      return failure();
+    }
+    pipe = mapSyncOpTypeToPipe(*opTypeOr);
+  }
+  if (!isConcreteSyncPipe(pipe))
+    return op->emitOpError("expects 'op_type' to map to a concrete pipe, not PIPE_ALL/PIPE_UNASSIGNED");
+
+  if (!bufId)
+    return op->emitOpError("expects 'buf_id' operand");
+
+  if (modeAttr) {
+    int64_t mode = modeAttr.getInt();
+    if (mode < 0)
+      return op->emitOpError("expects 'mode' to be non-negative");
+  }
+
+  return success();
+}
+
+LogicalResult GetBufDynOp::verify() {
+  return verifyBufDynSyncOp(getOperation(), getOpTypeAttr(), getBufId(),
+                            getModeAttr());
+}
+
+LogicalResult RlsBufDynOp::verify() {
+  return verifyBufDynSyncOp(getOperation(), getOpTypeAttr(), getBufId(),
+                            getModeAttr());
 }
 
 static ParseResult parseLegacyOrAttrMemBar(OpAsmParser &parser,
@@ -8474,6 +8511,7 @@ void MemBarOp::print(OpAsmPrinter &p) {
 
 static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
   Attribute opTypeAttr;
+  IntegerAttr bufIdAttr;
   IntegerAttr modeAttr;
 
   auto loc = parser.getCurrentLocation();
@@ -8486,25 +8524,102 @@ static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
     else
       return parser.emitError(loc) << "invalid get_buf/rls_buf token: " << token;
 
+    if (parser.parseComma() || parseI32LiteralAttr(parser, bufIdAttr))
+      return failure();
+    if (succeeded(parser.parseOptionalComma())) {
+      if (parseI32LiteralAttr(parser, modeAttr))
+        return failure();
+    } else {
+      modeAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), 0);
+    }
+  } else if (succeeded(parser.parseOptionalLSquare())) {
+    if (parser.parseAttribute(opTypeAttr) || parser.parseComma() ||
+        parseI32LiteralAttr(parser, bufIdAttr))
+      return failure();
+    if (succeeded(parser.parseOptionalComma())) {
+      if (parseI32LiteralAttr(parser, modeAttr))
+        return failure();
+    } else {
+      modeAttr = IntegerAttr::get(IntegerType::get(parser.getContext(), 32), 0);
+    }
+    if (parser.parseRSquare())
+      return failure();
+  } else {
+    return parser.emitError(loc, "expected string pipe/op_type or '['");
+  }
+
+  if (parser.parseOptionalAttrDict(result.attributes))
+    return failure();
+  result.addAttribute("op_type", opTypeAttr);
+  result.addAttribute("buf_id", bufIdAttr);
+  result.addAttribute("mode", modeAttr);
+  return success();
+}
+
+static void printBufSyncOp(OpAsmPrinter &p, Attribute opTypeAttr,
+                           IntegerAttr bufIdAttr, IntegerAttr modeAttr,
+                           ArrayRef<NamedAttribute> attrs) {
+  if (auto pipeAttr = dyn_cast<PipeAttr>(opTypeAttr)) {
+    p << " \"" << stringifyPIPE(pipeAttr.getPipe()) << "\", "
+      << bufIdAttr.getInt() << ", " << modeAttr.getInt();
+  } else if (auto pipeEventType = dyn_cast<PipeEventTypeAttr>(opTypeAttr)) {
+    p << "[" << opTypeAttr << ", " << bufIdAttr.getInt() << ", "
+      << modeAttr.getInt() << "]";
+  } else if (auto syncOpType = dyn_cast<SyncOpTypeAttr>(opTypeAttr)) {
+    p << "[" << opTypeAttr << ", " << bufIdAttr.getInt() << ", "
+      << modeAttr.getInt() << "]";
+  } else {
+    p << "[" << opTypeAttr << ", " << bufIdAttr.getInt() << ", "
+      << modeAttr.getInt() << "]";
+  }
+  p.printOptionalAttrDict(attrs, {"op_type", "buf_id", "mode"});
+}
+
+ParseResult GetBufOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseBufSyncOp(parser, result);
+}
+
+void GetBufOp::print(OpAsmPrinter &p) {
+  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getModeAttr(),
+                 (*this)->getAttrs());
+}
+
+ParseResult RlsBufOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseBufSyncOp(parser, result);
+}
+
+void RlsBufOp::print(OpAsmPrinter &p) {
+  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getModeAttr(),
+                 (*this)->getAttrs());
+}
+
+// ---- GetBufDynOp / RlsBufDynOp parse/print ----
+static ParseResult parseBufDynSyncOp(OpAsmParser &parser,
+                                     OperationState &result) {
+  Attribute opTypeAttr;
+  IntegerAttr modeAttr;
+
+  auto loc = parser.getCurrentLocation();
+  std::string token;
+  if (succeeded(parser.parseOptionalString(&token))) {
+    if (auto pipe = symbolizePIPE(token))
+      opTypeAttr = PipeAttr::get(parser.getContext(), *pipe);
+    else if (auto opType = symbolizeSyncOpType(token))
+      opTypeAttr = PipeEventTypeAttr::get(parser.getContext(), *opType);
+    else
+      return parser.emitError(loc)
+             << "invalid get_buf_dyn/rls_buf_dyn token: " << token;
+
     if (parser.parseComma())
       return failure();
 
     OpAsmParser::UnresolvedOperand bufOperand;
-    OptionalParseResult parseBufOperand =
-        parser.parseOptionalOperand(bufOperand);
-    if (parseBufOperand.has_value()) {
-      if (failed(*parseBufOperand))
-        return failure();
-      if (parser.resolveOperand(bufOperand,
-                                parser.getBuilder().getIndexType(),
-                                result.operands))
-        return failure();
-    } else {
-      IntegerAttr bufIdAttr;
-      if (parseI32LiteralAttr(parser, bufIdAttr))
-        return failure();
-      result.addAttribute("buf_id", bufIdAttr);
-    }
+    if (parser.parseOperand(bufOperand))
+      return failure();
+    if (parser.resolveOperand(bufOperand,
+                              parser.getBuilder().getIndexType(),
+                              result.operands))
+      return failure();
 
     if (succeeded(parser.parseOptionalComma())) {
       if (parseI32LiteralAttr(parser, modeAttr))
@@ -8517,21 +8632,12 @@ static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
       return failure();
 
     OpAsmParser::UnresolvedOperand bufOperand;
-    OptionalParseResult parseBufOperand =
-        parser.parseOptionalOperand(bufOperand);
-    if (parseBufOperand.has_value()) {
-      if (failed(*parseBufOperand))
-        return failure();
-      if (parser.resolveOperand(bufOperand,
-                                parser.getBuilder().getIndexType(),
-                                result.operands))
-        return failure();
-    } else {
-      IntegerAttr bufIdAttr;
-      if (parseI32LiteralAttr(parser, bufIdAttr))
-        return failure();
-      result.addAttribute("buf_id", bufIdAttr);
-    }
+    if (parser.parseOperand(bufOperand))
+      return failure();
+    if (parser.resolveOperand(bufOperand,
+                              parser.getBuilder().getIndexType(),
+                              result.operands))
+      return failure();
 
     if (succeeded(parser.parseOptionalComma())) {
       if (parseI32LiteralAttr(parser, modeAttr))
@@ -8552,58 +8658,35 @@ static ParseResult parseBufSyncOp(OpAsmParser &parser, OperationState &result) {
   return success();
 }
 
-static void printBufSyncOp(OpAsmPrinter &p, Attribute opTypeAttr,
-                           IntegerAttr bufIdAttr, Value bufIdDyn,
-                           IntegerAttr modeAttr,
-                           ArrayRef<NamedAttribute> attrs) {
+static void printBufDynSyncOp(OpAsmPrinter &p, Attribute opTypeAttr,
+                              Value bufId, IntegerAttr modeAttr,
+                              ArrayRef<NamedAttribute> attrs) {
   if (auto pipeAttr = dyn_cast<PipeAttr>(opTypeAttr)) {
-    p << " \"" << stringifyPIPE(pipeAttr.getPipe()) << "\", ";
-    if (bufIdAttr)
-      p << bufIdAttr.getInt();
-    else
-      p << bufIdDyn;
-    p << ", " << modeAttr.getInt();
-  } else if (auto pipeEventType = dyn_cast<PipeEventTypeAttr>(opTypeAttr)) {
-    p << "[" << opTypeAttr << ", ";
-    if (bufIdAttr)
-      p << bufIdAttr.getInt();
-    else
-      p << bufIdDyn;
-    p << ", " << modeAttr.getInt() << "]";
-  } else if (auto syncOpType = dyn_cast<SyncOpTypeAttr>(opTypeAttr)) {
-    p << "[" << opTypeAttr << ", ";
-    if (bufIdAttr)
-      p << bufIdAttr.getInt();
-    else
-      p << bufIdDyn;
-    p << ", " << modeAttr.getInt() << "]";
+    p << " \"" << stringifyPIPE(pipeAttr.getPipe()) << "\", " << bufId << ", "
+      << modeAttr.getInt();
   } else {
-    p << "[" << opTypeAttr << ", ";
-    if (bufIdAttr)
-      p << bufIdAttr.getInt();
-    else
-      p << bufIdDyn;
-    p << ", " << modeAttr.getInt() << "]";
+    p << "[" << opTypeAttr << ", " << bufId << ", " << modeAttr.getInt()
+      << "]";
   }
-  p.printOptionalAttrDict(attrs, {"op_type", "buf_id", "mode"});
+  p.printOptionalAttrDict(attrs, {"op_type", "mode"});
 }
 
-ParseResult GetBufOp::parse(OpAsmParser &parser, OperationState &result) {
-  return parseBufSyncOp(parser, result);
+ParseResult GetBufDynOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseBufDynSyncOp(parser, result);
 }
 
-void GetBufOp::print(OpAsmPrinter &p) {
-  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getBufIdDyn(),
-                 getModeAttr(), (*this)->getAttrs());
+void GetBufDynOp::print(OpAsmPrinter &p) {
+  printBufDynSyncOp(p, getOpTypeAttr(), getBufId(), getModeAttr(),
+                    (*this)->getAttrs());
 }
 
-ParseResult RlsBufOp::parse(OpAsmParser &parser, OperationState &result) {
-  return parseBufSyncOp(parser, result);
+ParseResult RlsBufDynOp::parse(OpAsmParser &parser, OperationState &result) {
+  return parseBufDynSyncOp(parser, result);
 }
 
-void RlsBufOp::print(OpAsmPrinter &p) {
-  printBufSyncOp(p, getOpTypeAttr(), getBufIdAttr(), getBufIdDyn(),
-                 getModeAttr(), (*this)->getAttrs());
+void RlsBufDynOp::print(OpAsmPrinter &p) {
+  printBufDynSyncOp(p, getOpTypeAttr(), getBufId(), getModeAttr(),
+                    (*this)->getAttrs());
 }
 // ---- TOp ----
 LogicalResult TGemvBiasOp::verify() {

--- a/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
@@ -87,9 +87,11 @@ LogicalResult BufidSyncCodegen::run() {
       }
 
       rewriter.setInsertionPoint(op);
-      auto opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
-      rewriter.create<pto::GetBufOp>(op->getLoc(), opTypeAttr,
-                                     static_cast<uint32_t>(physicalId), 0);
+      Attribute opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
+      rewriter.create<pto::GetBufOp>(
+          op->getLoc(), Attribute(opTypeAttr),
+          rewriter.getI32IntegerAttr(static_cast<int32_t>(physicalId)),
+          rewriter.getI32IntegerAttr(0), Value());
     }
 
     for (auto &syncAfter : pipeAfter) {
@@ -106,9 +108,11 @@ LogicalResult BufidSyncCodegen::run() {
       } else {
         rewriter.setInsertionPointAfter(op);
       }
-      auto opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
-      rewriter.create<pto::RlsBufOp>(op->getLoc(), opTypeAttr,
-                                     static_cast<uint32_t>(physicalId), 0);
+      Attribute opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
+      rewriter.create<pto::RlsBufOp>(
+          op->getLoc(), Attribute(opTypeAttr),
+          rewriter.getI32IntegerAttr(static_cast<int32_t>(physicalId)),
+          rewriter.getI32IntegerAttr(0), Value());
     }
 
     return WalkResult::advance();

--- a/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncCodegen.cpp
@@ -87,11 +87,9 @@ LogicalResult BufidSyncCodegen::run() {
       }
 
       rewriter.setInsertionPoint(op);
-      Attribute opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
-      rewriter.create<pto::GetBufOp>(
-          op->getLoc(), Attribute(opTypeAttr),
-          rewriter.getI32IntegerAttr(static_cast<int32_t>(physicalId)),
-          rewriter.getI32IntegerAttr(0), Value());
+      auto opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
+      rewriter.create<pto::GetBufOp>(op->getLoc(), opTypeAttr,
+                                     static_cast<uint32_t>(physicalId), 0);
     }
 
     for (auto &syncAfter : pipeAfter) {
@@ -109,10 +107,8 @@ LogicalResult BufidSyncCodegen::run() {
         rewriter.setInsertionPointAfter(op);
       }
       Attribute opTypeAttr = getOpTypeAttr(rewriter, *syncOpType);
-      rewriter.create<pto::RlsBufOp>(
-          op->getLoc(), Attribute(opTypeAttr),
-          rewriter.getI32IntegerAttr(static_cast<int32_t>(physicalId)),
-          rewriter.getI32IntegerAttr(0), Value());
+      rewriter.create<pto::RlsBufOp>(op->getLoc(), opTypeAttr,
+                                     static_cast<uint32_t>(physicalId), 0);
     }
 
     return WalkResult::advance();

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6113,7 +6113,6 @@ struct PTOGetBufToEmitC : public OpConversionPattern<mlir::pto::GetBufOp> {
 
   LogicalResult matchAndRewrite(mlir::pto::GetBufOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
-    (void)adaptor;
     auto *ctx = rewriter.getContext();
 
     auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
@@ -6123,17 +6122,33 @@ struct PTOGetBufToEmitC : public OpConversionPattern<mlir::pto::GetBufOp> {
     if (!isConcreteSyncPipe(pipe))
       return rewriter.notifyMatchFailure(op, "get_buf op_type cannot map to a concrete pipe");
     std::string pipeTok = pipeTokFromPipeEnum(pipe);
-    auto argsAttr = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, pipeTok),
-        op.getBufIdAttr(),
-        op.getModeAttr(),
-    });
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        op, TypeRange{}, "get_buf",
-        /*args=*/argsAttr,
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/ValueRange{});
+    IntegerAttr bufIdAttr = op.getBufIdAttr();
+    Value bufIdDyn = adaptor.getBufIdDyn();
+
+    if (bufIdAttr) {
+      auto argsAttr = rewriter.getArrayAttr({
+          emitc::OpaqueAttr::get(ctx, pipeTok),
+          bufIdAttr,
+          op.getModeAttr(),
+      });
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          op, TypeRange{}, "get_buf",
+          /*args=*/argsAttr,
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ValueRange{});
+    } else {
+      auto argsAttr = rewriter.getArrayAttr({
+          emitc::OpaqueAttr::get(ctx, pipeTok),
+          IntegerAttr::get(IndexType::get(ctx), 0),
+          op.getModeAttr(),
+      });
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          op, TypeRange{}, "get_buf",
+          /*args=*/argsAttr,
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ValueRange{bufIdDyn});
+    }
     return success();
   }
 };
@@ -6143,7 +6158,6 @@ struct PTORlsBufToEmitC : public OpConversionPattern<mlir::pto::RlsBufOp> {
 
   LogicalResult matchAndRewrite(mlir::pto::RlsBufOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
-    (void)adaptor;
     auto *ctx = rewriter.getContext();
 
     auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
@@ -6153,17 +6167,33 @@ struct PTORlsBufToEmitC : public OpConversionPattern<mlir::pto::RlsBufOp> {
     if (!isConcreteSyncPipe(pipe))
       return rewriter.notifyMatchFailure(op, "rls_buf op_type cannot map to a concrete pipe");
     std::string pipeTok = pipeTokFromPipeEnum(pipe);
-    auto argsAttr = rewriter.getArrayAttr({
-        emitc::OpaqueAttr::get(ctx, pipeTok),
-        op.getBufIdAttr(),
-        op.getModeAttr(),
-    });
 
-    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-        op, TypeRange{}, "rls_buf",
-        /*args=*/argsAttr,
-        /*templateArgs=*/ArrayAttr{},
-        /*operands=*/ValueRange{});
+    IntegerAttr bufIdAttr = op.getBufIdAttr();
+    Value bufIdDyn = adaptor.getBufIdDyn();
+
+    if (bufIdAttr) {
+      auto argsAttr = rewriter.getArrayAttr({
+          emitc::OpaqueAttr::get(ctx, pipeTok),
+          bufIdAttr,
+          op.getModeAttr(),
+      });
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          op, TypeRange{}, "rls_buf",
+          /*args=*/argsAttr,
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ValueRange{});
+    } else {
+      auto argsAttr = rewriter.getArrayAttr({
+          emitc::OpaqueAttr::get(ctx, pipeTok),
+          IntegerAttr::get(IndexType::get(ctx), 0),
+          op.getModeAttr(),
+      });
+      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+          op, TypeRange{}, "rls_buf",
+          /*args=*/argsAttr,
+          /*templateArgs=*/ArrayAttr{},
+          /*operands=*/ValueRange{bufIdDyn});
+    }
     return success();
   }
 };

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -6113,6 +6113,7 @@ struct PTOGetBufToEmitC : public OpConversionPattern<mlir::pto::GetBufOp> {
 
   LogicalResult matchAndRewrite(mlir::pto::GetBufOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
     auto *ctx = rewriter.getContext();
 
     auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
@@ -6122,33 +6123,46 @@ struct PTOGetBufToEmitC : public OpConversionPattern<mlir::pto::GetBufOp> {
     if (!isConcreteSyncPipe(pipe))
       return rewriter.notifyMatchFailure(op, "get_buf op_type cannot map to a concrete pipe");
     std::string pipeTok = pipeTokFromPipeEnum(pipe);
+    auto argsAttr = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        op.getBufIdAttr(),
+        op.getModeAttr(),
+    });
 
-    IntegerAttr bufIdAttr = op.getBufIdAttr();
-    Value bufIdDyn = adaptor.getBufIdDyn();
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "get_buf",
+        /*args=*/argsAttr,
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange{});
+    return success();
+  }
+};
 
-    if (bufIdAttr) {
-      auto argsAttr = rewriter.getArrayAttr({
-          emitc::OpaqueAttr::get(ctx, pipeTok),
-          bufIdAttr,
-          op.getModeAttr(),
-      });
-      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-          op, TypeRange{}, "get_buf",
-          /*args=*/argsAttr,
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ValueRange{});
-    } else {
-      auto argsAttr = rewriter.getArrayAttr({
-          emitc::OpaqueAttr::get(ctx, pipeTok),
-          IntegerAttr::get(IndexType::get(ctx), 0),
-          op.getModeAttr(),
-      });
-      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-          op, TypeRange{}, "get_buf",
-          /*args=*/argsAttr,
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ValueRange{bufIdDyn});
-    }
+struct PTOGetBufDynToEmitC : public OpConversionPattern<mlir::pto::GetBufDynOp> {
+  using OpConversionPattern<mlir::pto::GetBufDynOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::GetBufDynOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto *ctx = rewriter.getContext();
+
+    auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
+    if (failed(opTypeOr))
+      return rewriter.notifyMatchFailure(op, "get_buf_dyn expects pipe_event_type/sync_op_type attr");
+    auto pipe = mapSyncOpTypeToPipe(*opTypeOr);
+    if (!isConcreteSyncPipe(pipe))
+      return rewriter.notifyMatchFailure(op, "get_buf_dyn op_type cannot map to a concrete pipe");
+    std::string pipeTok = pipeTokFromPipeEnum(pipe);
+    auto argsAttr = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        IntegerAttr::get(IndexType::get(ctx), 0),
+        op.getModeAttr(),
+    });
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "get_buf",
+        /*args=*/argsAttr,
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange{adaptor.getBufId()});
     return success();
   }
 };
@@ -6158,6 +6172,7 @@ struct PTORlsBufToEmitC : public OpConversionPattern<mlir::pto::RlsBufOp> {
 
   LogicalResult matchAndRewrite(mlir::pto::RlsBufOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
     auto *ctx = rewriter.getContext();
 
     auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
@@ -6167,33 +6182,46 @@ struct PTORlsBufToEmitC : public OpConversionPattern<mlir::pto::RlsBufOp> {
     if (!isConcreteSyncPipe(pipe))
       return rewriter.notifyMatchFailure(op, "rls_buf op_type cannot map to a concrete pipe");
     std::string pipeTok = pipeTokFromPipeEnum(pipe);
+    auto argsAttr = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        op.getBufIdAttr(),
+        op.getModeAttr(),
+    });
 
-    IntegerAttr bufIdAttr = op.getBufIdAttr();
-    Value bufIdDyn = adaptor.getBufIdDyn();
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "rls_buf",
+        /*args=*/argsAttr,
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange{});
+    return success();
+  }
+};
 
-    if (bufIdAttr) {
-      auto argsAttr = rewriter.getArrayAttr({
-          emitc::OpaqueAttr::get(ctx, pipeTok),
-          bufIdAttr,
-          op.getModeAttr(),
-      });
-      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-          op, TypeRange{}, "rls_buf",
-          /*args=*/argsAttr,
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ValueRange{});
-    } else {
-      auto argsAttr = rewriter.getArrayAttr({
-          emitc::OpaqueAttr::get(ctx, pipeTok),
-          IntegerAttr::get(IndexType::get(ctx), 0),
-          op.getModeAttr(),
-      });
-      rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
-          op, TypeRange{}, "rls_buf",
-          /*args=*/argsAttr,
-          /*templateArgs=*/ArrayAttr{},
-          /*operands=*/ValueRange{bufIdDyn});
-    }
+struct PTORlsBufDynToEmitC : public OpConversionPattern<mlir::pto::RlsBufDynOp> {
+  using OpConversionPattern<mlir::pto::RlsBufDynOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(mlir::pto::RlsBufDynOp op, OpAdaptor adaptor,
+                                ConversionPatternRewriter &rewriter) const override {
+    auto *ctx = rewriter.getContext();
+
+    auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
+    if (failed(opTypeOr))
+      return rewriter.notifyMatchFailure(op, "rls_buf_dyn expects pipe_event_type/sync_op_type attr");
+    auto pipe = mapSyncOpTypeToPipe(*opTypeOr);
+    if (!isConcreteSyncPipe(pipe))
+      return rewriter.notifyMatchFailure(op, "rls_buf_dyn op_type cannot map to a concrete pipe");
+    std::string pipeTok = pipeTokFromPipeEnum(pipe);
+    auto argsAttr = rewriter.getArrayAttr({
+        emitc::OpaqueAttr::get(ctx, pipeTok),
+        IntegerAttr::get(IndexType::get(ctx), 0),
+        op.getModeAttr(),
+    });
+
+    rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
+        op, TypeRange{}, "rls_buf",
+        /*args=*/argsAttr,
+        /*templateArgs=*/ArrayAttr{},
+        /*operands=*/ValueRange{adaptor.getBufId()});
     return success();
   }
 };
@@ -14018,7 +14046,9 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOSyncToEmitC>(typeConverter, ctx);
   patterns.add<PTOSyncAllToEmitC>(typeConverter, ctx);
   patterns.add<PTOGetBufToEmitC>(typeConverter, ctx);
+  patterns.add<PTOGetBufDynToEmitC>(typeConverter, ctx);
   patterns.add<PTORlsBufToEmitC>(typeConverter, ctx);
+  patterns.add<PTORlsBufDynToEmitC>(typeConverter, ctx);
   patterns.add<PTOSetFFTsToEmitC>(typeConverter, ctx);
   patterns.add<PTOXORSToEmitC>(typeConverter, ctx);
   patterns.add<PTOSubSToEmitC>(typeConverter, ctx);

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -8881,10 +8881,28 @@ public:
     if (!pipeImm)
       return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
 
-    StringRef calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
+    StringRef calleeName;
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
-    Value bufIdValue =
-        getI64Constant(rewriter, op.getLoc(), op.getBufIdAttr().getInt());
+    Value bufIdValue;
+    if (IntegerAttr bufIdAttr = op.getBufIdAttr()) {
+      bufIdValue = getI64Constant(rewriter, op.getLoc(), bufIdAttr.getInt());
+      calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
+    } else {
+      Value bufIdDyn = adaptor.getBufIdDyn();
+      if (!bufIdDyn)
+        return rewriter.notifyMatchFailure(
+            op, "expected static or dynamic buf-id operand");
+      bufIdValue = castIntegerLikeTo(op, bufIdDyn, rewriter.getI64Type());
+      if (!bufIdValue)
+        return rewriter.notifyMatchFailure(
+            op, "failed to cast dynamic buf-id to i64");
+      if constexpr (std::is_same_v<BufSyncOp, pto::GetBufOp>)
+        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.GET.BUF.mode")
+                         .getValue();
+      else
+        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.RLS.BUF.mode")
+                         .getValue();
+    }
     Value modeValue =
         getI64Constant(rewriter, op.getLoc(), op.getModeAttr().getInt());
     auto funcType = rewriter.getFunctionType(

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -4166,6 +4166,13 @@ StringRef buildSyncCallee<pto::RlsBufOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.RLS.BUFI.mode").getValue();
 }
 
+static StringRef buildBufDynSyncCallee(MLIRContext *context, bool isGetBuf) {
+  return StringAttr::get(context,
+                         isGetBuf ? "llvm.hivm.GET.BUF.mode"
+                                  : "llvm.hivm.RLS.BUF.mode")
+      .getValue();
+}
+
 template <typename QueryOp>
 static StringRef buildRuntimeQueryCallee(MLIRContext *context);
 
@@ -8881,28 +8888,71 @@ public:
     if (!pipeImm)
       return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
 
-    StringRef calleeName;
+    StringRef calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
-    Value bufIdValue;
-    if (IntegerAttr bufIdAttr = op.getBufIdAttr()) {
-      bufIdValue = getI64Constant(rewriter, op.getLoc(), bufIdAttr.getInt());
-      calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
+    Value bufIdValue =
+        getI64Constant(rewriter, op.getLoc(), op.getBufIdAttr().getInt());
+    Value modeValue =
+        getI64Constant(rewriter, op.getLoc(), op.getModeAttr().getInt());
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{rewriter.getI64Type(), rewriter.getI64Type(),
+                  rewriter.getI64Type()},
+        TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
+                                  ValueRange{pipeValue, bufIdValue, modeValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename BufDynSyncOp>
+class LowerBufDynSyncOpPattern final
+    : public OpConversionPattern<BufDynSyncOp> {
+public:
+  explicit LowerBufDynSyncOpPattern(TypeConverter &typeConverter,
+                                    MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<BufDynSyncOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(BufDynSyncOp op, typename BufDynSyncOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    PIPE pipe = PIPE::PIPE_UNASSIGNED;
+    if (auto pipeAttr = dyn_cast<PipeAttr>(op.getOpTypeAttr())) {
+      pipe = pipeAttr.getPipe();
     } else {
-      Value bufIdDyn = adaptor.getBufIdDyn();
-      if (!bufIdDyn)
+      auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
+      if (failed(opTypeOr))
         return rewriter.notifyMatchFailure(
-            op, "expected static or dynamic buf-id operand");
-      bufIdValue = castIntegerLikeTo(op, bufIdDyn, rewriter.getI64Type());
-      if (!bufIdValue)
-        return rewriter.notifyMatchFailure(
-            op, "failed to cast dynamic buf-id to i64");
-      if constexpr (std::is_same_v<BufSyncOp, pto::GetBufOp>)
-        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.GET.BUF.mode")
-                         .getValue();
-      else
-        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.RLS.BUF.mode")
-                         .getValue();
+            op, "buffer sync expects pipe/sync_op_type/pipe_event_type attr");
+      pipe = mapSyncOpTypeToPipe(*opTypeOr);
     }
+    if (!isConcreteSyncPipe(pipe))
+      return rewriter.notifyMatchFailure(
+          op, "buffer sync op_type cannot map to concrete pipe");
+
+    auto pipeImm = parsePipeImmediate(stringifyPIPE(pipe));
+    if (!pipeImm)
+      return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
+
+    Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
+    Value bufIdDyn = adaptor.getBufId();
+    if (!bufIdDyn)
+      return rewriter.notifyMatchFailure(
+          op, "expected dynamic buf-id operand");
+    Value bufIdValue = castIntegerLikeTo(op, bufIdDyn, rewriter.getI64Type());
+    if (!bufIdValue)
+      return rewriter.notifyMatchFailure(
+          op, "failed to cast dynamic buf-id to i64");
+
+    bool isGetBuf =
+        std::is_same_v<BufDynSyncOp, pto::GetBufDynOp>;
+    StringRef calleeName =
+        buildBufDynSyncCallee(op.getContext(), isGetBuf);
     Value modeValue =
         getI64Constant(rewriter, op.getLoc(), op.getModeAttr().getInt());
     auto funcType = rewriter.getFunctionType(
@@ -10276,6 +10326,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerDcciOpPattern,
                LowerBufSyncOpPattern<pto::GetBufOp>,
                LowerBufSyncOpPattern<pto::RlsBufOp>,
+               LowerBufDynSyncOpPattern<pto::GetBufDynOp>,
+               LowerBufDynSyncOpPattern<pto::RlsBufDynOp>,
                LowerRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockIdxOp>,
                LowerRuntimeQueryOpPattern<pto::GetBlockNumOp>,

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -10389,7 +10389,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
                       pto::CmoCacheInvalidOp, pto::FenceBarrierAllOp,
                       pto::DsbOp, pto::DcciOp,
-                      pto::GetBufOp, pto::RlsBufOp>();
+                      pto::GetBufOp, pto::RlsBufOp,
+                      pto::GetBufDynOp, pto::RlsBufDynOp>();
   target.addIllegalOp<pto::GetBlockIdxOp, pto::GetSubBlockIdxOp,
                       pto::GetBlockNumOp, pto::GetSubBlockNumOp,
                       pto::GetCtrlOp, pto::GetVms4SrOp, pto::GetTidXOp,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -8825,10 +8825,28 @@ public:
     if (!pipeImm)
       return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
 
-    StringRef calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
+    StringRef calleeName;
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
-    Value bufIdValue =
-        getI64Constant(rewriter, op.getLoc(), op.getBufIdAttr().getInt());
+    Value bufIdValue;
+    if (IntegerAttr bufIdAttr = op.getBufIdAttr()) {
+      bufIdValue = getI64Constant(rewriter, op.getLoc(), bufIdAttr.getInt());
+      calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
+    } else {
+      Value bufIdDyn = adaptor.getBufIdDyn();
+      if (!bufIdDyn)
+        return rewriter.notifyMatchFailure(
+            op, "expected static or dynamic buf-id operand");
+      bufIdValue = castIntegerLikeTo(op, bufIdDyn, rewriter.getI64Type());
+      if (!bufIdValue)
+        return rewriter.notifyMatchFailure(
+            op, "failed to cast dynamic buf-id to i64");
+      if constexpr (std::is_same_v<BufSyncOp, pto::GetBufOp>)
+        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.GET.BUF.mode")
+                         .getValue();
+      else
+        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.RLS.BUF.mode")
+                         .getValue();
+    }
     Value modeValue =
         getI64Constant(rewriter, op.getLoc(), op.getModeAttr().getInt());
     auto funcType = rewriter.getFunctionType(

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -4108,6 +4108,13 @@ StringRef buildSyncCallee<pto::RlsBufOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.RLS.BUFI.mode").getValue();
 }
 
+static StringRef buildBufDynSyncCallee(MLIRContext *context, bool isGetBuf) {
+  return StringAttr::get(context,
+                         isGetBuf ? "llvm.hivm.GET.BUF.mode"
+                                  : "llvm.hivm.RLS.BUF.mode")
+      .getValue();
+}
+
 template <typename QueryOp>
 static StringRef buildRuntimeQueryCallee(MLIRContext *context);
 
@@ -8825,28 +8832,71 @@ public:
     if (!pipeImm)
       return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
 
-    StringRef calleeName;
+    StringRef calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
-    Value bufIdValue;
-    if (IntegerAttr bufIdAttr = op.getBufIdAttr()) {
-      bufIdValue = getI64Constant(rewriter, op.getLoc(), bufIdAttr.getInt());
-      calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
+    Value bufIdValue =
+        getI64Constant(rewriter, op.getLoc(), op.getBufIdAttr().getInt());
+    Value modeValue =
+        getI64Constant(rewriter, op.getLoc(), op.getModeAttr().getInt());
+    auto funcType = rewriter.getFunctionType(
+        TypeRange{rewriter.getI64Type(), rewriter.getI64Type(),
+                  rewriter.getI64Type()},
+        TypeRange{});
+    rewriter.create<func::CallOp>(op.getLoc(), calleeName, TypeRange{},
+                                  ValueRange{pipeValue, bufIdValue, modeValue});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
+template <typename BufDynSyncOp>
+class LowerBufDynSyncOpPattern final
+    : public OpConversionPattern<BufDynSyncOp> {
+public:
+  explicit LowerBufDynSyncOpPattern(TypeConverter &typeConverter,
+                                    MLIRContext *context, LoweringState &state)
+      : OpConversionPattern<BufDynSyncOp>(typeConverter, context),
+        state(state) {}
+
+  LogicalResult
+  matchAndRewrite(BufDynSyncOp op, typename BufDynSyncOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    PIPE pipe = PIPE::PIPE_UNASSIGNED;
+    if (auto pipeAttr = dyn_cast<PipeAttr>(op.getOpTypeAttr())) {
+      pipe = pipeAttr.getPipe();
     } else {
-      Value bufIdDyn = adaptor.getBufIdDyn();
-      if (!bufIdDyn)
+      auto opTypeOr = parseSyncOpTypeLikeAttr(op.getOpTypeAttr());
+      if (failed(opTypeOr))
         return rewriter.notifyMatchFailure(
-            op, "expected static or dynamic buf-id operand");
-      bufIdValue = castIntegerLikeTo(op, bufIdDyn, rewriter.getI64Type());
-      if (!bufIdValue)
-        return rewriter.notifyMatchFailure(
-            op, "failed to cast dynamic buf-id to i64");
-      if constexpr (std::is_same_v<BufSyncOp, pto::GetBufOp>)
-        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.GET.BUF.mode")
-                         .getValue();
-      else
-        calleeName = StringAttr::get(op.getContext(), "llvm.hivm.RLS.BUF.mode")
-                         .getValue();
+            op, "buffer sync expects pipe/sync_op_type/pipe_event_type attr");
+      pipe = mapSyncOpTypeToPipe(*opTypeOr);
     }
+    if (!isConcreteSyncPipe(pipe))
+      return rewriter.notifyMatchFailure(
+          op, "buffer sync op_type cannot map to concrete pipe");
+
+    auto pipeImm = parsePipeImmediate(stringifyPIPE(pipe));
+    if (!pipeImm)
+      return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
+
+    Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
+    Value bufIdDyn = adaptor.getBufId();
+    if (!bufIdDyn)
+      return rewriter.notifyMatchFailure(
+          op, "expected dynamic buf-id operand");
+    Value bufIdValue = castIntegerLikeTo(op, bufIdDyn, rewriter.getI64Type());
+    if (!bufIdValue)
+      return rewriter.notifyMatchFailure(
+          op, "failed to cast dynamic buf-id to i64");
+
+    bool isGetBuf =
+        std::is_same_v<BufDynSyncOp, pto::GetBufDynOp>;
+    StringRef calleeName =
+        buildBufDynSyncCallee(op.getContext(), isGetBuf);
     Value modeValue =
         getI64Constant(rewriter, op.getLoc(), op.getModeAttr().getInt());
     auto funcType = rewriter.getFunctionType(
@@ -10222,6 +10272,8 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerDcciOpPattern,
                LowerBufSyncOpPattern<pto::GetBufOp>,
                LowerBufSyncOpPattern<pto::RlsBufOp>,
+               LowerBufDynSyncOpPattern<pto::GetBufDynOp>,
+               LowerBufDynSyncOpPattern<pto::RlsBufDynOp>,
                LowerRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockIdxOp>,
                LowerRuntimeQueryOpPattern<pto::GetBlockNumOp>,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -10335,7 +10335,8 @@ static void configureVPTOOpLoweringTarget(ConversionTarget &target,
                       pto::SyncWaitOp, pto::BarrierOp, pto::MemBarOp,
                       pto::CmoCacheInvalidOp, pto::FenceBarrierAllOp,
                       pto::DsbOp, pto::DcciOp,
-                      pto::GetBufOp, pto::RlsBufOp>();
+                      pto::GetBufOp, pto::RlsBufOp,
+                      pto::GetBufDynOp, pto::RlsBufDynOp>();
   target.addIllegalOp<pto::GetBlockIdxOp, pto::GetSubBlockIdxOp,
                       pto::GetBlockNumOp, pto::GetSubBlockNumOp,
                       pto::GetCtrlOp, pto::GetVms4SrOp, pto::GetTidXOp,

--- a/ptodsl/docs/user_guide/10-sync-ops.md
+++ b/ptodsl/docs/user_guide/10-sync-ops.md
@@ -190,9 +190,16 @@ def gemm_block(
 
 ---
 
-## 10.3 Buffer management: `get_buf`, `rls_buf`
+## 10.3 Buffer management: `get_buf`, `rls_buf`, `get_buf_dyn`, `rls_buf_dyn`
 
 Double-buffering is a common optimization in NPU kernels: while one buffer is being computed on, the other is being loaded with the next block of data. The `get_buf` / `rls_buf` pair coordinates buffer ownership between pipelines.
+
+PTODSL provides two variants:
+
+- **Static** (`get_buf` / `rls_buf`): `buf_id` is an integer literal, suitable when the buffer assignment is fixed at compile time.
+- **Dynamic** (`get_buf_dyn` / `rls_buf_dyn`): `buf_id` is an **index-typed SSA value**, enabling runtime-computed patterns such as SIMT ping-pong buffering where the active buffer toggles per iteration (e.g., `iter & 1`).
+
+The `pipe` and `mode` parameters are identical between the static and dynamic variants.
 
 ### `pto.get_buf(pipe, buf_id, mode=0)`
 
@@ -203,8 +210,8 @@ Double-buffering is a common optimization in NPU kernels: while one buffer is be
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Pipeline identifier of the acquiring pipeline |
-| `buf_id` | `pto.i64` | Buffer identifier (0-based index into the buffer pool) |
-| `mode` | `pto.i64` | Acquisition mode (default 0) |
+| `buf_id` | `int` | Buffer identifier (0-based static integer index into the buffer pool) |
+| `mode` | `int` | Acquisition mode (default 0) |
 
 **Returns**: None (side-effect operation).
 
@@ -217,12 +224,12 @@ Double-buffering is a common optimization in NPU kernels: while one buffer is be
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Pipeline identifier of the releasing pipeline |
-| `buf_id` | `pto.i64` | Buffer identifier matching the corresponding `get_buf` |
-| `mode` | `pto.i64` | Release mode (default 0) |
+| `buf_id` | `int` | Buffer identifier matching the corresponding `get_buf` |
+| `mode` | `int` | Release mode (default 0) |
 
 **Returns**: None (side-effect operation).
 
-### Double-buffering example
+### Static double-buffering example
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
 ```python
@@ -240,6 +247,49 @@ pto.get_buf(pto.Pipe.MTE2, 0, 0)
 # ... DMA loads next block into buffer 0 ...
 
 pto.rls_buf(pto.Pipe.MTE2, 0, 0)
+```
+
+### `pto.get_buf_dyn(pipe, buf_id, mode=0)`
+
+**Description**: Acquire a buffer slot with a runtime-computed buffer identifier. The static version `get_buf` accepts an integer literal; this variant accepts an **index-typed SSA value** so the buffer-id can change at runtime.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pipe` | `Pipe` | Pipeline identifier of the acquiring pipeline |
+| `buf_id` | index-like SSA value | Runtime-computed buffer identifier (e.g., `iter & 1` for double-buffering) |
+| `mode` | `int` | Acquisition mode (default 0) |
+
+**Returns**: None (side-effect operation).
+
+### `pto.rls_buf_dyn(pipe, buf_id, mode=0)`
+
+**Description**: Release a buffer slot with a runtime-computed buffer identifier, matching the corresponding `get_buf_dyn` call.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pipe` | `Pipe` | Pipeline identifier of the releasing pipeline |
+| `buf_id` | index-like SSA value | Runtime-computed buffer identifier matching the acquire |
+| `mode` | `int` | Release mode (default 0) |
+
+**Returns**: None (side-effect operation).
+
+### Dynamic double-buffering (ping-pong) example
+
+When the buffer-id toggles between 0 and 1 per loop iteration, compute the
+buf-id from the loop variable:
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
+```python
+# Ping-pong: acquire buffer (iter & 1) each iteration
+with pto.for_(0, 4, step=1) as iter:
+    buf_id = iter & 1
+    pto.get_buf_dyn(pto.Pipe.MTE2, buf_id)
+    # ... DMA load into buf_id ...
+    pto.rls_buf_dyn(pto.Pipe.MTE2, buf_id)
 ```
 
 ---

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5416,21 +5416,35 @@ def pipe_barrier(pipe):
 
 
 def get_buf(pipe, buf_id, mode=0):
-    """``pto.get_buf(pipe, buf_id, mode=0)`` – acquire a buffer token."""
-    _pto.GetBufOp(
-        _pipe_attr(pipe),
-        buf_id,
-        mode=mode,
-    )
+    """``pto.get_buf(pipe, buf_id, mode=0)`` – acquire a buffer token.
+
+    ``buf_id`` may be a static integer (0–31) or a dynamic SSA value
+    (e.g. ``iter & 1`` for double-buffering).
+    """
+    if isinstance(buf_id, int):
+        _pto.GetBufOp(_pipe_attr(pipe), buf_id, mode=mode)
+    else:
+        _pto.GetBufOp(
+            _pipe_attr(pipe),
+            mode=mode,
+            buf_id_dyn=_coerce_index(buf_id, context="get_buf(..., buf_id=...)"),
+        )
 
 
 def rls_buf(pipe, buf_id, mode=0):
-    """``pto.rls_buf(pipe, buf_id, mode=0)`` – release a buffer token."""
-    _pto.RlsBufOp(
-        _pipe_attr(pipe),
-        buf_id,
-        mode=mode,
-    )
+    """``pto.rls_buf(pipe, buf_id, mode=0)`` – release a buffer token.
+
+    ``buf_id`` may be a static integer (0–31) or a dynamic SSA value
+    (e.g. ``iter & 1`` for double-buffering).
+    """
+    if isinstance(buf_id, int):
+        _pto.RlsBufOp(_pipe_attr(pipe), buf_id, mode=mode)
+    else:
+        _pto.RlsBufOp(
+            _pipe_attr(pipe),
+            mode=mode,
+            buf_id_dyn=_coerce_index(buf_id, context="rls_buf(..., buf_id=...)"),
+        )
 
 
 def _sync_event_id_operand(event_id, *, context: str):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5418,33 +5418,43 @@ def pipe_barrier(pipe):
 def get_buf(pipe, buf_id, mode=0):
     """``pto.get_buf(pipe, buf_id, mode=0)`` – acquire a buffer token.
 
-    ``buf_id`` may be a static integer (0–31) or a dynamic SSA value
-    (e.g. ``iter & 1`` for double-buffering).
+    ``buf_id`` must be a static integer (0–31). For dynamic buf_id,
+    use :func:`get_buf_dyn`.
     """
-    if isinstance(buf_id, int):
-        _pto.GetBufOp(_pipe_attr(pipe), buf_id, mode=mode)
-    else:
-        _pto.GetBufOp(
-            _pipe_attr(pipe),
-            mode=mode,
-            buf_id_dyn=_coerce_index(buf_id, context="get_buf(..., buf_id=...)"),
-        )
+    _pto.GetBufOp(_pipe_attr(pipe), buf_id, mode=mode)
+
+
+def get_buf_dyn(pipe, buf_id, mode=0):
+    """``pto.get_buf_dyn(pipe, buf_id, mode=0)`` – acquire a buffer token with dynamic buf_id.
+
+    ``buf_id`` must be an SSA value (e.g. ``iter & 1`` for double-buffering).
+    """
+    _pto.GetBufDynOp(
+        _pipe_attr(pipe),
+        mode=mode,
+        buf_id=_coerce_index(buf_id, context="get_buf_dyn(..., buf_id=...)"),
+    )
 
 
 def rls_buf(pipe, buf_id, mode=0):
     """``pto.rls_buf(pipe, buf_id, mode=0)`` – release a buffer token.
 
-    ``buf_id`` may be a static integer (0–31) or a dynamic SSA value
-    (e.g. ``iter & 1`` for double-buffering).
+    ``buf_id`` must be a static integer (0–31). For dynamic buf_id,
+    use :func:`rls_buf_dyn`.
     """
-    if isinstance(buf_id, int):
-        _pto.RlsBufOp(_pipe_attr(pipe), buf_id, mode=mode)
-    else:
-        _pto.RlsBufOp(
-            _pipe_attr(pipe),
-            mode=mode,
-            buf_id_dyn=_coerce_index(buf_id, context="rls_buf(..., buf_id=...)"),
-        )
+    _pto.RlsBufOp(_pipe_attr(pipe), buf_id, mode=mode)
+
+
+def rls_buf_dyn(pipe, buf_id, mode=0):
+    """``pto.rls_buf_dyn(pipe, buf_id, mode=0)`` – release a buffer token with dynamic buf_id.
+
+    ``buf_id`` must be an SSA value (e.g. ``iter & 1`` for double-buffering).
+    """
+    _pto.RlsBufDynOp(
+        _pipe_attr(pipe),
+        mode=mode,
+        buf_id=_coerce_index(buf_id, context="rls_buf_dyn(..., buf_id=...)"),
+    )
 
 
 def _sync_event_id_operand(event_id, *, context: str):

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -131,7 +131,7 @@ from ._ops import (             # noqa: F401
     fmin, fmax, fma, convert,
     syncthreads, threadfence, threadfence_block, keep, resume,
     pipe_barrier,
-    get_buf, rls_buf,
+    get_buf, get_buf_dyn, rls_buf, rls_buf_dyn,
     set_cross_flag, wait_cross_flag, set_intra_flag, wait_intra_flag,
     set_flag, wait_flag,
     reserve_buffer, import_reserved_buffer,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -5338,8 +5338,16 @@ def main() -> None:
         'rls_buf_dyn(Pipe.MTE2, const_buf_id, 2) should lower to pto.rls_buf_dyn with PIPE_MTE2',
     )
     expect(
-        dynamic_buf_sync_text.count('"PIPE_MTE2"') >= 4,
-        "dynamic buf-id in pto.for_ should preserve PIPE_MTE2 pipe for each get/rls pair",
+        dynamic_buf_sync_text.count('pto.get_buf_dyn "PIPE_V"') == 1,
+        "constant SSA buf-id get_buf_dyn should preserve PIPE_V",
+    )
+    expect(
+        dynamic_buf_sync_text.count('pto.get_buf_dyn "PIPE_MTE2"') == 1,
+        "loop get_buf_dyn should preserve PIPE_MTE2",
+    )
+    expect(
+        dynamic_buf_sync_text.count('pto.rls_buf_dyn "PIPE_MTE2"') == 2,
+        "constant and loop rls_buf_dyn calls should preserve PIPE_MTE2",
     )
     expect(
         "arith.andi" in dynamic_buf_sync_text,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -314,6 +314,32 @@ def process_row_ptr_kernel_module(
 
 
 @pto.jit(target="a5", entry=False, backend="vpto", mode="explicit", insert_sync=False)
+def dynamic_buf_kernel_module(
+    src_gm: pto.ptr(pto.f32, "gm"),
+    dst_gm: pto.ptr(pto.f32, "gm"),
+    row: pto.i32,
+):
+    with pto.simd():
+        c0_i64 = pto.const(0, dtype=pto.i64)
+        row_offset = row * 16
+        src_row = pto.addptr(src_gm, row_offset)
+        dst_row = pto.addptr(dst_gm, row_offset)
+        ub_ptr = pto.castptr(c0_i64, pto.ptr(pto.f32, "ub"))
+
+        # Compute dynamic buf-id from the row index: row & 1
+        buf_id = row & 1
+        pto.get_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
+        pto.mte_gm_ub(src_row, ub_ptr, 0, 64, nburst=(1, 64, 64))
+        pto.rls_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
+
+        buf_id2 = row & 1
+        pto.get_buf_dyn(pto.Pipe.MTE3, buf_id2, 0)
+        pto.mte_ub_gm(ub_ptr, dst_row, 64, nburst=(1, 64, 64))
+        pto.rls_buf_dyn(pto.Pipe.MTE3, buf_id2, 0)
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5", entry=False, backend="vpto", mode="explicit", insert_sync=False)
 def ast_rewrite_kernel_module_probe(
     src_ptr: pto.ptr(pto.f32, "ub"),
     dst_ptr: pto.ptr(pto.f32, "ub"),
@@ -377,6 +403,26 @@ def emitc_entry_calls_vpto_kernel_module_probe(
         pto.tile.adds(a_tile, 1.0, o_tile)
         pto.tile.store(o_tile, o_part)
         process_row_ptr_kernel_module(A_ptr, O_ptr, row)
+
+
+@pto.jit(target="a5", backend="emitc")
+def emitc_entry_calls_dynamic_buf_kernel_module_probe(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    O_ptr: pto.ptr(pto.f32, "gm"),
+    rows: pto.i32,
+):
+    a_view = pto.make_tensor_view(A_ptr, shape=[rows, 16], strides=[16, 1])
+    o_view = pto.make_tensor_view(O_ptr, shape=[rows, 16], strides=[16, 1])
+    a_tile = pto.alloc_tile(shape=[1, 16], dtype=pto.f32)
+    o_tile = pto.alloc_tile(shape=[1, 16], dtype=pto.f32)
+
+    with pto.for_(0, rows, step=1) as row:
+        a_part = pto.partition_view(a_view, offsets=[row, 0], sizes=[1, 16])
+        o_part = pto.partition_view(o_view, offsets=[row, 0], sizes=[1, 16])
+        pto.tile.load(a_part, a_tile)
+        pto.tile.adds(a_tile, 1.0, o_tile)
+        pto.tile.store(o_tile, o_part)
+        dynamic_buf_kernel_module(A_ptr, O_ptr, row)
 
 
 @pto.simd
@@ -2405,6 +2451,18 @@ def public_sync_surface_probe():
     pto.wait_intra_flag(pto.Pipe.V, dynamic_event)
 
 
+@pto.jit(target="a5")
+def public_dynamic_buf_sync_surface_probe():
+    const_buf_id = pto.const(3)
+    pto.get_buf_dyn(pto.Pipe.V, const_buf_id)
+    pto.rls_buf_dyn(pto.Pipe.MTE2, const_buf_id, 2)
+
+    with pto.for_(0, 4, step=1) as iter:
+        buf_id = iter & 1
+        pto.get_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
+        pto.rls_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
+
+
 @pto.jit(target="a5", ast_rewrite=False)
 def explicit_runtime_index_bitwise_event_probe():
     with pto.for_(0, 4, step=1) as i:
@@ -2827,6 +2885,18 @@ def auto_mode_explicit_surface_violation_probe():
     pto.mte_gm_ub(gm_src, ub_dst, 0, 256, nburst=(8, 256, 256))
 
 
+@pto.jit(target="a5")
+def dynamic_buf_invalid_type_probe():
+    bad = pto.const(1.0, dtype=pto.f32)
+    pto.get_buf_dyn(pto.Pipe.V, bad)
+
+
+@pto.jit(target="a5")
+def dynamic_rls_buf_invalid_type_probe():
+    bad = pto.const(0.0, dtype=pto.f32)
+    pto.rls_buf_dyn(pto.Pipe.MTE2, bad)
+
+
 class _FakeTensor:
     def __init__(self, shape):
         self.shape = tuple(shape)
@@ -2918,6 +2988,8 @@ def main() -> None:
         "pipe_barrier",
         "get_buf",
         "rls_buf",
+        "get_buf_dyn",
+        "rls_buf_dyn",
         "set_cross_flag",
         "wait_cross_flag",
         "set_intra_flag",
@@ -3762,6 +3834,35 @@ def main() -> None:
     expect(
         "pto.mte_gm_ub" in mixed_backend_text and "pto.mte_ub_gm" in mixed_backend_text,
         "mixed-backend ptr/scalar kernel modules should be able to keep explicit VPTO data-movement ops in the callee child",
+    )
+    dynamic_buf_emitc_text = emitc_entry_calls_dynamic_buf_kernel_module_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        dynamic_buf_emitc_text,
+        "emitc entry calling dynamic buf kernel-module specialization",
+    )
+    expect(
+        'module attributes {pto.backend = "emitc", pto.target_arch = "a5"}' in dynamic_buf_emitc_text,
+        "dynamic-buf emitc entry should encode the EmitC backend",
+    )
+    expect(
+        "pto.get_buf_dyn" in dynamic_buf_emitc_text,
+        "dynamic-buf kernel module IR should contain pto.get_buf_dyn ops",
+    )
+    expect(
+        "pto.rls_buf_dyn" in dynamic_buf_emitc_text,
+        "dynamic-buf kernel module IR should contain pto.rls_buf_dyn ops",
+    )
+    expect(
+        dynamic_buf_emitc_text.count("pto.get_buf_dyn") == 2,
+        "mixed-backend dynamic buf callee should keep both MTE2 and MTE3 get_buf_dyn ops",
+    )
+    expect(
+        dynamic_buf_emitc_text.count("pto.rls_buf_dyn") == 2,
+        "mixed-backend dynamic buf callee should keep both MTE2 and MTE3 rls_buf_dyn ops",
+    )
+    expect(
+        "func.call @dynamic_buf_kernel_module__ptodsl_" in dynamic_buf_emitc_text,
+        "emitc entry should call into the dynamic buf kernel module",
     )
     decorated_mixed_backend_text = emitc_entry_calls_vpto_kernel_module_via_decorated_simd_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(
@@ -5179,6 +5280,8 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(mask_surface_text, "public mask surface specialization")
     sync_surface_text = public_sync_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(sync_surface_text, "public sync surface specialization")
+    dynamic_buf_sync_text = public_dynamic_buf_sync_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(dynamic_buf_sync_text, "dynamic buf sync surface specialization")
     explicit_runtime_index_bitwise_event_text = explicit_runtime_index_bitwise_event_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(
         explicit_runtime_index_bitwise_event_text,
@@ -5224,6 +5327,24 @@ def main() -> None:
     expect("start(" not in public_surface_text, "mte_l1_l0a/l0b start_row/start_col should lower as operands")
     expect('pto.get_buf "PIPE_V", 0, 0' in sync_surface_text, 'get_buf(Pipe.V, 0) should lower to pto.get_buf with PIPE_V')
     expect('pto.rls_buf "PIPE_MTE2", 1, 2' in sync_surface_text, 'rls_buf(Pipe.MTE2, 1, 2) should lower to pto.rls_buf with PIPE_MTE2')
+    expect("pto.get_buf_dyn" in dynamic_buf_sync_text, "get_buf_dyn should lower to pto.get_buf_dyn")
+    expect("pto.rls_buf_dyn" in dynamic_buf_sync_text, "rls_buf_dyn should lower to pto.rls_buf_dyn")
+    expect(
+        'pto.get_buf_dyn "PIPE_V"' in dynamic_buf_sync_text,
+        'get_buf_dyn(Pipe.V, const_buf_id) should lower to pto.get_buf_dyn with PIPE_V',
+    )
+    expect(
+        'pto.rls_buf_dyn "PIPE_MTE2"' in dynamic_buf_sync_text,
+        'rls_buf_dyn(Pipe.MTE2, const_buf_id, 2) should lower to pto.rls_buf_dyn with PIPE_MTE2',
+    )
+    expect(
+        dynamic_buf_sync_text.count('"PIPE_MTE2"') >= 4,
+        "dynamic buf-id in pto.for_ should preserve PIPE_MTE2 pipe for each get/rls pair",
+    )
+    expect(
+        "arith.andi" in dynamic_buf_sync_text,
+        "iter & 1 in pto.for_ should lower to arith.andi for dynamic buf_id computation",
+    )
     expect("pto.set_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]" in sync_surface_text, "set_flag(..., event_id=0) should lower static event ids to pto.set_flag")
     expect("pto.wait_flag[<PIPE_MTE2>, <PIPE_V>, <EVENT_ID0>]" in sync_surface_text, "wait_flag(..., event_id=0) should lower static event ids to pto.wait_flag")
     expect("pto.set_flag_dyn[<PIPE_V>, <PIPE_MTE3>, %c3]" in sync_surface_text, "set_flag(..., event_id=dynamic_event) should lower runtime event ids to pto.set_flag_dyn")
@@ -5364,6 +5485,16 @@ def main() -> None:
     expect(mask_bitcast_text.count("pto.pbitcast") == 2, "pbitcast(...) should lower to pto.pbitcast for each authored mask reinterpretation")
     expect("!pto.mask<b16>" in mask_bitcast_text, "pbitcast(mask, pto.mask_b16) should materialize the requested result mask type")
     expect("!pto.mask<b32>" in mask_bitcast_text, "pbitcast(mask, pto.mask_b32) should materialize the requested result mask type")
+    expect_raises(
+        TypeError,
+        lambda: dynamic_buf_invalid_type_probe.compile(),
+        "get_buf_dyn",
+    )
+    expect_raises(
+        TypeError,
+        lambda: dynamic_rls_buf_invalid_type_probe.compile(),
+        "rls_buf_dyn",
+    )
     expect_raises(
         ValueError,
         lambda: vmulscvt_surface_invalid_attr_probe.compile(),

--- a/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/compare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import os
+import sys
+
+import numpy as np
+
+
+def main():
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    golden = np.fromfile("golden_v1.bin", dtype=np.int32)
+    out = np.fromfile("v1.bin", dtype=np.int32)
+    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    if not ok:
+        idxs = np.nonzero(golden != out)[0]
+        idx = int(idxs[0]) if idxs.size else 0
+        print(
+            f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"
+        )
+        if strict:
+            sys.exit(2)
+    print("[INFO] compare passed" if ok else "[WARN] compare failed (non-gating)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/golden.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 128
+
+
+def generate(output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    lanes = np.arange(32, dtype=np.int32)
+    v1 = np.full(ELEMS, -1, dtype=np.int32)
+    v1[:32] = lanes
+    golden_v1 = v1.copy()
+    golden_v1[32:64] = v1[:32] + 100
+    v1.tofile(output_dir / "v1.bin")
+    golden_v1.tofile(output_dir / "golden_v1.bin")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/kernel.pto
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Test dynamic buf_id operand for pto.get_buf / pto.rls_buf in a SIMT kernel.
+// The buf_id is computed from an scf.for loop induction variable (iter & 1),
+// producing a non-constant SSA value that exercises the GET.BUF.mode (register)
+// lowering path. This avoids the bisheng bug triggered by hivm intrinsic results
+// flowing into GET.BUF.mode/RLS.BUF.mode register arguments.
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @simt_bufid_dynamic_core_kernel(%arg0: !pto.ptr<i32, gm>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %dim_z = arith.constant 1 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_x = arith.constant 32 : i32
+
+    // Double buffering: 2 iterations with dynamic buf_id = iter & 1
+    // The loop induction variable is a standard SSA value, not a hivm intrinsic.
+    scf.for %iter = %c0 to %c2 step %c1 {
+      %buf_id = arith.andi %iter, %c1 : index
+      pto.get_buf "PIPE_V", %buf_id, 0
+      pto.simt_launch @simt_bufid_dynamic_core_body<<<%dim_x, %dim_y, %dim_z>>>(%arg0) : (!pto.ptr<i32, gm>) -> ()
+      pto.barrier #pto.pipe<PIPE_ALL>
+      pto.rls_buf "PIPE_V", %buf_id, 0
+    }
+    return
+  }
+
+  func.func @simt_bufid_dynamic_core_body(%gm: !pto.ptr<i32, gm>) attributes {pto.simt_entry} {
+    %tx = pto.get_tid_x : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c100_i32 = arith.constant 100 : i32
+
+    %src_idx = arith.index_castui %tx : i32 to index
+    %loaded = pto.load %gm[%src_idx] : !pto.ptr<i32, gm> -> i32
+    %result = arith.addi %loaded, %c100_i32 : i32
+
+    %dst_i32 = arith.addi %tx, %c32_i32 : i32
+    %dst_idx = arith.index_castui %dst_i32 : i32 to index
+    pto.store %result, %gm[%dst_idx] : !pto.ptr<i32, gm>, i32
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/kernel.pto
@@ -6,7 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// Test dynamic buf_id operand for pto.get_buf / pto.rls_buf in a SIMT kernel.
+// Test dynamic buf_id operand for pto.get_buf_dyn / pto.rls_buf_dyn in a SIMT kernel.
 // The buf_id is computed from an scf.for loop induction variable (iter & 1),
 // producing a non-constant SSA value that exercises the GET.BUF.mode (register)
 // lowering path. This avoids the bisheng bug triggered by hivm intrinsic results
@@ -24,10 +24,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     // The loop induction variable is a standard SSA value, not a hivm intrinsic.
     scf.for %iter = %c0 to %c2 step %c1 {
       %buf_id = arith.andi %iter, %c1 : index
-      pto.get_buf "PIPE_V", %buf_id, 0
+      pto.get_buf_dyn "PIPE_V", %buf_id, 0
       pto.simt_launch @simt_bufid_dynamic_core_body<<<%dim_x, %dim_y, %dim_z>>>(%arg0) : (!pto.ptr<i32, gm>) -> ()
       pto.barrier #pto.pipe<PIPE_ALL>
-      pto.rls_buf "PIPE_V", %buf_id, 0
+      pto.rls_buf_dyn "PIPE_V", %buf_id, 0
     }
     return
   }

--- a/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/launch.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/launch.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#include <stdint.h>
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+extern "C" __global__ [aicore] void simt_bufid_dynamic_core_kernel(__gm__ int *v1);
+void LaunchSimt_bufid_dynamic_core_kernel(int *v1, void *stream) {
+  simt_bufid_dynamic_core_kernel<<<1, nullptr, stream>>>((__gm__ int *)v1);
+}

--- a/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/main.cpp
+++ b/test/vpto/cases/micro-op/simt/simt-bufid-dynamic-core/main.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+#include "test_common.h"
+#include "acl/acl.h"
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr) do { const aclError _ret = (expr); if (_ret != ACL_SUCCESS) { std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr, (int)_ret, __FILE__, __LINE__); rc = 1; goto cleanup; } } while (0)
+
+void LaunchSimt_bufid_dynamic_core_kernel(int *v1, void *stream);
+
+int main() {
+  size_t elemCount_v1 = 128;
+  size_t fileSize_v1 = elemCount_v1 * sizeof(int);
+  int *v1Host = nullptr;
+  int *v1Device = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchSimt_bufid_dynamic_core_kernel(v1Device, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v1Host, fileSize_v1, v1Device, fileSize_v1, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v1.bin", v1Host, fileSize_v1);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFreeHost(v1Host);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}


### PR DESCRIPTION
Allow buf_id to be provided as a dynamic SSA value (index type) in addition to the existing static integer attribute. The two forms are mutually exclusive — exactly one must be provided.

This enables SIMT double-buffering patterns where buf_id is computed at runtime, e.g. (iter & 1) for ping-pong buffering.

Changes across layers:
- ODS (PTOOps.td): buf_id attr → OptionalAttr, add buf_id_dyn operand
- IR (PTO.cpp): verifier enforces mutual exclusion, custom assembly format handles both static/dynamic forms
- VPTO LLVM emitter: static→GET.BUFI.mode (immediate), dynamic→ GET.BUF.mode (register)
- CANN900 LLVM emitter: same pattern
- EmitC: static passes attr, dynamic passes via operands
- BufidSync pass: adapted to new constructor signature
- Python DSL: get_buf/rls_buf accept int or SSA value for buf_id
- Docs (17-simt.md): documented barrier, get_buf/rls_buf with both static and dynamic syntax

Test: simt-bufid-dynamic-core exercises dynamic buf_id from scf.for loop induction variable with ping-pong pattern, verified on simulator (compare passed).