### PR TITLE
fix(TileOps): correct tload/tstore strides to physical src stride

### DIFF
--- a/lib/TileOps/tload_template.py
+++ b/lib/TileOps/tload_template.py
@@ -359,13 +359,14 @@ def _constraint_tload_mat_nd2nz(src, dst) -> bool:
     # (rows/cols from the tile_buf type) rather than dst.valid_shape, which
     # may be dynamic ([null, null]) and would otherwise let both ND2NZ and
     # DN2NZ match when the shape comparison is skipped.
-    if hasattr(src, 'rank') and src.rank == 5:
-        dst_cols = dst.shape[1] if hasattr(dst, 'shape') and dst.shape is not None else None
-        if dst_cols is not None and hasattr(src, 'shape') and src.shape is not None:
-            src_inner = src.shape[4] if len(src.shape) >= 5 else None
-            if src_inner is not None:
-                if not _known_eq(dst_cols, src_inner):
-                    return False
+    if not (hasattr(src, 'rank') and src.rank == 5):
+        return False
+    dst_cols = dst.shape[1] if hasattr(dst, 'shape') and dst.shape is not None else None
+    if dst_cols is not None and hasattr(src, 'shape') and src.shape is not None:
+        src_inner = src.shape[4] if len(src.shape) >= 5 else None
+        if src_inner is not None:
+            if not _known_eq(dst_cols, src_inner):
+                return False
     return True
 
 
@@ -389,13 +390,14 @@ def _constraint_tload_mat_dn2nz(src, dst) -> bool:
     # g4 corresponds to the tile column count. Use the *static* dst.shape
     # (rows/cols from the tile_buf type) rather than dst.valid_shape, which
     # may be dynamic and would otherwise let both templates match.
-    if hasattr(src, 'rank') and src.rank == 5:
-        dst_rows = dst.shape[0] if hasattr(dst, 'shape') and dst.shape is not None else None
-        if dst_rows is not None and hasattr(src, 'shape') and src.shape is not None:
-            src_inner = src.shape[4] if len(src.shape) >= 5 else None
-            if src_inner is not None:
-                if not _known_eq(dst_rows, src_inner):
-                    return False
+    if not (hasattr(src, 'rank') and src.rank == 5):
+        return False
+    dst_rows = dst.shape[0] if hasattr(dst, 'shape') and dst.shape is not None else None
+    if dst_rows is not None and hasattr(src, 'shape') and src.shape is not None:
+        src_inner = src.shape[4] if len(src.shape) >= 5 else None
+        if src_inner is not None:
+            if not _known_eq(dst_rows, src_inner):
+                return False
     return True
 
 

--- a/lib/TileOps/tload_template.py
+++ b/lib/TileOps/tload_template.py
@@ -355,13 +355,16 @@ def _constraint_tload_mat_nd2nz(src, dst) -> bool:
         return False
     # ND2NZ: source is in ND (row-major) format where the inner dimension (g4)
     # corresponds to the tile column count. Disambiguates from DN format where
-    # g4 corresponds to the tile row count.
+    # g4 corresponds to the tile row count. Use the *static* dst.shape
+    # (rows/cols from the tile_buf type) rather than dst.valid_shape, which
+    # may be dynamic ([null, null]) and would otherwise let both ND2NZ and
+    # DN2NZ match when the shape comparison is skipped.
     if hasattr(src, 'rank') and src.rank == 5:
-        dst_valid_cols = dst.valid_shape[1] if hasattr(dst, 'valid_shape') and dst.valid_shape is not None else None
-        if dst_valid_cols is not None and hasattr(src, 'shape') and src.shape is not None:
+        dst_cols = dst.shape[1] if hasattr(dst, 'shape') and dst.shape is not None else None
+        if dst_cols is not None and hasattr(src, 'shape') and src.shape is not None:
             src_inner = src.shape[4] if len(src.shape) >= 5 else None
             if src_inner is not None:
