### PR TITLE
refactor(ptodsl): Remove max_regs parameter from @pto.simt decorator

### DIFF
--- a/docs/designs/ptodsl-simt-micro-op-api-design.md
+++ b/docs/designs/ptodsl-simt-micro-op-api-design.md
@@ -34,7 +34,7 @@ math, conversion, sync, and state preservation.
 Current PTO-DSL already has a narrow SIMT surface:
 
 - `@pto.simt` decorator and `with pto.simt():` inline scope.
-- `@pto.simt(max_threads=..., max_regs=...)` optional entry resource
+- `@pto.simt(max_threads=...)` optional entry resource
   attributes.
 - `pto.store_vfsimt_info(dim_z, dim_y, dim_x)`.
 - `pto.get_tid_x()`, `pto.get_tid_y()`, `pto.get_tid_z()`.
@@ -284,15 +284,14 @@ explicit peer function symbol.
 
 ### 5.6 `@pto.simt` Decorator Attributes
 
-SIMT entry functions may carry optional VPTO attributes:
+SIMT entry functions may carry an optional VPTO attribute:
 
 - `pto.simt_max_threads`
-- `pto.simt_max_regs`
 
-PTO-DSL exposes them through `@pto.simt`:
+PTO-DSL exposes it through `@pto.simt`:
 
 ```python
-@pto.simt(max_threads=256, max_regs=48)
+@pto.simt(max_threads=256)
 def body(...):
     ...
 ```
@@ -302,14 +301,13 @@ Lowering:
 ```mlir
 func.func @body(...) attributes {
   pto.simt_entry,
-  pto.simt_max_threads = 256 : i32,
-  pto.simt_max_regs = 48 : i32
+  pto.simt_max_threads = 256 : i32
 }
 ```
 
-Lowering attaches these attributes to the generated specialized helper function,
-not to the authored Python symbol. Omitting either argument emits no explicit
-attribute and lets backend defaults apply.
+Lowering attaches the attribute to the generated specialized helper function,
+not to the authored Python symbol. Omitting the argument emits no explicit
+attribute and lets the backend default (1024) apply.
 
 Validation:
 
@@ -432,8 +430,10 @@ Minimum Python/frontend tests:
    produces distinct helper functions and distinct traced bodies.
 8. `pto.simt_launch` callee attributes reference the actual generated helper
    symbols.
-9. `@pto.simt(max_threads=..., max_regs=...)` emits `pto.simt_max_threads` and
-   `pto.simt_max_regs` on the generated helper function.
+9. `@pto.simt(max_threads=...)` emits `pto.simt_max_threads` on the generated
+   helper function. The register budget (`simt-max-registers`) is automatically
+   derived from `max_threads` by the backend according to the hardware resource
+   partition and is no longer a configurable attribute.
 
 Suggested lit/frontend assertions:
 

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -986,7 +986,7 @@ Parameters are `Tile` references, typed UB pointers, and PTO scalars. The
 sub-kernel reads and writes individual elements through tile handles; results
 flow back to the caller via mutable tile parameters.
 
-**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None, max_regs=None)`
+**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None)`
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"kernel_entry.simt_signature","symbol":"kernel_entry_simt_signature_probe","compile":{"BLOCK":8}} -->
 ```python
@@ -1026,28 +1026,31 @@ in parallel, making it efficient for per-element operations.
 
 #### SIMT resource attributes
 
-Optional `max_threads` and `max_regs` arguments attach VPTO resource attributes
+An optional `max_threads` argument attaches a VPTO resource attribute
 to the generated `pto.simt_entry` helper.
 
-**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None, max_regs=None)`
+**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None)`
 
 **Parameters**:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `max_threads` | positive Python `int` | backend default `1024` | Compile-time launch envelope for this SIMT helper |
-| `max_regs` | positive Python `int` | backend default `32` | Scalar register budget per work-item |
 
 `max_threads` is not the launch size. The actual work-item count comes from the
-SIMT launch dimensions. Both arguments must be Python integers known at trace
-time, greater than zero, and fit in signless `i32`. They are only valid on
+SIMT launch dimensions. The argument must be a Python integer known at trace
+time, greater than zero, and fit in signless `i32`. It is only valid on
 decorated SIMT helper functions, not inline `with pto.simt():` scopes.
+
+The per-workitem register budget (`simt-max-registers`) is automatically
+derived from `max_threads` by the VPTO backend according to the hardware
+resource partition.
 
 **Example**:
 
 <!-- ptodsl-doc-test: {"mode":"compile","symbol":"kernel_entry_simt_resource_probe","compile":{}} -->
 ```python
-@pto.simt(max_threads=256, max_regs=48)
+@pto.simt(max_threads=256)
 def write_tid(dst: pto.ptr(pto.i32, "gm")):
     tid = pto.get_tid_x()
     idx = scalar.index_cast(tid)

--- a/ptodsl/ptodsl/_subkernels.py
+++ b/ptodsl/ptodsl/_subkernels.py
@@ -75,7 +75,6 @@ class SubkernelSpec:
     symbol_name: str
     target: str = "a5"
     simt_max_threads: int | None = None
-    simt_max_regs: int | None = None
 
 
 class SubkernelTemplate:
@@ -404,7 +403,6 @@ class _SubkernelSurface:
         target: str = "a5",
         ast_rewrite: bool = True,
         simt_max_threads: int | None = None,
-        simt_max_regs: int | None = None,
         simt_inline_dims: tuple | None = None,
     ):
         self._role = role
@@ -412,7 +410,6 @@ class _SubkernelSurface:
         self._target = target
         self._ast_rewrite = ast_rewrite
         self._simt_max_threads = simt_max_threads
-        self._simt_max_regs = simt_max_regs
         self._simt_inline_dims = simt_inline_dims
         self._session_cm = None
 
