### PR TITLE
fix(ptodsl): validate VecValue arithmetic with SIMT

### DIFF
--- a/ptodsl/ptodsl/_surface_values.py
+++ b/ptodsl/ptodsl/_surface_values.py
@@ -304,6 +304,18 @@ class VecValue(_SurfaceValue):
         self.size = int(vec_type.shape[0])
         self.element_type = vec_type.element_type
 
+    def __add__(self, other):
+        return _emit_vec_binary_op("add", self, other)
+
+    def __radd__(self, other):
+        return _emit_vec_binary_op("add", other, self)
+
+    def __sub__(self, other):
+        return _emit_vec_binary_op("sub", self, other)
+
+    def __rsub__(self, other):
+        return _emit_vec_binary_op("sub", other, self)
+
     def __mul__(self, other):
         return _emit_vec_binary_op("mul", self, other)
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1679,6 +1679,28 @@ def scalar_contiguous_vector_probe():
 
 
 @pto.simt
+def scalar_contiguous_vector_arith_simt_body(data_ptr):
+    tid = pto.get_tid_x()
+    base = tid * 4
+    x4 = scalar.load(data_ptr, base, contiguous=4)
+    y4 = scalar.load(data_ptr, 32 + base, contiguous=4)
+    sum4 = x4 + y4
+    diff4 = x4 - y4
+    prod4 = x4 * y4
+    scalar.store(sum4, data_ptr, 64 + base)
+    scalar.store(diff4, data_ptr, 96 + base)
+    scalar.store(prod4, data_ptr, 128 + base)
+
+
+@pto.jit(target="a5", mode="explicit")
+def scalar_contiguous_vector_arith_probe():
+    scalar_contiguous_vector_arith_simt_body[8, 1, 1](
+        pto.castptr(pto.const(0, dtype=pto.ui64), pto.ptr(pto.f32, "ub"))
+    )
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.simt
 def scalar_contiguous_local_alloc_buffer_helper():
     data = pto.alloc_buffer((16,), pto.f32)
     x4 = scalar.load(data, 0, contiguous=4)
@@ -3067,6 +3089,7 @@ def main() -> None:
     integer_loop_bound_probe.verify()
     scalar_pointer_offset_probe.verify()
     scalar_contiguous_vector_probe.verify()
+    scalar_contiguous_vector_arith_probe.verify()
     addptr_surface_probe.verify()
     simt_pointer_offset_probe.verify()
     scalar_store_element_coercion_probe.verify()
@@ -5078,6 +5101,29 @@ def main() -> None:
         TypeError,
         lambda: scalar_contiguous_scalar_store_probe.compile(),
         "scalar.store(scalar, ..., contiguous=N) is not supported",
+    )
+
+    vec_arith_text = scalar_contiguous_vector_arith_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(vec_arith_text, "scalar contiguous vector arithmetic specialization")
+    expect(
+        "pto.simt_launch" in vec_arith_text,
+        "VecValue arithmetic probe should lower through a SIMT launch",
+    )
+    expect("arith.addf" in vec_arith_text, "VecValue addition should lower to arith.addf")
+    expect("arith.subf" in vec_arith_text, "VecValue subtraction should lower to arith.subf")
+    expect("arith.mulf" in vec_arith_text, "VecValue multiplication should lower to arith.mulf")
+    expect("vector<4xf32>" in vec_arith_text, "vector arithmetic should keep vector<4xf32> type")
+    expect(
+        vec_arith_text.count("arith.addf") == 1,
+        "VecValue __add__ should emit exactly one arith.addf",
+    )
+    expect(
+        vec_arith_text.count("arith.subf") == 1,
+        "VecValue __sub__ should emit exactly one arith.subf",
+    )
+    expect(
+        vec_arith_text.count("arith.mulf") == 1,
+        "VecValue __mul__ should emit exactly one arith.mulf",
     )
 
     addptr_surface_text = addptr_surface_probe.compile().mlir_text()

--- a/ptodsl/tests/test_ptoas_frontend_verify.py
+++ b/ptodsl/tests/test_ptoas_frontend_verify.py
@@ -313,6 +313,29 @@ def low_precision_vcvt_frontend():
     pto.vsts(roundtrip, dst_ptr, pto.const(0), mask_b32)
 
 
+@pto.simt
+def vec_value_arith_simt_body(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    O_ptr: pto.ptr(pto.f32, "gm"),
+):
+    tid = pto.get_tid_x()
+    base = tid * 4
+    x4 = scalar.load(A_ptr, base, contiguous=4)
+    y4 = scalar.load(A_ptr, 32 + base, contiguous=4)
+    scalar.store(x4 + y4, O_ptr, base)
+    scalar.store(x4 - y4, O_ptr, 32 + base)
+    scalar.store(x4 * y4, O_ptr, 64 + base)
+
+
+@pto.jit(target="a5", mode="explicit")
+def vec_value_arith_frontend(
+    A_ptr: pto.ptr(pto.f32, "gm"),
+    O_ptr: pto.ptr(pto.f32, "gm"),
+):
+    vec_value_arith_simt_body[8, 1, 1](A_ptr, O_ptr)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
 def main() -> None:
     ptoas_bin = resolve_ptoas_binary()
     mixed_backend_example = REPO_ROOT / "ptodsl" / "examples" / "mixed_backend_kernel_module.py"
