### PR TITLE
build: speed up LLVM21 local rebuilds (ccache + optional hardening)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,10 @@ include(AddMLIR)
 # =========================================================
 # 3. 配置构建环境
 # =========================================================
+# Prefer ccache/sccache for incremental rebuilds (especially after LLVM21,
+# where large TUs such as PTO.cpp / PTOToEmitC.cpp dominate wall time).
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CompilerCache.cmake)
+
 # Keep warning policy in CMake so CI, wheel, and external build entrypoints
 # all enforce the same diagnostics contract.
 option(PTOAS_ENABLE_WERROR "Treat PTOAS warnings as errors" ON)

--- a/README.md
+++ b/README.md
@@ -143,7 +143,19 @@ cmake -G Ninja \
 ninja -C build-llvm21
 ninja -C build-llvm21 install
 
-# 5. 检查构建产物
+# 5. （推荐）开发机加速：安装 ccache 后二次编译会显著变快
+#    CMake 默认开启 PTOAS_USE_COMPILER_CACHE=ON，会自动探测 ccache/sccache。
+#    也可显式指定：
+#      export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+#      export CMAKE_C_COMPILER_LAUNCHER=ccache
+#
+#    日常开发（非发布）可关闭 Linux hardening（含 -ftrapv）：
+#      export PTOAS_ENABLE_LINUX_HARDENING=0
+#      ./quick_install.sh
+#    或：
+#      PTOAS_ENABLE_LINUX_HARDENING=0 pip install . --no-build-isolation
+
+# 6. 检查构建产物
 # build 输出（便于本地开发/调试）
 $PTO_SOURCE_DIR/build-llvm21/python/
 ├── mlir

--- a/_ptoas_build_backend.py
+++ b/_ptoas_build_backend.py
@@ -19,6 +19,11 @@ Environment variables (all optional):
   PTO_INSTALL_DIR              Install prefix (default: <repo>/install)
   CMAKE_C_COMPILER             Optional C compiler passed through to CMake
   CMAKE_CXX_COMPILER           Optional C++ compiler passed through to CMake
