### PR TITLE
feat(ptodsl): add A5 pto.ttrans 2D tile transpose

### DIFF
--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -2831,6 +2831,15 @@ def tmov(src, dst, *, mode=None):
     _pto.TMovOp(None, unwrap_surface_value(src), unwrap_surface_value(dst), **kwargs)
 
 
+def ttrans(src, tmp, dst):
+    """``pto.ttrans ins(src, tmp) outs(dst)`` – tile transpose (DPS)."""
+    _pto.ttrans(
+        unwrap_surface_value(src),
+        unwrap_surface_value(tmp),
+        unwrap_surface_value(dst),
+    )
+
+
 def textract(src, dst, index_row, index_col):
     """``pto.textract ins(src, index_row, index_col) outs(dst)``."""
     _pto.TExtractOp(

--- a/ptodsl/ptodsl/_tile_namespace.py
+++ b/ptodsl/ptodsl/_tile_namespace.py
@@ -54,6 +54,7 @@ def _resolve_row_reduction_tmp(src, tmp):
 
 class _TileNamespace:
     mov = staticmethod(_ops.tmov)
+    transpose = staticmethod(_ops.ttrans)
     extract = staticmethod(_ops.textract)
     insert = staticmethod(_ops.tinsert)
     matmul = staticmethod(_ops.tmatmul)

--- a/ptodsl/ptodsl/tilelib/templates/__init__.py
+++ b/ptodsl/ptodsl/tilelib/templates/__init__.py
@@ -115,6 +115,7 @@ _TEMPLATE_MODULES = {
     ("a5", "pto.tsort32"): ".a5.tsort32",
     ("a5", "pto.tstore"): ".a5.tstore",
     ("a5", "pto.tstore_fp"): ".a5.tstore",
+    ("a5", "pto.ttrans"): ".a5.ttrans",
     ("a5", "pto.tsub"): ".a5.tsub",
     ("a5", "pto.tsubs"): ".a5.tsubs",
     ("a5", "pto.tsqrt"): ".a5.tsqrt",

--- a/ptodsl/ptodsl/tilelib/templates/a5/ttrans.py
+++ b/ptodsl/ptodsl/tilelib/templates/a5/ttrans.py
@@ -1,5 +1,10 @@
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
-# CANN OSL v2.0
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
 """PTODSL TileLib templates for ``pto.ttrans`` (A5 2D tile transpose).
 
 Ports the 2D-vectorized logic from ``include/pto/npu/a5/TTrans.hpp`` of the

--- a/ptodsl/ptodsl/tilelib/templates/a5/ttrans.py
+++ b/ptodsl/ptodsl/tilelib/templates/a5/ttrans.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# CANN OSL v2.0
+"""PTODSL TileLib templates for ``pto.ttrans`` (A5 2D tile transpose).
+
+Ports the 2D-vectorized logic from ``include/pto/npu/a5/TTrans.hpp`` of the
+pto-isa repo. Only the 2D row-major transpose path (``TTransTile``) is covered;
+ConvTile format conversions are out of scope.
+
+The ``tmp`` operand is required by the ``pto.ttrans`` op contract (matching
+the C++ ``TTRANS(dst, src, tmp)`` intrinsic) but is unused in the 2D
+row-major path; the C++ ``TTrans.hpp`` 2D path also does not use ``tmp``.
+"""
+
+from ptodsl import pto
+import ptodsl.tilelib as tilelib
+
+
+B32_DTYPES = ("f32", "i32", "ui32")
+B16_DTYPES = ("f16", "bf16", "i16", "ui16")
+B8_DTYPES = ("i8", "ui8")
+
+_BYTEWIDTH_BY_NAME = {"f32": 4, "i32": 4, "ui32": 4,
+                      "f16": 2, "bf16": 2, "i16": 2, "ui16": 2,
+                      "i8": 1, "ui8": 1}
+
+
+def _ub_row_major_2d(operand_memory_spaces, operand_b_layouts, operand_s_layouts, **_):
+    return (
+        all(space in {"ub", "vec"} for space in operand_memory_spaces)
+        and all(layout == "row_major" for layout in operand_b_layouts)
+        and all(layout == "none_box" for layout in operand_s_layouts)
+    )
+
+
+def _wide_shape(src_valid_shape, **_):
+    rows, cols = src_valid_shape
+    return rows < cols
+
+
+def _tall_shape(src_valid_shape, **_):
+    rows, cols = src_valid_shape
+    return rows >= cols
+
+
+def _major_32byte_aligned(src_valid_shape, src_dtype, dst_dtype, **_):
+    dtype_name = getattr(src_dtype, "name", str(src_dtype))
+    bytewidth = _BYTEWIDTH_BY_NAME.get(dtype_name)
+    if bytewidth is None:
+        return False
+    rows, cols = src_valid_shape
+    return (cols * bytewidth) % 32 == 0
+
+
+@tilelib.tile_template(
+    op="pto.ttrans",
+    target="a5",
+    name="template_ttrans_b32_rowwise",
+    dtypes=[(d, d, d) for d in B32_DTYPES],
+    iteration_axis="none",
+    op_engine="vector",
+    op_class="movement",
+    constraints=[
+        _ub_row_major_2d,
+        _wide_shape,
+        _major_32byte_aligned,
+    ],
+    id=0,
+    loop_depth=2,
+    is_post_update=False,
+    tags=("trans", "ub", "b32", "rowwise"),
+)
+def template_ttrans_b32_rowwise(src: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
+    """dst[j,i] = src[i,j] for wide (Rows<Cols) b32 tiles. Port of TTransB32RowWise."""
+    dtype = dst.dtype
+    valid_rows, valid_cols = src.valid_shape
+    lanes = pto.elements_per_vreg(dtype)
+    dst_stride = dst.shape[1]
+    valid_cols_minus_1 = valid_cols - 1
+    dst_ptr = dst.as_ptr()
+    # vci generates [0,1,...,lanes-1] once outside the loop (base index sequence).
+    base_idx = pto.vci(pto.i32(0), "ASC")
+
+    for row in range(0, valid_rows, 1):
+        remained = valid_cols
+        for col in range(0, valid_cols, lanes):
+            mask, remained = pto.make_mask(dtype, remained)
+            data = pto.vlds(src[row, col:])
+            # transpose dst col index = col + [0..lanes-1], clamp, *dst_stride, +row
+            idx = pto.vadds(base_idx, col, mask)
+            idx = pto.vmins(idx, valid_cols_minus_1, mask)
+            idx = pto.vmuls(idx, dst_stride, mask)
+            idx = pto.vadds(idx, row, mask)
+            pto.vscatter(data, dst_ptr, idx, mask)
+
+
+@tilelib.tile_template(
+    op="pto.ttrans",
+    target="a5",
+    name="template_ttrans_b32_colwise",
+    dtypes=[(d, d, d) for d in B32_DTYPES],
+    iteration_axis="none",
+    op_engine="vector",
+    op_class="movement",
+    constraints=[
+        _ub_row_major_2d,
+        _tall_shape,
+        _major_32byte_aligned,
+    ],
+    id=1,
+    loop_depth=2,
+    is_post_update=False,
+    tags=("trans", "ub", "b32", "colwise"),
+)
+def template_ttrans_b32_colwise(src: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
+    """dst[j,i] = src[i,j] for tall (Rows>=Cols) b32 tiles. Port of TTransB32ColWise."""
+    dtype = dst.dtype
+    valid_rows, valid_cols = src.valid_shape
+    lanes = pto.elements_per_vreg(dtype)
+    src_stride = src.shape[1]
+    valid_rows_minus_1 = valid_rows - 1
+    src_ptr = src.as_ptr()
+    base_idx = pto.vci(pto.i32(0), "ASC")
+
+    for col in range(0, valid_cols, 1):
+        remained = valid_rows
+        for row in range(0, valid_rows, lanes):
+            mask, remained = pto.make_mask(dtype, remained)
+            # src row index = row + [0..lanes-1], clamp, *src_stride, +col
+            idx = pto.vadds(base_idx, row, mask)
+            idx = pto.vmins(idx, valid_rows_minus_1, mask)
+            idx = pto.vmuls(idx, src_stride, mask)
+            idx = pto.vadds(idx, col, mask)
+            data = pto.vgather2(src_ptr, idx, mask)
+            pto.vsts(data, dst[col, row:], mask)
+
+
+@tilelib.tile_template(
+    op="pto.ttrans",
+    target="a5",
+    name="template_ttrans_b16_colwise",
+    dtypes=[(d, d, d) for d in B16_DTYPES],
+    iteration_axis="none",
+    op_engine="vector",
+    op_class="movement",
+    constraints=[
+        _ub_row_major_2d,
+        _tall_shape,
+        _major_32byte_aligned,
+    ],
+    id=3,
+    loop_depth=2,
+    is_post_update=False,
+    tags=("trans", "ub", "b16", "colwise"),
+)
+def template_ttrans_b16_colwise(src: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
+    """dst[j,i] = src[i,j] for tall b16 tiles. Port of TTransB16ColWise (TTrans.hpp:111).
+
+    Note: only ColWise is supported for b16/b8 because pto.vscatter currently
+    requires 32-bit offsets (see pto-as VPTO.cpp VscatterOp::verify), while
+    b16/b8 data vectors need 16-bit offsets to match element count. Wide
+    (Rows<Cols) b16/b8 tiles are not covered by this template.
+    """
+    dtype = dst.dtype
+    valid_rows, valid_cols = src.valid_shape
+    lanes = pto.elements_per_vreg(dtype)
+    src_stride = src.shape[1]
+    valid_rows_minus_1 = valid_rows - 1
+    src_ptr = src.as_ptr()
+    base_idx = pto.vci(pto.i16(0), "ASC")
+
+    for col in range(0, valid_cols, 1):
+        remained = valid_rows
+        for row in range(0, valid_rows, lanes):
+            mask, remained = pto.make_mask(dtype, remained)
+            idx = pto.vadds(base_idx, row, mask)
+            idx = pto.vmins(idx, valid_rows_minus_1, mask)
+            idx = pto.vmuls(idx, src_stride, mask)
+            idx = pto.vadds(idx, col, mask)
+            data = pto.vgather2(src_ptr, idx, mask)
+            pto.vsts(data, dst[col, row:], mask)
+
+
+@tilelib.tile_template(
+    op="pto.ttrans",
+    target="a5",
+    name="template_ttrans_b8_colwise",
+    dtypes=[(d, d, d) for d in B8_DTYPES],
+    iteration_axis="none",
+    op_engine="vector",
+    op_class="movement",
+    constraints=[
+        _ub_row_major_2d,
+        _tall_shape,
+        _major_32byte_aligned,
+    ],
+    id=5,
+    loop_depth=2,
+    is_post_update=False,
+    tags=("trans", "ub", "b8", "colwise"),
+)
+def template_ttrans_b8_colwise(src: pto.Tile, tmp: pto.Tile, dst: pto.Tile):
+    """dst[j,i] = src[i,j] for tall b8 tiles (paired-packed as b16).
+
+    Port of TTransB8ColWise (TTrans.hpp:200). Two b8 elements pack into one
+    b16 lane (C++ sregLower = elementsPerRepeat >> 1). vgather2 produces a
+    128xi16 result (paired-pack) from the i8 source; mask is b16.
+
+    Note: only ColWise; RowWise needs vscatter which does not support 16-bit
+    offsets (see template_ttrans_b16_colwise docstring). This template is not
+    yet covered by the ST harness (b8 transpose hits a deeper emitc/intrinsic
+    issue under investigation).
+    """
+    dtype = dst.dtype  # i8/ui8
+    valid_rows, valid_cols = src.valid_shape
+    # packed lanes: two b8 per b16 lane
+    packed_lanes = pto.elements_per_vreg(dtype) >> 1   # 256/2 = 128
+    src_stride = src.shape[1]
+    valid_rows_minus_1 = valid_rows - 1
+    src_ptr = src.as_ptr()
+    base_idx = pto.vci(pto.i16(0), "ASC")
+    # b8 gather uses paired-pack: i8 source -> i16 result, ui8 -> ui16 result
+    _b8_index_elem = pto.ui16 if str(dtype) in ("ui8",) else pto.i16
+    result_ty = pto.vreg_type(packed_lanes, _b8_index_elem)
+
+    for col in range(0, valid_cols, 1):
+        remained = valid_rows
+        for row in range(0, valid_rows, packed_lanes):
+            mask, remained = pto.make_mask(pto.i16, remained)
+            idx = pto.vadds(base_idx, row, mask)
+            idx = pto.vmins(idx, valid_rows_minus_1, mask)
+            idx = pto.vmuls(idx, src_stride, mask)
+            idx = pto.vadds(idx, col, mask)
+            data = pto.vgather2(src_ptr, idx, mask, result_vreg_type=result_ty)
+            pto.vsts(data, dst[col, row:], mask)

--- a/test/tilelib-st/a5/ttrans/case.py
+++ b/test/tilelib-st/a5/ttrans/case.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
-# CANN OSL v2.0
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
 """PTODSL TileLib ST case for ``pto.ttrans`` (A5 2D tile transpose).
 
 Port of test/tilelang_st/npu/a5/src/st/testcase/ttrans from the pto-isa repo.

--- a/test/tilelib-st/a5/ttrans/case.py
+++ b/test/tilelib-st/a5/ttrans/case.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# CANN OSL v2.0
+"""PTODSL TileLib ST case for ``pto.ttrans`` (A5 2D tile transpose).
+
+Port of test/tilelang_st/npu/a5/src/st/testcase/ttrans from the pto-isa repo.
+Each case loads a source tile, transposes it via ``pto.tile.transpose``, and
+stores the result; the golden is a numpy ``.T``.
+"""
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from common import auto_main, golden_output_case
+from ptodsl import pto
+
+
+# (name, dtype, rows, cols). rows/cols chosen so the major dim is 32-byte
+# aligned: cols * sizeof(dtype) % 32 == 0.
+CASE_SHAPES = [
+    ("f32_8x64", pto.f32, 8, 64),    # wide b32: RowWise path
+    ("f32_64x8", pto.f32, 64, 8),    # tall b32: ColWise path
+    ("f32_32x32", pto.f32, 32, 32),  # square b32
+    ("i32_8x64", pto.i32, 8, 64),
+    ("f16_64x16", pto.f16, 64, 16),  # tall b16 (16*2=32 aligned)
+]
+
+
+def _ttrans_body(src_ptr, dst_ptr, *, rows, cols, dtype):
+    """Shared kernel body: load src, transpose into dst (with tmp), store."""
+    src_view = pto.make_tensor_view(src_ptr, shape=[rows, cols], strides=[cols, 1])
+    dst_view = pto.make_tensor_view(dst_ptr, shape=[cols, rows], strides=[rows, 1])
+
+    src_tile = pto.alloc_tile(shape=[rows, cols], dtype=dtype)
+    tmp_tile = pto.alloc_tile(shape=[cols, rows], dtype=dtype)
+    dst_tile = pto.alloc_tile(shape=[cols, rows], dtype=dtype)
+
+    pto.tile.load(src_view, src_tile)
+    pto.tile.transpose(src_tile, tmp_tile, dst_tile)
+    pto.tile.store(dst_tile, dst_view)
+
+
+_ttrans_kernels = {}
+for _name, _dtype, _rows, _cols in CASE_SHAPES:
+    _r, _c = _rows, _cols
+
+    def _make(r=_r, c=_c, dtype=_dtype, kernel_name=f"ttrans_{_name}"):
+        @pto.jit(name=kernel_name, target="a5")
+        def _kernel(
+            src_ptr: pto.ptr(dtype, "gm"),
+            dst_ptr: pto.ptr(dtype, "gm"),
+        ):
+            _ttrans_body(src_ptr, dst_ptr, rows=r, cols=c, dtype=dtype)
+
+        return _kernel
+
+    _ttrans_kernels[_name] = _make()
+
+
+# numpy dtype mapping for input generation + golden
+_PTO_TO_NP = {
+    pto.f32: np.float32, pto.f16: np.float16,
+    pto.i32: np.int32,
+}
+
+
+def _make_inputs(name, dtype, rows, cols):
+    import zlib
+    np_dtype = _PTO_TO_NP[dtype]
+    np.random.seed(zlib.crc32(name.encode("utf-8")) & 0xFFFFFFFF)
+    # use small ints in float range to avoid f16 overflow / bf16 precision loss
+    a = np.random.randint(1, 10, size=(rows, cols)).astype(np_dtype)
+    return [a]
+
+
+def _make_expected(a):
+    return np.ascontiguousarray(a.T)
+
+
+CASES = []
+for _name, _dtype, _rows, _cols in CASE_SHAPES:
+    CASES.append(
+        golden_output_case(
+            "ttrans_" + _name,
+            _ttrans_kernels[_name],
+            inputs=lambda _n=_name, _d=_dtype, _r=_rows, _c=_cols: _make_inputs(_n, _d, _r, _c),
+            expected=_make_expected,
+            rtol=1e-3,  # f16/bf16 need looser tol
+            atol=1e-3,
+        )
+    )
+
+
+auto_main(globals())


### PR DESCRIPTION
## What

Ports the 2D tile transpose from `pto-isa/include/pto/npu/a5/TTrans.hpp` into PTODSL, following the tgatherb-style complete op pattern (high-level API + tile-template + ST case).

## Changes

### High-level API (new)
- `_ops.ttrans(src, tmp, dst)` in `ptodsl/ptodsl/_ops.py`: wrapper calling `_pto.ttrans`.
- `_TileNamespace.transpose` in `ptodsl/ptodsl/_tile_namespace.py`: exposes `pto.tile.transpose(src, tmp, dst)` for `@pto.jit` kernels.

### Tile-template (`ptodsl/ptodsl/tilelib/templates/a5/ttrans.py`)
4 templates covering b32/b16/b8 × RowWise/ColWise (B16/B8 RowWise limited by pto-as `VscatterOp::verify` 32-bit offset requirement):

| dtype group | RowWise (Rows<Cols) | ColWise (Rows>=Cols) |
|---|---|---|
| b32 (f32/i32/ui32) | `template_ttrans_b32_rowwise` | `template_ttrans_b32_colwise` |
| b16 (f16/bf16/i16/ui16) | — (vscatter 16-bit unsupported) | `template_ttrans_b16_colwise` |
| b8 (i8/ui8, paired-pack) | — (same) | `template_ttrans_b8_colwise` |

Template registration in `ptodsl/ptodsl/tilelib/templates/__init__.py` (`_TEMPLATE_MODULES` map).

### ST case (`test/tilelib-st/a5/ttrans/case.py`)
Verified **PASS on NPU hardware** (A5) for 5 cases via `golden_output_case`:
- `ttrans_f32_8x64` (wide b32)
- `ttrans_f32_64x8` (tall b32)
- `ttrans_f32_32x32` (square b32)
- `ttrans_i32_8x64` (b32 i32)
- `ttrans_f16_64x16` (tall b16)

bf16/i8 cases omitted: bf16 isn't supported by the ST harness (`torch.from_numpy` rejects `ml_dtypes.bfloat16`); i8 transpose hits a deeper emitc/C++ intrinsic issue under investigation.

## Bug fixes found via ST verification
- `require_same_valid_shape("src", "dst")` removed from ttrans template constraints: transpose src/dst shapes differ by design (R x C -> C x R).
- `vci(order="INC_ORDER")` changed to `order="ASC"`: pto-as `parseOrderImmediate` (VPTOLLVMEmitter.cpp) only accepts ASC/DESC.

## Limitation: B16/B8 RowWise not supported

`pto.vscatter` `VscatterOp::verify` (`lib/PTO/IR/VPTO.cpp:4592`) hard-codes "currently requires 32-bit offset vector elements" and requires `offset count == value count`. For b16/b8 value vectors this overflows a vector register. `vgather2` is dtype-aware, so ColWise works for all dtype groups. Prerequisite for B16/B8 RowWise: pto-as change relaxing `VscatterOp::verify` (tracked separately).

## Out of scope
- ConvTile format conversions (NCHW<->NC1HWC0 etc.)
- Non-aligned-stride tmp-relay path
