### PR TITLE
Allow alloc_buffer outside SIMT scopes

### DIFF
--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -365,7 +365,7 @@ scalar.store(y4, ptr, offset)
 
 ## 4.10 Explicit scratch buffers
 
-A scratch buffer is a lane-local temporary buffer inside SIMT code. Allocate scratch buffers with `pto.alloc_buffer`:
+A scratch buffer is a local temporary buffer inside an explicit kernel or helper body. Allocate scratch buffers with `pto.alloc_buffer`. A buffer allocated outside dimensioned inline SIMT scopes, or passed to SIMT helpers, can be accessed by those scopes or helpers in the enclosing explicit body:
 
 ```text
 pto.alloc_buffer(shape, dtype)

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -87,6 +87,7 @@ from mlir.ir import (
     Operation,
     Type,
     TypeAttr,
+    UnitAttr,
 )
 
 # Pipe name shorthands → canonical PIPE_* names
@@ -2394,13 +2395,16 @@ def _alloc_local_buffer(shape, dtype, element_type, element_count, byte_size):
     i32 = IntegerType.get_signless(32)
     count = _materialize_integer_literal(i32, element_count)
     llvm_ptr_type = Type.parse("!llvm.ptr")
+    attributes = {
+        "elem_type": TypeAttr.get(element_type),
+    }
+    if _is_outside_simt_subkernel():
+        attributes["pto.persistent"] = UnitAttr.get()
     alloca = Operation.create(
         "llvm.alloca",
         results=[llvm_ptr_type],
         operands=[count],
-        attributes={
-            "elem_type": TypeAttr.get(element_type),
-        },
+        attributes=attributes,
     ).results[0]
     return AllocatedBufferValue(
         alloca,
@@ -2410,6 +2414,16 @@ def _alloc_local_buffer(shape, dtype, element_type, element_count, byte_size):
         element_count=element_count,
         byte_size=byte_size,
     )
+
+
+def _is_outside_simt_subkernel() -> bool:
+    try:
+        from ._tracing.active import current_session
+        session = current_session()
+    except Exception:
+        session = None
+    frame = session.current_subkernel if session is not None else None
+    return frame is None or frame.role != "simt"
 
 
 def _normalize_alloc_buffer_shape_metadata(shape):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -2337,21 +2337,20 @@ def _tile_transfer_partition(tv, tile, *, offsets=None, sizes=None, context: str
 
 def alloc_buffer(shape, dtype, **kwargs):
     """
-    Allocate SIMT lane-local scratch storage and return an address-like value.
+    Allocate explicit-body scratch storage and return an address-like value.
 
-    The allocation emits an LLVM stack allocation in the surrounding SIMT
-    helper. UB scratch uses explicit ``pto.castptr`` / ``pto.addptr`` pointer
-    authoring and an appropriate host launch wrapper.
+    The allocation emits an LLVM stack allocation in the surrounding explicit
+    kernel or helper body. UB scratch uses explicit ``pto.castptr`` /
+    ``pto.addptr`` pointer authoring and an appropriate host launch wrapper.
     """
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(
             f"pto.alloc_buffer(...) does not accept keyword argument(s): {unexpected}. "
-            "It only allocates SIMT local buffers; author UB scratch explicitly with "
+            "It only allocates explicit-body local buffers; author UB scratch explicitly with "
             "pto.castptr/pto.addptr and pass the dynamic UB byte count at launch."
         )
     _require_explicit_mode("pto.alloc_buffer(...)")
-    _require_simt_subkernel("pto.alloc_buffer(...)")
     element_type = _resolve(dtype)
     element_count = _static_alloc_buffer_element_count(shape)
     elem_bytes = _element_bytewidth(element_type)

--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -623,6 +623,8 @@ def wrap_like_surface_value(template, value):
                 for dim in valid_shape
             )
         return TileValue(value, **metadata)
+    if isinstance(template, AllocatedBufferValue):
+        return AllocatedBufferValue(value, **template.surface_metadata)
     if isinstance(template, AddressValue):
         return AddressValue(value)
     return wrap_surface_value(value)

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4352,6 +4352,10 @@ def main() -> None:
         "alloc_buffer should lower to an LLVM stack allocation in the SIMT helper",
     )
     expect(
+        "pto.persistent" not in alloc_buffer_local_text,
+        "alloc_buffer inside a SIMT helper should remain section-local",
+    )
+    expect(
         re.search(
             r"func\.func @alloc_buffer_local_helper__simt_\d+\(\) attributes \{pto\.simt_entry\}",
             alloc_buffer_local_text,
@@ -4361,6 +4365,10 @@ def main() -> None:
     )
     alloc_buffer_top_level_text = alloc_buffer_outside_simt_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(alloc_buffer_top_level_text, "alloc_buffer top-level specialization")
+    expect(
+        "llvm.alloca" in alloc_buffer_top_level_text and "pto.persistent" in alloc_buffer_top_level_text,
+        "alloc_buffer outside a SIMT helper should be marked as a persistent fragment candidate",
+    )
     rmsnorm_alloc_buffer_text = rmsnorm_alloc_buffer_layout_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(rmsnorm_alloc_buffer_text, "RMSNorm hand-authored UB layout specialization")
     for expected_offset in (4096, 4224, 12416, 20608):

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4359,11 +4359,8 @@ def main() -> None:
         is not None,
         "alloc_buffer probe should keep allocation inside the SIMT helper body",
     )
-    expect_raises(
-        RuntimeError,
-        alloc_buffer_outside_simt_probe.compile,
-        "pto.alloc_buffer(...) may only be used inside a @pto.simt helper or inline pto.simt() scope",
-    )
+    alloc_buffer_top_level_text = alloc_buffer_outside_simt_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(alloc_buffer_top_level_text, "alloc_buffer top-level specialization")
     rmsnorm_alloc_buffer_text = rmsnorm_alloc_buffer_layout_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(rmsnorm_alloc_buffer_text, "RMSNorm hand-authored UB layout specialization")
     for expected_offset in (4096, 4224, 12416, 20608):


### PR DESCRIPTION
允许alloc_buffer声明于simt外，即视为跨simt的buffer
非simt内部打上驻存标签

参考 https://github.com/KurrinQu/PTOAS/blob/qkl/ptoas-persistent-simt-fragment-design/docs/designs/ptoas_persistent_simt_fragment_plan.md