### PR TITLE
fix(ptodsl): correct AST rewrite loop scope

### DIFF
--- a/ptodsl/docs/user_guide/05-control-flow.md
+++ b/ptodsl/docs/user_guide/05-control-flow.md
@@ -304,6 +304,22 @@ def ast_rewrite_side_effect_kernel():
         pto.pipe_barrier(pto.Pipe.ALL)
 ```
 
+### Conditional expressions
+
+A conditional expression used as the complete right-hand side of a normal
+(`=`) or annotated assignment is rewritten with the same device-side branch
+semantics. For example,
+`count = remaining if has_tail else 64` produces a merged runtime value when
+`has_tail` is a PTO runtime condition. A Python scalar literal branch is
+materialized using the other branch's runtime scalar type. Both branches must
+therefore provide, or allow PTODSL to infer, one compatible runtime scalar type.
+
+This rewrite does not apply to augmented assignments such as `+=`, or to a
+conditional expression nested inside a larger right-hand-side expression. Those
+forms keep normal Python tracing semantics, so their condition must be a
+trace-time Python boolean. For a runtime condition in either form, first assign
+the conditional result directly or use an explicit `pto.if_`.
+
 ### Runtime loops
 
 Native `range(...)` loops become device-side loops:

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -156,8 +156,11 @@ class _NameInfoVisitor(ast.NodeVisitor):
     def __init__(self):
         self.loads = set()
         self.stores = set()
+        self._comprehension_bindings = set()
 
     def visit_Name(self, node):
+        if node.id in self._comprehension_bindings:
+            return
         if isinstance(node.ctx, ast.Load):
             self.loads.add(node.id)
         elif isinstance(node.ctx, (ast.Store, ast.Del)):
@@ -182,14 +185,14 @@ class _NameInfoVisitor(ast.NodeVisitor):
         for decorator in node.decorator_list:
             self.visit(decorator)
         self._visit_arguments_defaults(node.args)
-        self.loads.update(_function_free_vars(node))
+        self._add_loads(_function_free_vars(node))
 
     def visit_AsyncFunctionDef(self, node):
         self.visit_FunctionDef(node)
 
     def visit_Lambda(self, node):
         self._visit_arguments_defaults(node.args)
-        self.loads.update(_lambda_free_vars(node))
+        self._add_loads(_lambda_free_vars(node))
 
     def visit_ClassDef(self, node):
         self.stores.add(node.name)
@@ -199,7 +202,7 @@ class _NameInfoVisitor(ast.NodeVisitor):
             self.visit(base)
         for keyword in node.keywords:
             self.visit(keyword.value)
-        self.loads.update(_class_body_free_vars(node))
+        self._add_loads(_class_body_free_vars(node))
 
     def _visit_arguments_defaults(self, args):
         for default in args.defaults:
@@ -207,6 +210,39 @@ class _NameInfoVisitor(ast.NodeVisitor):
         for default in args.kw_defaults:
             if default is not None:
                 self.visit(default)
+
+    def _add_loads(self, names):
+        self.loads.update(name for name in names if name not in self._comprehension_bindings)
+
+    def _visit_comprehension(self, generators, result_nodes):
+        saved_bindings = self._comprehension_bindings
+        self._comprehension_bindings = set(saved_bindings)
+        try:
+            for generator in generators:
+                # The iterator is evaluated before this generator target is
+                # bound. Later generators and the result run in the nested
+                # comprehension scope.
+                self.visit(generator.iter)
+                self._comprehension_bindings.update(_target_binding_names(generator.target))
+                self.visit(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            for result_node in result_nodes:
+                self.visit(result_node)
+        finally:
+            self._comprehension_bindings = saved_bindings
+
+    def visit_ListComp(self, node):
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_SetComp(self, node):
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_DictComp(self, node):
+        self._visit_comprehension(node.generators, [node.key, node.value])
+
+    def visit_GeneratorExp(self, node):
+        self._visit_comprehension(node.generators, [node.elt])
 
 
 def _name_info(node) -> _NameInfo:
@@ -224,9 +260,10 @@ class _ScopeBindingVisitor(ast.NodeVisitor):
         self.stores = set()
         self.globals = set()
         self.nonlocals = set()
+        self._comprehension_bindings = set()
 
     def visit_Name(self, node):
-        if isinstance(node.ctx, (ast.Store, ast.Del)):
+        if node.id not in self._comprehension_bindings and isinstance(node.ctx, (ast.Store, ast.Del)):
             self.stores.add(node.id)
 
     def visit_FunctionDef(self, node):
@@ -256,6 +293,33 @@ class _ScopeBindingVisitor(ast.NodeVisitor):
             if alias.name == "*":
                 continue
             self.stores.add(alias.asname or alias.name)
+
+    def _visit_comprehension(self, generators, result_nodes):
+        saved_bindings = self._comprehension_bindings
+        self._comprehension_bindings = set(saved_bindings)
+        try:
+            for generator in generators:
+                self.visit(generator.iter)
+                self._comprehension_bindings.update(_target_binding_names(generator.target))
+                self.visit(generator.target)
+                for condition in generator.ifs:
+                    self.visit(condition)
+            for result_node in result_nodes:
+                self.visit(result_node)
+        finally:
+            self._comprehension_bindings = saved_bindings
+
+    def visit_ListComp(self, node):
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_SetComp(self, node):
+        self._visit_comprehension(node.generators, [node.elt])
+
+    def visit_DictComp(self, node):
+        self._visit_comprehension(node.generators, [node.key, node.value])
+
+    def visit_GeneratorExp(self, node):
+        self._visit_comprehension(node.generators, [node.elt])
 
 
 def _argument_names(args) -> set[str]:
@@ -296,6 +360,19 @@ def _class_body_free_vars(node) -> set[str]:
 
 def _target_stores(node) -> set[str]:
     return _name_info(node).stores
+
+
+def _target_binding_names(node) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, ast.Starred):
+        return _target_binding_names(node.value)
+    if isinstance(node, (ast.List, ast.Tuple)):
+        names = set()
+        for element in node.elts:
+            names.update(_target_binding_names(element))
+        return names
+    return set()
 
 
 def _live_before_block(stmts, live_after) -> set[str]:
@@ -380,16 +457,23 @@ class _ControlFlowRewriter:
         return value
 
     def rewrite_block(self, stmts, *, live_after, allow_loop_control=False):
-        rewritten_reversed = []
+        # Analyze the original source block before any nested rewrite replaces
+        # a statement with generated AST. Generated carry/branch scaffolding
+        # has different bindings from the authored Python source.
+        rewrite_plan = []
         live = set(live_after)
         for stmt in reversed(stmts):
+            rewrite_plan.append((stmt, set(live)))
+            live = _live_before_stmt(stmt, live)
+
+        rewritten_reversed = []
+        for stmt, source_live_after in rewrite_plan:
             rewritten = self.rewrite_stmt(
                 stmt,
-                live_after=live,
+                live_after=source_live_after,
                 allow_loop_control=allow_loop_control,
             )
             rewritten_reversed[:0] = rewritten
-            live = _live_before_stmt(stmt, live)
         return rewritten_reversed
 
     def rewrite_stmt(self, stmt, *, live_after, allow_loop_control=False):
@@ -401,6 +485,12 @@ class _ControlFlowRewriter:
             )
         if isinstance(stmt, ast.For):
             return self._rewrite_for(
+                stmt,
+                live_after=live_after,
+                allow_loop_control=allow_loop_control,
+            )
+        if isinstance(stmt, (ast.Assign, ast.AnnAssign)) and isinstance(stmt.value, ast.IfExp):
+            return self._rewrite_ifexp_assignment(
                 stmt,
                 live_after=live_after,
                 allow_loop_control=allow_loop_control,
@@ -596,6 +686,26 @@ class _ControlFlowRewriter:
             )
         )
         return result
+
+    def _rewrite_ifexp_assignment(self, stmt, *, live_after, allow_loop_control=False):
+        ifexp = stmt.value
+        then_stmt = copy.deepcopy(stmt)
+        then_stmt.value = copy.deepcopy(ifexp.body)
+        else_stmt = copy.deepcopy(stmt)
+        else_stmt.value = copy.deepcopy(ifexp.orelse)
+        conditional = ast.copy_location(
+            ast.If(
+                test=copy.deepcopy(ifexp.test),
+                body=[then_stmt],
+                orelse=[else_stmt],
+            ),
+            stmt,
+        )
+        return self._rewrite_if(
+            conditional,
+            live_after=live_after,
+            allow_loop_control=allow_loop_control,
+        )
 
     def _branch_assign(self, branch_name, names, *, old_value_names, assigned_names):
         return ast.Expr(

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -23,6 +23,7 @@ Public API
 
 from ._bootstrap import make_context  # noqa: F401
 from ._runtime_index_ops import coerce_runtime_index
+from ._scalar_coercion import coerce_scalar_to_type
 from ._surface_types import const_expr
 from ._tracing.active import current_session
 from ._surface_values import unwrap_surface_value, wrap_like_surface_value, wrap_surface_value
@@ -415,11 +416,6 @@ class _IfCM:
         order = tuple(kwargs.keys())
         for name, value in kwargs.items():
             raw_value = unwrap_surface_value(value)
-            if not hasattr(raw_value, "type"):
-                raise TypeError(
-                    "br.assign(...) expects PTO runtime values or authored surface values; "
-                    f"'{name}' received {type(value).__name__}"
-                )
             raw_values[name] = raw_value
             templates[name] = value
         self._branch_assignments[branch_name] = {
@@ -490,22 +486,62 @@ class _IfCM:
 
         order = then_assignment["order"]
         result_types = []
+        result_templates = {}
         for name in order:
             then_value = then_assignment["raw_values"][name]
             else_value = else_assignment["raw_values"][name]
+            then_type = getattr(then_value, "type", None)
+            else_type = getattr(else_value, "type", None)
+            then_template = then_assignment["templates"][name]
+
+            if then_type is None and else_type is None:
+                raise TypeError(
+                    "br.assign(...) requires at least one PTO runtime value to infer the result type; "
+                    f"'{name}' received {type(then_value).__name__} and {type(else_value).__name__}"
+                )
+            if then_type is None:
+                then_value = self._materialize_branch_literal(
+                    "then",
+                    name,
+                    then_value,
+                    else_type,
+                )
+                then_assignment["raw_values"][name] = then_value
+                then_type = then_value.type
+                then_template = else_assignment["templates"][name]
+            if else_type is None:
+                else_value = self._materialize_branch_literal(
+                    "else",
+                    name,
+                    else_value,
+                    then_type,
+                )
+                else_assignment["raw_values"][name] = else_value
+                else_type = else_value.type
             if then_value.type != else_value.type:
                 raise RuntimeError(
                     f"br.assign(...) type mismatch for '{name}': "
                     f"then branch yields {then_value.type}, else branch yields {else_value.type}"
                 )
             result_types.append(then_value.type)
+            result_templates[name] = then_template
 
         return {
             "order": order,
             "result_types": result_types,
+            "result_templates": result_templates,
             "then": then_assignment,
             "else": else_assignment,
         }
+
+    def _materialize_branch_literal(self, branch_name, name, value, target_type):
+        block = self._tmp_if.then_block if branch_name == "then" else self._tmp_if.else_block
+        with InsertionPoint(block):
+            return coerce_scalar_to_type(
+                value,
+                target_type,
+                context=f"br.assign(...) value '{name}'",
+            )
 
     def _finalize_side_effect_if(self):
         has_else = self._branch_entered["else"]
@@ -533,7 +569,7 @@ class _IfCM:
         merged = {}
         for name, template, result in zip(
             merge_spec["order"],
-            (merge_spec["then"]["templates"][name] for name in merge_spec["order"]),
+            (merge_spec["result_templates"][name] for name in merge_spec["order"]),
             final_if.results,
         ):
             merged[name] = wrap_like_surface_value(template, result)

--- a/ptodsl/tests/test_ast_rewrite.py
+++ b/ptodsl/tests/test_ast_rewrite.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import ast
+from pathlib import Path
+import sys
+import textwrap
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "ptodsl"))
+
+from ptodsl._ast_rewrite import (
+    PTODSLAstRewriteError,
+    _ControlFlowRewriter,
+    _name_info,
+)
+
+
+def rewrite_source(source):
+    tree = ast.parse(textwrap.dedent(source))
+    function = tree.body[0]
+    function.body = _ControlFlowRewriter().rewrite_block(function.body, live_after=set())
+    ast.fix_missing_locations(tree)
+    compile(tree, "<ast-rewrite-test>", "exec")
+    return tree
+
+
+class AstRewriteRegressionTest(unittest.TestCase):
+    def test_sibling_runtime_loop_target_reuse_is_not_live_out(self):
+        rewrite_source(
+            """
+            def probe(rows, cols):
+                for t in range(rows):
+                    for c in range(cols):
+                        col = c * 64
+                        mask = col
+                    for mo in pto.static_range(4):
+                        mix_acc = 0
+                        for c in range(cols):
+                            col = c * 64
+                            mask = col
+                            mix_acc = mix_acc + mask
+                        sink = mix_acc
+            """
+        )
+
+    def test_sibling_loop_temporary_reuse_is_not_last_iteration_value(self):
+        rewrite_source(
+            """
+            def probe(rows, cols):
+                for t in range(rows):
+                    for mo in pto.static_range(4):
+                        mix_acc = 0
+                        for dpost_chunk in range(cols):
+                            col = dpost_chunk * 64
+                            cnt = cols - col
+                            mask = cnt
+                            d_reg = mask
+                            mix_acc = mix_acc + d_reg
+                        sink = mix_acc
+                    for mi in pto.static_range(4):
+                        for mo in pto.static_range(4):
+                            mix_acc = 0
+                            for dcomb_chunk in range(cols):
+                                col = dcomb_chunk * 64
+                                cnt = cols - col
+                                mask = cnt
+                                d_reg = mask
+                                mix_acc = mix_acc + d_reg
+                            sink = mix_acc
+            """
+        )
+
+    def test_real_runtime_loop_escapes_remain_rejected(self):
+        with self.assertRaisesRegex(PTODSLAstRewriteError, "loop induction variable"):
+            rewrite_source(
+                """
+                def probe(rows):
+                    for i in range(rows):
+                        value = i
+                    sink = i
+                """
+            )
+        with self.assertRaisesRegex(PTODSLAstRewriteError, "last-iteration-only"):
+            rewrite_source(
+                """
+                def probe(rows):
+                    for i in range(rows):
+                        last = i
+                    sink = last
+                """
+            )
+
+    def test_comprehension_targets_do_not_escape_the_comprehension_scope(self):
+        for expression in (
+            "[h for h in pto.static_range(4)]",
+            "{h for h in pto.static_range(4)}",
+            "{h: h for h in pto.static_range(4)}",
+            "(h for h in pto.static_range(4))",
+        ):
+            info = _name_info(ast.parse(f"values = {expression}").body[0])
+            self.assertNotIn("h", info.loads)
+            self.assertNotIn("h", info.stores)
+
+        tree = rewrite_source(
+            """
+            def probe(rows, cols):
+                for t in range(rows):
+                    for chunk in range(cols):
+                        values = [h for h in pto.static_range(4)]
+                        sink = values[0]
+            """
+        )
+        self.assertNotIn("carry(h=h)", ast.unparse(tree))
+
+    def test_direct_assignment_conditional_expression_rewrites_to_a_branch(self):
+        tree = rewrite_source(
+            """
+            def probe(rows, cols):
+                for t in range(rows):
+                    cnt = cols - t if t < 64 else 64
+                    sink = cnt
+            """
+        )
+        self.assertFalse(any(isinstance(node, ast.IfExp) for node in ast.walk(tree)))
+        self.assertIn("pto.if_", ast.unparse(tree))
+
+    def test_nested_trace_time_conditional_expressions_are_preserved(self):
+        tree = rewrite_source(
+            """
+            def probe(enabled, cols):
+                scaled = (cols if enabled else 0) * 2
+                selected = 1 if (enabled if True else False) else 0
+                if (enabled if True else False):
+                    scaled = scaled + selected
+                for index in range(1 if enabled else 0):
+                    scaled = scaled + index
+                return scaled
+            """
+        )
+        rewritten = ast.unparse(tree)
+        self.assertIn("(cols if enabled else 0) * 2", rewritten)
+        self.assertIn("enabled if True else False", rewritten)
+        self.assertIn("pto.for_(0, 1 if enabled else 0, step=1)", rewritten)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1256,6 +1256,99 @@ def ast_runtime_for_branch_local_temp_probe(rows: pto.i32):
         _ = out
 
 
+@pto.jit(target="a5")
+def ast_sibling_loop_target_reuse_probe(rows: pto.i32, cols: pto.i32):
+    for t in range(rows):
+        for c in range(cols):
+            col = c * 64
+            _ = col
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+        for _ in pto.static_range(2):
+            for c in range(cols):
+                col = c * 64
+                _ = col
+                pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_sibling_loop_temporary_reuse_probe(rows: pto.i32, cols: pto.i32):
+    for t in range(rows):
+        for _ in pto.static_range(2):
+            for dpost_chunk in range(cols):
+                col = dpost_chunk * 64
+                cnt = col + 1
+                mask = cnt
+                d_reg = mask
+                _ = d_reg
+                pto.pipe_barrier(pto.Pipe.ALL)
+
+        for _ in pto.static_range(2):
+            for _ in pto.static_range(2):
+                for dcomb_chunk in range(cols):
+                    col = dcomb_chunk * 64
+                    cnt = col + 1
+                    mask = cnt
+                    d_reg = mask
+                    _ = d_reg
+                    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_comprehension_scope_probe(rows: pto.i32, cols: pto.i32):
+    for t in range(rows):
+        for chunk in range(cols):
+            heads = [h for h in pto.static_range(4)]
+            for h in pto.static_range(4):
+                value = heads[h]
+                _ = value
+                pto.pipe_barrier(pto.Pipe.ALL)
+
+            for _ in pto.static_range(2):
+                for h in pto.static_range(4):
+                    value = heads[h]
+                    _ = value
+                    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_runtime_conditional_expression_probe(rows: pto.i32, cols: pto.i32):
+    for t in range(rows):
+        col = t * 64
+        cnt = cols - col if cols - col < 64 else 64
+        _ = cnt
+        pto.pipe_barrier(pto.Pipe.ALL)
+
+
+@pto.jit(target="a5")
+def ast_combined_loop_scope_probe(rows: pto.i32, cols: pto.i32):
+    mask1 = pto.const(1, dtype=pto.index)
+    mask_all = pto.const(2, dtype=pto.index)
+    for t in range(rows):
+        for c in range(cols):
+            col = c * 64
+            mask = col
+            d_heads = [mask + h for h in pto.static_range(4)]
+            acc = None
+            for h in pto.static_range(4):
+                term = d_heads[h]
+                acc = term if acc is None else acc + term
+            sink = acc + col + mask
+            _ = sink
+            pto.pipe_barrier(pto.Pipe.ALL)
+
+        for _ in pto.static_range(4):
+            mix_acc = pto.const(0, dtype=pto.index)
+            for c in range(cols):
+                col = c * 64
+                mask = col
+                mix_acc = mix_acc + mask
+                pto.pipe_barrier(pto.Pipe.ALL)
+            sum_v = mix_acc + mask_all
+            out = sum_v + mask1
+            _ = out
+
+
 @pto.jit(target="a5", ast_rewrite=False)
 def ast_rewrite_disabled_nested_helper_python_control_probe():
     def helper(enabled):
@@ -4834,6 +4927,80 @@ def main() -> None:
     expect(
         "iter_args(" not in ast_runtime_for_branch_local_temp_text,
         "branch-local temporaries should not be inferred as loop-carried state",
+    )
+
+    ast_sibling_loop_target_reuse_text = ast_sibling_loop_target_reuse_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_sibling_loop_target_reuse_text,
+        "AST-rewritten sibling runtime loop-target reuse specialization",
+    )
+    expect(
+        ast_sibling_loop_target_reuse_text.count("scf.for") == 4,
+        "sibling runtime loops reusing an induction-variable name should all lower to scf.for",
+    )
+    expect(
+        "iter_args(" not in ast_sibling_loop_target_reuse_text,
+        "sibling loop-target reuse should not infer a synthetic carried induction variable",
+    )
+
+    ast_sibling_loop_temporary_reuse_text = ast_sibling_loop_temporary_reuse_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_sibling_loop_temporary_reuse_text,
+        "AST-rewritten sibling loop-local temporary reuse specialization",
+    )
+    expect(
+        ast_sibling_loop_temporary_reuse_text.count("scf.for") == 7,
+        "sibling runtime loops reusing loop-local temporary names should all lower to scf.for",
+    )
+    expect(
+        "iter_args(" not in ast_sibling_loop_temporary_reuse_text,
+        "sibling loop-local temporaries should not be inferred as last-iteration values",
+    )
+
+    ast_comprehension_scope_text = ast_comprehension_scope_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_comprehension_scope_text,
+        "AST-rewritten static_range comprehension scope specialization",
+    )
+    expect(
+        ast_comprehension_scope_text.count("scf.for") == 2,
+        "comprehension targets should not become carried runtime-loop values",
+    )
+    expect(
+        "iter_args(" not in ast_comprehension_scope_text,
+        "comprehension-local targets should not be materialized as loop carry state",
+    )
+
+    ast_runtime_conditional_expression_text = ast_runtime_conditional_expression_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_runtime_conditional_expression_text,
+        "AST-rewritten conditional-expression specialization",
+    )
+    expect(
+        ast_runtime_conditional_expression_text.count("scf.for") == 1,
+        "conditional expressions inside runtime loops should retain the authored scf.for",
+    )
+    expect(
+        ast_runtime_conditional_expression_text.count("scf.if") == 1,
+        "a runtime conditional expression should lower through one merged scf.if",
+    )
+    expect(
+        "arith.constant 64" in ast_runtime_conditional_expression_text,
+        "a literal conditional-expression branch should materialize with the runtime branch type",
+    )
+
+    ast_combined_loop_scope_text = ast_combined_loop_scope_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_combined_loop_scope_text,
+        "AST-rewritten combined sibling-loop/comprehension/conditional specialization",
+    )
+    expect(
+        ast_combined_loop_scope_text.count("scf.for") == 6,
+        "the combined pattern should retain all authored runtime loops",
+    )
+    expect(
+        ast_combined_loop_scope_text.count("iter_args(") == 4,
+        "the combined pattern should carry only the four intended mix_acc accumulators",
     )
 
     ast_rewrite_disabled_nested_helper_python_control_text = (


### PR DESCRIPTION
## Summary
- analyze runtime-loop liveness from authored source AST before generating control-flow scaffolding
- preserve Python comprehension-local bindings during AST rewrite analysis
- lower direct assignment conditional expressions through merged PTODSL branches

## Validation
- rebuilt local LLVM21 PTOAS Python modules and ptoas
- ptodsl/tests/test_ast_rewrite.py
- ptodsl/tests/test_jit_compile.py
- ptodsl/tests/test_jit_diagnostics.py
- ptodsl/tests/test_docs_as_test.py
- ctest --test-dir build-local-vpto --output-on-failure -R '^ptodsl_ast_rewrite$'

Closes #933