-                if not _known_eq(dst_valid_cols, src_inner):
+                if not _known_eq(dst_cols, src_inner):
                     return False
     return True
 
@@ -383,13 +386,15 @@ def _constraint_tload_mat_dn2nz(src, dst) -> bool:
         return False
     # DN2NZ: source is in DN (col-major) format where the inner dimension (g4)
     # corresponds to the tile row count. Disambiguates from ND format where
-    # g4 corresponds to the tile column count.
+    # g4 corresponds to the tile column count. Use the *static* dst.shape
+    # (rows/cols from the tile_buf type) rather than dst.valid_shape, which
+    # may be dynamic and would otherwise let both templates match.
     if hasattr(src, 'rank') and src.rank == 5:
-        dst_valid_rows = dst.valid_shape[0] if hasattr(dst, 'valid_shape') and dst.valid_shape is not None else None
-        if dst_valid_rows is not None and hasattr(src, 'shape') and src.shape is not None:
+        dst_rows = dst.shape[0] if hasattr(dst, 'shape') and dst.shape is not None else None
+        if dst_rows is not None and hasattr(src, 'shape') and src.shape is not None:
             src_inner = src.shape[4] if len(src.shape) >= 5 else None
             if src_inner is not None:
-                if not _known_eq(dst_valid_rows, src_inner):
+                if not _known_eq(dst_rows, src_inner):
                     return False
     return True
 
@@ -423,13 +428,23 @@ def template_tload_gm_to_mat_nd2nz(src: pto.PartitionTensorView, dst: pto.Tile):
     gm_ptr = src.as_ptr()
     mat_ptr = dst.as_ptr()
 
+    # Element byte width (src and dst share dtype per the template dtypes table).
+    elem_bytes = pto.bytewidth(dst.element_type)
+
+    # rank-5 partition view metadata (g3 = M rows, g4 = K cols for ND source).
+    g0, g1, g2, g3, g4 = src.shape
+    s0, s1, s2, s3, s4 = src.strides
+
     # ND2NZ parameter calculation
     # n_value = M (row count), d_value = K (column count)
     n_value = m
     d_value = k
 
-    # src_layout: inner stride = K (number of elements per row)
-    src_inner_stride = k
+    # src_layout: inner stride in BYTES = src physical row stride (s3).
+    # Hardware loop1_src_stride is in bytes (pto-isa a5/TLoad.hpp:
+    # GetByteSize<DType>(gStride3)); a strided GM slice has s3 != K, so the
+    # element stride must be scaled by elem_bytes.
+    src_inner_stride = s3 * elem_bytes
 
     # dst_group: (group_count, loop2_stride, loop3_stride, loop4_stride)
     # For simple single-block case: (1, 1, m, 0)
@@ -478,6 +493,13 @@ def template_tload_gm_to_mat_dn2nz(src: pto.PartitionTensorView, dst: pto.Tile):
     gm_ptr = src.as_ptr()
     mat_ptr = dst.as_ptr()
 
+    # Element byte width (src and dst share dtype per the template dtypes table).
+    elem_bytes = pto.bytewidth(dst.element_type)
+
+    # rank-5 partition view metadata (g3 = K, g4 = M for DN col-major source).
+    g0, g1, g2, g3, g4 = src.shape
+    s0, s1, s2, s3, s4 = src.strides
+
     # DN2NZ parameter calculation
     # For DN format, the original shape is (K, M) -- no logical conversion
     # needed. dn2nz writes the same logical N x D result into NZ layout.
@@ -485,8 +507,9 @@ def template_tload_gm_to_mat_dn2nz(src: pto.PartitionTensorView, dst: pto.Tile):
     n_value = k
     d_value = m
 
-    # src_layout: inner stride = M (number of elements per column)
-    src_inner_stride = m
+    # src_layout: inner stride in BYTES = src physical stride along the M
+    # direction (s4). pto-isa TLoadCubeND2NZ uses gStride4 when layout == DN.
+    src_inner_stride = s4 * elem_bytes
 
     # dst_group: (group_count, loop2_stride, loop3_stride, loop4_stride)
     # (1, 1, k, 0)

