### PR TITLE
Version-Aware Fusion Plan

### DIFF
--- a/docs/designs/tile-fusion-version-aware-planning.md
+++ b/docs/designs/tile-fusion-version-aware-planning.md
@@ -1,0 +1,877 @@
+# Tile Fusion Version-Aware Planning
+
+## Goal
+
+`PTOFusionPlan.cpp` currently creates fusion groups over `FusionComputeNode`
+objects only. The next planner should create and compare groups over:
+
+```text
+compute node + selected TileOp implementation version
+```
+
+The implementation versions come from the `candidates` metadata attached by
+`InsertTemplateAttributes.cpp`. Different versions may have different loop
+nests or requirements. For example, a tile op may have a normal 2D
+implementation and a specialized 1D implementation when the tile is contiguous.
+
+The planner should:
+
+1. Read legal implementation versions for every plannable tile op.
+2. Enumerate valid versioned groups from each seed.
+3. Score every valid group with a cost model.
+4. Pick the best group for that seed.
+5. Insert the selected group into the final group list.
+
+Implementation note: the existing `PTOFusionPlan.cpp` pass stays as the
+node-only baseline. Version-aware work should live in the separate
+`PTOVersionAwareFusionPlan.cpp` pass registered as:
+
+```text
+pto-version-aware-fusion-plan
+```
+
+This design intentionally preserves the current block-local greedy assignment:
+after a selected group is emitted, its compute nodes are marked assigned and
+cannot participate in later seed groups.
+
+## Current Planner
+
+The active planner uses:
+
+```text
+ConservativeDAGGreedyCostModel
+ConservativeDAGGreedyStrategyEngine
+```
+
+The current group shape is logically:
+
+```text
+PlannedFusionGroup
+  members: [A, B, C]
+```
+
+The active block algorithm is:
+
+```text
+assigned = {}
+
+for seed in block.computeNodes:
+  if seed is assigned:
+    continue
+  if seed cannot start a group:
+    continue
+
+  group = [seed]
+
+  repeat while group changed:
+    for candidate in block.computeNodes:
+      if candidate is assigned or already in group:
+        continue
+      if candidate can append to group:
+        group.push(candidate)
+
+  if group.size >= 2:
+    emit group
+    mark all group nodes assigned
+```
+
+Diagram:
+
+```text
+Block order:
+
+  A    noise0    B    noise1    C
+  |              |              ^
+  |              +--------------+
+  +-----------------------------+
+
+Current DAG greedy result:
+
+  group 0 = [A, B, C]
+  noise0 and noise1 are not grouped
+```
+
+## Target Planner Model
+
+The group must become version-aware:
+
+```text
+PlannedFusionGroup
+  members:
+    A : candidate version 0
+    B : candidate version 2
+    C : candidate version 1
+  cost:
+    dependencyBenefit
+    loopMergeBenefit
+    liveTilePenalty
+    vfParameterPenalty
+```
+
+This lets the planner distinguish groups with the same nodes but different
+implementations:
+
+```text
+Group candidate 1:
+  A:2D -> B:2D -> C:2D
+
+Group candidate 2:
+  A:1D -> B:1D -> C:1D
+
+Group candidate 3:
+  A:2D -> B:1D -> C:1D
+```
+
+## Template Candidate Metadata
+
+`InsertTemplateAttributes.cpp` attaches legal implementation candidates as:
+
+```text
+candidates = [
+  {
+    id = 0,
+    name = "...",
+    loop_depth = 2,
+    postupdate = 0,
+    tail = 0
+  },
+  {
+    id = 1,
+    name = "...",
+    loop_depth = 1,
+    postupdate = 0,
+    tail = 0
+  }
+]
+```
+
+The authoritative operation attribute name is:
+
+```text
+candidates
+```
+
+Both `InsertTemplateAttributes.cpp` and `PTOFusionPlan.cpp` should use the same
+constant and parser. The preferred shared home is a focused transform helper,
+not the generic transform utilities:
+
+```text
+include/PTO/Transforms/TemplateAttributes.h
+lib/PTO/Transforms/TemplateAttributes.cpp
+```
+
+Suggested shared API:
+
+```cpp
+struct TemplateCandidateMetadata {
+  int64_t id;
+  std::string name;
+  int64_t loopDepth;
+  bool isPostUpdate;
+  bool hasTail;
+};
+
+constexpr llvm::StringLiteral kTemplateCandidatesAttr = "candidates";
+
+FailureOr<SmallVector<TemplateCandidateMetadata, 4>>
+getTemplateCandidates(Operation *op);
+```
+
+`Utils.h`/`Utils.cpp` should stay for broadly reusable transform utilities. The
+candidate metadata schema is specific enough that a named helper file makes the
+contract clearer and avoids turning `Utils` into a catch-all.
+
+The planner-side representation is:
+
+```cpp
+struct TileOpImplVersion {
+  int64_t id = 0;
+  std::string name;
+  int64_t loopDepth = 0;
+  bool isPostUpdate = false;
+  bool hasTail = false;
+};
+
+struct PlannedFusionMember {
+  const pto::FusionComputeNode *node = nullptr;
+  TileOpImplVersion version;
+};
+
+struct PlannedFusionGroup {
+  SmallVector<PlannedFusionMember, 8> members;
+  PlanningCost cost;
+};
+```
+
+The first compatibility step is:
+
+```text
+If op has candidates:
+  use candidate list
+If op has no candidates:
+  use one default implementation version
+```
+
+This keeps existing non-PTODSL tests working while the version-aware planner is
+introduced.
+
+## Search State
+
+The new planner should not grow one group per seed. It should grow many partial
+group states:
+
+```cpp
+struct GroupState {
+  SmallVector<PlannedFusionMember, 8> members;
+  DenseSet<unsigned> nodeIds;
+  PlanningCost cost;
+  GroupConstraints constraints;
+};
+```
+
+`GroupConstraints` can start small and grow as needed:
+
+```text
+GroupConstraints
+  commonIterationDomainClass
+  loopDepth compatibility
+  contiguous-layout requirements
+  tail handling requirements
+```
+
+At the beginning, `GroupConstraints` can be implicit in `tryAppend`. It does not
+need to be a full struct until the rules become non-trivial.
+
+## Version-Aware Enumeration
+
+For one seed:
+
+```text
+frontier = all legal seed versions
+validGroups = {}
+
+while frontier is not empty:
+  state = pop(frontier)
+
+  for candidate in block.computeNodes:
+    if candidate is already assigned globally:
+      continue
+    if candidate is already in state:
+      continue
+
+    for version in legal versions of candidate:
+      next = tryAppend(state, candidate, version)
+      if next is invalid:
+        continue
+
+      push next into frontier
+
+      if next.members.size >= 2:
+        add next to validGroups
+
+best = chooseBest(validGroups)
+```
+
+The loop belongs inside the current first seed loop in
+`ConservativeDAGGreedyStrategyEngine::planBlock`:
+
+```text
+for seed in block.computeNodes:
+  if seed is assigned:
+    continue
+  if seed cannot start a group:
+    continue
+
+  old:
+    greedily grow one node-only group
+
+  new:
+    enumerate many versioned group states from this seed
+    choose the best state by cost
+    emit only that selected state
+```
+
+Concrete skeleton:
+
+```cpp
+for (const FusionComputeNode &seed : ctx.blockAnalysis.computeNodes) {
+  if (assignedNodes.contains(seed.id))
+    continue;
+
+  if (!costModel.evaluateSeed(ctx, seed).accept)
+    continue;
+
+  FailureOr<SmallVector<GroupState, 8>> groupsForSeed =
+      enumerateGroupsForSeed(ctx, costModel, seed, assignedNodes);
+  if (failed(groupsForSeed) || groupsForSeed->empty())
+    continue;
+
+  GroupState best = chooseBestGroup(*groupsForSeed);
+  groups.push_back(toPlannedFusionGroup(best));
+
+  for (const PlannedFusionMember &member : best.members)
+    assignedNodes.insert(member.node->id);
+}
+```
+
+Diagram:
+
+```text
+                       seed A
+                         |
+          --------------------------------
+          |                              |
+        A:2D                           A:1D
+          |                              |
+     -------------                 -------------
+     |           |                 |           |
+  +B:2D       +B:1D             +B:2D       +B:1D
+     |           |                 |           |
+ [A:2D,      [A:2D,            reject      [A:1D,
+  B:2D]       B:1D]                        B:1D]
+     |           |                             |
+  +C:2D      reject                         +C:1D
+     |                                         |
+ [A:2D, B:2D, C:2D]                    [A:1D, B:1D, C:1D]
+```
+
+The planner compares every valid group:
+
+```text
+candidate groups:
+
+  G0 = [A:2D, B:2D]          cost = 12
+  G1 = [A:2D, B:2D, C:2D]    cost = 15
+  G2 = [A:1D, B:1D]          cost = 18
+  G3 = [A:1D, B:1D, C:1D]    cost = 16
+
+choose G2
+```
+
+Important: the planner must keep non-terminal groups. The best group is not
+necessarily the largest group.
+
+```text
+[A, B]        cost = 20
+[A, B, C]     cost = 14
+[A, B, C, D]  cost = -2
+
+Best group is [A, B], not the maximal group.
+```
+
+## Exhaustiveness
+
+For one seed, all possible groups have been found when:
+
+```text
+No partial group state in the frontier can append any unassigned candidate
+node with any legal implementation version.
+```
+
+The search is finite because:
+
+```text
+1. A state cannot contain the same compute node twice.
+2. Every append increases state.members.size.
+3. state.members.size <= number of compute nodes in the block.
+4. Each node has a finite candidate version list.
+```
+
+Diagram:
+
+```text
+frontier level 0:
+  [A:v0]
+  [A:v1]
+
+frontier level 1:
+  [A:v0, B:v0]
+  [A:v0, B:v1]
+  [A:v1, C:v0]
+
+frontier level 2:
+  [A:v0, B:v0, C:v0]
+
+frontier level 3:
+  empty
+
+At empty frontier:
+  enumeration for seed A is complete.
+```
+
+## Append Rules
+
+The existing DAG append rules remain the base legality checks:
+
+```text
+candidate is supported
+candidate has proven iteration domain
+candidate has same iterationDomainClass as the group
+no hard boundary exists between candidate and any member
+candidate has direct data-flow connection to the group
+cost total is profitable
+```
+
+Version-aware append adds rules such as:
+
+```text
+candidate version is legal for candidate op
+candidate version is compatible with existing group versions
+candidate version satisfies required tile layout or contiguity constraints
+candidate version does not break loop-depth compatibility
+candidate version has acceptable tail/postupdate behavior
+```
+
+The first version-aware implementation can keep the existing node-only
+`CostModel::evaluateAppend` as the base check and layer version checks around
+it:
+
+```text
+tryAppend(state, candidate, candidateVersion):
+  currentNodes = nodes(state.members)
+
+  if base evaluateAppend(currentNodes, candidate) rejects:
+    reject
+
+  if candidateVersion is not compatible with state constraints:
+    reject
+
+  next = state + candidate:version
+  next.cost = computeVersionAwareCost(next)
+  accept next
+```
+
+This keeps the existing dynamic-shape, hard-boundary, iteration-domain, and
+data-flow behavior intact while version-specific rules are added incrementally.
+
+Base data-flow diagram:
+
+```text
+Accepted:
+
+  A produces %x
+       |
+       v
+  B consumes %x
+
+  [A:*] + B:* can be considered
+
+Rejected:
+
+  A produces %x       C produces %y
+       |                   |
+       v                   v
+  B consumes %x       D consumes %y
+
+  [A:*, B:*] + C:* has no direct connection
+```
+
+Hard-boundary diagram:
+
+```text
+Accepted:
+
+  A
+  pure/simple op
+  B
+
+Rejected:
+
+  A
+  call / region op / terminator
+  B
+```
+
+## Cost Model Direction
+
+The current DAG cost is:
+
+```text
+dependencyBenefit = 4 * connectionCount
+loopMergeBenefit  = 4
+liveTilePenalty   = max(0, liveTileCount - 10)
+vfParameterPenalty= max(0, vfParameterCount - 12)
+
+accept if:
+  dependencyBenefit + loopMergeBenefit
+  - liveTilePenalty - vfParameterPenalty > 0
+```
+
+Version-aware cost should extend this with implementation-specific terms:
+
+```text
+versionLoopBenefit
+  reward compatible loop depths or 1D loop merging
+
+layoutBenefit
+  reward contiguous layouts when a 1D implementation is selected
+
+tailPenalty
+  penalize versions with tail handling if other choices avoid it
+
+postUpdatePenalty
+  penalize post-update versions when they complicate fusion
+
+versionMismatchPenalty
+  penalize groups mixing incompatible loop forms
+```
+
+Example:
+
+```text
+Group A:
+  A:2D, B:2D
+  base cost = 12
+  version cost = 0
+  total = 12
+
+Group B:
+  A:1D, B:1D
+  base cost = 12
+  versionLoopBenefit = 8
+  total = 20
+
+Group C:
+  A:1D, B:2D
+  base cost = 12
+  versionMismatchPenalty = 6
+  total = 6
+```
+
+## Group Selection
+
+For each seed:
+
+```text
+allGroups = enumerateGroupsForSeed(seed)
+best = min/max by cost model objective
+emit best
+mark best node ids assigned
+```
+
+The existing global behavior remains greedy:
+
+```text
+Once a group is selected, its nodes are assigned.
+Later seeds cannot reuse those nodes.
+```
+
+Tie-breaking should be deterministic so tests are stable:
+
+```text
+1. higher total cost
+2. larger member count
+3. earlier first member blockOrder
+4. lower lexicographic member node ids
+5. lower lexicographic version ids
+```
+
+This is not globally optimal across the whole block, but it preserves the
+current planner architecture and keeps the first version-aware implementation
+small.
+
+Diagram:
+
+```text
+Block nodes:
+
+  A -> B -> C -> D
+
+Seed A alternatives:
+  G0 = [A:v0, B:v0]          cost 10
+  G1 = [A:v1, B:v1, C:v1]    cost 18  <-- choose
+
+assigned = {A, B, C}
+
+Seed B:
+  skipped, already assigned
+
+Seed C:
+  skipped, already assigned
+
+Seed D:
+  no size >= 2 group
+```
+
+## Pruning
+
+The exact enumeration can grow quickly:
+
+```text
+number of states roughly grows with:
+  node choices * version choices * append order choices
+```
+
+Start exact first. Add pruning only after correctness is clear.
+
+Safe first pruning:
+
+```text
+For the same member node set:
+  keep only states that are not dominated.
+```
+
+Dominance means:
+
+```text
+State X dominates State Y if:
+  same member node ids
+  X has no worse cost
+  X has equivalent or less restrictive constraints
+  X has at least the same future append capability
+```
+
+If future append capability is hard to prove, do not prune aggressively.
+
+Heuristic later:
+
+```text
+beam size per seed
+maximum group size
+maximum versions per op
+minimum cost threshold
+```
+
+These are useful, but they make the search non-exhaustive.
+
+## Staged Implementation Plan
+
+### Step 1: Shared metadata helper
+
+Create the shared metadata contract:
+
+```text
+include/PTO/Transforms/TemplateAttributes.h
+lib/PTO/Transforms/TemplateAttributes.cpp
+```
+
+Move the candidate struct, attr name, parser, and builder there so both
+`InsertTemplateAttributes.cpp` and `PTOFusionPlan.cpp` consume one schema.
+
+Diagram:
+
+```text
+Before:
+
+  InsertTemplateAttributes.cpp owns CandidateMetadata
+  PTOFusionPlan.cpp owns TileOpImplVersion parser
+
+After:
+
+  TemplateAttributes.h/.cpp owns candidate schema
+       ^                                  ^
+       |                                  |
+  InsertTemplateAttributes.cpp       PTOFusionPlan.cpp
+```
+
+### Step 2: Version-aware group data
+
+Done conceptually:
+
+```text
+PlannedFusionMember = FusionComputeNode* + TileOpImplVersion
+PlannedFusionGroup  = members + PlanningCost
+```
+
+Short-term compatibility:
+
+```text
+Old algorithms still build node-only groups internally.
+Before emitting a PlannedFusionGroup, wrap each node with the first legal
+version or default version.
+```
+
+### Step 3: Read legal versions
+
+Add helpers:
+
+```text
+getDefaultImplVersion()
+getLegalImplVersions(node)
+```
+
+Behavior:
+
+```text
+if candidates attr exists:
+  parse candidates into TileOpImplVersion list
+else:
+  return [default version]
+```
+
+### Step 4: Make existing planner compile with versioned members
+
+Bridge old raw-node paths:
+
+```text
+raw nodes:
+  [A, B, C]
+
+wrapped members:
+  [A:firstOrDefault, B:firstOrDefault, C:firstOrDefault]
+```
+
+Update metadata assignment:
+
+```text
+member.node->op->setAttr(pto.fusion.group_id, ...)
+member.node->op->setAttr(pto.fusion.order, ...)
+```
+
+### Step 5: Add GroupState
+
+Introduce a separate state for enumeration:
+
+```text
+GroupState
+  members
+  nodeIds
+  cost
+  constraints
+```
+
+Keep `PlannedFusionGroup` as the final emitted result.
+
+### Step 6: Add version-aware seed initialization
+
+Current:
+
+```text
+group = [seed]
+```
+
+New:
+
+```text
+frontier = []
+for seedVersion in getLegalImplVersions(seed):
+  frontier.push([seed:seedVersion])
+```
+
+### Step 7: Add version-aware append
+
+Current:
+
+```text
+evaluateAppend(currentGroupNodes, candidate)
+```
+
+New:
+
+```text
+tryAppend(currentState, candidate, candidateVersion)
+```
+
+It should check:
+
+```text
+existing DAG legality
+version compatibility
+updated group footprint
+updated cost
+```
+
+### Step 8: Enumerate all groups for a seed
+
+Add:
+
+```text
+enumerateGroupsForSeed(ctx, costModel, seed, assignedNodes)
+```
+
+Return:
+
+```text
+SmallVector<GroupState>
+```
+
+containing every valid group with size >= 2.
+
+### Step 9: Choose the best group
+
+Add:
+
+```text
+chooseBestGroup(ArrayRef<GroupState>)
+```
+
+Initial tie-breakers:
+
+```text
+1. higher total cost
+2. larger member count
+3. earlier first blockOrder
+4. stable lexicographic version id order
+```
+
+### Step 10: Preserve downstream metadata contract
+
+The downstream passes still consume:
+
+```text
+pto.fusion.group_id
+pto.fusion.order
+```
+
+Version choice needs its own metadata only when a later pass must consume it.
+Potential attr:
+
+```text
+pto.fusion.impl_version = candidate id
+```
+
+Do not add this until a downstream pass needs it.
+
+### Step 11: Tests
+
+Add focused tests:
+
+```text
+1. Missing candidates uses default version and preserves existing grouping.
+2. Multiple candidates produce deterministic selected version.
+3. 1D-compatible chain prefers 1D versions.
+4. Mixed incompatible versions are rejected or penalized.
+5. Non-terminal group can beat a larger terminal group.
+6. Interleaved join still groups connected ops and ignores unrelated ops.
+7. Dynamic-shape and hard-boundary negatives still hold.
+```
+
+## Open Questions
+
+1. Should missing `candidates` mean default version or no fusion?
+2. Which pass consumes the selected version?
+3. Should version id be written as an IR attr immediately?
+4. Is the objective maximum benefit or minimum estimated runtime?
+5. Which version constraints are hard legality and which are soft cost terms?
+6. Is greedy global assignment good enough, or do we eventually need block-level
+   global optimization?
+
+## Summary Diagram
+
+```text
+InsertTemplateAttributes
+        |
+        | attaches candidates attr
+        v
+Tile ops with legal versions
+        |
+        v
+PreFusionAnalysis DFG
+        |
+        v
+FusionPlan
+  for each seed:
+    enumerate versioned group states
+    score every valid state
+    choose best state
+    emit group_id/order
+        |
+        v
+OpScheduling
+        |
+        v
+FusionRegionGen
+        |
+        v
+Lowering / codegen
+```

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -86,6 +86,9 @@ std::unique_ptr<Pass> createPrintPreFusionAnalysisPass();
 std::unique_ptr<Pass> createFusionPlanPass();
 std::unique_ptr<Pass>
 createFusionPlanPass(const FusionPlanOptions &options);
