### PR TITLE
inline SIMT & persistent dsl前端实现

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1733,6 +1733,26 @@ class PTO_SectionOp<string mnemonic>
 def SectionCubeOp : PTO_SectionOp<"section.cube">;
 def SectionVectorOp : PTO_SectionOp<"section.vector">;
 
+def SectionSimtOp : PTO_Op<"section.simt", [SingleBlock, NoTerminator]> {
+  let summary = "Container for inline SIMT code";
+  let description = [{
+    `pto.section.simt` keeps an inline SIMT body in the enclosing kernel
+    function until downstream PTOAS lowering consumes it.  It is a
+    source-level carrier for transformations that need to observe the lexical
+    relationship between surrounding code and SIMT regions.
+
+    The textual launch dimension order matches `pto.simt_launch`:
+    `<<<dimX, dimY, dimZ>>>`.
+  }];
+  let arguments = (ins I32:$dimX, I32:$dimY, I32:$dimZ);
+  let regions = (region SizedRegion<1>:$body);
+  let assemblyFormat = [{
+    `<` `<` `<` $dimX `,` $dimY `,` $dimZ `>` `>` `>` $body attr-dict
+    `:` type($dimX) `,` type($dimY) `,` type($dimZ)
+  }];
+  let hasVerifier = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Tile Fusion Region Ops
 //===----------------------------------------------------------------------===//

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1741,14 +1741,14 @@ def SectionSimtOp : PTO_Op<"section.simt", [SingleBlock, NoTerminator]> {
     source-level carrier for transformations that need to observe the lexical
     relationship between surrounding code and SIMT regions.
 
-    The textual launch dimension order matches `pto.simt_launch`:
+    Launch dimensions are explicit static i32 attributes.  The textual launch
+    dimension order matches `pto.simt_launch`:
     `<<<dimX, dimY, dimZ>>>`.
   }];
-  let arguments = (ins I32:$dimX, I32:$dimY, I32:$dimZ);
+  let arguments = (ins I32Attr:$dimX, I32Attr:$dimY, I32Attr:$dimZ);
   let regions = (region SizedRegion<1>:$body);
   let assemblyFormat = [{
     `<` `<` `<` $dimX `,` $dimY `,` $dimZ `>` `>` `>` $body attr-dict
-    `:` type($dimX) `,` type($dimY) `,` type($dimZ)
   }];
   let hasVerifier = 1;
 }

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2345,6 +2345,25 @@ static std::optional<int64_t> getConstantIntegerValue(Value value) {
   return std::nullopt;
 }
 
