### PR TITLE
Support packed VSTS mask granularity

### DIFF
--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -1739,11 +1739,7 @@ getVstsMaskGranularityOverride(StringRef dist, Type elementType) {
     return StringRef("b32");
   if (dist == "PK_B16")
     return StringRef("b16");
-  if (dist == "PK_B32")
-    return StringRef("b32");
-  if (dist == "PK_B64")
-    return StringRef("b32");
-  if (dist == "PK4_B32")
+  if (dist == "PK_B32" || dist == "PK_B64" || dist == "PK4_B32")
     return StringRef("b32");
 
   return std::nullopt;

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -1741,6 +1741,10 @@ getVstsMaskGranularityOverride(StringRef dist, Type elementType) {
     return StringRef("b16");
   if (dist == "PK_B32")
     return StringRef("b32");
+  if (dist == "PK_B64")
+    return StringRef("b32");
+  if (dist == "PK4_B32")
+    return StringRef("b32");
 
   return std::nullopt;
 }

--- a/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
@@ -483,6 +483,16 @@ private:
         return VPTOMaskGranularity::B32;
       return std::nullopt;
     }
+    if (dist == "PK_B64") {
+      if (width == 32)
+        return VPTOMaskGranularity::B32;
+      return std::nullopt;
+    }
+    if (dist == "PK4_B32") {
+      if (width == 8)
+        return VPTOMaskGranularity::B32;
+      return std::nullopt;
+    }
     if (dist == "MRG4CHN_B8") {
       if (width == 8)
         return VPTOMaskGranularity::B32;

--- a/test/lit/vpto/vsts_packed_dist_mask_granularity.pto
+++ b/test/lit/vpto/vsts_packed_dist_mask_granularity.pto
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsts_packed_dist_mask_granularity(
+      %f32: !pto.vreg<64xf32>,
+      %u8: !pto.vreg<256xui8>,
+      %f32_dst: !pto.ptr<f32, ub>,
+      %u8_dst: !pto.ptr<ui8, ub>,
+      %mask: !pto.mask<b32>) {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      pto.vsts %f32, %f32_dst[%c0], %mask {dist = "PK_B64"}
+          : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+      pto.vsts %u8, %u8_dst[%c0], %mask {dist = "PK4_B32"}
+          : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vsts_packed_dist_mask_granularity
+// CHECK: pto.vsts {{.*}} {dist = "PK_B64"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+// CHECK: pto.vsts {{.*}} {dist = "PK4_B32"} : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b32>

--- a/test/lit/vpto/vsts_packed_dist_mask_granularity_invalid.pto
+++ b/test/lit/vpto/vsts_packed_dist_mask_granularity_invalid.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsts_pk4_b32_requires_b32_mask(
+      %u8: !pto.vreg<256xui8>,
+      %dst: !pto.ptr<ui8, ub>,
+      %mask: !pto.mask<b8>) {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      // CHECK: mask type must be !pto.mask<b32>
+      pto.vsts %u8, %dst[%c0], %mask {dist = "PK4_B32"}
+          : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b8>
+    }
+    return
+  }
+
+  func.func @vsts_pk_b64_requires_b32_mask(
+      %f32: !pto.vreg<64xf32>,
+      %dst: !pto.ptr<f32, ub>,
+      %mask: !pto.mask<b16>) {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      // CHECK: mask type must be !pto.mask<b32>
+      pto.vsts %f32, %dst[%c0], %mask {dist = "PK_B64"}
+          : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b16>
+    }
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/compare.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/compare.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# case: micro-op/vector-load-store/vsts-packed-dist-mask-granularity
+# family: micro-op/vector-load-store
+# target_ops: pto.vlds, pto.vsts
+# scenarios: packed-store, pk-b64, pk4-b32, b32-mask-granularity
+
+import os
+import sys
+
+import numpy as np
+
+
+def compare_bin(golden_path: str, output_path: str, dtype) -> bool:
+    if not os.path.exists(golden_path):
+        print(f"[ERROR] Golden missing: {golden_path}")
+        return False
+    if not os.path.exists(output_path):
+        print(f"[ERROR] Output missing: {output_path}")
+        return False
+    golden = np.fromfile(golden_path, dtype=dtype)
+    output = np.fromfile(output_path, dtype=dtype)
+    if golden.shape != output.shape:
+        print(f"[ERROR] Shape mismatch for {output_path}: golden={golden.shape}, output={output.shape}")
+        return False
+    if np.array_equal(golden, output):
+        return True
+    diff = np.nonzero(golden != output)[0]
+    idx = int(diff[0]) if diff.size else 0
+    print(f"[ERROR] First mismatch for {output_path} at idx={idx}: golden={golden[idx]}, output={output[idx]}")
+    return False
+
+
+def main() -> None:
+    strict = os.getenv("COMPARE_STRICT", "1") != "0"
+    ok = compare_bin("golden_v2.bin", "v2.bin", np.float32)
+    ok = compare_bin("golden_v4.bin", "v4.bin", np.uint8) and ok
+    if not ok:
+        if strict:
+            print("[ERROR] compare failed")
+            sys.exit(2)
+        print("[WARN] compare failed (non-gating)")
+        return
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/golden.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/golden.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# case: micro-op/vector-load-store/vsts-packed-dist-mask-granularity
+# family: micro-op/vector-load-store
+# target_ops: pto.vlds, pto.vsts
+# scenarios: packed-store, pk-b64, pk4-b32, b32-mask-granularity
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+I64_ELEMS = 1024
+F32_ELEMS = 512
+U8_ELEMS = 256
+SEED = 910
+
+
+def generate(output_dir: Path, seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    edge = np.array(
+        [
+            -(1 << 31),
+            -(1 << 24) - 3,
+            -(1 << 24),
+            -(1 << 24) + 1,
+            -65537,
+            -32768,
+            -1,
+            0,
+            1,
+            32767,
+            65537,
+            (1 << 24) - 1,
+            1 << 24,
+            (1 << 24) + 1,
+            (1 << 31) - 2,
+            (1 << 31) - 1,
+        ],
+        dtype=np.int32,
+    )
+    i64_base = rng.integers(
+        np.iinfo(np.int32).min, np.iinfo(np.int32).max, size=I64_ELEMS, dtype=np.int32
+    )
+    i64_base[: edge.size] = edge
+    v1 = i64_base.astype(np.int64)
+
+    v3 = rng.integers(0, 256, size=U8_ELEMS, dtype=np.uint8)
+    ramp = np.arange(U8_ELEMS, dtype=np.uint16)
+    v3 = ((v3.astype(np.uint16) + ramp) & 0xFF).astype(np.uint8)
+
+    golden_v2 = np.concatenate(
+        [i64_base[offset : offset + 16] for offset in range(0, I64_ELEMS, 32)]
+    ).astype(np.float32)
+    golden_v4 = np.zeros(U8_ELEMS, dtype=np.uint8)
+    golden_v4[: U8_ELEMS // 4] = v3[0::4]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    v1.tofile(output_dir / "v1.bin")
+    np.zeros(F32_ELEMS, dtype=np.float32).tofile(output_dir / "v2.bin")
+    v3.tofile(output_dir / "v3.bin")
+    np.zeros(U8_ELEMS, dtype=np.uint8).tofile(output_dir / "v4.bin")
+    golden_v2.tofile(output_dir / "golden_v2.bin")
+    golden_v4.tofile(output_dir / "golden_v4.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate inputs/golden for packed vsts mask granularity validation."
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+    generate(args.output_dir, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/kernel.pto
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/kernel.pto
@@ -1,0 +1,69 @@
+// -----------------------------------------------------------------------------
+// case: micro-op/vector-load-store/vsts-packed-dist-mask-granularity
+// family: micro-op/vector-load-store
+// target_ops: pto.vlds, pto.vsts
+// scenarios: packed-store, pk-b64, pk4-b32, b32-mask-granularity
+// -----------------------------------------------------------------------------
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsts_packed_dist_mask_granularity_kernel(
+      %arg0: !pto.ptr<si64, gm>,
+      %arg1: !pto.ptr<f32, gm>,
+      %arg2: !pto.ptr<ui8, gm>,
+      %arg3: !pto.ptr<ui8, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c16 = arith.constant 16 : index
+    %c512 = arith.constant 512 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+
+    %ub_i64_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<si64, ub>
+    %ub_f32_out = pto.castptr %c8192_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_u8_in = pto.castptr %c12288_i64 : i64 -> !pto.ptr<ui8, ub>
+    %ub_u8_pk4 = pto.castptr %c16384_i64 : i64 -> !pto.ptr<ui8, ub>
+
+    pto.mte_gm_ub %arg0, %ub_i64_in, %c0_i64, %c256_i64
+      nburst(%c32_i64, %c256_i64, %c256_i64)
+      : !pto.ptr<si64, gm>, !pto.ptr<si64, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg2, %ub_u8_in, %c0_i64, %c256_i64
+      nburst(%c1_i64, %c256_i64, %c256_i64)
+      : !pto.ptr<ui8, gm>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %mask_b32 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+
+      scf.for %store_offset = %c0 to %c512 step %c16 {
+        %input_offset = arith.muli %store_offset, %c2 : index
+        %loaded_i64 = pto.vlds %ub_i64_in[%input_offset] : !pto.ptr<si64, ub> -> !pto.vreg<32xsi64>
+        %converted = pto.vcvt %loaded_i64, %mask_b32 {rnd = "R", part = "EVEN"}
+            : !pto.vreg<32xsi64>, !pto.mask<b32> -> !pto.vreg<64xf32>
+        pto.vsts %converted, %ub_f32_out[%store_offset], %mask_b32 {dist = "PK_B64"}
+            : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+      }
+
+      %packed_u8 = pto.vlds %ub_u8_in[%c0] : !pto.ptr<ui8, ub> -> !pto.vreg<256xui8>
+      pto.vsts %packed_u8, %ub_u8_pk4[%c0], %mask_b32 {dist = "PK4_B32"}
+          : !pto.vreg<256xui8>, !pto.ptr<ui8, ub>, !pto.mask<b32>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_f32_out, %arg1, %c64_i64
+      nburst(%c32_i64, %c64_i64, %c64_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %ub_u8_pk4, %arg3, %c64_i64
+      nburst(%c1_i64, %c64_i64, %c64_i64)
+      : !pto.ptr<ui8, ub>, !pto.ptr<ui8, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/launch.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/launch.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// -----------------------------------------------------------------------------
+// case: micro-op/vector-load-store/vsts-packed-dist-mask-granularity
+// family: micro-op/vector-load-store
+// target_ops: pto.vlds, pto.vsts
+// scenarios: packed-store, pk-b64, pk4-b32, b32-mask-granularity
+// -----------------------------------------------------------------------------
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+
+#if defined(__CCE_AICORE__) && defined(PTOAS_ENABLE_CCE_PRINT)
+#include <ccelib/print/print.h>
+#endif
+
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void vsts_packed_dist_mask_granularity_kernel(
+    __gm__ int64_t *v1, __gm__ float *v2, __gm__ uint8_t *v3, __gm__ uint8_t *v4);
+
+void LaunchVstsPackedDistMaskGranularityKernel(int64_t *v1, float *v2,
+                                               uint8_t *v3, uint8_t *v4,
+                                               void *stream) {
+  vsts_packed_dist_mask_granularity_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int64_t *)v1, (__gm__ float *)v2, (__gm__ uint8_t *)v3,
+      (__gm__ uint8_t *)v4);
+}

--- a/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/main.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vsts-packed-dist-mask-granularity/main.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// -----------------------------------------------------------------------------
+// case: micro-op/vector-load-store/vsts-packed-dist-mask-granularity
+// family: micro-op/vector-load-store
+// target_ops: pto.vlds, pto.vsts
+// scenarios: packed-store, pk-b64, pk4-b32, b32-mask-granularity
+// -----------------------------------------------------------------------------
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#ifndef TMRGSORT_HPP
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+
+#define ACL_CHECK(expr)                                                         \
+  do {                                                                          \
+    const aclError _ret = (expr);                                               \
+    if (_ret != ACL_SUCCESS) {                                                  \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,           \
+                   (int)_ret, __FILE__, __LINE__);                              \
+      const char *_recent = aclGetRecentErrMsg();                               \
+      if (_recent != nullptr && _recent[0] != '\0')                             \
+        std::fprintf(stderr, "[ERROR] RecentErrMsg: %s\n", _recent);           \
+      rc = 1;                                                                   \
+      goto cleanup;                                                             \
+    }                                                                           \
+  } while (0)
+
+void LaunchVstsPackedDistMaskGranularityKernel(int64_t *v1, float *v2,
+                                               uint8_t *v3, uint8_t *v4,
+                                               void *stream);
+
+int main() {
+  size_t fileSizeV1 = 1024 * sizeof(int64_t);
+  size_t fileSizeV2 = 512 * sizeof(float);
+  size_t fileSizeV3 = 256 * sizeof(uint8_t);
+  size_t fileSizeV4 = 256 * sizeof(uint8_t);
+
+  int64_t *v1Host = nullptr;
+  float *v2Host = nullptr;
+  uint8_t *v3Host = nullptr;
+  uint8_t *v4Host = nullptr;
+  int64_t *v1Device = nullptr;
+  float *v2Device = nullptr;
+  uint8_t *v3Device = nullptr;
+  uint8_t *v4Device = nullptr;
+
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+
+  ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSizeV1));
+  ACL_CHECK(aclrtMallocHost((void **)(&v2Host), fileSizeV2));
+  ACL_CHECK(aclrtMallocHost((void **)(&v3Host), fileSizeV3));
+  ACL_CHECK(aclrtMallocHost((void **)(&v4Host), fileSizeV4));
+  ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSizeV1, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v2Device, fileSizeV2, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v3Device, fileSizeV3, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&v4Device, fileSizeV4, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", fileSizeV1, v1Host, fileSizeV1);
+  ReadFile("./v2.bin", fileSizeV2, v2Host, fileSizeV2);
+  ReadFile("./v3.bin", fileSizeV3, v3Host, fileSizeV3);
+  ReadFile("./v4.bin", fileSizeV4, v4Host, fileSizeV4);
+  ACL_CHECK(aclrtMemcpy(v1Device, fileSizeV1, v1Host, fileSizeV1, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v2Device, fileSizeV2, v2Host, fileSizeV2, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v3Device, fileSizeV3, v3Host, fileSizeV3, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(v4Device, fileSizeV4, v4Host, fileSizeV4, ACL_MEMCPY_HOST_TO_DEVICE));
+
+  LaunchVstsPackedDistMaskGranularityKernel(v1Device, v2Device, v3Device,
+                                            v4Device, stream);
+
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(v2Host, fileSizeV2, v2Device, fileSizeV2, ACL_MEMCPY_DEVICE_TO_HOST));
+  ACL_CHECK(aclrtMemcpy(v4Host, fileSizeV4, v4Device, fileSizeV4, ACL_MEMCPY_DEVICE_TO_HOST));
+
+  WriteFile("./v2.bin", v2Host, fileSizeV2);
+  WriteFile("./v4.bin", v4Host, fileSizeV4);
+
+cleanup:
+  aclrtFree(v1Device);
+  aclrtFree(v2Device);
+  aclrtFree(v3Device);
+  aclrtFree(v4Device);
+  aclrtFreeHost(v1Host);
+  aclrtFreeHost(v2Host);
+  aclrtFreeHost(v3Host);
+  aclrtFreeHost(v4Host);
+  if (stream != nullptr)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}


### PR DESCRIPTION
## Summary
- accept b32 masks for PK_B64 and PK4_B32 VSTS dist forms
- mirror the same legality in VPTO validation
- add positive and negative VPTO lit coverage

## Validation
- built ptoas with LLVM21 in the main worktree
- llvm-lit -v build-llvm21/test/lit --filter 'vsts_packed_dist_mask_granularity'