### PR TITLE
fix(ptoas): clamp host -target-cpu for bisheng host stub compile

### DIFF
--- a/tools/ptoas/ObjectEmission.cpp
+++ b/tools/ptoas/ObjectEmission.cpp
@@ -523,6 +523,19 @@ static bool compileCppDeviceSourceToFatobj(
                               "C++ fatobj compilation");
 }
 
+static std::string resolveHostTargetCPU() {
+  if (const char *envCPU = std::getenv("PTOAS_HOST_TARGET_CPU")) {
+    if (envCPU[0] != '\0')
+      return std::string(envCPU);
+  }
+  std::string hostCPU = llvm::sys::getHostCPUName().str();
+  if (hostCPU == "cortex-x925")
+    return "tsv200m";
+  if (hostCPU == "znver4" || hostCPU == "znver5")
+    return "znver3";
+  return hostCPU;
+}
+
 static bool compileHostStubToObject(llvm::StringRef stubPath,
                                     llvm::StringRef outObjPath,
                                     llvm::StringRef moduleId,
@@ -534,6 +547,7 @@ static bool compileHostStubToObject(llvm::StringRef stubPath,
   std::string coverageDir = ".";
   std::string debugDir = ".";
   std::string hostTriple = llvm::sys::getProcessTriple();
+  std::string hostTargetCPU = resolveHostTargetCPU();
 
   llvm::SmallVector<std::string, 32> args = {
       toolchain.bishengCc1Path,
@@ -541,7 +555,7 @@ static bool compileHostStubToObject(llvm::StringRef stubPath,
       "-triple",
       hostTriple,
       "-target-cpu",
-      llvm::sys::getHostCPUName().str(),
+      hostTargetCPU,
       "-fcce-aicpu-legacy-launch",
       "-fcce-is-host",
       "-cce-enable-mix",


### PR DESCRIPTION
ptoas passes llvm::sys::getHostCPUName() from the (newer) LLVM it is built against straight to 'bisheng -cc1 -target-cpu', but bisheng's Clang 15 only recognizes up to znver3, so every target="pto" compile fails on Zen 4/Zen 5 hosts with 'unknown target CPU'.

Add resolveHostCPUName(): clamp znver4/znver5 to znver3 and allow PTOAS_HOST_CPU to override detection. Marked as WORKAROUND to drop once bisheng upgrades to LLVM 21.

Fixes #958