@@ -593,6 +616,34 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         "'pto.vcvt' op unsupported vcvt source/result element type pair" in invalid_lowp_stderr,
         "invalid low-precision vcvt artifact should fail specifically on vcvt pair verification",
     )
+
+    vec_arith_text = vec_value_arith_frontend.compile().mlir_text()
+    expect("vector<4xf32>" in vec_arith_text, "vec_value_arith_frontend source MLIR should contain vector<4xf32> values")
+    expect(
+        "pto.simt_launch" in vec_arith_text,
+        "vec_value_arith_frontend source MLIR should lower through a SIMT launch",
+    )
+    expect(
+        "arith.addf" in vec_arith_text
+        and "arith.subf" in vec_arith_text
+        and "arith.mulf" in vec_arith_text,
+        "vec_value_arith_frontend source MLIR should contain all three VecValue arithmetic ops before frontend verification",
+    )
+    vec_arith_frontend_texts = run_ptoas_frontend_verify(
+        ptoas_bin,
+        vec_arith_text,
+        "vec_value_arith_frontend PTODSL artifact",
+    )
+    expect(
+        len(vec_arith_frontend_texts) == 1,
+        "vec_value_arith_frontend PTODSL artifact should lower to exactly one backend child module",
+    )
+    vec_arith_frontend_text = vec_arith_frontend_texts[0]
+    expect(
+        vec_arith_frontend_text == "",
+        "vec_value_arith_frontend should compile through the VPTO fallback object path when --emit-pto-ir is unavailable",
+    )
+
     print("ptodsl_ptoas_frontend_verify: PASS")
 
 

--- a/test/dsl-st/vec_value_arith.py
+++ b/test/dsl-st/vec_value_arith.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""
+VecValue arithmetic end-to-end ST.
+
+Exercises the add / sub / mul floating-point vector arithmetic operators on
+``vector<4xf32>`` values produced by ``scalar.load(..., contiguous=VEC)`` and
+consumed by ``scalar.store`` inside an ``@pto.simt`` body. ``pto.Vec`` is the
+SIMT lane-local vector type, so the SIMT kernel is the target scenario.
+
+Vector division is intentionally omitted: the backend does not support it, so
+the PTODSL surface does not expose ``__truediv__`` on ``VecValue``.
+"""
+
+import numpy as np
+
+from common import auto_main, golden_output_case
+from ptodsl import pto, scalar
+
+
+VEC = 4
+THREADS = 32
+SEED = 0x5761
+
+
+@pto.simt
+def vec_value_arith_body(
+    a_ptr: pto.ptr(pto.f32, "gm"),
+    o_ptr: pto.ptr(pto.f32, "gm"),
+):
+    tid = pto.get_tid_x()
+    idx = scalar.index_cast(tid)
+    base = idx * 2 * VEC
+    x = scalar.load(a_ptr, base, contiguous=VEC)
+    y = scalar.load(a_ptr, base + VEC, contiguous=VEC)
+    scalar.store(x + y, o_ptr, idx * VEC)
+    scalar.store(x - y, o_ptr, THREADS * VEC + idx * VEC)
+    scalar.store(x * y, o_ptr, 2 * THREADS * VEC + idx * VEC)
+
+
+@pto.jit(
+    name="vec_value_arith_kernel",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def vec_value_arith_kernel(
+    a_ptr: pto.ptr(pto.f32, "gm"),
+    o_ptr: pto.ptr(pto.f32, "gm"),
+):
+    vec_value_arith_body[THREADS, 1, 1](a_ptr, o_ptr)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+def make_inputs():
+    rng = np.random.RandomState(SEED)
+    xy = rng.uniform(0.5, 2.0, size=(THREADS, 2 * VEC)).astype(np.float32)
+    return [xy.reshape(-1)]
+
+
+def make_expected(inp):
+    xy = inp.reshape(THREADS, 2 * VEC)
+    x = xy[:, :VEC]
+    y = xy[:, VEC:]
+    return np.concatenate([
+        (x + y).reshape(-1),
+        (x - y).reshape(-1),
+        (x * y).reshape(-1),
+    ]).astype(np.float32)
+
+
+CASES = [
+    golden_output_case(
+        "vec_value_arith",
+        vec_value_arith_kernel,
+        inputs=make_inputs,
+        expected=make_expected,
+        rtol=1.0e-5,
+        atol=1.0e-5,
+    ),
+]
+
+
+auto_main(globals())


### PR DESCRIPTION
## Summary

- add reflected and non-reflected add/sub support for PTODSL `VecValue`
- keep vector division out of the PTODSL surface because the SIMT backend does not support it
- validate VecValue add/sub/mul through SIMT compile, PTOAS frontend, and runtime ST paths
- add an Ascend950 SIMT golden-output case for vector arithmetic


## Validation

- clean LLVM 21.1.8 build: `ptoas` and `PTOPythonModules`
- `ptodsl/tests/test_jit_compile.py`
- `ptodsl/tests/test_ptoas_frontend_verify.py`
- Python syntax, `git diff --check`, and license-header checks
- Ascend950PR_9599 simulator: `PASS vec_value_arith` / `All cases passed.`

## Notes

- the VecValue compile/frontend probes use `@pto.simt` helpers and assert `pto.simt_launch`
- emitted MLIR contains `arith.addf`, `arith.subf`, and `arith.mulf`, with no `arith.divf`
