### PR TITLE
fix: distinguish FBUF and MX scaling pipes

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -1465,11 +1465,28 @@ def TMovOp  : PTO_TOp<"tmov", [
         return ::mlir::pto::PIPE::PIPE_V;
       }
 
-      // MAT -> L0 (Left/Right/Bias/Scaling) are MTE1 moves.
+      // MAT -> L0A/L0B/Bias moves run on MTE1.
       if ((s == ::mlir::pto::AddressSpace::MAT &&
            (d == ::mlir::pto::AddressSpace::LEFT || d == ::mlir::pto::AddressSpace::RIGHT ||
-            d == ::mlir::pto::AddressSpace::BIAS || d == ::mlir::pto::AddressSpace::SCALING))) {
+            d == ::mlir::pto::AddressSpace::BIAS))) {
         return ::mlir::pto::PIPE::PIPE_MTE1;
+      }
+
+      if (s == ::mlir::pto::AddressSpace::MAT &&
+          d == ::mlir::pto::AddressSpace::SCALING) {
+        // PTOAS uses SCALING for two distinct PTO-ISA destinations. A5 MX
+        // scale tiles are ScaleLeft/ScaleRight loads into L0A/L0B and run on
+        // MTE1. Regular Scaling tiles are FBUF loads (TMOV_M2S) and run on
+        // FIX. PTOViewToMemref preserves the element type but erases the tile
+        // role before sync insertion, so distinguish the MX-only f8E8M0 type.
+        Type dstElemTy;
+        if (auto tb = llvm::dyn_cast<::mlir::pto::TileBufType>(getDst().getType()))
+          dstElemTy = tb.getElementType();
+        else if (auto mr = llvm::dyn_cast<::mlir::MemRefType>(getDst().getType()))
+          dstElemTy = mr.getElementType();
+        if (dstElemTy && llvm::isa<::mlir::pto::F8E8M0Type>(dstElemTy))
+          return ::mlir::pto::PIPE::PIPE_MTE1;
+        return ::mlir::pto::PIPE::PIPE_FIX;
       }
 
       // ACC -> MAT / VEC use FIX in PTO-ISA sync mapping (TMOV_A2M/TMOV_A2V).