+  CMAKE_C_COMPILER_LAUNCHER    Optional C compiler launcher (ccache/sccache)
+  CMAKE_CXX_COMPILER_LAUNCHER  Optional C++ compiler launcher (ccache/sccache)
+  PTOAS_ENABLE_LINUX_HARDENING Apply cmake/LinuxHardeningCache.cmake on Linux
+                               (default: 1). Set to 0 for faster local rebuilds.
+  PTOAS_USE_COMPILER_CACHE     Auto-detect ccache/sccache in CMake (default: ON)
   PTOAS_PYTHON_PACKAGE_VERSION Wheel version override
 """
 from __future__ import annotations
@@ -120,8 +125,20 @@ def build_sdist(sdist_directory, config_settings=None):
     )
 
 
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _should_use_linux_hardening_cache() -> bool:
-    return sys.platform.startswith("linux")
+    # Release/wheel builds keep hardening on by default. Local iteration after
+    # the LLVM21 upgrade can set PTOAS_ENABLE_LINUX_HARDENING=0 to skip
+    # -ftrapv / fortify costs that dominate giant TUs such as PTOToEmitC.cpp.
+    return sys.platform.startswith("linux") and _env_flag(
+        "PTOAS_ENABLE_LINUX_HARDENING", True
+    )
 
 
 def _cmake_configure_and_build():
@@ -146,10 +163,18 @@ def _cmake_configure_and_build():
         f"-DCMAKE_INSTALL_PREFIX={_PTO_INSTALL_DIR}",
     ]
 
-    for compiler_var in ("CMAKE_C_COMPILER", "CMAKE_CXX_COMPILER"):
-        compiler = os.environ.get(compiler_var, "").strip()
-        if compiler:
-            cmake_cmd.append(f"-D{compiler_var}={compiler}")
+    for cmake_var in (
+        "CMAKE_C_COMPILER",
+        "CMAKE_CXX_COMPILER",
+        "CMAKE_C_COMPILER_LAUNCHER",
+        "CMAKE_CXX_COMPILER_LAUNCHER",
+    ):
+        value = os.environ.get(cmake_var, "").strip()
+        if value:
+            cmake_cmd.append(f"-D{cmake_var}={value}")
+
+    if not _env_flag("PTOAS_USE_COMPILER_CACHE", True):
+        cmake_cmd.append("-DPTOAS_USE_COMPILER_CACHE=OFF")
 
     release_version = os.environ.get("PTOAS_RELEASE_VERSION_OVERRIDE", "")
     if release_version:
@@ -158,14 +183,23 @@ def _cmake_configure_and_build():
     hardening_cache = _REPO / "cmake" / "LinuxHardeningCache.cmake"
     if _should_use_linux_hardening_cache() and hardening_cache.exists():
         cmake_cmd.insert(1, f"-C{hardening_cache}")
+    elif sys.platform.startswith("linux"):
+        print(
+            "ptoas build: Linux hardening cache disabled "
+            "(PTOAS_ENABLE_LINUX_HARDENING=0)",
+            file=sys.stderr,
+        )
 
     subprocess.check_call(cmake_cmd)
-    subprocess.check_call(["cmake", "--build", str(_BUILD_DIR)])
+    build_cmd = ["cmake", "--build", str(_BUILD_DIR)]
+    parallel = os.environ.get("CMAKE_BUILD_PARALLEL_LEVEL", "").strip()
+    if parallel:
+        build_cmd.extend(["--parallel", parallel])
+    subprocess.check_call(build_cmd)
     subprocess.check_call(
         ["cmake", "--build", str(_BUILD_DIR), "--target", "install"]
     )
     _assert_installed_ptodsl_payload()
-
 
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     _cmake_configure_and_build()

--- a/cmake/CompilerCache.cmake
+++ b/cmake/CompilerCache.cmake
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# Optional compiler cache for faster local rebuilds after the LLVM21 upgrade.
+# Enable with -DPTOAS_USE_COMPILER_CACHE=ON (default). Explicit
+# CMAKE_CXX_COMPILER_LAUNCHER / CMAKE_C_COMPILER_LAUNCHER always win.
+
+option(PTOAS_USE_COMPILER_CACHE
+  "Auto-detect ccache/sccache when CMAKE_*_COMPILER_LAUNCHER is unset"
+  ON)
+
+function(ptoas_try_enable_compiler_cache)
+  if(NOT PTOAS_USE_COMPILER_CACHE)
+    message(STATUS "PTOAS compiler cache: disabled (PTOAS_USE_COMPILER_CACHE=OFF)")
+    return()
+  endif()
+
+  if(DEFINED CMAKE_CXX_COMPILER_LAUNCHER AND NOT CMAKE_CXX_COMPILER_LAUNCHER STREQUAL "")
+    message(STATUS "PTOAS compiler cache: using CMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}")
+    return()
+  endif()
+  if(DEFINED ENV{CMAKE_CXX_COMPILER_LAUNCHER} AND NOT "$ENV{CMAKE_CXX_COMPILER_LAUNCHER}" STREQUAL "")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "$ENV{CMAKE_CXX_COMPILER_LAUNCHER}" CACHE STRING
+        "C++ compiler launcher from environment" FORCE)
+    if(NOT DEFINED CMAKE_C_COMPILER_LAUNCHER OR CMAKE_C_COMPILER_LAUNCHER STREQUAL "")
+      if(DEFINED ENV{CMAKE_C_COMPILER_LAUNCHER} AND NOT "$ENV{CMAKE_C_COMPILER_LAUNCHER}" STREQUAL "")
+        set(CMAKE_C_COMPILER_LAUNCHER "$ENV{CMAKE_C_COMPILER_LAUNCHER}" CACHE STRING
+            "C compiler launcher from environment" FORCE)
+      else()
+        set(CMAKE_C_COMPILER_LAUNCHER "${CMAKE_CXX_COMPILER_LAUNCHER}" CACHE STRING
+            "C compiler launcher (matched CXX launcher)" FORCE)
+      endif()
+    endif()
+    message(STATUS "PTOAS compiler cache: using env launcher ${CMAKE_CXX_COMPILER_LAUNCHER}")
+    return()
+  endif()
+
+  find_program(PTOAS_COMPILER_CACHE_PROGRAM NAMES ccache sccache)
+  if(NOT PTOAS_COMPILER_CACHE_PROGRAM)
+    message(STATUS "PTOAS compiler cache: no ccache/sccache found; install one for faster rebuilds")
+    return()
+  endif()
+
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${PTOAS_COMPILER_CACHE_PROGRAM}" CACHE STRING
+      "C++ compiler launcher auto-detected by PTOAS" FORCE)
+  set(CMAKE_C_COMPILER_LAUNCHER "${PTOAS_COMPILER_CACHE_PROGRAM}" CACHE STRING
+      "C compiler launcher auto-detected by PTOAS" FORCE)
+  message(STATUS "PTOAS compiler cache: enabled (${PTOAS_COMPILER_CACHE_PROGRAM})")
+endfunction()
+
+ptoas_try_enable_compiler_cache()

--- a/quick_install.sh
+++ b/quick_install.sh
@@ -7,13 +7,17 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-# For quick development, build and install ptoas and its python bindings 
+# For quick development, build and install ptoas and its python bindings
 # on top of Docker image https://github.com/learning-chip/agent_docker_npu/pull/8
-# assume MLIR is already installed to save time, takes <3min to finish the build of pto extension
+# assume MLIR is already installed to save time.
 #
 # Optional env:
-#   LLVM_BUILD_DIR   - default: ${LLVM_SOURCE_DIR:-/llvm-workspace/llvm-project}/build-shared
-#   PTO_INSTALL_DIR  - default: <repo>/install
+#   LLVM_BUILD_DIR                 default: ${LLVM_SOURCE_DIR:-/llvm-workspace/llvm-project}/build-shared
+#   PTO_INSTALL_DIR                default: <repo>/install
+#   PTOAS_ENABLE_LINUX_HARDENING   default: 0 for this quick path (set 1 for release-like flags)
+#   PTOAS_USE_COMPILER_CACHE       default: ON (auto-detect ccache/sccache)
+#   CMAKE_CXX_COMPILER_LAUNCHER    force a launcher (ccache/sccache)
+#   CMAKE_BUILD_PARALLEL_LEVEL     ninja/cmake --build parallelism
 
 set -euo pipefail
 
@@ -22,6 +26,7 @@ PTO_INSTALL_DIR="${PTO_INSTALL_DIR:-${PTO_SOURCE_DIR}/install}"
 
 LLVM_SOURCE_DIR="${LLVM_SOURCE_DIR:-/llvm-workspace/llvm-project}"
 LLVM_BUILD_DIR="${LLVM_BUILD_DIR:-${LLVM_SOURCE_DIR}/build-shared}"
+PTOAS_ENABLE_LINUX_HARDENING="${PTOAS_ENABLE_LINUX_HARDENING:-0}"
 
 PY_ROOT="$(python -c 'import sys; print(sys.prefix)')"
 
@@ -37,20 +42,41 @@ PTOAS_VERSION="${PTOAS_VERSION:-$(python "${PTO_SOURCE_DIR}/.github/scripts/comp
 
 cd "$PTO_SOURCE_DIR"
 
-cmake -C "${PTO_SOURCE_DIR}/cmake/LinuxHardeningCache.cmake" -G Ninja \
-  -S . \
-  -B build \
-  -DLLVM_DIR="${LLVM_BUILD_DIR}/lib/cmake/llvm" \
-  -DMLIR_DIR="${LLVM_BUILD_DIR}/lib/cmake/mlir" \
-  -DPython3_ROOT_DIR="${PY_ROOT}" \
-  -DPython3_EXECUTABLE=python \
-  -DPython3_FIND_STRATEGY=LOCATION \
-  -Dpybind11_DIR="${PYBIND11_DIR}" \
-  -DMLIR_PYTHON_PACKAGE_DIR="${MLIR_PY_PKG}" \
-  -DPTOAS_RELEASE_VERSION_OVERRIDE="${PTOAS_VERSION}" \
+CMAKE_ARGS=(
+  -G Ninja
+  -S .
+  -B build
+  -DCMAKE_BUILD_TYPE=Release
+  -DLLVM_DIR="${LLVM_BUILD_DIR}/lib/cmake/llvm"
+  -DMLIR_DIR="${LLVM_BUILD_DIR}/lib/cmake/mlir"
+  -DPython3_ROOT_DIR="${PY_ROOT}"
+  -DPython3_EXECUTABLE=python
+  -DPython3_FIND_STRATEGY=LOCATION
+  -Dpybind11_DIR="${PYBIND11_DIR}"
+  -DMLIR_PYTHON_PACKAGE_DIR="${MLIR_PY_PKG}"
+  -DPTOAS_RELEASE_VERSION_OVERRIDE="${PTOAS_VERSION}"
   -DCMAKE_INSTALL_PREFIX="${PTO_INSTALL_DIR}"
+)
 
-ninja -C build
+if [[ "${PTOAS_ENABLE_LINUX_HARDENING}" == "1" || "${PTOAS_ENABLE_LINUX_HARDENING}" == "true" ]]; then
+  CMAKE_ARGS=(-C "${PTO_SOURCE_DIR}/cmake/LinuxHardeningCache.cmake" "${CMAKE_ARGS[@]}")
+  echo "quick_install.sh: Linux hardening enabled"
+else
+  echo "quick_install.sh: Linux hardening disabled (set PTOAS_ENABLE_LINUX_HARDENING=1 for release-like flags)"
+fi
+
+if [[ -n "${CMAKE_CXX_COMPILER_LAUNCHER:-}" ]]; then
+  CMAKE_ARGS+=(-DCMAKE_CXX_COMPILER_LAUNCHER="${CMAKE_CXX_COMPILER_LAUNCHER}")
+  CMAKE_ARGS+=(-DCMAKE_C_COMPILER_LAUNCHER="${CMAKE_C_COMPILER_LAUNCHER:-${CMAKE_CXX_COMPILER_LAUNCHER}}")
+fi
+
+cmake "${CMAKE_ARGS[@]}"
+
+BUILD_ARGS=(-C build)
+if [[ -n "${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]]; then
+  BUILD_ARGS+=(-j "${CMAKE_BUILD_PARALLEL_LEVEL}")
+fi
+ninja "${BUILD_ARGS[@]}"
 ninja -C build install
 
 export PTO_SOURCE_DIR PTO_INSTALL_DIR LLVM_BUILD_DIR


### PR DESCRIPTION
## Summary

LLVM21 made clean/incremental PTOAS builds noticeably slower because a few giant TUs (`PTO.cpp`, `PTOToEmitC.cpp`, VPTO emitters) dominate compile time.

This draft tries low-risk **local/dev** build-speed helpers without changing release defaults:

- Auto-detect **ccache/sccache** when `CMAKE_*_COMPILER_LAUNCHER` is unset (`PTOAS_USE_COMPILER_CACHE=ON` by default)
- Allow opting out of `LinuxHardeningCache.cmake` for local iteration via `PTOAS_ENABLE_LINUX_HARDENING=0`
- `quick_install.sh` defaults hardening **off** (fast path); release/wheel path still defaults hardening **on**
- Document the recommended developer flags in `README.md`

## Usage

```bash
# recommended local loop after LLVM21
export CMAKE_CXX_COMPILER_LAUNCHER=ccache   # optional if ccache is on PATH
export CMAKE_C_COMPILER_LAUNCHER=ccache
export PTOAS_ENABLE_LINUX_HARDENING=0       # optional for non-release builds
./quick_install.sh
# or
PTOAS_ENABLE_LINUX_HARDENING=0 pip install . --no-build-isolation
```

## Non-goals (this PR)

- No source split of mega `.cpp` files yet (still the biggest clean-build win later)
- No change to release CI hardening defaults

## Test plan

- [ ] Configure on Linux with ccache installed; cmake status shows cache launcher
- [ ] Configure without ccache; build still succeeds
- [ ] `PTOAS_ENABLE_LINUX_HARDENING=0 pip install . --no-build-isolation` skips hardening cache
- [ ] Default wheel/release path still applies hardening on Linux
- [ ] `./quick_install.sh` works with hardening off by default
- [ ] CI build-and-test green on this draft