+std::unique_ptr<Pass> createVersionAwareFusionPlanPass();
+std::unique_ptr<Pass>
+createVersionAwareFusionPlanPass(const VersionAwareFusionPlanOptions &options);
 std::unique_ptr<Pass> createOpSchedulingPass();
 std::unique_ptr<Pass> createPTOMarkLastUsePass();
 std::unique_ptr<Pass> createPTOFusionRegionGenPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -284,6 +284,29 @@ def FusionPlan : Pass<"pto-fusion-plan", "func::FuncOp"> {
   ];
 }
 
+def VersionAwareFusionPlan
+    : Pass<"pto-version-aware-fusion-plan", "func::FuncOp"> {
+  let summary = "Build version-aware tile-fusion planning groups from block-local analysis";
+  let description = [{
+    Consumes PreFusionAnalysis results, forms conservative block-local fusion
+    groups for currently supported tile-native compute ops, reads TileOp
+    implementation candidates from the candidates attribute, and annotates
+    accepted group members with:
+      - pto.fusion.group_id
+      - pto.fusion.order
+  }];
+  let constructor = "mlir::pto::createVersionAwareFusionPlanPass()";
+  let dependentDialects = ["mlir::pto::PTODialect"];
+  let options = [
+    Option<"enableShapeInference", "enable-shape-inference",
+           "bool", /*default=*/"false",
+           "Enable shape inference (ShapeConstraintSolver) for tile fusion. "
+           "When disabled (default), fall back to static/direct-bound "
+           "iteration-domain inference.  VersionAwareFusionPlan consumes this "
+           "option for the same iteration-domain inference step as FusionPlan.">
+  ];
+}
+
 def OpScheduling : Pass<"pto-op-scheduling", "func::FuncOp"> {
   let summary = "Compact planned fusion groups into block-local contiguous spans";
   let description = [{

--- a/include/PTO/Transforms/TemplateAttributes.h
+++ b/include/PTO/Transforms/TemplateAttributes.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef MLIR_DIALECT_PTO_TRANSFORMS_TEMPLATEATTRIBUTES_H
+#define MLIR_DIALECT_PTO_TRANSFORMS_TEMPLATEATTRIBUTES_H
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <string>
+
+namespace mlir {
+class MLIRContext;
+
+namespace pto {
+
+inline constexpr llvm::StringLiteral kTemplateCandidatesAttr = "candidates";
+inline constexpr llvm::StringLiteral kTemplateCandidateIdAttr = "id";
+inline constexpr llvm::StringLiteral kTemplateCandidateNameAttr = "name";
+inline constexpr llvm::StringLiteral kTemplateCandidateLoopDepthAttr =
+    "loop_depth";
+inline constexpr llvm::StringLiteral kTemplateCandidatePostUpdateAttr =
+    "postupdate";
+inline constexpr llvm::StringLiteral kTemplateCandidateTailAttr = "tail";
+
+struct TemplateCandidateMetadata {
+  int64_t id = 0;
+  std::string name;
+  int64_t loopDepth = 0;
+  bool isPostUpdate = false;
+  bool hasTail = false;
+};
+
+DictionaryAttr
+buildTemplateCandidateAttr(MLIRContext *context,
+                           const TemplateCandidateMetadata &candidate);
+
+ArrayAttr buildTemplateCandidateArrayAttr(
+    MLIRContext *context, ArrayRef<TemplateCandidateMetadata> candidates);
+
+FailureOr<TemplateCandidateMetadata>
+parseTemplateCandidateAttr(DictionaryAttr attr);
+
+FailureOr<SmallVector<TemplateCandidateMetadata, 4>>
+getTemplateCandidateAttrs(Operation *operation);
+
+} // namespace pto
+} // namespace mlir
+
+#endif // MLIR_DIALECT_PTO_TRANSFORMS_TEMPLATEATTRIBUTES_H

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ add_mlir_dialect_library(PTOTransforms
   PTOViewToMemref.cpp
   PTORematerializeFixpipeVectorQuant.cpp
   PTOValidateIntToPtrUses.cpp
+  TemplateAttributes.cpp
   InsertTemplateAttributes.cpp
   ExpandTileOp.cpp
   FoldTileBufIntrinsics.cpp

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ add_mlir_dialect_library(PTOTransforms
   TileFusion/PTOPreFusionAnalysis.cpp
   TileFusion/PTOPrintPreFusionAnalysis.cpp
   TileFusion/PTOFusionPlan.cpp
+  TileFusion/PTOVersionAwareFusionPlan.cpp
   TileFusion/PTOOpScheduling.cpp
   TileFusion/PTOMarkLastUse.cpp
   TileFusion/PTOFusionRegionGen.cpp

--- a/lib/PTO/Transforms/InsertTemplateAttributes.cpp
+++ b/lib/PTO/Transforms/InsertTemplateAttributes.cpp
@@ -8,6 +8,7 @@
 
 #include "PTO/IR/PTO.h"
 <<<<<<< HEAD
+<<<<<<< HEAD
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -18,12 +19,17 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 =======
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 #include "PTO/Transforms/Passes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+<<<<<<< HEAD
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 #include "mlir/Pass/Pass.h"
 
 #include "llvm/ADT/STLExtras.h"
@@ -71,18 +77,22 @@ struct CandidateMetadata {
 
 static std::string getDtypeString(Type elementType) {
 <<<<<<< HEAD
+<<<<<<< HEAD
   if (elementType.isIndex())
     return "i32";
   if (elementType.isInteger(1))
     return "i1";
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
   if (elementType.isF32())
     return "f32";
   if (elementType.isF16())
     return "f16";
   if (elementType.isBF16())
     return "bf16";
+<<<<<<< HEAD
 <<<<<<< HEAD
   if (isa<Float8E4M3FNType>(elementType))
     return "f8e4m3";
@@ -114,6 +124,8 @@ static std::string getDtypeString(Type elementType) {
     return "i64";
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
   if (elementType.isSignlessInteger(32))
     return "i32";
   if (elementType.isSignlessInteger(16))
@@ -154,6 +166,7 @@ static std::string getMemorySpaceString(pto::TileBufType tileType) {
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 static std::string getMemorySpaceString(MemRefType memrefType) {
   auto memorySpace =
       dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace());
@@ -167,6 +180,8 @@ static std::string getMemorySpaceString(pto::PartitionTensorViewType) {
 
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 static StringRef getBLayoutString(pto::BLayout layout) {
   return layout == pto::BLayout::ColMajor ? "col_major" : "row_major";
 }
@@ -189,6 +204,7 @@ static void appendJsonIntArray(std::string &json, ArrayRef<int64_t> values) {
   json += "]";
 }
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 static void appendJsonDimArray(std::string &json, ArrayRef<int64_t> values) {
   json += "[";
@@ -659,10 +675,13 @@ static void appendScalarOperandSpecJson(std::string &json, Value operand) {
 
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 static std::optional<std::string>
 buildOperandSpecsJson(Operation *operation) {
   std::string json = "[";
   for (auto [index, operand] : llvm::enumerate(operation->getOperands())) {
+<<<<<<< HEAD
 <<<<<<< HEAD
     if (index != 0)
       json += ",";
@@ -718,6 +737,8 @@ buildOperandSpecsJson(Operation *operation) {
         << type;
     return std::nullopt;
 =======
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
     auto tileType = dyn_cast<pto::TileBufType>(operand.getType());
     if (!tileType) {
       operation->emitError(
@@ -765,7 +786,10 @@ buildOperandSpecsJson(Operation *operation) {
     json += ",\"pad_value\":\"0x";
     json += llvm::utohexstr(padValue, /*LowerCase=*/false);
     json += "\"}}";
+<<<<<<< HEAD
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
   }
   json += "]";
   return json;
@@ -780,6 +804,7 @@ getTargetArch(Operation *operation) {
     return std::nullopt;
   }
 <<<<<<< HEAD
+<<<<<<< HEAD
 
   for (ModuleOp current = module; current;
        current = current->getParentOfType<ModuleOp>()) {
@@ -791,6 +816,8 @@ getTargetArch(Operation *operation) {
       "InsertTemplateAttributes requires pto.target_arch");
   return std::nullopt;
 =======
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
   auto target = module->getAttrOfType<StringAttr>("pto.target_arch");
   if (!target) {
     operation->emitError(
@@ -798,7 +825,10 @@ getTargetArch(Operation *operation) {
     return std::nullopt;
   }
   return target.getValue().str();
+<<<<<<< HEAD
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 }
 
 static std::optional<std::string>
@@ -817,9 +847,12 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
   if (!target || !operandSpecs)
     return std::nullopt;
 <<<<<<< HEAD
+<<<<<<< HEAD
   std::string contextAttrs = buildContextAttrsJson(operation);
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 
   llvm::SmallString<128> outputPath;
   int outputFd;
@@ -832,6 +865,7 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
   }
   ::close(outputFd);
 
+<<<<<<< HEAD
 <<<<<<< HEAD
   llvm::SmallString<128> errorPath;
   int errorFd;
@@ -847,6 +881,8 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
 
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
   std::string opName = operation->getName().getStringRef().str();
   SmallVector<StringRef> args = {
       *pythonPath,       "-m",            daemonHelperModule,
@@ -856,21 +892,28 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
       *operandSpecs,
   };
 <<<<<<< HEAD
+<<<<<<< HEAD
   if (contextAttrs != "{}") {
     args.push_back("--context-attrs");
     args.push_back(contextAttrs);
   }
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 
   std::optional<StringRef> redirects[] = {
       std::nullopt,
       StringRef(outputPath),
 <<<<<<< HEAD
+<<<<<<< HEAD
       StringRef(errorPath),
 =======
       std::nullopt,
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+      std::nullopt,
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
   };
 
   SmallVector<StringRef> environment;
@@ -902,6 +945,7 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
       redirects, /*secondsToWait=*/30, /*memoryLimit=*/0, &errorMessage);
   if (result != 0) {
 <<<<<<< HEAD
+<<<<<<< HEAD
     auto errorOutput = llvm::MemoryBuffer::getFile(errorPath);
     llvm::sys::fs::remove(outputPath);
     llvm::sys::fs::remove(errorPath);
@@ -921,15 +965,23 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
     operation->emitError("InsertTemplateAttributes metadata RPC failed: ")
         << errorMessage;
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+    llvm::sys::fs::remove(outputPath);
+    operation->emitError("InsertTemplateAttributes metadata RPC failed: ")
+        << errorMessage;
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
     return std::nullopt;
   }
 
   auto output = llvm::MemoryBuffer::getFile(outputPath);
   llvm::sys::fs::remove(outputPath);
 <<<<<<< HEAD
+<<<<<<< HEAD
   llvm::sys::fs::remove(errorPath);
 =======
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
   if (!output) {
     operation->emitError(
         "InsertTemplateAttributes cannot read metadata output");
@@ -952,6 +1004,7 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
   auto *candidates = root ? root->getObject("candidates") : nullptr;
   if (!candidates || candidates->empty()) {
 <<<<<<< HEAD
+<<<<<<< HEAD
     operation->emitError("InsertTemplateAttributes found no legal template "
                          "candidates for ")
         << operation->getName();
@@ -959,6 +1012,10 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
     operation->emitError(
         "InsertTemplateAttributes found no legal template candidates");
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+    operation->emitError(
+        "InsertTemplateAttributes found no legal template candidates");
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
     return failure();
   }
 

--- a/lib/PTO/Transforms/InsertTemplateAttributes.cpp
+++ b/lib/PTO/Transforms/InsertTemplateAttributes.cpp
@@ -11,6 +11,7 @@
 <<<<<<< HEAD
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
+#include "PTO/Transforms/TemplateAttributes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -64,16 +65,6 @@ namespace pto {
 } // namespace mlir
 
 namespace {
-
-constexpr llvm::StringLiteral kCandidatesAttr = "candidates";
-
-struct CandidateMetadata {
-  int64_t id;
-  std::string name;
-  int64_t loopDepth;
-  bool postUpdate;
-  bool tail;
-};
 
 static std::string getDtypeString(Type elementType) {
 <<<<<<< HEAD
@@ -1019,7 +1010,7 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
     return failure();
   }
 
-  SmallVector<CandidateMetadata> parsedCandidates;
+  SmallVector<pto::TemplateCandidateMetadata> parsedCandidates;
   parsedCandidates.reserve(candidates->size());
   for (const auto &entry : *candidates) {
     auto *metadata = entry.second.getAsObject();
@@ -1047,7 +1038,7 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
       return failure();
     }
 
-    parsedCandidates.push_back(CandidateMetadata{
+    parsedCandidates.push_back(pto::TemplateCandidateMetadata{
         id.value_or(0),
         name->str(),
         *loopDepth,
@@ -1057,8 +1048,8 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
   }
 
   llvm::sort(parsedCandidates,
-             [](const CandidateMetadata &left,
-                const CandidateMetadata &right) {
+             [](const pto::TemplateCandidateMetadata &left,
+                const pto::TemplateCandidateMetadata &right) {
                if (left.id != right.id)
                  return left.id < right.id;
                return left.name < right.name;
@@ -1071,27 +1062,8 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
     }
   }
 
-  Builder builder(operation->getContext());
-  SmallVector<Attribute> attributes;
-  attributes.reserve(parsedCandidates.size());
-  for (const CandidateMetadata &candidate : parsedCandidates) {
-    attributes.push_back(DictionaryAttr::get(
-        operation->getContext(),
-        {
-            builder.getNamedAttr("id", builder.getI64IntegerAttr(candidate.id)),
-            builder.getNamedAttr("name",
-                                 builder.getStringAttr(candidate.name)),
-            builder.getNamedAttr(
-                "loop_depth",
-                builder.getI64IntegerAttr(candidate.loopDepth)),
-            builder.getNamedAttr(
-                "postupdate",
-                builder.getI64IntegerAttr(candidate.postUpdate ? 1 : 0)),
-            builder.getNamedAttr(
-                "tail", builder.getI64IntegerAttr(candidate.tail ? 1 : 0)),
-        }));
-  }
-  return builder.getArrayAttr(attributes);
+  return pto::buildTemplateCandidateArrayAttr(operation->getContext(),
+                                              parsedCandidates);
 }
 
 struct InsertTemplateAttributesPass
@@ -1125,7 +1097,7 @@ struct InsertTemplateAttributesPass
       auto candidates = parseCandidateAttributes(operation, *metadata);
       if (failed(candidates))
         return signalPassFailure();
-      operation->setAttr(kCandidatesAttr, *candidates);
+      operation->setAttr(pto::kTemplateCandidatesAttr, *candidates);
     }
   }
 };

--- a/lib/PTO/Transforms/InsertTemplateAttributes.cpp
+++ b/lib/PTO/Transforms/InsertTemplateAttributes.cpp
@@ -7,6 +7,7 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 #include "PTO/IR/PTO.h"
+<<<<<<< HEAD
 #include "PTO/IR/PTOTypeUtils.h"
 #include "PTO/Transforms/Passes.h"
 
@@ -16,6 +17,13 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+=======
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
 #include "mlir/Pass/Pass.h"
 
 #include "llvm/ADT/STLExtras.h"
@@ -62,16 +70,20 @@ struct CandidateMetadata {
 };
 
 static std::string getDtypeString(Type elementType) {
+<<<<<<< HEAD
   if (elementType.isIndex())
     return "i32";
   if (elementType.isInteger(1))
     return "i1";
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
   if (elementType.isF32())
     return "f32";
   if (elementType.isF16())
     return "f16";
   if (elementType.isBF16())
     return "bf16";
+<<<<<<< HEAD
   if (isa<Float8E4M3FNType>(elementType))
     return "f8e4m3";
   if (isa<Float8E5M2Type>(elementType))
@@ -100,6 +112,8 @@ static std::string getDtypeString(Type elementType) {
     return "si8";
   if (elementType.isSignlessInteger(64))
     return "i64";
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
   if (elementType.isSignlessInteger(32))
     return "i32";
   if (elementType.isSignlessInteger(16))
@@ -139,6 +153,7 @@ static std::string getMemorySpaceString(pto::TileBufType tileType) {
                      : "ub";
 }
 
+<<<<<<< HEAD
 static std::string getMemorySpaceString(MemRefType memrefType) {
   auto memorySpace =
       dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace());
@@ -150,6 +165,8 @@ static std::string getMemorySpaceString(pto::PartitionTensorViewType) {
   return "gm";
 }
 
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
 static StringRef getBLayoutString(pto::BLayout layout) {
   return layout == pto::BLayout::ColMajor ? "col_major" : "row_major";
 }
@@ -172,6 +189,7 @@ static void appendJsonIntArray(std::string &json, ArrayRef<int64_t> values) {
   json += "]";
 }
 
+<<<<<<< HEAD
 static void appendJsonDimArray(std::string &json, ArrayRef<int64_t> values) {
   json += "[";
   for (auto [index, value] : llvm::enumerate(values)) {
@@ -639,10 +657,13 @@ static void appendScalarOperandSpecJson(std::string &json, Value operand) {
   json += "}";
 }
 
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
 static std::optional<std::string>
 buildOperandSpecsJson(Operation *operation) {
   std::string json = "[";
   for (auto [index, operand] : llvm::enumerate(operation->getOperands())) {
+<<<<<<< HEAD
     if (index != 0)
       json += ",";
 
@@ -696,6 +717,55 @@ buildOperandSpecsJson(Operation *operation) {
         "InsertTemplateAttributes encountered an unsupported operand type ")
         << type;
     return std::nullopt;
+=======
+    auto tileType = dyn_cast<pto::TileBufType>(operand.getType());
+    if (!tileType) {
+      operation->emitError(
+          "InsertTemplateAttributes currently supports only tile operands");
+      return std::nullopt;
+    }
+
+    std::string dtype = getDtypeString(tileType.getElementType());
+    if (dtype.empty()) {
+      operation->emitError(
+          "InsertTemplateAttributes encountered an unsupported tile dtype");
+      return std::nullopt;
+    }
+
+    if (index != 0)
+      json += ",";
+    json += "{\"kind\":\"tile\",\"dtype\":\"" + dtype + "\",\"shape\":";
+    appendJsonIntArray(json, tileType.getShape());
+    json += ",\"valid_shape\":";
+    auto validShape = tileType.getValidShape();
+    appendJsonIntArray(json,
+                       validShape.empty() ? tileType.getShape() : validShape);
+    json += ",\"memory_space\":\"";
+    json += getMemorySpaceString(tileType);
+    json += "\",\"config\":{";
+
+    pto::BLayout bLayout = pto::BLayout::RowMajor;
+    pto::SLayout sLayout = pto::SLayout::NoneBox;
+    int64_t fractalSize = 0;
+    uint64_t padValue = 0;
+    if (auto config = tileType.getConfigAttr()) {
+      bLayout = config.getBLayout().getValue();
+      sLayout = config.getSLayout().getValue();
+      if (config.getSFractalSize())
+        fractalSize = config.getSFractalSize().getInt();
+      padValue = static_cast<uint64_t>(config.getPad().getValue());
+    }
+
+    json += "\"b_layout\":\"";
+    json += getBLayoutString(bLayout);
+    json += "\",\"s_layout\":\"";
+    json += getSLayoutString(sLayout);
+    json += "\",\"s_fractal_size\":";
+    json += std::to_string(fractalSize);
+    json += ",\"pad_value\":\"0x";
+    json += llvm::utohexstr(padValue, /*LowerCase=*/false);
+    json += "\"}}";
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
   }
   json += "]";
   return json;
@@ -709,6 +779,7 @@ getTargetArch(Operation *operation) {
         "InsertTemplateAttributes requires a parent module");
     return std::nullopt;
   }
+<<<<<<< HEAD
 
   for (ModuleOp current = module; current;
        current = current->getParentOfType<ModuleOp>()) {
@@ -719,6 +790,15 @@ getTargetArch(Operation *operation) {
   operation->emitError(
       "InsertTemplateAttributes requires pto.target_arch");
   return std::nullopt;
+=======
+  auto target = module->getAttrOfType<StringAttr>("pto.target_arch");
+  if (!target) {
+    operation->emitError(
+        "InsertTemplateAttributes requires pto.target_arch");
+    return std::nullopt;
+  }
+  return target.getValue().str();
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
 }
 
 static std::optional<std::string>
@@ -736,7 +816,10 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
   auto operandSpecs = buildOperandSpecsJson(operation);
   if (!target || !operandSpecs)
     return std::nullopt;
+<<<<<<< HEAD
   std::string contextAttrs = buildContextAttrsJson(operation);
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
 
   llvm::SmallString<128> outputPath;
   int outputFd;
@@ -749,6 +832,7 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
   }
   ::close(outputFd);
 
+<<<<<<< HEAD
   llvm::SmallString<128> errorPath;
   int errorFd;
   if (auto error = llvm::sys::fs::createTemporaryFile(
@@ -761,6 +845,8 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
   }
   ::close(errorFd);
 
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
   std::string opName = operation->getName().getStringRef().str();
   SmallVector<StringRef> args = {
       *pythonPath,       "-m",            daemonHelperModule,
@@ -769,15 +855,22 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
       "--op",            opName,          "--operand-specs",
       *operandSpecs,
   };
+<<<<<<< HEAD
   if (contextAttrs != "{}") {
     args.push_back("--context-attrs");
     args.push_back(contextAttrs);
   }
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
 
   std::optional<StringRef> redirects[] = {
       std::nullopt,
       StringRef(outputPath),
+<<<<<<< HEAD
       StringRef(errorPath),
+=======
+      std::nullopt,
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
   };
 
   SmallVector<StringRef> environment;
@@ -808,6 +901,7 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
           : std::nullopt,
       redirects, /*secondsToWait=*/30, /*memoryLimit=*/0, &errorMessage);
   if (result != 0) {
+<<<<<<< HEAD
     auto errorOutput = llvm::MemoryBuffer::getFile(errorPath);
     llvm::sys::fs::remove(outputPath);
     llvm::sys::fs::remove(errorPath);
@@ -822,12 +916,20 @@ invokeMetadataHelper(Operation *operation, StringRef pythonExe,
 
     operation->emitError("InsertTemplateAttributes metadata RPC failed: ")
         << detail;
+=======
+    llvm::sys::fs::remove(outputPath);
+    operation->emitError("InsertTemplateAttributes metadata RPC failed: ")
+        << errorMessage;
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
     return std::nullopt;
   }
 
   auto output = llvm::MemoryBuffer::getFile(outputPath);
   llvm::sys::fs::remove(outputPath);
+<<<<<<< HEAD
   llvm::sys::fs::remove(errorPath);
+=======
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
   if (!output) {
     operation->emitError(
         "InsertTemplateAttributes cannot read metadata output");
@@ -849,9 +951,14 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
   auto *root = parsed->getAsObject();
   auto *candidates = root ? root->getObject("candidates") : nullptr;
   if (!candidates || candidates->empty()) {
+<<<<<<< HEAD
     operation->emitError("InsertTemplateAttributes found no legal template "
                          "candidates for ")
         << operation->getName();
+=======
+    operation->emitError(
+        "InsertTemplateAttributes found no legal template candidates");
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
     return failure();
   }
 

--- a/lib/PTO/Transforms/TemplateAttributes.cpp
+++ b/lib/PTO/Transforms/TemplateAttributes.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/TemplateAttributes.h"
+
+#include "mlir/IR/Builders.h"
+
+using namespace mlir;
+
+namespace mlir {
+namespace pto {
+
+DictionaryAttr
+buildTemplateCandidateAttr(MLIRContext *context,
+                           const TemplateCandidateMetadata &candidate) {
+  Builder builder(context);
+  return DictionaryAttr::get(
+      context,
+      {
+          builder.getNamedAttr(kTemplateCandidateIdAttr,
+                               builder.getI64IntegerAttr(candidate.id)),
+          builder.getNamedAttr(kTemplateCandidateNameAttr,
+                               builder.getStringAttr(candidate.name)),
+          builder.getNamedAttr(kTemplateCandidateLoopDepthAttr,
+                               builder.getI64IntegerAttr(candidate.loopDepth)),
+          builder.getNamedAttr(
+              kTemplateCandidatePostUpdateAttr,
+              builder.getI64IntegerAttr(candidate.isPostUpdate ? 1 : 0)),
+          builder.getNamedAttr(kTemplateCandidateTailAttr,
+                               builder.getI64IntegerAttr(candidate.hasTail ? 1
+                                                                           : 0)),
+      });
+}
+
+ArrayAttr buildTemplateCandidateArrayAttr(
+    MLIRContext *context, ArrayRef<TemplateCandidateMetadata> candidates) {
+  Builder builder(context);
+  SmallVector<Attribute> attributes;
+  attributes.reserve(candidates.size());
+  for (const TemplateCandidateMetadata &candidate : candidates)
+    attributes.push_back(buildTemplateCandidateAttr(context, candidate));
+  return builder.getArrayAttr(attributes);
+}
+
+FailureOr<TemplateCandidateMetadata>
+parseTemplateCandidateAttr(DictionaryAttr attr) {
+  auto id =
+      dyn_cast_or_null<IntegerAttr>(attr.get(kTemplateCandidateIdAttr));
+  auto name =
+      dyn_cast_or_null<StringAttr>(attr.get(kTemplateCandidateNameAttr));
+  auto loopDepth = dyn_cast_or_null<IntegerAttr>(
+      attr.get(kTemplateCandidateLoopDepthAttr));
+  auto postUpdate = dyn_cast_or_null<IntegerAttr>(
+      attr.get(kTemplateCandidatePostUpdateAttr));
+  auto tail =
+      dyn_cast_or_null<IntegerAttr>(attr.get(kTemplateCandidateTailAttr));
+
+  if (!id || !name || !loopDepth || !postUpdate || !tail)
+    return failure();
+
+  return TemplateCandidateMetadata{
+      id.getInt(),
+      name.getValue().str(),
+      loopDepth.getInt(),
+      postUpdate.getInt() != 0,
+      tail.getInt() != 0,
+  };
+}
+
+FailureOr<SmallVector<TemplateCandidateMetadata, 4>>
+getTemplateCandidateAttrs(Operation *operation) {
+  auto candidates = operation->getAttrOfType<ArrayAttr>(kTemplateCandidatesAttr);
+  if (!candidates)
+    return SmallVector<TemplateCandidateMetadata, 4>{};
+
+  SmallVector<TemplateCandidateMetadata, 4> parsedCandidates;
+  parsedCandidates.reserve(candidates.size());
+  for (Attribute attr : candidates) {
+    auto dict = dyn_cast<DictionaryAttr>(attr);
+    if (!dict)
+      return failure();
+
+    FailureOr<TemplateCandidateMetadata> candidate =
+        parseTemplateCandidateAttr(dict);
+    if (failed(candidate))
+      return failure();
+
+    parsedCandidates.push_back(std::move(*candidate));
+  }
+  return parsedCandidates;
+}
+
+} // namespace pto
+} // namespace mlir

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -199,6 +199,41 @@ static bool isSupportedPlanningNode(const pto::FusionComputeNode &node) {
          isCurrentlyPlannableOp(node.semantics.opName);
 }
 
+static TileOpImplVersion getDefaultImplVersion() {
+  return TileOpImplVersion{/*id=*/0, /*name=*/"default", /*loopDepth=*/2,
+                           /*isPostUpdate=*/false, /*hasTail=*/false};
+}
+
+static FailureOr<SmallVector<TileOpImplVersion, 4>>
+getLegalImplVersions(const pto::FusionComputeNode &node) {
+  auto candidates = node.op->getAttrOfType<ArrayAttr>(kTemplateCandidatesAttr);
+  if (!candidates || candidates.empty())
+    return SmallVector<TileOpImplVersion, 4>{getDefaultImplVersion()};
+
+  SmallVector<TileOpImplVersion, 4> versions;
+  versions.reserve(candidates.size());
+
+  for (Attribute attr : candidates) {
+    auto dict = dyn_cast<DictionaryAttr>(attr);
+    if (!dict)
+      return failure();
+
+    auto id = dyn_cast_or_null<IntegerAttr>(dict.get("id"));
+    auto name = dyn_cast_or_null<StringAttr>(dict.get("name"));
+    auto loopDepth = dyn_cast_or_null<IntegerAttr>(dict.get("loop_depth"));
+    auto postUpdate = dyn_cast_or_null<IntegerAttr>(dict.get("postupdate"));
+    auto tail = dyn_cast_or_null<IntegerAttr>(dict.get("tail"));
+    if (!id || !name || !loopDepth || !postUpdate || !tail)
+      return failure();
+
+    versions.push_back(TileOpImplVersion{
+        id.getInt(), name.getValue().str(), loopDepth.getInt(),
+        postUpdate.getInt() != 0, tail.getInt() != 0});
+  }
+
+  return versions;
+}
+
 static unsigned
 countEdgesFromGroup(const pto::FusionBlockAnalysis &blockAnalysis,
                     ArrayRef<const pto::FusionComputeNode *> group,

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -42,8 +42,22 @@ static constexpr llvm::StringLiteral kFusionGroupIdAttr =
     "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
 
+struct TileOpImplVersion {
+  int64_t id;
+  string name;
+  int64_t loopDepth;
+  bool isPostUpdate;
+  bool hasTail; 
+}
+
+struct PlannedFusionMember {
+  const pto::FusionComputeNode *node = nullptr;
+  TileOpImplVersion version;
+}
+
 struct PlannedFusionGroup {
-  SmallVector<const pto::FusionComputeNode *, 8> members;
+  SmallVector<PlannedFusionMember, 8> members;
+  PlanningCost cost;
 };
 
 struct PlanningContext {

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -44,21 +44,12 @@ static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
 
 struct TileOpImplVersion {
   int64_t id;
-  string name;
+  std::string name;
   int64_t loopDepth;
   bool isPostUpdate;
   bool hasTail; 
-}
-
-struct PlannedFusionMember {
-  const pto::FusionComputeNode *node = nullptr;
-  TileOpImplVersion version;
-}
-
-struct PlannedFusionGroup {
-  SmallVector<PlannedFusionMember, 8> members;
-  PlanningCost cost;
 };
+
 
 struct PlanningContext {
   const pto::FusionBlockAnalysis &blockAnalysis;
@@ -75,6 +66,16 @@ struct PlanningCost {
     return dependencyBenefit + loopMergeBenefit - liveTilePenalty -
            vfParameterPenalty;
   }
+};
+
+struct PlannedFusionMember {
+  const pto::FusionComputeNode *node = nullptr;
+  TileOpImplVersion version;
+};
+
+struct PlannedFusionGroup {
+  SmallVector<PlannedFusionMember, 8> members;
+  PlanningCost cost;
 };
 
 struct PlanningDecision {

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -41,13 +41,14 @@ namespace {
 static constexpr llvm::StringLiteral kFusionGroupIdAttr =
     "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+static constexpr llvm::StringLiteral kTemplateCandidatesAttr = "versions";
 
 struct TileOpImplVersion {
-  int64_t id;
+  int64_t id = 0;
   std::string name;
-  int64_t loopDepth;
-  bool isPostUpdate;
-  bool hasTail; 
+  int64_t loopDepth = 0;
+  bool isPostUpdate = false;
+  bool hasTail = false;
 };
 
 

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -53,13 +53,16 @@ struct PlanningContext {
 struct PlanningCost {
   int64_t dependencyBenefit = 0;
   int64_t loopMergeBenefit = 0;
+  int64_t versionCompatibilityBenefit = 0;
   int64_t liveTilePenalty = 0;
   int64_t vfParameterPenalty = 0;
+  int64_t versionPenalty = 0;
   bool rejectedForDynamicShape = false;
 
   int64_t total() const {
-    return dependencyBenefit + loopMergeBenefit - liveTilePenalty -
-           vfParameterPenalty;
+    return dependencyBenefit + loopMergeBenefit +
+           versionCompatibilityBenefit - liveTilePenalty -
+           vfParameterPenalty - versionPenalty;
   }
 };
 
@@ -99,12 +102,45 @@ struct GroupState {
     nodeIds.insert(member.node->id);
     cost.dependencyBenefit += appendCost.dependencyBenefit;
     cost.loopMergeBenefit += appendCost.loopMergeBenefit;
+    cost.versionCompatibilityBenefit +=
+        appendCost.versionCompatibilityBenefit;
     cost.liveTilePenalty += appendCost.liveTilePenalty;
     cost.vfParameterPenalty += appendCost.vfParameterPenalty;
+    cost.versionPenalty += appendCost.versionPenalty;
     cost.rejectedForDynamicShape |= appendCost.rejectedForDynamicShape;
     members.push_back(std::move(member));
   }
 };
+
+[[maybe_unused]] static PlanningCost
+computeVersionTraitCost(ArrayRef<PlannedFusionMember> members) {
+  static constexpr int64_t kAllOneDimensionalBenefit = 3;
+  static constexpr int64_t kMixedLoopDepthPenalty = 2;
+  static constexpr int64_t kTailPenalty = 1;
+  static constexpr int64_t kPostUpdatePenalty = 2;
+
+  PlanningCost cost;
+  if (members.empty())
+    return cost;
+
+  bool allOneDimensional = true;
+  DenseSet<int64_t> loopDepths;
+  for (const PlannedFusionMember &member : members) {
+    loopDepths.insert(member.version.loopDepth);
+    allOneDimensional &= member.version.loopDepth == 1;
+    if (member.version.hasTail)
+      cost.versionPenalty += kTailPenalty;
+    if (member.version.isPostUpdate)
+      cost.versionPenalty += kPostUpdatePenalty;
+  }
+
+  if (members.size() > 1 && allOneDimensional)
+    cost.versionCompatibilityBenefit += kAllOneDimensionalBenefit;
+  if (loopDepths.size() > 1)
+    cost.versionPenalty +=
+        kMixedLoopDepthPenalty * static_cast<int64_t>(loopDepths.size() - 1);
+  return cost;
+}
 
 static bool isCurrentlyPlannableOp(StringRef opName) {
   return llvm::StringSwitch<bool>(opName)

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/StringSwitch.h"
 
 #include <algorithm>
+#include <optional>
 #include <string>
 
 namespace mlir {
@@ -140,6 +141,26 @@ computeVersionTraitCost(ArrayRef<PlannedFusionMember> members) {
     cost.versionPenalty +=
         kMixedLoopDepthPenalty * static_cast<int64_t>(loopDepths.size() - 1);
   return cost;
+}
+
+[[maybe_unused]] static PlanningCost combineCosts(const PlanningCost &lhs,
+                                                  const PlanningCost &rhs) {
+  PlanningCost cost;
+  cost.dependencyBenefit = lhs.dependencyBenefit + rhs.dependencyBenefit;
+  cost.loopMergeBenefit = lhs.loopMergeBenefit + rhs.loopMergeBenefit;
+  cost.versionCompatibilityBenefit =
+      lhs.versionCompatibilityBenefit + rhs.versionCompatibilityBenefit;
+  cost.liveTilePenalty = lhs.liveTilePenalty + rhs.liveTilePenalty;
+  cost.vfParameterPenalty = lhs.vfParameterPenalty + rhs.vfParameterPenalty;
+  cost.versionPenalty = lhs.versionPenalty + rhs.versionPenalty;
+  cost.rejectedForDynamicShape =
+      lhs.rejectedForDynamicShape || rhs.rejectedForDynamicShape;
+  return cost;
+}
+
+[[maybe_unused]] static PlanningCost
+computeFinalGroupCost(const GroupState &state) {
+  return combineCosts(state.cost, computeVersionTraitCost(state.members));
 }
 
 static bool isCurrentlyPlannableOp(StringRef opName) {
@@ -471,6 +492,28 @@ public:
                  ArrayRef<const pto::FusionComputeNode *> currentGroup,
                  const pto::FusionComputeNode &candidate) const = 0;
 };
+
+[[maybe_unused]] static FailureOr<std::optional<GroupState>>
+tryAppendVersionedCandidate(const PlanningContext &ctx,
+                            const CostModel &costModel,
+                            const GroupState &state,
+                            const pto::FusionComputeNode &candidate,
+                            const TileOpImplVersion &version) {
+  if (state.contains(candidate))
+    return std::optional<GroupState>{};
+
+  SmallVector<const pto::FusionComputeNode *, 8> currentNodes =
+      state.getNodes();
+  PlanningDecision appendDecision =
+      costModel.evaluateAppend(ctx, currentNodes, candidate);
+  if (!appendDecision.accept)
+    return std::optional<GroupState>{};
+
+  GroupState nextState = state;
+  nextState.append(PlannedFusionMember{&candidate, version},
+                   appendDecision.cost);
+  return std::optional<GroupState>{std::move(nextState)};
+}
 
 class ConservativeGreedyCostModel final : public CostModel {
 public:

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -743,6 +743,40 @@ public:
   }
 };
 
+[[maybe_unused]] static FailureOr<SmallVector<PlannedFusionGroup, 8>>
+planBlockExactVersionAware(const PlanningContext &ctx,
+                           const CostModel &costModel) {
+  SmallVector<PlannedFusionGroup, 8> groups;
+  DenseSet<unsigned> assignedNodes;
+
+  for (const pto::FusionComputeNode &seed : ctx.blockAnalysis.computeNodes) {
+    if (assignedNodes.contains(seed.id))
+      continue;
+
+    PlanningDecision seedDecision = costModel.evaluateSeed(ctx, seed);
+    if (!seedDecision.accept)
+      continue;
+
+    FailureOr<std::optional<GroupState>> maybeBestState =
+        findBestVersionedGroupForSeed(ctx, costModel, seed, assignedNodes);
+    if (failed(maybeBestState))
+      return failure();
+    if (!*maybeBestState)
+      continue;
+
+    GroupState bestState = std::move(**maybeBestState);
+    PlannedFusionGroup group;
+    group.members = buildStableInGroupMemberOrder(bestState.members);
+    group.cost = bestState.cost;
+    groups.push_back(std::move(group));
+
+    for (const PlannedFusionMember &member : groups.back().members)
+      assignedNodes.insert(member.node->id);
+  }
+
+  return groups;
+}
+
 static void clearPlanningAttrs(func::FuncOp func) {
   func.walk([](Operation *op) {
     op->removeAttr(kFusionGroupIdAttr);

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -20,9 +20,11 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
 #include <optional>
+#include <set>
 #include <string>
 
 namespace mlir {
@@ -210,24 +212,6 @@ static bool hasHardBoundaryToGroup(
   return false;
 }
 
-static bool dependsOnPreviousNode(
-    const pto::FusionBlockAnalysis &blockAnalysis,
-    const pto::FusionComputeNode &previous,
-    const pto::FusionComputeNode &current) {
-  for (unsigned edgeId : current.incomingEdges) {
-    if (edgeId >= blockAnalysis.edges.size())
-      continue;
-    if (blockAnalysis.edges[edgeId].producerNode == previous.id)
-      return true;
-  }
-
-  for (Value output : previous.semantics.tileOutputs)
-    if (llvm::is_contained(current.semantics.tileInputs, output))
-      return true;
-
-  return false;
-}
-
 static SmallVector<const pto::FusionComputeNode *, 8>
 buildStableInGroupOrder(ArrayRef<const pto::FusionComputeNode *> members) {
   SmallVector<const pto::FusionComputeNode *, 8> ordered(members.begin(),
@@ -390,24 +374,6 @@ makePlannedFusionMembersWithDefaultVersions(
   return members;
 }
 
-static unsigned
-countEdgesFromGroup(const pto::FusionBlockAnalysis &blockAnalysis,
-                    ArrayRef<const pto::FusionComputeNode *> group,
-                    const pto::FusionComputeNode &candidate) {
-  DenseSet<unsigned> producerIds;
-  for (const pto::FusionComputeNode *member : group)
-    producerIds.insert(member->id);
-
-  unsigned count = 0;
-  for (unsigned edgeId : candidate.incomingEdges) {
-    if (edgeId >= blockAnalysis.edges.size())
-      continue;
-    if (producerIds.contains(blockAnalysis.edges[edgeId].producerNode))
-      ++count;
-  }
-  return count;
-}
-
 struct GroupFootprint {
   unsigned liveTileCount = 0;
   unsigned vfParameterCount = 0;
@@ -515,65 +481,67 @@ tryAppendVersionedCandidate(const PlanningContext &ctx,
   return std::optional<GroupState>{std::move(nextState)};
 }
 
-class ConservativeGreedyCostModel final : public CostModel {
-public:
-  PlanningDecision
-  evaluateSeed(const PlanningContext &ctx,
-               const pto::FusionComputeNode &candidate) const override {
-    PlanningDecision decision;
-    if (!isSupportedPlanningNode(candidate))
-      return decision;
+[[maybe_unused]] static std::string getStateSignature(const GroupState &state) {
+  SmallVector<PlannedFusionMember, 8> orderedMembers =
+      buildStableInGroupMemberOrder(state.members);
 
-    if (!isProvenIterationDomain(ctx.blockAnalysis, candidate)) {
-      decision.cost.rejectedForDynamicShape = true;
-      return decision;
+  std::string signature;
+  llvm::raw_string_ostream os(signature);
+  for (const PlannedFusionMember &member : orderedMembers)
+    os << member.node->id << ':' << member.version.id << ';';
+  return os.str();
+}
+
+[[maybe_unused]] static FailureOr<SmallVector<GroupState, 16>>
+enumerateVersionedStatesFromSeed(const PlanningContext &ctx,
+                                 const CostModel &costModel,
+                                 const pto::FusionComputeNode &seed,
+                                 const DenseSet<unsigned> &assignedNodes) {
+  FailureOr<SmallVector<GroupState, 4>> seedStates = createSeedStates(seed);
+  if (failed(seedStates))
+    return failure();
+
+  SmallVector<GroupState, 16> validStates;
+  SmallVector<GroupState, 16> frontier(seedStates->begin(), seedStates->end());
+  std::set<std::string> seenStates;
+  for (const GroupState &state : frontier)
+    seenStates.insert(getStateSignature(state));
+
+  while (!frontier.empty()) {
+    GroupState state = std::move(frontier.pop_back_val());
+    for (const pto::FusionComputeNode &candidate :
+         ctx.blockAnalysis.computeNodes) {
+      if (assignedNodes.contains(candidate.id) || state.contains(candidate))
+        continue;
+
+      FailureOr<SmallVector<TileOpImplVersion, 4>> versions =
+          getLegalImplVersions(candidate);
+      if (failed(versions))
+        return failure();
+
+      for (const TileOpImplVersion &version : *versions) {
+        FailureOr<std::optional<GroupState>> maybeNextState =
+            tryAppendVersionedCandidate(ctx, costModel, state, candidate,
+                                        version);
+        if (failed(maybeNextState))
+          return failure();
+        if (!*maybeNextState)
+          continue;
+
+        GroupState nextState = std::move(**maybeNextState);
+        std::string signature = getStateSignature(nextState);
+        if (!seenStates.insert(signature).second)
+          continue;
+
+        if (nextState.members.size() >= 2)
+          validStates.push_back(nextState);
+        frontier.push_back(std::move(nextState));
+      }
     }
-
-    decision.accept = true;
-    return decision;
   }
 
-  PlanningDecision
-  evaluateAppend(const PlanningContext &ctx,
-                 ArrayRef<const pto::FusionComputeNode *> currentGroup,
-                 const pto::FusionComputeNode &candidate) const override {
-    PlanningDecision seedDecision = evaluateSeed(ctx, candidate);
-    if (!seedDecision.accept)
-      return seedDecision;
-
-    PlanningDecision decision;
-    if (currentGroup.empty()) {
-      decision.accept = true;
-      return decision;
-    }
-
-    const pto::FusionComputeNode &previous = *currentGroup.back();
-    const bool sameDomainClass =
-        previous.iterationDomainClass == candidate.iterationDomainClass;
-    const bool contiguousInBlock =
-        candidate.blockOrder == previous.blockOrder + 1;
-    const bool directlyDependent =
-        dependsOnPreviousNode(ctx.blockAnalysis, previous, candidate);
-    if (!sameDomainClass || !contiguousInBlock || !directlyDependent)
-      return decision;
-
-    SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
-        currentGroup.begin(), currentGroup.end());
-    proposedGroup.push_back(&candidate);
-    GroupFootprint footprint = computeGroupFootprint(proposedGroup);
-
-    decision.cost.dependencyBenefit =
-        4 * static_cast<int64_t>(
-                countEdgesFromGroup(ctx.blockAnalysis, currentGroup, candidate));
-    decision.cost.loopMergeBenefit = 2;
-    decision.cost.liveTilePenalty =
-        std::max<int64_t>(0, static_cast<int64_t>(footprint.liveTileCount) - 4);
-    decision.cost.vfParameterPenalty = std::max<int64_t>(
-        0, static_cast<int64_t>(footprint.vfParameterCount) - 6);
-    decision.accept = decision.cost.total() > 0;
-    return decision;
-  }
-};
+  return validStates;
+}
 
 class ConservativeDAGGreedyCostModel final : public CostModel {
 public:

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -332,6 +332,23 @@ getLegalImplVersions(const pto::FusionComputeNode &node) {
   return versions;
 }
 
+[[maybe_unused]] static FailureOr<SmallVector<GroupState, 4>>
+createSeedStates(const pto::FusionComputeNode &seed) {
+  FailureOr<SmallVector<TileOpImplVersion, 4>> versions =
+      getLegalImplVersions(seed);
+  if (failed(versions))
+    return failure();
+
+  SmallVector<GroupState, 4> states;
+  states.reserve(versions->size());
+  for (const TileOpImplVersion &version : *versions) {
+    GroupState state;
+    state.append(PlannedFusionMember{&seed, version});
+    states.push_back(std::move(state));
+  }
+  return states;
+}
+
 static PlannedFusionMember
 makePlannedFusionMemberWithDefaultVersion(const pto::FusionComputeNode &node) {
   TileOpImplVersion version = getDefaultImplVersion();

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -21,15 +21,16 @@
 #include "llvm/ADT/StringSwitch.h"
 
 #include <algorithm>
+#include <string>
 
 namespace mlir {
 namespace pto {
 // Passes.h (included above) pulls in the global GEN_PASS_DECL block, which
-// defines GEN_PASS_DECL_FUSIONPLAN and leaves it set.  Undef it before
+// defines GEN_PASS_DECL_VERSIONAWAREFUSIONPLAN and leaves it set.  Undef it before
 // re-including the .inc for GEN_PASS_DEF so the options struct is not defined
 // twice.
-#undef GEN_PASS_DECL_FUSIONPLAN
-#define GEN_PASS_DEF_FUSIONPLAN
+#undef GEN_PASS_DECL_VERSIONAWAREFUSIONPLAN
+#define GEN_PASS_DEF_VERSIONAWAREFUSIONPLAN
 #include "PTO/Transforms/Passes.h.inc"
 } // namespace pto
 } // namespace mlir
@@ -41,9 +42,14 @@ namespace {
 static constexpr llvm::StringLiteral kFusionGroupIdAttr =
     "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+static constexpr llvm::StringLiteral kTemplateCandidatesAttr = "candidates";
 
-struct PlannedFusionGroup {
-  SmallVector<const pto::FusionComputeNode *, 8> members;
+struct TileOpImplVersion {
+  int64_t id = 0;
+  std::string name;
+  int64_t loopDepth = 0;
+  bool isPostUpdate = false;
+  bool hasTail = false;
 };
 
 struct PlanningContext {
@@ -61,6 +67,16 @@ struct PlanningCost {
     return dependencyBenefit + loopMergeBenefit - liveTilePenalty -
            vfParameterPenalty;
   }
+};
+
+struct PlannedFusionMember {
+  const pto::FusionComputeNode *node = nullptr;
+  TileOpImplVersion version;
+};
+
+struct PlannedFusionGroup {
+  SmallVector<PlannedFusionMember, 8> members;
+  PlanningCost cost;
 };
 
 struct PlanningDecision {
@@ -146,6 +162,18 @@ buildStableInGroupOrder(ArrayRef<const pto::FusionComputeNode *> members) {
   return ordered;
 }
 
+static SmallVector<PlannedFusionMember, 8>
+buildStableInGroupMemberOrder(ArrayRef<PlannedFusionMember> members) {
+  SmallVector<PlannedFusionMember, 8> ordered(members.begin(), members.end());
+  llvm::stable_sort(ordered, [](const PlannedFusionMember &lhs,
+                                const PlannedFusionMember &rhs) {
+    if (lhs.node->blockOrder != rhs.node->blockOrder)
+      return lhs.node->blockOrder < rhs.node->blockOrder;
+    return lhs.node->id < rhs.node->id;
+  });
+  return ordered;
+}
+
 static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
                                       MLIRContext *ctx,
                                       int64_t &nextGroupId) {
@@ -156,8 +184,8 @@ static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
 
   llvm::stable_sort(orderedGroups, [](const PlannedFusionGroup *lhs,
                                       const PlannedFusionGroup *rhs) {
-    const pto::FusionComputeNode *lhsFirst = lhs->members.front();
-    const pto::FusionComputeNode *rhsFirst = rhs->members.front();
+    const pto::FusionComputeNode *lhsFirst = lhs->members.front().node;
+    const pto::FusionComputeNode *rhsFirst = rhs->members.front().node;
     if (lhsFirst->blockOrder != rhsFirst->blockOrder)
       return lhsFirst->blockOrder < rhsFirst->blockOrder;
     return lhsFirst->id < rhsFirst->id;
@@ -165,9 +193,10 @@ static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
 
   for (const PlannedFusionGroup *group : orderedGroups) {
     const int64_t groupId = nextGroupId++;
-    SmallVector<const pto::FusionComputeNode *, 8> stableOrder =
-        buildStableInGroupOrder(group->members);
-    for (auto [order, node] : llvm::enumerate(stableOrder)) {
+    SmallVector<PlannedFusionMember, 8> stableOrder =
+        buildStableInGroupMemberOrder(group->members);
+    for (auto [order, member] : llvm::enumerate(stableOrder)) {
+      const pto::FusionComputeNode *node = member.node;
       node->op->setAttr(kFusionGroupIdAttr,
                         IntegerAttr::get(IntegerType::get(ctx, 64), groupId));
       node->op->setAttr(
@@ -181,6 +210,61 @@ static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
 static bool isSupportedPlanningNode(const pto::FusionComputeNode &node) {
   return node.semantics.kind == pto::FusionOpKind::Compute &&
          isCurrentlyPlannableOp(node.semantics.opName);
+}
+
+static TileOpImplVersion getDefaultImplVersion() {
+  return TileOpImplVersion{/*id=*/0, /*name=*/"default", /*loopDepth=*/2,
+                           /*isPostUpdate=*/false, /*hasTail=*/false};
+}
+
+static FailureOr<SmallVector<TileOpImplVersion, 4>>
+getLegalImplVersions(const pto::FusionComputeNode &node) {
+  auto candidates = node.op->getAttrOfType<ArrayAttr>(kTemplateCandidatesAttr);
+  if (!candidates || candidates.empty())
+    return SmallVector<TileOpImplVersion, 4>{getDefaultImplVersion()};
+
+  SmallVector<TileOpImplVersion, 4> versions;
+  versions.reserve(candidates.size());
+
+  for (Attribute attr : candidates) {
+    auto dict = dyn_cast<DictionaryAttr>(attr);
+    if (!dict)
+      return failure();
+
+    auto id = dyn_cast_or_null<IntegerAttr>(dict.get("id"));
+    auto name = dyn_cast_or_null<StringAttr>(dict.get("name"));
+    auto loopDepth = dyn_cast_or_null<IntegerAttr>(dict.get("loop_depth"));
+    auto postUpdate = dyn_cast_or_null<IntegerAttr>(dict.get("postupdate"));
+    auto tail = dyn_cast_or_null<IntegerAttr>(dict.get("tail"));
+    if (!id || !name || !loopDepth || !postUpdate || !tail)
+      return failure();
+
+    versions.push_back(TileOpImplVersion{
+        id.getInt(), name.getValue().str(), loopDepth.getInt(),
+        postUpdate.getInt() != 0, tail.getInt() != 0});
+  }
+
+  return versions;
+}
+
+static PlannedFusionMember
+makePlannedFusionMemberWithDefaultVersion(const pto::FusionComputeNode &node) {
+  TileOpImplVersion version = getDefaultImplVersion();
+  FailureOr<SmallVector<TileOpImplVersion, 4>> versions =
+      getLegalImplVersions(node);
+  if (succeeded(versions) && !versions->empty())
+    version = versions->front();
+  return PlannedFusionMember{&node, std::move(version)};
+}
+
+static SmallVector<PlannedFusionMember, 8>
+makePlannedFusionMembersWithDefaultVersions(
+    ArrayRef<const pto::FusionComputeNode *> nodes) {
+  SmallVector<PlannedFusionMember, 8> members;
+  members.reserve(nodes.size());
+  for (const pto::FusionComputeNode *node : nodes)
+    members.push_back(makePlannedFusionMemberWithDefaultVersion(*node));
+  return members;
 }
 
 static unsigned
@@ -429,7 +513,7 @@ public:
       }
 
       PlannedFusionGroup group;
-      group.members = chain;
+      group.members = makePlannedFusionMembersWithDefaultVersions(chain);
       groups.push_back(std::move(group));
       chain.clear();
     };
@@ -507,10 +591,12 @@ public:
         continue;
 
       PlannedFusionGroup group;
-      group.members = buildStableInGroupOrder(groupMembers);
+      SmallVector<const pto::FusionComputeNode *, 8> stableNodes =
+          buildStableInGroupOrder(groupMembers);
+      group.members = makePlannedFusionMembersWithDefaultVersions(stableNodes);
       groups.push_back(group);
-      for (const pto::FusionComputeNode *member : group.members)
-        assignedNodes.insert(member->id);
+      for (const PlannedFusionMember &member : group.members)
+        assignedNodes.insert(member.node->id);
     }
 
     return groups;
@@ -524,10 +610,13 @@ static void clearPlanningAttrs(func::FuncOp func) {
   });
 }
 
-struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
-  using pto::impl::FusionPlanBase<FusionPlanPass>::FusionPlanBase;
+struct VersionAwareFusionPlanPass
+    : public pto::impl::VersionAwareFusionPlanBase<
+          VersionAwareFusionPlanPass> {
+  using pto::impl::VersionAwareFusionPlanBase<
+      VersionAwareFusionPlanPass>::VersionAwareFusionPlanBase;
 
-  FusionPlanPass() = default;
+  VersionAwareFusionPlanPass() = default;
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
@@ -578,11 +667,12 @@ struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
 
 } // namespace
 
-std::unique_ptr<Pass> mlir::pto::createFusionPlanPass() {
-  return std::make_unique<FusionPlanPass>();
+std::unique_ptr<Pass> mlir::pto::createVersionAwareFusionPlanPass() {
+  return std::make_unique<VersionAwareFusionPlanPass>();
 }
 
 std::unique_ptr<Pass>
-mlir::pto::createFusionPlanPass(const pto::FusionPlanOptions &options) {
-  return std::make_unique<FusionPlanPass>(options);
+mlir::pto::createVersionAwareFusionPlanPass(
+    const pto::VersionAwareFusionPlanOptions &options) {
+  return std::make_unique<VersionAwareFusionPlanPass>(options);
 }

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -543,6 +543,33 @@ enumerateVersionedStatesFromSeed(const PlanningContext &ctx,
   return validStates;
 }
 
+[[maybe_unused]] static FailureOr<std::optional<GroupState>>
+findBestVersionedGroupForSeed(const PlanningContext &ctx,
+                              const CostModel &costModel,
+                              const pto::FusionComputeNode &seed,
+                              const DenseSet<unsigned> &assignedNodes) {
+  FailureOr<SmallVector<GroupState, 16>> states =
+      enumerateVersionedStatesFromSeed(ctx, costModel, seed, assignedNodes);
+  if (failed(states))
+    return failure();
+
+  std::optional<GroupState> bestState;
+  PlanningCost bestCost;
+  for (GroupState &state : *states) {
+    PlanningCost finalCost = computeFinalGroupCost(state);
+    if (bestState &&
+        !isBetterCandidateGroup(state.members, finalCost, bestState->members,
+                                bestCost))
+      continue;
+
+    state.cost = finalCost;
+    bestCost = finalCost;
+    bestState = std::move(state);
+  }
+
+  return bestState;
+}
+
 class ConservativeDAGGreedyCostModel final : public CostModel {
 public:
   PlanningDecision

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -11,6 +11,7 @@
 
 #include "PTO/IR/PTO.h"
 #include "PTO/Transforms/Passes.h"
+#include "PTO/Transforms/TemplateAttributes.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -42,15 +43,8 @@ namespace {
 static constexpr llvm::StringLiteral kFusionGroupIdAttr =
     "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
-static constexpr llvm::StringLiteral kTemplateCandidatesAttr = "candidates";
 
-struct TileOpImplVersion {
-  int64_t id = 0;
-  std::string name;
-  int64_t loopDepth = 0;
-  bool isPostUpdate = false;
-  bool hasTail = false;
-};
+using TileOpImplVersion = pto::TemplateCandidateMetadata;
 
 struct PlanningContext {
   const pto::FusionBlockAnalysis &blockAnalysis;
@@ -219,31 +213,17 @@ static TileOpImplVersion getDefaultImplVersion() {
 
 static FailureOr<SmallVector<TileOpImplVersion, 4>>
 getLegalImplVersions(const pto::FusionComputeNode &node) {
-  auto candidates = node.op->getAttrOfType<ArrayAttr>(kTemplateCandidatesAttr);
-  if (!candidates || candidates.empty())
+  FailureOr<SmallVector<pto::TemplateCandidateMetadata, 4>> candidates =
+      pto::getTemplateCandidateAttrs(node.op);
+  if (failed(candidates))
+    return failure();
+  if (candidates->empty())
     return SmallVector<TileOpImplVersion, 4>{getDefaultImplVersion()};
 
   SmallVector<TileOpImplVersion, 4> versions;
-  versions.reserve(candidates.size());
-
-  for (Attribute attr : candidates) {
-    auto dict = dyn_cast<DictionaryAttr>(attr);
-    if (!dict)
-      return failure();
-
-    auto id = dyn_cast_or_null<IntegerAttr>(dict.get("id"));
-    auto name = dyn_cast_or_null<StringAttr>(dict.get("name"));
-    auto loopDepth = dyn_cast_or_null<IntegerAttr>(dict.get("loop_depth"));
-    auto postUpdate = dyn_cast_or_null<IntegerAttr>(dict.get("postupdate"));
-    auto tail = dyn_cast_or_null<IntegerAttr>(dict.get("tail"));
-    if (!id || !name || !loopDepth || !postUpdate || !tail)
-      return failure();
-
-    versions.push_back(TileOpImplVersion{
-        id.getInt(), name.getValue().str(), loopDepth.getInt(),
-        postUpdate.getInt() != 0, tail.getInt() != 0});
-  }
-
+  versions.reserve(candidates->size());
+  for (const pto::TemplateCandidateMetadata &candidate : *candidates)
+    versions.push_back(candidate);
   return versions;
 }
 

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -212,19 +212,6 @@ static bool hasHardBoundaryToGroup(
   return false;
 }
 
-static SmallVector<const pto::FusionComputeNode *, 8>
-buildStableInGroupOrder(ArrayRef<const pto::FusionComputeNode *> members) {
-  SmallVector<const pto::FusionComputeNode *, 8> ordered(members.begin(),
-                                                         members.end());
-  llvm::stable_sort(ordered, [](const pto::FusionComputeNode *lhs,
-                                const pto::FusionComputeNode *rhs) {
-    if (lhs->blockOrder != rhs->blockOrder)
-      return lhs->blockOrder < rhs->blockOrder;
-    return lhs->id < rhs->id;
-  });
-  return ordered;
-}
-
 static SmallVector<PlannedFusionMember, 8>
 buildStableInGroupMemberOrder(ArrayRef<PlannedFusionMember> members) {
   SmallVector<PlannedFusionMember, 8> ordered(members.begin(), members.end());
@@ -352,26 +339,6 @@ createSeedStates(const pto::FusionComputeNode &seed) {
     states.push_back(std::move(state));
   }
   return states;
-}
-
-static PlannedFusionMember
-makePlannedFusionMemberWithDefaultVersion(const pto::FusionComputeNode &node) {
-  TileOpImplVersion version = getDefaultImplVersion();
-  FailureOr<SmallVector<TileOpImplVersion, 4>> versions =
-      getLegalImplVersions(node);
-  if (succeeded(versions) && !versions->empty())
-    version = versions->front();
-  return PlannedFusionMember{&node, std::move(version)};
-}
-
-static SmallVector<PlannedFusionMember, 8>
-makePlannedFusionMembersWithDefaultVersions(
-    ArrayRef<const pto::FusionComputeNode *> nodes) {
-  SmallVector<PlannedFusionMember, 8> members;
-  members.reserve(nodes.size());
-  for (const pto::FusionComputeNode *node : nodes)
-    members.push_back(makePlannedFusionMemberWithDefaultVersion(*node));
-  return members;
 }
 
 struct GroupFootprint {
@@ -627,119 +594,6 @@ public:
         0, static_cast<int64_t>(footprint.vfParameterCount) - 12);
     decision.accept = decision.cost.total() > 0;
     return decision;
-  }
-};
-
-class StrategyEngine {
-public:
-  virtual ~StrategyEngine() = default;
-
-  virtual SmallVector<PlannedFusionGroup, 8>
-  planBlock(const PlanningContext &ctx, const CostModel &costModel) const = 0;
-};
-
-class ConservativeGreedyStrategyEngine final : public StrategyEngine {
-public:
-  SmallVector<PlannedFusionGroup, 8>
-  planBlock(const PlanningContext &ctx,
-            const CostModel &costModel) const override {
-    SmallVector<PlannedFusionGroup, 8> groups;
-    SmallVector<const pto::FusionComputeNode *, 8> chain;
-
-    auto flushChain = [&]() {
-      if (chain.size() < 2) {
-        chain.clear();
-        return;
-      }
-
-      PlannedFusionGroup group;
-      group.members = makePlannedFusionMembersWithDefaultVersions(chain);
-      groups.push_back(std::move(group));
-      chain.clear();
-    };
-
-    for (const pto::FusionComputeNode &node : ctx.blockAnalysis.computeNodes) {
-      PlanningDecision seedDecision = costModel.evaluateSeed(ctx, node);
-      if (!seedDecision.accept) {
-        flushChain();
-        continue;
-      }
-
-      if (chain.empty()) {
-        chain.push_back(&node);
-        continue;
-      }
-
-      PlanningDecision appendDecision =
-          costModel.evaluateAppend(ctx, chain, node);
-      if (!appendDecision.accept) {
-        flushChain();
-        chain.push_back(&node);
-        continue;
-      }
-
-      chain.push_back(&node);
-    }
-
-    flushChain();
-    return groups;
-  }
-};
-
-class ConservativeDAGGreedyStrategyEngine final : public StrategyEngine {
-public:
-  SmallVector<PlannedFusionGroup, 8>
-  planBlock(const PlanningContext &ctx,
-            const CostModel &costModel) const override {
-    SmallVector<PlannedFusionGroup, 8> groups;
-    DenseSet<unsigned> assignedNodes;
-
-    for (const pto::FusionComputeNode &seed : ctx.blockAnalysis.computeNodes) {
-      if (assignedNodes.contains(seed.id))
-        continue;
-
-      PlanningDecision seedDecision = costModel.evaluateSeed(ctx, seed);
-      if (!seedDecision.accept)
-        continue;
-
-      SmallVector<const pto::FusionComputeNode *, 8> groupMembers;
-      DenseSet<unsigned> groupNodeIds;
-      groupMembers.push_back(&seed);
-      groupNodeIds.insert(seed.id);
-
-      bool changed = true;
-      while (changed) {
-        changed = false;
-        for (const pto::FusionComputeNode &candidate :
-             ctx.blockAnalysis.computeNodes) {
-          if (assignedNodes.contains(candidate.id) ||
-              groupNodeIds.contains(candidate.id))
-            continue;
-
-          PlanningDecision appendDecision =
-              costModel.evaluateAppend(ctx, groupMembers, candidate);
-          if (!appendDecision.accept)
-            continue;
-
-          groupMembers.push_back(&candidate);
-          groupNodeIds.insert(candidate.id);
-          changed = true;
-        }
-      }
-
-      if (groupMembers.size() < 2)
-        continue;
-
-      PlannedFusionGroup group;
-      SmallVector<const pto::FusionComputeNode *, 8> stableNodes =
-          buildStableInGroupOrder(groupMembers);
-      group.members = makePlannedFusionMembersWithDefaultVersions(stableNodes);
-      groups.push_back(group);
-      for (const PlannedFusionMember &member : group.members)
-        assignedNodes.insert(member.node->id);
-    }
-
-    return groups;
   }
 };
 

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -232,6 +232,47 @@ buildStableInGroupMemberOrder(ArrayRef<PlannedFusionMember> members) {
   return ordered;
 }
 
+static unsigned
+getEarliestBlockOrder(ArrayRef<PlannedFusionMember> members) {
+  unsigned earliest = ~0u;
+  for (const PlannedFusionMember &member : members)
+    earliest = std::min(earliest, member.node->blockOrder);
+  return earliest;
+}
+
+[[maybe_unused]] static bool
+isBetterCandidateGroup(ArrayRef<PlannedFusionMember> lhsMembers,
+                       const PlanningCost &lhsCost,
+                       ArrayRef<PlannedFusionMember> rhsMembers,
+                       const PlanningCost &rhsCost) {
+  if (rhsMembers.empty())
+    return !lhsMembers.empty();
+
+  if (lhsCost.total() != rhsCost.total())
+    return lhsCost.total() > rhsCost.total();
+
+  if (lhsMembers.size() != rhsMembers.size())
+    return lhsMembers.size() > rhsMembers.size();
+
+  const unsigned lhsFirstOrder = getEarliestBlockOrder(lhsMembers);
+  const unsigned rhsFirstOrder = getEarliestBlockOrder(rhsMembers);
+  if (lhsFirstOrder != rhsFirstOrder)
+    return lhsFirstOrder < rhsFirstOrder;
+
+  SmallVector<PlannedFusionMember, 8> lhsOrdered =
+      buildStableInGroupMemberOrder(lhsMembers);
+  SmallVector<PlannedFusionMember, 8> rhsOrdered =
+      buildStableInGroupMemberOrder(rhsMembers);
+  for (auto [lhsMember, rhsMember] : llvm::zip(lhsOrdered, rhsOrdered)) {
+    if (lhsMember.node->id != rhsMember.node->id)
+      return lhsMember.node->id < rhsMember.node->id;
+    if (lhsMember.version.id != rhsMember.version.id)
+      return lhsMember.version.id < rhsMember.version.id;
+  }
+
+  return false;
+}
+
 static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
                                       MLIRContext *ctx,
                                       int64_t &nextGroupId) {

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -78,6 +78,34 @@ struct PlanningDecision {
   PlanningCost cost;
 };
 
+struct GroupState {
+  SmallVector<PlannedFusionMember, 8> members;
+  DenseSet<unsigned> nodeIds;
+  PlanningCost cost;
+
+  bool contains(const pto::FusionComputeNode &node) const {
+    return nodeIds.contains(node.id);
+  }
+
+  SmallVector<const pto::FusionComputeNode *, 8> getNodes() const {
+    SmallVector<const pto::FusionComputeNode *, 8> nodes;
+    nodes.reserve(members.size());
+    for (const PlannedFusionMember &member : members)
+      nodes.push_back(member.node);
+    return nodes;
+  }
+
+  void append(PlannedFusionMember member, const PlanningCost &appendCost = {}) {
+    nodeIds.insert(member.node->id);
+    cost.dependencyBenefit += appendCost.dependencyBenefit;
+    cost.loopMergeBenefit += appendCost.loopMergeBenefit;
+    cost.liveTilePenalty += appendCost.liveTilePenalty;
+    cost.vfParameterPenalty += appendCost.vfParameterPenalty;
+    cost.rejectedForDynamicShape |= appendCost.rejectedForDynamicShape;
+    members.push_back(std::move(member));
+  }
+};
+
 static bool isCurrentlyPlannableOp(StringRef opName) {
   return llvm::StringSwitch<bool>(opName)
       .Cases("tmul", "tdiv", "tadd", "tsub", "tmax", "tmin", true)

--- a/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOVersionAwareFusionPlan.cpp
@@ -821,13 +821,16 @@ struct VersionAwareFusionPlanPass
     MLIRContext *ctx = &getContext();
     int64_t nextGroupId = 0;
     ConservativeDAGGreedyCostModel costModel;
-    ConservativeDAGGreedyStrategyEngine strategyEngine;
 
     for (const pto::FusionBlockAnalysis &blockAnalysis : analysis.blocks) {
       PlanningContext planningCtx{blockAnalysis};
-      SmallVector<PlannedFusionGroup, 8> groups =
-          strategyEngine.planBlock(planningCtx, costModel);
-      assignStableGroupMetadata(groups, ctx, nextGroupId);
+      FailureOr<SmallVector<PlannedFusionGroup, 8>> groups =
+          planBlockExactVersionAware(planningCtx, costModel);
+      if (failed(groups)) {
+        signalPassFailure();
+        return;
+      }
+      assignStableGroupMetadata(*groups, ctx, nextGroupId);
     }
 
     // The fusion metadata we annotate (group_id/order) is a planning *output*;

--- a/ptodsl/docs/tilelib-migration-testing.md
+++ b/ptodsl/docs/tilelib-migration-testing.md
@@ -1,0 +1,143 @@
+# PTODSL TileLib Migration Test Checklist
+
+This page tracks the tests used while migrating PTOAS TileLib expansion from
+the legacy TileLang implementation to PTODSL. Run commands from the repository
+root.
+
+## Environment
+
+Set up PTOAS, PTODSL, MLIR, and LLVM test-tool paths:
+
+```bash
+export PTOAS_ENV_SKIP_SMOKE_TEST=1
+source scripts/ptoas_env.sh
+export FILECHECK="$LLVM_BUILD_DIR/bin/FileCheck"
+```
+
+The Python-only tests do not require rebuilding PTOAS. Tests that invoke
+`ptoas` must use a binary rebuilt after the corresponding C++ or TableGen
+changes.
+
+## Milestone coverage
+
+| Milestone | Test | Purpose |
+|---|---|---|
+| Legacy baseline | `expand_tile_op_tilelang_tsub.pto` | Confirms the default TileLang backend still works |
+| PTODSL TileLib package | `test_tilelib_constraints.py`, `test_tilelib_elementwise.py`, `test_tilelib_render.py`, `test_tilelib_select.py` | Covers legality constraints, template registration and selection, and rendering |
+| PTODSL daemon | `test_tilelib_daemon.py` | Covers the Unix-socket protocol, metadata, rendering, candidate IDs, and caching |
+| PTOAS daemon selection | `expand_tile_op_ptodsl_tsub.pto` | Confirms `--tile-lib-backend=ptodsl` starts and uses the PTODSL daemon |
+| Separate metadata/render passes | `expand_tile_op_ptodsl_tadd.pto` | Confirms `InsertTemplateAttributes` records compact metadata before `ExpandTileOp` renders |
+| Multi-candidate fallback | `expand_tile_op_ptodsl_tadd.pto` | Confirms `ExpandTileOp` renders candidate index zero when several candidates remain |
+
+## Python TileLib tests
+
+Run every Python TileLib test:
+
+```bash
+python3 -m unittest discover -s ptodsl/tests -p 'test_tilelib_*.py'
+```
+
+Run the layers individually:
+
+```bash
+python3 ptodsl/tests/test_tilelib_constraints.py
+python3 ptodsl/tests/test_tilelib_elementwise.py
+python3 ptodsl/tests/test_tilelib_render.py
+python3 ptodsl/tests/test_tilelib_select.py
+python3 ptodsl/tests/test_tilelib_daemon.py
+```
+
+Each command prints `OK` when successful.
+
+## PTOAS integration tests
+
+Run the focused lit tests through the generated site configuration. Start lit
+from `build/test/lit`; passing source files under `test/lit` directly bypasses
+the generated LLVM configuration:
+
+```bash
+"$LLVM_BUILD_DIR/bin/llvm-lit" -sv build/test/lit \
+  --filter='expand_tile_op_(ptodsl_tsub|ptodsl_tadd|tilelang_tsub)'
+```
+
+### PTODSL positive path: one legal candidate
+
+`pto.tsub` has one legal PTODSL candidate. The test checks that PTOAS expands
+it into vector operations:
+
+```bash
+ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+  --tile-lib-backend=ptodsl \
+  test/lit/vpto/expand_tile_op_ptodsl_tsub.pto -o - 2>/dev/null |
+"$FILECHECK" test/lit/vpto/expand_tile_op_ptodsl_tsub.pto
+```
+
+### PTODSL candidate attributes and multi-candidate fallback
+
+Inspect the compact candidate list inserted before fusion:
+
+```bash
+ptoas --pto-arch=a5 --pto-backend=vpto --emit-pto-ir \
+  --tile-lib-backend=ptodsl \
+  --mlir-print-ir-after=pto-insert-template-attributes \
+  test/lit/vpto/expand_tile_op_ptodsl_tadd.pto \
+  -o /dev/null 2>&1 |
+"$FILECHECK" test/lit/vpto/expand_tile_op_ptodsl_tadd.pto \
+  --check-prefix=META
+```
+
+Confirm that insertion also runs before `FusionPlan` when fusion is enabled:
+
+```bash
+ptoas --pto-arch=a5 --pto-backend=vpto --pto-level=level2 \
+  --enable-op-fusion --emit-pto-ir --tile-lib-backend=ptodsl \
+  --mlir-print-ir-before=pto-fusion-plan \
+  test/lit/vpto/expand_tile_op_ptodsl_tadd.pto \
+  -o /dev/null 2>&1 |
+"$FILECHECK" test/lit/vpto/expand_tile_op_ptodsl_tadd.pto \
+  --check-prefix=PREFUSION
+```
+
+Inspect `ExpandTileOp` immediately after selection and confirm candidate zero
+was used:
+
+```bash
+ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+  --tile-lib-backend=ptodsl \
+  --mlir-print-ir-after=pto-expand-tile-op \
+  test/lit/vpto/expand_tile_op_ptodsl_tadd.pto \
+  -o /dev/null 2>&1 |
+"$FILECHECK" test/lit/vpto/expand_tile_op_ptodsl_tadd.pto \
+  --check-prefix=SELECT
+```
+
+Confirm the selected template expands through the full VPTO pipeline:
+
+```bash
+ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+  --tile-lib-backend=ptodsl \
+  test/lit/vpto/expand_tile_op_ptodsl_tadd.pto -o - 2>/dev/null |
+"$FILECHECK" test/lit/vpto/expand_tile_op_ptodsl_tadd.pto \
+  --check-prefix=EXPAND
+```
+
+### Legacy backend regression
+
+Omitting `--tile-lib-backend` must continue to select TileLang:
+
+```bash
+ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto \
+  test/lit/vpto/expand_tile_op_tilelang_tsub.pto -o - 2>/dev/null |
+"$FILECHECK" test/lit/vpto/expand_tile_op_tilelang_tsub.pto
+```
+
+## Reading the result
+
+`FileCheck` is silent when it succeeds. Immediately check its status with:
+
+```bash
+echo $?
+```
+
+`0` means the check passed. When fusion begins filtering candidates, add
+coverage for the filtered array while retaining the index-zero fallback test.

--- a/ptodsl/ptodsl/tilelib/serving/daemon.py
+++ b/ptodsl/ptodsl/tilelib/serving/daemon.py
@@ -279,19 +279,33 @@ def metadata_request(
     context_attrs: dict | None = None,
 ) -> dict:
     """Return every legal candidate and its selection metadata."""
+<<<<<<< HEAD
     legal = _legal_candidate_specs(target, op, operand_specs, context_attrs)
+=======
+    tile_specs = _tile_specs_for_request(target, op, operand_specs)
+    legal = _registry.legal_candidates(op, target, tile_specs, context_attrs)
+    constraint_context = _constraints.build_context(tile_specs, target, op)
+    if context_attrs:
+        constraint_context.update(context_attrs)
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
     return {
         "target": target,
         "op": op,
         "candidates": {
             descriptor.name: _metadata_for_descriptor(
                 descriptor,
+<<<<<<< HEAD
                 {
                     **_constraints.build_context(specs, target, op),
                     **(context_attrs or {}),
                 },
             )
             for descriptor, specs in legal
+=======
+                constraint_context,
+            )
+            for descriptor in legal
+>>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
         },
     }
 

--- a/ptodsl/ptodsl/tilelib/serving/daemon.py
+++ b/ptodsl/ptodsl/tilelib/serving/daemon.py
@@ -287,13 +287,17 @@ def metadata_request(
     constraint_context = _constraints.build_context(tile_specs, target, op)
     if context_attrs:
         constraint_context.update(context_attrs)
+<<<<<<< HEAD
 >>>>>>> 3b9fcabf (feat(ptodsl): add a pass to insert template candidates)
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
     return {
         "target": target,
         "op": op,
         "candidates": {
             descriptor.name: _metadata_for_descriptor(
                 descriptor,
+<<<<<<< HEAD
 <<<<<<< HEAD
                 {
                     **_constraints.build_context(specs, target, op),
@@ -302,6 +306,8 @@ def metadata_request(
             )
             for descriptor, specs in legal
 =======
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
                 constraint_context,
             )
             for descriptor in legal

--- a/ptodsl/ptodsl/tilelib/templates/a5/tcolmax.py
+++ b/ptodsl/ptodsl/tilelib/templates/a5/tcolmax.py
@@ -15,6 +15,7 @@ from ._reductions import register_column_reduction
 template_tcolmax = register_column_reduction(
     op="pto.tcolmax",
     name="template_tcolmax",
+<<<<<<< HEAD
     vector_op=pto.vmax,
     dtypes=[
         ("i8", "i8"),
@@ -27,4 +28,14 @@ template_tcolmax = register_column_reduction(
         ("bf16", "bf16"),
         ("f32", "f32"),
     ],
+=======
+    dtypes=[("f32", "f32")],
+    layouts=["row_major"],
+    memory_spaces=["ub"],
+    constraints=[_validate_tcolmax],
+    priority=0,
+    id=0,
+    loop_depth=2,
+    is_post_update=False,
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 )

--- a/ptodsl/tests/test_tilelib_daemon.py
+++ b/ptodsl/tests/test_tilelib_daemon.py
@@ -124,6 +124,19 @@ class TileLibDaemonTest(unittest.TestCase):
         self.assertEqual(selected["op_class"], "elementwise")
         self.assertEqual(selected["tags"], ["elementwise", "binary"])
 
+    def test_get_metadata_evaluates_tail_for_each_request(self):
+        tail_operands = [
+            _tile_spec(shape=(7, 65)),
+            _tile_spec(shape=(7, 65)),
+            _tile_spec(shape=(7, 65)),
+        ]
+
+        metadata = self.client.get_metadata("a5", "pto.tadd", tail_operands)
+
+        self.assertTrue(
+            metadata["candidates"][TADD_2D_NO_POST_UPDATE]["has_tail"]
+        )
+
     def test_cache_stats_and_clear_are_available_over_rpc(self):
         arguments = (
             "a5",

--- a/ptodsl/tests/test_tilelib_daemon.py
+++ b/ptodsl/tests/test_tilelib_daemon.py
@@ -137,6 +137,19 @@ class TileLibDaemonTest(unittest.TestCase):
             metadata["candidates"][TADD_2D_NO_POST_UPDATE]["has_tail"]
         )
 
+    def test_get_metadata_evaluates_tail_for_each_request(self):
+        tail_operands = [
+            _tile_spec(shape=(7, 65)),
+            _tile_spec(shape=(7, 65)),
+            _tile_spec(shape=(7, 65)),
+        ]
+
+        metadata = self.client.get_metadata("a5", "pto.tadd", tail_operands)
+
+        self.assertTrue(
+            metadata["candidates"][TADD_2D_NO_POST_UPDATE]["has_tail"]
+        )
+
     def test_cache_stats_and_clear_are_available_over_rpc(self):
         arguments = (
             "a5",

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -498,7 +498,10 @@ static pto::ExpandTileOpOptions resolveExpandTileOpOptions(int argc,
   return expandOpts;
 }
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
 static pto::InsertTemplateAttributesOptions
 buildInsertTemplateAttributesOptions(
     const pto::ExpandTileOpOptions &expandOptions) {
@@ -510,7 +513,11 @@ buildInsertTemplateAttributesOptions(
   return options;
 }
 
+<<<<<<< HEAD
 static llvm::cl::opt<llvm::cl::boolOrDefault> enableOpFusion(
+=======
+static llvm::cl::opt<bool> enableOpFusion(
+>>>>>>> 1358a9b5 (feat(ptodsl): add a pass to insert template candidates)
     "enable-op-fusion",
     llvm::cl::desc("Control A5 tile fusion on level2/level3. Defaults to "
                    "enabled on A5, disabled on A3. EmitC uses last-use "


### PR DESCRIPTION
## Description

This draft PR starts the version-aware fusion planning work for Tile Fusion.

The main motivation is that a single `TileOp` / `FusionComputeNode` may have
multiple legal implementation versions. For example, when tile regions are
contiguous, a tile op may be implementable with a simpler 1D loop nest;
otherwise it may need a different loop structure. The fusion planner therefore
should not treat each compute node as a single fixed unit. Instead, it should
eventually reason about:

```text
FusionComputeNode
  |-- version 0: default / 2D
  |-- version 1: contiguous / 1D
  `-- version 2: tail / post-update / other variant
```

The long-term goal is to enumerate possible fusion groups per seed across these
implementation versions, score them with a cost model, and select the best
version-aware group.

This PR is currently a foundation/draft PR. It does not yet replace the
existing `PTOFusionPlan` behavior and does not yet wire in the full
version-aware search algorithm.

## Goal

- Share template-candidate metadata parsing between:
  - `InsertTemplateAttributes`
  - `PTOVersionAwareFusionPlan`
- Represent fusion members as `(compute node, implementation version)`.
- Prepare internal state and comparison helpers for exact per-seed
  version-aware search.

## Current Algorithm Direction

The intended version-aware planning algorithm is:

```mermaid
flowchart TD
    A[Block compute nodes] --> B[Pick next unassigned seed]
    B --> C[Read legal versions for seed]
    C --> D[Create one GroupState per seed version]

    D --> E[Explore append candidates]
    E --> F[For each candidate node]
    F --> G[Read legal versions for candidate]
    G --> H[Try appending each version]

    H --> I{Append legal by DAG / domain / boundary rules?}
    I -- no --> E
    I -- yes --> J[Create new GroupState]

    J --> K[Compute base fusion cost]
    K --> L[Add version trait cost]
    L --> M[Record valid group states]

    M --> N{More expansions?}
    N -- yes --> E
    N -- no --> O[Select best group by deterministic comparator]

    O --> P[Assign group_id / order]
    P --> B
```

Each `GroupState` represents one possible version-aware group:

```text
GroupState
  members:
    - (node A, version A1)
    - (node B, version B0)
    - (node C, version C2)

  nodeIds:
    {A, B, C}

  cost:
    dependencyBenefit
    loopMergeBenefit
    versionCompatibilityBenefit
    liveTilePenalty
    vfParameterPenalty
    versionPenalty
```

The key difference from the current node-only planner is that the search
frontier branches by implementation version:

```text
Seed node A

Current planner:
  A  ---> grow one group

Version-aware planner:
  (A, v0) ---> grow group candidates
  (A, v1) ---> grow group candidates
  (A, v2) ---> grow group candidates
```

## Cost Model Direction

The planner will compare candidate groups using both existing fusion cost and
version-specific cost.

Base fusion terms:

```text
+ dependencyBenefit
+ loopMergeBenefit
- liveTilePenalty
- vfParameterPenalty
```

Version-aware terms added by this PR:

```text
+ versionCompatibilityBenefit
- versionPenalty
```

Current version-trait scoring helper models:

```text
all members use 1D versions        => benefit
mixed loop depths                  => penalty
tail versions                      => penalty
post-update versions               => penalty
```

The deterministic tie-break order is:

1. Higher total cost.
2. Larger group size.
3. Earlier first block order.
4. Lexicographically smaller compute node ids.
5. Lexicographically smaller version ids.

## Current State of This PR

Implemented so far:

- Added shared template-candidate metadata utility:
  - `include/PTO/Transforms/TemplateAttributes.h`
  - `lib/PTO/Transforms/TemplateAttributes.cpp`
- Moved shared candidate schema into that utility:
  - `candidates`
  - `id`
  - `name`
  - `loop_depth`
  - `postupdate`
  - `tail`
- Updated `InsertTemplateAttributes.cpp` to build candidate attrs through the
  shared helper.
- Updated `PTOVersionAwareFusionPlan.cpp` to parse candidate attrs through the
  shared helper.
- Added internal version-aware planning data structures:
  - `TileOpImplVersion`
  - `PlannedFusionMember`
  - `PlannedFusionGroup`
  - `GroupState`
- Added preparatory helpers:
  - version-trait cost computation
  - deterministic candidate-group comparison
  - seed-state creation with one `GroupState` per legal implementation version

Not implemented yet:

- The exact per-seed enumeration loop is not wired into `planBlock`.
- The current version-aware pass still relies on the existing greedy group
  formation behavior.
- Version-aware cost is not yet used to choose final groups.
- No selected implementation-version metadata is emitted to IR yet.
- `PTOFusionPlan.cpp` remains unchanged intentionally.