@@ -425,17 +422,14 @@ class _SubkernelSurface:
                 symbol_name=self._name or fn.__name__,
                 target=self._target,
                 simt_max_threads=self._simt_max_threads,
-                simt_max_regs=self._simt_max_regs,
             ),
             fn,
             ast_rewrite=self._ast_rewrite,
         )
 
     def __enter__(self):
-        if self._role == KernelRole.SIMT and (
-            self._simt_max_threads is not None or self._simt_max_regs is not None
-        ):
-            raise TypeError("@pto.simt(max_threads=..., max_regs=...) is only supported as a function decorator")
+        if self._role == KernelRole.SIMT and self._simt_max_threads is not None:
+            raise TypeError("@pto.simt(max_threads=...) is only supported as a function decorator")
         runtime = current_runtime()
         if runtime is None:
             raise RuntimeError(
@@ -469,7 +463,6 @@ def _subkernel_decorator(
     target: str = "a5",
     ast_rewrite: bool = True,
     simt_max_threads: int | None = None,
-    simt_max_regs: int | None = None,
     simt_inline_dims: tuple | None = None,
 ):
     return _SubkernelSurface(
@@ -478,7 +471,6 @@ def _subkernel_decorator(
         target=target,
         ast_rewrite=ast_rewrite,
         simt_max_threads=simt_max_threads,
-        simt_max_regs=simt_max_regs,
         simt_inline_dims=simt_inline_dims,
     )
 
@@ -491,7 +483,6 @@ def _decorate_subkernel(
     target: str = "a5",
     ast_rewrite: bool = True,
     simt_max_threads: int | None = None,
-    simt_max_regs: int | None = None,
     simt_inline_dims: tuple | None = None,
 ):
     if fn is not None:
@@ -501,7 +492,6 @@ def _decorate_subkernel(
             target=target,
             ast_rewrite=ast_rewrite,
             simt_max_threads=simt_max_threads,
-            simt_max_regs=simt_max_regs,
             simt_inline_dims=simt_inline_dims,
         )(fn)
     return _subkernel_decorator(
@@ -510,7 +500,6 @@ def _decorate_subkernel(
         target=target,
         ast_rewrite=ast_rewrite,
         simt_max_threads=simt_max_threads,
-        simt_max_regs=simt_max_regs,
         simt_inline_dims=simt_inline_dims,
     )
 
@@ -542,10 +531,8 @@ def simt(
     target: str = "a5",
     ast_rewrite: bool = True,
     max_threads: int | None = None,
-    max_regs: int | None = None,
 ):
     max_threads = _validate_simt_resource_attr("max_threads", max_threads)
-    max_regs = _validate_simt_resource_attr("max_regs", max_regs)
     simt_inline_dims = None
     if fn is not None and not callable(fn):
         dims = (fn, *dims)
@@ -561,7 +548,6 @@ def simt(
         target=target,
         ast_rewrite=ast_rewrite,
         simt_max_threads=max_threads,
-        simt_max_regs=max_regs,
         simt_inline_dims=simt_inline_dims,
     )
 

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -596,13 +596,6 @@ class TraceSession:
                     IntegerAttr.get(i32_attr_type, subkernel.spec.simt_max_threads),
                 )
             )
-        if subkernel.spec.simt_max_regs is not None:
-            helper_attributes.append(
-                (
-                    "pto.simt_max_regs",
-                    IntegerAttr.get(i32_attr_type, subkernel.spec.simt_max_regs),
-                )
-            )
         helper_fn = self._create_named_helper_function(
             helper_symbol,
             arg_types,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -838,7 +838,7 @@ def simt_grouped_query_probe():
     pto.keep(grid_z, slot=8)
 
 
-@pto.simt(max_threads=256, max_regs=48)
+@pto.simt(max_threads=256)
 def simt_resource_attr_probe():
     pto.get_tid_x()
 
@@ -4562,20 +4562,15 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(simt_resource_attr_text, "simt resource attr launch specialization")
     expect(
         re.search(
-            r"func\.func @simt_resource_attr_probe__simt_\d+\(\) attributes \{pto\.simt_entry, pto\.simt_max_regs = 48 : i32, pto\.simt_max_threads = 256 : i32\}",
+            r"func\.func @simt_resource_attr_probe__simt_\d+\(\) attributes \{pto\.simt_entry, pto\.simt_max_threads = 256 : i32\}",
             simt_resource_attr_text,
         ) is not None,
-        "@pto.simt(max_threads=..., max_regs=...) should attach resource attrs to the helper function",
+        "@pto.simt(max_threads=...) should attach resource attrs to the helper function",
     )
     expect_raises(
         ValueError,
         lambda: pto.simt(max_threads=0)(lambda: None),
         "max_threads",
-    )
-    expect_raises(
-        TypeError,
-        lambda: pto.simt(max_regs=True)(lambda: None),
-        "max_regs",
     )
 
     def _enter_inline_simt_with_resource_attr():


### PR DESCRIPTION
删除 @pto.simt 装饰器的 max_regs 参数，不再作为对外公开接口。
simt-max-registers 已由 VPTO 后端根据 max_threads 自动推导（#949）， 无需用户手工指定，PTODSL 侧同步删除对应参数。

变更：
- _subkernels.py: 从 SubkernelSpec、_SubkernelSurface、simt() 等 删除 max_regs 参数和相关逻辑
- _tracing/session.py: 删除 pto.simt_max_regs 的 MLIR 属性发射
- test_jit_compile.py: 更新测试，移除 max_regs 相关断言
- 设计文档和用户指南: 移除 max_regs 描述，标注寄存器预算自动推导


相关 issue [#527](https://github.com/mouliangyu/PTOAS/issues/527)