### PR TITLE
fix: TMOV mat→scaling uses PIPE_FIX for A3 fixpipe quant

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1465,11 +1465,19 @@ def TMovOp  : PTO_TOp<"tmov", [
         return ::mlir::pto::PIPE::PIPE_V;
       }
 
-      // MAT -> L0 (Left/Right/Bias/Scaling) are MTE1 moves.
+      // MAT -> L0A/L0B/Bias follow TMOV_M2L/M2R/M2B and run on MTE1.
       if ((s == ::mlir::pto::AddressSpace::MAT &&
            (d == ::mlir::pto::AddressSpace::LEFT || d == ::mlir::pto::AddressSpace::RIGHT ||
-            d == ::mlir::pto::AddressSpace::BIAS || d == ::mlir::pto::AddressSpace::SCALING))) {
+            d == ::mlir::pto::AddressSpace::BIAS))) {
         return ::mlir::pto::PIPE::PIPE_MTE1;
+      }
+
+      // MAT -> Scaling is TMOV_M2S / copy_cbuf_to_fbuf and must use PIPE_FIX.
+      // Classifying it as MTE1 drops the MTE2->FIX wait before FBUF is ready
+      // and races with later FIX consumers (SET_QUANT_VECTOR + fixpipe TPUSH).
+      if (s == ::mlir::pto::AddressSpace::MAT &&
+          d == ::mlir::pto::AddressSpace::SCALING) {
+        return ::mlir::pto::PIPE::PIPE_FIX;
       }
 
       // ACC -> MAT / VEC use FIX in PTO-ISA sync mapping (TMOV_A2M/TMOV_A2V).

--- a/test/lit/pto/tmov_mat_scaling_pipe_selection.pto
+++ b/test/lit/pto/tmov_mat_scaling_pipe_selection.pto
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// RUN: ptoas --pto-arch a3 --enable-insert-sync %s | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s --check-prefix=A5
+
+module {
+  // TMOV mat->scaling maps to TMOV_M2S / copy_cbuf_to_fbuf and must be treated
+  // as PIPE_FIX so InsertSync emits MTE2->FIX around the FBUF fill. Treating it
+  // as MTE1 races with later fixpipe consumers (SET_QUANT_VECTOR + TPUSH).
+  func.func @tmov_mat_scaling_sync(%in: memref<1x16xui64, #pto.address_space<gm>>) {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%in : memref<1x16xui64, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmov ins(%src : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A3-LABEL: AICORE void tmov_mat_scaling_sync(
+// A3: set_flag(PIPE_MTE2, PIPE_FIX,
+// A3: wait_flag(PIPE_MTE2, PIPE_FIX,
+// A3-NOT: set_flag(PIPE_MTE2, PIPE_MTE1,
+// A3: TMOV(
+
+// A5-LABEL: AICORE void tmov_mat_scaling_sync(
+// A5: set_flag(PIPE_MTE2, PIPE_FIX,
+// A5: wait_flag(PIPE_MTE2, PIPE_FIX,
+// A5-NOT: set_flag(PIPE_MTE2, PIPE_MTE1,
+// A5: TMOV(

--- a/test/lit/pto/tmov_mat_scaling_pipe_selection_gss.pto
+++ b/test/lit/pto/tmov_mat_scaling_pipe_selection_gss.pto
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// RUN: ptoas --pto-arch a3 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s --check-prefix=A3
+// RUN: ptoas --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s --check-prefix=A5
+
+module {
+  // GraphSyncSolver path: mat->scaling must still be PIPE_FIX / TMOV_M2S.
+  func.func @tmov_mat_scaling_sync(%in: memref<1x16xui64, #pto.address_space<gm>>) {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%in : memref<1x16xui64, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmov ins(%src : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// A3-LABEL: AICORE void tmov_mat_scaling_sync(
+// A3: set_flag(PIPE_MTE2, PIPE_FIX,
+// A3: wait_flag(PIPE_MTE2, PIPE_FIX,
+// A3-NOT: set_flag(PIPE_MTE2, PIPE_MTE1,
+// A3: TMOV(
+
+// A5-LABEL: AICORE void tmov_mat_scaling_sync(
+// A5: set_flag(PIPE_MTE2, PIPE_FIX,
+// A5: wait_flag(PIPE_MTE2, PIPE_FIX,
+// A5-NOT: set_flag(PIPE_MTE2, PIPE_MTE1,
+// A5: TMOV(


### PR DESCRIPTION
## Summary

Fixes the post-#883 A3 board failure on `movfp_fixpipe_reuse_a3` (golden ~±120 vs out ~0).

Root cause: `TMovOp::getPipe()` classified **mat→scaling** as `PIPE_MTE1` together with left/right/bias. In pto-isa this path is **`TMOV_M2S` / `copy_cbuf_to_fbuf` → `PIPE_FIX`**. With InsertSync (board default), the wrong pipe:

1. Emitted `MTE2→MTE1` waits instead of **`MTE2→FIX`** before FBUF fill
2. Raced with later **FIX** consumers (`SET_QUANT_VECTOR` + fixpipe `TPUSH` / `VDEQF16`)
3. Produced near-zero dequant outputs (all three outs wrong; out0/out2 identical)

## Change

- Split `AddressSpace::SCALING` out of the mat→L0 MTE1 bucket; return `PIPE_FIX`
- Add lit tests for insert-sync and graph-sync-solver on a3/a5 checking `MTE2→FIX` around mat→scaling `TMOV`

## Verification

Locally (rebuilt `ptoas`):

- FileCheck: `tmov_mat_scaling_pipe_selection{,_gss}.pto` a3/a5 **PASS**
- `movfp_fixpipe_reuse_a3-pto.pto` with `--enable-insert-sync` now generates:

```text
TLOAD(quant)
set_flag(PIPE_MTE2, PIPE_FIX, ...)
wait_flag(PIPE_MTE2, PIPE_FIX, ...)
TMOV(scaling, mat)   // was wrongly gated as MTE1
...
TMATMUL
set_flag(PIPE_M, PIPE_FIX, ...)
wait_flag(PIPE_M, PIPE_FIX, ...)
SET_QUANT_VECTOR
TPUSH(...VDEQF16...)
```

## Board follow-up

Please re-run:

```text
/run a3 movfp_fixpipe_reuse_a3
```

## Test plan

- [x] Local lit FileCheck for new pipe-selection tests (a3/a5, insert-sync + GSS)
- [x] Local codegen inspect of `movfp_fixpipe_reuse_a3` with `--enable-insert-sync`
- [ ] CI lit / unit
- [ ] A3 board: `movfp_fixpipe_reuse_a3`
- [ ] Optional smoke: A5 `movfp_fixpipe_reuse` (should be unchanged / still green)