### PR TITLE
refactor(ptodsl): unify get_buf/rls_buf DSL interface

### DIFF
--- a/ptodsl/docs/user_guide/10-sync-ops.md
+++ b/ptodsl/docs/user_guide/10-sync-ops.md
@@ -190,16 +190,13 @@ def gemm_block(
 
 ---
 
-## 10.3 Buffer management: `get_buf`, `rls_buf`, `get_buf_dyn`, `rls_buf_dyn`
+## 10.3 Buffer management: `get_buf`, `rls_buf`
 
 Double-buffering is a common optimization in NPU kernels: while one buffer is being computed on, the other is being loaded with the next block of data. The `get_buf` / `rls_buf` pair coordinates buffer ownership between pipelines.
 
-PTODSL provides two variants:
+`buf_id` accepts both a **static integer** (0–31) and a **runtime index-like SSA value** (e.g., `iter & 1` for ping-pong buffering). The DSL automatically selects the appropriate IR form (`pto.get_buf` for static, `pto.get_buf_dyn` for dynamic).
 
-- **Static** (`get_buf` / `rls_buf`): `buf_id` is an integer literal, suitable when the buffer assignment is fixed at compile time.
-- **Dynamic** (`get_buf_dyn` / `rls_buf_dyn`): `buf_id` is an **index-typed SSA value**, enabling runtime-computed patterns such as SIMT ping-pong buffering where the active buffer toggles per iteration (e.g., `iter & 1`).
-
-The `pipe` and `mode` parameters are identical between the static and dynamic variants.
+The `pipe` and `mode` parameters are identical regardless of whether `buf_id` is static or dynamic.
 
 ### `pto.get_buf(pipe, buf_id, mode=0)`
 
@@ -210,7 +207,7 @@ The `pipe` and `mode` parameters are identical between the static and dynamic va
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Pipeline identifier of the acquiring pipeline |
-| `buf_id` | `int` | Buffer identifier (0-based static integer index into the buffer pool) |
+| `buf_id` | `int` or index-like SSA value | Buffer identifier — static integer (0–31) or runtime-computed index (e.g., `iter & 1`) |
 | `mode` | `int` | Acquisition mode (default 0) |
 
 **Returns**: None (side-effect operation).
@@ -224,7 +221,7 @@ The `pipe` and `mode` parameters are identical between the static and dynamic va
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Pipeline identifier of the releasing pipeline |
-| `buf_id` | `int` | Buffer identifier matching the corresponding `get_buf` |
+| `buf_id` | `int` or index-like SSA value | Buffer identifier matching the corresponding `get_buf` |
 | `mode` | `int` | Release mode (default 0) |
 
 **Returns**: None (side-effect operation).
@@ -249,47 +246,20 @@ pto.get_buf(pto.Pipe.MTE2, 0, 0)
 pto.rls_buf(pto.Pipe.MTE2, 0, 0)
 ```
 
-### `pto.get_buf_dyn(pipe, buf_id, mode=0)`
-
-**Description**: Acquire a buffer slot with a runtime-computed buffer identifier. The static version `get_buf` accepts an integer literal; this variant accepts an **index-typed SSA value** so the buffer-id can change at runtime.
-
-**Parameters**:
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `pipe` | `Pipe` | Pipeline identifier of the acquiring pipeline |
-| `buf_id` | index-like SSA value | Runtime-computed buffer identifier (e.g., `iter & 1` for double-buffering) |
-| `mode` | `int` | Acquisition mode (default 0) |
-
-**Returns**: None (side-effect operation).
-
-### `pto.rls_buf_dyn(pipe, buf_id, mode=0)`
-
-**Description**: Release a buffer slot with a runtime-computed buffer identifier, matching the corresponding `get_buf_dyn` call.
-
-**Parameters**:
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `pipe` | `Pipe` | Pipeline identifier of the releasing pipeline |
-| `buf_id` | index-like SSA value | Runtime-computed buffer identifier matching the acquire |
-| `mode` | `int` | Release mode (default 0) |
-
-**Returns**: None (side-effect operation).
-
 ### Dynamic double-buffering (ping-pong) example
 
 When the buffer-id toggles between 0 and 1 per loop iteration, compute the
-buf-id from the loop variable:
+buf-id from the loop variable. Pass the SSA value directly — the DSL
+dispatches to the dynamic IR form automatically:
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
 ```python
 # Ping-pong: acquire buffer (iter & 1) each iteration
 with pto.for_(0, 4, step=1) as iter:
     buf_id = iter & 1
-    pto.get_buf_dyn(pto.Pipe.MTE2, buf_id)
+    pto.get_buf(pto.Pipe.MTE2, buf_id)
     # ... DMA load into buf_id ...
-    pto.rls_buf_dyn(pto.Pipe.MTE2, buf_id)
+    pto.rls_buf(pto.Pipe.MTE2, buf_id)
 ```
 
 ---

--- a/ptodsl/docs/user_guide/10-sync-ops.md
+++ b/ptodsl/docs/user_guide/10-sync-ops.md
@@ -194,7 +194,7 @@ def gemm_block(
 
 Double-buffering is a common optimization in NPU kernels: while one buffer is being computed on, the other is being loaded with the next block of data. The `get_buf` / `rls_buf` pair coordinates buffer ownership between pipelines.
 
-`buf_id` accepts both a **static integer** (0–31) and a **runtime index-like SSA value** (e.g., `iter & 1` for ping-pong buffering). The DSL automatically selects the appropriate IR form (`pto.get_buf` for static, `pto.get_buf_dyn` for dynamic).
+`buf_id` accepts both a **static integer** (0–31) and a **runtime index-like PTO scalar** (e.g., `iter & 1` for ping-pong buffering). The DSL automatically selects the appropriate IR form (`pto.get_buf` for static, `pto.get_buf_dyn` for dynamic).
 
 The `pipe` and `mode` parameters are identical regardless of whether `buf_id` is static or dynamic.
 
@@ -207,7 +207,7 @@ The `pipe` and `mode` parameters are identical regardless of whether `buf_id` is
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Pipeline identifier of the acquiring pipeline |
-| `buf_id` | `int` or index-like SSA value | Buffer identifier — static integer (0–31) or runtime-computed index (e.g., `iter & 1`) |
+| `buf_id` | `int` or index-like PTO scalar | Buffer identifier — static integer (0–31) or runtime-computed index (e.g., `iter & 1`) |
 | `mode` | `int` | Acquisition mode (default 0) |
 
 **Returns**: None (side-effect operation).
@@ -221,7 +221,7 @@ The `pipe` and `mode` parameters are identical regardless of whether `buf_id` is
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `pipe` | `Pipe` | Pipeline identifier of the releasing pipeline |
-| `buf_id` | `int` or index-like SSA value | Buffer identifier matching the corresponding `get_buf` |
+| `buf_id` | `int` or index-like PTO scalar | Buffer identifier matching the corresponding `get_buf` |
 | `mode` | `int` | Release mode (default 0) |
 
 **Returns**: None (side-effect operation).
@@ -249,7 +249,7 @@ pto.rls_buf(pto.Pipe.MTE2, 0, 0)
 ### Dynamic double-buffering (ping-pong) example
 
 When the buffer-id toggles between 0 and 1 per loop iteration, compute the
-buf-id from the loop variable. Pass the SSA value directly — the DSL
+buf-id from the loop variable. Pass the index value directly — the DSL
 dispatches to the dynamic IR form automatically:
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -140,6 +140,13 @@ def _validate_static_event_id(event_id, *, context: str):
         raise ValueError(f"{context} expects static event_id in [0, 7], got {event_id}")
 
 
+def _validate_static_buf_id(buf_id, *, context: str):
+    if isinstance(buf_id, bool):
+        raise TypeError(f"{context} does not accept bool values")
+    if isinstance(buf_id, int) and not 0 <= buf_id <= 31:
+        raise ValueError(f"{context} expects static buf_id in [0, 31], got {buf_id}")
+
+
 def _validate_sync_pipe(pipe, *, context: str, allowed: tuple[str, ...]):
     canonical = _canonical_pipe_token(pipe)
     if canonical is None:
@@ -5658,43 +5665,46 @@ def pipe_barrier(pipe):
 def get_buf(pipe, buf_id, mode=0):
     """``pto.get_buf(pipe, buf_id, mode=0)`` – acquire a buffer token.
 
-    ``buf_id`` must be a static integer (0–31). For dynamic buf_id,
-    use :func:`get_buf_dyn`.
+    ``buf_id`` accepts a static integer (0–31) or a runtime index-like SSA value.
     """
-    _pto.GetBufOp(_pipe_attr(pipe), buf_id, mode=mode)
-
-
-def get_buf_dyn(pipe, buf_id, mode=0):
-    """``pto.get_buf_dyn(pipe, buf_id, mode=0)`` – acquire a buffer token with dynamic buf_id.
-
-    ``buf_id`` must be an SSA value (e.g. ``iter & 1`` for double-buffering).
-    """
+    buf_id_op, is_static = _buf_id_operand(
+        buf_id,
+        context="get_buf(..., buf_id=...)",
+    )
+    if is_static:
+        _pto.GetBufOp(_pipe_attr(pipe), buf_id_op, mode=mode)
+        return
     _pto.GetBufDynOp(
         _pipe_attr(pipe),
         mode=mode,
-        buf_id=_coerce_index(buf_id, context="get_buf_dyn(..., buf_id=...)"),
+        buf_id=buf_id_op,
     )
 
 
 def rls_buf(pipe, buf_id, mode=0):
     """``pto.rls_buf(pipe, buf_id, mode=0)`` – release a buffer token.
 
-    ``buf_id`` must be a static integer (0–31). For dynamic buf_id,
-    use :func:`rls_buf_dyn`.
+    ``buf_id`` accepts a static integer (0–31) or a runtime index-like SSA value.
     """
-    _pto.RlsBufOp(_pipe_attr(pipe), buf_id, mode=mode)
-
-
-def rls_buf_dyn(pipe, buf_id, mode=0):
-    """``pto.rls_buf_dyn(pipe, buf_id, mode=0)`` – release a buffer token with dynamic buf_id.
-
-    ``buf_id`` must be an SSA value (e.g. ``iter & 1`` for double-buffering).
-    """
+    buf_id_op, is_static = _buf_id_operand(
+        buf_id,
+        context="rls_buf(..., buf_id=...)",
+    )
+    if is_static:
+        _pto.RlsBufOp(_pipe_attr(pipe), buf_id_op, mode=mode)
+        return
     _pto.RlsBufDynOp(
         _pipe_attr(pipe),
         mode=mode,
-        buf_id=_coerce_index(buf_id, context="rls_buf_dyn(..., buf_id=...)"),
+        buf_id=buf_id_op,
     )
+
+
+def _buf_id_operand(buf_id, *, context: str):
+    if isinstance(buf_id, int):
+        _validate_static_buf_id(buf_id, context=context)
+        return buf_id, True
+    return _coerce_index(buf_id, context=context), False
 
 
 def _sync_event_id_operand(event_id, *, context: str):

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5665,7 +5665,7 @@ def pipe_barrier(pipe):
 def get_buf(pipe, buf_id, mode=0):
     """``pto.get_buf(pipe, buf_id, mode=0)`` – acquire a buffer token.
 
-    ``buf_id`` accepts a static integer (0–31) or a runtime index-like SSA value.
+    ``buf_id`` accepts a static integer (0–31) or a runtime index-like PTO scalar.
     """
     buf_id_op, is_static = _buf_id_operand(
         buf_id,
@@ -5684,7 +5684,7 @@ def get_buf(pipe, buf_id, mode=0):
 def rls_buf(pipe, buf_id, mode=0):
     """``pto.rls_buf(pipe, buf_id, mode=0)`` – release a buffer token.
 
-    ``buf_id`` accepts a static integer (0–31) or a runtime index-like SSA value.
+    ``buf_id`` accepts a static integer (0–31) or a runtime index-like PTO scalar.
     """
     buf_id_op, is_static = _buf_id_operand(
         buf_id,

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -140,7 +140,7 @@ from ._ops import (             # noqa: F401
     fmin, fmax, fma, convert,
     syncthreads, threadfence, threadfence_block, keep, resume,
     pipe_barrier,
-    get_buf, get_buf_dyn, rls_buf, rls_buf_dyn,
+    get_buf, rls_buf,
     set_cross_flag, wait_cross_flag, set_intra_flag, wait_intra_flag,
     set_flag, wait_flag,
     reserve_buffer, import_reserved_buffer,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3010,8 +3010,6 @@ def main() -> None:
         "pipe_barrier",
         "get_buf",
         "rls_buf",
-        "get_buf_dyn",
-        "rls_buf_dyn",
         "set_cross_flag",
         "wait_cross_flag",
         "set_intra_flag",
@@ -3079,6 +3077,8 @@ def main() -> None:
     expect(not hasattr(pto, "tload"), "legacy pto.tload should not remain on the public pto namespace")
     expect(not hasattr(pto, "tstore"), "legacy pto.tstore should not remain on the public pto namespace")
     expect(not hasattr(pto, "tadd"), "legacy pto.tadd should not remain on the public pto namespace")
+    expect(not hasattr(pto, "get_buf_dyn"), "pto.get_buf_dyn should not remain on the public pto namespace")
+    expect(not hasattr(pto, "rls_buf_dyn"), "pto.rls_buf_dyn should not remain on the public pto namespace")
     expect(not hasattr(pto, "tile_buf_type"), "pto.tile_buf_type should not remain on the public pto namespace")
     expect(not hasattr(pto, "vecscope"), "pto.vecscope should not remain on the public pto namespace")
     expect(not hasattr(pto, "as_ptr"), "pto.as_ptr should not remain on the public pto namespace")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -328,14 +328,14 @@ def dynamic_buf_kernel_module(
 
         # Compute dynamic buf-id from the row index: row & 1
         buf_id = row & 1
-        pto.get_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
+        pto.get_buf(pto.Pipe.MTE2, buf_id, 0)
         pto.mte_gm_ub(src_row, ub_ptr, 0, 64, nburst=(1, 64, 64))
-        pto.rls_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
+        pto.rls_buf(pto.Pipe.MTE2, buf_id, 0)
 
         buf_id2 = row & 1
-        pto.get_buf_dyn(pto.Pipe.MTE3, buf_id2, 0)
+        pto.get_buf(pto.Pipe.MTE3, buf_id2, 0)
         pto.mte_ub_gm(ub_ptr, dst_row, 64, nburst=(1, 64, 64))
-        pto.rls_buf_dyn(pto.Pipe.MTE3, buf_id2, 0)
+        pto.rls_buf(pto.Pipe.MTE3, buf_id2, 0)
         pto.pipe_barrier(pto.Pipe.ALL)
 
 
@@ -2476,13 +2476,13 @@ def public_sync_surface_probe():
 @pto.jit(target="a5")
 def public_dynamic_buf_sync_surface_probe():
     const_buf_id = pto.const(3)
-    pto.get_buf_dyn(pto.Pipe.V, const_buf_id)
-    pto.rls_buf_dyn(pto.Pipe.MTE2, const_buf_id, 2)
+    pto.get_buf(pto.Pipe.V, const_buf_id)
+    pto.rls_buf(pto.Pipe.MTE2, const_buf_id, 2)
 
     with pto.for_(0, 4, step=1) as iter:
         buf_id = iter & 1
-        pto.get_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
-        pto.rls_buf_dyn(pto.Pipe.MTE2, buf_id, 0)
+        pto.get_buf(pto.Pipe.MTE2, buf_id, 0)
+        pto.rls_buf(pto.Pipe.MTE2, buf_id, 0)
 
 
 @pto.jit(target="a5", ast_rewrite=False)
@@ -2910,13 +2910,13 @@ def auto_mode_explicit_surface_violation_probe():
 @pto.jit(target="a5")
 def dynamic_buf_invalid_type_probe():
     bad = pto.const(1.0, dtype=pto.f32)
-    pto.get_buf_dyn(pto.Pipe.V, bad)
+    pto.get_buf(pto.Pipe.V, bad)
 
 
 @pto.jit(target="a5")
 def dynamic_rls_buf_invalid_type_probe():
     bad = pto.const(0.0, dtype=pto.f32)
-    pto.rls_buf_dyn(pto.Pipe.MTE2, bad)
+    pto.rls_buf(pto.Pipe.MTE2, bad)
 
 
 class _FakeTensor:
@@ -5542,12 +5542,12 @@ def main() -> None:
     expect_raises(
         TypeError,
         lambda: dynamic_buf_invalid_type_probe.compile(),
-        "get_buf_dyn",
+        "get_buf",
     )
     expect_raises(
         TypeError,
         lambda: dynamic_rls_buf_invalid_type_probe.compile(),
-        "rls_buf_dyn",
+        "rls_buf",
     )
     expect_raises(
         ValueError,


### PR DESCRIPTION
Merge get_buf_dyn/rls_buf_dyn into get_buf/rls_buf so the DSL frontend auto-detects whether buf_id is a static int or an SSA value, following the same pattern as set_flag/wait_flag with _flag_event_id_operand.

- Add _validate_static_buf_id and _buf_id_operand helpers in _ops.py
- get_buf/rls_buf dispatch to GetBufOp/RlsBufOp (static) or GetBufDynOp/RlsBufDynOp (dynamic) based on buf_id type
- Remove standalone get_buf_dyn/rls_buf_dyn functions
- Update docs and tests to use the unified API