### PR TITLE
fix(vpto): lower SIMT block queries to TPE intrinsics

### DIFF
--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -4212,6 +4212,21 @@ StringRef buildRuntimeQueryCallee<pto::GetSubBlockNumOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.GET.SUBBLOCKDIM").getValue();
 }
 
+template <typename QueryOp>
+static StringRef buildSimtBlockQueryCallee(MLIRContext *context);
+
+template <>
+StringRef
+buildSimtBlockQueryCallee<pto::GetBlockIdxOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.tpe.get.BLOCK.IDX").getValue();
+}
+
+template <>
+StringRef
+buildSimtBlockQueryCallee<pto::GetBlockNumOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.tpe.get.BLOCK.NUM").getValue();
+}
+
 static LogicalResult
 materializeDecls(ModuleOp module, ArrayRef<PlannedDecl> plannedDecls,
                  llvm::raw_ostream &diagOS) {
@@ -8991,6 +9006,53 @@ private:
   LoweringState &state;
 };
 
+template <typename QueryOp>
+class LowerBlockRuntimeQueryOpPattern final
+    : public OpConversionPattern<QueryOp> {
+public:
+  explicit LowerBlockRuntimeQueryOpPattern(TypeConverter &typeConverter,
+                                           MLIRContext *context,
+                                           LoweringState &state)
+      : OpConversionPattern<QueryOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(QueryOp op, typename QueryOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    Type resultType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(
+          op, "failed to convert block runtime-query result type");
+
+    auto funcOp = op->template getParentOfType<func::FuncOp>();
+    bool isSimtEntry =
+        funcOp && funcOp->hasAttr(pto::kPTOSimtEntryAttrName);
+    if (isSimtEntry && !resultType.isInteger(64))
+      return rewriter.notifyMatchFailure(
+          op, "SIMT block runtime-query expects an i64 PTO result");
+
+    StringRef calleeName =
+        isSimtEntry ? buildSimtBlockQueryCallee<QueryOp>(op.getContext())
+                    : buildRuntimeQueryCallee<QueryOp>(op.getContext());
+    Type callResultType = isSimtEntry ? rewriter.getI32Type() : resultType;
+    auto funcType =
+        rewriter.getFunctionType(TypeRange{}, TypeRange{callResultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), calleeName, TypeRange{callResultType}, ValueRange{});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+
+    Value result = call.getResult(0);
+    if (isSimtEntry)
+      result = rewriter.create<arith::ExtUIOp>(op.getLoc(), resultType, result);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 template <typename VoteOp>
 class LowerVoteOpPattern final : public OpConversionPattern<VoteOp> {
 public:
@@ -10350,9 +10412,9 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerBufSyncOpPattern<pto::RlsBufOp>,
                LowerBufDynSyncOpPattern<pto::GetBufDynOp>,
                LowerBufDynSyncOpPattern<pto::RlsBufDynOp>,
-               LowerRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
+               LowerBlockRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockIdxOp>,
-               LowerRuntimeQueryOpPattern<pto::GetBlockNumOp>,
+               LowerBlockRuntimeQueryOpPattern<pto::GetBlockNumOp>,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockNumOp>,
                LowerVldsOpPattern, LowerVldsx2OpPattern, LowerVsldbOpPattern,
                LowerVldasOpPattern, LowerInitAlignOpPattern,

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -4154,6 +4154,21 @@ StringRef buildRuntimeQueryCallee<pto::GetSubBlockNumOp>(MLIRContext *context) {
   return StringAttr::get(context, "llvm.hivm.GET.SUBBLOCKDIM").getValue();
 }
 
+template <typename QueryOp>
+static StringRef buildSimtBlockQueryCallee(MLIRContext *context);
+
+template <>
+StringRef
+buildSimtBlockQueryCallee<pto::GetBlockIdxOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.tpe.get.BLOCK.IDX").getValue();
+}
+
+template <>
+StringRef
+buildSimtBlockQueryCallee<pto::GetBlockNumOp>(MLIRContext *context) {
+  return StringAttr::get(context, "llvm.hivm.tpe.get.BLOCK.NUM").getValue();
+}
+
 static LogicalResult
 materializeDecls(ModuleOp module, ArrayRef<PlannedDecl> plannedDecls,
                  llvm::raw_ostream &diagOS) {
@@ -8933,6 +8948,53 @@ private:
   LoweringState &state;
 };
 
+template <typename QueryOp>
+class LowerBlockRuntimeQueryOpPattern final
+    : public OpConversionPattern<QueryOp> {
+public:
+  explicit LowerBlockRuntimeQueryOpPattern(TypeConverter &typeConverter,
+                                           MLIRContext *context,
+                                           LoweringState &state)
+      : OpConversionPattern<QueryOp>(typeConverter, context), state(state) {}
+
+  LogicalResult
+  matchAndRewrite(QueryOp op, typename QueryOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    (void)adaptor;
+    Type resultType =
+        this->getTypeConverter()->convertType(op.getResult().getType());
+    if (!resultType)
+      return rewriter.notifyMatchFailure(
+          op, "failed to convert block runtime-query result type");
+
+    auto funcOp = op->template getParentOfType<func::FuncOp>();
+    bool isSimtEntry =
+        funcOp && funcOp->hasAttr(pto::kPTOSimtEntryAttrName);
+    if (isSimtEntry && !resultType.isInteger(64))
+      return rewriter.notifyMatchFailure(
+          op, "SIMT block runtime-query expects an i64 PTO result");
+
+    StringRef calleeName =
+        isSimtEntry ? buildSimtBlockQueryCallee<QueryOp>(op.getContext())
+                    : buildRuntimeQueryCallee<QueryOp>(op.getContext());
+    Type callResultType = isSimtEntry ? rewriter.getI32Type() : resultType;
+    auto funcType =
+        rewriter.getFunctionType(TypeRange{}, TypeRange{callResultType});
+    auto call = rewriter.create<func::CallOp>(
+        op.getLoc(), calleeName, TypeRange{callResultType}, ValueRange{});
+    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+
+    Value result = call.getResult(0);
+    if (isSimtEntry)
+      result = rewriter.create<arith::ExtUIOp>(op.getLoc(), resultType, result);
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+
+private:
+  LoweringState &state;
+};
+
 template <typename VoteOp>
 class LowerVoteOpPattern final : public OpConversionPattern<VoteOp> {
 public:
@@ -10294,9 +10356,9 @@ static void populateVPTOOpLoweringPatterns(VPTOTypeConverter &typeConverter,
                LowerBufSyncOpPattern<pto::RlsBufOp>,
                LowerBufDynSyncOpPattern<pto::GetBufDynOp>,
                LowerBufDynSyncOpPattern<pto::RlsBufDynOp>,
-               LowerRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
+               LowerBlockRuntimeQueryOpPattern<pto::GetBlockIdxOp>,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockIdxOp>,
-               LowerRuntimeQueryOpPattern<pto::GetBlockNumOp>,
+               LowerBlockRuntimeQueryOpPattern<pto::GetBlockNumOp>,
                LowerRuntimeQueryOpPattern<pto::GetSubBlockNumOp>,
                LowerVldsOpPattern, LowerVldsx2OpPattern, LowerVsldbOpPattern,
                LowerVldasOpPattern, LowerInitAlignOpPattern,

--- a/test/lit/vpto/simt_block_query_vpto_llvm.pto
+++ b/test/lit/vpto/simt_block_query_vpto_llvm.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @block_query_kernel(%dst: !pto.ptr<i64, ub>) attributes {pto.aicore} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %block_idx = pto.get_block_idx
+    %block_num = pto.get_block_num
+    pto.store %block_idx, %dst[%c0] : !pto.ptr<i64, ub>, i64
+    pto.store %block_num, %dst[%c1] : !pto.ptr<i64, ub>, i64
+    return
+  }
+
+  func.func @simt_block_query(%dst: !pto.ptr<i64, ub>) attributes {pto.simt_entry} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %block_idx = pto.get_block_idx
+    %block_num = pto.get_block_num
+    pto.store %block_idx, %dst[%c0] : !pto.ptr<i64, ub>, i64
+    pto.store %block_num, %dst[%c1] : !pto.ptr<i64, ub>, i64
+    return
+  }
+}
+
+// CHECK-DAG: declare i64 @llvm.hivm.GET.BLOCK.IDX()
+// CHECK-DAG: declare i64 @llvm.hivm.GET.BLOCK.NUM()
+// CHECK-DAG: declare i32 @llvm.hivm.tpe.get.BLOCK.IDX()
+// CHECK-DAG: declare i32 @llvm.hivm.tpe.get.BLOCK.NUM()
+
+// CHECK-LABEL: define {{.*}}@block_query_kernel_mix_aiv(
+// CHECK: call i64 @llvm.hivm.GET.BLOCK.IDX()
+// CHECK: call i64 @llvm.hivm.GET.BLOCK.NUM()
+
+// CHECK-LABEL: define linkonce_odr simt_entry void @simt_block_query(
+// CHECK-NOT: call i64 @llvm.hivm.GET.BLOCK
+// CHECK: [[BLOCK_IDX_I32:%.*]] = call i32 @llvm.hivm.tpe.get.BLOCK.IDX()
+// CHECK: [[BLOCK_IDX_I64:%.*]] = zext i32 [[BLOCK_IDX_I32]] to i64
+// CHECK: [[BLOCK_NUM_I32:%.*]] = call i32 @llvm.hivm.tpe.get.BLOCK.NUM()
+// CHECK: [[BLOCK_NUM_I64:%.*]] = zext i32 [[BLOCK_NUM_I32]] to i64
+// CHECK-NOT: call i64 @llvm.hivm.GET.BLOCK
+// CHECK: ret void


### PR DESCRIPTION
  ## Problem

  VPTO emitted `pto.get_block_idx` and `pto.get_block_num` as the generic
  `i64 llvm.hivm.GET.BLOCK.*` intrinsics inside `pto.simt_entry` functions.
  BiSheng later rewrites these calls to the `i32 llvm.hivm.tpe.get.BLOCK.*`
  intrinsics, causing a result type mismatch and a compiler crash.

  ## Changes

  - Lower block queries in `pto.simt_entry` directly to the `i32` TPE intrinsics.
  - Zero-extend the result to the existing PTO `i64` query type.
  - Keep normal AICore block-query lowering unchanged.
  - Apply the fix to both default and CANN 9.0 VPTO emitters.
  - Add LLVM IR regression coverage for both contexts and emitters.