### PR TITLE
ub->gm传递l2_cache_ctl参数

### DIFF
--- a/docs/isa/micro-isa/01-pipeline-sync.md
+++ b/docs/isa/micro-isa/01-pipeline-sync.md
@@ -58,12 +58,12 @@ pipe_barrier(pipe);
 
 ```mlir
 // Both stores target the same GM address — order matters!
-pto.mte_ub_gm %ub_partial_0, %gm_result, ...
+pto.mte_ub_gm %ub_partial_0, %gm_result, %len_burst ...
 // Without pipe_barrier, MTE3 could execute the second copy before the first
 // completes, producing a non-deterministic result at %gm_result.
 pto.pipe_barrier "PIPE_MTE3"
 // After barrier: first copy is guaranteed complete. Second copy overwrites deterministically.
-pto.mte_ub_gm %ub_partial_1, %gm_result, ...
+pto.mte_ub_gm %ub_partial_1, %gm_result, %len_burst ...
 ```
 
 ---
@@ -341,7 +341,7 @@ pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
 // MTE3 waits until Vector's signal arrives
 pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
 
-pto.mte_ub_gm %ub_out, %gm_out, ...
+pto.mte_ub_gm %ub_out, %gm_out, %len_burst ...
 ```
 
 **Key property:** Every cross-pipeline edge is an explicit `(set_flag, wait_flag)` pair. Simple for straight-line code, but gets verbose in loops (see Example 3).
@@ -381,7 +381,7 @@ pto.rls_buf "PIPE_V", %bufid_ub_out, %c0 : i64, i64
 // ─── Stage 3: MTE3 stores result to GM ───
 // MTE3 acquires ub_out — blocks until Vector releases it (RAW: V write → MTE3 read)
 pto.get_buf "PIPE_MTE3", %bufid_ub_out, %c0 : i64, i64
-pto.mte_ub_gm %ub_out, %gm_out, ...
+pto.mte_ub_gm %ub_out, %gm_out, %len_burst ...
 // MTE3 done reading ub_out — release so Vector can reuse it in next iteration
 pto.rls_buf "PIPE_MTE3", %bufid_ub_out, %c0 : i64, i64
 ```
@@ -457,7 +457,7 @@ scf.for %i = %c0 to %N step %c1 {
   // ── MTE3: store result from buf_out[i%2] to GM ──
   // RAW: wait for Vector to finish writing buf_out[i%2]
   pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVT_OUT_FWD_{pp}"]
-  pto.mte_ub_gm %ub_out[%pp], %gm_out[%i], ...
+  pto.mte_ub_gm %ub_out[%pp], %gm_out[%i], %len_burst ...
   // WAR: tell Vector "done reading buf_out[i%2]"
   pto.set_flag["PIPE_MTE3", "PIPE_V", "EVT_OUT_REV_{pp}"]
 }
@@ -508,7 +508,7 @@ scf.for %i = %c0 to %N step %c1 {
   // ── MTE3: store result ──
   // Acquires out[i%2] — blocks until Vector releases it (RAW: automatic)
   pto.get_buf "PIPE_MTE3", %bufid_out[%pp], %c0 : i64, i64
-  pto.mte_ub_gm %ub_out[%pp], %gm_out[%i], ...
+  pto.mte_ub_gm %ub_out[%pp], %gm_out[%i], %len_burst ...
   pto.rls_buf "PIPE_MTE3", %bufid_out[%pp], %c0 : i64, i64
 }
 // No post-loop drain needed — last rls_buf completes the pipeline.

--- a/docs/isa/micro-isa/02-dma-copy.md
+++ b/docs/isa/micro-isa/02-dma-copy.md
@@ -73,12 +73,13 @@ pto.mte_gm_ub %gm_in, %ub_out, %cache, %len_burst
 - **syntax:**
 ```mlir
 pto.mte_ub_gm %ub_src, %gm_dst, %len_burst
-  nburst(%n_burst, %src_stride, %dst_stride)
+  nburst(%n_burst, %src_stride, %dst_stride) l2_cache_ctl(%l2_cache_ctl)
   [loop(%loop_count, %loop_src_stride, %loop_dst_stride)]*
-  : !pto.ptr<T, ub>, !pto.ptr<T, gm>, i64, i64, i64, i64,
+  : !pto.ptr<T, ub>, !pto.ptr<T, gm>, i64, i64, i64, i64, i64,
     [loop i64, i64, i64,]*
 ```
 - **semantics:** Grouped UB→GM DMA transfer. `nburst(...)` defines the innermost repeated burst transfer, and optional `loop(...)` groups add outer repetition levels.
+  The `l2_cache_ctl(...)` group is optional in textual VPTO IR; when omitted, lowering uses `0`.
 
 **Parameter Table:**
 
@@ -88,6 +89,7 @@ pto.mte_ub_gm %ub_src, %gm_dst, %len_burst
 | `%gm_dst` | ptr | GM destination pointer (`!pto.ptr<T, gm>`) |
 | `%len_burst` | 16 bits | Contiguous bytes transferred per burst row |
 | `nburst(%n_burst, %src_stride, %dst_stride)` | 16 bits / 21 bits / 40 bits | Required innermost burst group: count, UB source stride, GM destination stride |
+| `l2_cache_ctl(%l2_cache_ctl)` | 4 bits | Optional GM store-side L2 cache control; omitted means `0` |
 | `loop(%loop_count, %loop_src_stride, %loop_dst_stride)` | 21 bits / 21 bits / 40 bits | Optional outer repetition group: count, UB source stride, GM destination stride |
 
 **Constraints:**
@@ -103,10 +105,10 @@ pto.mte_ub_gm %ub_src, %gm_dst, %len_burst
 
 ```mlir
 pto.mte_ub_gm %ub_in, %gm_out, %len_burst
-  nburst(%rows, %ub_row_stride, %gm_row_stride)
+  nburst(%rows, %ub_row_stride, %gm_row_stride) l2_cache_ctl(%l2_cache_ctl)
   loop(%tiles, %ub_tile_stride, %gm_tile_stride)
   loop(%batches, %ub_batch_stride, %gm_batch_stride)
-  : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64,
+  : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64,
     loop i64, i64, i64, loop i64, i64, i64
 ```
 
@@ -336,6 +338,7 @@ For a form
 ```mlir
 pto.mte_ub_gm %ub_src, %dst, %len_burst
   nburst(%n_burst, %src_stride, %dst_stride)
+  l2_cache_ctl(%l2_cache_ctl)
   loop(%c0, %s0, %d0)
   loop(%c1, %s1, %d1)
   ...
@@ -507,8 +510,8 @@ GM (dest, 32 × 32 f32):
 
 ```mlir
 pto.mte_ub_gm %ub_out, %arg1, %c128_i64
-  nburst(%c32_i64, %c128_i64, %c128_i64)
-  : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+  nburst(%c32_i64, %c128_i64, %c128_i64) l2_cache_ctl(%c0_i64)
+  : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64
 ```
 
 ---
@@ -545,8 +548,8 @@ GM (dest, into 1024 × 512 matrix):
 
 ```mlir
 pto.mte_ub_gm %ub_ptr, %gm_ptr, %c256_i64
-  nburst(%c64_i64, %c256_i64, %c1024_i64)
-  : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+  nburst(%c64_i64, %c256_i64, %c1024_i64) l2_cache_ctl(%c0_i64)
+  : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64
 ```
 
 ---

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -1063,8 +1063,8 @@ func.call @body(%ub_out) : (!pto.ptr<i32, ub>) -> ()
 pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
 pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
 pto.mte_ub_gm %ub_out, %gm_out, %len
-  nburst(%n, %src_stride, %dst_stride)
-  : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+  nburst(%n, %src_stride, %dst_stride) l2_cache_ctl(%l2_cache_ctl)
+  : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64, i64
 ```
 
 For pipeline synchronization semantics, see
@@ -1095,8 +1095,8 @@ module attributes {pto.target_arch = "a5",
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.mte_ub_gm %ub_out, %out, %c128_i64
-      nburst(%c32_i64, %c128_i64, %c128_i64)
-      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64
+      nburst(%c32_i64, %c128_i64, %c128_i64) l2_cache_ctl(%c0_i64)
+      : !pto.ptr<i32, ub>, !pto.ptr<i32, gm>, i64, i64, i64, i64, i64
     pto.barrier #pto.pipe<PIPE_ALL>
     return
   }

