### PR TITLE
Vf costmodel unroll support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "3rdparty/PTO-Gym"]
 	path = 3rdparty/PTO-Gym
 	url = git@github.com:PTO-ISA/PTO-Gym.git
+[submodule "3rdparty/VfSimulator"]
+	path = 3rdparty/VfSimulator
+	url = git@github.com:wang-chonghao/VfSimulator.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,8 @@ include(CTest)
 # 开启 Python 绑定选项
 option(PTO_ENABLE_PYTHON_BINDING "Enable Python bindings" ON)
 
+include(cmake/VfSimulator.cmake)
+
 if(PTO_ENABLE_PYTHON_BINDING)
   find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
   find_package(pybind11 CONFIG REQUIRED)

--- a/cmake/VfSimulator.cmake
+++ b/cmake/VfSimulator.cmake
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+option(PTO_ENABLE_VFSIM_COSTMODEL
+       "Enable source-level VfSimulator cost model integration" OFF)
+
+set(PTO_VFSIM_SOURCE_DIR
+    "${PROJECT_SOURCE_DIR}/3rdparty/VfSimulator"
+    CACHE PATH "Path to the VfSimulator source tree")
+
+if(PTO_ENABLE_VFSIM_COSTMODEL)
+  # TODO: Export/install embedded VfSimulator targets when the costmodel
+  # integration becomes a supported install-tree feature.
+  message(WARNING
+    "PTO_ENABLE_VFSIM_COSTMODEL=ON is currently supported only for "
+    "build-tree development. Install/export is not supported yet because "
+    "embedded VfSimulator targets are not exported.")
+
+  if(NOT EXISTS "${PTO_VFSIM_SOURCE_DIR}/README.md")
+    message(FATAL_ERROR
+      "PTO_ENABLE_VFSIM_COSTMODEL=ON requires VfSimulator sources at "
+      "${PTO_VFSIM_SOURCE_DIR}. Run `git submodule update --init "
+      "3rdparty/VfSimulator` or set PTO_VFSIM_SOURCE_DIR.")
+  endif()
+  if(NOT EXISTS "${PTO_VFSIM_SOURCE_DIR}/native/CMakeLists.txt")
+    message(FATAL_ERROR
+      "PTO_ENABLE_VFSIM_COSTMODEL=ON requires the native C++ VfSimulator "
+      "CMake entry at ${PTO_VFSIM_SOURCE_DIR}/native. Update the "
+      "3rdparty/VfSimulator submodule to vfsim-native-v0.2 or newer.")
+  endif()
+
+  message(STATUS "VfSimulator cost model source: ${PTO_VFSIM_SOURCE_DIR}")
+  set(VFSIM_ENABLE_MLIR_PLANNER ON CACHE BOOL
+      "Build VfSimulator MLIR IR planner when embedded in PTOAS")
+  if(NOT VFSIM_ENABLE_MLIR_PLANNER)
+    message(FATAL_ERROR
+      "PTO_ENABLE_VFSIM_COSTMODEL=ON requires "
+      "VFSIM_ENABLE_MLIR_PLANNER=ON.")
+  endif()
+  if(NOT TARGET vfsim_native_core)
+    add_subdirectory("${PTO_VFSIM_SOURCE_DIR}/native"
+                     "${CMAKE_BINARY_DIR}/3rdparty/VfSimulator/native")
+  endif()
+endif()

