### PR TITLE
fix: align MAT fill and expand sync pipes

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -4535,7 +4535,30 @@ def TExpandsOp : PTO_TOp<"texpands", [
   }];
 
   let extraClassDeclaration = [{
-    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_V; }
+    ::mlir::pto::PIPE getPipe() {
+      auto getASFromType = [](Type ty)
+          -> std::optional<::mlir::pto::AddressSpace> {
+        if (auto tb = ::mlir::dyn_cast<::mlir::pto::TileBufType>(ty)) {
+          if (auto as = ::mlir::dyn_cast_or_null<::mlir::pto::AddressSpaceAttr>(
+                  tb.getMemorySpace()))
+            return as.getAddressSpace();
+          return std::nullopt;
+        }
+        if (auto mr = ::mlir::dyn_cast<::mlir::MemRefType>(ty)) {
+          if (auto ms = mr.getMemorySpace()) {
+            if (auto as = ::mlir::dyn_cast<::mlir::pto::AddressSpaceAttr>(ms))
+              return as.getAddressSpace();
+          }
+          return std::nullopt;
+        }
+        return std::nullopt;
+      };
+
+      auto dstAS = getASFromType(getDst().getType());
+      if (dstAS && *dstAS == ::mlir::pto::AddressSpace::MAT)
+        return ::mlir::pto::PIPE::PIPE_MTE2;
+      return ::mlir::pto::PIPE::PIPE_V;
+    }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }
   }];
 }
@@ -4837,7 +4860,7 @@ def TFillPadOp : PTO_TOp<"tfillpad", [
       if (sOpt.has_value() && dOpt.has_value() &&
           sOpt.value() == ::mlir::pto::AddressSpace::MAT &&
           dOpt.value() == ::mlir::pto::AddressSpace::MAT)
-        return ::mlir::pto::PIPE::PIPE_MTE1;
+        return ::mlir::pto::PIPE::PIPE_MTE2;
       return ::mlir::pto::PIPE::PIPE_V;
     }
     ::mlir::MutableOperandRange getDpsInitsMutable() { return getDstMutable(); }

--- a/test/lit/pto/texpands_mat_pipe_selection.pto
+++ b/test/lit/pto/texpands_mat_pipe_selection.pto
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
+// RUN: ptoas --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s
+
+module attributes {"pto.target_arch" = "a5"} {
+  // MAT TEXPANDS runs on MTE2. The following MAT->RIGHT TMOV runs on MTE1,
+  // so sync insertion must order TEXPANDS before TMOV across those pipes.
+  func.func @texpands_mat_sync(%scalar: f16)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %src = pto.alloc_tile
+      : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=col_major, slayout=row_major, fractal=512, pad=0>
+    %dst = pto.alloc_tile
+      : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                      blayout=row_major, slayout=col_major, fractal=512, pad=0>
+
+    pto.texpands ins(%scalar : f16)
+                 outs(%src : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                           blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+    pto.tmov ins(%src : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                      blayout=col_major, slayout=row_major, fractal=512, pad=0>)
+             outs(%dst : !pto.tile_buf<loc=right, dtype=f16, rows=32, cols=32, v_row=32, v_col=32,
+                                       blayout=row_major, slayout=col_major, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void texpands_mat_sync(
+// CHECK: TEXPANDS(
+// CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID{{[0-9]+}});
+// CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID{{[0-9]+}});
+// CHECK: TMOV(

--- a/test/lit/pto/tfillpad_a5_mat_pipe_selection.pto
+++ b/test/lit/pto/tfillpad_a5_mat_pipe_selection.pto
@@ -1,9 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
 // RUN: ptoas --pto-arch a5 --enable-insert-sync %s | FileCheck %s
+// RUN: ptoas --pto-arch a5 --enable-graph-sync-solver --graph-sync-solver-event-id-max=64 %s | FileCheck %s
 
 module attributes {"pto.target_arch" = "a5"} {
-  // A5: mat->mat TFILLPAD follows the cube data-movement path and must not be
-  // treated as PIPE_V, otherwise sync insertion emits invalid V pipe events.
-  func.func @tfillpad_mat_sync(%in: memref<32x16xf16, #pto.address_space<gm>>) {
+  // A5: mat->mat TFILLPAD runs on MTE2. The following MAT->RIGHT TMOV runs on
+  // MTE1, so sync insertion must order TFILLPAD before TMOV across those pipes.
+  func.func @tfillpad_mat_sync(%in: memref<32x16xf16, #pto.address_space<gm>>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
     %src = pto.alloc_tile
       : !pto.tile_buf<loc=mat, dtype=f16, rows=32, cols=32, v_row=32, v_col=16,
                       blayout=col_major, slayout=row_major, fractal=512, pad=1>
@@ -27,8 +37,7 @@ module attributes {"pto.target_arch" = "a5"} {
 }
 
 // CHECK-LABEL: AICORE void tfillpad_mat_sync(
+// CHECK: TFILLPAD(
 // CHECK: set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID{{[0-9]+}});
 // CHECK: wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID{{[0-9]+}});
-// CHECK: TFILLPAD(
-// CHECK-NOT: set_flag(PIPE_MTE2, PIPE_V, EVENT_ID{{[0-9]+}});
-// CHECK-NOT: wait_flag(PIPE_V, PIPE_MTE1, EVENT_ID{{[0-9]+}});
+// CHECK: TMOV(


### PR DESCRIPTION
## Summary

Align PTOAS automatic sync pipe selection with the current pto-isa event contract for MAT tile operations:

- classify `TFILLPAD(MAT)` as `PIPE_MTE2` instead of `PIPE_MTE1`
- classify `TEXPANDS(MAT)` as `PIPE_MTE2` while preserving `PIPE_V` for vector destinations
- cover both InsertSync and GraphSyncSolver

## Root cause

The current pto-isa mapping defines:

- `TFILLPAD_MAT -> PIPE_MTE2`
- `TEXPANDS_MAT -> PIPE_MTE2`
- `TEXPANDS -> PIPE_V`

PTOAS classified MAT TFILLPAD as MTE1 and all TEXPANDS as V. For a MAT producer followed by a MAT-to-RIGHT TMOV, sync insertion therefore placed an event before the producer or emitted an event for the wrong source pipe, leaving the actual MTE2 producer unordered with the MTE1 consumer.

## Change

- Update `TExpandsOp::getPipe()` to inspect the destination address space in both tile and lowered memref form.
- Update the MAT-to-MAT `TFillPadOp::getPipe()` result to MTE2.
- Update the existing TFILLPAD regression to check event placement after TFILLPAD.
- Add a focused TEXPANDS MAT regression.
- Exercise both sync implementations in both tests.

## Verification

- Release/Werror `ptoas` build completed successfully.
- Focused InsertSync and GraphSyncSolver checks passed for both TFILLPAD and TEXPANDS.
- `check-pto`: 847/847 passed.

Reviewed against pto-isa `ecb6c303f797749f811a494742c3c08156aacabb`.