### PR TITLE
fix(SIMT): Auto-derive simt-max-registers from max_threads

### DIFF
--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -48,24 +48,36 @@ The current PTO SIMT surface supports these operation families:
 | Conversion | `pto.convert` |
 | Entry synchronization and state | `pto.syncthreads`, `pto.threadfence`, `pto.threadfence_block`, `pto.keep`, `pto.resume` |
 
-Two optional function attributes may be attached to a `pto.simt_entry`
-function:
+One optional function attribute may be attached to a `pto.simt_entry` function:
 
 | Function attribute | Type | Default | Meaning |
 |--------------------|------|---------|---------|
 | `pto.simt_max_threads` | signless `i32` integer attribute | `1024` | Compile-time launch envelope. It should cover the largest `dim_x * dim_y * dim_z` launch count used for this entry. |
-| `pto.simt_max_regs` | signless `i32` integer attribute | `32` | Compile-time scalar register budget per workitem. Lower values constrain scalar live state; higher values permit more scalar live values with higher resource pressure. |
 
-Both attributes are optional. If present, they must be positive `i32`
-attributes and may only appear on functions that also carry `pto.simt_entry`.
-They do not launch work by themselves; the actual workitem count comes from
+The attribute is optional. If present, it must be a positive `i32` attribute
+and may only appear on functions that also carry `pto.simt_entry`. It does not
+launch work by itself; the actual workitem count comes from
 `pto.store_vfsimt_info` or `pto.simt_launch`.
+
+The per-workitem register budget (`simt-max-registers`) is **automatically
+derived** from `pto.simt_max_threads` according to the hardware resource
+partition:
+
+| `max_threads` | Derived `max_regs` |
+|---|---|
+| ≤ 256 | 128 |
+| ≤ 512 | 64 |
+| ≤ 1024 | 32 |
+| ≤ 2048 | 16 |
+
+The `pto.simt_max_regs` attribute is **deprecated** as a public interface.
+Existing IR that carries it will still parse, but the emitter ignores its
+value and always computes `simt-max-registers` from `pto.simt_max_threads`.
 
 ```mlir
 func.func @body(%dst: !pto.ptr<i32, ub>)
     attributes {pto.simt_entry,
-                pto.simt_max_threads = 256 : i32,
-                pto.simt_max_regs = 48 : i32} {
+                pto.simt_max_threads = 256 : i32} {
   return
 }
 ```

--- a/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
@@ -534,10 +534,25 @@ LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
   return success();
 }
 
+// Derive the per-workitem register budget from the compile-time thread count.
+// The hardware imposes a fixed resource partition:
+//   max_threads <= 256   → max_regs = 128
+//   max_threads <= 512   → max_regs = 64
+//   max_threads <= 1024  → max_regs = 32
+//   max_threads <= 2048  → max_regs = 16
+static uint32_t deriveMaxRegsFromMaxThreads(uint32_t maxThreads) {
+  if (maxThreads <= 256)
+    return 128;
+  if (maxThreads <= 512)
+    return 64;
+  if (maxThreads <= 1024)
+    return 32;
+  return 16;
+}
+
 void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
                                  ModuleOp sourceModule) {
   constexpr uint32_t kDefaultSimtMaxThreads = 1024;
-  constexpr uint32_t kDefaultSimtMaxRegisters = 32;
 
   llvm::NamedMDNode *annotations =
       llvmModule.getOrInsertNamedMetadata("hivm.annotations");
@@ -558,13 +573,13 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
       return;
 
     uint32_t maxThreads = kDefaultSimtMaxThreads;
-    uint32_t maxRegisters = kDefaultSimtMaxRegisters;
     if (auto attr =
             funcOp->getAttrOfType<IntegerAttr>(pto::kPTOSimtMaxThreadsAttrName))
       maxThreads = static_cast<uint32_t>(attr.getInt());
-    if (auto attr = funcOp->getAttrOfType<IntegerAttr>(
-            pto::kPTOSimtMaxRegistersAttrName))
-      maxRegisters = static_cast<uint32_t>(attr.getInt());
+    // max_regs is derived from max_threads according to the hardware resource
+    // partition; the pto.simt_max_regs attribute (if present) is intentionally
+    // ignored for the final annotation value.
+    uint32_t maxRegisters = deriveMaxRegsFromMaxThreads(maxThreads);
 
     simtConfigByName[symName] = {maxThreads, maxRegisters};
   });
