### PR TITLE
ci: remove obsolete PyPTO PTO-ISA pytest option

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -467,7 +467,6 @@ jobs:
             python3 -m pytest "$@" \
               -v \
               --platform="${platform}" \
-              --pto-isa-commit="${PTO_ISA_COMMIT}" \
               --save-kernels \
               --kernels-dir="${kernels_dir}" \
               2>&1 | tee "${log_file}"


### PR DESCRIPTION
## Summary

- stop passing the removed `--pto-isa-commit` option to PyPTO simulator pytest runs
- keep the existing explicit PTO-ISA checkout and `PTO_ISA_ROOT` wiring unchanged

## Background

PyPTO commit [`86549ddd`](https://github.com/hw-native-sys/pypto/commit/86549ddd4602f26576d95f04ea0a4d026d56ed57) removed the `--pto-isa-commit` pytest option. Because this workflow checks out PyPTO `main`, pytest now exits during argument parsing before collecting any simulator test:

```text
error: unrecognized arguments: --pto-isa-commit=...
```

This caused the [vpto-sim-validation job](https://github.com/hw-native-sys/PTOAS/actions/runs/29795974828/job/88527287460) to fail independently of the PTOAS change under test.

## Validation

- `git diff --check`
- parsed `.github/workflows/ci_sim.yml` with PyYAML
- ran PyPTO's hello-world simulator test with the remaining workflow arguments and `--collect-only` (1 test collected)
