### PR TITLE
fix(ci): stabilize frontend pipe lowering and VPTO IR checks

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -467,7 +467,6 @@ jobs:
             python3 -m pytest "$@" \
               -v \
               --platform="${platform}" \
-              --pto-isa-commit="${PTO_ISA_COMMIT}" \
               --save-kernels \
               --kernels-dir="${kernels_dir}" \
               2>&1 | tee "${log_file}"

--- a/test/lit/pto/fixpipe_frontend_emitc_low_precision_scalar_quant_a5.pto
+++ b/test/lit/pto/fixpipe_frontend_emitc_low_precision_scalar_quant_a5.pto
@@ -7,6 +7,9 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 //
 // RUN: ptoas --pto-arch=a5 %s 2>&1 | FileCheck %s --check-prefix=A5
+//
+// Regression coverage for serial frontend pipe lowering: the fixpipe verifier
+// resolves each AIV consumer against AIC producer state in a sibling function.
 
 module {
   func.func @cube_kernel() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {

--- a/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
+++ b/test/lit/vpto/mte_ub_gm_l2_cache_ctl.pto
@@ -6,8 +6,12 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ROUNDTRIP
-// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=EXPAND
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null > %t.roundtrip 2>&1
+// RUN: FileCheck %s --input-file=%t.roundtrip --check-prefix=ROUNDTRIP-EXPLICIT
+// RUN: FileCheck %s --input-file=%t.roundtrip --check-prefix=ROUNDTRIP-DEFAULT
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null > %t.expand 2>&1
+// RUN: FileCheck %s --input-file=%t.expand --check-prefix=EXPAND-EXPLICIT
+// RUN: FileCheck %s --input-file=%t.expand --check-prefix=EXPAND-DEFAULT
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @mte_ub_gm_l2_cache_ctl(%out: !pto.ptr<f16, gm>) attributes {pto.aicore} {
@@ -36,19 +40,19 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
   }
 }
 
-// ROUNDTRIP-LABEL: func.func @mte_ub_gm_l2_cache_ctl
-// ROUNDTRIP: %[[L2:.*]] = arith.constant 5 : i64
-// ROUNDTRIP: pto.mte_ub_gm %{{[^,]+}}, %arg0, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}}) l2_cache_ctl(%[[L2]])
-// ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64{{$}}
-// ROUNDTRIP-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default
-// ROUNDTRIP: pto.mte_ub_gm %{{[^,]+}}, %arg0, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}})
-// ROUNDTRIP-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64{{$}}
+// ROUNDTRIP-EXPLICIT-LABEL: func.func @mte_ub_gm_l2_cache_ctl(
+// ROUNDTRIP-EXPLICIT: %[[L2:.*]] = arith.constant 5 : i64
+// ROUNDTRIP-EXPLICIT: pto.mte_ub_gm %{{[^,]+}}, %arg0, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}}) l2_cache_ctl(%[[L2]])
+// ROUNDTRIP-EXPLICIT-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64{{$}}
+// ROUNDTRIP-DEFAULT-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default(
+// ROUNDTRIP-DEFAULT: pto.mte_ub_gm %{{[^,]+}}, %arg0, %{{[^ ]+}} nburst(%{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}})
+// ROUNDTRIP-DEFAULT-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64{{$}}
 
-// EXPAND-LABEL: func.func @mte_ub_gm_l2_cache_ctl
-// EXPAND: %[[L2:.*]] = arith.constant 5 : i64
-// EXPAND: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg0, %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[L2]], %{{[^,]+}}, %{{[^:]+}}
-// EXPAND-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64
-// EXPAND-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default
-// EXPAND: %[[ZERO:.*]] = arith.constant 0 : i64
-// EXPAND: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg0, %[[ZERO]], %{{[^,]+}}, %{{[^,]+}}, %[[ZERO]], %{{[^,]+}}, %{{[^:]+}}
-// EXPAND-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64
+// EXPAND-EXPLICIT-LABEL: func.func @mte_ub_gm_l2_cache_ctl(
+// EXPAND-EXPLICIT: %[[L2:.*]] = arith.constant 5 : i64
+// EXPAND-EXPLICIT: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg0, %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %[[L2]], %{{[^,]+}}, %{{[^:]+}}
+// EXPAND-EXPLICIT-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64
+// EXPAND-DEFAULT-LABEL: func.func @mte_ub_gm_l2_cache_ctl_default(
+// EXPAND-DEFAULT: %[[ZERO:.*]] = arith.constant 0 : i64
+// EXPAND-DEFAULT: pto.copy_ubuf_to_gm %{{[^,]+}}, %arg0, %[[ZERO]], %{{[^,]+}}, %{{[^,]+}}, %[[ZERO]], %{{[^,]+}}, %{{[^:]+}}
+// EXPAND-DEFAULT-SAME: : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64, i64, i64

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -1059,6 +1059,41 @@ static std::unique_ptr<Pass> createNarrowUnusedMultiResultProvenancePass() {
   return std::make_unique<NarrowUnusedMultiResultProvenancePass>();
 }
 
+namespace {
+struct SerialFrontendPipeLoweringPass
+    : public PassWrapper<SerialFrontendPipeLoweringPass,
+                         OperationPass<ModuleOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(
+      SerialFrontendPipeLoweringPass)
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<func::FuncDialect, pto::PTODialect>();
+  }
+
+  void runOnOperation() override {
+    OpPassManager functionPM(func::FuncOp::getOperationName());
+    functionPM.addPass(pto::createPTOAssignDefaultFrontendPipeIdPass());
+    functionPM.addPass(pto::createPTOLowerFrontendPipeOpsPass());
+
+    // Fixpipe frontend verifiers resolve peer contracts by inspecting sibling
+    // functions. Running this function pipeline through a regular nested pass
+    // adaptor allows one function to be verified while another function is
+    // still mutating its pipe ops. Keep these two small passes serial so every
+    // verifier observes either the complete frontend or complete lowered form.
+    for (func::FuncOp funcOp : getOperation().getOps<func::FuncOp>()) {
+      if (failed(runPipeline(functionPM, funcOp))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+} // namespace
+
+static std::unique_ptr<Pass> createSerialFrontendPipeLoweringPass() {
+  return std::make_unique<SerialFrontendPipeLoweringPass>();
+}
+
 static void collectNonEntryBlocksInSourceOrder(
     Operation *op, SmallVectorImpl<Block *> &blocks) {
   for (Region &region : op->getRegions()) {
@@ -2952,10 +2987,7 @@ int mlir::pto::compilePTOASModule(
   // lifted to make it unconditional for all backends.
   if (effectiveBackend == PTOBackend::VPTO)
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCanonicalizeIRPass());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      pto::createPTOAssignDefaultFrontendPipeIdPass());
-  pm.addNestedPass<mlir::func::FuncOp>(
-      pto::createPTOLowerFrontendPipeOpsPass());
+  pm.addPass(createSerialFrontendPipeLoweringPass());
   //pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addPass(pto::createPTOInferValidatePipeInitPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());


### PR DESCRIPTION
## Summary

- run frontend pipe ID assignment and lowering serially across functions so cross-function Fixpipe verification never observes a concurrently mutating peer
- keep the rest of the MLIR pipeline multithreaded
- make the VPTO L2 cache-control IR test independent of nested pass dump order and exact-bound both function names
- stop forwarding the removed PyPTO `--pto-isa-commit` pytest option while retaining the pinned PTO-ISA checkout and `PTO_ISA_ROOT`

## Root cause

`PTOAssignDefaultFrontendPipeId` and `PTOLowerFrontendPipeOps` were registered as nested function passes. MLIR can execute sibling function pipelines concurrently, but the Fixpipe verifier reads producer state from a sibling function. It could therefore inspect that peer between its assignment and lowering passes and report a false missing-producer error.

The VPTO test used ordered `CHECK-LABEL` directives for two functions whose nested pass dumps can arrive in either order. Its first function name was also a prefix of the `_default` function.

PyPTO PR #2090 removed the `--pto-isa-commit` pytest option in favor of its managed runtime pin. PTOAS ci-sim still passed that option while checking out PyPTO main, so pytest exited during argument parsing. The workflow already checks out the requested PTO-ISA revision into `PTO_ISA_ROOT`, so the removed argument is redundant.

## Validation

- built `ptoas` against LLVM 21.1.8
- 41 related Fixpipe and MTE lit tests passed
- failing Fixpipe regression passed 50 consecutive runs
- VPTO L2 cache-control regression passed 50 consecutive runs
- workflow actionlint output matches the pre-change baseline with no new diagnostics
- `git diff --check` passed

Reproduces and fixes the failures seen in https://github.com/hw-native-sys/PTOAS/actions/runs/29740186239/job/88344898978?pr=962 and https://github.com/hw-native-sys/PTOAS/actions/runs/29795053194/job/88525445925?pr=964.