+LogicalResult mlir::pto::SectionSimtOp::verify() {
+  func::FuncOp func = getOperation()->getParentOfType<func::FuncOp>();
+  if (!func)
+    return emitOpError("must be nested under a func.func");
+
+  if (func->hasAttr(pto::kPTOSimtEntryAttrName))
+    return emitOpError("must not appear inside a function marked with '")
+           << pto::kPTOSimtEntryAttrName << "'";
+
+  WalkResult nested = getBody().walk([&](SectionSimtOp nestedOp) {
+    nestedOp.emitOpError("nested pto.section.simt is not allowed");
+    return WalkResult::interrupt();
+  });
+  if (nested.wasInterrupted())
+    return failure();
+
+  return success();
+}
+
 LogicalResult mlir::pto::FusionRegionOp::verify() {
   Region &bodyRegion = getBody();
   if (bodyRegion.empty())
@@ -17691,24 +17710,30 @@ static bool isSupportedSimtKeepResumeType(Type type) {
   return type.isF16() || type.isBF16() || type.isF32();
 }
 
-static LogicalResult verifyInsideSimtEntry(Operation *op) {
+static bool isInsideSimtExecutionScope(Operation *op) {
   func::FuncOp func = getParentFunc(op);
-  if (!func || !func->hasAttr(pto::kPTOSimtEntryAttrName))
+  return (func && func->hasAttr(pto::kPTOSimtEntryAttrName)) ||
+         op->getParentOfType<pto::SectionSimtOp>();
+}
+
+static LogicalResult verifyInsideSimtExecutionScope(Operation *op) {
+  if (!isInsideSimtExecutionScope(op))
     return op->emitOpError("must appear inside a function marked with '")
-           << pto::kPTOSimtEntryAttrName << "'";
+           << pto::kPTOSimtEntryAttrName
+           << "' or inside pto.section.simt";
   return success();
 }
 
 LogicalResult SyncthreadsOp::verify() {
-  return verifyInsideSimtEntry(getOperation());
+  return verifyInsideSimtExecutionScope(getOperation());
 }
 
 LogicalResult ThreadfenceOp::verify() {
-  return verifyInsideSimtEntry(getOperation());
+  return verifyInsideSimtExecutionScope(getOperation());
 }
 
 LogicalResult ThreadfenceBlockOp::verify() {
-  return verifyInsideSimtEntry(getOperation());
+  return verifyInsideSimtExecutionScope(getOperation());
 }
 
 void SyncthreadsOp::getEffects(

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2350,8 +2350,8 @@ LogicalResult mlir::pto::SectionSimtOp::verify() {
   if (!func)
     return emitOpError("must be nested under a func.func");
 
-  if (getDimX().getInt() < 0 || getDimY().getInt() < 0 ||
-      getDimZ().getInt() < 0)
+  if (getDimXAttr().getInt() < 0 || getDimYAttr().getInt() < 0 ||
+      getDimZAttr().getInt() < 0)
     return emitOpError("requires non-negative i32 launch dimensions");
 
   if (func->hasAttr(pto::kPTOSimtEntryAttrName))

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -2350,6 +2350,10 @@ LogicalResult mlir::pto::SectionSimtOp::verify() {
   if (!func)
     return emitOpError("must be nested under a func.func");
 
+  if (getDimX().getInt() < 0 || getDimY().getInt() < 0 ||
+      getDimZ().getInt() < 0)
+    return emitOpError("requires non-negative i32 launch dimensions");
+
   if (func->hasAttr(pto::kPTOSimtEntryAttrName))
     return emitOpError("must not appear inside a function marked with '")
            << pto::kPTOSimtEntryAttrName << "'";

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -272,9 +272,10 @@ static bool isVector2F16OrBF16Type(Type type) {
   });
 }
 
-static bool isInsideSimtEntry(Operation *op) {
+static bool isInsideSimtExecutionScope(Operation *op) {
   auto funcOp = op->getParentOfType<func::FuncOp>();
-  return funcOp && funcOp->hasAttr(pto::kPTOSimtEntryAttrName);
+  return (funcOp && funcOp->hasAttr(pto::kPTOSimtEntryAttrName)) ||
+         op->getParentOfType<pto::SectionSimtOp>();
 }
 
 static bool isSupportedConvertType(Type type) {
@@ -505,10 +506,10 @@ static LogicalResult verifyAtomicCommon(Operation *op, Value ptr, Type valueType
     return op->emitOpError()
            << "does not accept signedness for floating-point atomics";
   if (isVector2F16OrBF16Type(valueType)) {
-    if (!isInsideSimtEntry(op))
+    if (!isInsideSimtExecutionScope(op))
       return op->emitOpError()
              << "requires packed atomics to be inside a pto.simt_entry "
-                "function on beta.1";
+                "function or pto.section.simt on beta.1";
     if (!op->getResult(0).use_empty())
       return op->emitOpError()
              << "does not support using the old value result for packed "

--- a/ptodsl/docs/user_guide/01-introduction.md
+++ b/ptodsl/docs/user_guide/01-introduction.md
@@ -262,7 +262,9 @@ These are reusable hardware-bound compute helpers:
 - **`@pto.simt`** is a scalar-programmable processor group that executes scalar instructions across many work-items in parallel. Typical operations: `lds`, `sts`, scalar arithmetic and comparison. Well-suited for per-element tile walks, boundary metadata, and pointwise blends.
 
 Named helpers use `@pto.tileop` or `@pto.simt`. One-off unit scopes use
-`with pto.tileop():` or `with pto.simt(...):`.
+`with pto.tileop():`, `with pto.simt():`, or
+`with pto.simt(dim_x, dim_y, dim_z):`; inline SIMT dimensions must be Python
+integers known at trace time.
 
 The boundary contract is strict: transient compute values do not escape, and
 data crosses helper boundaries only through Tiles, permitted scalars, or the

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -1120,6 +1120,12 @@ with pto.simt():
     scalar.store(o_next, o_next_tile[row, col])
 ```
 
+```python
+with pto.simt(128, 1, 1):
+    tid = pto.get_tid_x()
+    scalar.store(tid, scratch_ub, scalar.index_cast(tid))
+```
+
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"kernel_entry.inline_cube_scope","symbol":"kernel_entry_inline_cube_scope_probe","compile":{"BLOCK_M":16,"BLOCK_K":16,"BLOCK_N":16}} -->
 ```python
 with pto.tileop():

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -1092,8 +1092,8 @@ TileOp and SIMT provide inline context manager forms: `with pto.tileop():`,
 `with pto.simt():`, and `with pto.simt(dim_x, dim_y, dim_z):`. These open
 one-off anonymous sub-kernel bodies without requiring a separate named Python
 function. Inline scopes are supported in top-level `@pto.jit` bodies. The
-dimensioned SIMT form uses the same inline body style while making the caller
-emit an explicit `pto.simt_launch`.
+dimensioned SIMT form remains in `pto.section.simt` with the authored launch
+dimensions.
 
 The examples below use `mode="auto"`. Inline TileOps use the same boundary
 contract in explicit callers, but explicit examples normally keep compute in
@@ -1120,12 +1120,6 @@ with pto.simt():
     scalar.store(o_next, o_next_tile[row, col])
 ```
 
-```python
-with pto.simt(128, 1, 1):
-    tid = pto.get_tid_x()
-    scalar.store(tid, scratch_ub, scalar.index_cast(tid))
-```
-
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"kernel_entry.inline_cube_scope","symbol":"kernel_entry_inline_cube_scope_probe","compile":{"BLOCK_M":16,"BLOCK_K":16,"BLOCK_N":16}} -->
 ```python
 with pto.tileop():
@@ -1144,11 +1138,10 @@ with pto.tileop():
   `mode="explicit"`. Explicit examples normally keep pure compute directly in
   the kernel body; use an inline scope when an anonymous helper boundary is
   intentional.
-- `with pto.simt():` preserves its scalar body inside one outlined
-  `pto.simt_entry` helper, and the caller emits `pto.store_vfsimt_info`.
-- `with pto.simt(dim_x, dim_y, dim_z):` uses the same inline outlining and
-  automatic capture rules, but emits a caller-side explicit SIMT launch with
-  the authored dimensions.
+- `with pto.simt():` remains in the enclosing kernel as `pto.section.simt`
+  with default launch dimensions `(1, 1, 1)`.
+- `with pto.simt(dim_x, dim_y, dim_z):` remains in the enclosing kernel as
+  `pto.section.simt` with the authored launch dimensions.
 - Inline TileOp captures obey the same ABI as `@pto.tileop`: only `pto.Tile`
   and PTO scalar values may cross into the helper. Pointer, TensorView, memref,
   vreg, and mask captures are rejected.
@@ -1157,8 +1150,6 @@ with pto.tileop():
 - Tile allocation, MTE, pipe synchronization, and other orchestration remain
   in the calling `@pto.jit` body. Cube-local scratch (`l0a`, `l0b`, `acc`) must
   be allocated by the caller before entering the block.
-- `with pto.simd():` and `with pto.cube():` are legacy interfaces and raise the
-  same migration diagnostic as `@pto.simd` and `@pto.cube`.
 
 ### Comparison
 

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -1092,8 +1092,8 @@ TileOp and SIMT provide inline context manager forms: `with pto.tileop():`,
 `with pto.simt():`, and `with pto.simt(dim_x, dim_y, dim_z):`. These open
 one-off anonymous sub-kernel bodies without requiring a separate named Python
 function. Inline scopes are supported in top-level `@pto.jit` bodies. The
-dimensioned SIMT form remains in `pto.section.simt` with the authored launch
-dimensions.
+dimensioned SIMT form remains in `pto.section.simt` with the authored static
+launch dimensions. The dimensions must be Python integers known at trace time.
 
 The examples below use `mode="auto"`. Inline TileOps use the same boundary
 contract in explicit callers, but explicit examples normally keep compute in
@@ -1147,7 +1147,8 @@ with pto.tileop():
 - `with pto.simt():` remains in the enclosing kernel as `pto.section.simt`
   with default launch dimensions `(1, 1, 1)`.
 - `with pto.simt(dim_x, dim_y, dim_z):` remains in the enclosing kernel as
-  `pto.section.simt` with the authored launch dimensions.
+  `pto.section.simt` with the authored launch dimensions. The dimensions must
+  be Python integers known at trace time.
 - Inline TileOp captures obey the same ABI as `@pto.tileop`: only `pto.Tile`
   and PTO scalar values may cross into the helper. Pointer, TensorView, memref,
   vreg, and mask captures are rejected.

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -365,7 +365,7 @@ scalar.store(y4, ptr, offset)
 
 ## 4.10 Explicit scratch buffers
 
-A scratch buffer is a local temporary buffer inside an explicit kernel or helper body. Allocate scratch buffers with `pto.alloc_buffer`. A buffer allocated outside dimensioned inline SIMT scopes, or passed to SIMT helpers, can be accessed by those scopes or helpers in the enclosing explicit body:
+A scratch buffer is a local temporary buffer inside an explicit kernel or helper body. Allocate scratch buffers with `pto.alloc_buffer`. A buffer allocated in the top-level explicit entry body can be used by an inline SIMT scope in the same lexical body, including both `with pto.simt():` and dimensioned `with pto.simt(x, y, z):` scopes. It cannot be used by other SIMT forms. SIMT helpers should allocate their own local scratch with `pto.alloc_buffer`, or receive ordinary typed pointers authored with `pto.castptr` / `pto.addptr`.
 
 ```text
 pto.alloc_buffer(shape, dtype)

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -365,7 +365,7 @@ scalar.store(y4, ptr, offset)
 
 ## 4.10 Explicit scratch buffers
 
-A scratch buffer is a lane-local temporary buffer inside SIMT code. Allocate scratch buffers with `pto.alloc_buffer`:
+A scratch buffer is a local temporary buffer inside an explicit kernel or helper body. Allocate scratch buffers with `pto.alloc_buffer`. A buffer allocated outside dimensioned inline SIMT scopes, or passed to SIMT helpers, can be accessed by those scopes or helpers in the enclosing explicit body:
 
 ```text
 pto.alloc_buffer(shape, dtype)

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -2698,7 +2698,7 @@ def _alloc_local_buffer(shape, dtype, element_type, element_count, byte_size):
     attributes = {
         "elem_type": TypeAttr.get(element_type),
     }
-    if _is_outside_simt_subkernel():
+    if _is_persistent_alloc_buffer_candidate():
         attributes["pto.persistent"] = UnitAttr.get()
     alloca = Operation.create(
         "llvm.alloca",
@@ -2716,14 +2716,19 @@ def _alloc_local_buffer(shape, dtype, element_type, element_count, byte_size):
     )
 
 
-def _is_outside_simt_subkernel() -> bool:
+def _is_persistent_alloc_buffer_candidate() -> bool:
     try:
         from ._tracing.active import current_session
         session = current_session()
     except Exception:
         session = None
-    frame = session.current_subkernel if session is not None else None
-    return frame is None or frame.role != "simt"
+    if session is None:
+        return False
+    if getattr(session.module_spec, "entry", False) is not True:
+        return False
+    if session.current_function is not session.entry_function:
+        return False
+    return session.current_subkernel is None
 
 
 def _normalize_alloc_buffer_shape_metadata(shape):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -88,6 +88,7 @@ from mlir.ir import (
     Operation,
     Type,
     TypeAttr,
+    UnitAttr,
 )
 
 # Pipe name shorthands → canonical PIPE_* names
@@ -2694,13 +2695,16 @@ def _alloc_local_buffer(shape, dtype, element_type, element_count, byte_size):
     i32 = IntegerType.get_signless(32)
     count = _materialize_integer_literal(i32, element_count)
     llvm_ptr_type = Type.parse("!llvm.ptr")
+    attributes = {
+        "elem_type": TypeAttr.get(element_type),
+    }
+    if _is_outside_simt_subkernel():
+        attributes["pto.persistent"] = UnitAttr.get()
     alloca = Operation.create(
         "llvm.alloca",
         results=[llvm_ptr_type],
         operands=[count],
-        attributes={
-            "elem_type": TypeAttr.get(element_type),
-        },
+        attributes=attributes,
     ).results[0]
     return AllocatedBufferValue(
         alloca,
@@ -2710,6 +2714,16 @@ def _alloc_local_buffer(shape, dtype, element_type, element_count, byte_size):
         element_count=element_count,
         byte_size=byte_size,
     )
+
+
+def _is_outside_simt_subkernel() -> bool:
+    try:
+        from ._tracing.active import current_session
+        session = current_session()
+    except Exception:
+        session = None
+    frame = session.current_subkernel if session is not None else None
+    return frame is None or frame.role != "simt"
 
 
 def _normalize_alloc_buffer_shape_metadata(shape):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -2637,21 +2637,20 @@ def _tile_transfer_partition(tv, tile, *, offsets=None, sizes=None, context: str
 
 def alloc_buffer(shape, dtype, **kwargs):
     """
-    Allocate SIMT lane-local scratch storage and return an address-like value.
+    Allocate explicit-body scratch storage and return an address-like value.
 
-    The allocation emits an LLVM stack allocation in the surrounding SIMT
-    helper. UB scratch uses explicit ``pto.castptr`` / ``pto.addptr`` pointer
-    authoring and an appropriate host launch wrapper.
+    The allocation emits an LLVM stack allocation in the surrounding explicit
+    kernel or helper body. UB scratch uses explicit ``pto.castptr`` /
+    ``pto.addptr`` pointer authoring and an appropriate host launch wrapper.
     """
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(
             f"pto.alloc_buffer(...) does not accept keyword argument(s): {unexpected}. "
-            "It only allocates SIMT local buffers; author UB scratch explicitly with "
+            "It only allocates explicit-body local buffers; author UB scratch explicitly with "
             "pto.castptr/pto.addptr and pass the dynamic UB byte count at launch."
         )
     _require_explicit_mode("pto.alloc_buffer(...)")
-    _require_simt_subkernel("pto.alloc_buffer(...)")
     element_type = _resolve(dtype)
     element_count = _static_alloc_buffer_element_count(shape)
     elem_bytes = _element_bytewidth(element_type)

--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -655,6 +655,8 @@ def wrap_like_surface_value(template, value):
                 for dim in valid_shape
             )
         return TileValue(value, **metadata)
+    if isinstance(template, AllocatedBufferValue):
+        return AllocatedBufferValue(value, **template.surface_metadata)
     if isinstance(template, AddressValue):
         return AddressValue(value)
     return wrap_surface_value(value)

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -248,9 +248,14 @@ class TraceSession:
             return _pto.SectionCubeOp()
         return None
 
-    def _create_inline_subkernel_wrapper(self, role: str):
+    def _create_inline_subkernel_wrapper(
+        self,
+        role: str,
+        *,
+        simt_launch_dims: tuple | None = None,
+    ):
         if role == "simt":
-            dim_x, dim_y, dim_z = _coerce_default_simt_section_dims()
+            dim_x, dim_y, dim_z = _coerce_simt_section_dims(simt_launch_dims)
             wrapper_op = _pto.SectionSimtOp(dim_x, dim_y, dim_z)
             body_block = wrapper_op.body.blocks.append()
             return wrapper_op, body_block
@@ -348,7 +353,10 @@ class TraceSession:
             symbol_name=symbol_name,
             target=target,
         )
-        wrapper_op, body_block = self._create_inline_subkernel_wrapper(role)
+        wrapper_op, body_block = self._create_inline_subkernel_wrapper(
+            role,
+            simt_launch_dims=simt_launch_dims,
+        )
         outline_frame = InlineSubkernelOutlineFrame(
             trace_frame=frame,
             helper_symbol_name=self._next_inline_subkernel_symbol(symbol_name),
@@ -923,10 +931,14 @@ def _coerce_simt_launch_dims(dims):
     )
 
 
-def _coerce_default_simt_section_dims():
+def _coerce_simt_section_dims(dims):
+    if dims is None:
+        dims = (1, 1, 1)
+    if not isinstance(dims, (tuple, list)) or len(dims) != 3:
+        raise TypeError("pto.simt(...) expects exactly three launch dimensions: dim_x, dim_y, dim_z")
     return tuple(
         _coerce_i32_dim(dim, context=f"pto.simt(..., dim[{index}])")
-        for index, dim in enumerate((1, 1, 1))
+        for index, dim in enumerate(dims)
     )
 
 

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -249,6 +249,12 @@ class TraceSession:
         return None
 
     def _create_inline_subkernel_wrapper(self, role: str):
+        if role == "simt":
+            dim_x, dim_y, dim_z = _coerce_default_simt_section_dims()
+            wrapper_op = _pto.SectionSimtOp(dim_x, dim_y, dim_z)
+            body_block = wrapper_op.body.blocks.append()
+            return wrapper_op, body_block
+
         wrapper_op = None
         if self._subkernel_section_policy(role) != "function_kind":
             wrapper_op = self._create_subkernel_section_op(role)
@@ -359,7 +365,13 @@ class TraceSession:
             self._erase_attached_op(wrapper_op)
             raise
         else:
-            self._outline_inline_subkernel(outline_frame)
+            if role == "simt":
+                self._note_escaped_inline_values(
+                    self._collect_defined_values((wrapper_op,)),
+                    role=role,
+                )
+            else:
+                self._outline_inline_subkernel(outline_frame)
         finally:
             popped = self._subkernel_stack.pop()
             if popped is not frame:
@@ -908,6 +920,13 @@ def _coerce_simt_launch_dims(dims):
     return tuple(
         _coerce_i32_dim(dim, context=f"pto.simt_launch(..., dims[{index}])")
         for index, dim in enumerate(dims)
+    )
+
+
+def _coerce_default_simt_section_dims():
+    return tuple(
+        _coerce_i32_dim(dim, context=f"pto.simt(..., dim[{index}])")
+        for index, dim in enumerate((1, 1, 1))
     )
 
 

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -21,6 +21,8 @@ from .._diagnostics import (
 from .._kernel_signature import RuntimeScalarParameterSpec
 from .._ops import const
 from .._surface_values import (
+    AddressOffsetValue,
+    AllocatedBufferValue,
     is_runtime_scalar_ir_type,
     is_tile_ir_type,
     unwrap_surface_value,
@@ -602,6 +604,7 @@ class TraceSession:
             raise RuntimeError("@pto.simt helper lowering does not support nested SIMT helper calls")
 
         arg_templates = tuple(args)
+        _reject_simt_helper_alloc_buffer_args(arg_templates)
         arg_types = tuple(unwrap_surface_value(arg).type for arg in arg_templates)
         static_kwargs = _simt_static_kwargs_signature(kwargs)
         owner_symbol_name = self.current_function_owner_symbol_name
@@ -973,6 +976,22 @@ def _coerce_i32_dim_attr(value, *, context: str):
             raise ValueError(f"{context} expects a signed i32 launch dimension, got {raw_value}")
         return IntegerAttr.get(i32, raw_value)
     raise TypeError(f"{context} expects a static Python int launch dimension, got {type(value).__name__}")
+
+
+def _is_alloc_buffer_arg(value) -> bool:
+    if isinstance(value, AllocatedBufferValue):
+        return True
+    return isinstance(value, AddressOffsetValue) and isinstance(value.base, AllocatedBufferValue)
+
+
+def _reject_simt_helper_alloc_buffer_args(args):
+    for index, arg in enumerate(args):
+        if _is_alloc_buffer_arg(arg):
+            raise TypeError(
+                "@pto.simt helpers do not accept pto.alloc_buffer persistent buffers; "
+                "use an inline pto.simt(...) scope or pass an explicitly authored typed pointer"
+                f" (argument {index})"
+            )
 
 
 def _symbol_name(ir_fn) -> str:

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -937,7 +937,7 @@ def _coerce_simt_section_dims(dims):
     if not isinstance(dims, (tuple, list)) or len(dims) != 3:
         raise TypeError("pto.simt(...) expects exactly three launch dimensions: dim_x, dim_y, dim_z")
     return tuple(
-        _coerce_i32_dim(dim, context=f"pto.simt(..., dim[{index}])")
+        _coerce_i32_dim_attr(dim, context=f"pto.simt(..., dim[{index}])")
         for index, dim in enumerate(dims)
     )
 
@@ -959,6 +959,20 @@ def _coerce_i32_dim(value, *, context: str):
             raise TypeError(f"{context} expects i32 launch dimension, got {raw_value.type}")
         return _strip_integer_signedness(raw_value)
     raise TypeError(f"{context} expects i32 launch dimension, got {raw_value.type}")
+
+
+def _coerce_i32_dim_attr(value, *, context: str):
+    raw_value = unwrap_surface_value(value)
+    i32 = IntegerType.get_signless(32)
+    if isinstance(raw_value, bool):
+        raise TypeError(f"{context} does not accept bool values")
+    if isinstance(raw_value, int):
+        if raw_value < 0:
+            raise ValueError(f"{context} expects a non-negative i32 launch dimension, got {raw_value}")
+        if raw_value > 0x7FFFFFFF:
+            raise ValueError(f"{context} expects a signed i32 launch dimension, got {raw_value}")
+        return IntegerAttr.get(i32, raw_value)
+    raise TypeError(f"{context} expects a static Python int launch dimension, got {type(value).__name__}")
 
 
 def _symbol_name(ir_fn) -> str:

--- a/ptodsl/tests/test_allreduce.py
+++ b/ptodsl/tests/test_allreduce.py
@@ -263,8 +263,10 @@ def main():
     compiled = kernel_128.compile()
     mlir = compiled.mlir_text()
 
-    expect("pto.simt_entry" in mlir,
-           "IR: helper carries pto.simt_entry")
+    expect("pto.section.simt" in mlir,
+           "IR: inline SIMT body stays in pto.section.simt during DSL tracing")
+    expect("pto.simt_entry" not in mlir,
+           "IR: inline SIMT body does not become pto.simt_entry during DSL tracing")
 
     for op_name in (
         "pto.redux_add", "pto.syncthreads", "pto.store", "pto.load",
@@ -598,81 +600,6 @@ def main():
     expect(
         simt_allreduce_min(1.0, threads=2, scale=2) == 1.0,
         "Path 0 (min): threads <= scale returns identity (value unchanged)",
-    )
-
-    # ══════════════════════════════════════════════════════════════════════════
-    # Lowering verification — ptoas VPTO LLVM IR emission
-    #
-    # Tests that the allreduce MLIR survives the complete ptoas pipeline:
-    #   MLIR (PTO dialect) → VPTO passes → LLVM IR
-    #
-    # KNOWN TOOLCHAIN ISSUES (bisheng, not allreduce):
-    #   a) bisheng stack-smashing on SIMT code that stores to GM
-    #   b) bisheng stack-smashing on cross-warp scratch-buffer code (≥ 128 lanes)
-    #
-    # Keep this regression at --emit-vpto-llvm-ir so PTODSL CI does not require
-    # ASCEND_HOME_PATH or a bisheng installation.
-    # ══════════════════════════════════════════════════════════════════════════
-
-    import subprocess
-    import tempfile
-    from pathlib import Path
-    from ptodsl._runtime.toolchain import resolve_ptoas_binary
-
-    def _ptoas_binary() -> Path:
-        return resolve_ptoas_binary()
-
-    def _emit_vpto_llvm_ir_and_check(compiled, case_label: str) -> bool:
-        """Run ``ptoas --emit-vpto-llvm-ir`` on *compiled* MLIR."""
-        ptoas = _ptoas_binary()
-        mlir_text = compiled.mlir_text()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            mlir_path = Path(tmpdir) / "kernel.mlir"
-            llvm_ir_path = Path(tmpdir) / "kernel.ll"
-            mlir_path.write_text(mlir_text)
-            result = subprocess.run(
-                [str(ptoas), "--pto-arch=a5", "--pto-backend=vpto",
-                 "--enable-tile-op-expand", "--emit-vpto-llvm-ir",
-                 str(mlir_path), "-o", str(llvm_ir_path)],
-                capture_output=True, text=True,
-            )
-            ok = result.returncode == 0 and llvm_ir_path.is_file() and llvm_ir_path.stat().st_size > 0
-            if ok:
-                return True
-            sys.stderr.write(
-                f"\n  [FAIL] {case_label} (exit={result.returncode})\n"
-                f"  STDERR: {result.stderr[:500]}\n"
-            )
-            return False
-
-    # ── Warp-reduce (≤ 32 lanes, NO scratch, NO GM store) ──
-    # These are the simplest kernels — they only compute a value and return
-    # from the SIMT body without writing to GM.  They MUST lower cleanly
-    # because they avoid both known bisheng issues.
-    expect(
-        _emit_vpto_llvm_ir_and_check(kernel_warp.compile(), "warp_sum_t32"),
-        "lowering: warp_sum (32 lanes, hw redux, no GM store) must pass",
-    )
-    expect(
-        _emit_vpto_llvm_ir_and_check(kernel_max_warp_hw.compile(), "warp_max_t32"),
-        "lowering: warp_max (32 lanes, hw redux, no GM store) must pass",
-    )
-    expect(
-        _emit_vpto_llvm_ir_and_check(kernel_min_warp_hw.compile(), "warp_min_t32"),
-        "lowering: warp_min (32 lanes, hw redux, no GM store) must pass",
-    )
-
-    # ── Cross-warp (128 lanes, UB scratch) ─────────────────────────────────
-    @pto.jit(target="a5")
-    def _kernel_cross_lowering(scratch_gm: pto.ptr(pto.f32, "gm")):
-        zero_u64 = pto.const(0, dtype=pto.ui64)
-        ub_scratch = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
-        with pto.simt():
-            x = pto.const(1.0, dtype=pto.f32)
-            _result = pto.simt_allreduce_sum(x, scratch=ub_scratch, threads=128, scale=1)
-    expect(
-        _emit_vpto_llvm_ir_and_check(_kernel_cross_lowering.compile(), "cross_sum_t128"),
-        "lowering: cross_sum (128 lanes, UB scratch) must emit VPTO LLVM IR",
     )
 
     print("ptodsl_allreduce: PASS")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4544,17 +4544,21 @@ def main() -> None:
     inline_simt_launch_text = inline_simt_launch_dims_probe.compile(TRACE_TOKEN=1).mlir_text()
     expect_parse_roundtrip_and_verify(inline_simt_launch_text, "inline simt launch-dims specialization")
     expect(
-        inline_simt_launch_text.count("pto.section.simt") == 1
-        and re.search(r"pto\.section\.simt\s*<<<", inline_simt_launch_text) is not None,
-        "with pto.simt(dim_x, dim_y, dim_z) should keep one inline pto.section.simt region",
+        re.search(r"pto\.section\.simt\s*<<<", inline_simt_launch_text) is not None
+        and "arith.constant 32 : i32" in inline_simt_launch_text
+        and "arith.constant 2 : i32" in inline_simt_launch_text,
+        "with pto.simt(dim_x, dim_y, dim_z) should emit inline pto.section.simt with launch dims",
     )
     expect(
-        "pto.simt_launch" not in inline_simt_launch_text,
-        "with pto.simt(dim_x, dim_y, dim_z) should not emit a separate pto.simt_launch",
+        "pto.simt_launch" not in inline_simt_launch_text
+        and "pto.store_vfsimt_info" not in inline_simt_launch_text,
+        "with pto.simt(dim_x, dim_y, dim_z) should not emit caller-side SIMT launch metadata",
     )
     expect(
-        "pto.store_vfsimt_info" not in inline_simt_launch_text,
-        "with pto.simt(dim_x, dim_y, dim_z) should not materialize caller-side launch metadata",
+        re.search(r"func\.func @inline_simt_[0-9]+__ptodsl_[0-9a-f]+", inline_simt_launch_text)
+        is None
+        and "pto.simt_entry" not in inline_simt_launch_text,
+        "inline SIMT launch-dims body should remain in the enclosing kernel during DSL tracing",
     )
     expect_raises(
         TypeError,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -971,6 +971,32 @@ def alloc_buffer_outside_simt_probe():
     _ = pto.alloc_buffer((32,), pto.f32)
 
 
+@pto.simd
+def alloc_buffer_simd_helper():
+    _ = pto.alloc_buffer((32,), pto.f32)
+
+
+@pto.jit(target="a5", mode="explicit", kernel_kind="vector")
+def alloc_buffer_simd_helper_probe():
+    alloc_buffer_simd_helper()
+
+
+@pto.cube
+def alloc_buffer_cube_helper():
+    _ = pto.alloc_buffer((32,), pto.f32)
+
+
+@pto.jit(target="a5", mode="explicit", kernel_kind="cube")
+def alloc_buffer_cube_helper_probe():
+    alloc_buffer_cube_helper()
+
+
+@pto.jit(target="a5", mode="explicit")
+def alloc_buffer_inline_simt_probe():
+    with pto.simt(32, 1, 1):
+        _ = pto.alloc_buffer((32,), pto.f32)
+
+
 @pto.simt
 def rmsnorm_alloc_buffer_frag_helper(
     w_ub: pto.ptr(pto.f32, pto.MemorySpace.UB),
@@ -4631,6 +4657,24 @@ def main() -> None:
     expect(
         "llvm.alloca" in alloc_buffer_top_level_text and "pto.persistent" in alloc_buffer_top_level_text,
         "alloc_buffer outside a SIMT helper should be marked as a persistent fragment candidate",
+    )
+    alloc_buffer_simd_helper_text = alloc_buffer_simd_helper_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(alloc_buffer_simd_helper_text, "alloc_buffer simd helper specialization")
+    expect(
+        "llvm.alloca" in alloc_buffer_simd_helper_text and "pto.persistent" not in alloc_buffer_simd_helper_text,
+        "alloc_buffer inside a SIMD helper should remain local",
+    )
+    alloc_buffer_cube_helper_text = alloc_buffer_cube_helper_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(alloc_buffer_cube_helper_text, "alloc_buffer cube helper specialization")
+    expect(
+        "llvm.alloca" in alloc_buffer_cube_helper_text and "pto.persistent" not in alloc_buffer_cube_helper_text,
+        "alloc_buffer inside a Cube helper should remain local",
+    )
+    alloc_buffer_inline_simt_text = alloc_buffer_inline_simt_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(alloc_buffer_inline_simt_text, "alloc_buffer inline simt specialization")
+    expect(
+        "llvm.alloca" in alloc_buffer_inline_simt_text and "pto.persistent" not in alloc_buffer_inline_simt_text,
+        "alloc_buffer inside an inline SIMT section should remain local",
     )
     rmsnorm_alloc_buffer_text = rmsnorm_alloc_buffer_layout_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(rmsnorm_alloc_buffer_text, "RMSNorm hand-authored UB layout specialization")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -773,6 +773,13 @@ def inline_simt_launch_dims_probe(
         pto.stg(tid, gm, scalar.index_cast(tid))
 
 
+@pto.jit(target="a5", mode="explicit")
+def inline_simt_dynamic_launch_dim_probe(*, TRACE_TOKEN: pto.const_expr = 0):
+    dynamic_dim = pto.const(32, dtype=pto.i32)
+    with pto.simt(dynamic_dim, 1, 1):
+        pto.get_tid_x()
+
+
 @pto.simt
 def simt_tid_probe():
     pto.get_tid_x()
@@ -4544,10 +4551,8 @@ def main() -> None:
     inline_simt_launch_text = inline_simt_launch_dims_probe.compile(TRACE_TOKEN=1).mlir_text()
     expect_parse_roundtrip_and_verify(inline_simt_launch_text, "inline simt launch-dims specialization")
     expect(
-        re.search(r"pto\.section\.simt\s*<<<", inline_simt_launch_text) is not None
-        and "arith.constant 32 : i32" in inline_simt_launch_text
-        and "arith.constant 2 : i32" in inline_simt_launch_text,
-        "with pto.simt(dim_x, dim_y, dim_z) should emit inline pto.section.simt with launch dims",
+        "pto.section.simt<<<32, 2, 1>>>" in inline_simt_launch_text,
+        "with pto.simt(dim_x, dim_y, dim_z) should emit static inline pto.section.simt launch dims",
     )
     expect(
         "pto.simt_launch" not in inline_simt_launch_text
@@ -4564,6 +4569,11 @@ def main() -> None:
         TypeError,
         lambda: pto.simt(32, 1),
         "expects exactly three",
+    )
+    expect_raises(
+        TypeError,
+        lambda: inline_simt_dynamic_launch_dim_probe.compile(TRACE_TOKEN=1),
+        "static Python int",
     )
 
     simt_text = simt_helper_lowering_probe.compile(TRACE_TOKEN=1).mlir_text()

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4612,11 +4612,8 @@ def main() -> None:
         is not None,
         "alloc_buffer probe should keep allocation inside the SIMT helper body",
     )
-    expect_raises(
-        RuntimeError,
-        alloc_buffer_outside_simt_probe.compile,
-        "pto.alloc_buffer(...) may only be used inside a @pto.simt helper or inline pto.simt() scope",
-    )
+    alloc_buffer_top_level_text = alloc_buffer_outside_simt_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(alloc_buffer_top_level_text, "alloc_buffer top-level specialization")
     rmsnorm_alloc_buffer_text = rmsnorm_alloc_buffer_layout_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(rmsnorm_alloc_buffer_text, "RMSNorm hand-authored UB layout specialization")
     for expected_offset in (4096, 4224, 12416, 20608):

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -971,24 +971,15 @@ def alloc_buffer_outside_simt_probe():
     _ = pto.alloc_buffer((32,), pto.f32)
 
 
-@pto.simd
-def alloc_buffer_simd_helper():
+@pto.tileop
+def alloc_buffer_tileop_helper():
     _ = pto.alloc_buffer((32,), pto.f32)
+    tileop_noop_simt_probe[1, 1, 1]()
 
 
 @pto.jit(target="a5", mode="explicit", kernel_kind="vector")
-def alloc_buffer_simd_helper_probe():
-    alloc_buffer_simd_helper()
-
-
-@pto.cube
-def alloc_buffer_cube_helper():
-    _ = pto.alloc_buffer((32,), pto.f32)
-
-
-@pto.jit(target="a5", mode="explicit", kernel_kind="cube")
-def alloc_buffer_cube_helper_probe():
-    alloc_buffer_cube_helper()
+def alloc_buffer_tileop_helper_probe():
+    alloc_buffer_tileop_helper()
 
 
 @pto.jit(target="a5", mode="explicit")
@@ -4675,17 +4666,12 @@ def main() -> None:
         "llvm.alloca" in alloc_buffer_top_level_text and "pto.persistent" in alloc_buffer_top_level_text,
         "alloc_buffer outside a SIMT helper should be marked as a persistent fragment candidate",
     )
-    alloc_buffer_simd_helper_text = alloc_buffer_simd_helper_probe.compile().mlir_text()
-    expect_parse_roundtrip_and_verify(alloc_buffer_simd_helper_text, "alloc_buffer simd helper specialization")
+    alloc_buffer_tileop_helper_text = alloc_buffer_tileop_helper_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(alloc_buffer_tileop_helper_text, "alloc_buffer tileop helper specialization")
     expect(
-        "llvm.alloca" in alloc_buffer_simd_helper_text and "pto.persistent" not in alloc_buffer_simd_helper_text,
-        "alloc_buffer inside a SIMD helper should remain local",
-    )
-    alloc_buffer_cube_helper_text = alloc_buffer_cube_helper_probe.compile().mlir_text()
-    expect_parse_roundtrip_and_verify(alloc_buffer_cube_helper_text, "alloc_buffer cube helper specialization")
-    expect(
-        "llvm.alloca" in alloc_buffer_cube_helper_text and "pto.persistent" not in alloc_buffer_cube_helper_text,
-        "alloc_buffer inside a Cube helper should remain local",
+        "llvm.alloca" in alloc_buffer_tileop_helper_text
+        and "pto.persistent" not in alloc_buffer_tileop_helper_text,
+        "alloc_buffer inside a TileOp helper should remain local",
     )
     alloc_buffer_inline_simt_text = alloc_buffer_inline_simt_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(alloc_buffer_inline_simt_text, "alloc_buffer inline simt specialization")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4524,40 +4524,37 @@ def main() -> None:
         f"unexpected inline subkernel scope observations: {INLINE_SUBKERNEL_SCOPE_OBSERVATIONS!r}",
     )
     expect(
-        inline_subkernel_scope_text.count("pto.store_vfsimt_info") == 1,
-        "inline pto.simt() should materialize one caller-side store_vfsimt_info before the helper call",
+        inline_subkernel_scope_text.count("pto.section.simt") == 1
+        and re.search(r"pto\.section\.simt\s*<<<", inline_subkernel_scope_text) is not None,
+        "inline pto.simt() should lower to one inline pto.section.simt region",
     )
     expect(
-        re.search(r"call @inline_simt_[0-9]+__ptodsl_[0-9a-f]+\([^\\n]*\)", inline_subkernel_scope_text) is not None
+        re.search(r"call @inline_simt_[0-9]+__ptodsl_[0-9a-f]+\([^\\n]*\)", inline_subkernel_scope_text) is None
         and re.search(r"call @inline_tileop_[0-9]+__ptodsl_[0-9a-f]+\([^\\n]*\)", inline_subkernel_scope_text) is not None,
-        "inline pto.simt()/pto.tileop() scopes should each lower to one helper call",
+        "inline pto.simt() should stay in-place while inline pto.tileop() still lowers to one helper call",
     )
     expect(
         "pto.tileop.helper" in inline_subkernel_scope_text
         and "pto.section.vector {" not in inline_subkernel_scope_text
         and "pto.section.cube {" not in inline_subkernel_scope_text
         and "pto.store" in inline_subkernel_scope_text,
-        "outlined inline helpers should mark TileOp helpers and preserve SIMT scalar ops",
+        "outlined inline TileOp helpers should mark TileOp helpers and preserve SIMT scalar ops",
     )
 
     inline_simt_launch_text = inline_simt_launch_dims_probe.compile(TRACE_TOKEN=1).mlir_text()
     expect_parse_roundtrip_and_verify(inline_simt_launch_text, "inline simt launch-dims specialization")
     expect(
-        re.search(r"pto\.simt_launch @inline_simt_[0-9]+__ptodsl_[0-9a-f]+<<<", inline_simt_launch_text)
-        is not None,
-        "with pto.simt(dim_x, dim_y, dim_z) should emit VPTO simt_launch sugar",
+        inline_simt_launch_text.count("pto.section.simt") == 1
+        and re.search(r"pto\.section\.simt\s*<<<", inline_simt_launch_text) is not None,
+        "with pto.simt(dim_x, dim_y, dim_z) should keep one inline pto.section.simt region",
+    )
+    expect(
+        "pto.simt_launch" not in inline_simt_launch_text,
+        "with pto.simt(dim_x, dim_y, dim_z) should not emit a separate pto.simt_launch",
     )
     expect(
         "pto.store_vfsimt_info" not in inline_simt_launch_text,
-        "with pto.simt(dim_x, dim_y, dim_z) should leave launch metadata to simt_launch expansion",
-    )
-    expect(
-        re.search(
-            r"func\.func @inline_simt_[0-9]+__ptodsl_[0-9a-f]+\(%arg0: !pto\.ptr<i32, gm>\) attributes \{[^}]*pto\.simt_entry[^}]*\}",
-            inline_simt_launch_text,
-        )
-        is not None,
-        "inline SIMT launch-dims helper should capture enclosing values as helper arguments",
+        "with pto.simt(dim_x, dim_y, dim_z) should not materialize caller-side launch metadata",
     )
     expect_raises(
         TypeError,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4605,6 +4605,10 @@ def main() -> None:
         "alloc_buffer should lower to an LLVM stack allocation in the SIMT helper",
     )
     expect(
+        "pto.persistent" not in alloc_buffer_local_text,
+        "alloc_buffer inside a SIMT helper should remain section-local",
+    )
+    expect(
         re.search(
             r"func\.func @alloc_buffer_local_helper__simt_\d+\(\) attributes \{pto\.simt_entry\}",
             alloc_buffer_local_text,
@@ -4614,6 +4618,10 @@ def main() -> None:
     )
     alloc_buffer_top_level_text = alloc_buffer_outside_simt_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(alloc_buffer_top_level_text, "alloc_buffer top-level specialization")
+    expect(
+        "llvm.alloca" in alloc_buffer_top_level_text and "pto.persistent" in alloc_buffer_top_level_text,
+        "alloc_buffer outside a SIMT helper should be marked as a persistent fragment candidate",
+    )
     rmsnorm_alloc_buffer_text = rmsnorm_alloc_buffer_layout_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(rmsnorm_alloc_buffer_text, "RMSNorm hand-authored UB layout specialization")
     for expected_offset in (4096, 4224, 12416, 20608):

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1031,6 +1031,23 @@ def rmsnorm_alloc_buffer_layout_probe(
     _ = reduce_scratch
 
 
+@pto.simt
+def simt_alloc_buffer_arg_probe(buf: pto.ptr(pto.f32, "ub")):
+    _ = buf
+
+
+@pto.jit(target="a5", mode="explicit")
+def simt_helper_reject_alloc_buffer_probe():
+    scratch = pto.alloc_buffer((32,), pto.f32)
+    pto.simt_launch(simt_alloc_buffer_arg_probe, scratch, dims=(32, 1, 1))
+
+
+@pto.jit(target="a5", mode="explicit")
+def simt_helper_reject_alloc_buffer_offset_probe():
+    scratch = pto.alloc_buffer((32,), pto.f32)
+    pto.simt_launch(simt_alloc_buffer_arg_probe, scratch + 4, dims=(32, 1, 1))
+
+
 @pto.jit(target="a5")
 def simt_explicit_launch_probe(*, TRACE_TOKEN: pto.const_expr = 0):
     pto.simt_launch(simt_query_probe, dims=(32, 2, 1))
@@ -4690,7 +4707,17 @@ def main() -> None:
     expect(
         re.search(r"call @rmsnorm_alloc_buffer_frag_helper__simt_\d+\(", rmsnorm_alloc_buffer_text)
         is not None,
-        "RMSNorm alloc_buffer layout should pass UB scratch pointers through the existing SIMT helper call path",
+        "RMSNorm alloc_buffer layout should pass explicitly authored UB pointers through the existing SIMT helper call path",
+    )
+    expect_raises(
+        TypeError,
+        lambda: simt_helper_reject_alloc_buffer_probe.compile(),
+        "do not accept pto.alloc_buffer",
+    )
+    expect_raises(
+        TypeError,
+        lambda: simt_helper_reject_alloc_buffer_offset_probe.compile(),
+        "do not accept pto.alloc_buffer",
     )
 
     simt_launch_text = simt_explicit_launch_probe.compile(TRACE_TOKEN=1).mlir_text()

--- a/test/lit/pto/section_simt_roundtrip.pto
+++ b/test/lit/pto/section_simt_roundtrip.pto
@@ -10,16 +10,12 @@
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @section_simt_kernel() attributes {pto.aicore} {
-    %dim_x = arith.constant 32 : i32
-    %dim_y = arith.constant 2 : i32
-    %dim_z = arith.constant 1 : i32
-
-    pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
-    } : i32, i32, i32
+    pto.section.simt <<<32, 2, 1>>> {
+    }
 
     return
   }
 }
 
-// CHECK: pto.section.simt<<<{{.*}}, {{.*}}, {{.*}}>>> {
-// CHECK-NEXT: } : i32, i32, i32
+// CHECK: pto.section.simt<<<32, 2, 1>>> {
+// CHECK-NEXT: }

--- a/test/lit/pto/section_simt_roundtrip.pto
+++ b/test/lit/pto/section_simt_roundtrip.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @section_simt_kernel() attributes {pto.aicore} {
+    %dim_x = arith.constant 32 : i32
+    %dim_y = arith.constant 2 : i32
+    %dim_z = arith.constant 1 : i32
+
+    pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
+    } : i32, i32, i32
+
+    return
+  }
+}
+
+// CHECK: pto.section.simt<<<{{.*}}, {{.*}}, {{.*}}>>> {
+// CHECK-NEXT: } : i32, i32, i32

--- a/test/lit/pto/section_simt_syncthreads_roundtrip.pto
+++ b/test/lit/pto/section_simt_syncthreads_roundtrip.pto
@@ -10,13 +10,9 @@
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @section_simt_syncthreads_kernel() attributes {pto.aicore} {
-    %dim_x = arith.constant 32 : i32
-    %dim_y = arith.constant 1 : i32
-    %dim_z = arith.constant 1 : i32
-
-    pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
+    pto.section.simt <<<32, 1, 1>>> {
       pto.syncthreads
-    } : i32, i32, i32
+    }
 
     return
   }

--- a/test/lit/pto/section_simt_syncthreads_roundtrip.pto
+++ b/test/lit/pto/section_simt_syncthreads_roundtrip.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --emit-pto-ir %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @section_simt_syncthreads_kernel() attributes {pto.aicore} {
+    %dim_x = arith.constant 32 : i32
+    %dim_y = arith.constant 1 : i32
+    %dim_z = arith.constant 1 : i32
+
+    pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
+      pto.syncthreads
+    } : i32, i32, i32
+
+    return
+  }
+}
+
+// CHECK: pto.section.simt
+// CHECK: pto.syncthreads

--- a/test/lit/pto/section_simt_verify_invalid_negative_dim.pto
+++ b/test/lit/pto/section_simt_verify_invalid_negative_dim.pto
@@ -8,15 +8,13 @@
 
 // RUN: not ptoas --pto-arch=a5 --emit-pto-ir %s -o - 2>&1 | FileCheck %s
 
-module attributes {pto.target_arch = "a5"} {
-  func.func @nested_section_simt_kernel() attributes {pto.kernel} {
-    pto.section.simt <<<32, 2, 1>>> {
-      pto.section.simt <<<32, 2, 1>>> {
-      }
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @section_simt_negative_dim_kernel() attributes {pto.aicore} {
+    pto.section.simt <<<32, -1, 1>>> {
     }
-
     return
   }
 }
 
-// CHECK: nested pto.section.simt is not allowed
+// CHECK: pto.section.simt
+// CHECK-SAME: requires non-negative i32 launch dimensions

--- a/test/lit/pto/section_simt_verify_invalid_nested.pto
+++ b/test/lit/pto/section_simt_verify_invalid_nested.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @nested_section_simt_kernel() attributes {pto.kernel} {
+    %dim_x = arith.constant 32 : i32
+    %dim_y = arith.constant 2 : i32
+    %dim_z = arith.constant 1 : i32
+
+    pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
+      pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
+      } : i32, i32, i32
+    } : i32, i32, i32
+
+    return
+  }
+}
+
+// CHECK: nested pto.section.simt is not allowed

--- a/test/lit/pto/section_simt_verify_invalid_simt_entry.pto
+++ b/test/lit/pto/section_simt_verify_invalid_simt_entry.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a5 --emit-pto-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @section_simt_in_entry() attributes {pto.simt_entry} {
+    %dim_x = arith.constant 32 : i32
+    %dim_y = arith.constant 2 : i32
+    %dim_z = arith.constant 1 : i32
+
+    pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
+    } : i32, i32, i32
+
+    return
+  }
+}
+
+// CHECK: pto.section.simt
+// CHECK-SAME: must not appear inside a function marked with 'pto.simt_entry'

--- a/test/lit/pto/section_simt_verify_invalid_simt_entry.pto
+++ b/test/lit/pto/section_simt_verify_invalid_simt_entry.pto
@@ -10,12 +10,8 @@
 
 module attributes {pto.target_arch = "a5"} {
   func.func @section_simt_in_entry() attributes {pto.simt_entry} {
-    %dim_x = arith.constant 32 : i32
-    %dim_y = arith.constant 2 : i32
-    %dim_z = arith.constant 1 : i32
-
-    pto.section.simt <<<%dim_x, %dim_y, %dim_z>>> {
-    } : i32, i32, i32
+    pto.section.simt <<<32, 2, 1>>> {
+    }
 
     return
   }


### PR DESCRIPTION
实现：
* 添加dsl 层面的simt inline(with pto.simt(x, y, z) -> pto.section.simt)
* 允许alloc_buffer声明于simt外，即视为跨simt的buffer
* alloc_buffer不在simt内部时，打上驻存persistent标签

需求参考：
https://github.com/mouliangyu/PTOAS/issues/495
https://github.com/KurrinQu/PTOAS/blob/qkl/ptoas-persistent-simt-fragment-design/docs/designs/ptoas_persistent_simt_fragment_plan.md
