### PR TITLE
ci: honor ARM wheel build parallelism

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -86,6 +86,11 @@ jobs:
           # (see pybind11 static_assert on def_property + keep_alive).
           pip install --no-cache-dir numpy 'pybind11<3' nanobind setuptools wheel auditwheel
 
+      - name: Test PEP 517 build backend
+        run: |
+          export PATH="${PY_PATH}/bin:$PATH"
+          PYTHONPATH="$GITHUB_WORKSPACE" python test/python/test_ptoas_build_backend.py
+
       - name: Set build directories
         run: |
           echo "WORKSPACE_DIR=/llvm-workspace" >> $GITHUB_ENV

--- a/_ptoas_build_backend.py
+++ b/_ptoas_build_backend.py
@@ -9,7 +9,7 @@
 """
 PEP 517 build backend for ptoas.
 
-Runs the CMake/Ninja build (assuming LLVM is already built), then delegates
+Runs the CMake build (assuming LLVM is already built), then delegates
 wheel packaging to docker/create_wheel.sh.
 
 Environment variables (all optional):
@@ -125,7 +125,7 @@ def _should_use_linux_hardening_cache() -> bool:
 
 
 def _cmake_configure_and_build():
-    """CMake configure + Ninja build + install."""
+    """CMake configure + build + install."""
     _BUILD_DIR.mkdir(parents=True, exist_ok=True)
 
     pybind11_dir = subprocess.check_output(
@@ -160,8 +160,10 @@ def _cmake_configure_and_build():
         cmake_cmd.insert(1, f"-C{hardening_cache}")
 
     subprocess.check_call(cmake_cmd)
-    subprocess.check_call(["ninja", "-C", str(_BUILD_DIR)])
-    subprocess.check_call(["ninja", "-C", str(_BUILD_DIR), "install"])
+    subprocess.check_call(["cmake", "--build", str(_BUILD_DIR)])
+    subprocess.check_call(
+        ["cmake", "--build", str(_BUILD_DIR), "--target", "install"]
+    )
     _assert_installed_ptodsl_payload()
 
 

--- a/test/python/test_ptoas_build_backend.py
+++ b/test/python/test_ptoas_build_backend.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import _ptoas_build_backend as build_backend
+
+
+class PtoasBuildBackendTests(unittest.TestCase):
+    def test_cmake_build_driver_is_used_for_build_and_install(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            repo = temp_root / "repo"
+            build_dir = temp_root / "build"
+            llvm_build = temp_root / "llvm-build"
+            install_dir = temp_root / "install"
+            (repo / "cmake").mkdir(parents=True)
+
+            check_call_args = []
+
+            def fake_check_call(args):
+                check_call_args.append(args)
+
+            with mock.patch.object(build_backend, "_REPO", repo), mock.patch.object(
+                build_backend, "_BUILD_DIR", build_dir
+            ), mock.patch.object(
+                build_backend, "_LLVM_BUILD_DIR", llvm_build
+            ), mock.patch.object(
+                build_backend, "_PTO_INSTALL_DIR", install_dir
+            ), mock.patch.object(
+                build_backend,
+                "_should_use_linux_hardening_cache",
+                return_value=False,
+            ), mock.patch.object(
+                build_backend.subprocess,
+                "check_output",
+                return_value="/tmp/pybind11-cmake",
+            ), mock.patch.object(
+                build_backend.subprocess,
+                "check_call",
+                side_effect=fake_check_call,
+            ), mock.patch.object(
+                build_backend,
+                "_assert_installed_ptodsl_payload",
+            ):
+                build_backend._cmake_configure_and_build()
+
+        self.assertEqual(
+            check_call_args[-2],
+            ["cmake", "--build", str(build_dir)],
+        )
+        self.assertEqual(
+            check_call_args[-1],
+            ["cmake", "--build", str(build_dir), "--target", "install"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Route the PEP 517 backend through `cmake --build` so `CMAKE_BUILD_PARALLEL_LEVEL=2` is honored by aarch64 wheel jobs.
- Preserve install semantics with `cmake --build <dir> --target install`.
- Add a lightweight backend unittest and run it early in the Build Wheel workflow.

## Testing
- `PYTHONPATH=. python3 test/python/test_ptoas_build_backend.py`
- `python3 -m py_compile _ptoas_build_backend.py test/python/test_ptoas_build_backend.py`
- `git diff --cached --check`