@@ -611,7 +626,7 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
       continue;
     if (function.getCallingConv() == llvm::CallingConv::SimtEntry) {
       uint32_t maxThreads = kDefaultSimtMaxThreads;
-      uint32_t maxRegisters = kDefaultSimtMaxRegisters;
+      uint32_t maxRegisters = deriveMaxRegsFromMaxThreads(maxThreads);
       if (auto it = simtConfigByName.find(function.getName());
           it != simtConfigByName.end()) {
         maxThreads = it->second.first;

--- a/test/lit/vpto/simt_lowlevel_launch_config_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_launch_config_vpto_llvm.pto
@@ -8,27 +8,130 @@
 
 // RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
 
+// Verify:
+// 1. MLIR attributes (pto.simt_max_threads, pto.simt_entry) are preserved
+//    through lowering.
+// 2. The deprecated pto.simt_max_regs attribute is preserved in MLIR for
+//    backward compatibility (the emitter will ignore it and derive the final
+//    simt-max-registers annotation from pto.simt_max_threads instead).
+
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @launch_config_kernel(%dst: !pto.ptr<i32, ub>) attributes {pto.aicore} {
     %dim_z = arith.constant 1 : i32
     %dim_y = arith.constant 1 : i32
     %dim_x = arith.constant 32 : i32
     pto.store_vfsimt_info %dim_z, %dim_y, %dim_x : i32, i32, i32
-    func.call @launch_config_body(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_boundary_256(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_boundary_257(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_boundary_512(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_boundary_513(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_boundary_1024(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_boundary_1025(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_boundary_2048(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_default(%dst) : (!pto.ptr<i32, ub>) -> ()
+    func.call @body_explicit_max_regs_ignored(%dst) : (!pto.ptr<i32, ub>) -> ()
     return
   }
 
-  func.func @launch_config_body(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 256 : i32, pto.simt_max_regs = 48 : i32} {
+  // max_threads=256 (boundary ≤256 → regs=128 at emission)
+  func.func @body_boundary_256(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 256 : i32} {
     %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
     %tid_x = pto.get_tid_x : i32
-    %laneid = pto.get_laneid : i32
     pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
-    pto.store %laneid, %dst[%c1] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // max_threads=257 (boundary ≤512 → regs=64 at emission)
+  func.func @body_boundary_257(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 257 : i32} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // max_threads=512 (boundary ≤512 → regs=64 at emission)
+  func.func @body_boundary_512(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 512 : i32} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // max_threads=513 (boundary ≤1024 → regs=32 at emission)
+  func.func @body_boundary_513(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 513 : i32} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // max_threads=1024 (boundary ≤1024 → regs=32 at emission)
+  func.func @body_boundary_1024(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 1024 : i32} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // max_threads=1025 (boundary ≤2048 → regs=16 at emission)
+  func.func @body_boundary_1025(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 1025 : i32} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // max_threads=2048 (boundary ≤2048 → regs=16 at emission)
+  func.func @body_boundary_2048(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 2048 : i32} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // No max_threads specified → defaults to 1024 → regs=32 at emission
+  func.func @body_default(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
+    return
+  }
+
+  // max_threads=256 with deprecated pto.simt_max_regs=48.
+  // Both attributes survive lowering, but the emitter derives max-regs (128)
+  // from max_threads (256), ignoring the explicit pto.simt_max_regs value.
+  func.func @body_explicit_max_regs_ignored(%dst: !pto.ptr<i32, ub>) attributes {pto.simt_entry, pto.simt_max_threads = 256 : i32, pto.simt_max_regs = 48 : i32} {
+    %c0 = arith.constant 0 : index
+    %tid_x = pto.get_tid_x : i32
+    pto.store %tid_x, %dst[%c0] : !pto.ptr<i32, ub>, i32
     return
   }
 }
 
-// CHECK-LABEL: llvm.func @launch_config_body
+// CHECK-LABEL: llvm.func @body_boundary_256
+// CHECK-SAME: pto.simt_max_threads = 256 : i32
+
+// CHECK-LABEL: llvm.func @body_boundary_257
+// CHECK-SAME: pto.simt_max_threads = 257 : i32
+
+// CHECK-LABEL: llvm.func @body_boundary_512
+// CHECK-SAME: pto.simt_max_threads = 512 : i32
+
+// CHECK-LABEL: llvm.func @body_boundary_513
+// CHECK-SAME: pto.simt_max_threads = 513 : i32
+
+// CHECK-LABEL: llvm.func @body_boundary_1024
+// CHECK-SAME: pto.simt_max_threads = 1024 : i32
+
+// CHECK-LABEL: llvm.func @body_boundary_1025
+// CHECK-SAME: pto.simt_max_threads = 1025 : i32
+
+// CHECK-LABEL: llvm.func @body_boundary_2048
+// CHECK-SAME: pto.simt_max_threads = 2048 : i32
+
+// CHECK-LABEL: llvm.func @body_default
+// CHECK: pto.simt_entry
+
+// CHECK-LABEL: llvm.func @body_explicit_max_regs_ignored
 // CHECK-SAME: pto.simt_max_regs = 48 : i32
 // CHECK-SAME: pto.simt_max_threads = 256 : i32


### PR DESCRIPTION
根据硬件资源分区规则，从 max_threads 自动推导每线程寄存器预算：
  max_threads ≤ 256  → max_regs = 128
  max_threads ≤ 512  → max_regs = 64
  max_threads ≤ 1024 → max_regs = 32
  max_threads ≤ 2048 → max_regs = 16

Emitter 不再读取 pto.simt_max_regs 属性计算最终 annotation，
simt-max-registers 仅由 pto.simt_max_threads 决定。

变更：
- VPTOLLVMEmitterHelper: 新增 deriveMaxRegsFromMaxThreads()，移除对 pto.simt_max_regs 的读取和使用
- 文档: pto.simt_max_regs 标记为 deprecated，添加推导映射表
- 测试: 覆盖 256/257/512/513/1024/1025/2048 边界值及默认值场景
- 保留 pto.simt_max_regs 属性定义和验证器，保证已有 IR 向后兼容

修复 #527