### PR TITLE
Fix vgather2 lowering for 16-bit and 8-bit gather forms

### DIFF
--- a/docs/isa/micro-isa/03-vector-load-store.md
+++ b/docs/isa/micro-isa/03-vector-load-store.md
@@ -302,14 +302,46 @@ for (int blk = 0; blk < 8; ++blk) {
 - **syntax:** `%result = pto.vgather2 %source, %offsets, %mask : !pto.ptr<T, ub>, !pto.vreg<NxI>, !pto.mask<G> -> !pto.vreg<NxT>`
 - **semantics:** Indexed gather from UB.
 - **inputs:**
-  `%source` is the UB base pointer, `%offsets` provides per-lane element
-  offsets, and `%mask` selects the active requests.
+  `%source` is the UB base pointer, `%offsets` provides one unsigned element
+  index for each logical gather lane, and `%mask` selects those logical
+  index/result lanes.
 - **outputs:**
   `%result` is the gathered vector.
+- **addressing:**
+  Each active lane computes its UB byte address from the source element width:
+
+  ```text
+  addr[i] = byte_address(%source) + unsigned(%offsets[i]) * sizeof(source element)
+  ```
+
+  For `i8/ui8` sources, `sizeof(source element) == 1`; for 16-bit sources it is
+  `2`; for 32-bit sources it is `4`. The computed address must be aligned for
+  the source element type. For `i8/ui8` sources, each loaded 8-bit payload is
+  zero-extended into a 16-bit result lane.
+- **semantic pseudocode:**
+
+  ```text
+  for i in lanes:
+    if mask[i]:
+      value = UB_load(source_element_type, addr[i])
+      if source_element_type is i8 or ui8:
+        result[i] = zero_extend_to_16_bits(value)
+      else:
+        result[i] = value
+    else:
+      result[i] = 0
+  ```
 - **constraints and limitations:**
   Only masked-on indices participate. The index element width
   and interpretation MUST match the selected gather form, and each effective
   address must satisfy that form's alignment rules.
+  Supported forms are:
+  `i8/ui8 -> i16/ui16` with `!pto.vreg<128xui16>` offsets and
+  `!pto.mask<b16>`; `i16/ui16/f16/bf16 -> same type` with
+  `!pto.vreg<128xui16>` offsets and `!pto.mask<b16>`; and
+  `i32/ui32/f32 -> same type` with `!pto.vreg<64xui32>` offsets and
+  `!pto.mask<b32>`. Signless integer offsets are accepted as storage-compatible
+  aliases for the unsigned offset register payload.
 - **Latency:** **27–28** cycles per `RV_VGATHER2`; throughput much lower than contiguous `RV_VLD` (see **Latency and throughput (A5)** at the start of this chapter).
 
 ```c

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -1859,6 +1859,14 @@ static int64_t getBufferElementByteSize(Type type) {
   return getPTOStorageElemByteSize(elementType);
 }
 
+static Type getBufferElementType(Type type) {
+  if (auto ptrType = dyn_cast<pto::PtrType>(type))
+    return ptrType.getElementType();
+  if (auto memrefType = dyn_cast<BaseMemRefType>(type))
+    return memrefType.getElementType();
+  return {};
+}
+
 static std::optional<AddressSpace> getBufferAddressSpace(Type type) {
   if (auto ptrType = dyn_cast<pto::PtrType>(type))
     return ptrType.getMemorySpace().getAddressSpace();
@@ -4378,6 +4386,31 @@ void Vgather2Op::getEffects(
   effects.emplace_back(MemoryEffects::Read::get(), &getSourceMutable());
 }
 
+static bool isUnsignedOrSignlessIntegerOfWidth(Type type, unsigned width) {
+  auto intType = dyn_cast<IntegerType>(type);
+  return intType && intType.getWidth() == width && !intType.isSigned();
+}
+
+static bool isSameVgather2IntegerSemantics(IntegerType sourceType,
+                                           IntegerType resultType) {
+  if (!sourceType || !resultType ||
+      sourceType.getWidth() != resultType.getWidth())
+    return false;
+  if (sourceType.isUnsigned())
+    return resultType.isUnsigned();
+  return !resultType.isUnsigned();
+}
+
+static bool isVgather2B8ResultType(IntegerType sourceType,
+                                   IntegerType resultType) {
+  if (!sourceType || !resultType || sourceType.getWidth() != 8 ||
+      resultType.getWidth() != 16)
+    return false;
+  if (sourceType.isUnsigned())
+    return resultType.isUnsigned();
+  return !resultType.isUnsigned();
+}
+
 LogicalResult Vgather2Op::verify() {
   if (!isBufferLike(getSource().getType()))
     return emitOpError("requires a pointer-like source");
@@ -4389,11 +4422,72 @@ LogicalResult Vgather2Op::verify() {
   auto resultType = dyn_cast<VRegType>(getResult().getType());
   if (!offsetsType || !resultType)
     return emitOpError("offsets and result must be !pto.vreg<...>");
-  if (!isa<IntegerType>(offsetsType.getElementType()))
+
+  auto offsetsElemType = dyn_cast<IntegerType>(offsetsType.getElementType());
+  if (!offsetsElemType)
     return emitOpError("offset vector must use integer element type");
   if (offsetsType.getElementCount() != resultType.getElementCount())
     return emitOpError("offset and result vectors must have the same element count");
-  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+
+  Type sourceElemType = getBufferElementType(getSource().getType());
+  Type resultElemType = resultType.getElementType();
+  unsigned sourceElemWidth = getPTOStorageElemBitWidth(sourceElemType);
+  unsigned resultElemWidth = getPTOStorageElemBitWidth(resultElemType);
+  unsigned expectedOffsetWidth = 0;
+  StringRef expectedMaskGranularity;
+  int64_t expectedLanes = 0;
+
+  if (sourceElemWidth == 8 && isa<IntegerType>(sourceElemType)) {
+    if (!isVgather2B8ResultType(cast<IntegerType>(sourceElemType),
+                                dyn_cast<IntegerType>(resultElemType)))
+      return emitOpError(
+          "8-bit gather requires i8/ui8 source and matching i16/ui16 result");
+    expectedOffsetWidth = 16;
+    expectedMaskGranularity = "b16";
+    expectedLanes = 128;
+  } else if (sourceElemWidth == 16) {
+    if (auto sourceInt = dyn_cast<IntegerType>(sourceElemType)) {
+      if (!isSameVgather2IntegerSemantics(
+              sourceInt, dyn_cast<IntegerType>(resultElemType)))
+        return emitOpError(
+            "16-bit integer gather requires matching i16/ui16 result");
+    } else if (!(sourceElemType.isF16() || sourceElemType.isBF16()) ||
+               sourceElemType != resultElemType) {
+      return emitOpError(
+          "16-bit gather requires i16/ui16/f16/bf16 source and matching result");
+    }
+    expectedOffsetWidth = 16;
+    expectedMaskGranularity = "b16";
+    expectedLanes = 128;
+  } else if (sourceElemWidth == 32) {
+    if (auto sourceInt = dyn_cast<IntegerType>(sourceElemType)) {
+      if (!isSameVgather2IntegerSemantics(
+              sourceInt, dyn_cast<IntegerType>(resultElemType)))
+        return emitOpError(
+            "32-bit integer gather requires matching i32/ui32 result");
+    } else if (!sourceElemType.isF32() || sourceElemType != resultElemType) {
+      return emitOpError(
+          "32-bit gather requires i32/ui32/f32 source and matching result");
+    }
+    expectedOffsetWidth = 32;
+    expectedMaskGranularity = "b32";
+    expectedLanes = 64;
+  } else {
+    return emitOpError(
+        "requires source element type i8/ui8/i16/ui16/i32/ui32/f16/bf16/f32");
+  }
+
+  if (resultElemWidth != 16 && resultElemWidth != 32)
+    return emitOpError("result element type must be 16-bit or 32-bit");
+  if (resultType.getElementCount() != expectedLanes)
+    return emitOpError() << "expects result type "
+                         << formatVRegType(expectedLanes, resultElemType);
+  if (!isUnsignedOrSignlessIntegerOfWidth(offsetsElemType, expectedOffsetWidth))
+    return emitOpError() << "requires ui" << expectedOffsetWidth << "/i"
+                         << expectedOffsetWidth << " offset vector elements";
+  if (failed(verifyMaskTypeWithGranularityLike(
+          getOperation(), getMask().getType(), "mask type",
+          expectedMaskGranularity)))
     return failure();
   return success();
 }

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -3685,6 +3685,41 @@ static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
       .getValue();
 }
 
+static std::optional<uint64_t> getFixedVectorBitWidth(Type type) {
+  auto vectorType = dyn_cast<VectorType>(type);
+  if (!vectorType || vectorType.getRank() != 1 || vectorType.isScalable())
+    return std::nullopt;
+  int64_t lanes = vectorType.getDimSize(0);
+  if (lanes <= 0)
+    return std::nullopt;
+  auto elementType = dyn_cast<IntegerType>(vectorType.getElementType());
+  if (!elementType)
+    return std::nullopt;
+  return static_cast<uint64_t>(lanes) * elementType.getWidth();
+}
+
+static FailureOr<Type> getVgather2OffsetsCarrierType(PatternRewriter &rewriter,
+                                                     Type resultType,
+                                                     Type offsetsType) {
+  Type elementType = getElementTypeFromVectorLike(resultType);
+  auto lanes = getElementCountFromVectorLike(resultType);
+  if (!elementType || !lanes || *lanes <= 0)
+    return failure();
+
+  Type carrierType = offsetsType;
+  if (pto::getPTOStorageElemBitWidth(elementType) == 16) {
+    if (*lanes % 2 != 0)
+      return failure();
+    carrierType = VectorType::get({*lanes / 2}, rewriter.getI32Type());
+  }
+
+  std::optional<uint64_t> offsetsBits = getFixedVectorBitWidth(offsetsType);
+  std::optional<uint64_t> carrierBits = getFixedVectorBitWidth(carrierType);
+  if (!offsetsBits || !carrierBits || *offsetsBits != *carrierBits)
+    return failure();
+  return carrierType;
+}
+
 static FailureOr<StringRef> buildVgather2BcCallee(MLIRContext *context,
                                                   Type resultType) {
   return buildLaneTypedCallee(context, resultType, "vgather2.bc", "");
@@ -7265,13 +7300,22 @@ public:
     if (failed(calleeName))
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 signature");
 
+    Value offsets = adaptor.getOffsets();
+    FailureOr<Type> offsetsCarrierType = getVgather2OffsetsCarrierType(
+        rewriter, op.getResult().getType(), offsets.getType());
+    if (failed(offsetsCarrierType))
+      return rewriter.notifyMatchFailure(op, "unsupported vgather2 offsets carrier");
+    if (offsets.getType() != *offsetsCarrierType)
+      offsets = rewriter.create<LLVM::BitcastOp>(op.getLoc(), *offsetsCarrierType,
+                                                 offsets);
+
     auto funcType = rewriter.getFunctionType(
-        TypeRange{adaptor.getSource().getType(), adaptor.getOffsets().getType(),
+        TypeRange{adaptor.getSource().getType(), *offsetsCarrierType,
                   adaptor.getMask().getType()},
         TypeRange{resultType});
     auto call = rewriter.create<func::CallOp>(
         op.getLoc(), *calleeName, TypeRange{resultType},
-        ValueRange{adaptor.getSource(), adaptor.getOffsets(), adaptor.getMask()});
+        ValueRange{adaptor.getSource(), offsets, adaptor.getMask()});
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     rewriter.replaceOp(op, call.getResults());
     return success();

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -3673,15 +3673,36 @@ static StringRef buildVsstbPostCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.vsstb.post").getValue();
 }
 
+static Type getVgather2SourceElementType(Type sourceType) {
+  if (auto ptrType = dyn_cast<pto::PtrType>(sourceType))
+    return ptrType.getElementType();
+  if (auto memrefType = dyn_cast<BaseMemRefType>(sourceType))
+    return memrefType.getElementType();
+  return {};
+}
+
 static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
+                                                Type sourceType,
                                                 Type resultType) {
-  std::string vec =
-      getElementTypeFragment(getElementTypeFromVectorLike(resultType));
+  Type sourceElemType = getVgather2SourceElementType(sourceType);
+  Type resultElemType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
-  if (vec.empty() || !lanes)
+  if (!sourceElemType || !resultElemType || !lanes)
     return failure();
+
+  std::string vec;
+  int64_t intrinsicLanes = *lanes;
+  if (pto::getPTOStorageElemBitWidth(sourceElemType) == 8) {
+    vec = getElementTypeFragment(sourceElemType);
+    intrinsicLanes *= 2;
+  } else {
+    vec = getElementTypeFragment(resultElemType);
+  }
+  if (vec.empty())
+    return failure();
+
   return StringAttr::get(context, "llvm.hivm.vgather2.v300.v" +
-                                      std::to_string(*lanes) + vec)
+                                      std::to_string(intrinsicLanes) + vec)
       .getValue();
 }
 
@@ -3699,11 +3720,13 @@ static std::optional<uint64_t> getFixedVectorBitWidth(Type type) {
 }
 
 static FailureOr<Type> getVgather2OffsetsCarrierType(PatternRewriter &rewriter,
+                                                     Type sourceType,
                                                      Type resultType,
                                                      Type offsetsType) {
+  Type sourceElemType = getVgather2SourceElementType(sourceType);
   Type elementType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
-  if (!elementType || !lanes || *lanes <= 0)
+  if (!sourceElemType || !elementType || !lanes || *lanes <= 0)
     return failure();
 
   Type carrierType = offsetsType;
@@ -7296,13 +7319,15 @@ public:
       return rewriter.notifyMatchFailure(op, "failed to convert vgather2 result type");
 
     FailureOr<StringRef> calleeName =
-        buildVgather2Callee(op.getContext(), op.getResult().getType());
+        buildVgather2Callee(op.getContext(), op.getSource().getType(),
+                            op.getResult().getType());
     if (failed(calleeName))
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 signature");
 
     Value offsets = adaptor.getOffsets();
     FailureOr<Type> offsetsCarrierType = getVgather2OffsetsCarrierType(
-        rewriter, op.getResult().getType(), offsets.getType());
+        rewriter, op.getSource().getType(), op.getResult().getType(),
+        offsets.getType());
     if (failed(offsetsCarrierType))
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 offsets carrier");
     if (offsets.getType() != *offsetsCarrierType)

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -3609,15 +3609,36 @@ static StringRef buildVsstbPostCallee(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.vsstb.post").getValue();
 }
 
+static Type getVgather2SourceElementType(Type sourceType) {
+  if (auto ptrType = dyn_cast<pto::PtrType>(sourceType))
+    return ptrType.getElementType();
+  if (auto memrefType = dyn_cast<BaseMemRefType>(sourceType))
+    return memrefType.getElementType();
+  return {};
+}
+
 static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
+                                                Type sourceType,
                                                 Type resultType) {
-  std::string vec =
-      getElementTypeFragment(getElementTypeFromVectorLike(resultType));
+  Type sourceElemType = getVgather2SourceElementType(sourceType);
+  Type resultElemType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
-  if (vec.empty() || !lanes)
+  if (!sourceElemType || !resultElemType || !lanes)
     return failure();
+
+  std::string vec;
+  int64_t intrinsicLanes = *lanes;
+  if (pto::getPTOStorageElemBitWidth(sourceElemType) == 8) {
+    vec = getElementTypeFragment(sourceElemType);
+    intrinsicLanes *= 2;
+  } else {
+    vec = getElementTypeFragment(resultElemType);
+  }
+  if (vec.empty())
+    return failure();
+
   return StringAttr::get(context, "llvm.hivm.vgather2.v300.v" +
-                                      std::to_string(*lanes) + vec)
+                                      std::to_string(intrinsicLanes) + vec)
       .getValue();
 }
 
@@ -3635,11 +3656,13 @@ static std::optional<uint64_t> getFixedVectorBitWidth(Type type) {
 }
 
 static FailureOr<Type> getVgather2OffsetsCarrierType(PatternRewriter &rewriter,
+                                                     Type sourceType,
                                                      Type resultType,
                                                      Type offsetsType) {
+  Type sourceElemType = getVgather2SourceElementType(sourceType);
   Type elementType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
-  if (!elementType || !lanes || *lanes <= 0)
+  if (!sourceElemType || !elementType || !lanes || *lanes <= 0)
     return failure();
 
   Type carrierType = offsetsType;
@@ -7223,13 +7246,15 @@ public:
       return rewriter.notifyMatchFailure(op, "failed to convert vgather2 result type");
 
     FailureOr<StringRef> calleeName =
-        buildVgather2Callee(op.getContext(), op.getResult().getType());
+        buildVgather2Callee(op.getContext(), op.getSource().getType(),
+                            op.getResult().getType());
     if (failed(calleeName))
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 signature");
 
     Value offsets = adaptor.getOffsets();
     FailureOr<Type> offsetsCarrierType = getVgather2OffsetsCarrierType(
-        rewriter, op.getResult().getType(), offsets.getType());
+        rewriter, op.getSource().getType(), op.getResult().getType(),
+        offsets.getType());
     if (failed(offsetsCarrierType))
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 offsets carrier");
     if (offsets.getType() != *offsetsCarrierType)

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -3621,6 +3621,41 @@ static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
       .getValue();
 }
 
+static std::optional<uint64_t> getFixedVectorBitWidth(Type type) {
+  auto vectorType = dyn_cast<VectorType>(type);
+  if (!vectorType || vectorType.getRank() != 1 || vectorType.isScalable())
+    return std::nullopt;
+  int64_t lanes = vectorType.getDimSize(0);
+  if (lanes <= 0)
+    return std::nullopt;
+  auto elementType = dyn_cast<IntegerType>(vectorType.getElementType());
+  if (!elementType)
+    return std::nullopt;
+  return static_cast<uint64_t>(lanes) * elementType.getWidth();
+}
+
+static FailureOr<Type> getVgather2OffsetsCarrierType(PatternRewriter &rewriter,
+                                                     Type resultType,
+                                                     Type offsetsType) {
+  Type elementType = getElementTypeFromVectorLike(resultType);
+  auto lanes = getElementCountFromVectorLike(resultType);
+  if (!elementType || !lanes || *lanes <= 0)
+    return failure();
+
+  Type carrierType = offsetsType;
+  if (pto::getPTOStorageElemBitWidth(elementType) == 16) {
+    if (*lanes % 2 != 0)
+      return failure();
+    carrierType = VectorType::get({*lanes / 2}, rewriter.getI32Type());
+  }
+
+  std::optional<uint64_t> offsetsBits = getFixedVectorBitWidth(offsetsType);
+  std::optional<uint64_t> carrierBits = getFixedVectorBitWidth(carrierType);
+  if (!offsetsBits || !carrierBits || *offsetsBits != *carrierBits)
+    return failure();
+  return carrierType;
+}
+
 static FailureOr<StringRef> buildVgather2BcCallee(MLIRContext *context,
                                                   Type resultType) {
   return buildLaneTypedCallee(context, resultType, "vgather2.bc", "");
@@ -7192,13 +7227,22 @@ public:
     if (failed(calleeName))
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 signature");
 
+    Value offsets = adaptor.getOffsets();
+    FailureOr<Type> offsetsCarrierType = getVgather2OffsetsCarrierType(
+        rewriter, op.getResult().getType(), offsets.getType());
+    if (failed(offsetsCarrierType))
+      return rewriter.notifyMatchFailure(op, "unsupported vgather2 offsets carrier");
+    if (offsets.getType() != *offsetsCarrierType)
+      offsets = rewriter.create<LLVM::BitcastOp>(op.getLoc(), *offsetsCarrierType,
+                                                 offsets);
+
     auto funcType = rewriter.getFunctionType(
-        TypeRange{adaptor.getSource().getType(), adaptor.getOffsets().getType(),
+        TypeRange{adaptor.getSource().getType(), *offsetsCarrierType,
                   adaptor.getMask().getType()},
         TypeRange{resultType});
     auto call = rewriter.create<func::CallOp>(
         op.getLoc(), *calleeName, TypeRange{resultType},
-        ValueRange{adaptor.getSource(), adaptor.getOffsets(), adaptor.getMask()});
+        ValueRange{adaptor.getSource(), offsets, adaptor.getMask()});
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     rewriter.replaceOp(op, call.getResults());
     return success();

--- a/test/lit/vpto/vgather2_supported_types_vpto_llvm.pto
+++ b/test/lit/vpto/vgather2_supported_types_vpto_llvm.pto
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vgather2_supported_types(
+      %src_u8: !pto.ptr<ui8, ub>, %src_i8: !pto.ptr<i8, ub>,
+      %src_u16: !pto.ptr<ui16, ub>, %src_i16: !pto.ptr<i16, ub>,
+      %src_f16: !pto.ptr<f16, ub>, %src_bf16: !pto.ptr<bf16, ub>,
+      %src_u32: !pto.ptr<ui32, ub>, %src_i32: !pto.ptr<i32, ub>,
+      %src_f32: !pto.ptr<f32, ub>,
+      %offsets16: !pto.vreg<128xui16>, %offsets32: !pto.vreg<64xui32>)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %dst_u16 = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui16, ub>
+    %dst_i16 = pto.castptr %c0_i64 : i64 -> !pto.ptr<i16, ub>
+    pto.vecscope {
+      %mask16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %mask32 = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %r_u8 = pto.vgather2 %src_u8, %offsets16, %mask16
+          : !pto.ptr<ui8, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+      pto.vsts %r_u8, %dst_u16[%c0], %mask16
+          : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
+      %r_i8 = pto.vgather2 %src_i8, %offsets16, %mask16
+          : !pto.ptr<i8, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+      pto.vsts %r_i8, %dst_i16[%c0], %mask16
+          : !pto.vreg<128xi16>, !pto.ptr<i16, ub>, !pto.mask<b16>
+      %r_u16 = pto.vgather2 %src_u16, %offsets16, %mask16
+          : !pto.ptr<ui16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+      pto.vsts %r_u16, %src_u16[%c0], %mask16
+          : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
+      %r_i16 = pto.vgather2 %src_i16, %offsets16, %mask16
+          : !pto.ptr<i16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+      pto.vsts %r_i16, %src_i16[%c0], %mask16
+          : !pto.vreg<128xi16>, !pto.ptr<i16, ub>, !pto.mask<b16>
+      %r_f16 = pto.vgather2 %src_f16, %offsets16, %mask16
+          : !pto.ptr<f16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+      pto.vsts %r_f16, %src_f16[%c0], %mask16
+          : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+      %r_bf16 = pto.vgather2 %src_bf16, %offsets16, %mask16
+          : !pto.ptr<bf16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+      pto.vsts %r_bf16, %src_bf16[%c0], %mask16
+          : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
+      %r_u32 = pto.vgather2 %src_u32, %offsets32, %mask32
+          : !pto.ptr<ui32, ub>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+      pto.vsts %r_u32, %src_u32[%c0], %mask32
+          : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+      %r_i32 = pto.vgather2 %src_i32, %offsets32, %mask32
+          : !pto.ptr<i32, ub>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+      pto.vsts %r_i32, %src_i32[%c0], %mask32
+          : !pto.vreg<64xi32>, !pto.ptr<i32, ub>, !pto.mask<b32>
+      %r_f32 = pto.vgather2 %src_f32, %offsets32, %mask32
+          : !pto.ptr<f32, ub>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+      pto.vsts %r_f32, %src_f32[%c0], %mask32
+          : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @vgather2_supported_types_mix_aiv
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v256u8({{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<128xi16>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v256s8({{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<128xi16>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v128u16({{.*}}, {{.*}}, {{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<128xi16>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v128s16({{.*}}, {{.*}}, {{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<128xi16>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v128f16({{.*}}, {{.*}}, {{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<128xf16>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v128bf16({{.*}}, {{.*}}, {{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<128xbf16>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v64u32({{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<64xi32>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v64s32({{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<64xi32>
+// CHECK-DAG: llvm.call @llvm.hivm.vgather2.v300.v64f32({{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<64xf32>

--- a/test/lit/vpto/vgather2_u16_offsets_vpto_llvm.pto
+++ b/test/lit/vpto/vgather2_u16_offsets_vpto_llvm.pto
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vgather2_u16_offsets(%source: !pto.ptr<f16, ub>, %offsets: !pto.vreg<128xui16>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %result = pto.vgather2 %source, %offsets, %mask
+          : !pto.ptr<f16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+      pto.vsts %result, %source[%c0], %mask
+          : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: llvm.func @vgather2_u16_offsets_mix_aiv
+// CHECK: %[[CARRIER:.*]] = llvm.bitcast %arg1 : vector<128xi16> to vector<64xi32>
+// CHECK: llvm.call @llvm.hivm.vgather2.v300.v128f16({{.*}}, %[[CARRIER]], {{.*}}) : (!llvm.ptr<{{[0-9]+}}>, vector<64xi32>, vector<256xi1>) -> vector<128xf16>

--- a/test/lit/vpto/vgather2_verify_invalid_b8_result.pto
+++ b/test/lit/vpto/vgather2_verify_invalid_b8_result.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vgather2_invalid_b8_result(%source: !pto.ptr<ui8, ub>, %offsets: !pto.vreg<128xui16>) attributes {pto.kernel} {
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %result = pto.vgather2 %source, %offsets, %mask
+          : !pto.ptr<ui8, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xi16>
+    }
+    return
+  }
+}
+
+// CHECK: error: 'pto.vgather2' op 8-bit gather requires i8/ui8 source and matching i16/ui16 result

--- a/test/lit/vpto/vgather2_verify_invalid_mask.pto
+++ b/test/lit/vpto/vgather2_verify_invalid_mask.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vgather2_invalid_mask(%source: !pto.ptr<f16, ub>, %offsets: !pto.vreg<128xui16>) attributes {pto.kernel} {
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %result = pto.vgather2 %source, %offsets, %mask
+          : !pto.ptr<f16, ub>, !pto.vreg<128xui16>, !pto.mask<b32> -> !pto.vreg<128xf16>
+    }
+    return
+  }
+}
+
+// CHECK: error: 'pto.vgather2' op mask type must be !pto.mask<b16>

--- a/test/lit/vpto/vgather2_verify_invalid_offset.pto
+++ b/test/lit/vpto/vgather2_verify_invalid_offset.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vgather2_invalid_offset(%source: !pto.ptr<f16, ub>, %offsets: !pto.vreg<128xsi16>) attributes {pto.kernel} {
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %result = pto.vgather2 %source, %offsets, %mask
+          : !pto.ptr<f16, ub>, !pto.vreg<128xsi16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+    }
+    return
+  }
+}
+
+// CHECK: error: 'pto.vgather2' op requires ui16/i16 offset vector elements

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/compare.py
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/compare.py
@@ -10,7 +10,7 @@
 # case: micro-op/gather-scatter/vgather2
 # family: gather-scatter
 # target_ops: pto.vgather2
-# scenarios: core-f32, core-f16-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
+# scenarios: core-f32, core-f16-u16-offsets, core-u8-u16-offsets, core-i8-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
 # NOTE: bulk-generated coverage skeleton.
 # coding=utf-8
 
@@ -197,6 +197,8 @@ def main():
     ok = True
     ok = compare_bin("golden_v3.bin", "v3.bin", np.float32, 0.0001) and ok
     ok = compare_bin("golden_v6.bin", "v6.bin", np.float16, 0.001) and ok
+    ok = compare_bin("golden_v8.bin", "v8.bin", np.uint16, 0) and ok
+    ok = compare_bin("golden_v10.bin", "v10.bin", np.int16, 0) and ok
     if not ok:
         if strict:
             print("[ERROR] compare failed")

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/compare.py
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/compare.py
@@ -10,7 +10,7 @@
 # case: micro-op/gather-scatter/vgather2
 # family: gather-scatter
 # target_ops: pto.vgather2
-# scenarios: core-f32, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
+# scenarios: core-f32, core-f16-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
 # NOTE: bulk-generated coverage skeleton.
 # coding=utf-8
 
@@ -196,6 +196,7 @@ def main():
     strict = os.getenv("COMPARE_STRICT", "1") != "0"
     ok = True
     ok = compare_bin("golden_v3.bin", "v3.bin", np.float32, 0.0001) and ok
+    ok = compare_bin("golden_v6.bin", "v6.bin", np.float16, 0.001) and ok
     if not ok:
         if strict:
             print("[ERROR] compare failed")

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/golden.py
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/golden.py
@@ -10,7 +10,7 @@
 # case: micro-op/gather-scatter/vgather2
 # family: gather-scatter
 # target_ops: pto.vgather2
-# scenarios: core-f32, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
+# scenarios: core-f32, core-f16-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
 # NOTE: bulk-generated coverage skeleton.
 # coding=utf-8
 
@@ -34,11 +34,23 @@ def generate(output_dir: Path, seed: int) -> None:
     v2 = offsets.reshape(ROWS, COLS)
     v3 = np.zeros((ROWS, COLS), dtype=np.float32)
 
+    flat_f16 = rng.uniform(-4.0, 4.0, size=(ROWS * COLS,)).astype(np.float16)
+    offsets_u16 = (((np.arange(ROWS * COLS, dtype=np.uint32) * 11) + 5) %
+                   (ROWS * COLS)).astype(np.uint16)
+    gathered_f16 = flat_f16[offsets_u16.astype(np.int32)].reshape(ROWS, COLS)
+    v4 = flat_f16.reshape(ROWS, COLS)
+    v5 = offsets_u16.reshape(ROWS, COLS)
+    v6 = np.zeros((ROWS, COLS), dtype=np.float16)
+
     output_dir.mkdir(parents=True, exist_ok=True)
     v1.reshape(-1).tofile(output_dir / "v1.bin")
     v2.reshape(-1).tofile(output_dir / "v2.bin")
     v3.reshape(-1).tofile(output_dir / "v3.bin")
+    v4.reshape(-1).tofile(output_dir / "v4.bin")
+    v5.reshape(-1).tofile(output_dir / "v5.bin")
+    v6.reshape(-1).tofile(output_dir / "v6.bin")
     gathered.reshape(-1).tofile(output_dir / "golden_v3.bin")
+    gathered_f16.reshape(-1).tofile(output_dir / "golden_v6.bin")
 
 
 def main() -> None:

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/golden.py
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/golden.py
@@ -10,7 +10,7 @@
 # case: micro-op/gather-scatter/vgather2
 # family: gather-scatter
 # target_ops: pto.vgather2
-# scenarios: core-f32, core-f16-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
+# scenarios: core-f32, core-f16-u16-offsets, core-u8-u16-offsets, core-i8-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
 # NOTE: bulk-generated coverage skeleton.
 # coding=utf-8
 
@@ -42,6 +42,16 @@ def generate(output_dir: Path, seed: int) -> None:
     v5 = offsets_u16.reshape(ROWS, COLS)
     v6 = np.zeros((ROWS, COLS), dtype=np.float16)
 
+    flat_u8 = rng.integers(0, 256, size=(ROWS * COLS,), dtype=np.uint8)
+    gathered_u8 = flat_u8[offsets_u16.astype(np.int32)].astype(np.uint16).reshape(ROWS, COLS)
+    v7 = flat_u8.reshape(ROWS, COLS)
+    v8 = np.zeros((ROWS, COLS), dtype=np.uint16)
+
+    flat_i8 = rng.integers(-128, 128, size=(ROWS * COLS,), dtype=np.int16).astype(np.int8)
+    gathered_i8 = flat_i8[offsets_u16.astype(np.int32)].view(np.uint8).astype(np.int16).reshape(ROWS, COLS)
+    v9 = flat_i8.reshape(ROWS, COLS)
+    v10 = np.zeros((ROWS, COLS), dtype=np.int16)
+
     output_dir.mkdir(parents=True, exist_ok=True)
     v1.reshape(-1).tofile(output_dir / "v1.bin")
     v2.reshape(-1).tofile(output_dir / "v2.bin")
@@ -49,8 +59,14 @@ def generate(output_dir: Path, seed: int) -> None:
     v4.reshape(-1).tofile(output_dir / "v4.bin")
     v5.reshape(-1).tofile(output_dir / "v5.bin")
     v6.reshape(-1).tofile(output_dir / "v6.bin")
+    v7.reshape(-1).tofile(output_dir / "v7.bin")
+    v8.reshape(-1).tofile(output_dir / "v8.bin")
+    v9.reshape(-1).tofile(output_dir / "v9.bin")
+    v10.reshape(-1).tofile(output_dir / "v10.bin")
     gathered.reshape(-1).tofile(output_dir / "golden_v3.bin")
     gathered_f16.reshape(-1).tofile(output_dir / "golden_v6.bin")
+    gathered_u8.reshape(-1).tofile(output_dir / "golden_v8.bin")
+    gathered_i8.reshape(-1).tofile(output_dir / "golden_v10.bin")
 
 
 def main() -> None:

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/kernel.pto
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/kernel.pto
@@ -1,5 +1,5 @@
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-    func.func @vgather2_deep_merged_kernel(%arg0: !pto.ptr<f32, gm>, %arg1: !pto.ptr<i32, gm>, %arg2: !pto.ptr<f32, gm>, %arg3: !pto.ptr<f32, gm>, %arg4: !pto.ptr<i32, gm>, %arg5: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    func.func @vgather2_deep_merged_kernel(%arg0: !pto.ptr<f32, gm>, %arg1: !pto.ptr<i32, gm>, %arg2: !pto.ptr<f32, gm>, %arg3: !pto.ptr<f32, gm>, %arg4: !pto.ptr<i32, gm>, %arg5: !pto.ptr<f32, gm>, %arg6: !pto.ptr<f16, gm>, %arg7: !pto.ptr<ui16, gm>, %arg8: !pto.ptr<f16, gm>) attributes {pto.kernel} {
     %__deep_merge_guard = arith.constant false
     // inactive merged from vgather2_duplicate_index_kernel_2d
     scf.if %__deep_merge_guard {
@@ -404,6 +404,51 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
           pto.barrier #pto.pipe<PIPE_ALL>
     }
+
+    // active coverage for f16 gather with ui16 offset vectors. This locks the
+    // lowering path that reinterprets 128xui16 offsets as a 64xi32 carrier for
+    // the vgather2 v128f16 intrinsic.
+    %c0_f16 = arith.constant 0 : index
+    %c128_f16 = arith.constant 128 : index
+    %c1024_f16 = arith.constant 1024 : index
+    %c0_i64_f16 = arith.constant 0 : i64
+    %c1_i64_f16 = arith.constant 1 : i64
+    %c32_i64_f16 = arith.constant 32 : i64
+    %c64_i64_f16 = arith.constant 64 : i64
+    %c4096_i64_f16 = arith.constant 4096 : i64
+    %c8192_i64_f16 = arith.constant 8192 : i64
+    %c1024_i32_f16 = arith.constant 1024 : i32
+
+    %ub_in_f16 = pto.castptr %c0_i64_f16 : i64 -> !pto.ptr<f16, ub>
+    %ub_offsets_f16 = pto.castptr %c4096_i64_f16 : i64 -> !pto.ptr<ui16, ub>
+    %ub_out_f16 = pto.castptr %c8192_i64_f16 : i64 -> !pto.ptr<f16, ub>
+
+    pto.mte_gm_ub %arg6, %ub_in_f16, %c0_i64_f16, %c64_i64_f16
+      nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg7, %ub_offsets_f16, %c0_i64_f16, %c64_i64_f16
+      nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
+      : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %__f16:1 = scf.for %offset_f16 = %c0_f16 to %c1024_f16 step %c128_f16 iter_args(%remaining_f16 = %c1024_i32_f16) -> (i32) {
+        %mask_f16, %next_remaining_f16 = pto.plt_b16 %remaining_f16 : i32 -> !pto.mask<b16>, i32
+        %offsets_f16 = pto.vlds %ub_offsets_f16[%offset_f16] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
+        %out_f16 = pto.vgather2 %ub_in_f16, %offsets_f16, %mask_f16 : !pto.ptr<f16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+        pto.vsts %out_f16, %ub_out_f16[%offset_f16], %mask_f16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+        scf.yield %next_remaining_f16 : i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out_f16, %arg8, %c64_i64_f16
+      nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
+      : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
 
     return
   }

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/kernel.pto
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/kernel.pto
@@ -1,5 +1,5 @@
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-    func.func @vgather2_deep_merged_kernel(%arg0: !pto.ptr<f32, gm>, %arg1: !pto.ptr<i32, gm>, %arg2: !pto.ptr<f32, gm>, %arg3: !pto.ptr<f32, gm>, %arg4: !pto.ptr<i32, gm>, %arg5: !pto.ptr<f32, gm>, %arg6: !pto.ptr<f16, gm>, %arg7: !pto.ptr<ui16, gm>, %arg8: !pto.ptr<f16, gm>) attributes {pto.kernel} {
+    func.func @vgather2_deep_merged_kernel(%arg0: !pto.ptr<f32, gm>, %arg1: !pto.ptr<i32, gm>, %arg2: !pto.ptr<f32, gm>, %arg3: !pto.ptr<f32, gm>, %arg4: !pto.ptr<i32, gm>, %arg5: !pto.ptr<f32, gm>, %arg6: !pto.ptr<f16, gm>, %arg7: !pto.ptr<ui16, gm>, %arg8: !pto.ptr<f16, gm>, %arg9: !pto.ptr<ui8, gm>, %arg10: !pto.ptr<ui16, gm>, %arg11: !pto.ptr<i8, gm>, %arg12: !pto.ptr<i16, gm>) attributes {pto.kernel} {
     %__deep_merge_guard = arith.constant false
     // inactive merged from vgather2_duplicate_index_kernel_2d
     scf.if %__deep_merge_guard {
@@ -405,23 +405,32 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
           pto.barrier #pto.pipe<PIPE_ALL>
     }
 
-    // active coverage for f16 gather with ui16 offset vectors. This locks the
-    // lowering path that reinterprets 128xui16 offsets as a 64xi32 carrier for
-    // the vgather2 v128f16 intrinsic.
+    // active coverage for f16 and ui8 gather with ui16 offset vectors. This
+    // locks the lowering paths for both 16-bit gathers and b8 gathers that
+    // widen the loaded byte values into 16-bit result lanes.
     %c0_f16 = arith.constant 0 : index
     %c128_f16 = arith.constant 128 : index
     %c1024_f16 = arith.constant 1024 : index
     %c0_i64_f16 = arith.constant 0 : i64
     %c1_i64_f16 = arith.constant 1 : i64
+    %c16_i64_f16 = arith.constant 16 : i64
     %c32_i64_f16 = arith.constant 32 : i64
     %c64_i64_f16 = arith.constant 64 : i64
     %c4096_i64_f16 = arith.constant 4096 : i64
     %c8192_i64_f16 = arith.constant 8192 : i64
+    %c12288_i64_f16 = arith.constant 12288 : i64
+    %c14336_i64_f16 = arith.constant 14336 : i64
+    %c16384_i64_f16 = arith.constant 16384 : i64
+    %c18432_i64_f16 = arith.constant 18432 : i64
     %c1024_i32_f16 = arith.constant 1024 : i32
 
     %ub_in_f16 = pto.castptr %c0_i64_f16 : i64 -> !pto.ptr<f16, ub>
     %ub_offsets_f16 = pto.castptr %c4096_i64_f16 : i64 -> !pto.ptr<ui16, ub>
     %ub_out_f16 = pto.castptr %c8192_i64_f16 : i64 -> !pto.ptr<f16, ub>
+    %ub_in_u8 = pto.castptr %c12288_i64_f16 : i64 -> !pto.ptr<ui8, ub>
+    %ub_out_u8 = pto.castptr %c14336_i64_f16 : i64 -> !pto.ptr<ui16, ub>
+    %ub_in_i8 = pto.castptr %c16384_i64_f16 : i64 -> !pto.ptr<i8, ub>
+    %ub_out_i8 = pto.castptr %c18432_i64_f16 : i64 -> !pto.ptr<i16, ub>
 
     pto.mte_gm_ub %arg6, %ub_in_f16, %c0_i64_f16, %c64_i64_f16
       nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
@@ -429,6 +438,12 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.mte_gm_ub %arg7, %ub_offsets_f16, %c0_i64_f16, %c64_i64_f16
       nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
       : !pto.ptr<ui16, gm>, !pto.ptr<ui16, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg9, %ub_in_u8, %c0_i64_f16, %c64_i64_f16
+      nburst(%c16_i64_f16, %c64_i64_f16, %c64_i64_f16)
+      : !pto.ptr<ui8, gm>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64
+    pto.mte_gm_ub %arg11, %ub_in_i8, %c0_i64_f16, %c64_i64_f16
+      nburst(%c16_i64_f16, %c64_i64_f16, %c64_i64_f16)
+      : !pto.ptr<i8, gm>, !pto.ptr<i8, ub>, i64, i64, i64, i64, i64
 
     pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
     pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
@@ -438,7 +453,11 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %mask_f16, %next_remaining_f16 = pto.plt_b16 %remaining_f16 : i32 -> !pto.mask<b16>, i32
         %offsets_f16 = pto.vlds %ub_offsets_f16[%offset_f16] : !pto.ptr<ui16, ub> -> !pto.vreg<128xui16>
         %out_f16 = pto.vgather2 %ub_in_f16, %offsets_f16, %mask_f16 : !pto.ptr<f16, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+        %out_u8 = pto.vgather2 %ub_in_u8, %offsets_f16, %mask_f16 : !pto.ptr<ui8, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xui16>
+        %out_i8 = pto.vgather2 %ub_in_i8, %offsets_f16, %mask_f16 : !pto.ptr<i8, ub>, !pto.vreg<128xui16>, !pto.mask<b16> -> !pto.vreg<128xi16>
         pto.vsts %out_f16, %ub_out_f16[%offset_f16], %mask_f16 : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.mask<b16>
+        pto.vsts %out_u8, %ub_out_u8[%offset_f16], %mask_f16 : !pto.vreg<128xui16>, !pto.ptr<ui16, ub>, !pto.mask<b16>
+        pto.vsts %out_i8, %ub_out_i8[%offset_f16], %mask_f16 : !pto.vreg<128xi16>, !pto.ptr<i16, ub>, !pto.mask<b16>
         scf.yield %next_remaining_f16 : i32
       }
     }
@@ -448,6 +467,12 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.mte_ub_gm %ub_out_f16, %arg8, %c64_i64_f16
       nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
       : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %ub_out_u8, %arg10, %c64_i64_f16
+      nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
+      : !pto.ptr<ui16, ub>, !pto.ptr<ui16, gm>, i64, i64, i64, i64
+    pto.mte_ub_gm %ub_out_i8, %arg12, %c64_i64_f16
+      nburst(%c32_i64_f16, %c64_i64_f16, %c64_i64_f16)
+      : !pto.ptr<i16, ub>, !pto.ptr<i16, gm>, i64, i64, i64, i64
     pto.barrier #pto.pipe<PIPE_ALL>
 
     return

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/launch.cpp
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/launch.cpp
@@ -33,14 +33,22 @@ extern "C" __global__ [aicore] void vgather2_deep_merged_kernel(
     __gm__ float * arg2,
     __gm__ float * arg3,
     __gm__ int32_t * arg4,
-    __gm__ float * arg5);
+    __gm__ float * arg5,
+    __gm__ half * arg6,
+    __gm__ uint16_t * arg7,
+    __gm__ half * arg8);
 
-void LaunchVgather2DeepMerged(float * p0, int * p1, float * p2, void *stream) {
+void LaunchVgather2DeepMerged(float * p0, int * p1, float * p2,
+                              uint16_t * p3, uint16_t * p4, uint16_t * p5,
+                              void *stream) {
   vgather2_deep_merged_kernel<<<1, nullptr, stream>>>(
       (__gm__ float *)p0,
       (__gm__ int32_t *)p0,
       (__gm__ float *)p0,
       (__gm__ float *)p0,
       (__gm__ int32_t *)p1,
-      (__gm__ float *)p2);
+      (__gm__ float *)p2,
+      (__gm__ half *)p3,
+      (__gm__ uint16_t *)p4,
+      (__gm__ half *)p5);
 }

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/launch.cpp
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/launch.cpp
@@ -36,10 +36,16 @@ extern "C" __global__ [aicore] void vgather2_deep_merged_kernel(
     __gm__ float * arg5,
     __gm__ half * arg6,
     __gm__ uint16_t * arg7,
-    __gm__ half * arg8);
+    __gm__ half * arg8,
+    __gm__ uint8_t * arg9,
+    __gm__ uint16_t * arg10,
+    __gm__ int8_t * arg11,
+    __gm__ int16_t * arg12);
 
 void LaunchVgather2DeepMerged(float * p0, int * p1, float * p2,
                               uint16_t * p3, uint16_t * p4, uint16_t * p5,
+                              uint8_t * p6, uint16_t * p7,
+                              int8_t * p8, int16_t * p9,
                               void *stream) {
   vgather2_deep_merged_kernel<<<1, nullptr, stream>>>(
       (__gm__ float *)p0,
@@ -50,5 +56,9 @@ void LaunchVgather2DeepMerged(float * p0, int * p1, float * p2,
       (__gm__ float *)p2,
       (__gm__ half *)p3,
       (__gm__ uint16_t *)p4,
-      (__gm__ half *)p5);
+      (__gm__ half *)p5,
+      (__gm__ uint8_t *)p6,
+      (__gm__ uint16_t *)p7,
+      (__gm__ int8_t *)p8,
+      (__gm__ int16_t *)p9);
 }

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/main.cpp
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/main.cpp
@@ -10,7 +10,7 @@
 // case: micro-op/gather-scatter/vgather2
 // family: gather-scatter
 // target_ops: pto.vgather2
-// scenarios: core-f32, core-f16-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
+// scenarios: core-f32, core-f16-u16-offsets, core-u8-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
 // -----------------------------------------------------------------------------
@@ -58,6 +58,8 @@ struct MrgSortExecutedNumList {
 
 void LaunchVgather2DeepMerged(float * p0, int * p1, float * p2,
                               uint16_t * p3, uint16_t * p4, uint16_t * p5,
+                              uint8_t * p6, uint16_t * p7,
+                              int8_t * p8, int16_t * p9,
                               void *stream);
 int main() {
     size_t elemCount_v1 = 1024;
@@ -72,6 +74,14 @@ int main() {
     size_t fileSize_v5 = elemCount_v5 * sizeof(uint16_t);
     size_t elemCount_v6 = 1024;
     size_t fileSize_v6 = elemCount_v6 * sizeof(uint16_t);
+    size_t elemCount_v7 = 1024;
+    size_t fileSize_v7 = elemCount_v7 * sizeof(uint8_t);
+    size_t elemCount_v8 = 1024;
+    size_t fileSize_v8 = elemCount_v8 * sizeof(uint16_t);
+    size_t elemCount_v9 = 1024;
+    size_t fileSize_v9 = elemCount_v9 * sizeof(int8_t);
+    size_t elemCount_v10 = 1024;
+    size_t fileSize_v10 = elemCount_v10 * sizeof(int16_t);
     float *v1Host = nullptr;
     float *v1Device = nullptr;
     int *v2Host = nullptr;
@@ -84,6 +94,14 @@ int main() {
     uint16_t *v5Device = nullptr;
     uint16_t *v6Host = nullptr;
     uint16_t *v6Device = nullptr;
+    uint8_t *v7Host = nullptr;
+    uint8_t *v7Device = nullptr;
+    uint16_t *v8Host = nullptr;
+    uint16_t *v8Device = nullptr;
+    int8_t *v9Host = nullptr;
+    int8_t *v9Device = nullptr;
+    int16_t *v10Host = nullptr;
+    int16_t *v10Device = nullptr;
 
     int rc = 0;
     bool aclInited = false;
@@ -106,12 +124,20 @@ int main() {
     ACL_CHECK(aclrtMallocHost((void **)(&v4Host), fileSize_v4));
     ACL_CHECK(aclrtMallocHost((void **)(&v5Host), fileSize_v5));
     ACL_CHECK(aclrtMallocHost((void **)(&v6Host), fileSize_v6));
+    ACL_CHECK(aclrtMallocHost((void **)(&v7Host), fileSize_v7));
+    ACL_CHECK(aclrtMallocHost((void **)(&v8Host), fileSize_v8));
+    ACL_CHECK(aclrtMallocHost((void **)(&v9Host), fileSize_v9));
+    ACL_CHECK(aclrtMallocHost((void **)(&v10Host), fileSize_v10));
     ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
     ACL_CHECK(aclrtMalloc((void **)&v2Device, fileSize_v2, ACL_MEM_MALLOC_HUGE_FIRST));
     ACL_CHECK(aclrtMalloc((void **)&v3Device, fileSize_v3, ACL_MEM_MALLOC_HUGE_FIRST));
     ACL_CHECK(aclrtMalloc((void **)&v4Device, fileSize_v4, ACL_MEM_MALLOC_HUGE_FIRST));
     ACL_CHECK(aclrtMalloc((void **)&v5Device, fileSize_v5, ACL_MEM_MALLOC_HUGE_FIRST));
     ACL_CHECK(aclrtMalloc((void **)&v6Device, fileSize_v6, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc((void **)&v7Device, fileSize_v7, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc((void **)&v8Device, fileSize_v8, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc((void **)&v9Device, fileSize_v9, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc((void **)&v10Device, fileSize_v10, ACL_MEM_MALLOC_HUGE_FIRST));
 
     ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
     ReadFile("./v2.bin", fileSize_v2, v2Host, fileSize_v2);
@@ -119,21 +145,35 @@ int main() {
     ReadFile("./v4.bin", fileSize_v4, v4Host, fileSize_v4);
     ReadFile("./v5.bin", fileSize_v5, v5Host, fileSize_v5);
     ReadFile("./v6.bin", fileSize_v6, v6Host, fileSize_v6);
+    ReadFile("./v7.bin", fileSize_v7, v7Host, fileSize_v7);
+    ReadFile("./v8.bin", fileSize_v8, v8Host, fileSize_v8);
+    ReadFile("./v9.bin", fileSize_v9, v9Host, fileSize_v9);
+    ReadFile("./v10.bin", fileSize_v10, v10Host, fileSize_v10);
     ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
     ACL_CHECK(aclrtMemcpy(v2Device, fileSize_v2, v2Host, fileSize_v2, ACL_MEMCPY_HOST_TO_DEVICE));
     ACL_CHECK(aclrtMemcpy(v3Device, fileSize_v3, v3Host, fileSize_v3, ACL_MEMCPY_HOST_TO_DEVICE));
     ACL_CHECK(aclrtMemcpy(v4Device, fileSize_v4, v4Host, fileSize_v4, ACL_MEMCPY_HOST_TO_DEVICE));
     ACL_CHECK(aclrtMemcpy(v5Device, fileSize_v5, v5Host, fileSize_v5, ACL_MEMCPY_HOST_TO_DEVICE));
     ACL_CHECK(aclrtMemcpy(v6Device, fileSize_v6, v6Host, fileSize_v6, ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(v7Device, fileSize_v7, v7Host, fileSize_v7, ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(v8Device, fileSize_v8, v8Host, fileSize_v8, ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(v9Device, fileSize_v9, v9Host, fileSize_v9, ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(v10Device, fileSize_v10, v10Host, fileSize_v10, ACL_MEMCPY_HOST_TO_DEVICE));
     LaunchVgather2DeepMerged(v1Device, v2Device, v3Device,
-                              v4Device, v5Device, v6Device, stream);
+                              v4Device, v5Device, v6Device,
+                              v7Device, v8Device,
+                              v9Device, v10Device, stream);
 
     ACL_CHECK(aclrtSynchronizeStream(stream));
     ACL_CHECK(aclrtMemcpy(v3Host, fileSize_v3, v3Device, fileSize_v3, ACL_MEMCPY_DEVICE_TO_HOST));
     ACL_CHECK(aclrtMemcpy(v6Host, fileSize_v6, v6Device, fileSize_v6, ACL_MEMCPY_DEVICE_TO_HOST));
+    ACL_CHECK(aclrtMemcpy(v8Host, fileSize_v8, v8Device, fileSize_v8, ACL_MEMCPY_DEVICE_TO_HOST));
+    ACL_CHECK(aclrtMemcpy(v10Host, fileSize_v10, v10Device, fileSize_v10, ACL_MEMCPY_DEVICE_TO_HOST));
 
     WriteFile("./v3.bin", v3Host, fileSize_v3);
     WriteFile("./v6.bin", v6Host, fileSize_v6);
+    WriteFile("./v8.bin", v8Host, fileSize_v8);
+    WriteFile("./v10.bin", v10Host, fileSize_v10);
 
 cleanup:
     aclrtFree(v1Device);
@@ -142,12 +182,20 @@ cleanup:
     aclrtFree(v4Device);
     aclrtFree(v5Device);
     aclrtFree(v6Device);
+    aclrtFree(v7Device);
+    aclrtFree(v8Device);
+    aclrtFree(v9Device);
+    aclrtFree(v10Device);
     aclrtFreeHost(v1Host);
     aclrtFreeHost(v2Host);
     aclrtFreeHost(v3Host);
     aclrtFreeHost(v4Host);
     aclrtFreeHost(v5Host);
     aclrtFreeHost(v6Host);
+    aclrtFreeHost(v7Host);
+    aclrtFreeHost(v8Host);
+    aclrtFreeHost(v9Host);
+    aclrtFreeHost(v10Host);
     if (stream != nullptr) {
         const aclError _ret = aclrtDestroyStream(stream);
         if (_ret != ACL_SUCCESS) {

--- a/test/vpto/cases/micro-op/gather-scatter/vgather2/main.cpp
+++ b/test/vpto/cases/micro-op/gather-scatter/vgather2/main.cpp
@@ -10,7 +10,7 @@
 // case: micro-op/gather-scatter/vgather2
 // family: gather-scatter
 // target_ops: pto.vgather2
-// scenarios: core-f32, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
+// scenarios: core-f32, core-f16-u16-offsets, full-mask, non-contiguous, explicit-index-pattern, load-effect-validation, no-alias
 // NOTE: bulk-generated coverage skeleton. Parser/verifier/lowering failure is
 // still a valid test conclusion in the current coverage-first phase.
 // -----------------------------------------------------------------------------
@@ -56,7 +56,9 @@ struct MrgSortExecutedNumList {
     } while (0)
 
 
-void LaunchVgather2DeepMerged(float * p0, int * p1, float * p2, void *stream);
+void LaunchVgather2DeepMerged(float * p0, int * p1, float * p2,
+                              uint16_t * p3, uint16_t * p4, uint16_t * p5,
+                              void *stream);
 int main() {
     size_t elemCount_v1 = 1024;
     size_t fileSize_v1 = elemCount_v1 * sizeof(float);
@@ -64,12 +66,24 @@ int main() {
     size_t fileSize_v2 = elemCount_v2 * sizeof(int);
     size_t elemCount_v3 = 1024;
     size_t fileSize_v3 = elemCount_v3 * sizeof(float);
+    size_t elemCount_v4 = 1024;
+    size_t fileSize_v4 = elemCount_v4 * sizeof(uint16_t);
+    size_t elemCount_v5 = 1024;
+    size_t fileSize_v5 = elemCount_v5 * sizeof(uint16_t);
+    size_t elemCount_v6 = 1024;
+    size_t fileSize_v6 = elemCount_v6 * sizeof(uint16_t);
     float *v1Host = nullptr;
     float *v1Device = nullptr;
     int *v2Host = nullptr;
     int *v2Device = nullptr;
     float *v3Host = nullptr;
     float *v3Device = nullptr;
+    uint16_t *v4Host = nullptr;
+    uint16_t *v4Device = nullptr;
+    uint16_t *v5Host = nullptr;
+    uint16_t *v5Device = nullptr;
+    uint16_t *v6Host = nullptr;
+    uint16_t *v6Device = nullptr;
 
     int rc = 0;
     bool aclInited = false;
@@ -89,30 +103,51 @@ int main() {
     ACL_CHECK(aclrtMallocHost((void **)(&v1Host), fileSize_v1));
     ACL_CHECK(aclrtMallocHost((void **)(&v2Host), fileSize_v2));
     ACL_CHECK(aclrtMallocHost((void **)(&v3Host), fileSize_v3));
+    ACL_CHECK(aclrtMallocHost((void **)(&v4Host), fileSize_v4));
+    ACL_CHECK(aclrtMallocHost((void **)(&v5Host), fileSize_v5));
+    ACL_CHECK(aclrtMallocHost((void **)(&v6Host), fileSize_v6));
     ACL_CHECK(aclrtMalloc((void **)&v1Device, fileSize_v1, ACL_MEM_MALLOC_HUGE_FIRST));
     ACL_CHECK(aclrtMalloc((void **)&v2Device, fileSize_v2, ACL_MEM_MALLOC_HUGE_FIRST));
     ACL_CHECK(aclrtMalloc((void **)&v3Device, fileSize_v3, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc((void **)&v4Device, fileSize_v4, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc((void **)&v5Device, fileSize_v5, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc((void **)&v6Device, fileSize_v6, ACL_MEM_MALLOC_HUGE_FIRST));
 
     ReadFile("./v1.bin", fileSize_v1, v1Host, fileSize_v1);
     ReadFile("./v2.bin", fileSize_v2, v2Host, fileSize_v2);
     ReadFile("./v3.bin", fileSize_v3, v3Host, fileSize_v3);
+    ReadFile("./v4.bin", fileSize_v4, v4Host, fileSize_v4);
+    ReadFile("./v5.bin", fileSize_v5, v5Host, fileSize_v5);
+    ReadFile("./v6.bin", fileSize_v6, v6Host, fileSize_v6);
     ACL_CHECK(aclrtMemcpy(v1Device, fileSize_v1, v1Host, fileSize_v1, ACL_MEMCPY_HOST_TO_DEVICE));
     ACL_CHECK(aclrtMemcpy(v2Device, fileSize_v2, v2Host, fileSize_v2, ACL_MEMCPY_HOST_TO_DEVICE));
     ACL_CHECK(aclrtMemcpy(v3Device, fileSize_v3, v3Host, fileSize_v3, ACL_MEMCPY_HOST_TO_DEVICE));
-        LaunchVgather2DeepMerged(v1Device, v2Device, v3Device, stream);
+    ACL_CHECK(aclrtMemcpy(v4Device, fileSize_v4, v4Host, fileSize_v4, ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(v5Device, fileSize_v5, v5Host, fileSize_v5, ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(v6Device, fileSize_v6, v6Host, fileSize_v6, ACL_MEMCPY_HOST_TO_DEVICE));
+    LaunchVgather2DeepMerged(v1Device, v2Device, v3Device,
+                              v4Device, v5Device, v6Device, stream);
 
     ACL_CHECK(aclrtSynchronizeStream(stream));
     ACL_CHECK(aclrtMemcpy(v3Host, fileSize_v3, v3Device, fileSize_v3, ACL_MEMCPY_DEVICE_TO_HOST));
+    ACL_CHECK(aclrtMemcpy(v6Host, fileSize_v6, v6Device, fileSize_v6, ACL_MEMCPY_DEVICE_TO_HOST));
 
     WriteFile("./v3.bin", v3Host, fileSize_v3);
+    WriteFile("./v6.bin", v6Host, fileSize_v6);
 
 cleanup:
     aclrtFree(v1Device);
     aclrtFree(v2Device);
     aclrtFree(v3Device);
+    aclrtFree(v4Device);
+    aclrtFree(v5Device);
+    aclrtFree(v6Device);
     aclrtFreeHost(v1Host);
     aclrtFreeHost(v2Host);
     aclrtFreeHost(v3Host);
+    aclrtFreeHost(v4Host);
+    aclrtFreeHost(v5Host);
+    aclrtFreeHost(v6Host);
     if (stream != nullptr) {
         const aclError _ret = aclrtDestroyStream(stream);
         if (_ret != ACL_SUCCESS) {


### PR DESCRIPTION
## Summary

本 PR 修复并补充 `pto.vgather2` 在 A5 VPTO 后端中对 16-bit gather form 和 8-bit gather form 的支持。

- 修复 16-bit gather forms 的 lowering：
  - 覆盖 `f16/bf16/i16/ui16` source/result。
  - 这些 forms 使用 `!pto.vreg<128xui16>` offsets，语义上是 128 个 16-bit element index。
  - lowering 到 Bisheng LLVM intrinsic 时，offset register 需要作为 `vector<64xi32>` carrier 传入。

- 修复 8-bit gather forms 的 lowering：
  - 覆盖 `ui8 -> ui16` 和 `i8 -> i16`。
  - 根据 source element type 选择 `v256u8` / `v256s8` intrinsic。
  - 结果仍是 128 个 16-bit lanes。
  - 8-bit load payload zero-extend 到 16-bit result lane。

- 收紧 `pto.vgather2` verifier：
  - b8 forms：`i8/ui8` source，`i16/ui16` result，`128xui16/i16` offsets，`mask<b16>`。
  - b16 forms：`i16/ui16/f16/bf16` source/result，`128xui16/i16` offsets，`mask<b16>`。
  - b32 forms：`i32/ui32/f32` source/result，`64xui32/i32` offsets，`mask<b32>`。

- 更新文档：
  - 说明 `%offsets` 是按 source element 计数的 element index，不是 byte offset。
  - 写清地址计算：`base + unsigned(offset[i]) * sizeof(source element)`。
  - 写清 8-bit gather 的 zero-extension 语义。

## Tests

- 新增 lit 覆盖：
  - 16-bit gather forms 的 `128xui16` offsets lowering 到 `vector<64xi32>` carrier。
  - `ui8/i8/ui16/i16/f16/bf16/ui32/i32/f32` supported forms。
  - invalid b8 result、invalid offset、invalid mask。

- 扩展已有 SIM runtime case：
  - 在 `test/vpto/cases/micro-op/gather-scatter/vgather2` 中补充 active runtime 覆盖。
  - `f16` gather 覆盖 16-bit gather form 的 SIM 路径。
  - `ui8 -> ui16` 和 `i8 -> i16` gather 覆盖 8-bit gather forms 和 zero-extension 行为。
  - 新增 runtime 操作放在已有 vecscope 内，复用同一组 `ui16` offsets 和 `b16` mask。

## Validation

- `cmake --build .work/build-llvm21 --target ptoas -j8`
- `llvm-lit -v .work/build-llvm21/test/lit/vpto/vgather2_supported_types_vpto_llvm.pto .work/build-llvm21/test/lit/vpto/vgather2_u16_offsets_vpto_llvm.pto .work/build-llvm21/test/lit/vpto/vgather2_verify_invalid_b8_result.pto .work/build-llvm21/test/lit/vpto/vgather2_verify_invalid_offset.pto .work/build-llvm21/test/lit/vpto/vgather2_verify_invalid_mask.pto`
- `ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0 PTOAS_BIN=$PWD/.work/build-llvm21/tools/ptoas/ptoas WORK_SPACE=$PWD/.work/vpto-validation CASE_NAME=micro-op/gather-scatter/vgather2 COMPILE_ONLY=1 test/vpto/scripts/run_host_vpto_validation.sh`
- `ASCEND_HOME_PATH=/usr/local/Ascend/cann-9.0.0 PTOAS_BIN=$PWD/.work/build-llvm21/tools/ptoas/ptoas WORK_SPACE=$PWD/.work/vpto-validation CASE_NAME=micro-op/gather-scatter/vgather2 test/vpto/scripts/run_host_vpto_validation.sh`