--- a/docs/designs/vf_costmodel_external_planner_protocol.md
+++ b/docs/designs/vf_costmodel_external_planner_protocol.md
@@ -1,0 +1,343 @@
+# PTOAS + VfSim Costmodel 接口设计
+
+本文描述 PTOAS 以源码级 submodule 方式接入 VfSimulator costmodel 的当前接口形式。
+当前实现面向 A5 tile fusion 路径：PTOAS 负责生成合法 fusion group，VfSim 基于
+已选 group 做 costmodel 优化决策，并把结果写回同一份 MLIR IR。
+
+## 接入形式
+
+VfSimulator 作为 PTOAS 的 git submodule 引入：
+
+```text
+PTOAS/
+  3rdparty/
+    VfSimulator/
+```
+
+PTOAS 仓库只记录 submodule commit；VfSimulator 的源码历史仍由 VfSimulator 仓库维护。
+当前 `PTO_ENABLE_VFSIM_COSTMODEL=ON` 只支持 build-tree/source-tree 开发使用，
+尚不支持 install/export。
+
+## 控制选项
+
+| 选项 | 类型 | 作用 |
+|---|---|---|
+| `-DPTO_ENABLE_VFSIM_COSTMODEL=ON` | CMake 编译期选项 | 编译并链接 VfSim native planner。默认 `OFF`。 |
+| `--enable-vfsim-costmodel-optimization` | `ptoas` 运行期选项 | 启用 VfSim costmodel 优化，负责生成/标注 costmodel 决策 attrs。 |
+| `--enable-unroll-after-loop-fusion` | `ptoas` 运行期选项 | 启用 VPTO 后端 unroll pass，负责消费已有 `pto.fusion.row/col_unroll_factor` attrs。 |
+| `--dump-vfsim-unroll-test` | `ptoas` 运行期调试选项 | 只打印 VfSim 对各个 unroll candidate 的预测 cycle，不控制优化是否启用。 |
+
+用户侧常用命令形态：
+
+```bash
+ptoas \
+  --pto-backend=vpto \
+  --pto-arch=a5 \
+  --pto-level=level2 \
+  --enable-op-fusion \
+  --enable-vfsim-costmodel-optimization \
+  --enable-unroll-after-loop-fusion \
+  input.pto
+```
+
+## 构建接入
+
+| 文件 | 作用 |
+|---|---|
+| `CMakeLists.txt` | 引入 `cmake/VfSimulator.cmake`。 |
+| `cmake/VfSimulator.cmake` | 定义 `PTO_ENABLE_VFSIM_COSTMODEL`，校验 submodule，加入 `3rdparty/VfSimulator/native`。 |
+| `lib/PTO/Transforms/CMakeLists.txt` | 将 `vfsim::native_core` 和 `vfsim::ir_planner` 链接进 `PTOTransforms`。 |
+
+VfSim native 侧主要 target：
+
+```text
+vfsim::native_core
+vfsim::ir_planner
+```
+
+## 编译链路
+
+```text
+PreFusionAnalysis
+  -> FusionPlan
+       - PTOAS 生成合法 fusion group
+       - PTOAS 写入 pto.fusion.group_id / pto.fusion.order
+       - 启用 --enable-vfsim-costmodel-optimization 时调用 VfSim planner
+       - VfSim 写回 pto.fusion.row_unroll_factor / pto.fusion.col_unroll_factor
+  -> OpScheduling
+  -> FusionRegionGen
+       - 将 tileop group 包成 pto.fusion_region
+       - 将一致的 row/col unroll attrs 提升到 pto.fusion_region
+  -> ExpandTileOp / Inline / shape-only fold
+  -> PTOLowLevelLoopFusion
+  -> PTOUnrollAfterLoopFusion
+       - 启用 --enable-unroll-after-loop-fusion 时消费 row/col unroll attrs
+       - 成功消费后将对应 factor 复位为 1
+  -> FlattenFusionRegion
+```
+
+EmitC 路径可以运行 FusionPlan 和 VfSim planner，但当前 unroll attrs 只由 VPTO
+后端的 `PTOUnrollAfterLoopFusion` 消费。
+
+## PTOAS 调用点
+
+| 文件 | 符号 | 作用 |
+|---|---|---|
+| `include/PTO/Transforms/Passes.td` | `FusionPlan` options | 定义 `enableVfSimCostmodelOptimization` 和 `dumpVfSimUnrollTest` pass options。 |
+| `tools/ptoas/ptoas.cpp` | `enableVfSimCostmodelOptimization` | 定义用户侧 `--enable-vfsim-costmodel-optimization`。 |
+| `tools/ptoas/ptoas.cpp` | `enableUnrollAfterLoopFusion` | 定义用户侧 `--enable-unroll-after-loop-fusion`。 |
+| `tools/ptoas/ptoas.cpp` | `compilePTOASModule` | 将 costmodel 选项传入 `FusionPlanOptions`；将 unroll 选项用于 VPTO 后端 pass 插入。 |
+| `lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp` | `runVfSimFusionPlanner` | 调用 `vfsim::planTileFusionIR`。 |
+| `lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp` | `getCommonSpanI64Attr` | 校验并提升 row/col unroll attrs 到 `pto.fusion_region`。 |
+| `lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp` | `PTOUnrollAfterLoopFusion` | 消费 `pto.fusion_region` 上的 row/col unroll attrs。 |
+
+## VfSim C++ API
+
+VfSim 向 PTOAS 暴露源码级 C++ API：
+
+```cpp
+namespace vfsim {
+
+struct PlannerOptions {
+  bool dumpCandidates = false;
+  unsigned maxUnroll = 8;
+};
+
+mlir::LogicalResult planTileFusionIR(
+    mlir::Operation *candidateIR,
+    const PlannerOptions &options = {});
+
+} // namespace vfsim
+```
+
+接口约定：
+
+| 项 | 约定 |
+|---|---|
+| 输入 IR | FusionPlan 后的 MLIR operation；当前自动 tileop fusion 路线传入 `func::FuncOp`。 |
+| 输入内容 | PTOAS 已写好 `pto.fusion.group_id` 和 `pto.fusion.order` 的 tileop-level IR。 |
+| 输出方式 | VfSim 原地写回 `pto.fusion.row_unroll_factor` / `pto.fusion.col_unroll_factor`。 |
+| 返回值 | `success()` 表示 planner 完成、没有可处理 group，或某些 group 被 warning 降级跳过；`failure()` 表示接口级错误。 |
+| 修改范围 | Planner 只能写 attrs，不允许增删、替换、移动 op，也不允许修改 operand/result/type。 |
+
+## 输入 IR
+
+PTOAS 传给 VfSim 的 IR 必须已经包含：
+
+| 属性 | 含义 |
+|---|---|
+| `pto.fusion.group_id` | PTOAS 已选择的 fusion group ID。 |
+| `pto.fusion.order` | group 内 tileop 的执行顺序。 |
+
+VfSim 从 IR 中读取：
+
+| 信息 | 来源 |
+|---|---|
+| group 边界 | `pto.fusion.group_id` |
+| group 内顺序 | `pto.fusion.order` |
+| tileop 类型 | MLIR op name，例如 `pto.tadd` |
+| 数据依赖 | SSA use-def |
+| 输入输出 value | tileop operands |
+| dtype | operand/result type |
+| shape | tile buffer type |
+| 模板参数 | tileop attrs |
+
+示例：
+
+```mlir
+pto.tadd ins(%b, %c : !pto.tile_buf<vec, 32x128xf32>,
+                      !pto.tile_buf<vec, 32x128xf32>)
+         outs(%a : !pto.tile_buf<vec, 32x128xf32>)
+         {pto.fusion.group_id = 0 : i64,
+          pto.fusion.order = 0 : i64}
+
+pto.tmul ins(%a, %b : !pto.tile_buf<vec, 32x128xf32>,
+                      !pto.tile_buf<vec, 32x128xf32>)
+         outs(%d : !pto.tile_buf<vec, 32x128xf32>)
+         {pto.fusion.group_id = 0 : i64,
+          pto.fusion.order = 1 : i64}
+```
+
+VfSim 不重新判断这组 tileop 是否可以融合，只基于 PTOAS 已选 group 生成优化决策。
+
+## 输出 IR
+
+VfSim 输出仍然是同一份 tileop-level IR，通过 attrs 表示优化计划：
+
+| 属性 | 含义 |
+|---|---|
+| `pto.fusion.row_unroll_factor` | 当 row loop 是实际最内层 loop 时使用的 unroll factor。 |
+| `pto.fusion.col_unroll_factor` | 当 col loop 是实际最内层 loop 时使用的 unroll factor。 |
+
+当前 unroll 语义：
+
+| 情况 | VfSim 输出 |
+|---|---|
+| col trip count 为 1 | `row_unroll_factor > 1`，`col_unroll_factor = 1` |
+| col trip count 大于 1 | `row_unroll_factor = 1`，`col_unroll_factor > 1` |
+
+示例：
+
+```mlir
+pto.tadd ... {
+  pto.fusion.group_id = 0 : i64,
+  pto.fusion.order = 0 : i64,
+  pto.fusion.row_unroll_factor = 1 : i64,
+  pto.fusion.col_unroll_factor = 2 : i64
+}
+
+pto.tmul ... {
+  pto.fusion.group_id = 0 : i64,
+  pto.fusion.order = 1 : i64,
+  pto.fusion.row_unroll_factor = 1 : i64,
+  pto.fusion.col_unroll_factor = 2 : i64
+}
+```
+
+## RegionGen 属性提升
+
+`FusionRegionGen` 会把同一个 group 包成 `pto.fusion_region`，并将一致的
+row/col unroll attrs 从 tileop 提升到 region：
+
+```mlir
+%0 = pto.fusion_region {
+  pto.tadd ...
+  pto.tmul ...
+  pto.yield(%d) : (!pto.tile_buf<vec, 32x128xf32>) -> ()
+} {
+  pto.fusion.group_id = 0 : i64,
+  pto.fusion.row_unroll_factor = 1 : i64,
+  pto.fusion.col_unroll_factor = 2 : i64
+} : !pto.tile_buf<vec, 32x128xf32>
+```
+
+提升规则：
+
+- 同一个 group 内，某个 unroll attr 要么所有成员都没有，要么所有成员都有。
+- 如果所有成员都有，值必须一致。
+- factor 必须是正整数。
+- 部分成员有、部分成员没有，或者值不一致，会报错。
+
+## VPTO Unroll 消费
+
+`PTOUnrollAfterLoopFusion` 在 VPTO low-level loop fusion 后运行。它读取
+`pto.fusion_region` 上的：
+
+```text
+pto.fusion.row_unroll_factor
+pto.fusion.col_unroll_factor
+```
+
+消费规则：
+
+- 只展开当前最内层 `scf.for`。
+- 只处理常量 trip count，且 trip count 必须能被 factor 整除。
+- 当前约定下，col loop 存在时消费 `col_unroll_factor`；col loop 已被折叠后，
+  row loop 成为最内层时消费 `row_unroll_factor`。
+- 成功消费某个 factor 后，将该 region 上对应 attr 复位为 `1`，避免同一 factor
+  在后续 greedy/walk 过程中被重复应用。
+
+示意：
+
+```mlir
+// Before PTOUnrollAfterLoopFusion
+pto.fusion_region {
+  scf.for %row = %c0 to %c32 step %c1 {
+    scf.for %col = %c0 to %c2 step %c1 {
+      pto.vadd ...
+      pto.vmul ...
+    }
+  }
+} {
+  pto.fusion.row_unroll_factor = 1 : i64,
+  pto.fusion.col_unroll_factor = 2 : i64
+}
+
+// After PTOUnrollAfterLoopFusion
+pto.fusion_region {
+  scf.for %row = %c0 to %c32 step %c1 {
+    pto.vadd ...
+    pto.vmul ...
+    pto.vadd ...
+    pto.vmul ...
+  }
+} {
+  pto.fusion.row_unroll_factor = 1 : i64,
+  pto.fusion.col_unroll_factor = 1 : i64
+}
+```
+
+## VfSim Planner 行为
+
+VfSim native planner 位于 `3rdparty/VfSimulator/native`。
+
+| 文件 | 作用 |
+|---|---|
+| `IRPlanner.h` | 定义 `PlannerOptions` 和 `planTileFusionIR`。 |
+| `IRPlanner.cpp` | 收集 fusion group，枚举 unroll candidate，调用 native VfInfo simulator，写回 attrs。 |
+| `TileOpTemplates.h/cpp` | 将 PTOAS tileop group lower 成 VfSim `VfInfo` micro-op program。 |
+| `ParamDB.h/cpp` | 加载 ISA/uarch/forwarding/initiation-interval 参数。 |
+
+候选枚举规则：
+
+- 搜索范围是 `1..maxUnroll`。
+- 当前默认 `maxUnroll = 8`。
+- 只考虑能够整除目标 loop trip count 的 factor。
+
+降级诊断：
+
+| 场景 | 行为 |
+|---|---|
+| 参数表加载失败 | 打印 warning，planner 对本次编译降级，不写 unroll attrs，PTOAS 继续编译。 |
+| group 中存在不支持的 tileop/template | 打印 warning，跳过该 group。 |
+| micro-op/dtype 参数缺失或所有 candidate 仿真失败 | 打印 warning，跳过该 group。 |
+
+`--dump-vfsim-unroll-test` 只额外打印候选值预测结果，例如：
+
+```text
+unroll=1 trip=2 dtype=fp32 cycles=278
+unroll=2 trip=2 dtype=fp32 cycles=131
+```
+
+## 当前模板覆盖范围
+
+当前源码级 planner 主要覆盖 elementwise 风格 tileop。
+
+| TileOp | Micro-op |
+|---|---|
+| `tadd` | `VADD` |
+| `tsub` | `VSUB` |
+| `tmul` | `VMUL` |
+| `tdiv` | `VDIV` |
+| `tmax` | `VMAX` |
+| `tmin` | `VMIN` |
+| `tabs` | `VABS` |
+| `texp` | `VEXP` |
+| `tadds` | `VADDS` |
+| `tsubs` | `VSUB`，标量通过 `VBR` 转成向量 |
+| `tmuls` | `VMULS` |
+| `tdivs` | `VDIV`，标量通过 `VBR` 转成向量 |
+| `tmaxs` | `VMAXS` |
+| `tmins` | `VMINS` |
+| `tcvt` | `VCVT_F16_TO_F32` 或 `VCVT_F32_TO_F16` |
+
+模板选择原则：
+
+- 根据 op name 选择 tileop 模板族。
+- 根据 dtype 选择 micro-op 参数和 vector lanes。
+- 根据 shape / valid shape 推导 row/col loop 结构。
+- 模板语义需要与 VPTO 后端 tileop template 保持一致。
+
+## 手写 VF IR 扩展方向
+
+除自动 tileop fusion 路线外，后续也可以支持开发者直接提供 VF/micro-op IR。
+该路线仍可复用源码级 submodule 接入方式，但输入不再是 tileop group，而是开发者
+已经写好的 VF IR。
+
+```text
+developer VF IR
+  -> VfSim analyzer
+  -> VF IR with cost/advice attrs or diagnostic report
+```
+
+该路线不决定 fusion group，而是评估已有 VF 实现，并给出预测和优化建议。