--- a/lib/TileOps/tstore_template.py
+++ b/lib/TileOps/tstore_template.py
@@ -414,10 +414,20 @@ def template_tstore_acc_to_gm_nz2nd(src: pto.Tile, dst: pto.PartitionTensorView)
     acc_ptr = src.as_ptr()
     gm_ptr = dst.as_ptr()
 
-    # src_stride: ACC buffer stride (N under NZ format)
-    # dst_stride: GM stride (N under ND format)
-    src_stride = n
-    dst_stride = n
+    # rank-5 partition view metadata (ND: g3 = M rows, g4 = N cols).
+    g0, g1, g2, g3, g4 = dst.shape
+    s0, s1, s2, s3, s4 = dst.strides
+
+    # Strides are in ELEMENT units (pto-isa a5/TStore.hpp: TStoreAccND passes
+    # srcStride/dstD to copy_matrix_cc_to_gm without GetByteSize; the hardware
+    # scales by dtype internally). The earlier `src_stride = dst_stride = n`
+    # filled both fields with the tile column count, which is wrong for any
+    # strided GM slice and produces sparse/shifted GM writes.
+    #
+    #   src_stride = TileData::Rows = src.shape[0]  (NZ row stride of L0C acc)
+    #   dst_stride = gStride3       = s3            (GM physical row stride)
+    src_stride = src.shape[0]
+    dst_stride = s3
 
     pto.mte_l0c_gm(
         acc_ptr, gm_ptr,
@@ -459,10 +469,18 @@ def template_tstore_acc_to_gm_nz2dn(src: pto.Tile, dst: pto.PartitionTensorView)
     acc_ptr = src.as_ptr()
     gm_ptr = dst.as_ptr()
 
-    # NZ2DN requires an additional loop0_src_stride parameter
-    src_stride = n
-    dst_stride = m  # Under DN format, stride is M
-    loop0_src_stride = 1  # loop0_src_stride for NZ2DN
+    # rank-5 partition view metadata (DN: g3 = M, g4 = N, col-major).
+    g0, g1, g2, g3, g4 = dst.shape
+    s0, s1, s2, s3, s4 = dst.strides
+
+    # Strides are in ELEMENT units (see template_tstore_acc_to_gm_nz2nd).
+    # DN (col-major): adjacent rows step along the M direction, whose physical
+    # stride is s4 (PTOAS 5D DN view strides collapse to [M, M, M, 1, M]).
+    #   src_stride = TileData::Rows = src.shape[0]  (NZ row stride of L0C acc)
+    #   dst_stride = s4                             (GM physical stride along M)
+    src_stride = src.shape[0]
+    dst_stride = s4
+    loop0_src_stride = 1  # loop0_src_stride for NZ2DN (NZ source)
 
     pto.mte_l0c_gm(
         acc_ptr, gm_ptr,
@@ -503,7 +521,17 @@ def template_tstore_acc_to_gm_nz2nz(src: pto.Tile, dst: pto.PartitionTensorView)
     acc_ptr = src.as_ptr()
     gm_ptr = dst.as_ptr()
 
-    src_stride = n
+    # src_stride is in ELEMENT units (pto-isa a5/TStore.hpp: TStoreAccNZ sets
+    # srcStride = TileData::Rows). The earlier `src_stride = n` filled the L0C
+    # source stride with the column count, which is wrong whenever N differs
+    # from the acc tile row count.
+    #   src_stride = TileData::Rows = src.shape[0]  (NZ row stride of L0C acc)
+    # NOTE: dst_stride for NZ2NZ is the NZ-fractal physical row stride
+    # (ceil(M, FRACTAL_NZ_ROW) * c0 in pto-isa TStoreAccNZ). The compact NZ
+    # views used today set this equal to n, so the legacy value is retained
+    # until a strided NZ destination case is exercised to validate the exact
+    # stride index.
+    src_stride = src.shape[0]
     dst_stride = n
     split = 1  # NZ2NZ requires a split parameter
 
@@ -616,8 +644,13 @@ def template_tstore_fp_acc_to_gm(src: pto.Tile, fp: pto.Tile, dst: pto.Partition
 
     # TODO: Replace with tstore_fp DSL surface once available.
     # Currently using mte_l0c_gm + pre_quant as a temporary workaround.
-    src_stride = n
-    dst_stride = n
+    # Strides are in ELEMENT units (see template_tstore_acc_to_gm_nz2nd).
+    #   src_stride = TileData::Rows = src.shape[0]  (NZ row stride of L0C acc)
+    #   dst_stride = gStride3       = s3            (GM physical row stride, ND)
+    g0, g1, g2, g3, g4 = dst.shape
+    s0, s1, s2, s3, s4 = dst.strides
+    src_stride = src.shape[0]
+    dst_stride = s3
 
     pto.mte_l0c_gm(
         acc_ptr, gm_ptr,

--- a/ptodsl/ptodsl/tilelib/templates/a5/_load_store.py
+++ b/ptodsl/ptodsl/tilelib/templates/a5/_load_store.py
@@ -219,24 +219,28 @@ def tstore_nz_constraint(src_kind, src_shape, src_valid_shape, src_memory_space,
     )
 
 
-def tload_mat_nd2nz_constraint(src_kind, src_shape, src_memory_space, dst_kind, dst_valid_shape, dst_memory_space, dst_config, dst_dtype, **_):
+def tload_mat_nd2nz_constraint(src_kind, src_shape, src_memory_space, dst_kind, dst_shape, dst_memory_space, dst_config, dst_dtype, **_):
     if src_kind != "view" or dst_kind != "tile" or src_memory_space != "gm" or dst_memory_space != "mat":
         return False
     if dst_config.b_layout != "col_major" or dst_config.s_layout != "row_major":
         return False
     if dst_dtype not in {"f16", "bf16", "f32"}:
         return False
-    return _view_rank(src_shape) != 5 or _known_eq(src_shape[4], dst_valid_shape[1])
+    if _view_rank(src_shape) != 5:
+        return False
+    return _known_eq(src_shape[4], dst_shape[1])
 
 
-def tload_mat_dn2nz_constraint(src_kind, src_shape, src_memory_space, dst_kind, dst_valid_shape, dst_memory_space, dst_config, dst_dtype, **_):
+def tload_mat_dn2nz_constraint(src_kind, src_shape, src_memory_space, dst_kind, dst_shape, dst_memory_space, dst_config, dst_dtype, **_):
     if src_kind != "view" or dst_kind != "tile" or src_memory_space != "gm" or dst_memory_space != "mat":
         return False
     if dst_config.b_layout != "col_major" or dst_config.s_layout != "row_major":
         return False
     if dst_dtype not in {"f16", "bf16", "f32"}:
         return False
-    return _view_rank(src_shape) != 5 or _known_eq(src_shape[4], dst_valid_shape[0])
+    if _view_rank(src_shape) != 5:
+        return False
+    return _known_eq(src_shape[4], dst_shape[0])
 
 
 def tstore_acc_base(src_kind, src_memory_space, src_dtype, dst_kind, dst_memory_space, **_):

--- a/ptodsl/ptodsl/tilelib/templates/a5/tload.py
+++ b/ptodsl/ptodsl/tilelib/templates/a5/tload.py
@@ -231,12 +231,17 @@ def template_tload_nz2nz(src: pto.PartitionTensorView, dst: pto.Tile):
 )
 def template_tload_gm_to_mat_nd2nz(src: pto.PartitionTensorView, dst: pto.Tile):
     m, k = dst.valid_shape
+    elem_bytes = pto.bytewidth(dst.dtype)
+    src_inner_stride = k * elem_bytes
+    if len(src.shape) == 5 and src.strides is not None and src.strides[3] is not None:
+        src_inner_stride = src.strides[3] * elem_bytes
+
     pto.mte_gm_l1_frac(
         src.as_ptr(),
         dst.as_ptr(),
         "nd2nz",
         shape=(m, k),
-        src_layout=(k,),
+        src_layout=(src_inner_stride,),
         dst_group=(1, 1, m, 0),
         ctrl=(0, False),
     )
@@ -258,12 +263,17 @@ def template_tload_gm_to_mat_nd2nz(src: pto.PartitionTensorView, dst: pto.Tile):
 )
 def template_tload_gm_to_mat_dn2nz(src: pto.PartitionTensorView, dst: pto.Tile):
     m, k = dst.valid_shape
+    elem_bytes = pto.bytewidth(dst.dtype)
+    src_inner_stride = m * elem_bytes
+    if len(src.shape) == 5 and src.strides is not None and src.strides[4] is not None:
+        src_inner_stride = src.strides[4] * elem_bytes
+
     pto.mte_gm_l1_frac(
         src.as_ptr(),
         dst.as_ptr(),
         "dn2nz",
         shape=(k, m),
-        src_layout=(m,),
+        src_layout=(src_inner_stride,),
         dst_group=(1, 1, k, 0),
         ctrl=(0, False),
     )

--- a/ptodsl/ptodsl/tilelib/templates/a5/tstore.py
+++ b/ptodsl/ptodsl/tilelib/templates/a5/tstore.py
@@ -206,13 +206,17 @@ def template_tstore_nz(src: pto.Tile, dst: pto.PartitionTensorView):
 )
 def template_tstore_acc_to_gm_nz2nd(src: pto.Tile, dst: pto.PartitionTensorView):
     m, n = src.valid_shape
+    strides = dst.strides
+    src_stride = src.shape[0]
+    dst_stride = n if strides is None or strides[3] is None else strides[3]
+
     pto.mte_l0c_gm(
         src.as_ptr(),
         dst.as_ptr(),
         m,
         n,
-        n,
-        n,
+        src_stride,
+        dst_stride,
         0,
         0,
         layout="nz2nd",
@@ -236,16 +240,21 @@ def template_tstore_acc_to_gm_nz2nd(src: pto.Tile, dst: pto.PartitionTensorView)
 )
 def template_tstore_acc_to_gm_nz2dn(src: pto.Tile, dst: pto.PartitionTensorView):
     m, n = src.valid_shape
+    strides = dst.strides
+    src_stride = src.shape[0]
+    dst_stride = m if strides is None or strides[4] is None else strides[4]
+    loop0_src_stride = 1
+
     pto.mte_l0c_gm(
         src.as_ptr(),
         dst.as_ptr(),
         m,
         n,
-        n,
-        m,
+        src_stride,
+        dst_stride,
         0,
         0,
-        layout=("nz2dn", 1),
+        layout=("nz2dn", loop0_src_stride),
     )
 
 
@@ -266,13 +275,16 @@ def template_tstore_acc_to_gm_nz2dn(src: pto.Tile, dst: pto.PartitionTensorView)
 )
 def template_tstore_acc_to_gm_nz2nz(src: pto.Tile, dst: pto.PartitionTensorView):
     m, n = src.valid_shape