--- a/docs/vpto-spec.md
+++ b/docs/vpto-spec.md
@@ -379,8 +379,8 @@ pto.vecscope {
 pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
 pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
 pto.mte_ub_gm %8, %14, %c128_i64
-  nburst(%c32_i64, %c128_i64, %c128_i64)
-  : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+  nburst(%c32_i64, %c128_i64, %c128_i64) l2_cache_ctl(%c0_i64)
+  : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64, i64
 ```
 
 ### Example: Strict VecScope

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -2624,7 +2624,7 @@ def PTO_CopyUbufToGmOp : PTO_Op<"copy_ubuf_to_gm", [
     I64:$sid,
     I64:$n_burst,
     I64:$len_burst,
-    I64:$reserved,
+    I64:$l2_cache_ctl,
     I64:$burst_dst_stride,
     I64:$burst_src_stride
   );
@@ -2635,9 +2635,9 @@ def PTO_CopyUbufToGmOp : PTO_Op<"copy_ubuf_to_gm", [
 
   let assemblyFormat = [{
     $source `,` $destination `,` $sid `,` $n_burst `,` $len_burst `,`
-    $reserved `,` $burst_dst_stride `,` $burst_src_stride
+    $l2_cache_ctl `,` $burst_dst_stride `,` $burst_src_stride
     attr-dict `:` type($source) `,` type($destination) `,` type($sid) `,` type($n_burst) `,`
-    type($len_burst) `,` type($reserved) `,`
+    type($len_burst) `,` type($l2_cache_ctl) `,`
     type($burst_dst_stride) `,` type($burst_src_stride)
   }];
 }
@@ -2653,6 +2653,7 @@ def PTO_MteUbGmOp : PTO_Op<"mte_ub_gm", [
     I64:$n_burst,
     I64:$nburst_src_stride,
     I64:$nburst_dst_stride,
+    Optional<I64>:$l2_cache_ctl,
     Variadic<I64>:$loop_counts,
     Variadic<I64>:$loop_src_strides,
     Variadic<I64>:$loop_dst_strides
@@ -2669,6 +2670,7 @@ def PTO_MteUbGmOp : PTO_Op<"mte_ub_gm", [
       "::mlir::Value":$destination,
       "::mlir::Value":$lenBurst,
       "::mlir::pto::DmaLoopConfig":$nburst,
+      "::mlir::Value":$l2CacheCtl,
       "::llvm::ArrayRef<::mlir::pto::DmaLoopConfig>":$loops
     )>,
     OpBuilder<(ins
@@ -2676,6 +2678,7 @@ def PTO_MteUbGmOp : PTO_Op<"mte_ub_gm", [
       "::mlir::Value":$destination,
       "::mlir::Value":$lenBurst,
       "::mlir::pto::DmaLoopConfig":$nburst,
+      "::mlir::Value":$l2CacheCtl,
       "::std::optional<::mlir::pto::DmaLoopConfig>":$loop1,
       "::std::optional<::mlir::pto::DmaLoopConfig>":$loop2
     )>

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -6588,10 +6588,13 @@ LogicalResult CopyUbufToGmOp::verify() {
 }
 
 void MteUbGmOp::build(OpBuilder &builder, OperationState &state, Value source,
-                       Value destination, Value lenBurst, pto::DmaLoopConfig nburst,
+                       Value destination, Value lenBurst,
+                       pto::DmaLoopConfig nburst, Value l2CacheCtl,
                        llvm::ArrayRef<pto::DmaLoopConfig> loops) {
   state.addOperands({source, destination, lenBurst, nburst.count,
                      nburst.srcStride, nburst.dstStride});
+  if (l2CacheCtl)
+    state.addOperands(l2CacheCtl);
   for (const pto::DmaLoopConfig &loop : loops)
     state.addOperands(loop.count);
   for (const pto::DmaLoopConfig &loop : loops)
@@ -6602,14 +6605,15 @@ void MteUbGmOp::build(OpBuilder &builder, OperationState &state, Value source,
   state.addAttribute(
       getOperandSegmentSizeAttr(),
       builder.getDenseI32ArrayAttr(
-          {1, 1, 1, 1, 1, 1,
+          {1, 1, 1, 1, 1, 1, l2CacheCtl ? 1 : 0,
            static_cast<int32_t>(loops.size()),
            static_cast<int32_t>(loops.size()),
            static_cast<int32_t>(loops.size())}));
 }
 
 void MteUbGmOp::build(OpBuilder &builder, OperationState &state, Value source,
-                       Value destination, Value lenBurst, pto::DmaLoopConfig nburst,
+                       Value destination, Value lenBurst,
+                       pto::DmaLoopConfig nburst, Value l2CacheCtl,
                        std::optional<pto::DmaLoopConfig> loop1,
                        std::optional<pto::DmaLoopConfig> loop2) {
   SmallVector<pto::DmaLoopConfig> loops;
@@ -6617,11 +6621,13 @@ void MteUbGmOp::build(OpBuilder &builder, OperationState &state, Value source,
     loops.push_back(*loop1);
   if (loop2)
     loops.push_back(*loop2);
-  build(builder, state, source, destination, lenBurst, nburst, loops);
+  build(builder, state, source, destination, lenBurst, nburst, l2CacheCtl,
+        loops);
 }
 
 ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
-  OpAsmParser::UnresolvedOperand source, destination, lenBurst;
+  OpAsmParser::UnresolvedOperand source, destination, lenBurst, l2CacheCtl;
+  bool hasL2CacheCtl = false;
   SmallVector<OpAsmParser::UnresolvedOperand> nburstOperands;
   SmallVector<OpAsmParser::UnresolvedOperand> loopCountOperands;
   SmallVector<OpAsmParser::UnresolvedOperand> loopSrcStrideOperands;
@@ -6631,6 +6637,12 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseOperand(lenBurst) ||
       parseDmaTripleGroup(parser, "nburst", nburstOperands))
     return failure();
+  if (succeeded(parser.parseOptionalKeyword("l2_cache_ctl"))) {
+    hasL2CacheCtl = true;
+    if (parser.parseLParen() || parser.parseOperand(l2CacheCtl) ||
+        parser.parseRParen())
+      return failure();
+  }
   while (true) {
     StringRef parsedKeyword;
     SmallVector<OpAsmParser::UnresolvedOperand, 3> loopGroupOperands;
@@ -6647,7 +6659,7 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
     return failure();
 
-  Type sourceType, destinationType, lenBurstType;
+  Type sourceType, destinationType, lenBurstType, l2CacheCtlType;
   SmallVector<Type> nburstTypes, loopCountTypes, loopSrcStrideTypes,
       loopDstStrideTypes;
   if (parser.parseType(sourceType) || parser.parseComma() ||
@@ -6655,6 +6667,10 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.parseType(lenBurstType) || parser.parseComma() ||
       parseDmaTripleTypes(parser, nburstTypes))
     return failure();
+  if (hasL2CacheCtl) {
+    if (parser.parseComma() || parser.parseType(l2CacheCtlType))
+      return failure();
+  }
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
     if (parser.parseKeyword(&keyword))
@@ -6686,6 +6702,7 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
   auto &segments =
       result.getOrAddProperties<MteUbGmOp::Properties>().operandSegmentSizes;
   llvm::copy(ArrayRef<int32_t>{1, 1, 1, 1, 1, 1,
+                               hasL2CacheCtl ? 1 : 0,
                                loopGroupCount, loopGroupCount, loopGroupCount},
              segments.begin());
 
@@ -6693,8 +6710,12 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
       parser.resolveOperand(destination, destinationType, result.operands) ||
       parser.resolveOperand(lenBurst, lenBurstType, result.operands) ||
       parser.resolveOperands(nburstOperands, nburstTypes, parser.getCurrentLocation(),
-                             result.operands) ||
-      parser.resolveOperands(loopCountOperands, loopCountTypes,
+                             result.operands))
+    return failure();
+  if (hasL2CacheCtl &&
+      parser.resolveOperand(l2CacheCtl, l2CacheCtlType, result.operands))
+    return failure();
+  if (parser.resolveOperands(loopCountOperands, loopCountTypes,
                              parser.getCurrentLocation(), result.operands) ||
       parser.resolveOperands(loopSrcStrideOperands, loopSrcStrideTypes,
                              parser.getCurrentLocation(), result.operands) ||
@@ -6710,6 +6731,8 @@ void MteUbGmOp::print(OpAsmPrinter &printer) {
           << getLenBurst();
   printDmaTripleGroup(printer, "nburst", getNBurst(), getNburstSrcStride(),
                       getNburstDstStride());
+  if (Value l2CacheCtl = getL2CacheCtl())
+    printer << " l2_cache_ctl(" << l2CacheCtl << ")";
   for (auto [count, srcStride, dstStride] :
        llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
     printDmaTripleGroup(printer, "loop", count, srcStride, dstStride);
@@ -6719,6 +6742,8 @@ void MteUbGmOp::print(OpAsmPrinter &printer) {
           << ", " << getNburstSrcStride().getType()
           << ", "
           << getNburstDstStride().getType();
+  if (Value l2CacheCtl = getL2CacheCtl())
+    printer << ", " << l2CacheCtl.getType();
   for (auto [count, srcStride, dstStride] :
        llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
     printDmaTripleTypes(printer, "loop", count.getType(), srcStride.getType(),
@@ -6749,6 +6774,13 @@ LogicalResult MteUbGmOp::verify() {
   if (sourceElemBytes != destinationElemBytes)
     return emitOpError(
         "requires source and destination element byte widths to match");
+  if (Value l2CacheCtlValue = getL2CacheCtl()) {
+    APInt l2CacheCtl;
+    if (matchPattern(l2CacheCtlValue, m_ConstantInt(&l2CacheCtl)) &&
+        (l2CacheCtl.isNegative() || l2CacheCtl.ugt(15)))
+      return emitOpError(
+          "requires constant l2_cache_ctl to fit in range [0, 15]");
+  }
   return verifyDmaLoadStoreLoopGroups(
       getOperation(), getLoopCounts(), getLoopSrcStrides(),
       getLoopDstStrides());

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -1574,8 +1574,8 @@ packCopyUbToGmConfig0(Operation *anchor, ValueRange operands) {
   Value sid = getI64Operand(2);
   Value nBurst = getI64Operand(3);
   Value lenBurst = getI64Operand(4);
-  Value reserved = getI64Operand(5);
-  if (!sid || !nBurst || !lenBurst || !reserved)
+  Value l2CacheCtl = getI64Operand(5);
+  if (!sid || !nBurst || !lenBurst || !l2CacheCtl)
     return failure();
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
@@ -1589,7 +1589,7 @@ packCopyUbToGmConfig0(Operation *anchor, ValueRange operands) {
   Value config = sid;
   config = bitOr(config, shl(nBurst, 4));
   config = bitOr(config, shl(lenBurst, 25));
-  config = bitOr(config, shl(reserved, 60));
+  config = bitOr(config, shl(l2CacheCtl, 60));
   return config;
 }
 
@@ -1602,12 +1602,12 @@ packCopyUbToGmConfig1(Operation *anchor, ValueRange operands) {
 
 [[maybe_unused]] static FailureOr<Value>
 packCopyUbToGmConfig0(Operation *anchor, Value sid, Value nBurst,
-                      Value lenBurst, Value reserved) {
+                      Value lenBurst, Value l2CacheCtl) {
   SmallVector<Value, 8> operands(8);
   operands[2] = sid;
   operands[3] = nBurst;
   operands[4] = lenBurst;
-  operands[5] = reserved;
+  operands[5] = l2CacheCtl;
   return packCopyUbToGmConfig0(anchor, operands);
 }
 

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -1196,9 +1196,10 @@ struct ExpandDmaStorePattern : public OpRewritePattern<pto::MteUbGmOp> {
           Value source = offsetPointerByBytes(op.getSource(), srcOffset, rewriter, loc);
           Value destination =
               offsetPointerByBytes(op.getDestination(), dstOffset, rewriter, loc);
+          Value l2CacheCtl = op.getL2CacheCtl() ? op.getL2CacheCtl() : zero;
           rewriter.create<pto::CopyUbufToGmOp>(
               loc, source, destination, zero, op.getNBurst(), op.getLenBurst(),
-              zero, op.getNburstDstStride(), op.getNburstSrcStride());
+              l2CacheCtl, op.getNburstDstStride(), op.getNburstSrcStride());
         });
     if (shouldRestoreDmaLoopSize(loop1Count, loop2Size))
       rewriter.create<pto::SetLoopSizeUbToOutOp>(loc, one, one);

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -1542,8 +1542,8 @@ packCopyUbToGmConfig0(Operation *anchor, ValueRange operands) {
   Value sid = getI64Operand(2);
   Value nBurst = getI64Operand(3);
   Value lenBurst = getI64Operand(4);
-  Value reserved = getI64Operand(5);
-  if (!sid || !nBurst || !lenBurst || !reserved)
+  Value l2CacheCtl = getI64Operand(5);
+  if (!sid || !nBurst || !lenBurst || !l2CacheCtl)
     return failure();
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
@@ -1557,7 +1557,7 @@ packCopyUbToGmConfig0(Operation *anchor, ValueRange operands) {
   Value config = sid;
   config = bitOr(config, shl(nBurst, 4));
   config = bitOr(config, shl(lenBurst, 25));
-  config = bitOr(config, shl(reserved, 60));
+  config = bitOr(config, shl(l2CacheCtl, 60));
   return config;
 }
 
@@ -1570,12 +1570,12 @@ packCopyUbToGmConfig1(Operation *anchor, ValueRange operands) {
 
 [[maybe_unused]] static FailureOr<Value>
 packCopyUbToGmConfig0(Operation *anchor, Value sid, Value nBurst,
-                      Value lenBurst, Value reserved) {
+                      Value lenBurst, Value l2CacheCtl) {
   SmallVector<Value, 8> operands(8);
   operands[2] = sid;
   operands[3] = nBurst;
   operands[4] = lenBurst;
-  operands[5] = reserved;
+  operands[5] = l2CacheCtl;
   return packCopyUbToGmConfig0(anchor, operands);
 }
 

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -166,7 +166,7 @@ pto.mte_gm_ub(gm_src, ub_dst, 0, 256,
 
 ### 7.2.2 UB → GM: `pto.mte_ub_gm`
 
-#### `pto.mte_ub_gm(ub_src: PtrType, gm_dst: PtrType, len_burst: int, *, nburst: tuple[int, int, int], loops: list[tuple[int, int, int]] | None = None, l2cache: str = "nmfv", l2_cache_ctl: int | None = None) -> None`
+#### `pto.mte_ub_gm(ub_src: PtrType, gm_dst: PtrType, len_burst: int, *, nburst: tuple[int, int, int], loops: list[tuple[int, int, int]] | None = None, l2_cache: str = "nmfv") -> None`
 
 **Description**: Grouped DMA transfer from Unified Buffer to Global Memory. The MTE reads `len_burst` bytes from each UB row (skipping any padding), writing only valid data to GM.
 
@@ -179,13 +179,7 @@ pto.mte_gm_ub(gm_src, ub_dst, 0, 256,
 | `len_burst` | `int` | Contiguous bytes transferred per burst row |
 | `nburst` | `tuple[int, int, int]` | `(n_burst, src_stride, dst_stride)` — innermost burst group (required) |
 | `loops` | `list[tuple[int, int, int]]` or `None` | Optional outer loop groups, ordered inner to outer |
-| `l2cache` | `str` | Store-side L2 cache policy. Defaults to `"nmfv"` |
-| `l2_cache_ctl` | `int` or runtime scalar | Compatibility interface for the raw 4-bit control value; do not combine it with a non-default `l2cache` |
-
-`l2cache` accepts the store/atomic cache tokens `nmfv`, `nmlv`, `nmprs`,
-`nmred`, `naci`, `napw`, `napi`, `nared`, `wbhfv`, `wbhlv`, `wbhprs`,
-`wbhred`, `wtsfv`, `wtslv`, `wtsprs`, and `wtsred`. These map to raw
-control values `0` through `15`, respectively.
+| `l2_cache` | `str` | Store-side L2 cache policy token. Defaults to `"nmfv"` (raw control `0`); supported tokens are `"nmfv"`, `"nmlv"`, `"nmprs"`, `"nmred"`, `"naci"`, `"napw"`, `"napi"`, `"nared"`, `"wbhfv"`, `"wbhlv"`, `"wbhprs"`, `"wbhred"`, `"wtsfv"`, `"wtslv"`, `"wtsprs"`, and `"wtsred"` |
 
 **Returns**: None (side-effect operation).
 
@@ -203,7 +197,7 @@ pto.mte_ub_gm(ub_src_f32, gm_dst_f32, 128,
 ```python
 pto.mte_ub_gm(ub_src, gm_dst, 256,
               nburst=(64, 256, 1024),
-              l2cache="nmfv")
+              l2_cache="nmfv")
 # UB: contiguous rows (256-byte stride).
 # GM: rows spaced at 1024-byte intervals (full matrix width).
 ```

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -166,7 +166,7 @@ pto.mte_gm_ub(gm_src, ub_dst, 0, 256,
 
 ### 7.2.2 UB → GM: `pto.mte_ub_gm`
 
-#### `pto.mte_ub_gm(ub_src: PtrType, gm_dst: PtrType, len_burst: int, *, nburst: tuple[int, int, int], loops: list[tuple[int, int, int]] | None = None) -> None`
+#### `pto.mte_ub_gm(ub_src: PtrType, gm_dst: PtrType, len_burst: int, *, nburst: tuple[int, int, int], loops: list[tuple[int, int, int]] | None = None, l2_cache_ctl: int = 0) -> None`
 
 **Description**: Grouped DMA transfer from Unified Buffer to Global Memory. The MTE reads `len_burst` bytes from each UB row (skipping any padding), writing only valid data to GM.
 
@@ -179,6 +179,7 @@ pto.mte_gm_ub(gm_src, ub_dst, 0, 256,
 | `len_burst` | `int` | Contiguous bytes transferred per burst row |
 | `nburst` | `tuple[int, int, int]` | `(n_burst, src_stride, dst_stride)` — innermost burst group (required) |
 | `loops` | `list[tuple[int, int, int]]` or `None` | Optional outer loop groups, ordered inner to outer |
+| `l2_cache_ctl` | `int` | L2 cache control field, default `0` |
 
 **Returns**: None (side-effect operation).
 

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -166,7 +166,7 @@ pto.mte_gm_ub(gm_src, ub_dst, 0, 256,
 
 ### 7.2.2 UB → GM: `pto.mte_ub_gm`
 
-#### `pto.mte_ub_gm(ub_src: PtrType, gm_dst: PtrType, len_burst: int, *, nburst: tuple[int, int, int], loops: list[tuple[int, int, int]] | None = None, l2_cache_ctl: int = 0) -> None`
+#### `pto.mte_ub_gm(ub_src: PtrType, gm_dst: PtrType, len_burst: int, *, nburst: tuple[int, int, int], loops: list[tuple[int, int, int]] | None = None, l2cache: str = "nmfv", l2_cache_ctl: int | None = None) -> None`
 
 **Description**: Grouped DMA transfer from Unified Buffer to Global Memory. The MTE reads `len_burst` bytes from each UB row (skipping any padding), writing only valid data to GM.
 
@@ -179,7 +179,13 @@ pto.mte_gm_ub(gm_src, ub_dst, 0, 256,
 | `len_burst` | `int` | Contiguous bytes transferred per burst row |
 | `nburst` | `tuple[int, int, int]` | `(n_burst, src_stride, dst_stride)` — innermost burst group (required) |
 | `loops` | `list[tuple[int, int, int]]` or `None` | Optional outer loop groups, ordered inner to outer |
-| `l2_cache_ctl` | `int` | L2 cache control field, default `0` |
+| `l2cache` | `str` | Store-side L2 cache policy. Defaults to `"nmfv"` |
+| `l2_cache_ctl` | `int` or runtime scalar | Compatibility interface for the raw 4-bit control value; do not combine it with a non-default `l2cache` |
+
+`l2cache` accepts the store/atomic cache tokens `nmfv`, `nmlv`, `nmprs`,
+`nmred`, `naci`, `napw`, `napi`, `nared`, `wbhfv`, `wbhlv`, `wbhprs`,
+`wbhred`, `wtsfv`, `wtslv`, `wtsprs`, and `wtsred`. These map to raw
+control values `0` through `15`, respectively.
 
 **Returns**: None (side-effect operation).
 
@@ -196,7 +202,8 @@ pto.mte_ub_gm(ub_src_f32, gm_dst_f32, 128,
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"data_movement.grouped_dma_ptrs","symbol":"data_movement_grouped_dma_ptrs_probe","compile":{}} -->
 ```python
 pto.mte_ub_gm(ub_src, gm_dst, 256,
-              nburst=(64, 256, 1024))
+              nburst=(64, 256, 1024),
+              l2cache="nmfv")
 # UB: contiguous rows (256-byte stride).
 # GM: rows spaced at 1024-byte intervals (full matrix width).
 ```

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -4200,8 +4200,7 @@ def mte_store(
     *,
     nburst,
     loops=None,
-    l2cache="nmfv",
-    l2_cache_ctl=None,
+    l2_cache="nmfv",
 ):
     """Ptr-based UB->GM DMA wrapper aligned with the underlying ``pto.dma_store`` surface."""
     n_burst, nburst_src_stride, nburst_dst_stride = _normalize_dma_group(
@@ -4224,11 +4223,7 @@ def mte_store(
         loop_src_strides,
         loop_dst_strides,
         l2_cache_ctl=_coerce_i64(
-            _normalize_mte_store_l2_cache_control(
-                l2cache,
-                l2_cache_ctl=l2_cache_ctl,
-                context="mte_store(...) l2cache",
-            ),
+            _normalize_mte_store_l2_cache(l2_cache, context="mte_store(...) l2_cache"),
             context="mte_store l2 cache control",
         ),
     )
@@ -4327,8 +4322,7 @@ def mte_ub_gm(
     *,
     nburst,
     loops=None,
-    l2cache="nmfv",
-    l2_cache_ctl=None,
+    l2_cache="nmfv",
 ):
     """``pto.mte_ub_gm`` – grouped UB-to-GM DMA surface."""
     n_burst, nburst_src_stride, nburst_dst_stride = _normalize_dma_group(
@@ -4351,11 +4345,7 @@ def mte_ub_gm(
         loop_src_strides,
         loop_dst_strides,
         l2_cache_ctl=_coerce_i64(
-            _normalize_mte_store_l2_cache_control(
-                l2cache,
-                l2_cache_ctl=l2_cache_ctl,
-                context="mte_ub_gm(...) l2cache",
-            ),
+            _normalize_mte_store_l2_cache(l2_cache, context="mte_ub_gm(...) l2_cache"),
             context="mte_ub_gm l2 cache control",
         ),
     )
@@ -5065,15 +5055,11 @@ def _st_l2_cache_attr(value, *, context: str):
     return _simt_enum_attr("st_l2cache", value, supported=_ST_L2_CACHE_TOKENS, context=context)
 
 
-def _normalize_mte_store_l2_cache_control(l2cache, *, l2_cache_ctl, context: str):
-    token = _normalize_token(l2cache, context=context)
+def _normalize_mte_store_l2_cache(l2_cache, *, context: str):
+    token = _normalize_token(l2_cache, context=context)
     if token not in _ST_L2_CACHE_CONTROL_VALUES:
         expected = ", ".join(sorted(_ST_L2_CACHE_CONTROL_VALUES))
-        raise ValueError(f"{context} does not support {l2cache!r}; expected one of {expected}")
-    if l2_cache_ctl is not None:
-        if token != "nmfv":
-            raise TypeError(f"{context} cannot be combined with l2_cache_ctl")
-        return l2_cache_ctl
+        raise ValueError(f"{context} does not support {l2_cache!r}; expected one of {expected}")
     return _ST_L2_CACHE_CONTROL_VALUES[token]
 
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -4193,7 +4193,16 @@ def mte_load(source, destination, l2_cache_ctl, len_burst, *, nburst, loops=None
 
 
 @_explicit_mode_only("pto.mte_store(...)")
-def mte_store(source, destination, len_burst, *, nburst, loops=None, l2_cache_ctl=0):
+def mte_store(
+    source,
+    destination,
+    len_burst,
+    *,
+    nburst,
+    loops=None,
+    l2cache="nmfv",
+    l2_cache_ctl=None,
+):
     """Ptr-based UB->GM DMA wrapper aligned with the underlying ``pto.dma_store`` surface."""
     n_burst, nburst_src_stride, nburst_dst_stride = _normalize_dma_group(
         "nburst",
@@ -4211,10 +4220,17 @@ def mte_store(source, destination, len_burst, *, nburst, loops=None, l2_cache_ct
         n_burst,
         nburst_src_stride,
         nburst_dst_stride,
-        _coerce_i64(l2_cache_ctl, context="mte_store l2_cache_ctl"),
         loop_counts,
         loop_src_strides,
         loop_dst_strides,
+        l2_cache_ctl=_coerce_i64(
+            _normalize_mte_store_l2_cache_control(
+                l2cache,
+                l2_cache_ctl=l2_cache_ctl,
+                context="mte_store(...) l2cache",
+            ),
+            context="mte_store l2 cache control",
+        ),
     )
 
 
@@ -4304,7 +4320,16 @@ def mte_gm_ub(source, destination, l2_cache_ctl, len_burst, *, nburst, loops=Non
 
 
 @_explicit_mode_only("pto.mte_ub_gm(...)")
-def mte_ub_gm(source, destination, len_burst, *, nburst, loops=None, l2_cache_ctl=0):
+def mte_ub_gm(
+    source,
+    destination,
+    len_burst,
+    *,
+    nburst,
+    loops=None,
+    l2cache="nmfv",
+    l2_cache_ctl=None,
+):
     """``pto.mte_ub_gm`` – grouped UB-to-GM DMA surface."""
     n_burst, nburst_src_stride, nburst_dst_stride = _normalize_dma_group(
         "nburst",
@@ -4322,10 +4347,17 @@ def mte_ub_gm(source, destination, len_burst, *, nburst, loops=None, l2_cache_ct
         n_burst,
         nburst_src_stride,
         nburst_dst_stride,
-        _coerce_i64(l2_cache_ctl, context="mte_ub_gm l2_cache_ctl"),
         loop_counts,
         loop_src_strides,
         loop_dst_strides,
+        l2_cache_ctl=_coerce_i64(
+            _normalize_mte_store_l2_cache_control(
+                l2cache,
+                l2_cache_ctl=l2_cache_ctl,
+                context="mte_ub_gm(...) l2cache",
+            ),
+            context="mte_ub_gm l2 cache control",
+        ),
     )
 
 
@@ -4987,6 +5019,24 @@ _ST_L2_CACHE_TOKENS = {
     "wbhfv", "wbhlv", "wbhprs", "wbhred",
     "wtsfv", "wtslv", "wtsprs", "wtsred",
 }
+_ST_L2_CACHE_CONTROL_VALUES = {
+    "nmfv": 0,
+    "nmlv": 1,
+    "nmprs": 2,
+    "nmred": 3,
+    "naci": 4,
+    "napw": 5,
+    "napi": 6,
+    "nared": 7,
+    "wbhfv": 8,
+    "wbhlv": 9,
+    "wbhprs": 10,
+    "wbhred": 11,
+    "wtsfv": 12,
+    "wtslv": 13,
+    "wtsprs": 14,
+    "wtsred": 15,
+}
 _ROUNDING_TOKENS = {"r", "a", "f", "c", "z", "o", "h"}
 _SATURATION_TOKENS = {"sat", "nosat"}
 
@@ -5013,6 +5063,18 @@ def _ld_l2_cache_attr(value, *, context: str):
 
 def _st_l2_cache_attr(value, *, context: str):
     return _simt_enum_attr("st_l2cache", value, supported=_ST_L2_CACHE_TOKENS, context=context)
+
+
+def _normalize_mte_store_l2_cache_control(l2cache, *, l2_cache_ctl, context: str):
+    token = _normalize_token(l2cache, context=context)
+    if token not in _ST_L2_CACHE_CONTROL_VALUES:
+        expected = ", ".join(sorted(_ST_L2_CACHE_CONTROL_VALUES))
+        raise ValueError(f"{context} does not support {l2cache!r}; expected one of {expected}")
+    if l2_cache_ctl is not None:
+        if token != "nmfv":
+            raise TypeError(f"{context} cannot be combined with l2_cache_ctl")
+        return l2_cache_ctl
+    return _ST_L2_CACHE_CONTROL_VALUES[token]
 
 
 def _rounding_attr(value, *, context: str):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -4193,7 +4193,7 @@ def mte_load(source, destination, l2_cache_ctl, len_burst, *, nburst, loops=None
 
 
 @_explicit_mode_only("pto.mte_store(...)")
-def mte_store(source, destination, len_burst, *, nburst, loops=None):
+def mte_store(source, destination, len_burst, *, nburst, loops=None, l2_cache_ctl=0):
     """Ptr-based UB->GM DMA wrapper aligned with the underlying ``pto.dma_store`` surface."""
     n_burst, nburst_src_stride, nburst_dst_stride = _normalize_dma_group(
         "nburst",
@@ -4211,6 +4211,7 @@ def mte_store(source, destination, len_burst, *, nburst, loops=None):
         n_burst,
         nburst_src_stride,
         nburst_dst_stride,
+        _coerce_i64(l2_cache_ctl, context="mte_store l2_cache_ctl"),
         loop_counts,
         loop_src_strides,
         loop_dst_strides,
@@ -4303,7 +4304,7 @@ def mte_gm_ub(source, destination, l2_cache_ctl, len_burst, *, nburst, loops=Non
 
 
 @_explicit_mode_only("pto.mte_ub_gm(...)")
-def mte_ub_gm(source, destination, len_burst, *, nburst, loops=None):
+def mte_ub_gm(source, destination, len_burst, *, nburst, loops=None, l2_cache_ctl=0):
     """``pto.mte_ub_gm`` – grouped UB-to-GM DMA surface."""
     n_burst, nburst_src_stride, nburst_dst_stride = _normalize_dma_group(
         "nburst",
@@ -4321,6 +4322,7 @@ def mte_ub_gm(source, destination, len_burst, *, nburst, loops=None):
         n_burst,
         nburst_src_stride,
         nburst_dst_stride,
+        _coerce_i64(l2_cache_ctl, context="mte_ub_gm l2_cache_ctl"),
         loop_counts,
         loop_src_strides,
         loop_dst_strides,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2447,8 +2447,8 @@ def public_data_movement_surface_probe():
     pto.mte_gm_ub(gm_src, ub_dst, 0, 256, nburst=(8, 256, 256), loops=[(4, 2048, 2048)])
     pto.mte_gm_ub(gm_src, ub_dst, 0, 200, nburst=(64, 200, 256), pad=(0.0, 0, 0))
     pto.mte_ub_gm(ub_src, gm_dst, 256, nburst=(64, 256, 1024))
-    pto.mte_ub_gm(ub_src, gm_dst, 128, nburst=(1, 128, 128), l2cache="nared")
-    pto.mte_ub_gm(ub_src, gm_dst, 64, nburst=(1, 64, 64), l2_cache_ctl=15)
+    pto.mte_ub_gm(ub_src, gm_dst, 128, nburst=(1, 128, 128), l2_cache="nared")
+    pto.mte_ub_gm(ub_src, gm_dst, 64, nburst=(1, 64, 64), l2_cache="wtsred")
     pto.mte_ub_ub(ub_src, ub_dst, 8, nburst=(16, 0, 4))
     pto.mte_ub_l1(ub_src, l1_dst, 8, nburst=(16, 0, 4))
     pto.mte_gm_l1(gm_src, l1_dst, 256, nburst=(8, 256, 256), loops=[(2, 2048, 2048)])
@@ -5278,11 +5278,11 @@ def main() -> None:
     expect("pto.mte_ub_gm" in data_movement_surface_text, "public grouped UB->GM wrapper should lower to pto.mte_ub_gm")
     expect(
         re.search(r"pto\.mte_ub_gm [^\n]+ nburst\([^)]+\) l2_cache_ctl\(%c7[^)\n]*\)", data_movement_surface_text) is not None,
-        "mte_ub_gm(..., l2cache='nared') should map the store cache token to control value 7",
+        "mte_ub_gm(..., l2_cache='nared') should map to the l2_cache_ctl group",
     )
     expect(
         re.search(r"pto\.mte_ub_gm [^\n]+ nburst\([^)]+\) l2_cache_ctl\(%c15[^)\n]*\)", data_movement_surface_text) is not None,
-        "mte_ub_gm(..., l2_cache_ctl=15) should preserve the legacy integer compatibility path",
+        "mte_ub_gm(..., l2_cache='wtsred') should map to the l2_cache_ctl group",
     )
     expect("pto.mte_ub_ub" in data_movement_surface_text, "public grouped UB->UB wrapper should lower to pto.mte_ub_ub")
     expect("pto.mte_ub_l1" in data_movement_surface_text, "public grouped UB->L1 wrapper should lower to pto.mte_ub_l1")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2447,7 +2447,8 @@ def public_data_movement_surface_probe():
     pto.mte_gm_ub(gm_src, ub_dst, 0, 256, nburst=(8, 256, 256), loops=[(4, 2048, 2048)])
     pto.mte_gm_ub(gm_src, ub_dst, 0, 200, nburst=(64, 200, 256), pad=(0.0, 0, 0))
     pto.mte_ub_gm(ub_src, gm_dst, 256, nburst=(64, 256, 1024))
-    pto.mte_ub_gm(ub_src, gm_dst, 128, nburst=(1, 128, 128), l2_cache_ctl=7)
+    pto.mte_ub_gm(ub_src, gm_dst, 128, nburst=(1, 128, 128), l2cache="nared")
+    pto.mte_ub_gm(ub_src, gm_dst, 64, nburst=(1, 64, 64), l2_cache_ctl=15)
     pto.mte_ub_ub(ub_src, ub_dst, 8, nburst=(16, 0, 4))
     pto.mte_ub_l1(ub_src, l1_dst, 8, nburst=(16, 0, 4))
     pto.mte_gm_l1(gm_src, l1_dst, 256, nburst=(8, 256, 256), loops=[(2, 2048, 2048)])
@@ -5277,7 +5278,11 @@ def main() -> None:
     expect("pto.mte_ub_gm" in data_movement_surface_text, "public grouped UB->GM wrapper should lower to pto.mte_ub_gm")
     expect(
         re.search(r"pto\.mte_ub_gm [^\n]+ nburst\([^)]+\) l2_cache_ctl\(%c7[^)\n]*\)", data_movement_surface_text) is not None,
-        "mte_ub_gm(..., l2_cache_ctl=7) should pass cache ctl through the l2_cache_ctl group",
+        "mte_ub_gm(..., l2cache='nared') should map the store cache token to control value 7",
+    )
+    expect(
+        re.search(r"pto\.mte_ub_gm [^\n]+ nburst\([^)]+\) l2_cache_ctl\(%c15[^)\n]*\)", data_movement_surface_text) is not None,
+        "mte_ub_gm(..., l2_cache_ctl=15) should preserve the legacy integer compatibility path",
     )
     expect("pto.mte_ub_ub" in data_movement_surface_text, "public grouped UB->UB wrapper should lower to pto.mte_ub_ub")
     expect("pto.mte_ub_l1" in data_movement_surface_text, "public grouped UB->L1 wrapper should lower to pto.mte_ub_l1")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2447,6 +2447,7 @@ def public_data_movement_surface_probe():
     pto.mte_gm_ub(gm_src, ub_dst, 0, 256, nburst=(8, 256, 256), loops=[(4, 2048, 2048)])
     pto.mte_gm_ub(gm_src, ub_dst, 0, 200, nburst=(64, 200, 256), pad=(0.0, 0, 0))
     pto.mte_ub_gm(ub_src, gm_dst, 256, nburst=(64, 256, 1024))
+    pto.mte_ub_gm(ub_src, gm_dst, 128, nburst=(1, 128, 128), l2_cache_ctl=7)
     pto.mte_ub_ub(ub_src, ub_dst, 8, nburst=(16, 0, 4))
     pto.mte_ub_l1(ub_src, l1_dst, 8, nburst=(16, 0, 4))
     pto.mte_gm_l1(gm_src, l1_dst, 256, nburst=(8, 256, 256), loops=[(2, 2048, 2048)])
@@ -5214,6 +5215,10 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(fixed_width_integer_text, "fixed-width integer specialization")
     expect("pto.mte_gm_ub" in public_surface_text, "mte_load(...) should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in public_surface_text, "mte_store(...) should lower to pto.mte_ub_gm")
+    expect(
+        re.search(r"pto\.mte_ub_gm [^\n]+ nburst\([^)]+\) l2_cache_ctl\(%c0[^)\n]*\)", public_surface_text) is not None,
+        "mte_store(...) should pass default l2_cache_ctl through the pto.mte_ub_gm l2_cache_ctl group",
+    )
     expect(public_surface_text.count("pto.mem_bar") >= 1, "mem_bar(...) should still lower explicit memory barriers")
     expect("pto.barrier <PIPE_ALL>" in public_surface_text, "pipe_barrier(Pipe.ALL) should lower to pto.barrier")
     expect("pto.vexp" in public_surface_text, "vexp(...) should lower to pto.vexp")
@@ -5270,6 +5275,10 @@ def main() -> None:
     expect("pto.sync.wait <PIPE_V>, %c3" in sync_surface_text, "wait_intra_flag(Pipe.V, dynamic_event) should lower dynamic event ids through pto.sync.wait")
     expect(data_movement_surface_text.count("pto.mte_gm_ub") == 2, "public grouped GM->UB wrappers should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in data_movement_surface_text, "public grouped UB->GM wrapper should lower to pto.mte_ub_gm")
+    expect(
+        re.search(r"pto\.mte_ub_gm [^\n]+ nburst\([^)]+\) l2_cache_ctl\(%c7[^)\n]*\)", data_movement_surface_text) is not None,
+        "mte_ub_gm(..., l2_cache_ctl=7) should pass cache ctl through the l2_cache_ctl group",
+    )
     expect("pto.mte_ub_ub" in data_movement_surface_text, "public grouped UB->UB wrapper should lower to pto.mte_ub_ub")
     expect("pto.mte_ub_l1" in data_movement_surface_text, "public grouped UB->L1 wrapper should lower to pto.mte_ub_l1")
     expect("pto.mte_gm_l1" in data_movement_surface_text, "public grouped GM->L1 wrapper should lower to pto.mte_gm_l1")

--- a/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
+++ b/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
@@ -17,19 +17,38 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %c64_i64 = arith.constant 64 : i64
     %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
 
-    pto.mte_ub_gm %ub, %out, %c5_i64, %c64_i64
-      nburst(%c1_i64, %c64_i64, %c64_i64)
+    pto.mte_ub_gm %ub, %out, %c64_i64
+      nburst(%c1_i64, %c64_i64, %c64_i64) l2_cache_ctl(%c5_i64)
       : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64
+    return
+  }
+
+  func.func @mte_ub_gm_l2_cache_ctl_default(%out: !pto.ptr<f16, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+
+    pto.mte_ub_gm %ub, %out, %c64_i64
+      nburst(%c1_i64, %c64_i64, %c64_i64)
+      : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
     return
   }
 }
 
 // ROUNDTRIP-LABEL: func.func @mte_ub_gm_l2_cache_ctl
 // ROUNDTRIP: %[[L2:.*]] = arith.constant 5 : i64
-// ROUNDTRIP: pto.mte_ub_gm %{{.*}}, %arg0, %[[L2]], %{{.*}} nburst(%{{.*}}, %{{.*}}, %{{.*}})
-// ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64
+// ROUNDTRIP: pto.mte_ub_gm %{{[^,]+}}, %arg0, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}}) l2_cache_ctl(%[[L2]])
+// ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64{{$}}
+// ROUNDTRIP-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default
+// ROUNDTRIP: pto.mte_ub_gm %{{[^,]+}}, %arg1, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}})
+// ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64{{$}}
 
 // EXPAND-LABEL: func.func @mte_ub_gm_l2_cache_ctl
 // EXPAND: %[[L2:.*]] = arith.constant 5 : i64
-// EXPAND: pto.copy_ubuf_to_gm %{{.*}}, %arg0, %{{.*}}, %{{.*}}, %{{.*}}, %[[L2]], %{{.*}}, %{{.*}}
+// EXPAND: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg0, %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[L2]], %{{[^,]+}}, %{{[^:]+}}
+// EXPAND-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64
+// EXPAND-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default
+// EXPAND: %[[ZERO:.*]] = arith.constant 0 : i64
+// EXPAND: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg1, %[[ZERO]], %{{[^,]+}}, %{{[^,]+}}, %[[ZERO]], %{{[^,]+}}, %{{[^:]+}}
 // EXPAND-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64

--- a/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
+++ b/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ROUNDTRIP
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=EXPAND
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @mte_ub_gm_l2_cache_ctl(%out: !pto.ptr<f16, gm>) attributes {pto.aicore} {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c5_i64 = arith.constant 5 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+
+    pto.mte_ub_gm %ub, %out, %c5_i64, %c64_i64
+      nburst(%c1_i64, %c64_i64, %c64_i64)
+      : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// ROUNDTRIP-LABEL: func.func @mte_ub_gm_l2_cache_ctl
+// ROUNDTRIP: %[[L2:.*]] = arith.constant 5 : i64
+// ROUNDTRIP: pto.mte_ub_gm %{{.*}}, %arg0, %[[L2]], %{{.*}} nburst(%{{.*}}, %{{.*}}, %{{.*}})
+// ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64
+
+// EXPAND-LABEL: func.func @mte_ub_gm_l2_cache_ctl
+// EXPAND: %[[L2:.*]] = arith.constant 5 : i64
+// EXPAND: pto.copy_ubuf_to_gm %{{.*}}, %arg0, %{{.*}}, %{{.*}}, %{{.*}}, %[[L2]], %{{.*}}, %{{.*}}
+// EXPAND-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64

--- a/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
+++ b/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
@@ -41,7 +41,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 // ROUNDTRIP: pto.mte_ub_gm %{{[^,]+}}, %arg0, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}}) l2_cache_ctl(%[[L2]])
 // ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64{{$}}
 // ROUNDTRIP-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default
-// ROUNDTRIP: pto.mte_ub_gm %{{[^,]+}}, %arg1, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}})
+// ROUNDTRIP: pto.mte_ub_gm %{{[^,]+}}, %arg0, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}})
 // ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64{{$}}
 
 // EXPAND-LABEL: func.func @mte_ub_gm_l2_cache_ctl
@@ -50,5 +50,5 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 // EXPAND-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64
 // EXPAND-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default
 // EXPAND: %[[ZERO:.*]] = arith.constant 0 : i64
-// EXPAND: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg1, %[[ZERO]], %{{[^,]+}}, %{{[^,]+}}, %[[ZERO]], %{{[^,]+}}, %{{[^:]+}}
+// EXPAND: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg0, %[[ZERO]], %{{[^,]+}}, %{{[^,]+}}, %[[ZERO]], %{{[^,]+}}, %{{[^:]+}}
 // EXPAND-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64

--- a/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
+++ b/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
@@ -388,7 +388,7 @@ pto.mte_gm_ub(
 )
 ```
 