--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -101,6 +101,7 @@ std::unique_ptr<Pass>
 createPTOLowLevelLoopFusionPass(const PTOLowLevelLoopFusionOptions &options = {});
 std::unique_ptr<Pass> createPTOFusionPredicateElisionPass();
 std::unique_ptr<Pass> createPTOFusionLoadStoreElisionPass();
+std::unique_ptr<Pass> createPTOUnrollAfterLoopFusionPass();
 std::unique_ptr<Pass> createPTOFlattenFusionRegionPass();
 std::unique_ptr<Pass> createVPTOPtrNormalizePass();
 std::unique_ptr<Pass> createVPTOPtrCastCleanupPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -280,7 +280,17 @@ def FusionPlan : Pass<"pto-fusion-plan", "func::FuncOp"> {
            "iteration-domain inference.  Only FusionPlan consumes this option; "
            "FusionRegionGen consumes only the shared pre-fusion dataflow graph "
            "(cached by the analysis manager) and never consults iteration-domain "
-           "classes, so it does not need the option.">
+           "classes, so it does not need the option.">,
+    Option<"enableVfSimCostmodelOptimization",
+           "enable-vfsim-costmodel-optimization",
+           "bool", /*default=*/"false",
+           "Invoke the optional VfSimulator costmodel planner after PTOAS has "
+           "emitted FusionPlan group/order metadata.">,
+    Option<"dumpVfSimUnrollTest", "dump-vfsim-unroll-test",
+           "bool", /*default=*/"false",
+           "Print VfSimulator unroll candidate timings for accepted fusion "
+           "groups. This is a debug dump only and does not enable or disable "
+           "the VfSimulator planner.">
   ];
 }
 