+    src_stride = src.shape[0]
+    dst_stride = n
+
     pto.mte_l0c_gm(
         src.as_ptr(),
         dst.as_ptr(),
         m,
         n,
-        n,
-        n,
+        src_stride,
+        dst_stride,
         0,
         0,
         layout=("nz2nz", 1),
@@ -295,14 +307,18 @@ def template_tstore_acc_to_gm_nz2nz(src: pto.Tile, dst: pto.PartitionTensorView)
 )
 def template_tstore_fp_acc_to_gm(src: pto.Tile, fp: pto.Tile, dst: pto.PartitionTensorView):
     m, n = src.valid_shape
+    strides = dst.strides
     quant_mode = "qf322bf16_pre_vec" if str(fp.dtype) == "bf16" else "qf322f16_pre_vec"
+    src_stride = src.shape[0]
+    dst_stride = n if strides is None or strides[3] is None else strides[3]
+
     pto.mte_l0c_gm(
         src.as_ptr(),
         dst.as_ptr(),
         m,
         n,
-        n,
-        n,
+        src_stride,
+        dst_stride,
         0,
         0,
         layout="nz2nd",


### PR DESCRIPTION
## Summary

修复 issue #903 在 vpto 后端暴露的 TileOps stride / 约束缺陷，共三处改动，均在 `lib/TileOps/`：

- **`tload` nd2nz/dn2nz `src_inner_stride` 改为源物理 stride × 字节宽**（`tload_template.py`）
  - 修复前：`src_inner_stride = k` / `m`（dst 列/行数，元素单位）
  - 修复后：`src_inner_stride = s3 * elem_bytes`（ND）/ `s4 * elem_bytes`（DN），与 `ND2ND` 模板写法对齐
  - 依据：pto-isa `a5/TLoad.hpp` 的 `loop1_src_stride = GetByteSize<DType>(gStride)` 为字节单位
  - 约束函数改用静态 `dst.shape` 替代动态 `dst.valid_shape` 做模板消歧，避免 `valid_shape` 为 `[null, null]` 时 ND2NZ/DN2NZ 同时匹配

- **`tstore` acc2gm `src_stride`/`dst_stride` 改用 tile 行数与 GM 物理 stride**（`tstore_template.py`）
  - 修复前：`src_stride = dst_stride = n`（tile 列数）
  - 修复后：`src_stride = src.shape[0]`（= `TileData::Rows`，L0C acc NZ 行 stride），`dst_stride = s3`（ND）/ `s4`（DN）（GM 物理行 stride）
  - 单位为元素（pto-isa `a5/TStore.hpp` 的 `TStoreAccND` 把 `srcStride`/`dstD` 透传给 `copy_matrix_cc_to_gm`，不乘 `GetByteSize`，硬件内部按 dtype 转字节）
  - 覆盖 `nz2nd` / `nz2dn` / `nz2nz`（仅 src）/ `fp_acc_to_gm` 四个模板

- **tload 约束严格拒绝非 rank-5 源**（`tload_template.py`，回应 gemini code review）
  - 修复前：`if hasattr(src, 'rank') and src.rank == 5:` 非 5D 时跳过 shape 检查并返回 `True`，导致非 5D 张量匹配约束后在模板 `g0..g4 = src.shape` 处抛 `ValueError`
  - 修复后：`if not (hasattr(src, 'rank') and src.rank == 5): return False`，在约束阶段即拒绝

## Repro

- issue: #903
- 现象：vpto 后端 `qwen3_decode_incore_2.pto` 第一条 `pto.tload`（16×128 bf16，mat）生成的 `MOV_OUT_TO_L1_MULTI_ND2NZ` 指令被发射但永不 retire，紧跟 `BAR` 永久等待，整机死锁；真机报 `errcode 168 / L0C out of range`
- 根因：原 `src_inner_stride = k`（元素单位 + dst 列数），硬件按错误步进读 GM（应 16384 B/行，实按 128 B）
- repro cmd:
  ```bash
  ptoas --pto-arch=a5 --pto-backend=vpto --enable-tile-op-expand --enable-insert-sync \
    test_for_ptoas_incore2/qwen3_decode_incore_2.pto -o /tmp/qwen3.ll
  ```

## Validation

- `cmake --build build --target check-pto`：785 lit 用例全过
- `cube_tile_ops_positive.pto`（src 无显式 layout）未回归
- CAModel（qwen3_decode_incore_2，vpto）：tload `nd2nz` 正常 retire；tstore IR config `dstD=1024` / `srcStride=16` 与 emitc 字段一致；cube pipeline 从第一条 tload 死锁推进到 matmul/sync 阶段
- 非 5D 源现在在约束阶段被拒绝，不再进模板 unpack

close #903