-#### `pto.mte_ub_gm(ub_src, gm_dst, len_burst, *, nburst, loops=None, l2cache="nmfv", l2_cache_ctl=None) -> None`  [Advanced Tier]
+#### `pto.mte_ub_gm(ub_src, gm_dst, len_burst, *, nburst, loops=None, l2_cache="nmfv") -> None`  [Advanced Tier]
 
 **Description**: Grouped UB→GM DMA transfer.
 
@@ -400,12 +400,7 @@ pto.mte_gm_ub(
 | `len_burst` | `pto.i64` | Bytes transferred per burst row |
 | `nburst` | `tuple[i64, i64, i64]` | Required burst triple `(count, src_stride, dst_stride)` |
 | `loops` | `tuple[tuple[i64, i64, i64], ...] \| None` | Optional outer loop triples from inner to outer |
-| `l2cache` | `str` | Store-side L2 cache policy. Defaults to `"nmfv"` |
-| `l2_cache_ctl` | `pto.i64` | Compatibility interface for a raw control value; cannot be combined with `l2cache` |
-
-`l2cache` accepts `nmfv`, `nmlv`, `nmprs`, `nmred`, `naci`, `napw`, `napi`,
-`nared`, `wbhfv`, `wbhlv`, `wbhprs`, `wbhred`, `wtsfv`, `wtslv`, `wtsprs`,
-and `wtsred`, mapped to raw values `0` through `15`.
+| `l2_cache` | `str` | Store-side L2 cache policy token. Defaults to `"nmfv"` (raw control `0`); supported tokens are `"nmfv"`, `"nmlv"`, `"nmprs"`, `"nmred"`, `"naci"`, `"napw"`, `"napi"`, `"nared"`, `"wbhfv"`, `"wbhlv"`, `"wbhprs"`, `"wbhred"`, `"wtsfv"`, `"wtslv"`, `"wtsprs"`, and `"wtsred"` |
 
 **Example**:
 ```python
@@ -414,7 +409,7 @@ pto.mte_ub_gm(
     gm_ptr,
     128,
     nburst=(32, 128, 128),
-    l2cache="nmfv",
+    l2_cache="nmfv",
 )
 ```
 

--- a/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
+++ b/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
@@ -388,7 +388,7 @@ pto.mte_gm_ub(
 )
 ```
 
-#### `pto.mte_ub_gm(ub_src, gm_dst, len_burst, *, nburst, loops=None) -> None`  [Advanced Tier]
+#### `pto.mte_ub_gm(ub_src, gm_dst, len_burst, *, nburst, loops=None, l2_cache_ctl=0) -> None`  [Advanced Tier]
 
 **Description**: Grouped UB→GM DMA transfer.
 
@@ -400,6 +400,7 @@ pto.mte_gm_ub(
 | `len_burst` | `pto.i64` | Bytes transferred per burst row |
 | `nburst` | `tuple[i64, i64, i64]` | Required burst triple `(count, src_stride, dst_stride)` |
 | `loops` | `tuple[tuple[i64, i64, i64], ...] \| None` | Optional outer loop triples from inner to outer |
+| `l2_cache_ctl` | `pto.i64` | Optional L2 cache control field. Defaults to `0` |
 
 **Example**:
 ```python

--- a/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
+++ b/tilelang-dsl/docs/user_guide/08-sync-dma-operations.md
@@ -388,7 +388,7 @@ pto.mte_gm_ub(
 )
 ```
 
-#### `pto.mte_ub_gm(ub_src, gm_dst, len_burst, *, nburst, loops=None, l2_cache_ctl=0) -> None`  [Advanced Tier]
+#### `pto.mte_ub_gm(ub_src, gm_dst, len_burst, *, nburst, loops=None, l2cache="nmfv", l2_cache_ctl=None) -> None`  [Advanced Tier]
 
 **Description**: Grouped UB→GM DMA transfer.
 
@@ -400,7 +400,12 @@ pto.mte_gm_ub(
 | `len_burst` | `pto.i64` | Bytes transferred per burst row |
 | `nburst` | `tuple[i64, i64, i64]` | Required burst triple `(count, src_stride, dst_stride)` |
 | `loops` | `tuple[tuple[i64, i64, i64], ...] \| None` | Optional outer loop triples from inner to outer |
-| `l2_cache_ctl` | `pto.i64` | Optional L2 cache control field. Defaults to `0` |
+| `l2cache` | `str` | Store-side L2 cache policy. Defaults to `"nmfv"` |
+| `l2_cache_ctl` | `pto.i64` | Compatibility interface for a raw control value; cannot be combined with `l2cache` |
+
+`l2cache` accepts `nmfv`, `nmlv`, `nmprs`, `nmred`, `naci`, `napw`, `napi`,
+`nared`, `wbhfv`, `wbhlv`, `wbhprs`, `wbhred`, `wtsfv`, `wtslv`, `wtsprs`,
+and `wtsred`, mapped to raw values `0` through `15`.
 
 **Example**:
 ```python
@@ -409,6 +414,7 @@ pto.mte_ub_gm(
     gm_ptr,
     128,
     nburst=(32, 128, 128),
+    l2cache="nmfv",
 )
 ```
 

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -809,7 +809,7 @@ _BOOL_OP_NAMES = {
 _DMA_CALL_KEYWORDS: dict[str, frozenset[str]] = {
     "Tile": frozenset({"valid_shape", "blayout", "slayout", "fractal_size", "pad_value", "compact_mode", "addr"}),
     "mte_gm_ub": frozenset({"nburst", "loops", "pad"}),
-    "mte_ub_gm": frozenset({"nburst", "loops", "l2cache", "l2_cache_ctl"}),
+    "mte_ub_gm": frozenset({"nburst", "loops", "l2_cache"}),
     "mte_ub_ub": frozenset({"nburst"}),
     "mte_ub_l1": frozenset({"nburst"}),
     "set_mov_pad_val": frozenset({"pad_value"}),

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -809,7 +809,7 @@ _BOOL_OP_NAMES = {
 _DMA_CALL_KEYWORDS: dict[str, frozenset[str]] = {
     "Tile": frozenset({"valid_shape", "blayout", "slayout", "fractal_size", "pad_value", "compact_mode", "addr"}),
     "mte_gm_ub": frozenset({"nburst", "loops", "pad"}),
-    "mte_ub_gm": frozenset({"nburst", "loops", "l2_cache_ctl"}),
+    "mte_ub_gm": frozenset({"nburst", "loops", "l2cache", "l2_cache_ctl"}),
     "mte_ub_ub": frozenset({"nburst"}),
     "mte_ub_l1": frozenset({"nburst"}),
     "set_mov_pad_val": frozenset({"pad_value"}),

--- a/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
+++ b/tilelang-dsl/python/tilelang_dsl/frontend_ast.py
@@ -809,7 +809,7 @@ _BOOL_OP_NAMES = {
 _DMA_CALL_KEYWORDS: dict[str, frozenset[str]] = {
     "Tile": frozenset({"valid_shape", "blayout", "slayout", "fractal_size", "pad_value", "compact_mode", "addr"}),
     "mte_gm_ub": frozenset({"nburst", "loops", "pad"}),
-    "mte_ub_gm": frozenset({"nburst", "loops"}),
+    "mte_ub_gm": frozenset({"nburst", "loops", "l2_cache_ctl"}),
     "mte_ub_ub": frozenset({"nburst"}),
     "mte_ub_l1": frozenset({"nburst"}),
     "set_mov_pad_val": frozenset({"pad_value"}),

--- a/tilelang-dsl/python/tilelang_dsl/lowering.py
+++ b/tilelang-dsl/python/tilelang_dsl/lowering.py
@@ -2536,16 +2536,19 @@ class _AuthoringRenderer:
         source = self._lower_expr(expr.args[0], env, indent=indent, into=into)
         destination = self._lower_expr(expr.args[1], env, indent=indent, into=into)
         len_burst = self._lower_to_i64(expr.args[2], env, indent=indent, into=into)
-        nburst = self._lower_cube_i64_tuple(expr.args[3], env, indent=indent, into=into, expected_len=3)
-        loop_groups = self._lower_cube_loop_groups(expr.args[4], env, indent=indent, into=into)
+        l2_cache_ctl = self._lower_to_i64(expr.args[3], env, indent=indent, into=into)
+        nburst = self._lower_cube_i64_tuple(expr.args[4], env, indent=indent, into=into, expected_len=3)
+        loop_groups = self._lower_cube_loop_groups(expr.args[5], env, indent=indent, into=into)
         op_text = (
             f"pto.{expr.name} {source.name}, {destination.name}, {len_burst.name}"
             f" nburst({nburst[0].name}, {nburst[1].name}, {nburst[2].name})"
+            f" l2_cache_ctl({l2_cache_ctl.name})"
         )
         type_text = (
             f"{self._render_type(source.type)}, {self._render_type(destination.type)}, "
-            f"{self._render_type(len_burst.type)}, {self._render_type(nburst[0].type)}, "
-            f"{self._render_type(nburst[1].type)}, {self._render_type(nburst[2].type)}"
+            f"{self._render_type(len_burst.type)}, "
+            f"{self._render_type(nburst[0].type)}, {self._render_type(nburst[1].type)}, "
+            f"{self._render_type(nburst[2].type)}, {self._render_type(l2_cache_ctl.type)}"
         )
         for count, src_stride, dst_stride in loop_groups:
             op_text += f" loop({count.name}, {src_stride.name}, {dst_stride.name})"

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -4251,31 +4251,26 @@ class _SemanticAnalyzer:
         dst = self._require_pointer_expr(args[1], "pto.mte_ub_gm destination", memory_space="gm")
         self._require_matching_pointer_element_dtypes(src, dst, "pto.mte_ub_gm")
         self._require_i64_like_expr(args[2], "pto.mte_ub_gm len_burst")
-        allowed_keywords = {"nburst", "loops", "l2cache", "l2_cache_ctl"}
+        allowed_keywords = {"nburst", "loops", "l2_cache"}
         unsupported = sorted(set(keywords) - allowed_keywords)
         if unsupported:
             raise TypeError(
-                "pto.mte_ub_gm only accepts keyword(s) nburst, loops, l2cache, l2_cache_ctl in TileLang DSL v1; "
+                "pto.mte_ub_gm only accepts keyword(s) nburst, loops, l2_cache in TileLang DSL v1; "
                 f"got unsupported keyword(s): {', '.join(unsupported)}"
             )
-        if "l2cache" in keywords and "l2_cache_ctl" in keywords:
-            raise TypeError("pto.mte_ub_gm accepts either l2cache or l2_cache_ctl, not both")
-        if "l2cache" in keywords:
-            l2cache = self._require_string_expr(keywords["l2cache"], "pto.mte_ub_gm l2cache").strip().lower()
-            if l2cache not in _MTE_STORE_L2_CACHE_CONTROL_VALUES:
+        if "l2_cache" in keywords:
+            l2_cache = self._require_string_expr(keywords["l2_cache"], "pto.mte_ub_gm l2_cache").strip().lower()
+            if l2_cache not in _MTE_STORE_L2_CACHE_CONTROL_VALUES:
                 expected = ", ".join(sorted(_MTE_STORE_L2_CACHE_CONTROL_VALUES))
                 raise ValueError(
-                    f"pto.mte_ub_gm l2cache does not support {l2cache!r}; expected one of {expected}"
+                    f"pto.mte_ub_gm l2_cache does not support {l2_cache!r}; expected one of {expected}"
                 )
             l2_cache_ctl = SemanticLiteralExpr(
-                value=_MTE_STORE_L2_CACHE_CONTROL_VALUES[l2cache],
+                value=_MTE_STORE_L2_CACHE_CONTROL_VALUES[l2_cache],
                 type=SemanticScalarType(dtype=ScalarType("i64")),
             )
         else:
-            l2_cache_ctl = keywords.get(
-                "l2_cache_ctl",
-                SemanticLiteralExpr(value=0, type=SemanticScalarType(dtype=ScalarType("i64"))),
-            )
+            l2_cache_ctl = SemanticLiteralExpr(value=0, type=SemanticScalarType(dtype=ScalarType("i64")))
         self._require_i64_like_expr(l2_cache_ctl, "pto.mte_ub_gm l2_cache_ctl")
         nburst_expr = self._require_grouped_mte_nburst(keywords, "pto.mte_ub_gm")
         loops_expr = self._normalize_cube_loop_groups(keywords.get("loops"), "pto.mte_ub_gm loops")

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -3891,6 +3891,19 @@ class _SemanticAnalyzer:
                     return
             raise TypeError(f"{context} requires source/destination pointer element dtypes to match")
 
+    def _require_matching_pointer_element_dtypes(
+        self,
+        lhs: SemanticExpr,
+        rhs: SemanticExpr,
+        context: str,
+    ) -> None:
+        lhs_dtype = lhs.type.element_dtype
+        rhs_dtype = rhs.type.element_dtype
+        if lhs_dtype is None or rhs_dtype is None:
+            return
+        if lhs_dtype != rhs_dtype:
+            raise TypeError(f"{context} requires source/destination pointer element dtypes to match")
+
     def _require_cube_i64_tuple(
         self,
         expr: SemanticExpr,
@@ -4218,19 +4231,24 @@ class _SemanticAnalyzer:
         dst = self._require_pointer_expr(args[1], "pto.mte_ub_gm destination", memory_space="gm")
         self._require_matching_pointer_element_dtypes(src, dst, "pto.mte_ub_gm")
         self._require_i64_like_expr(args[2], "pto.mte_ub_gm len_burst")
-        allowed_keywords = {"nburst", "loops"}
+        allowed_keywords = {"nburst", "loops", "l2_cache_ctl"}
         unsupported = sorted(set(keywords) - allowed_keywords)
         if unsupported:
             raise TypeError(
-                "pto.mte_ub_gm only accepts keyword(s) nburst, loops in TileLang DSL v1; "
+                "pto.mte_ub_gm only accepts keyword(s) nburst, loops, l2_cache_ctl in TileLang DSL v1; "
                 f"got unsupported keyword(s): {', '.join(unsupported)}"
             )
+        l2_cache_ctl = keywords.get(
+            "l2_cache_ctl",
+            SemanticLiteralExpr(value=0, type=SemanticScalarType(dtype=ScalarType("i64"))),
+        )
+        self._require_i64_like_expr(l2_cache_ctl, "pto.mte_ub_gm l2_cache_ctl")
         nburst_expr = self._require_grouped_mte_nburst(keywords, "pto.mte_ub_gm")
         loops_expr = self._normalize_cube_loop_groups(keywords.get("loops"), "pto.mte_ub_gm loops")
         return SemanticCallExpr(
             namespace="pto",
             name="mte_ub_gm",
-            args=(args[0], args[1], args[2], nburst_expr, loops_expr),
+            args=(args[0], args[1], args[2], l2_cache_ctl, nburst_expr, loops_expr),
             type=None,
         )
 

--- a/tilelang-dsl/python/tilelang_dsl/semantic.py
+++ b/tilelang-dsl/python/tilelang_dsl/semantic.py
@@ -112,6 +112,26 @@ from .types import (
 )
 
 
+_MTE_STORE_L2_CACHE_CONTROL_VALUES = {
+    "nmfv": 0,
+    "nmlv": 1,
+    "nmprs": 2,
+    "nmred": 3,
+    "naci": 4,
+    "napw": 5,
+    "napi": 6,
+    "nared": 7,
+    "wbhfv": 8,
+    "wbhlv": 9,
+    "wbhprs": 10,
+    "wbhred": 11,
+    "wtsfv": 12,
+    "wtslv": 13,
+    "wtsprs": 14,
+    "wtsred": 15,
+}
+
+
 _DTYPE_SYMBOLS = {
     "i1": i1,
     "i8": i8,
@@ -4231,17 +4251,31 @@ class _SemanticAnalyzer:
         dst = self._require_pointer_expr(args[1], "pto.mte_ub_gm destination", memory_space="gm")
         self._require_matching_pointer_element_dtypes(src, dst, "pto.mte_ub_gm")
         self._require_i64_like_expr(args[2], "pto.mte_ub_gm len_burst")
-        allowed_keywords = {"nburst", "loops", "l2_cache_ctl"}
+        allowed_keywords = {"nburst", "loops", "l2cache", "l2_cache_ctl"}
         unsupported = sorted(set(keywords) - allowed_keywords)
         if unsupported:
             raise TypeError(
-                "pto.mte_ub_gm only accepts keyword(s) nburst, loops, l2_cache_ctl in TileLang DSL v1; "
+                "pto.mte_ub_gm only accepts keyword(s) nburst, loops, l2cache, l2_cache_ctl in TileLang DSL v1; "
                 f"got unsupported keyword(s): {', '.join(unsupported)}"
             )
-        l2_cache_ctl = keywords.get(
-            "l2_cache_ctl",
-            SemanticLiteralExpr(value=0, type=SemanticScalarType(dtype=ScalarType("i64"))),
-        )
+        if "l2cache" in keywords and "l2_cache_ctl" in keywords:
+            raise TypeError("pto.mte_ub_gm accepts either l2cache or l2_cache_ctl, not both")
+        if "l2cache" in keywords:
+            l2cache = self._require_string_expr(keywords["l2cache"], "pto.mte_ub_gm l2cache").strip().lower()
+            if l2cache not in _MTE_STORE_L2_CACHE_CONTROL_VALUES:
+                expected = ", ".join(sorted(_MTE_STORE_L2_CACHE_CONTROL_VALUES))
+                raise ValueError(
+                    f"pto.mte_ub_gm l2cache does not support {l2cache!r}; expected one of {expected}"
+                )
+            l2_cache_ctl = SemanticLiteralExpr(
+                value=_MTE_STORE_L2_CACHE_CONTROL_VALUES[l2cache],
+                type=SemanticScalarType(dtype=ScalarType("i64")),
+            )
+        else:
+            l2_cache_ctl = keywords.get(
+                "l2_cache_ctl",
+                SemanticLiteralExpr(value=0, type=SemanticScalarType(dtype=ScalarType("i64"))),
+            )
         self._require_i64_like_expr(l2_cache_ctl, "pto.mte_ub_gm l2_cache_ctl")
         nburst_expr = self._require_grouped_mte_nburst(keywords, "pto.mte_ub_gm")
         loops_expr = self._normalize_cube_loop_groups(keywords.get("loops"), "pto.mte_ub_gm loops")

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3189,7 +3189,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         @pto.vkernel(op="mte_ub_gm_l2_explicit_unique", dtypes=[(pto.f16,)], advanced=True)
         def explicit_kernel(out: pto.TensorView):
             ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
-            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2cache="nared")
+            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2_cache="nared")
             return None
 
         explicit_text = pto.select_kernel(
@@ -3203,45 +3203,13 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             r"\([^)]+\) l2_cache_ctl\(%c7_i64\)",
         )
 
-        @pto.vkernel(op="mte_ub_gm_l2_legacy_unique", dtypes=[(pto.f16,)], advanced=True)
-        def legacy_kernel(out: pto.TensorView):
-            ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
-            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2_cache_ctl=15)
-            return None
-
-        legacy_text = pto.select_kernel(
-            "a5",
-            "mte_ub_gm_l2_legacy_unique",
-            (pto.f16,),
-        ).mlir_text()
-        self.assertRegex(
-            legacy_text,
-            r"(?s)%(?P<legacy_l2>[A-Za-z0-9_]+) = arith\.index_cast %c15 : index to i64.*"
-            r"pto\.mte_ub_gm %[A-Za-z0-9_]+, %[A-Za-z0-9_]+, %[A-Za-z0-9_]+ nburst"
-            r"\([^)]+\) l2_cache_ctl\(%(?P=legacy_l2)\)",
-        )
-
-        @pto.vkernel(op="mte_ub_gm_l2_conflict_unique", dtypes=[(pto.f16,)], advanced=True)
-        def conflict_kernel(out: pto.TensorView):
-            ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
-            pto.mte_ub_gm(
-                ub.as_ptr(),
-                out.as_ptr(),
-                128,
-                nburst=(1, 128, 128),
-                l2cache="nared",
-                l2_cache_ctl=7,
-            )
-
-        with self.assertRaisesRegex(TypeError, "either l2cache or l2_cache_ctl"):
-            pto.select_kernel("a5", "mte_ub_gm_l2_conflict_unique", (pto.f16,)).mlir_text()
-
         @pto.vkernel(op="mte_ub_gm_l2_invalid_unique", dtypes=[(pto.f16,)], advanced=True)
         def invalid_kernel(out: pto.TensorView):
             ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
-            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2cache="invalid")
+            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2_cache="invalid")
+            return None
 
-        with self.assertRaisesRegex(ValueError, "l2cache does not support 'invalid'"):
+        with self.assertRaisesRegex(ValueError, "l2_cache does not support 'invalid'"):
             pto.select_kernel("a5", "mte_ub_gm_l2_invalid_unique", (pto.f16,)).mlir_text()
 
     def test_ckernel_full_pipeline_bridge_ops_lower_one_to_one_in_authoring_form(self) -> None:

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3164,6 +3164,46 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
             r"%acc_ptr_\d+ = pto\.tile_buf_addr %arg5 : !pto\.tile_buf<loc=acc, dtype=f32, rows=16, cols=16, v_row=16, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0> -> !pto\.ptr<f32, l0c>",
         )
 
+    def test_ckernel_mte_ub_gm_lowers_l2_cache_ctl_operand(self) -> None:
+        @pto.vkernel(op="mte_ub_gm_l2_default_unique", dtypes=[(pto.f16,)], advanced=True)
+        def default_kernel(out: pto.TensorView):
+            ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
+            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128))
+            return None
+
+        default_text = pto.select_kernel(
+            "a5",
+            "mte_ub_gm_l2_default_unique",
+            (pto.f16,),
+        ).mlir_text()
+        self.assertRegex(
+            default_text,
+            r"pto\.mte_ub_gm %[A-Za-z0-9_]+, %[A-Za-z0-9_]+, %[A-Za-z0-9_]+ nburst"
+            r"\([^)]+\) l2_cache_ctl\(%c0_i64\)",
+        )
+        self.assertRegex(
+            default_text,
+            r"pto\.mte_ub_gm [^\n]+ : !pto\.ptr<f16, ub>, !pto\.ptr<f16, gm>, i64, i64, i64, i64, i64",
+        )
+
+        @pto.vkernel(op="mte_ub_gm_l2_explicit_unique", dtypes=[(pto.f16,)], advanced=True)
+        def explicit_kernel(out: pto.TensorView):
+            ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
+            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2_cache_ctl=7)
+            return None
+
+        explicit_text = pto.select_kernel(
+            "a5",
+            "mte_ub_gm_l2_explicit_unique",
+            (pto.f16,),
+        ).mlir_text()
+        self.assertRegex(
+            explicit_text,
+            r"(?s)%(?P<l2>[A-Za-z0-9_]+) = arith\.index_cast %c7 : index to i64.*"
+            r"pto\.mte_ub_gm %[A-Za-z0-9_]+, %[A-Za-z0-9_]+, %[A-Za-z0-9_]+ nburst"
+            r"\([^)]+\) l2_cache_ctl\(%(?P=l2)\)",
+        )
+
     def test_ckernel_full_pipeline_bridge_ops_lower_one_to_one_in_authoring_form(self) -> None:
         @pto.ckernel(op="cube_bridge_pipeline_query_unique", dtypes=[(pto.f16,)], name="cube_bridge_pipeline_unique")
         def kernel(inp: pto.TensorView):

--- a/tilelang-dsl/tests/test_tilelang_dsl_v1.py
+++ b/tilelang-dsl/tests/test_tilelang_dsl_v1.py
@@ -3189,7 +3189,7 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         @pto.vkernel(op="mte_ub_gm_l2_explicit_unique", dtypes=[(pto.f16,)], advanced=True)
         def explicit_kernel(out: pto.TensorView):
             ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
-            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2_cache_ctl=7)
+            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2cache="nared")
             return None
 
         explicit_text = pto.select_kernel(
@@ -3199,10 +3199,50 @@ class TileLangDSLDescriptorTests(unittest.TestCase):
         ).mlir_text()
         self.assertRegex(
             explicit_text,
-            r"(?s)%(?P<l2>[A-Za-z0-9_]+) = arith\.index_cast %c7 : index to i64.*"
             r"pto\.mte_ub_gm %[A-Za-z0-9_]+, %[A-Za-z0-9_]+, %[A-Za-z0-9_]+ nburst"
-            r"\([^)]+\) l2_cache_ctl\(%(?P=l2)\)",
+            r"\([^)]+\) l2_cache_ctl\(%c7_i64\)",
         )
+
+        @pto.vkernel(op="mte_ub_gm_l2_legacy_unique", dtypes=[(pto.f16,)], advanced=True)
+        def legacy_kernel(out: pto.TensorView):
+            ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
+            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2_cache_ctl=15)
+            return None
+
+        legacy_text = pto.select_kernel(
+            "a5",
+            "mte_ub_gm_l2_legacy_unique",
+            (pto.f16,),
+        ).mlir_text()
+        self.assertRegex(
+            legacy_text,
+            r"(?s)%(?P<legacy_l2>[A-Za-z0-9_]+) = arith\.index_cast %c15 : index to i64.*"
+            r"pto\.mte_ub_gm %[A-Za-z0-9_]+, %[A-Za-z0-9_]+, %[A-Za-z0-9_]+ nburst"
+            r"\([^)]+\) l2_cache_ctl\(%(?P=legacy_l2)\)",
+        )
+
+        @pto.vkernel(op="mte_ub_gm_l2_conflict_unique", dtypes=[(pto.f16,)], advanced=True)
+        def conflict_kernel(out: pto.TensorView):
+            ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
+            pto.mte_ub_gm(
+                ub.as_ptr(),
+                out.as_ptr(),
+                128,
+                nburst=(1, 128, 128),
+                l2cache="nared",
+                l2_cache_ctl=7,
+            )
+
+        with self.assertRaisesRegex(TypeError, "either l2cache or l2_cache_ctl"):
+            pto.select_kernel("a5", "mte_ub_gm_l2_conflict_unique", (pto.f16,)).mlir_text()
+
+        @pto.vkernel(op="mte_ub_gm_l2_invalid_unique", dtypes=[(pto.f16,)], advanced=True)
+        def invalid_kernel(out: pto.TensorView):
+            ub = pto.Tile((1, 64), pto.f16, pto.MemorySpace.UB)
+            pto.mte_ub_gm(ub.as_ptr(), out.as_ptr(), 128, nburst=(1, 128, 128), l2cache="invalid")
+
+        with self.assertRaisesRegex(ValueError, "l2cache does not support 'invalid'"):
+            pto.select_kernel("a5", "mte_ub_gm_l2_invalid_unique", (pto.f16,)).mlir_text()
 
     def test_ckernel_full_pipeline_bridge_ops_lower_one_to_one_in_authoring_form(self) -> None:
         @pto.ckernel(op="cube_bridge_pipeline_query_unique", dtypes=[(pto.f16,)], name="cube_bridge_pipeline_unique")


### PR DESCRIPTION
TODO：
* 重构了接口，兼容旧.pto,dsl & .pto层面均可缺省，检查/ci中
* tileLang-dsl相关修改未检视

目标：增加兼容性，保持默认l2_cache_ctl=0，显式传值时则使用显式值
* dsl层面使用str表明l2_cache_ctl
* 高层 pto.mte_ub_gm 增加了 l2_cache_ctl参数
* 底层 pto.copy_ubuf_to_gm 里原来的 reserved 语义改成 l2_cache_ctl
*  更新相关 VPTO emitter/接口处的字段命名和语义，使它表示 reserved -> L2 cache policy