--- a/test/lit/pto/tmov_fbuf_pipe_selection.pto
+++ b/test/lit/pto/tmov_fbuf_pipe_selection.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s | FileCheck %s --check-prefix=FIX
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync %s | FileCheck %s --check-prefix=FIX
+// RUN: ptoas --pto-arch=a3 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s --check-prefix=FIX
+// RUN: ptoas --pto-arch=a5 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s --check-prefix=FIX
+
+module {
+  func.func @tmov_fbuf_pipe_selection(
+      %input: memref<1x16xui64, #pto.address_space<gm>>) {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%input : memref<1x16xui64, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmov ins(%src : !pto.tile_buf<loc=mat, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=scaling, dtype=ui64, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// FIX-LABEL: AICORE void tmov_fbuf_pipe_selection(
+// FIX: set_flag(PIPE_MTE2, PIPE_FIX,
+// FIX: wait_flag(PIPE_MTE2, PIPE_FIX,
+// FIX-NOT: set_flag(PIPE_MTE2, PIPE_MTE1,
+// FIX: TMOV(

--- a/test/lit/pto/tmov_mx_scale_pipe_selection_a5.pto
+++ b/test/lit/pto/tmov_mx_scale_pipe_selection_a5.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+//
+// RUN: ptoas --pto-arch=a5 --enable-insert-sync %s | FileCheck %s --check-prefix=MTE1
+// RUN: ptoas --pto-arch=a5 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s --check-prefix=MTE1
+
+module {
+  func.func @tmov_mx_scale_left_pipe_selection(
+      %input: memref<1x4x!pto.f8E8M0, #pto.address_space<gm>>) {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=!pto.f8E8M0, rows=1, cols=4, v_row=1, v_col=4, blayout=row_major, slayout=row_major, fractal=32, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=!pto.f8E8M0, rows=1, cols=4, v_row=1, v_col=4, blayout=row_major, slayout=row_major, fractal=32, pad=0>
+
+    pto.tload ins(%input : memref<1x4x!pto.f8E8M0, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=mat, dtype=!pto.f8E8M0, rows=1, cols=4, v_row=1, v_col=4, blayout=row_major, slayout=row_major, fractal=32, pad=0>)
+    pto.tmov ins(%src : !pto.tile_buf<loc=mat, dtype=!pto.f8E8M0, rows=1, cols=4, v_row=1, v_col=4, blayout=row_major, slayout=row_major, fractal=32, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=scaling, dtype=!pto.f8E8M0, rows=1, cols=4, v_row=1, v_col=4, blayout=row_major, slayout=row_major, fractal=32, pad=0>)
+    return
+  }
+
+  func.func @tmov_mx_scale_right_pipe_selection(
+      %input: memref<4x16x!pto.f8E8M0, #pto.address_space<gm>>) {
+    %src = pto.alloc_tile : !pto.tile_buf<loc=mat, dtype=!pto.f8E8M0, rows=4, cols=32, v_row=4, v_col=16, blayout=col_major, slayout=col_major, fractal=32, pad=0>
+    %dst = pto.alloc_tile : !pto.tile_buf<loc=scaling, dtype=!pto.f8E8M0, rows=4, cols=32, v_row=4, v_col=16, blayout=col_major, slayout=col_major, fractal=32, pad=0>
+
+    pto.tload ins(%input : memref<4x16x!pto.f8E8M0, #pto.address_space<gm>>)
+              outs(%src : !pto.tile_buf<loc=mat, dtype=!pto.f8E8M0, rows=4, cols=32, v_row=4, v_col=16, blayout=col_major, slayout=col_major, fractal=32, pad=0>)
+    pto.tmov ins(%src : !pto.tile_buf<loc=mat, dtype=!pto.f8E8M0, rows=4, cols=32, v_row=4, v_col=16, blayout=col_major, slayout=col_major, fractal=32, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=scaling, dtype=!pto.f8E8M0, rows=4, cols=32, v_row=4, v_col=16, blayout=col_major, slayout=col_major, fractal=32, pad=0>)
+    return
+  }
+}
+
+// MTE1-LABEL: AICORE void tmov_mx_scale_left_pipe_selection(
+// MTE1: set_flag(PIPE_MTE2, PIPE_MTE1,
+// MTE1: wait_flag(PIPE_MTE2, PIPE_MTE1,
+// MTE1-NOT: set_flag(PIPE_MTE2, PIPE_FIX,
+// MTE1: TMOV(
+// MTE1-LABEL: AICORE void tmov_mx_scale_right_pipe_selection(
+// MTE1: set_flag(PIPE_MTE2, PIPE_MTE1,
+// MTE1: wait_flag(PIPE_MTE2, PIPE_MTE1,
+// MTE1-NOT: set_flag(PIPE_MTE2, PIPE_FIX,
+// MTE1: TMOV(


### PR DESCRIPTION
## Summary

Fix automatic sync pipe selection for `pto.tmov` from MAT to the overloaded
`SCALING` address space without regressing A5 MX scale loads.

PTOAS currently represents three distinct PTO-ISA tile roles with one address
space:

- `TileType::Scaling`: FBUF load via `TMOV_M2S` / `copy_cbuf_to_fbuf`, `PIPE_FIX`
- `TileType::ScaleLeft`: MX scale load into L0A, `PIPE_MTE1`
- `TileType::ScaleRight`: MX scale load into L0B, `PIPE_MTE1`

The previous `TMovOp::getPipe()` classified all MAT-to-SCALING moves as MTE1.
That caused InsertSync to emit `MTE2 -> MTE1` waits for FBUF loads instead of
`MTE2 -> FIX`, allowing fixpipe vector-quant consumers to observe stale FBUF
data in `movfp_fixpipe_reuse_a3`.

## Change

- Classify regular MAT-to-SCALING FBUF loads as `PIPE_FIX`.
- Preserve `PIPE_MTE1` for A5 MX `f8E8M0` ScaleLeft/ScaleRight loads.
- Cover both InsertSync and GraphSyncSolver.
- Add A3/A5 FBUF tests plus A5 ScaleLeft/ScaleRight non-regression tests.

This follows the latest GitCode PTO-ISA `master` mapping, where
`TMOV_M2S -> PIPE_FIX`, while A5 MX scale loads use the L0A/L0B load paths.

## Verification

- Built `ptoas` from this branch with LLVM/MLIR 21.1.8.
- `check-pto`: 846/846 passed.
- `movfp_fixpipe_reuse_a3-pto.pto` with InsertSync and GraphSyncSolver emits
  `MTE2 -> FIX` waits before both FBUF `TMOV`s.
- Existing `Gemvmx` with both sync modes retains `MTE2 -> MTE1` for
  ScaleLeft/ScaleRight and `MTE1 -> M` before MX compute.

## Board follow-up

Please run:

```text
/run a3 movfp_fixpipe_reuse_a3
```
