### PR TITLE
fix: avoid async verifier races in frontend pipe lowering

### DIFF
--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -393,13 +393,19 @@ def VPTONormalizeContainer : Pass<"vpto-normalize-container", "ModuleOp"> {
   ];
 }
 
-def PTOLowerFrontendPipeOps : Pass<"pto-lower-frontend-pipe-ops", "func::FuncOp"> {
+def PTOLowerFrontendPipeOps : Pass<"pto-lower-frontend-pipe-ops", "ModuleOp"> {
   let summary = "Lower frontend TPUSH/TPOP pipe ops to internal pipe ops";
   let description = [{
     Converts frontend `aic/aiv_initialize_pipe`, `tpush_to_*`,
     `tpop_from_*`, and `tfree_from_*` ops into the internal unified pipe IR:
     `initialize_l2l_pipe` / `initialize_l2g2l_pipe`, `tpush`,
     `declare_tile`, `tpop`, and `tfree`.
+
+    This is a module pass because frontend pipe verification and fixpipe peer
+    contract checks may inspect peer functions while the lowering mutates the
+    producer and consumer functions. Running it as a nested function pass lets
+    MLIR schedule producer and consumer functions concurrently, which is unsafe
+    for these cross-function contracts.
   }];
 
   let constructor = "mlir::pto::createPTOLowerFrontendPipeOpsPass()";

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -416,13 +416,17 @@ def PTOLowerFrontendPipeOps : Pass<"pto-lower-frontend-pipe-ops", "ModuleOp"> {
   ];
 }
 
-def PTOAssignDefaultFrontendPipeId : Pass<"pto-assign-default-frontend-pipe-id", "func::FuncOp"> {
+def PTOAssignDefaultFrontendPipeId : Pass<"pto-assign-default-frontend-pipe-id", "ModuleOp"> {
   let summary = "Materialize default id = 0 on frontend TPUSH/TPOP pipe ops";
   let description = [{
     Preserves backward compatibility with older frontend pipe syntax that
     omitted `id`. This pass rewrites missing `id` attrs on
     `aic/aiv_initialize_pipe`, `tpush_to_*`, `tpop_from_*`, and
     `tfree_from_*` to an explicit `id = 0` before frontend pipe lowering.
+
+    This is a module pass so frontend pipe ops are not verified by MLIR's
+    asynchronous nested function pass adaptor before the module-level frontend
+    pipe lowering removes them.
   }];
 
   let constructor = "mlir::pto::createPTOAssignDefaultFrontendPipeIdPass()";

--- a/lib/PTO/Transforms/PTOAssignDefaultFrontendPipeIdPass.cpp
+++ b/lib/PTO/Transforms/PTOAssignDefaultFrontendPipeIdPass.cpp
@@ -33,11 +33,11 @@ struct PTOAssignDefaultFrontendPipeIdPass
     : public mlir::pto::impl::PTOAssignDefaultFrontendPipeIdBase<
           PTOAssignDefaultFrontendPipeIdPass> {
   void runOnOperation() override {
-    func::FuncOp funcOp = getOperation();
-    Builder builder(funcOp.getContext());
+    ModuleOp moduleOp = getOperation();
+    Builder builder(moduleOp.getContext());
     auto zeroAttr = builder.getI32IntegerAttr(0);
 
-    funcOp.walk([&](Operation *op) {
+    moduleOp.walk([&](Operation *op) {
       if (auto init = dyn_cast<AicInitializePipeOp>(op)) {
         assignDefaultIdIfMissing(init, zeroAttr);
         return WalkResult::advance();

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -617,19 +617,27 @@ struct PTOLowerFrontendPipeOpsPass
     : public mlir::pto::impl::PTOLowerFrontendPipeOpsBase<
           PTOLowerFrontendPipeOpsPass> {
   void runOnOperation() override {
-    func::FuncOp funcOp = getOperation();
-    if (!hasFrontendPipeOps(funcOp))
-      return;
+    ModuleOp moduleOp = getOperation();
+    SmallVector<func::FuncOp> funcs;
+    moduleOp.walk([&](func::FuncOp funcOp) {
+      if (hasFrontendPipeOps(funcOp))
+        funcs.push_back(funcOp);
+      return WalkResult::advance();
+    });
 
-    IRRewriter rewriter(funcOp.getContext());
-    auto loweredOr = lowerInitIfPresent(funcOp, rewriter);
-    if (failed(loweredOr)) {
-      signalPassFailure();
-      return;
+    IRRewriter rewriter(moduleOp.getContext());
+    for (func::FuncOp funcOp : funcs) {
+      auto loweredOr = lowerInitIfPresent(funcOp, rewriter);
+      if (failed(loweredOr)) {
+        signalPassFailure();
+        return;
+      }
+
+      if (failed(lowerFrontendDataOps(funcOp, *loweredOr, rewriter))) {
+        signalPassFailure();
+        return;
+      }
     }
-
-    if (failed(lowerFrontendDataOps(funcOp, *loweredOr, rewriter)))
-      signalPassFailure();
   }
 };
 

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -2952,8 +2952,7 @@ int mlir::pto::compilePTOASModule(
   // lifted to make it unconditional for all backends.
   if (effectiveBackend == PTOBackend::VPTO)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCanonicalizeIRPass());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      pto::createPTOAssignDefaultFrontendPipeIdPass());
+  pm.addPass(pto::createPTOAssignDefaultFrontendPipeIdPass());
   pm.addPass(pto::createPTOLowerFrontendPipeOpsPass());
   //pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addPass(pto::createPTOInferValidatePipeInitPass());

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -2954,8 +2954,7 @@ int mlir::pto::compilePTOASModule(
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCanonicalizeIRPass());
   pm.addNestedPass<mlir::func::FuncOp>(
       pto::createPTOAssignDefaultFrontendPipeIdPass());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      pto::createPTOLowerFrontendPipeOpsPass());
+  pm.addPass(pto::createPTOLowerFrontendPipeOpsPass());
   //pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addPass(pto::createPTOInferValidatePipeInitPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());


### PR DESCRIPTION
Summary
- Move frontend pipe id assignment and frontend pipe lowering to ModuleOp scope so they run serially over all funcs before MLIR async nested func verification can race on cross-function frontend pipe contracts.

Motivation
- Fix intermittent ptoas crashes under parallel lit on fixpipe frontend EmitC tests.
- The observed crash came from async verification walking peer functions while frontend pipe ops still existed.

Design
- PTOLowerFrontendPipeOps now runs as a module pass and lowers all funcs with frontend pipe ops in a single serial walk.
- PTOAssignDefaultFrontendPipeId now also runs as a module pass, so default-id materialization happens before nested func pipelines verify frontend pipe ops.
- No IR semantics change; this only changes pass scheduling and scope.

Testing
- ninja -C build-assert-local tools/ptoas/ptoas
- llvm-lit filtered fixpipe frontend EmitC tests passed:
  - fixpipe_frontend_emitc_qs322bf16_a5
  - fixpipe_frontend_emitc_layout_direct_convert_a5
  - fixpipe_frontend_quant_state_preserve_ir_a5
  - fixpipe_frontend_emitc_scalar_override_a5
- 10-iteration parallel pressure test over the same four cases passed without empty output or crashes.

Risk / Rollback
- Risk is low and localized to frontend pipe pass scheduling.
- Rollback is straightforward by reverting the two module-pass changes.