### PR TITLE
fix(insert-sync): fix reuse ub insert sync bug

### DIFF
--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -86,9 +86,11 @@ enum class TCoreType {
 struct BaseMemInfo {
   BaseMemInfo(
       Value baseBuffer, Value rootBuffer, pto::AddressSpace scope,
-      SmallVector<uint64_t> baseAddresses, uint64_t allocateSize)
+      SmallVector<uint64_t> baseAddresses, uint64_t allocateSize,
+      bool hasKnownPhysicalAddresses = false)
       : baseBuffer(baseBuffer), rootBuffer(rootBuffer), scope(scope),
-        baseAddresses(std::move(baseAddresses)), allocateSize(allocateSize) {}
+        baseAddresses(std::move(baseAddresses)), allocateSize(allocateSize),
+        hasKnownPhysicalAddresses(hasKnownPhysicalAddresses) {}
  
   /// baseBuffer: 当前操作直接使用的 Buffer (可能是 View 或 Alias)
   Value baseBuffer;
@@ -98,6 +100,9 @@ struct BaseMemInfo {
   pto::AddressSpace scope;
   SmallVector<uint64_t> baseAddresses; // 用于 Offset 分析
   uint64_t allocateSize;
+  // PlanMemory materializes static local allocations as pointer_cast constants.
+  // This distinguishes their physical addresses from root-relative offsets.
+  bool hasKnownPhysicalAddresses;
  
   bool areVectorEqual(const SmallVector<uint64_t>& vec1,
                       const SmallVector<uint64_t>& vec2) const {
@@ -121,12 +126,14 @@ struct BaseMemInfo {
  
   std::unique_ptr<BaseMemInfo> clone() const {
     return std::make_unique<BaseMemInfo>(
-        baseBuffer, rootBuffer, scope, baseAddresses, allocateSize);
+        baseBuffer, rootBuffer, scope, baseAddresses, allocateSize,
+        hasKnownPhysicalAddresses);
   }
- 
+
   std::unique_ptr<BaseMemInfo> clone(Value cloneBaseBuffer) const {
     return std::make_unique<BaseMemInfo>(
-        cloneBaseBuffer, rootBuffer, scope, baseAddresses, allocateSize);
+        cloneBaseBuffer, rootBuffer, scope, baseAddresses, allocateSize,
+        hasKnownPhysicalAddresses);
   }
 };
  

--- a/include/PTO/Transforms/InsertSync/SyncCommon.h
+++ b/include/PTO/Transforms/InsertSync/SyncCommon.h
@@ -117,6 +117,8 @@ struct BaseMemInfo {
     if (!areVectorEqual(baseAddresses, other.baseAddresses)) return false;
     if (rootBuffer != other.rootBuffer) return false;
     if (scope != other.scope) return false;
+    if (hasKnownPhysicalAddresses != other.hasKnownPhysicalAddresses)
+      return false;
     // allocateSize 和 baseBuffer 的严格相等性在某些别名分析中可能太强了，
     // 但为了保持原有逻辑，先保留。重点是 rootBuffer 必须一致。
     if (allocateSize != other.allocateSize) return false;

--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -154,7 +154,20 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
   }
  
   // 2. Local Memory (UB/L1)
-  
+  // PTOPlanMemory turns each allocation into a distinct pointer_cast. Once an
+  // async MTE3 store has consumed the source SSA, a later allocation can reuse
+  // the same physical range with a different pointer_cast root. Compare those
+  // ranges directly when both sides carry known physical local addresses.
+  if (a->hasKnownPhysicalAddresses && b->hasKnownPhysicalAddresses) {
+    if (isTraceEnabled())
+      llvm::errs() << "    -> Comparing known physical local ranges.\n";
+    if (a->baseAddresses.empty() || b->baseAddresses.empty())
+      return true;
+    if (a->allocateSize == 0 || b->allocateSize == 0)
+      return true;
+    return isBufferAddressRangeOverlap(a, b);
+  }
+
   if (a->rootBuffer == b->rootBuffer) {
     if (a->baseAddresses.empty() || b->baseAddresses.empty()) return true;
     if (a->allocateSize == 0 || b->allocateSize == 0) return true;

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -82,6 +82,18 @@ static bool getConstIndexValue(Value value, int64_t &out) {
   return true;
 }
 
+static std::optional<uint64_t> getKnownPhysicalAddress(Value value) {
+  int64_t address = 0;
+  if (!getConstIndexValue(value, address) || address < 0)
+    return std::nullopt;
+  return static_cast<uint64_t>(address);
+}
+
+static bool isLocalAddressSpace(pto::AddressSpace space) {
+  return space != pto::AddressSpace::GM &&
+         space != pto::AddressSpace::Zero;
+}
+
 static bool isStaticRank2Shape(ArrayRef<int64_t> shape) {
   return shape.size() == kTileRank2D &&
          llvm::none_of(shape, [](int64_t dim) {
@@ -540,13 +552,22 @@ LogicalResult PTOIRTranslator::UpdatePointerCastOpMemInfo(pto::PointerCastOp op)
   }
 
   if (op.getAddrs().size() == 1) {
-    // Single-address path: keep the historical semantics where `rootBuffer`
-    // is the i64 address SSA and `baseAddresses` starts at {0}. Downstream
-    // view ops accumulate a delta into baseAddresses[0]; MemAlias gates on
-    // rootBuffer SSA identity for single-buffer allocations.
+    // Keep the address SSA as the root so dynamic pointer casts retain their
+    // historical identity-based behavior. For a static local cast, also keep
+    // its byte address for cross-root physical range analysis; downstream view
+    // ops accumulate their delta into baseAddresses[0].
     Value rootSrc = op.getAddrs().front();
+    SmallVector<uint64_t> baseAddresses{0};
+    bool hasKnownPhysicalAddresses = false;
+    if (isLocalAddressSpace(space)) {
+      if (std::optional<uint64_t> address = getKnownPhysicalAddress(rootSrc)) {
+        baseAddresses[0] = *address;
+        hasKnownPhysicalAddresses = true;
+      }
+    }
     auto newMemInfo = std::make_unique<BaseMemInfo>(
-        res, rootSrc, space, SmallVector<uint64_t>{0}, sizeInBytes);
+        res, rootSrc, space, std::move(baseAddresses), sizeInBytes,
+        hasKnownPhysicalAddresses);
     buffer2MemInfoMap_[res].emplace_back(newMemInfo->clone());
     return success();
   }
@@ -561,9 +582,8 @@ LogicalResult PTOIRTranslator::UpdatePointerCastOpMemInfo(pto::PointerCastOp op)
   SmallVector<uint64_t> slotOffsets;
   slotOffsets.reserve(op.getAddrs().size());
   for (Value a : op.getAddrs()) {
-    auto cst = a.getDefiningOp<arith::ConstantOp>();
-    IntegerAttr attr;
-    if (!cst || !(attr = dyn_cast<IntegerAttr>(cst.getValue()))) {
+    std::optional<uint64_t> address = getKnownPhysicalAddress(a);
+    if (!address) {
       // Non-constant slot address: fall back to single-address semantics
       // with the first operand as rootBuffer so existing non-multi-buffer
       // codepaths that happen to feed non-constant i64s keep their
@@ -574,11 +594,12 @@ LogicalResult PTOIRTranslator::UpdatePointerCastOpMemInfo(pto::PointerCastOp op)
       buffer2MemInfoMap_[res].emplace_back(newMemInfo->clone());
       return success();
     }
-    slotOffsets.push_back(attr.getValue().getZExtValue());
+    slotOffsets.push_back(*address);
   }
 
   auto newMemInfo = std::make_unique<BaseMemInfo>(
-      res, res, space, std::move(slotOffsets), sizeInBytes);
+      res, res, space, std::move(slotOffsets), sizeInBytes,
+      isLocalAddressSpace(space));
   buffer2MemInfoMap_[res].emplace_back(newMemInfo->clone());
   return success();
 }

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -464,16 +464,13 @@ LogicalResult PTOIRTranslator::UpdateAllocTileOpMemInfo(pto::AllocTileOp op) {
   auto tileType = dyn_cast<pto::TileBufType>(res.getType());
   uint64_t sizeInBytes = 0;
   uint64_t baseAddr = 0;
+  std::optional<uint64_t> knownPhysicalAddress;
 
   // If alloc_tile carries an explicit address, record it when it's a constant.
   if (Value addr = op.getAddr()) {
-    llvm::APInt apIntValue;
-    if (matchPattern(addr, m_ConstantInt(&apIntValue))) {
-        // 将 APInt 转换为 int64_t，再转为 uint64_t
-        int64_t c = apIntValue.getSExtValue();  // 有符号扩展转换
-        // 如果确定是无符号值，也可以用：apIntValue.getZExtValue()
-        baseAddr = static_cast<uint64_t>(c);
-    }
+    knownPhysicalAddress = getKnownPhysicalAddress(addr);
+    if (knownPhysicalAddress)
+      baseAddr = *knownPhysicalAddress;
   }
 
   // 1. 计算大小
@@ -513,12 +510,8 @@ LogicalResult PTOIRTranslator::UpdateAllocTileOpMemInfo(pto::AllocTileOp op) {
 
   // 3. 注册 Buffer 信息
   auto newMemInfo = std::make_unique<BaseMemInfo>(
-      res,
-      res,
-      space, // 使用解析出的 space
-      SmallVector<uint64_t>{baseAddr},
-      sizeInBytes
-  );
+      res, res, space, SmallVector<uint64_t>{baseAddr}, sizeInBytes,
+      knownPhysicalAddress.has_value() && isLocalAddressSpace(space));
 
   buffer2MemInfoMap_[res].emplace_back(newMemInfo->clone());
   return success();

--- a/test/lit/pto/alloc_tile_physical_overlap_sync.pto
+++ b/test/lit/pto/alloc_tile_physical_overlap_sync.pto
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Explicit local alloc_tile addresses are physical UB addresses. Distinct SSA
+// roots whose ranges overlap must synchronize an asynchronous MTE3 read before
+// a later V-pipe write reuses the range.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @alloc_tile_physical_overlap_sync(
+      %src0: memref<16x128xf32, #pto.address_space<gm>>,
+      %src1: memref<16x128xf32, #pto.address_space<gm>>,
+      %dst: memref<16x128xf32, #pto.address_space<gm>>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c1280_i64 = arith.constant 1280 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %one = arith.constant 1.000000e+00 : f32
+
+    %input = pto.alloc_tile addr = %c16384_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %stored = pto.alloc_tile addr = %c1280_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reused = pto.alloc_tile addr = %c8192_i64 :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.tload ins(%src0 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%input : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%stored : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%input, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%stored : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%stored : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : memref<16x128xf32, #pto.address_space<gm>>)
+    pto.tmuls ins(%input, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%reused : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void alloc_tile_physical_overlap_sync(
+// CHECK:      TSTORE(
+// CHECK-NEXT: set_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V]]);
+// CHECK-NEXT: TMULS(

--- a/test/lit/pto/plan_memory_reused_tstore_sync.pto
+++ b/test/lit/pto/plan_memory_reused_tstore_sync.pto
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// PlanMemory lowers local allocations to pointer_casts before InsertSync. This
+// test models the lowered level2 form directly: `stored` occupies
+// [1280, 9472) and `reused` occupies [8192, 16384). `stored` dies at tstore,
+// but MTE3 still reads its physical range asynchronously, so the later vector
+// write needs an MTE3 -> V handshake.
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @plan_memory_reused_tstore_sync(
+      %src0: memref<16x128xf32, #pto.address_space<gm>>,
+      %src1: memref<16x128xf32, #pto.address_space<gm>>,
+      %dst: memref<16x128xf32, #pto.address_space<gm>>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c1280_i64 = arith.constant 1280 : i64
+    %c8192_i64 = arith.constant 8192 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %one = arith.constant 1.000000e+00 : f32
+
+    %input = pto.pointer_cast(%c16384_i64)
+      : memref<16x128xf32, #pto.address_space<vec>>
+    %stored = pto.pointer_cast(%c1280_i64)
+      : memref<16x128xf32, #pto.address_space<vec>>
+    %reused = pto.pointer_cast(%c8192_i64)
+      : memref<16x128xf32, #pto.address_space<vec>>
+
+    pto.tload ins(%src0 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%input : memref<16x128xf32, #pto.address_space<vec>>)
+    pto.tload ins(%src1 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%stored : memref<16x128xf32, #pto.address_space<vec>>)
+    pto.tmuls ins(%input, %one : memref<16x128xf32, #pto.address_space<vec>>, f32)
+              outs(%stored : memref<16x128xf32, #pto.address_space<vec>>)
+    pto.tstore ins(%stored : memref<16x128xf32, #pto.address_space<vec>>)
+               outs(%dst : memref<16x128xf32, #pto.address_space<gm>>)
+    pto.tmuls ins(%input, %one : memref<16x128xf32, #pto.address_space<vec>>, f32)
+              outs(%reused : memref<16x128xf32, #pto.address_space<vec>>)
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void plan_memory_reused_tstore_sync(
+// CHECK:      TSTORE(
+// CHECK-NEXT: set_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V:[0-9]+]]);
+// CHECK-NEXT: wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V]]);
+// CHECK-NEXT: TMULS(

--- a/test/lit/pto/plan_memory_reused_tstore_sync_level2.pto
+++ b/test/lit/pto/plan_memory_reused_tstore_sync_level2.pto
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// End-to-end level2 coverage for PlanMemory reuse followed by InsertSync. The
+// source uses logical alloc_tile operations without explicit addresses, so the
+// physical pointer_cast addresses checked below are produced by PlanMemory.
+// `stored` occupies [8192, 16384), while `reused` occupies [8448, 16640).
+//
+// RUN: ptoas --pto-arch=a3 --pto-level=level2 --enable-insert-sync --emit-pto-ir --mlir-print-ir-after=pto-plan-memory %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=PLAN
+// RUN: ptoas --pto-arch=a3 --pto-level=level2 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --check-prefix=SYNC
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @plan_memory_reused_tstore_sync_level2(
+      %pressure_src: memref<1x45056xf32, #pto.address_space<gm>>,
+      %pressure_dst: memref<1x45056xf32, #pto.address_space<gm>>,
+      %src0: memref<16x128xf32, #pto.address_space<gm>>,
+      %src1: memref<16x128xf32, #pto.address_space<gm>>,
+      %dst: memref<16x128xf32, #pto.address_space<gm>>,
+      %blocker_rows: index,
+      %blocker_cols: index)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %one = arith.constant 1.000000e+00 : f32
+
+    // Force PlanMemory's reuse path: 180224 bytes here plus the target tiles
+    // and the 256-byte blocker exceed the default 196608-byte UB capacity,
+    // while their actual live ranges remain non-overlapping enough to fit.
+    %pressure = pto.alloc_tile : !pto.tile_buf<vec, 1x45056xf32>
+    pto.tload ins(%pressure_src : memref<1x45056xf32, #pto.address_space<gm>>)
+              outs(%pressure : !pto.tile_buf<vec, 1x45056xf32>)
+    pto.tstore ins(%pressure : !pto.tile_buf<vec, 1x45056xf32>)
+               outs(%pressure_dst : memref<1x45056xf32, #pto.address_space<gm>>)
+
+    %input = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %stored = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.tload ins(%src0 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%input : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tload ins(%src1 : memref<16x128xf32, #pto.address_space<gm>>)
+              outs(%stored : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tmuls ins(%input, %one : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%stored : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tstore ins(%stored : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+               outs(%dst : memref<16x128xf32, #pto.address_space<gm>>)
+    %blocker = pto.alloc_tile valid_row = %blocker_rows valid_col = %blocker_cols :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %reused = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %blocker_row0, %blocker_col0 = pto.get_validshape %blocker :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %blocker_extent0 = arith.addi %blocker_row0, %blocker_col0 : index
+    %blocker_extent0_i64 = arith.index_cast %blocker_extent0 : index to i64
+    %blocker_scale0 = arith.sitofp %blocker_extent0_i64 : i64 to f32
+    pto.tmuls ins(%input, %blocker_scale0 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%reused : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    %blocker_row1, %blocker_col1 = pto.get_validshape %blocker :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %blocker_extent1 = arith.addi %blocker_row1, %blocker_col1 : index
+    %blocker_extent1_i64 = arith.index_cast %blocker_extent1 : index to i64
+    %blocker_scale1 = arith.sitofp %blocker_extent1_i64 : i64 to f32
+    pto.tmuls ins(%reused, %blocker_scale1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, f32)
+              outs(%reused : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=128, v_row=16, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// PLAN-LABEL: func.func @plan_memory_reused_tstore_sync_level2(
+// PLAN-DAG:   %[[STORED_ADDR:[A-Za-z0-9_]+]] = arith.constant 8192 : i64
+// PLAN-DAG:   %[[REUSED_ADDR:[A-Za-z0-9_]+]] = arith.constant 8448 : i64
+// PLAN:       %[[STORED_CAST:[0-9]+]] = pto.pointer_cast(%[[STORED_ADDR]]){{.*}} : memref<16x128xf32
+// PLAN-NEXT:  %[[STORED:[0-9]+]] = pto.bind_tile %[[STORED_CAST]]
+// PLAN:       pto.tstore ins(%[[STORED]]
+// PLAN:       %[[REUSED_CAST:[0-9]+]] = pto.pointer_cast(%[[REUSED_ADDR]]){{.*}} : memref<16x128xf32
+// PLAN-NEXT:  %[[REUSED:[0-9]+]] = pto.bind_tile %[[REUSED_CAST]]
+// PLAN:       pto.tmuls {{.*}} outs(%[[REUSED]]
+
+// SYNC-LABEL: AICORE void plan_memory_reused_tstore_sync_level2(
+// SYNC:      // pto: %stored
+// SYNC:      TSTORE(
+// SYNC-NEXT: set_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V:[0-9]+]]);
+// SYNC-NOT:  TMULS(
+// SYNC:      wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID[[MTE3_TO_V]]);
+// SYNC-NEXT: TMULS(


### PR DESCRIPTION
## 问题根因

在 `--pto-level=level2` 下，PlanMemory 会将不同的本地分配物化为不同的 `pto.pointer_cast`。旧 InsertSync 对单地址 `pointer_cast` 主要依赖地址 SSA 的 root 身份判断别名，无法识别不同 root 对应的物理 UB 区间重叠。

Issue #934 的根因是：PlanMemory 复用了 UB 物理内存，但 InsertSync 仍按 SSA 指针身份判断是否别名，导致漏掉同步。
具体过程：
PlanMemory 后：

stored = pointer_cast(1280)   // 占用 [1280, 9472)
reused = pointer_cast(8192)   // 占用 [8192, 16384)
两个区间在 [8192, 9472) 重叠。stored 在 tstore 之后，SSA 层面已经不再使用，因此 PlanMemory 认为其 UB 可复用给 reused。但 tstore 实际由 MTE3 异步执行，仍在从 stored 对应的 UB 区域读取数据。
随后 V pipe 的 tmuls 写入 reused，就可能提前覆盖 MTE3 尚未读完的 stored 数据：
TSTORE(stored -> GM)     // MTE3 异步读 UB
TMULS(... -> reused)     // V pipe 写入重叠的 UB 区间
旧 InsertSync 对单地址 pointer_cast 只记录相对偏移 {0}，并要求两侧的 rootBuffer 是同一个 SSA 值才继续做区间判断。pointer_cast(1280) 和 pointer_cast(8192) 的常量 SSA 不同，因此被误判为“不别名”，没有插入：
set_flag(PIPE_MTE3, PIPE_V, ...)
wait_flag(PIPE_MTE3, PIPE_V, ...)
结果是 MTE3 与 V pipe 存在数据竞争，表现为 tstore 输出偶发错误或被后续计算覆盖。

## 修复方案

1. 为 InsertSync 的内存信息增加 hasKnownPhysicalAddresses 标记，标识可静态解析且对应 local UB 物理地址的 `pto.pointer_cast`。
2. 静态 local `pto.pointer_cast` 保留真实起始字节地址，不只保留相对偏移。
3. 两侧都是已知物理地址的 local buffer 时，按真实内存区间是否重叠判断别名，不依赖 SSA root 是否相同。
4. 若 tstore 的 MTE3 异步读与后续 V pipe 写入重叠，插入 MTE3 -> V 的 set_flag/wait_flag。
5. 动态地址、GM 地址与原有基于相同 SSA root 的分析路径保持不变。

## 验证

- `ninja -C /private/tmp/ptoas-issue934-pr-build ptoas`
- `llvm-lit` 聚焦回归：
  - `plan_memory_reused_tstore_sync.pto`
  - `multi_tile_const_slot_disjoint_sync.pto`
  - `issue870_identity_tmov_pruning.pto`
- 使用完整 level2 复现输入验证生成代码中 k 路径已变为：
  `TSTORE -> set_flag(MTE3, V) -> wait_flag(MTE3, V) -> TMUL`

Fixes #934