@@ -1258,6 +1268,20 @@ def PTOFusionLoadStoreElision
     cleanup for non-escaping fusion-region internal buffers.
   }];
   let constructor = "mlir::pto::createPTOFusionLoadStoreElisionPass()";
+  let dependentDialects = ["mlir::func::FuncDialect", "mlir::pto::PTODialect",
+                           "mlir::arith::ArithDialect",
+                           "mlir::scf::SCFDialect"];
+}
+
+def PTOUnrollAfterLoopFusion
+    : Pass<"pto-unroll-after-loop-fusion", "func::FuncOp"> {
+  let summary = "Partial-unroll the innermost scf.for inside pto.fusion_region "
+                "after PTOLowLevelLoopFusion (divisible trip count only)";
+  let description = [{
+    Partial-unrolls the loop nests inside `pto.fusion_region` according to the
+    unroll factors supplied by the cost model.
+  }];
+  let constructor = "mlir::pto::createPTOUnrollAfterLoopFusionPass()";
   let dependentDialects = ["mlir::func::FuncDialect", "mlir::pto::PTODialect",
                            "mlir::arith::ArithDialect",
                            "mlir::scf::SCFDialect"];

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ add_mlir_dialect_library(PTOTransforms
   TileFusion/PTOLowLevelLoopFusion.cpp
   TileFusion/PTOFusionPredicateElision.cpp
   TileFusion/PTOFusionLoadStoreElision.cpp
+  TileFusion/PTOUnrollAfterLoopFusion.cpp
   TileFusion/PTOFlattenFusionRegion.cpp
   VPTOLLVMEmitter.cpp
   VPTOCANN900LLVMEmitter.cpp
@@ -141,6 +142,7 @@ add_mlir_dialect_library(PTOTransforms
   MLIRTransforms
   MLIRTensorDialect
   MLIRSCFDialect
+  MLIRSCFUtils
   MLIRVectorDialect
   MLIRParser
   MLIRArithTransforms
@@ -165,3 +167,19 @@ target_include_directories(PTOTransforms INTERFACE
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+
+if(TARGET vfsim::native_core)
+  target_link_libraries(PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::native_core>)
+  if(TARGET obj.PTOTransforms)
+    target_link_libraries(obj.PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::native_core>)
+  endif()
+endif()
+
+if(TARGET vfsim::ir_planner)
+  target_link_libraries(PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::ir_planner>)
+  target_compile_definitions(PTOTransforms PRIVATE PTO_ENABLE_VFSIM_IR_PLANNER=1)
+  if(TARGET obj.PTOTransforms)
+    target_link_libraries(obj.PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::ir_planner>)
+    target_compile_definitions(obj.PTOTransforms PRIVATE PTO_ENABLE_VFSIM_IR_PLANNER=1)
+  endif()
+endif()

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -22,6 +22,10 @@
 
 #include <algorithm>
 
+#ifdef PTO_ENABLE_VFSIM_IR_PLANNER
+#include "native/IRPlanner.h"
+#endif
+
 namespace mlir {
 namespace pto {
 // Passes.h (included above) pulls in the global GEN_PASS_DECL block, which
@@ -41,6 +45,10 @@ namespace {
 static constexpr llvm::StringLiteral kFusionGroupIdAttr =
     "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+static constexpr llvm::StringLiteral kFusionRowUnrollAttr =
+    "pto.fusion.row_unroll_factor";
+static constexpr llvm::StringLiteral kFusionColUnrollAttr =
+    "pto.fusion.col_unroll_factor";
 
 struct PlannedFusionGroup {
   SmallVector<const pto::FusionComputeNode *, 8> members;
@@ -521,7 +529,22 @@ static void clearPlanningAttrs(func::FuncOp func) {
   func.walk([](Operation *op) {
     op->removeAttr(kFusionGroupIdAttr);
     op->removeAttr(kFusionOrderAttr);
+    op->removeAttr(kFusionRowUnrollAttr);
+    op->removeAttr(kFusionColUnrollAttr);
   });
+}
+
+static LogicalResult runVfSimFusionPlanner(func::FuncOp func,
+                                           bool dumpCandidates) {
+#ifdef PTO_ENABLE_VFSIM_IR_PLANNER
+  vfsim::PlannerOptions options;
+  options.dumpCandidates = dumpCandidates;
+  return vfsim::planTileFusionIR(func.getOperation(), options);
+#else
+  return func.emitError()
+         << "--enable-vfsim-costmodel-optimization requires configuring PTOAS with "
+            "-DPTO_ENABLE_VFSIM_COSTMODEL=ON";
+#endif
 }
 
 struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
@@ -565,6 +588,12 @@ struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
       SmallVector<PlannedFusionGroup, 8> groups =
           strategyEngine.planBlock(planningCtx, costModel);
       assignStableGroupMetadata(groups, ctx, nextGroupId);
+    }
+
+    if (enableVfSimCostmodelOptimization &&
+        failed(runVfSimFusionPlanner(func, dumpVfSimUnrollTest))) {
+      signalPassFailure();
+      return;
     }
 
     // The fusion metadata we annotate (group_id/order) is a planning *output*;

--- a/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
@@ -36,6 +36,10 @@ namespace {
 static constexpr llvm::StringLiteral kFusionGroupIdAttr =
     "pto.fusion.group_id";
 static constexpr llvm::StringLiteral kFusionOrderAttr = "pto.fusion.order";
+static constexpr llvm::StringLiteral kFusionRowUnrollAttr =
+    "pto.fusion.row_unroll_factor";
+static constexpr llvm::StringLiteral kFusionColUnrollAttr =
+    "pto.fusion.col_unroll_factor";
 
 struct GroupSpanMember {
   Operation *op = nullptr;
@@ -349,7 +353,43 @@ static void clearSpanFusionMetadata(const GroupSpan &span) {
   for (const GroupSpanMember &member : span.members) {
     member.op->removeAttr(kFusionGroupIdAttr);
     member.op->removeAttr(kFusionOrderAttr);
+    member.op->removeAttr(kFusionRowUnrollAttr);
+    member.op->removeAttr(kFusionColUnrollAttr);
   }
+}
+
+static FailureOr<std::optional<int64_t>>
+getCommonSpanI64Attr(const GroupSpan &span, StringRef attrName) {
+  std::optional<int64_t> commonUnroll;
+  bool sawMissingAttr = false;
+  for (const GroupSpanMember &member : span.members) {
+    auto attr = member.op->getAttrOfType<IntegerAttr>(attrName);
+    if (!attr) {
+      sawMissingAttr = true;
+      continue;
+    }
+    int64_t unroll = attr.getInt();
+    if (unroll < 1) {
+      member.op->emitError("expected ")
+          << attrName << " to be a positive integer";
+      return failure();
+    }
+    if (!commonUnroll) {
+      commonUnroll = unroll;
+      continue;
+    }
+    if (*commonUnroll != unroll) {
+      member.op->emitError("inconsistent ")
+          << attrName << " within one pto.fusion.group_id";
+      return failure();
+    }
+  }
+  if (commonUnroll && sawMissingAttr) {
+    span.members.front().op->emitError("incomplete ")
+        << attrName << " within one pto.fusion.group_id";
+    return failure();
+  }
+  return commonUnroll;
 }
 
 static LogicalResult
@@ -359,6 +399,14 @@ encapsulateGroupSpan(const GroupSpan &span,
     return success();
 
   GroupSpanInterface iface = buildGroupSpanInterface(span, analysisIndex);
+  FailureOr<std::optional<int64_t>> commonRowUnroll =
+      getCommonSpanI64Attr(span, kFusionRowUnrollAttr);
+  if (failed(commonRowUnroll))
+    return failure();
+  FailureOr<std::optional<int64_t>> commonColUnroll =
+      getCommonSpanI64Attr(span, kFusionColUnrollAttr);
+  if (failed(commonColUnroll))
+    return failure();
 
   SmallVector<Type, 8> outputTypes;
   outputTypes.reserve(iface.externallyVisibleValues.size());
@@ -372,6 +420,12 @@ encapsulateGroupSpan(const GroupSpan &span,
       builder.create<pto::FusionRegionOp>(loc, TypeRange(outputTypes));
   fusionRegion->setAttr(kFusionGroupIdAttr,
                         builder.getI64IntegerAttr(span.groupId));
+  if (*commonRowUnroll)
+    fusionRegion->setAttr(kFusionRowUnrollAttr,
+                          builder.getI64IntegerAttr(**commonRowUnroll));
+  if (*commonColUnroll)
+    fusionRegion->setAttr(kFusionColUnrollAttr,
+                          builder.getI64IntegerAttr(**commonColUnroll));
 
   Block *body = new Block();
   fusionRegion.getBody().push_back(body);

--- a/lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "PTO/Transforms/Passes.h"
+
+#include "PTO/IR/PTO.h" // FusionRegionOp
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Utils/Utils.h" // loopUnrollByFactor
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Visitors.h" // walk, WalkOrder
+#include "mlir/Interfaces/LoopLikeInterface.h" // getConstantIntValue
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Debug.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace mlir {
+namespace pto {
+#define GEN_PASS_DEF_PTOUNROLLAFTERLOOPFUSION
+#include "PTO/Transforms/Passes.h.inc"
+} // namespace pto
+} // namespace mlir
+
+using namespace mlir;
+
+#define DEBUG_TYPE "pto-unroll-after-loop-fusion"
+
+static constexpr llvm::StringLiteral kRowUnrollFactorAttr =
+    "pto.fusion.row_unroll_factor";
+static constexpr llvm::StringLiteral kColUnrollFactorAttr =
+    "pto.fusion.col_unroll_factor";
+
+namespace {
+
+/// Read an i64 unroll factor from `region`; return the value only if it is
+/// present and strictly greater than 1, else 0.
+static int64_t getEffectiveFactor(pto::FusionRegionOp region,
+                                  llvm::StringRef attrName) {
+  if (auto attr = region->getAttrOfType<IntegerAttr>(attrName)) {
+    int64_t v = attr.getInt();
+    if (v > 1)
+      return v;
+  }
+  return 0;
+}
+
+/// Whether `forOp` has a child scf.for in its body (i.e. it is NOT the
+/// innermost loop of the nest).
+static bool hasChildForOp(scf::ForOp forOp) {
+  bool hasChild = false;
+  forOp.getBody()->walk([&](scf::ForOp) {
+    hasChild = true;
+    return WalkResult::interrupt();
+  });
+  return hasChild;
+}
+
+/// Constant trip count of a half-open scf.for (`lb <= i < ub`, `step > 0`),
+/// or std::nullopt if any bound/step is not a compile-time constant.
+static std::optional<int64_t> getConstantTripCount(scf::ForOp forOp) {
+  std::optional<int64_t> lb = getConstantIntValue(forOp.getLowerBound());
+  std::optional<int64_t> ub = getConstantIntValue(forOp.getUpperBound());
+  std::optional<int64_t> step = getConstantIntValue(forOp.getStep());
+  if (!lb || !ub || !step || *step <= 0 || *ub <= *lb)
+    return std::nullopt;
+  return (*ub - *lb + *step - 1) / *step; // ceilDiv
+}
+
+/// Attempt to partial-unroll a single leaf `scf.for` inside a fusion_region.
+/// Returns success on actual unroll, failure on every skip (non-fusion scope,
+/// non-leaf, no factor > 1, non-constant / indivisible trip)
+static LogicalResult tryUnrollLeafForOp(scf::ForOp forOp) {
+  // Scope gate: only loops inside a fusion_region.
+  auto region = forOp->getParentOfType<pto::FusionRegionOp>();
+  if (!region) {
+    LLVM_DEBUG(llvm::dbgs() << "PTOUnrollAfterLoopFusion: skip non-fusion "
+               << "scf.for at " << forOp.getLoc() << "\n");
+    return failure();
+  }
+
+  int64_t rowF = getEffectiveFactor(region, kRowUnrollFactorAttr);
+  int64_t colF = getEffectiveFactor(region, kColUnrollFactorAttr);
+
+  // Only unroll the innermost (leaf) loop.
+  if (hasChildForOp(forOp)) {
+    LLVM_DEBUG(llvm::dbgs() << "PTOUnrollAfterLoopFusion: skip non-leaf "
+               << "(outer) scf.for at " << forOp.getLoc()
+               << " -- unrolling outer breaks LoadStoreElision;"
+               << " row_f=" << rowF << " col_f=" << colF
+               << " (cost-model intent may target this layer but pass "
+               << "defers to the leaf)\n");
+    return failure();
+  }
+
+  // Leaf takes whichever factor is > 1 (col preferred; in a two-layer nest
+  // the leaf is the col loop). The cost model may place the > 1 value on
+  // either attribute depending on which layer is the effective innermost
+  // (e.g. col trip == 1 -> col gets folded away -> row becomes leaf -> the
+  // > 1 value lives on row_f). Both > 1 is a legal input; col wins.
+  int64_t factor;
+  llvm::StringRef src;
+  if (colF > 1) {
+    factor = colF;
+    src = "col";
+  } else if (rowF > 1) {
+    factor = rowF;
+    src = "row";
+  } else {
+    LLVM_DEBUG(llvm::dbgs() << "PTOUnrollAfterLoopFusion: skip no factor>1 "
+               << "scf.for at " << forOp.getLoc()
+               << " row_f=" << rowF << " col_f=" << colF << "\n");
+    return failure();
+  }
+
+  // Divisibility gate: constant trip count must be divisible by the factor
+  // (no epilogue tail loop). Non-constant / non-divisible -> leave untouched.
+  auto trip = getConstantTripCount(forOp);
+  if (!trip) {
+    LLVM_DEBUG(llvm::dbgs() << "PTOUnrollAfterLoopFusion: skip non-constant "
+               << "trip scf.for at " << forOp.getLoc()
+               << " factor(from " << src << ")=" << factor << "\n");
+    return failure();
+  }
+  if (*trip % factor != 0) {
+    LLVM_DEBUG(llvm::dbgs() << "PTOUnrollAfterLoopFusion: skip indivisible "
+               << "trip scf.for at " << forOp.getLoc()
+               << " trip=" << *trip << " factor=" << factor << "(from "
+               << src << ")\n");
+    return failure();
+  }
+
+  LLVM_DEBUG(llvm::dbgs() << "PTOUnrollAfterLoopFusion: unroll scf.for at "
+             << forOp.getLoc() << " factor=" << factor << "(from " << src
+             << ") trip=" << *trip
+             << " row_f=" << rowF << " col_f=" << colF << "\n");
+
+  // loopUnrollByFactor rewrites the loop in place (step scaled, body copied)
+  // via its own internal IRRewriter, bypassing any outer rewriter/listener --
+  // which is exactly why we are a walk and not an OpRewritePattern.
+  auto unrolled = loopUnrollByFactor(forOp, static_cast<uint64_t>(factor));
+  if (failed(unrolled)) {
+    LLVM_DEBUG(llvm::dbgs() << "  loopUnrollByFactor failed "
+               << "(iter_args live-out?) at " << forOp.getLoc() << "\n");
+    return failure();
+  }
+  (void)unrolled; // mainLoopOp/epilogueLoopOp unused: divisibility => no tail.
+
+  llvm::StringRef consumedAttr =
+      src == "col" ? kColUnrollFactorAttr : kRowUnrollFactorAttr;
+  region->setAttr(consumedAttr,
+                  Builder(region->getContext()).getI64IntegerAttr(/*value=*/1));
+  return success();
+}
+
+struct PTOUnrollAfterLoopFusion
+    : public pto::impl::PTOUnrollAfterLoopFusionBase<
+          PTOUnrollAfterLoopFusion> {
+  using pto::impl::PTOUnrollAfterLoopFusionBase<
+      PTOUnrollAfterLoopFusion>::PTOUnrollAfterLoopFusionBase;
+
+  void runOnOperation() override {
+    func::FuncOp func = getOperation();
+
+    // Gather all scf.for in post-order (innermost first). The walk callback
+    // only collects; every mutation happens in the loop below, after the walk
+    // completes, so we never walk IR being rewritten under us.
+    SmallVector<scf::ForOp, 4> candidates;
+    func.walk([&](scf::ForOp forOp) { candidates.push_back(forOp); });
+
+    for (scf::ForOp forOp : candidates)
+      (void)tryUnrollLeafForOp(forOp);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::pto::createPTOUnrollAfterLoopFusionPass() {
+  return std::make_unique<PTOUnrollAfterLoopFusion>();
+}

--- a/test/lit/lit.cfg.py
+++ b/test/lit/lit.cfg.py
@@ -46,6 +46,9 @@ config.ptoir_test_tools_dir = os.path.join(config.ptoir_obj_root,
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
 
+if getattr(config, 'pto_enable_vfsim_costmodel', False):
+    config.available_features.add('vfsim-costmodel')
+
 llvm_config.with_system_environment(
     ['HOME', 'INCLUDE', 'LIB', 'TMP', 'TEMP',
      'ASCEND_HOME_PATH', 'ASCEND_OPP_PATH', 'ASCEND_AICPU_PATH',

--- a/test/lit/lit.site.cfg.py.in
+++ b/test/lit/lit.site.cfg.py.in
@@ -22,6 +22,7 @@ config.python_executable = "@Python3_EXECUTABLE@"
 # config.enable_bindings_python = @MLIR_ENABLE_BINDINGS_PYTHON@
 config.ptoir_src_root = "@CMAKE_SOURCE_DIR@"
 config.ptoir_obj_root = "@CMAKE_BINARY_DIR@"
+config.pto_enable_vfsim_costmodel = "@PTO_ENABLE_VFSIM_COSTMODEL@" == "ON"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/test/lit/tile_fusion/vfsim_unroll_tadd_tmul_32x128.pto
+++ b/test/lit/tile_fusion/vfsim_unroll_tadd_tmul_32x128.pto
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS IS PROVIDED ON AN "AS IS" BASIS, WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// A=B+C; D=A*B elementwise fusion case.
+// Guards the VfSim IR planner col-unroll path on a small 32x128 tile.
+// The pinned VfSimulator commit is expected to choose col_unroll_factor = 2
+// for this case, expanding the fused inner loop to exercise the PTOAS
+// planner-to-region-to-unroll plumbing. If a future VfSimulator submodule
+// update changes that costmodel decision, update this expected value together
+// with the submodule bump.
+//
+//   (1) REGION  -- PTOAS forms one fusion_region containing tadd + tmul, and
+//       VfSim writes col_unroll_factor = 2.
+//   (2) LLF     -- pto-low-level-loop-fusion lowers the group to nested loops:
+//       row trip 32, col trip 2. The inner col loop still carries one vadd and
+//       one vmul before unroll.
+//   (3) UNROLL  -- pto-unroll-after-loop-fusion consumes col_unroll_factor=2,
+//       fully unrolls the inner col loop, and leaves two vadd/vmul copies in
+//       the row loop body.
+//
+// REQUIRES: vfsim-costmodel
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vfsim-costmodel-optimization --emit-pto-ir %s --mlir-print-ir-after=pto-fusion-region-gen -o /dev/null 2>&1 | FileCheck %s --check-prefix=REGION
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vfsim-costmodel-optimization --emit-vpto %s --mlir-print-ir-after=pto-low-level-loop-fusion -o /dev/null 2>&1 | FileCheck %s --check-prefix=LLF
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --pto-level=level2 --enable-op-fusion --enable-vfsim-costmodel-optimization --enable-unroll-after-loop-fusion --emit-vpto %s --mlir-print-ir-after=pto-unroll-after-loop-fusion -o /dev/null 2>&1 | FileCheck %s --check-prefix=UNROLL
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vfsim_unroll_tadd_tmul_32x128(
+      %b_ptr: !pto.ptr<f32>,
+      %c_ptr: !pto.ptr<f32>,
+      %d_ptr: !pto.ptr<f32>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c128 = arith.constant 128 : index
+
+    %b_view = pto.make_tensor_view %b_ptr,
+      shape = [%c32, %c128], strides = [%c128, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %c_view = pto.make_tensor_view %c_ptr,
+      shape = [%c32, %c128], strides = [%c128, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %d_view = pto.make_tensor_view %d_ptr,
+      shape = [%c32, %c128], strides = [%c128, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %b_part = pto.partition_view %b_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c128]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x128xf32>
+    %c_part = pto.partition_view %c_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c128]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x128xf32>
+    %d_part = pto.partition_view %d_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c128]
+      : !pto.tensor_view<?x?xf32> -> !pto.partition_tensor_view<32x128xf32>
+
+    %b = pto.alloc_tile : !pto.tile_buf<vec, 32x128xf32>
+    %c = pto.alloc_tile : !pto.tile_buf<vec, 32x128xf32>
+    %a = pto.alloc_tile : !pto.tile_buf<vec, 32x128xf32>
+    %d = pto.alloc_tile : !pto.tile_buf<vec, 32x128xf32>
+
+    pto.tload ins(%b_part : !pto.partition_tensor_view<32x128xf32>)
+              outs(%b : !pto.tile_buf<vec, 32x128xf32>)
+    pto.tload ins(%c_part : !pto.partition_tensor_view<32x128xf32>)
+              outs(%c : !pto.tile_buf<vec, 32x128xf32>)
+    pto.tadd ins(%b, %c : !pto.tile_buf<vec, 32x128xf32>, !pto.tile_buf<vec, 32x128xf32>)
+             outs(%a : !pto.tile_buf<vec, 32x128xf32>)
+    pto.tmul ins(%a, %b : !pto.tile_buf<vec, 32x128xf32>, !pto.tile_buf<vec, 32x128xf32>)
+             outs(%d : !pto.tile_buf<vec, 32x128xf32>)
+    pto.tstore ins(%d : !pto.tile_buf<vec, 32x128xf32>)
+               outs(%d_part : !pto.partition_tensor_view<32x128xf32>)
+    return
+  }
+}
+
+// REGION-LABEL: func.func @vfsim_unroll_tadd_tmul_32x128(
+// REGION: pto.fusion_region {
+// REGION: pto.tadd
+// REGION: pto.tmul
+// REGION: pto.yield(%{{.*}}) : (!pto.tile_buf<vec, 32x128xf32>) -> ()
+// REGION: } {pto.fusion.col_unroll_factor = 2 : i64, pto.fusion.group_id = 0 : i64, pto.fusion.row_unroll_factor = 1 : i64} : !pto.tile_buf<vec, 32x128xf32>
+
+// LLF-LABEL: func.func @vfsim_unroll_tadd_tmul_32x128(
+// LLF: pto.fusion_region {
+// LLF: scf.for %{{.*}} = %{{.*}} to %c32{{(_[0-9]+)?}} step %c1{{(_[0-9]+)?}} {
+// LLF: scf.for %{{.*}} = %{{.*}} to %c128{{(_[0-9]+)?}} step %c64{{(_[0-9]+)?}}
+// LLF: pto.vadd
+// LLF: pto.vmul
+// LLF-NOT: pto.vadd
+// LLF-NOT: pto.vmul
+// LLF: pto.yield
+// LLF: } {pto.fusion.col_unroll_factor = 2 : i64, pto.fusion.group_id = 0 : i64, pto.fusion.row_unroll_factor = 1 : i64} : !pto.tile_buf<vec, 32x128xf32>
+
+// UNROLL-LABEL: func.func @vfsim_unroll_tadd_tmul_32x128(
+// UNROLL: pto.fusion_region {
+// UNROLL: scf.for %{{.*}} = %{{.*}} to %c32 step %c1
+// UNROLL-NOT: step %c64
+// UNROLL: pto.vadd
+// UNROLL: pto.vmul
+// UNROLL: pto.vadd
+// UNROLL: pto.vmul
+// UNROLL-NOT: pto.vadd
+// UNROLL-NOT: pto.vmul
+// UNROLL: } {pto.fusion.col_unroll_factor = 1 : i64, pto.fusion.group_id = 0 : i64, pto.fusion.row_unroll_factor = 1 : i64} : !pto.tile_buf<vec, 32x128xf32>

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -554,6 +554,13 @@ static llvm::cl::opt<llvm::cl::boolOrDefault> enableOpFusion(
                    "annotation; VPTO uses fusion-region lifecycle."),
     llvm::cl::init(llvm::cl::BOU_UNSET));
 
+static llvm::cl::opt<bool> enableUnrollAfterLoopFusion(
+    "enable-unroll-after-loop-fusion",
+    llvm::cl::desc("Partial-unroll the innermost scf.for in pto.fusion_region "
+                   "by pto.fusion.row/col_unroll_factor. VPTO backend only; "
+                   "requires --pto-arch=a5 and --enable-op-fusion."),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<bool> enableShapeInference(
     "enable-shape-inference",
     llvm::cl::desc("Enable shape inference (ShapeConstraintSolver) for A5 tile "
@@ -561,6 +568,22 @@ static llvm::cl::opt<bool> enableShapeInference(
                   "iteration-domain inference; pass --enable-shape-inference=false "
                   "to fall back to static/direct-bound inference."),
     llvm::cl::init(true));
+
+static llvm::cl::opt<bool> enableVfSimCostmodelOptimization(
+    "enable-vfsim-costmodel-optimization",
+    llvm::cl::desc("Enable optional VfSimulator costmodel-driven fusion "
+                   "optimization. Requires the A5 tile-fusion pipeline. This "
+                   "may annotate pto.fusion.row/col_unroll_factor; pass "
+                   "--enable-unroll-after-loop-fusion to consume those "
+                   "attributes in the VPTO backend."),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool> dumpVfSimUnrollTest(
+    "dump-vfsim-unroll-test",
+    llvm::cl::desc("Print VfSimulator unroll candidate timings for accepted "
+                   "fusion groups. Debug dump only; does not enable or disable "
+                   "the VfSimulator planner."),
+    llvm::cl::init(false));
 
 static llvm::cl::opt<bool> disableInferLayout(
     "disable-infer-layout",
@@ -2750,6 +2773,14 @@ lowerPTOToVPTOBackend(PassManager &pm, ModuleOp module,
         pto::createPTOFusionPredicateElisionPass());
     kernelModulePM.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOFusionLoadStoreElisionPass());
+    if (enableUnrollAfterLoopFusion) {
+      kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+          pto::createPTOUnrollAfterLoopFusionPass());
+      kernelModulePM.addPass(mlir::createCanonicalizerPass());
+      kernelModulePM.addPass(mlir::createCSEPass());
+      kernelModulePM.addNestedPass<mlir::func::FuncOp>(
+          pto::createPTOFusionLoadStoreElisionPass());
+    }
     kernelModulePM.addNestedPass<mlir::func::FuncOp>(
         pto::createPTOFlattenFusionRegionPass());
     kernelModulePM.addPass(mlir::createCSEPass());
@@ -2953,6 +2984,23 @@ int mlir::pto::compilePTOASModule(
                     "--pto-level=level2 or level3 is required.\n";
   }
 
+  if (enableUnrollAfterLoopFusion && !(opFusionEnabled && arch == "a5")) {
+    llvm::errs() << "Error: --enable-unroll-after-loop-fusion requires "
+                    "--pto-arch=a5 and --enable-op-fusion.\n";
+    return 1;
+  }
+  if (enableUnrollAfterLoopFusion && effectiveBackend != PTOBackend::VPTO) {
+    llvm::errs() << "Error: --enable-unroll-after-loop-fusion requires "
+                    "--pto-backend=vpto; the pass is VPTO-only and is not "
+                    "inserted under other backends.\n";
+    return 1;
+  }
+  if (enableUnrollAfterLoopFusion && !enableVfSimCostmodelOptimization) {
+    llvm::errs() << "Warning: --enable-unroll-after-loop-fusion consumes "
+                    "pto.fusion.row/col_unroll_factor, which is produced by "
+                    "--enable-vfsim-costmodel-optimization.\n";
+  }
+
   const bool enableA5FusionPath =
       opFusionEnabled && arch == "a5" &&
       effectiveLevel != PTOBuildLevel::Level1;
@@ -2960,6 +3008,28 @@ int mlir::pto::compilePTOASModule(
       enableA5FusionPath && effectiveBackend == PTOBackend::EmitC;
   const bool enableA5VPTOFusionPath =
       enableA5FusionPath && effectiveBackend == PTOBackend::VPTO;
+
+  if (enableVfSimCostmodelOptimization &&
+      !(enableA5EmitCFusionPath || enableA5VPTOFusionPath)) {
+    llvm::errs() << "Warning: --enable-vfsim-costmodel-optimization is ignored "
+                    "because the A5 tile-fusion pipeline is not enabled; "
+                    "requires --pto-arch=a5, --pto-level=level2 or level3, "
+                    "and op fusion enabled.\n";
+  }
+  if (enableVfSimCostmodelOptimization && enableA5EmitCFusionPath) {
+    llvm::errs() << "Warning: --enable-vfsim-costmodel-optimization may "
+                    "annotate costmodel attributes on the EmitC fusion path, "
+                    "but current VfSim unroll attributes are consumed only by "
+                    "the VPTO backend; use --pto-backend=vpto for unroll "
+                    "consumption.\n";
+  }
+  if (enableVfSimCostmodelOptimization && enableA5VPTOFusionPath &&
+      !enableUnrollAfterLoopFusion) {
+    llvm::errs() << "Warning: --enable-vfsim-costmodel-optimization may "
+                    "annotate pto.fusion.row/col_unroll_factor, but "
+                    "--enable-unroll-after-loop-fusion is not enabled; unroll "
+                    "attributes will not be consumed by the VPTO backend.\n";
+  }
 
   bool invalidAutoSyncTailHint = false;
   module->walk([&](mlir::func::FuncOp func) {
@@ -3145,6 +3215,9 @@ int mlir::pto::compilePTOASModule(
   // so it takes no option here.
   pto::FusionPlanOptions fusionPlanOpts;
   fusionPlanOpts.enableShapeInference = enableShapeInference;
+  fusionPlanOpts.enableVfSimCostmodelOptimization =
+      enableVfSimCostmodelOptimization;
+  fusionPlanOpts.dumpVfSimUnrollTest = dumpVfSimUnrollTest;
   if (!isA2A3 && enableA5EmitCFusionPath) {
     pm.addNestedPass<mlir::func::FuncOp>(
         pto::createFusionPlanPass(fusionPlanOpts));


### PR DESCRIPTION
利用VfSim costmodel预测ptoas elementwise算子unroll展开后的时间，在IR上打上unroll attrs，供vpto后端消费