### PR TITLE
feat(vpto): VPTOSoftPostUpdate Step 2: accumulator analysis + stride analysis unification

### DIFF
--- a/docs/designs/vpto-soft-postupdate-design-zh.md
+++ b/docs/designs/vpto-soft-postupdate-design-zh.md
@@ -367,13 +367,15 @@ Post-Update 模式下 `repeat_stride` 从地址偏移变为指针前进量，因
 
 ### 5.1 在 Pipeline 中的位置
 
-pass 应运行在 VPTO 后端 pipeline 中，位于 `VPTOExpandWrapperOps` 之后、`PrepareVPTOLLVMLoweringPass` 之前：
+pass 应运行在 VPTO 后端 pipeline 中，位于 `PTOInferVPTOVecScope` 之后、`PrepareVPTOLLVMLoweringPass` 之前：
 
 ```
 VPTOExpandWrapperOps
 CSE
-→ VPTOSoftPostUpdate（新增）        ← 在此处
 PTOInferVPTOVecScope
+→ VPTOSoftPostUpdate（新增）        ← 在此处
+Canonicalizer
+CSE
 ...
 PrepareVPTOLLVMLoweringPass
 LowerVPTOOpsPass
@@ -381,8 +383,10 @@ LowerVPTOOpsPass
 
 该位置确保：
 - Wrapper op 已展开（IR 干净）
-- Vecscope 结构完整
+- **`pto.vecscope` 已存在**。pass 只改写 `pto.vecscope` 内的 op，而多数 kernel 的 vecscope 是由 `PTOInferVPTOVecScope` 创建的——排在它之前会让 pass 对这类输入静默失效。手写 vecscope 的测试用例不会暴露该问题，因此回归测试中必须包含不含手写 vecscope 的输入（`soft_postupdate_inferred-vecscope.pto`）
 - Post-Update 结果对 LLVM lowering 可见，后者根据 `getUpdatedBase()` 选择 `vldsx1` 或 `vldsx1.post`
+
+`PTOInferVPTOVecScope` 以整 op 方式把 `scf.for` 搬入 `pto.vecscope`（`wrapCluster` 用 `splice` 移动整个 op），循环体内部结构不变，因此 4.2.5 检查 2「op 直接位于循环体内」的判定不受影响。
 
 ### 5.2 Pass 注册
 

--- a/docs/designs/vpto-soft-postupdate-design-zh.md
+++ b/docs/designs/vpto-soft-postupdate-design-zh.md
@@ -344,13 +344,13 @@ def VPTOSoftPostUpdate : Pass<"vpto-soft-postupdate", "ModuleOp"> {
 5. ~~支持 `pto.vlds`、`pto.vsts`、`pto.vsstb`。~~
 6. ~~添加 delta 路径的 lit 测试和反向测试。~~
 
-### Step 2：循环累加器分析
+### ~~Step 2：循环累加器分析~~（已完成）
 
-7. 实现 `getIterArgIncrement` helper。
-8. 实现累加器分析（4.2.1）：base/offset 统一检测与 stride 合并。
-9. 实现累加器路径的改写（4.2.4）。
-10. 在遍历逻辑中将累加器分析置于 delta 分析之前。
-11. 添加累加器路径的 lit 测试（含非常量 stride、base 和 offset 都是 iter_arg 等场景）。
+7. ~~实现 `getIterArgIncrement` helper。~~
+8. ~~实现累加器分析（4.2.1）：base/offset 统一检测与 stride 合并。~~
+9. ~~实现累加器路径的改写（4.2.4）。~~
+10. ~~在遍历逻辑中将累加器分析置于 delta 分析之前。~~
+11. ~~添加累加器路径的 lit 测试（含非常量 stride、base 和 offset 都是 iter_arg 等场景）。~~
 
 ### Step 3：顺序路径
 

--- a/docs/designs/vpto-soft-postupdate-design-zh.md
+++ b/docs/designs/vpto-soft-postupdate-design-zh.md
@@ -279,11 +279,15 @@ delta 分析同样是纯符号的：表中每一行返回 `StrideExpr`，结果�
 
 2. **op 直接位于 `scf.for` 循环体内**（不嵌套在循环内的 `scf.if` 或其他控制流中），避免部分迭代问题。
 
-3. **`total_delta` 整除 `weight`。** weight=1 时自动满足；weight=32（vsstb/vsldb）时要求 `delta(base) % 32 == 0`。缩放在符号层折叠，因此只要 `delta(base)` 与 `delta(strideOperand)` 各自是常量，整除性即可判定。
+3. **`total_delta` 整除 `weight`。** weight=1 时自动满足。weight≠1 时，**当前实现要求整个 `total_delta` 是编译期常量**且整除 weight，不满足即放弃。
+
+   这比理论下限保守。由于 `weight * delta(strideOperand)` 天然整除 weight，整除性其实只取决于 `delta(base)`——原则上 `delta(strideOperand)` 可以是任意符号表达式，只要 `delta(base)` 是能被 weight 整除的常量即可。放宽需要给 `StrideExpr` 增加结构化的整除判定（识别 `Mul(e, Const(k))` 一类形式），暂未实现；此处记录该取舍，以免文档与实现口径不一致。
 
 4. **stride_new 为零时跳过。** 地址不前进，post-update 无收益。常量折叠使各项相消、合成结果恒为零的情形（如 base 每轮 +8、strideOperand 每轮 −8）同样能被识别。
 
 5. **类型一致性。** stride 表达式各子项须归结为同一类型，否则放弃，以免构造出 `arith.addi(index, i32)` 这类非法 op。`Const` 项不参与该约束——其类型在物化时按上下文决定。
+
+   此外，各 `Const` 项的数值须能被目标类型表示。`stride_new` 对块步长指令是窄整数（i16），超出范围的 stride 会构造出非法常量，因此在物化前一并检查并放弃。
 
 6. **操作数可用性（支配性）。** stride 表达式的每个叶子须在候选 op 处可用：循环不变量、block argument、或定义点早于候选 op。若叶子定义在候选 op **之后**，仅当其定义链全部为 pure op 时克隆到候选 op 之前（克隆保留原结果序号，多结果 op 亦正确）；否则放弃。该检查以只读方式先行完成，克隆发生在物化阶段。
 

--- a/docs/designs/vpto-soft-postupdate-design-zh.md
+++ b/docs/designs/vpto-soft-postupdate-design-zh.md
@@ -117,12 +117,14 @@ VPTOSoftPostUpdate pass:
   单次遍历 pto.vecscope 内所有指令，对每条指令查询
   PostUpdateSet（static DenseSet<OperationName>，维护第 2 章中的指令集合）:
     若命中:
-      若在 scf.for 内 → 循环路径（按优先级依次尝试）：
-        1. 累加器分析 —— offset 或 base 是否为 iter_arg 且 yield 中有显式递增？
-        2. 若累加器分析未命中 → delta 分析 —— stride 是否为循环不变量？
-        3. 合法性检查
-        4. 改写
-        5. 若产生了新的 iter_arg，向外层循环传播
+      若在 scf.for 内 → 循环路径（分析与物化两阶段）：
+        阶段一 · 纯符号分析（不产生任何 IR）：
+          1. 累加器分析 —— offset 或 base 是否为 iter_arg 且 yield 中有显式递增？
+          2. 若累加器分析未命中 → delta 分析 —— stride 是否为循环不变量？
+        阶段二 · 判定与物化：
+          3. 合法性检查（含类型一致性、操作数可用性）
+          4. 在唯一插入点物化 stride，然后改写
+          5. 若产生了新的 iter_arg，向外层循环传播
       若不在 scf.for 内 → 顺序路径：
         从当前指令起向后扫描，收集连续的同类型、同 base、等差常量偏移的序列，
         一次性链式改写为 post-update，迭代器跳过已处理的指令
@@ -130,9 +132,11 @@ VPTOSoftPostUpdate pass:
 
 ### 4.2 循环路径
 
-循环路径有两条互斥的分析路径：**累加器分析**（优先）和 **delta 分析**（兜底）。前者处理 base 或 strideOperand 已通过 `iter_args` 显式累加的场景（stride 可以是任意已计算的值），后者处理从 IV 全新计算、无累加器的场景（stride 须为循环不变量）。
+循环路径对 base 和 strideOperand **各自独立**分析：每个操作数先试 **累加器分析**（优先），未命中再退到 **delta 分析**（兜底），两者的结果最后合并为 `total_delta`。前者处理该操作数已通过 `iter_args` 显式累加的场景（stride 可以是任意已计算的值），后者处理从 IV 全新计算、无累加器的场景（stride 须为循环不变量）。因此同一条指令的 base 走累加器、strideOperand 走 delta 是允许的组合。
 
 两类指令（vlds/vsts 与 vsstb/vsldb）的分析和改写通过统一的地址描述符抽象，共享同一套分析流程。
+
+无论走哪条路径，分析都只产出**符号表达式**，不触碰 IR；确认候选可行后才在单一插入点物化（见 4.2.2）。
 
 #### 4.2.1 地址描述符
 
@@ -161,41 +165,68 @@ init_ptr    = base_0 + weight * strideOperand_0   // 通过 pto.addptr 创建
 
 约束：`total_delta` 必须整除 `weight`（weight=1 时自动满足，weight=32 时要求 `delta(base) % 32 == 0`，因为 `weight * delta(strideOperand)` 天然整除 32）。
 
-#### 4.2.2 累加器分析（优先）
+#### 4.2.2 分析与物化分离
+
+循环路径分两个阶段。**分析阶段**不产生任何 IR：`decomposeLinear`、`getIterArgIncrement`、`computeDelta` 均为纯函数，返回符号表达式 `StrideExpr`。**物化阶段**在候选通过全部合法性检查之后，由 `materialize` 在唯一插入点一次性发射 IR。
+
+```
+StrideExpr := Const(int64)                  // 类型在物化时按上下文决定
+            | Leaf(Value)                   // IR 中已存在的叶子值
+            | Add(e, e) | Sub(e, e) | Mul(e, e)
+            | Cast(op, e)                   // index_cast/index_castui，op 为克隆模板
+```
+
+`StrideExpr` 在构造时即做常量折叠（`foldConst`），因此 `total_delta` 是否为常量、是否整除 `weight`、是否恒为零，全部在符号层判定，判定不依赖任何已生成的 IR。
+
+该划分是正确性要求，而非代码组织风格。以下三条性质依赖于它：
+
+1. **支配性由构造保证。** 物化自底向上进行，每个新建 op 的操作数要么是刚发射的子表达式，要么是已通过可用性检查的叶子，因此结果天然支配插入点。
+
+   可用性检查（4.2.5 检查 6）本身也依赖分析不建 IR。分析期间考察的每个 `Value` 都先于本次变换存在；对这样的值，"定义点早于插入点"可**传递地**推出"其操作数也早于插入点"，于是只需检查表达式的叶子。而对于变换过程中新建的 op，这条蕴含关系并不成立——它自身位置合法，不代表它的操作数在该位置可用。把 IR 生成推迟到分析之后，正是为了让被检查的值始终落在前一种情形里。
+
+2. **递归可 memoize。** 纯函数的结果只取决于入参，`decomposeLinear` 与 `computeDelta` 按 `Value` 缓存，共享子表达式只分解一次，分解代价与定义链 DAG 的规模成线性关系。
+
+3. **被拒候选不留残留。** 合法性检查全部先于物化完成，放弃某个候选时 IR 尚未被触碰。`weight` 缩放这类中间运算也只存在于符号层，不会以 op 的形式落地。
+
+#### 4.2.3 累加器分析（优先）
 
 对 base 和 strideOperand 分别检查是否为 `scf.for` 的 block argument（来自 `iter_args`），且对应的 `scf.yield` 值可分解为 `blockArg + increment`。
 
 分解通过递归线性分解实现：沿 `arith.addi`/`arith.subi`/`arith.muli`/`arith.index_cast`/`pto.addptr` 定义链递归，将 yield 表达式分离为 `blockArg * coeff + increment`。要求 `coeff == 1`（保证等差递推），`increment` 不要求是常量或循环不变量。
 
 ```
-decomposeLinear(Value v, BlockArgument blockArg) -> {coeff, increment}:
-  v == blockArg           → {1, nullptr}
-  v 是循环不变量或其他 block arg → {0, v}
-  v = addi(a, b)         → {ca + cb, ia + ib}
-  v = subi(a, b)         → {ca - cb, ia - ib}
-  v = muli(a, b)（一侧不含 blockArg 且为常量 k）→ {c * k, i * k}
-  v = addptr(ptr, offset) → {c_ptr, i_ptr + offset}
-  v = index_cast(a)       → {ca, cast(ia)}
+decomposeLinear(Value v, BlockArgument blockArg) -> {coeff, StrideExpr increment}:
+  v == blockArg           → {1, Const(0)}
+  v 是循环不变量或其他 block arg → {0, Leaf(v)}
+  v = addi(a, b)         → {ca + cb, Add(ia, ib)}
+  v = subi(a, b)         → {ca - cb, Sub(ia, ib)}
+  v = muli(a, b)（一侧不含 blockArg 且为常量 k）→ {c * k, Mul(i, Const(k))}
+  v = addptr(ptr, offset) → {c_ptr, Add(i_ptr, Leaf(offset))}
+  v = index_cast(a)       → {ca, Cast(op, ia)}
   其他                    → unknown（放弃）
+  结果按 v 缓存
 
-getIterArgIncrement(Value v, ForOp forOp) -> std::optional<Value>:
+getIterArgIncrement(Value v, ForOp forOp) -> {status, StrideExpr}:
   沿 v 的定义链回溯，穿过 index_cast（记录类型转换）、addi/subi/addptr
   与循环不变量的组合（跳过偏移），直到找到 iter_arg BlockArgument。
-  对该 iter_arg 的 yield 操作数调用 decomposeLinear，coeff == 1 且
-  increment 非零时，将路径上收集的类型转换应用于 increment 后返回；
-  否则返回 nullopt。
+  对该 iter_arg 的 yield 操作数调用 decomposeLinear：
+    coeff == 1            → {Ok, 路径上收集的类型转换套用于 increment}
+    分解失败或 coeff != 1 → {Failed, -}
+  未回溯到 iter_arg       → {NotIterArg, -}
 ```
 
+三态返回是必要的：`NotIterArg` 表示该操作数与累加器无关，应回退 delta 路径；`Failed` 表示确实是 iter_arg 但增量无法分解，此时必须整体放弃——把未知增量当作 0 会静默算错地址。
+
 ```
-baseIncr = getIterArgIncrement(desc.base, forOp)
+baseIncr = getIterArgIncrement(desc.base, forOp)      // NotIterArg → 回退 delta
 soIncr   = getIterArgIncrement(desc.strideOperand, forOp)
 
-若两者均为 nullopt → 非累加器模式，走 delta 路径
-否则 → total_delta = (baseIncr or 0) + weight * (soIncr or 0)
+任一为 Failed → 放弃该候选
+否则 → total_delta = delta(base) + weight * delta(strideOperand)   // 符号相加
         stride_new = total_delta / weight
 ```
 
-不要求 stride 是常量或循环不变量，只要值在 IR 中已计算出来即可。
+不要求 stride 是常量或循环不变量；增量也不要求定义在候选 op 之前——不满足时由 4.2.5 的可用性检查决定克隆或放弃。
 
 **示例（vlds，weight=1）：**
 
@@ -209,9 +240,11 @@ scf.for %iv = %c0 to %c16 step %c1
   scf.yield %next_off
 }
 ```
-`baseIncr` = nullopt，`soIncr` = `%s`。`total_delta = %s`，`stride_new = %s / 1 = %s`。
+`baseIncr` = `NotIterArg`（回退 delta，得 `Const(0)`），`soIncr` = `{Ok, Leaf(%s)}`。`total_delta = Leaf(%s)`，`stride_new = %s / 1 = %s`。
 
-#### 4.2.3 delta 分析（累加器未命中时）
+注意 `%s` 在本例中定义于 `pto.vlds` 之前，但这不是前提：若 `%s` 定义在 `pto.vlds` 之后，4.2.5 会把它的定义链克隆到候选 op 之前，结果不变。
+
+#### 4.2.4 delta 分析（累加器未命中时）
 
 当 base 和 strideOperand 都不是 iter_arg 时，回退到 delta 分析。
 
@@ -236,27 +269,35 @@ stride_new  = total_delta / weight
 
 **正确性：** delta 表中的操作构成仿射函数的封闭运算集合。定义链仅由这些操作构成时，delta 计算不会遗漏。遇到表外操作时保守放弃。
 
-#### 4.2.4 合法性检查
+delta 分析同样是纯符号的：表中每一行返回 `StrideExpr`，结果按 `Value` 缓存。
 
-无论由累加器分析还是 delta 分析产出 stride，都须满足以下条件：
+#### 4.2.5 合法性检查
+
+无论由累加器分析还是 delta 分析产出 stride，都须满足以下条件。全部检查在物化之前完成，任一不满足即放弃该候选，且不留下任何 IR。
 
 1. **op 尚未处于 Post-Update 形式。** 检查 `op.getUpdatedBase()` 为空。
 
 2. **op 直接位于 `scf.for` 循环体内**（不嵌套在循环内的 `scf.if` 或其他控制流中），避免部分迭代问题。
 
-3. **`total_delta` 整除 `weight`。** weight=1 时自动满足；weight=32（vsstb/vsldb）时要求 `delta(base) % 32 == 0`。
+3. **`total_delta` 整除 `weight`。** weight=1 时自动满足；weight=32（vsstb/vsldb）时要求 `delta(base) % 32 == 0`。缩放在符号层折叠，因此只要 `delta(base)` 与 `delta(strideOperand)` 各自是常量，整除性即可判定。
 
-4. **stride_new 为零时跳过。** 地址不前进，post-update 无收益。
+4. **stride_new 为零时跳过。** 地址不前进，post-update 无收益。常量折叠使各项相消、合成结果恒为零的情形（如 base 每轮 +8、strideOperand 每轮 −8）同样能被识别。
 
-#### 4.2.5 改写
+5. **类型一致性。** stride 表达式各子项须归结为同一类型，否则放弃，以免构造出 `arith.addi(index, i32)` 这类非法 op。`Const` 项不参与该约束——其类型在物化时按上下文决定。
+
+6. **操作数可用性（支配性）。** stride 表达式的每个叶子须在候选 op 处可用：循环不变量、block argument、或定义点早于候选 op。若叶子定义在候选 op **之后**，仅当其定义链全部为 pure op 时克隆到候选 op 之前（克隆保留原结果序号，多结果 op 亦正确）；否则放弃。该检查以只读方式先行完成，克隆发生在物化阶段。
+
+#### 4.2.6 改写
 
 改写步骤对所有指令统一：
 
-1. 计算初始指针 `init_ptr = base_0 + weight * strideOperand_0`（通过 `pto.addptr`；若值为零则直接用 `base_0`）。
-2. 新增指针类型的 `iter_arg`，初始值为 `init_ptr`。
-3. 创建 Post-Update op：将 `strideOperand` 替换为 `stride_new`，base 替换为 iter_arg 的 block argument。其余操作数（block_stride、mask、dist 等）不变。
-4. 将 `updated_base` 通过 `scf.yield` 传出。
-5. 交由 DCE 清除死代码。
+1. **物化 stride。** 叶子全部循环不变时发射到循环外，否则发射到候选 op 之前。常量按 `(值, 类型)` 在同一循环内复用同一个 SSA 值——4.2.7 的分组按 `(base, stride_new)` 的 **Value 同一性** 判定，重复创建等值常量会把本可共享 `iter_arg` 的 op 拆成多组。
+
+2. 计算初始指针 `init_ptr = base_0 + weight * strideOperand_0`（通过 `pto.addptr`；若值为零则直接用 `base_0`）。
+3. 新增指针类型的 `iter_arg`，初始值为 `init_ptr`。
+4. 创建 Post-Update op：将 `strideOperand` 替换为 `stride_new`，base 替换为 iter_arg 的 block argument。其余操作数（block_stride、mask、dist 等）不变。
+5. 将 `updated_base` 通过 `scf.yield` 传出。
+6. 交由 DCE 清除死代码。
 
 **vsstb/vsldb 的硬件语义补充：**
 
@@ -265,11 +306,13 @@ Post-Update：`dest_p + blk*32*block_stride`（repeat_stride 不参与存储地�
 
 Post-Update 模式下 `repeat_stride` 从地址偏移变为指针前进量，因此初始指针需吸收原始偏移 `32*rs_0`。
 
-#### 4.2.6 同一循环中的多个 Op
+#### 4.2.7 同一循环中的多个 Op
 
 按 `(base, stride_new)` 分组。同组的 op 共享一个 `iter_arg`，所有 op 使用同一个 pre-update 指针（block argument），不链式传递 `updated_base`。原因：同一迭代内同组 op 访问相同地址，链式传递会使后续 op 的地址偏移一个 stride。每组只需 yield 一个 `updated_base`。
 
-#### 4.2.7 嵌套循环
+分组键按 **Value 同一性** 比较，因此 stride 的物化必须保证等值常量复用同一 SSA 值（见 4.2.6 步骤 1），否则语义相同的 op 会被拆成多组，退化为各自持有一个 `iter_arg`。
+
+#### 4.2.8 嵌套循环
 
 对于嵌套 `scf.for`，在每一层循环添加 `iter_arg` 携带指针，内层的 init 值接外层的当前值。处理方式：自内向外遍历。`scf.for` 的 `iter_args` 天然保证 init/yield 的对应关系。
 
@@ -353,7 +396,7 @@ def VPTOSoftPostUpdate : Pass<"vpto-soft-postupdate", "ModuleOp"> {
 ### ~~Step 1：pass 框架与循环 delta 分析~~（已完成）
 
 1. ~~搭建 pass 框架：PostUpdateSet、遍历逻辑、pipeline 集成、CLI 开关。~~
-2. ~~实现 delta 递归分析（4.2.3）。~~
+2. ~~实现 delta 递归分析（4.2.4）。~~
 3. ~~实现 delta 路径的合法性检查和改写（新增 iter_arg）。~~
 4. ~~支持同一循环中多个 op。~~
 5. ~~支持 `pto.vlds`、`pto.vsts`、`pto.vsstb`。~~
@@ -362,25 +405,29 @@ def VPTOSoftPostUpdate : Pass<"vpto-soft-postupdate", "ModuleOp"> {
 ### ~~Step 2：循环累加器分析~~（已完成）
 
 7. ~~实现 `getIterArgIncrement` helper。~~
-8. ~~实现累加器分析（4.2.1）：base/offset 统一检测与 stride 合并。~~
-9. ~~实现累加器路径的改写（4.2.4）。~~
+8. ~~实现累加器分析（4.2.3）：base/offset 统一检测与 stride 合并。~~
+9. ~~实现累加器路径的改写（4.2.6）。~~
 10. ~~在遍历逻辑中将累加器分析置于 delta 分析之前。~~
 11. ~~添加累加器路径的 lit 测试（含非常量 stride、base 和 offset 都是 iter_arg 等场景）。~~
+12. ~~实现 `StrideExpr` 符号表达式与常量折叠（4.2.2），使 `decomposeLinear` / `getIterArgIncrement` / `computeDelta` 成为纯函数并按 `Value` 缓存。~~
+13. ~~实现 `getIterArgIncrement` 的三态返回（`NotIterArg` / `Failed` / `Ok`）。~~
+14. ~~实现物化阶段：类型一致性检查、叶子可用性检查（必要时克隆 pure 定义链）、常量按 `(值, 类型)` 复用。~~
+15. ~~补充回归测试：增量定义在消费者之后、多增量组合、weight=32 非常量增量的负向用例。~~
 
 ### Step 3：顺序路径
 
-12. 实现顺序路径的序列检测（4.3.1）和合法性检查（4.3.2）。
-13. 实现链式改写（4.3.3）和迭代器跳过逻辑。
-14. 添加顺序路径的 lit 测试。
+16. 实现顺序路径的序列检测（4.3.1）和合法性检查（4.3.2）。
+17. 实现链式改写（4.3.3）和迭代器跳过逻辑。
+18. 添加顺序路径的 lit 测试。
 
 ### Step 4：扩展指令覆盖
 
-15. 为 2.2 中的指令（`vldsx2`、`vsldb`、`plds`、`pldi` 等）添加 ODS `updated_base` 定义。
-16. 扩展 PostUpdateSet，使 pass 覆盖新指令。
-17. 补充对应的 LLVM lowering（post intrinsic callee）和 lit 测试。
+19. 为 2.2 中的指令（`vldsx2`、`vsldb`、`plds`、`pldi` 等）添加 ODS `updated_base` 定义。
+20. 扩展 PostUpdateSet，使 pass 覆盖新指令。
+21. 补充对应的 LLVM lowering（post intrinsic callee）和 lit 测试。
 
 ### Step 5：验证与开启
 
-18. 端到端验证：用 ptoas 编译，与 bisheng Post-Update 输出对比已知 kernel。
-19. NPU 验证：在硬件上运行 Post-Update kernel（通过现有 `test/vpto/cases/micro-op/vector-load-store/` 框架）。
-20. 将默认值切换为开启。
+22. 端到端验证：用 ptoas 编译，与 bisheng Post-Update 输出对比已知 kernel。
+23. NPU 验证：在硬件上运行 Post-Update kernel（通过现有 `test/vpto/cases/micro-op/vector-load-store/` 框架）。
+24. 将默认值切换为开启。

--- a/docs/designs/vpto-soft-postupdate-design-zh.md
+++ b/docs/designs/vpto-soft-postupdate-design-zh.md
@@ -308,13 +308,17 @@ Post-Update 模式下 `repeat_stride` 从地址偏移变为指针前进量，因
 
 #### 4.2.7 同一循环中的多个 Op
 
-按 `(base, stride_new)` 分组。同组的 op 共享一个 `iter_arg`，所有 op 使用同一个 pre-update 指针（block argument），不链式传递 `updated_base`。原因：同一迭代内同组 op 访问相同地址，链式传递会使后续 op 的地址偏移一个 stride。每组只需 yield 一个 `updated_base`。
+两个 op 能共享同一个 `iter_arg`，当且仅当它们走**同一条地址序列**——起点 `init_ptr = base_0 + weight * strideOperand_0` 相同，且步长 `stride_new` 相同。
 
-分组键按 **Value 同一性** 比较，因此 stride 的物化必须保证等值常量复用同一 SSA 值（见 4.2.6 步骤 1），否则语义相同的 op 会被拆成多组，退化为各自持有一个 `iter_arg`。
+理想的分组键是 `(init_ptr, stride_new)`。但 `init_ptr` 不适合直接入键：分组按 **Value 同一性** 比较，而 `computeInitialPtr` 可能为每个候选各自物化一个 `pto.addptr`，起点数值相同也未必是同一个 SSA 值。因此改用决定 `init_ptr` 的**原始操作数**：分组键取 `(base, strideOperand, stride_new)`。操作数相同必然起点相同，这是一个充分条件——可能把本可合并的组拆开，但绝不会合并本应分开的组。
+
+同组的 op 共享一个 `iter_arg`，所有 op 使用同一个 pre-update 指针（block argument），不链式传递 `updated_base`。原因：同一迭代内同组 op 访问相同地址，链式传递会使后续 op 的地址偏移一个 stride。每组只需 yield 一个 `updated_base`。
+
+因为键按 Value 同一性比较，stride 的物化必须保证等值常量复用同一 SSA 值（见 4.2.6 步骤 1）；否则语义相同的 op 会被拆成多组，退化为各自持有一个 `iter_arg`。
 
 #### 4.2.8 嵌套循环
 
-对于嵌套 `scf.for`，在每一层循环添加 `iter_arg` 携带指针，内层的 init 值接外层的当前值。处理方式：自内向外遍历。`scf.for` 的 `iter_args` 天然保证 init/yield 的对应关系。
+对于嵌套 `scf.for`，在每一层循环添加 `iter_arg` 携带指针，内层的 init 值接外层的当前值。`scf.for` 的 `iter_args` 天然保证 init/yield 的对应关系。
 
 ### 4.3 顺序路径
 

--- a/docs/designs/vpto-soft-postupdate-design-zh.md
+++ b/docs/designs/vpto-soft-postupdate-design-zh.md
@@ -163,12 +163,27 @@ init_ptr    = base_0 + weight * strideOperand_0   // 通过 pto.addptr 创建
 
 #### 4.2.2 累加器分析（优先）
 
-对 base 和 strideOperand 分别检查是否为 `scf.for` 的 block argument（来自 `iter_args`），且对应的 `scf.yield` 值为该 block argument 加一个增量值：
+对 base 和 strideOperand 分别检查是否为 `scf.for` 的 block argument（来自 `iter_args`），且对应的 `scf.yield` 值可分解为 `blockArg + increment`。
+
+分解通过递归线性分解实现：沿 `arith.addi`/`arith.subi`/`arith.muli`/`arith.index_cast`/`pto.addptr` 定义链递归，将 yield 表达式分离为 `blockArg * coeff + increment`。要求 `coeff == 1`（保证等差递推），`increment` 不要求是常量或循环不变量。
 
 ```
+decomposeLinear(Value v, BlockArgument blockArg) -> {coeff, increment}:
+  v == blockArg           → {1, nullptr}
+  v 是循环不变量或其他 block arg → {0, v}
+  v = addi(a, b)         → {ca + cb, ia + ib}
+  v = subi(a, b)         → {ca - cb, ia - ib}
+  v = muli(a, b)（一侧不含 blockArg 且为常量 k）→ {c * k, i * k}
+  v = addptr(ptr, offset) → {c_ptr, i_ptr + offset}
+  v = index_cast(a)       → {ca, cast(ia)}
+  其他                    → unknown（放弃）
+
 getIterArgIncrement(Value v, ForOp forOp) -> std::optional<Value>:
-  若 v 是 forOp 的 block argument，且对应的 yield 操作数形如 arith.addi(v, s)
-  （或等价的指针加法），返回 s；否则返回 nullopt。
+  沿 v 的定义链回溯，穿过 index_cast（记录类型转换）、addi/subi/addptr
+  与循环不变量的组合（跳过偏移），直到找到 iter_arg BlockArgument。
+  对该 iter_arg 的 yield 操作数调用 decomposeLinear，coeff == 1 且
+  increment 非零时，将路径上收集的类型转换应用于 increment 后返回；
+  否则返回 nullopt。
 ```
 
 ```

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -79,35 +79,210 @@ static bool isDirectlyInForBody(Operation *op, scf::ForOp forOp) {
 }
 
 //===----------------------------------------------------------------------===//
-// Accumulator Analysis
+// Accumulator Analysis: Linear Decomposition
 //===----------------------------------------------------------------------===//
 
-// Check if `v` is an iter_arg of `forOp` whose yield is `v + increment`.
-// Returns the increment value if so, nullopt otherwise.
-// Handles arith.addi for integer/index types and pto.addptr for pointer types.
-static std::optional<Value> getIterArgIncrement(Value v, scf::ForOp forOp) {
-  auto blockArg = dyn_cast<BlockArgument>(v);
-  if (!blockArg || blockArg.getOwner() != forOp.getBody() ||
-      blockArg.getArgNumber() == 0)
-    return std::nullopt;
+// Result of decomposing a value into blockArg * coeff + increment.
+struct LinearDecomp {
+  int64_t coeff;
+  Value increment; // nullptr means 0
+};
 
-  unsigned idx = blockArg.getArgNumber() - 1;
-  auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
-  Value yieldVal = yieldOp.getOperand(idx);
+static Value addIncrements(Value a, Value b, scf::ForOp forOp,
+                           OpBuilder &builder) {
+  if (!a) return b;
+  if (!b) return a;
+  if (auto ca = getConstantIntValue(a); ca && *ca == 0) return b;
+  if (auto cb = getConstantIntValue(b); cb && *cb == 0) return a;
+  builder.setInsertionPoint(forOp.getBody()->getTerminator());
+  return builder.create<arith::AddIOp>(forOp.getLoc(), a, b);
+}
 
-  if (auto addOp = yieldVal.getDefiningOp<arith::AddIOp>()) {
-    if (addOp.getLhs() == blockArg)
-      return addOp.getRhs();
-    if (addOp.getRhs() == blockArg)
-      return addOp.getLhs();
+static Value subIncrements(Value a, Value b, scf::ForOp forOp,
+                           OpBuilder &builder) {
+  if (!b) return a;
+  if (auto cb = getConstantIntValue(b); cb && *cb == 0) return a;
+  builder.setInsertionPoint(forOp.getBody()->getTerminator());
+  if (!a) {
+    if (b.getType().isIndex())
+      a = builder.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
+    else
+      a = builder.create<arith::ConstantIntOp>(
+          forOp.getLoc(), 0, b.getType().getIntOrFloatBitWidth());
+  }
+  return builder.create<arith::SubIOp>(forOp.getLoc(), a, b);
+}
+
+// Decompose `v` into blockArg * coeff + increment by recursing through
+// addi/subi/muli/index_cast/addptr chains.
+static std::optional<LinearDecomp>
+decomposeLinear(Value v, BlockArgument blockArg, scf::ForOp forOp,
+                OpBuilder &builder) {
+  // v == blockArg → {1, nullptr}
+  if (v == blockArg)
+    return LinearDecomp{1, nullptr};
+
+  // v is other block arg (IV, different iter_arg, func arg) → {0, v}
+  Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return LinearDecomp{0, v};
+
+  // v is loop-invariant or constant → {0, v}
+  if (forOp.isDefinedOutsideOfLoop(v) ||
+      defOp->hasTrait<OpTrait::ConstantLike>())
+    return LinearDecomp{0, v};
+
+  // v = addi(a, b) → {ca + cb, ia + ib}
+  // v = subi(a, b) → {ca - cb, ia - ib}
+  if (isa<arith::AddIOp, arith::SubIOp>(defOp)) {
+    auto da = decomposeLinear(defOp->getOperand(0), blockArg, forOp, builder);
+    auto db = decomposeLinear(defOp->getOperand(1), blockArg, forOp, builder);
+    if (!da || !db)
+      return std::nullopt;
+    if (da->coeff == 0 && db->coeff == 0)
+      return LinearDecomp{0, v};
+    bool isSub = isa<arith::SubIOp>(defOp);
+    return LinearDecomp{
+        isSub ? da->coeff - db->coeff : da->coeff + db->coeff,
+        isSub ? subIncrements(da->increment, db->increment, forOp, builder)
+              : addIncrements(da->increment, db->increment, forOp, builder)};
   }
 
-  if (auto addPtrOp = yieldVal.getDefiningOp<pto::AddPtrOp>()) {
-    if (addPtrOp.getPtr() == blockArg)
-      return addPtrOp.getOffset();
+  // v = muli(a, b), one side blockArg-free with constant k → {c * k, i * k}
+  if (auto mulOp = dyn_cast<arith::MulIOp>(defOp)) {
+    auto da = decomposeLinear(mulOp.getLhs(), blockArg, forOp, builder);
+    auto db = decomposeLinear(mulOp.getRhs(), blockArg, forOp, builder);
+    if (!da || !db)
+      return std::nullopt;
+    if (da->coeff == 0 && db->coeff == 0)
+      return LinearDecomp{0, v};
+    if (da->coeff != 0 && db->coeff != 0)
+      return std::nullopt;
+    auto &withBA = (da->coeff != 0) ? *da : *db;
+    Value multiplier = (da->coeff != 0) ? mulOp.getRhs() : mulOp.getLhs();
+    auto constMul = getConstantIntValue(multiplier);
+    if (!constMul)
+      return std::nullopt;
+    Value newInc = nullptr;
+    if (withBA.increment && *constMul != 0) {
+      if (*constMul == 1)
+        newInc = withBA.increment;
+      else {
+        builder.setInsertionPoint(forOp.getBody()->getTerminator());
+        newInc = builder.create<arith::MulIOp>(forOp.getLoc(),
+                                                withBA.increment, multiplier);
+      }
+    }
+    return LinearDecomp{withBA.coeff * *constMul, newInc};
   }
 
+  // v = index_cast(a) → {ca, cast(ia)}
+  if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
+    auto d = decomposeLinear(defOp->getOperand(0), blockArg, forOp, builder);
+    if (!d)
+      return std::nullopt;
+    if (d->coeff == 0)
+      return LinearDecomp{0, v};
+    if (d->increment) {
+      builder.setInsertionPoint(forOp.getBody()->getTerminator());
+      Operation *cast = builder.clone(*defOp);
+      cast->setOperand(0, d->increment);
+      d->increment = cast->getResult(0);
+    }
+    return *d;
+  }
+
+  // v = addptr(ptr, offset) → {c_ptr, i_ptr + offset}
+  if (auto addPtrOp = dyn_cast<pto::AddPtrOp>(defOp)) {
+    auto dp = decomposeLinear(addPtrOp.getPtr(), blockArg, forOp, builder);
+    if (!dp)
+      return std::nullopt;
+    if (dp->coeff == 0)
+      return LinearDecomp{0, v};
+    return LinearDecomp{
+        dp->coeff,
+        addIncrements(dp->increment, addPtrOp.getOffset(), forOp, builder)};
+  }
+
+  // Unrecognized op → unknown
   return std::nullopt;
+}
+
+// Trace `v` back to an iter_arg BlockArgument of `forOp`, then decompose
+// the yield expression to extract the per-iteration increment. Walks through
+// index_cast (type-changing), addi/subi with loop-invariant offset, and
+// addptr with loop-invariant offset. Type casts along the path are applied
+// to the increment so its type matches v's context.
+static std::optional<Value> getIterArgIncrement(Value v, scf::ForOp forOp,
+                                                OpBuilder &builder) {
+  SmallVector<Operation *> casts;
+  Value current = v;
+
+  while (true) {
+    if (auto blockArg = dyn_cast<BlockArgument>(current)) {
+      if (blockArg.getOwner() != forOp.getBody() ||
+          blockArg.getArgNumber() == 0)
+        return std::nullopt;
+
+      unsigned idx = blockArg.getArgNumber() - 1;
+      auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      auto decomp =
+          decomposeLinear(yieldOp.getOperand(idx), blockArg, forOp, builder);
+      if (!decomp || decomp->coeff != 1)
+        return Value();
+
+      Value inc = decomp->increment;
+      if (!inc) {
+        builder.setInsertionPoint(forOp);
+        inc = builder.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
+      }
+      for (Operation *op : llvm::reverse(casts)) {
+        builder.setInsertionPoint(forOp.getBody()->getTerminator());
+        Operation *c = builder.clone(*op);
+        c->setOperand(0, inc);
+        inc = c->getResult(0);
+      }
+      return inc;
+    }
+
+    Operation *defOp = current.getDefiningOp();
+    if (!defOp || forOp.isDefinedOutsideOfLoop(current) ||
+        defOp->hasTrait<OpTrait::ConstantLike>())
+      return std::nullopt;
+
+    if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
+      casts.push_back(defOp);
+      current = defOp->getOperand(0);
+      continue;
+    }
+
+    if (isa<arith::AddIOp>(defOp)) {
+      if (forOp.isDefinedOutsideOfLoop(defOp->getOperand(1))) {
+        current = defOp->getOperand(0);
+        continue;
+      }
+      if (forOp.isDefinedOutsideOfLoop(defOp->getOperand(0))) {
+        current = defOp->getOperand(1);
+        continue;
+      }
+    }
+
+    if (isa<arith::SubIOp>(defOp)) {
+      if (forOp.isDefinedOutsideOfLoop(defOp->getOperand(1))) {
+        current = defOp->getOperand(0);
+        continue;
+      }
+    }
+
+    if (auto addPtrOp = dyn_cast<pto::AddPtrOp>(defOp)) {
+      if (forOp.isDefinedOutsideOfLoop(addPtrOp.getOffset())) {
+        current = addPtrOp.getPtr();
+        continue;
+      }
+    }
+
+    return std::nullopt;
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -210,6 +385,19 @@ static Value computeDelta(Value v, scf::ForOp forOp, OpBuilder &builder) {
   return nullptr;
 }
 
+// Get the per-iteration stride of `v`: tries accumulator analysis first
+// (for iter_arg-derived values with possibly loop-varying increment),
+// falls back to delta analysis (for IV-derived values, loop-invariant result).
+// getIterArgIncrement returns:
+//   nullopt        → not iter_arg-related, fall through to delta
+//   Some(Value())  → iter_arg found but decomposition failed, give up
+//   Some(non-null) → success
+static Value getStride(Value v, scf::ForOp forOp, OpBuilder &builder) {
+  if (auto result = getIterArgIncrement(v, forOp, builder))
+    return *result;
+  return computeDelta(v, forOp, builder);
+}
+
 //===----------------------------------------------------------------------===//
 // Rewrite: create new ForOp with additional iter_arg
 //===----------------------------------------------------------------------===//
@@ -291,6 +479,69 @@ static Value computeInitialPtr(Value base, Value strideOperand,
                                        scaledOffset);
 }
 
+// Combine per-operand strides into the final stride_new for the post-update op.
+// total = deltaBase + weight * deltaOffset; stride_new = total / weight.
+// Returns nullptr if stride is zero or weight doesn't divide evenly.
+// `strideOperandType` is needed for weight>1 to create the right integer type.
+static Value computeFinalStride(Value deltaBase, Value deltaOffset,
+                              int64_t weight, Type strideOperandType,
+                              Operation *op, scf::ForOp forOp,
+                              OpBuilder &builder) {
+  bool anyLoopVarying = !forOp.isDefinedOutsideOfLoop(deltaBase) ||
+                        !forOp.isDefinedOutsideOfLoop(deltaOffset);
+  auto setCombineIP = [&]() {
+    if (anyLoopVarying)
+      builder.setInsertionPoint(op);
+    else
+      builder.setInsertionPoint(forOp);
+  };
+
+  Value weightedDeltaOffset = deltaOffset;
+  if (weight != 1) {
+    if (auto co = getConstantIntValue(deltaOffset); co && *co != 0) {
+      setCombineIP();
+      weightedDeltaOffset = builder.create<arith::ConstantIndexOp>(
+          forOp.getLoc(), *co * weight);
+    } else if (auto co = getConstantIntValue(deltaOffset); co && *co == 0) {
+      // 0 * weight = 0
+    } else {
+      setCombineIP();
+      Value weightVal =
+          builder.create<arith::ConstantIndexOp>(forOp.getLoc(), weight);
+      weightedDeltaOffset =
+          builder.create<arith::MulIOp>(forOp.getLoc(), deltaOffset, weightVal);
+    }
+  }
+
+  Value stride;
+  auto cb = getConstantIntValue(deltaBase);
+  auto co = getConstantIntValue(weightedDeltaOffset);
+  if (cb && *cb == 0)
+    stride = weightedDeltaOffset;
+  else if (co && *co == 0)
+    stride = deltaBase;
+  else {
+    setCombineIP();
+    stride = builder.create<arith::AddIOp>(forOp.getLoc(), deltaBase,
+                                            weightedDeltaOffset);
+  }
+
+  if (auto constTotal = getConstantIntValue(stride);
+      constTotal && *constTotal == 0)
+    return nullptr;
+
+  if (weight != 1) {
+    auto constTotal = getConstantIntValue(stride);
+    if (!constTotal || *constTotal % weight != 0)
+      return nullptr;
+    setCombineIP();
+    unsigned bitWidth = strideOperandType.getIntOrFloatBitWidth();
+    return builder.create<arith::ConstantIntOp>(forOp.getLoc(),
+                                                *constTotal / weight, bitWidth);
+  }
+  return stride;
+}
+
 // Information about a post-update transformation to apply.
 struct PostUpdateRewrite {
   Operation *op;
@@ -298,88 +549,6 @@ struct PostUpdateRewrite {
   Value stride;  // stride value (stride_new for block-stride ops)
   Value initPtr; // base + weight * strideOperand_at_iter0
 };
-
-//===----------------------------------------------------------------------===//
-// Accumulator Analysis
-//===----------------------------------------------------------------------===//
-
-// Try accumulator-based analysis for a candidate op inside a scf.for.
-// Returns a PostUpdateRewrite if base or strideOperand is an iter_arg whose
-// yield is arg + increment. Unlike delta analysis, stride_new need not be
-// loop-invariant — it can depend on the IV or other loop-varying values.
-static std::optional<PostUpdateRewrite>
-tryAccumulatorAnalysis(Operation *op, Value base, Value strideOperand,
-                       const PostUpdateOpInfo &info, scf::ForOp forOp,
-                       OpBuilder &builder) {
-  auto baseIncr = getIterArgIncrement(base, forOp);
-  auto soIncr = getIterArgIncrement(strideOperand, forOp);
-  if (!baseIncr && !soIncr)
-    return std::nullopt;
-
-  int64_t weight = info.weight;
-  Value strideNew;
-
-  if (weight == 1) {
-    // stride_new = (baseIncr or 0) + (soIncr or 0)
-    if (baseIncr && soIncr) {
-      auto cb = getConstantIntValue(*baseIncr);
-      auto co = getConstantIntValue(*soIncr);
-      if (cb && *cb == 0)
-        strideNew = *soIncr;
-      else if (co && *co == 0)
-        strideNew = *baseIncr;
-      else {
-        builder.setInsertionPoint(op);
-        strideNew =
-            builder.create<arith::AddIOp>(op->getLoc(), *baseIncr, *soIncr);
-      }
-    } else if (baseIncr) {
-      strideNew = *baseIncr;
-    } else {
-      strideNew = *soIncr;
-    }
-  } else {
-    // weight > 1 (e.g. 32 for vsstb).
-    // total_delta = (baseIncr or 0) + weight * (soIncr or 0)
-    // stride_new = total_delta / weight
-    if (baseIncr && soIncr) {
-      auto cb = getConstantIntValue(*baseIncr);
-      if (!cb || *cb % weight != 0)
-        return std::nullopt;
-      int64_t baseContrib = *cb / weight;
-      if (baseContrib == 0) {
-        strideNew = *soIncr;
-      } else {
-        unsigned bitWidth = strideOperand.getType().getIntOrFloatBitWidth();
-        builder.setInsertionPoint(op);
-        Value constContrib = builder.create<arith::ConstantIntOp>(
-            op->getLoc(), baseContrib, bitWidth);
-        strideNew =
-            builder.create<arith::AddIOp>(op->getLoc(), *soIncr, constContrib);
-      }
-    } else if (baseIncr) {
-      auto cb = getConstantIntValue(*baseIncr);
-      if (!cb || *cb % weight != 0)
-        return std::nullopt;
-      unsigned bitWidth = strideOperand.getType().getIntOrFloatBitWidth();
-      builder.setInsertionPoint(forOp);
-      strideNew = builder.create<arith::ConstantIntOp>(forOp.getLoc(),
-                                                        *cb / weight, bitWidth);
-    } else {
-      strideNew = *soIncr;
-    }
-  }
-
-  if (auto cs = getConstantIntValue(strideNew); cs && *cs == 0)
-    return std::nullopt;
-
-  Value initPtr =
-      computeInitialPtr(base, strideOperand, weight, forOp, builder);
-  if (!initPtr)
-    return std::nullopt;
-
-  return PostUpdateRewrite{op, base, strideNew, initPtr};
-}
 
 // A unique key for grouping rewrites that can share an iter_arg.
 // Same base + same stride (by Value identity) = same group.
@@ -562,91 +731,20 @@ private:
 
       Value base, strideOperand;
       extractBaseAndStrideOperand(&op, *info, base, strideOperand);
-
-      // Accumulator analysis (priority): check iter_arg with explicit increment.
-      if (auto rw =
-              tryAccumulatorAnalysis(&op, base, strideOperand, *info, forOp,
-                                    builder)) {
-        rewrites.push_back(*rw);
-        continue;
-      }
-
-      // Delta analysis (fallback): compute per-iteration delta recursively.
       int64_t weight = info->weight;
-      Value deltaBase = computeDelta(base, forOp, builder);
-      Value deltaOffset = computeDelta(strideOperand, forOp, builder);
 
-      if (!deltaBase && !deltaOffset)
+      // Analyze each operand independently: accumulator (iter_arg) first,
+      // delta (IV/affine) fallback. Both return the per-iteration stride.
+      Value deltaBase = getStride(base, forOp, builder);
+      Value deltaOffset = getStride(strideOperand, forOp, builder);
+
+      if (!deltaBase || !deltaOffset)
         continue;
 
-      // Compute stride = delta(base) + weight * delta(strideOperand).
-      // For vlds/vsts (weight=1): stride = delta(base) + delta(offset).
-      // For vsstb (weight=32): stride = delta(dest) + 32*delta(rs).
-
-      // Scale deltaOffset by weight if needed.
-      Value weightedDeltaOffset = deltaOffset;
-      if (deltaOffset && weight != 1) {
-        if (auto co = getConstantIntValue(deltaOffset); co && *co != 0) {
-          builder.setInsertionPoint(forOp);
-          weightedDeltaOffset = builder.create<arith::ConstantIndexOp>(
-              forOp.getLoc(), *co * weight);
-        } else if (auto co = getConstantIntValue(deltaOffset); co && *co == 0) {
-          // 0 * weight = 0, keep as is.
-        } else {
-          builder.setInsertionPoint(forOp);
-          Value weightVal =
-              builder.create<arith::ConstantIndexOp>(forOp.getLoc(), weight);
-          weightedDeltaOffset =
-              builder.create<arith::MulIOp>(forOp.getLoc(), deltaOffset, weightVal);
-        }
-      }
-
-      Value stride;
-      if (deltaBase && weightedDeltaOffset) {
-        auto cb = getConstantIntValue(deltaBase);
-        auto co = getConstantIntValue(weightedDeltaOffset);
-        if (cb && *cb == 0)
-          stride = weightedDeltaOffset;
-        else if (co && *co == 0)
-          stride = deltaBase;
-        else {
-          builder.setInsertionPoint(forOp);
-          stride = builder.create<arith::AddIOp>(forOp.getLoc(),
-                                                  deltaBase, weightedDeltaOffset);
-        }
-      } else if (deltaBase) {
-        stride = deltaBase;
-      } else {
-        stride = weightedDeltaOffset;
-      }
-
-      if (!stride)
-        continue;
-
-      // Skip zero stride.
-      if (auto constTotal = getConstantIntValue(stride);
-          constTotal && *constTotal == 0)
-        continue;
-
-      // stride_new = stride / weight.
-      // weight=1: stride_new = stride (always valid).
-      // weight>1: stride must be a constant divisible by weight.
-      Value strideNew;
-      if (weight != 1) {
-        auto constTotal = getConstantIntValue(stride);
-        if (!constTotal || *constTotal % weight != 0)
-          continue;
-        builder.setInsertionPoint(forOp);
-        unsigned bitWidth =
-            strideOperand.getType().getIntOrFloatBitWidth();
-        strideNew = builder.create<arith::ConstantIntOp>(
-            forOp.getLoc(), *constTotal / weight, bitWidth);
-      } else {
-        strideNew = stride;
-      }
-
-      // Stride must be loop-invariant.
-      if (!forOp.isDefinedOutsideOfLoop(strideNew))
+      Value strideNew = computeFinalStride(deltaBase, deltaOffset, weight,
+                                          strideOperand.getType(), &op,
+                                          forOp, builder);
+      if (!strideNew)
         continue;
 
       Value initPtr =

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -31,13 +31,26 @@ using namespace mlir;
 
 namespace {
 
+// A hardware block is 32 bytes; block-strided ops count in these units.
+static constexpr int64_t kBlockSizeBytes = 32;
+
+// What one unit of an op's strideOperand means, in address terms.  This is a
+// property of the op's lowering, not of the pass: `Element` ops run their
+// offset through convertElementOffsetToBytes, `Block` ops pass a packed
+// control word straight to the intrinsic, and `Byte` ops pass a raw byte
+// offset.  See `strideUnitBytes` for the conversion.
+enum class StrideUnit {
+  Element, // vlds/vsts/vldsx2/vstas: offset in pointer elements
+  Block,   // vsstb/vsldb: repeat_stride in 32-byte blocks
+  Byte,    // sprsts/sprsti: raw byte offset
+};
+
 // Per-op-type descriptor: how to extract address operands and check post-update.
-// base/strideOperand indices are operand positions; updatedBaseResultIdx is the
-// result index for updated_base (or -1 if no such result exists).
+// base/strideOperand indices are operand positions.
 struct PostUpdateOpInfo {
   int baseOperandIdx;
   int strideOperandIdx;
-  int64_t weight;              // 1 for standard, 32 for block-stride
+  StrideUnit strideUnit;
   unsigned minResultsForPost;  // numResults > this means already post-update
 };
 
@@ -46,13 +59,49 @@ using PostUpdateTable = llvm::StringMap<PostUpdateOpInfo>;
 static const PostUpdateTable &getPostUpdateTable() {
   static const PostUpdateTable table = [] {
     PostUpdateTable t;
-    //                       base  strideOp  weight  minResultsForPost
-    t["pto.vlds"]         = { 0,    1,        1,      1 };
-    t["pto.vsts"]         = { 1,    2,        1,      0 };
-    t["pto.vsstb"]        = { 1,    3,        32,     0 };
+    //                       base  strideOp  strideUnit             minResults
+    t["pto.vlds"]         = { 0,    1,        StrideUnit::Element,   1 };
+    t["pto.vsts"]         = { 1,    2,        StrideUnit::Element,   0 };
+    t["pto.vsstb"]        = { 1,    3,        StrideUnit::Block,     0 };
     return t;
   }();
   return table;
+}
+
+// Bytes covered by one unit of `pto.addptr`'s offset on `base`.  This is the
+// size of the GEP element type the pointer lowers to, which for ordinary
+// int/float element types is just their byte width.  Packed low-precision
+// types are normalized to something else during lowering
+// (normalizeGEPElementTypeForLLVMLowering), so bail on anything that is not a
+// plain byte-sized int/float rather than guess.
+static std::optional<int64_t> addPtrUnitBytes(Value base) {
+  Type elemTy;
+  if (auto ptrTy = dyn_cast<pto::PtrType>(base.getType()))
+    elemTy = ptrTy.getElementType();
+  else if (auto memrefTy = dyn_cast<MemRefType>(base.getType()))
+    elemTy = memrefTy.getElementType();
+  else
+    return std::nullopt;
+
+  if (!elemTy || !elemTy.isIntOrFloat())
+    return std::nullopt;
+  unsigned bits = elemTy.getIntOrFloatBitWidth();
+  if (bits == 0 || bits % 8 != 0)
+    return std::nullopt;
+  return static_cast<int64_t>(bits / 8);
+}
+
+// Bytes covered by one unit of the op's strideOperand.
+static int64_t strideUnitBytes(StrideUnit unit, int64_t elemBytes) {
+  switch (unit) {
+  case StrideUnit::Element:
+    return elemBytes;
+  case StrideUnit::Block:
+    return kBlockSizeBytes;
+  case StrideUnit::Byte:
+    return 1;
+  }
+  llvm_unreachable("unhandled StrideUnit");
 }
 
 static const PostUpdateOpInfo *getPostUpdateInfo(Operation *op) {
@@ -569,11 +618,17 @@ static Value materializeAtLoopEntry(Value v, scf::ForOp forOp,
   return cloned->getResult(0);
 }
 
-// Compute the initial pointer: base_at_iter0 + weight * strideOperand_at_iter0.
-// weight=1 for vlds/vsts (offset in elements), weight=32 for vsstb/vsldb.
+// Compute the initial pointer, i.e. the address the op reaches on the first
+// iteration: base_at_iter0 + strideOperand_at_iter0 restated in addptr units.
+//
+// This is the mirror of the rescaling in `scaleBaseDelta`.  The initial offset
+// is W * strideOperand_0 bytes, and `pto.addptr` takes elements, so the offset
+// it needs is (W/E) * strideOperand_0.  For Element-class ops W == E and the
+// operand is used as-is; for Block-class ops the factor W/E is exact (E always
+// divides 32); for Byte-class ops the factor is a division that can fail.
 static Value computeInitialPtr(Value base, Value strideOperand,
-                               int64_t weight, scf::ForOp forOp,
-                               OpBuilder &builder) {
+                               int64_t elemBytes, int64_t unitBytes,
+                               scf::ForOp forOp, OpBuilder &builder) {
   Value baseAtEntry = materializeAtLoopEntry(base, forOp, builder);
   if (!baseAtEntry)
     return nullptr;
@@ -585,48 +640,89 @@ static Value computeInitialPtr(Value base, Value strideOperand,
   if (!soAtEntry)
     return nullptr;
 
-  if (auto constVal = getConstantIntValue(soAtEntry);
-      constVal && *constVal == 0)
+  auto constSo = getConstantIntValue(soAtEntry);
+  if (constSo && *constSo == 0)
     return baseAtEntry;
 
   builder.setInsertionPoint(forOp);
   Value scaledOffset = soAtEntry;
-  if (weight != 1) {
-    Value soIndex = soAtEntry;
-    if (soAtEntry.getType() != builder.getIndexType())
-      soIndex = builder.create<arith::IndexCastUIOp>(
-          forOp.getLoc(), builder.getIndexType(), soAtEntry);
-    Value weightVal =
-        builder.create<arith::ConstantIndexOp>(forOp.getLoc(), weight);
-    scaledOffset =
-        builder.create<arith::MulIOp>(forOp.getLoc(), soIndex, weightVal);
+  if (unitBytes != elemBytes) {
+    if (unitBytes % elemBytes == 0) {
+      Value soIndex = soAtEntry;
+      if (soAtEntry.getType() != builder.getIndexType())
+        soIndex = builder.create<arith::IndexCastUIOp>(
+            forOp.getLoc(), builder.getIndexType(), soAtEntry);
+      Value factor = builder.create<arith::ConstantIndexOp>(
+          forOp.getLoc(), unitBytes / elemBytes);
+      scaledOffset =
+          builder.create<arith::MulIOp>(forOp.getLoc(), soIndex, factor);
+    } else if (elemBytes % unitBytes == 0) {
+      // Finer stride unit than the pointer element (a raw byte offset on a
+      // wider element type): only representable when it lands on an element
+      // boundary, which we can only prove for a compile-time constant.
+      int64_t divisor = elemBytes / unitBytes;
+      if (!constSo || *constSo % divisor != 0)
+        return nullptr;
+      scaledOffset = builder.create<arith::ConstantIndexOp>(
+          forOp.getLoc(), *constSo / divisor);
+    } else {
+      return nullptr;
+    }
   }
   return builder.create<pto::AddPtrOp>(forOp.getLoc(), baseAtEntry,
                                        scaledOffset);
 }
 
+// Rescale a per-iteration base delta from `pto.addptr` units (elements) into
+// the op's strideOperand units.  Returns null when the conversion is not exact.
+//
+// Expanding the byte-denominated form
+//     stride_new = (E*delta(base) + W*delta(strideOperand)) / W
+//                = (E/W)*delta(base) + delta(strideOperand)
+// shows that only delta(base) is ever rescaled; delta(strideOperand) passes
+// through untouched.  That matters: it keeps the stride symbolic, so a
+// loop-varying increment stays supported for every op class.  When E == W the
+// factor is 1 and nothing is emitted at all, so Element-class ops (vlds/vsts)
+// behave exactly as before this scaling existed.
+static StrideExprRef scaleBaseDelta(StrideExprRef deltaBase, int64_t elemBytes,
+                                    int64_t unitBytes) {
+  if (unitBytes == elemBytes)
+    return deltaBase;
+
+  if (unitBytes % elemBytes == 0) {
+    // Coarser stride unit (e.g. 32-byte blocks over 4-byte elements): the base
+    // delta must be a compile-time constant that lands on a whole unit.
+    int64_t divisor = unitBytes / elemBytes;
+    auto constBase = foldConst(deltaBase);
+    if (!constBase || *constBase % divisor != 0)
+      return nullptr;
+    return makeConst(*constBase / divisor);
+  }
+
+  if (elemBytes % unitBytes == 0)
+    return makeMul(deltaBase, makeConst(elemBytes / unitBytes));
+
+  return nullptr;
+}
+
 // Combine per-operand strides into the final stride_new for the post-update op.
-// total = deltaBase + weight * deltaOffset; stride_new = total / weight.
-// Returns null if stride is zero or weight doesn't divide evenly.  Purely
-// symbolic: a rejected candidate leaves no IR behind, and the weight scaling
-// is folded rather than emitted, so no `index` weight is ever multiplied
-// against a narrower stride operand.
+// stride_new = (E/W) * deltaBase + deltaOffset, where E is the byte size of one
+// addptr unit and W the byte size of one strideOperand unit.  Returns null if
+// the stride is zero or the rescaling is inexact.  Purely symbolic: a rejected
+// candidate leaves no IR behind, and the scaling is folded rather than emitted,
+// so no `index` factor is ever multiplied against a narrower stride operand.
 static StrideExprRef combineStride(StrideExprRef deltaBase,
-                                   StrideExprRef deltaOffset, int64_t weight) {
-  StrideExprRef total =
-      makeAdd(deltaBase, makeMul(deltaOffset, makeConst(weight)));
-
-  auto constTotal = foldConst(total);
-  if (constTotal && *constTotal == 0)
+                                   StrideExprRef deltaOffset, int64_t elemBytes,
+                                   int64_t unitBytes) {
+  StrideExprRef scaledBase =
+      scaleBaseDelta(deltaBase, elemBytes, unitBytes);
+  if (!scaledBase)
     return nullptr;
-  if (weight == 1)
-    return total;
 
-  // Block-stride ops encode the stride pre-scaled by `weight`, so the total
-  // must be known at compile time and divide evenly.
-  if (!constTotal || *constTotal % weight != 0)
+  StrideExprRef total = makeAdd(scaledBase, deltaOffset);
+  if (auto constTotal = foldConst(total); constTotal && *constTotal == 0)
     return nullptr;
-  return makeConst(*constTotal / weight);
+  return total;
 }
 
 //===----------------------------------------------------------------------===//
@@ -785,7 +881,7 @@ struct PostUpdateRewrite {
   Value base;
   Value strideOperand; // original offset / repeat_stride operand
   Value stride;        // stride value (stride_new for block-stride ops)
-  Value initPtr;       // base + weight * strideOperand_at_iter0
+  Value initPtr;       // base + strideOperand_at_iter0, in addptr units
 };
 
 // A unique key for grouping rewrites that can share an iter_arg.
@@ -987,7 +1083,16 @@ private:
 
       Value base, strideOperand;
       extractBaseAndStrideOperand(&op, *info, base, strideOperand);
-      int64_t weight = info->weight;
+
+      // Both address terms have to be expressed in the same currency before
+      // they can be combined: delta(base) is measured in pto.addptr units
+      // (elements), while the strideOperand is counted in whatever unit the
+      // op's lowering expects.  Bail on pointers whose addptr unit we cannot
+      // pin down rather than guess at the scale.
+      std::optional<int64_t> elemBytes = addPtrUnitBytes(base);
+      if (!elemBytes)
+        continue;
+      int64_t unitBytes = strideUnitBytes(info->strideUnit, *elemBytes);
 
       // Analyze each operand independently: accumulator (iter_arg) first,
       // delta (IV/affine) fallback. Both return a symbolic per-iteration
@@ -999,7 +1104,8 @@ private:
       if (!deltaBase || !deltaOffset)
         continue;
 
-      StrideExprRef total = combineStride(deltaBase, deltaOffset, weight);
+      StrideExprRef total =
+          combineStride(deltaBase, deltaOffset, *elemBytes, unitBytes);
       if (!total)
         continue;
 
@@ -1034,8 +1140,8 @@ private:
       Value strideNew = materialize(finalExpr, strideType, op.getLoc(), forOp,
                                     constCache, builder);
 
-      Value initPtr =
-          computeInitialPtr(base, strideOperand, weight, forOp, builder);
+      Value initPtr = computeInitialPtr(base, strideOperand, *elemBytes,
+                                        unitBytes, forOp, builder);
       if (!initPtr)
         continue;
 

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -79,6 +79,38 @@ static bool isDirectlyInForBody(Operation *op, scf::ForOp forOp) {
 }
 
 //===----------------------------------------------------------------------===//
+// Accumulator Analysis
+//===----------------------------------------------------------------------===//
+
+// Check if `v` is an iter_arg of `forOp` whose yield is `v + increment`.
+// Returns the increment value if so, nullopt otherwise.
+// Handles arith.addi for integer/index types and pto.addptr for pointer types.
+static std::optional<Value> getIterArgIncrement(Value v, scf::ForOp forOp) {
+  auto blockArg = dyn_cast<BlockArgument>(v);
+  if (!blockArg || blockArg.getOwner() != forOp.getBody() ||
+      blockArg.getArgNumber() == 0)
+    return std::nullopt;
+
+  unsigned idx = blockArg.getArgNumber() - 1;
+  auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+  Value yieldVal = yieldOp.getOperand(idx);
+
+  if (auto addOp = yieldVal.getDefiningOp<arith::AddIOp>()) {
+    if (addOp.getLhs() == blockArg)
+      return addOp.getRhs();
+    if (addOp.getRhs() == blockArg)
+      return addOp.getLhs();
+  }
+
+  if (auto addPtrOp = yieldVal.getDefiningOp<pto::AddPtrOp>()) {
+    if (addPtrOp.getPtr() == blockArg)
+      return addPtrOp.getOffset();
+  }
+
+  return std::nullopt;
+}
+
+//===----------------------------------------------------------------------===//
 // Delta Analysis
 //===----------------------------------------------------------------------===//
 
@@ -223,13 +255,17 @@ static Value materializeAtLoopEntry(Value v, scf::ForOp forOp,
   return cloned->getResult(0);
 }
 
-// Compute the initial pointer: base + weight * strideOperand_at_iter0.
+// Compute the initial pointer: base_at_iter0 + weight * strideOperand_at_iter0.
 // weight=1 for vlds/vsts (offset in elements), weight=32 for vsstb/vsldb.
 static Value computeInitialPtr(Value base, Value strideOperand,
                                int64_t weight, scf::ForOp forOp,
                                OpBuilder &builder) {
+  Value baseAtEntry = materializeAtLoopEntry(base, forOp, builder);
+  if (!baseAtEntry)
+    return nullptr;
+
   if (!strideOperand)
-    return base;
+    return baseAtEntry;
 
   Value soAtEntry = materializeAtLoopEntry(strideOperand, forOp, builder);
   if (!soAtEntry)
@@ -237,7 +273,7 @@ static Value computeInitialPtr(Value base, Value strideOperand,
 
   if (auto constVal = getConstantIntValue(soAtEntry);
       constVal && *constVal == 0)
-    return base;
+    return baseAtEntry;
 
   builder.setInsertionPoint(forOp);
   Value scaledOffset = soAtEntry;
@@ -251,16 +287,99 @@ static Value computeInitialPtr(Value base, Value strideOperand,
     scaledOffset =
         builder.create<arith::MulIOp>(forOp.getLoc(), soIndex, weightVal);
   }
-  return builder.create<pto::AddPtrOp>(forOp.getLoc(), base, scaledOffset);
+  return builder.create<pto::AddPtrOp>(forOp.getLoc(), baseAtEntry,
+                                       scaledOffset);
 }
 
 // Information about a post-update transformation to apply.
 struct PostUpdateRewrite {
   Operation *op;
   Value base;
-  Value stride;  // loop-invariant stride value (stride_new for block-stride ops)
+  Value stride;  // stride value (stride_new for block-stride ops)
   Value initPtr; // base + weight * strideOperand_at_iter0
 };
+
+//===----------------------------------------------------------------------===//
+// Accumulator Analysis
+//===----------------------------------------------------------------------===//
+
+// Try accumulator-based analysis for a candidate op inside a scf.for.
+// Returns a PostUpdateRewrite if base or strideOperand is an iter_arg whose
+// yield is arg + increment. Unlike delta analysis, stride_new need not be
+// loop-invariant — it can depend on the IV or other loop-varying values.
+static std::optional<PostUpdateRewrite>
+tryAccumulatorAnalysis(Operation *op, Value base, Value strideOperand,
+                       const PostUpdateOpInfo &info, scf::ForOp forOp,
+                       OpBuilder &builder) {
+  auto baseIncr = getIterArgIncrement(base, forOp);
+  auto soIncr = getIterArgIncrement(strideOperand, forOp);
+  if (!baseIncr && !soIncr)
+    return std::nullopt;
+
+  int64_t weight = info.weight;
+  Value strideNew;
+
+  if (weight == 1) {
+    // stride_new = (baseIncr or 0) + (soIncr or 0)
+    if (baseIncr && soIncr) {
+      auto cb = getConstantIntValue(*baseIncr);
+      auto co = getConstantIntValue(*soIncr);
+      if (cb && *cb == 0)
+        strideNew = *soIncr;
+      else if (co && *co == 0)
+        strideNew = *baseIncr;
+      else {
+        builder.setInsertionPoint(op);
+        strideNew =
+            builder.create<arith::AddIOp>(op->getLoc(), *baseIncr, *soIncr);
+      }
+    } else if (baseIncr) {
+      strideNew = *baseIncr;
+    } else {
+      strideNew = *soIncr;
+    }
+  } else {
+    // weight > 1 (e.g. 32 for vsstb).
+    // total_delta = (baseIncr or 0) + weight * (soIncr or 0)
+    // stride_new = total_delta / weight
+    if (baseIncr && soIncr) {
+      auto cb = getConstantIntValue(*baseIncr);
+      if (!cb || *cb % weight != 0)
+        return std::nullopt;
+      int64_t baseContrib = *cb / weight;
+      if (baseContrib == 0) {
+        strideNew = *soIncr;
+      } else {
+        unsigned bitWidth = strideOperand.getType().getIntOrFloatBitWidth();
+        builder.setInsertionPoint(op);
+        Value constContrib = builder.create<arith::ConstantIntOp>(
+            op->getLoc(), baseContrib, bitWidth);
+        strideNew =
+            builder.create<arith::AddIOp>(op->getLoc(), *soIncr, constContrib);
+      }
+    } else if (baseIncr) {
+      auto cb = getConstantIntValue(*baseIncr);
+      if (!cb || *cb % weight != 0)
+        return std::nullopt;
+      unsigned bitWidth = strideOperand.getType().getIntOrFloatBitWidth();
+      builder.setInsertionPoint(forOp);
+      strideNew = builder.create<arith::ConstantIntOp>(forOp.getLoc(),
+                                                        *cb / weight, bitWidth);
+    } else {
+      strideNew = *soIncr;
+    }
+  }
+
+  if (auto cs = getConstantIntValue(strideNew); cs && *cs == 0)
+    return std::nullopt;
+
+  Value initPtr =
+      computeInitialPtr(base, strideOperand, weight, forOp, builder);
+  if (!initPtr)
+    return std::nullopt;
+
+  return PostUpdateRewrite{op, base, strideNew, initPtr};
+}
 
 // A unique key for grouping rewrites that can share an iter_arg.
 // Same base + same stride (by Value identity) = same group.
@@ -444,7 +563,16 @@ private:
       Value base, strideOperand;
       extractBaseAndStrideOperand(&op, *info, base, strideOperand);
 
-      // Delta analysis.
+      // Accumulator analysis (priority): check iter_arg with explicit increment.
+      if (auto rw =
+              tryAccumulatorAnalysis(&op, base, strideOperand, *info, forOp,
+                                    builder)) {
+        rewrites.push_back(*rw);
+        continue;
+      }
+
+      // Delta analysis (fallback): compute per-iteration delta recursively.
+      int64_t weight = info->weight;
       Value deltaBase = computeDelta(base, forOp, builder);
       Value deltaOffset = computeDelta(strideOperand, forOp, builder);
 
@@ -454,7 +582,6 @@ private:
       // Compute stride = delta(base) + weight * delta(strideOperand).
       // For vlds/vsts (weight=1): stride = delta(base) + delta(offset).
       // For vsstb (weight=32): stride = delta(dest) + 32*delta(rs).
-      int64_t weight = info->weight;
 
       // Scale deltaOffset by weight if needed.
       Value weightedDeltaOffset = deltaOffset;

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -783,16 +783,29 @@ static Value materialize(const StrideExprRef &e, Type wantType, Location loc,
 struct PostUpdateRewrite {
   Operation *op;
   Value base;
-  Value stride;  // stride value (stride_new for block-stride ops)
-  Value initPtr; // base + weight * strideOperand_at_iter0
+  Value strideOperand; // original offset / repeat_stride operand
+  Value stride;        // stride value (stride_new for block-stride ops)
+  Value initPtr;       // base + weight * strideOperand_at_iter0
 };
 
 // A unique key for grouping rewrites that can share an iter_arg.
-// Same base + same stride (by Value identity) = same group.
-using IterArgGroupKey = std::pair<Value, Value>;
+//
+// Two ops may share an iter_arg only if they walk the same address sequence,
+// i.e. they start at the same address and advance by the same stride.  The
+// start address is `initPtr`, which is derived from base *and* strideOperand,
+// so strideOperand has to be part of the key: same base and same stride but
+// different offsets (e.g. %ub[%iv] and %ub[%iv + 64]) are distinct sequences,
+// and merging them would make the second op start at the first one's address.
+//
+// Keying on the original operands rather than on `initPtr` itself keeps the
+// comparison by Value identity meaningful: computeInitialPtr may materialize a
+// fresh pto.addptr per candidate, so equal start addresses do not necessarily
+// share a Value.  This is conservative — it can split groups that could have
+// been merged — but never merges groups that must stay apart.
+using IterArgGroupKey = std::tuple<Value, Value, Value>;
 
 static IterArgGroupKey getGroupKey(const PostUpdateRewrite &rw) {
-  return {rw.base, rw.stride};
+  return {rw.base, rw.strideOperand, rw.stride};
 }
 
 // Apply post-update rewrites to a single scf.for.
@@ -943,13 +956,16 @@ struct VPTOSoftPostUpdatePass
 
 private:
   void processVecScope(pto::VecScopeOp vecscope, OpBuilder &builder) {
-    // Collect scf.for ops inside this vecscope (inner-to-outer order).
+    // Collect scf.for ops inside this vecscope.  Operation::walk defaults to
+    // post-order, so nested loops already come before the loops enclosing
+    // them.
     SmallVector<scf::ForOp> forOps;
     vecscope.walk([&](scf::ForOp forOp) { forOps.push_back(forOp); });
 
-    // Process inner-to-outer (walk gives us pre-order, reverse for post-order).
-    std::reverse(forOps.begin(), forOps.end());
-
+    // Process inner-to-outer, i.e. in collection order.  The order is load
+    // bearing: rewriting a loop erases it, which also destroys every loop
+    // nested inside it.  Visiting an enclosing loop first would leave the
+    // already-collected inner ForOp handles dangling.
     for (scf::ForOp forOp : forOps)
       processForOp(forOp, builder);
   }
@@ -1023,7 +1039,7 @@ private:
       if (!initPtr)
         continue;
 
-      rewrites.push_back({&op, base, strideNew, initPtr});
+      rewrites.push_back({&op, base, strideOperand, strideNew, initPtr});
     }
 
     if (!rewrites.empty())

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -14,9 +14,11 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include <memory>
 
 namespace mlir {
 namespace pto {
@@ -82,139 +84,275 @@ static bool isDirectlyInForBody(Operation *op, scf::ForOp forOp) {
 // Accumulator Analysis: Linear Decomposition
 //===----------------------------------------------------------------------===//
 
+// Stride analysis is purely symbolic: it never creates IR.  A candidate is
+// analyzed, checked for viability, and only then materialized at a single
+// insertion point.  Two properties follow from that split:
+//   - Every Value the analysis inspects is a pre-existing loop-body value, so
+//     "defined before insertPt" transitively implies its operands are too.
+//     Availability can be decided by looking at the expression's leaves alone.
+//   - The recursion is side-effect free, so it can be memoized; decomposition
+//     stays linear in the size of the def-chain DAG instead of exponential.
+struct StrideExpr;
+using StrideExprRef = std::shared_ptr<const StrideExpr>;
+
+struct StrideExpr {
+  enum class Kind { Const, Leaf, Add, Sub, Mul, Cast };
+  Kind kind;
+  int64_t constant = 0;        // Kind::Const
+  Value leaf;                  // Kind::Leaf
+  Operation *castOp = nullptr; // Kind::Cast — template op to clone
+  StrideExprRef lhs, rhs;
+};
+
+static StrideExprRef makeConst(int64_t c) {
+  auto e = std::make_shared<StrideExpr>();
+  e->kind = StrideExpr::Kind::Const;
+  e->constant = c;
+  return e;
+}
+
+static StrideExprRef makeLeaf(Value v) {
+  auto e = std::make_shared<StrideExpr>();
+  e->kind = StrideExpr::Kind::Leaf;
+  e->leaf = v;
+  return e;
+}
+
+// Compile-time value of `e`, if it has one.
+static std::optional<int64_t> foldConst(const StrideExprRef &e) {
+  if (!e)
+    return std::nullopt;
+  switch (e->kind) {
+  case StrideExpr::Kind::Const:
+    return e->constant;
+  case StrideExpr::Kind::Leaf:
+    return getConstantIntValue(e->leaf);
+  case StrideExpr::Kind::Cast:
+    // index_cast/index_castui preserve the numeric value; only the type
+    // changes, and the type is chosen at materialization time.
+    return foldConst(e->lhs);
+  case StrideExpr::Kind::Add:
+  case StrideExpr::Kind::Sub:
+  case StrideExpr::Kind::Mul: {
+    auto a = foldConst(e->lhs);
+    auto b = foldConst(e->rhs);
+    if (!a || !b)
+      return std::nullopt;
+    if (e->kind == StrideExpr::Kind::Add)
+      return *a + *b;
+    if (e->kind == StrideExpr::Kind::Sub)
+      return *a - *b;
+    return *a * *b;
+  }
+  }
+  return std::nullopt;
+}
+
+static StrideExprRef makeBinary(StrideExpr::Kind kind, StrideExprRef a,
+                                StrideExprRef b) {
+  auto e = std::make_shared<StrideExpr>();
+  e->kind = kind;
+  e->lhs = std::move(a);
+  e->rhs = std::move(b);
+  return e;
+}
+
+static StrideExprRef makeAdd(StrideExprRef a, StrideExprRef b) {
+  auto ca = foldConst(a), cb = foldConst(b);
+  if (ca && cb)
+    return makeConst(*ca + *cb);
+  if (ca && *ca == 0)
+    return b;
+  if (cb && *cb == 0)
+    return a;
+  return makeBinary(StrideExpr::Kind::Add, a, b);
+}
+
+static StrideExprRef makeSub(StrideExprRef a, StrideExprRef b) {
+  auto ca = foldConst(a), cb = foldConst(b);
+  if (ca && cb)
+    return makeConst(*ca - *cb);
+  if (cb && *cb == 0)
+    return a;
+  return makeBinary(StrideExpr::Kind::Sub, a, b);
+}
+
+static StrideExprRef makeMul(StrideExprRef a, StrideExprRef b) {
+  auto ca = foldConst(a), cb = foldConst(b);
+  if (ca && cb)
+    return makeConst(*ca * *cb);
+  if ((ca && *ca == 0) || (cb && *cb == 0))
+    return makeConst(0);
+  if (ca && *ca == 1)
+    return b;
+  if (cb && *cb == 1)
+    return a;
+  return makeBinary(StrideExpr::Kind::Mul, a, b);
+}
+
+static StrideExprRef makeCast(Operation *castOp, StrideExprRef a) {
+  if (auto c = foldConst(a))
+    return makeConst(*c);
+  auto e = std::make_shared<StrideExpr>();
+  e->kind = StrideExpr::Kind::Cast;
+  e->castOp = castOp;
+  e->lhs = std::move(a);
+  return e;
+}
+
+static void collectLeaves(const StrideExprRef &e,
+                          SmallVectorImpl<Value> &out) {
+  if (!e)
+    return;
+  if (e->kind == StrideExpr::Kind::Leaf) {
+    out.push_back(e->leaf);
+    return;
+  }
+  collectLeaves(e->lhs, out);
+  collectLeaves(e->rhs, out);
+}
+
+// Determine the concrete type `e` will materialize to.  Returns false when two
+// subexpressions demand different types (an expression we must not build).
+// `out` is left null when `e` is fully constant and can adapt to any type.
+static bool exprType(const StrideExprRef &e, Type &out) {
+  switch (e->kind) {
+  case StrideExpr::Kind::Const:
+    return true; // adapts to context
+  case StrideExpr::Kind::Leaf:
+    out = e->leaf.getType();
+    return true;
+  case StrideExpr::Kind::Cast:
+    out = e->castOp->getResult(0).getType();
+    return true;
+  case StrideExpr::Kind::Add:
+  case StrideExpr::Kind::Sub:
+  case StrideExpr::Kind::Mul: {
+    Type ta, tb;
+    if (!exprType(e->lhs, ta) || !exprType(e->rhs, tb))
+      return false;
+    if (ta && tb && ta != tb)
+      return false;
+    out = ta ? ta : tb;
+    return true;
+  }
+  }
+  return false;
+}
+
 // Result of decomposing a value into blockArg * coeff + increment.
 struct LinearDecomp {
   int64_t coeff;
-  Value increment; // nullptr means 0
+  StrideExprRef increment; // never null; zero is makeConst(0)
 };
 
-static Value addIncrements(Value a, Value b, scf::ForOp forOp,
-                           OpBuilder &builder) {
-  if (!a) return b;
-  if (!b) return a;
-  if (auto ca = getConstantIntValue(a); ca && *ca == 0) return b;
-  if (auto cb = getConstantIntValue(b); cb && *cb == 0) return a;
-  builder.setInsertionPoint(forOp.getBody()->getTerminator());
-  return builder.create<arith::AddIOp>(forOp.getLoc(), a, b);
-}
-
-static Value subIncrements(Value a, Value b, scf::ForOp forOp,
-                           OpBuilder &builder) {
-  if (!b) return a;
-  if (auto cb = getConstantIntValue(b); cb && *cb == 0) return a;
-  builder.setInsertionPoint(forOp.getBody()->getTerminator());
-  if (!a) {
-    if (b.getType().isIndex())
-      a = builder.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
-    else
-      a = builder.create<arith::ConstantIntOp>(
-          forOp.getLoc(), 0, b.getType().getIntOrFloatBitWidth());
-  }
-  return builder.create<arith::SubIOp>(forOp.getLoc(), a, b);
-}
+using DecompCache = DenseMap<Value, std::optional<LinearDecomp>>;
 
 // Decompose `v` into blockArg * coeff + increment by recursing through
-// addi/subi/muli/index_cast/addptr chains.
+// addi/subi/muli/index_cast/addptr chains.  Pure: builds only StrideExprs.
+// `cache` is scoped to one decomposition (a single `blockArg`).
 static std::optional<LinearDecomp>
 decomposeLinear(Value v, BlockArgument blockArg, scf::ForOp forOp,
-                OpBuilder &builder) {
-  // v == blockArg → {1, nullptr}
+                DecompCache &cache) {
+  // v == blockArg → {1, 0}
   if (v == blockArg)
-    return LinearDecomp{1, nullptr};
+    return LinearDecomp{1, makeConst(0)};
+
+  auto it = cache.find(v);
+  if (it != cache.end())
+    return it->second;
+  auto record = [&](std::optional<LinearDecomp> r) {
+    cache[v] = r;
+    return r;
+  };
 
   // v is other block arg (IV, different iter_arg, func arg) → {0, v}
   Operation *defOp = v.getDefiningOp();
   if (!defOp)
-    return LinearDecomp{0, v};
+    return record(LinearDecomp{0, makeLeaf(v)});
 
   // v is loop-invariant or constant → {0, v}
   if (forOp.isDefinedOutsideOfLoop(v) ||
       defOp->hasTrait<OpTrait::ConstantLike>())
-    return LinearDecomp{0, v};
+    return record(LinearDecomp{0, makeLeaf(v)});
 
   // v = addi(a, b) → {ca + cb, ia + ib}
   // v = subi(a, b) → {ca - cb, ia - ib}
   if (isa<arith::AddIOp, arith::SubIOp>(defOp)) {
-    auto da = decomposeLinear(defOp->getOperand(0), blockArg, forOp, builder);
-    auto db = decomposeLinear(defOp->getOperand(1), blockArg, forOp, builder);
+    auto da = decomposeLinear(defOp->getOperand(0), blockArg, forOp, cache);
+    auto db = decomposeLinear(defOp->getOperand(1), blockArg, forOp, cache);
     if (!da || !db)
-      return std::nullopt;
+      return record(std::nullopt);
     if (da->coeff == 0 && db->coeff == 0)
-      return LinearDecomp{0, v};
+      return record(LinearDecomp{0, makeLeaf(v)});
     bool isSub = isa<arith::SubIOp>(defOp);
-    return LinearDecomp{
+    return record(LinearDecomp{
         isSub ? da->coeff - db->coeff : da->coeff + db->coeff,
-        isSub ? subIncrements(da->increment, db->increment, forOp, builder)
-              : addIncrements(da->increment, db->increment, forOp, builder)};
+        isSub ? makeSub(da->increment, db->increment)
+              : makeAdd(da->increment, db->increment)});
   }
 
   // v = muli(a, b), one side blockArg-free with constant k → {c * k, i * k}
   if (auto mulOp = dyn_cast<arith::MulIOp>(defOp)) {
-    auto da = decomposeLinear(mulOp.getLhs(), blockArg, forOp, builder);
-    auto db = decomposeLinear(mulOp.getRhs(), blockArg, forOp, builder);
+    auto da = decomposeLinear(mulOp.getLhs(), blockArg, forOp, cache);
+    auto db = decomposeLinear(mulOp.getRhs(), blockArg, forOp, cache);
     if (!da || !db)
-      return std::nullopt;
+      return record(std::nullopt);
     if (da->coeff == 0 && db->coeff == 0)
-      return LinearDecomp{0, v};
+      return record(LinearDecomp{0, makeLeaf(v)});
     if (da->coeff != 0 && db->coeff != 0)
-      return std::nullopt;
-    auto &withBA = (da->coeff != 0) ? *da : *db;
+      return record(std::nullopt);
+    const LinearDecomp &withBA = (da->coeff != 0) ? *da : *db;
     Value multiplier = (da->coeff != 0) ? mulOp.getRhs() : mulOp.getLhs();
     auto constMul = getConstantIntValue(multiplier);
     if (!constMul)
-      return std::nullopt;
-    Value newInc = nullptr;
-    if (withBA.increment && *constMul != 0) {
-      if (*constMul == 1)
-        newInc = withBA.increment;
-      else {
-        builder.setInsertionPoint(forOp.getBody()->getTerminator());
-        newInc = builder.create<arith::MulIOp>(forOp.getLoc(),
-                                                withBA.increment, multiplier);
-      }
-    }
-    return LinearDecomp{withBA.coeff * *constMul, newInc};
+      return record(std::nullopt);
+    return record(LinearDecomp{withBA.coeff * *constMul,
+                               makeMul(withBA.increment, makeConst(*constMul))});
   }
 
   // v = index_cast(a) → {ca, cast(ia)}
   if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
-    auto d = decomposeLinear(defOp->getOperand(0), blockArg, forOp, builder);
+    auto d = decomposeLinear(defOp->getOperand(0), blockArg, forOp, cache);
     if (!d)
-      return std::nullopt;
+      return record(std::nullopt);
     if (d->coeff == 0)
-      return LinearDecomp{0, v};
-    if (d->increment) {
-      builder.setInsertionPoint(forOp.getBody()->getTerminator());
-      Operation *cast = builder.clone(*defOp);
-      cast->setOperand(0, d->increment);
-      d->increment = cast->getResult(0);
-    }
-    return *d;
+      return record(LinearDecomp{0, makeLeaf(v)});
+    return record(LinearDecomp{d->coeff, makeCast(defOp, d->increment)});
   }
 
   // v = addptr(ptr, offset) → {c_ptr, i_ptr + offset}
   if (auto addPtrOp = dyn_cast<pto::AddPtrOp>(defOp)) {
-    auto dp = decomposeLinear(addPtrOp.getPtr(), blockArg, forOp, builder);
+    auto dp = decomposeLinear(addPtrOp.getPtr(), blockArg, forOp, cache);
     if (!dp)
-      return std::nullopt;
+      return record(std::nullopt);
     if (dp->coeff == 0)
-      return LinearDecomp{0, v};
-    return LinearDecomp{
-        dp->coeff,
-        addIncrements(dp->increment, addPtrOp.getOffset(), forOp, builder)};
+      return record(LinearDecomp{0, makeLeaf(v)});
+    return record(LinearDecomp{
+        dp->coeff, makeAdd(dp->increment, makeLeaf(addPtrOp.getOffset()))});
   }
 
   // Unrecognized op → unknown
-  return std::nullopt;
+  return record(std::nullopt);
 }
+
+// Outcome of accumulator analysis.  Distinguishing "not an iter_arg" from
+// "is an iter_arg but could not be decomposed" matters: the former falls back
+// to delta analysis, the latter must give up (treating an unknown increment as
+// zero would silently miscompile).
+enum class StrideStatus { NotIterArg, Failed, Ok };
+
+struct StrideResult {
+  StrideStatus status;
+  StrideExprRef expr; // valid only when status == Ok
+};
 
 // Trace `v` back to an iter_arg BlockArgument of `forOp`, then decompose
 // the yield expression to extract the per-iteration increment. Walks through
 // index_cast (type-changing), addi/subi with loop-invariant offset, and
 // addptr with loop-invariant offset. Type casts along the path are applied
-// to the increment so its type matches v's context.
-static std::optional<Value> getIterArgIncrement(Value v, scf::ForOp forOp,
-                                                OpBuilder &builder) {
+// to the increment so its type matches v's context.  Pure: creates no IR.
+static StrideResult getIterArgIncrement(Value v, scf::ForOp forOp) {
   SmallVector<Operation *> casts;
   Value current = v;
 
@@ -222,33 +360,26 @@ static std::optional<Value> getIterArgIncrement(Value v, scf::ForOp forOp,
     if (auto blockArg = dyn_cast<BlockArgument>(current)) {
       if (blockArg.getOwner() != forOp.getBody() ||
           blockArg.getArgNumber() == 0)
-        return std::nullopt;
+        return {StrideStatus::NotIterArg, nullptr};
 
       unsigned idx = blockArg.getArgNumber() - 1;
       auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
+      DecompCache cache;
       auto decomp =
-          decomposeLinear(yieldOp.getOperand(idx), blockArg, forOp, builder);
+          decomposeLinear(yieldOp.getOperand(idx), blockArg, forOp, cache);
       if (!decomp || decomp->coeff != 1)
-        return Value();
+        return {StrideStatus::Failed, nullptr};
 
-      Value inc = decomp->increment;
-      if (!inc) {
-        builder.setInsertionPoint(forOp);
-        inc = builder.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
-      }
-      for (Operation *op : llvm::reverse(casts)) {
-        builder.setInsertionPoint(forOp.getBody()->getTerminator());
-        Operation *c = builder.clone(*op);
-        c->setOperand(0, inc);
-        inc = c->getResult(0);
-      }
-      return inc;
+      StrideExprRef inc = decomp->increment;
+      for (Operation *op : llvm::reverse(casts))
+        inc = makeCast(op, inc);
+      return {StrideStatus::Ok, inc};
     }
 
     Operation *defOp = current.getDefiningOp();
     if (!defOp || forOp.isDefinedOutsideOfLoop(current) ||
         defOp->hasTrait<OpTrait::ConstantLike>())
-      return std::nullopt;
+      return {StrideStatus::NotIterArg, nullptr};
 
     if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
       casts.push_back(defOp);
@@ -281,7 +412,7 @@ static std::optional<Value> getIterArgIncrement(Value v, scf::ForOp forOp,
       }
     }
 
-    return std::nullopt;
+    return {StrideStatus::NotIterArg, nullptr};
   }
 }
 
@@ -289,18 +420,29 @@ static std::optional<Value> getIterArgIncrement(Value v, scf::ForOp forOp,
 // Delta Analysis
 //===----------------------------------------------------------------------===//
 
+// Cached delta results.  A cached null expr means "delta is unknown"; absence
+// from the map means "not computed yet".
+using DeltaCache = DenseMap<Value, StrideExprRef>;
+
 // Compute the per-iteration delta of value `v` within `forOp`.
-// Returns the delta as a loop-invariant Value, or nullptr if unknown.
-static Value computeDelta(Value v, scf::ForOp forOp, OpBuilder &builder) {
+// Returns a loop-invariant symbolic delta, or null if unknown.  Pure.
+static StrideExprRef computeDelta(Value v, scf::ForOp forOp,
+                                  DeltaCache &cache) {
   // IV: delta = step
   if (v == forOp.getInductionVar())
-    return forOp.getStep();
+    return makeLeaf(forOp.getStep());
 
   // Constant or loop-invariant: delta = 0
-  if (forOp.isDefinedOutsideOfLoop(v)) {
-    builder.setInsertionPoint(forOp);
-    return builder.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
-  }
+  if (forOp.isDefinedOutsideOfLoop(v))
+    return makeConst(0);
+
+  auto it = cache.find(v);
+  if (it != cache.end())
+    return it->second;
+  auto record = [&](StrideExprRef r) {
+    cache[v] = r;
+    return r;
+  };
 
   // Block argument from iter_args: check yield = arg + c
   if (auto blockArg = dyn_cast<BlockArgument>(v)) {
@@ -316,41 +458,32 @@ static Value computeDelta(Value v, scf::ForOp forOp, OpBuilder &builder) {
         else if (addOp.getRhs() == blockArg)
           other = addOp.getLhs();
         if (other && forOp.isDefinedOutsideOfLoop(other))
-          return other;
+          return record(makeLeaf(other));
       }
-      return nullptr;
+      return record(nullptr);
     }
   }
 
   Operation *defOp = v.getDefiningOp();
   if (!defOp)
-    return nullptr;
+    return record(nullptr);
 
   // arith.addi(a, b): delta = delta(a) + delta(b)
   if (auto addOp = dyn_cast<arith::AddIOp>(defOp)) {
-    Value da = computeDelta(addOp.getLhs(), forOp, builder);
-    Value db = computeDelta(addOp.getRhs(), forOp, builder);
+    auto da = computeDelta(addOp.getLhs(), forOp, cache);
+    auto db = computeDelta(addOp.getRhs(), forOp, cache);
     if (!da || !db)
-      return nullptr;
-    // Optimize: if either is constant 0, return the other
-    if (auto ca = getConstantIntValue(da); ca && *ca == 0)
-      return db;
-    if (auto cb = getConstantIntValue(db); cb && *cb == 0)
-      return da;
-    builder.setInsertionPoint(forOp);
-    return builder.create<arith::AddIOp>(forOp.getLoc(), da, db);
+      return record(nullptr);
+    return record(makeAdd(da, db));
   }
 
   // arith.subi(a, b): delta = delta(a) - delta(b)
   if (auto subOp = dyn_cast<arith::SubIOp>(defOp)) {
-    Value da = computeDelta(subOp.getLhs(), forOp, builder);
-    Value db = computeDelta(subOp.getRhs(), forOp, builder);
+    auto da = computeDelta(subOp.getLhs(), forOp, cache);
+    auto db = computeDelta(subOp.getRhs(), forOp, cache);
     if (!da || !db)
-      return nullptr;
-    if (auto cb = getConstantIntValue(db); cb && *cb == 0)
-      return da;
-    builder.setInsertionPoint(forOp);
-    return builder.create<arith::SubIOp>(forOp.getLoc(), da, db);
+      return record(nullptr);
+    return record(makeSub(da, db));
   }
 
   // arith.muli(a, b) where one is loop-invariant:
@@ -360,42 +493,35 @@ static Value computeDelta(Value v, scf::ForOp forOp, OpBuilder &builder) {
     for (auto [invariant, variant] :
          {std::pair{rhs, lhs}, std::pair{lhs, rhs}}) {
       if (forOp.isDefinedOutsideOfLoop(invariant)) {
-        Value dv = computeDelta(variant, forOp, builder);
+        auto dv = computeDelta(variant, forOp, cache);
         if (!dv)
           continue;
-        if (auto cv = getConstantIntValue(dv); cv && *cv == 0) {
-          builder.setInsertionPoint(forOp);
-          return builder.create<arith::ConstantIndexOp>(forOp.getLoc(), 0);
-        }
-        if (auto cv = getConstantIntValue(dv); cv && *cv == 1)
-          return invariant;
-        builder.setInsertionPoint(forOp);
-        return builder.create<arith::MulIOp>(forOp.getLoc(), invariant, dv);
+        return record(makeMul(makeLeaf(invariant), dv));
       }
     }
-    return nullptr;
+    return record(nullptr);
   }
 
   // arith.index_castui / arith.index_cast: delta = delta(input)
   if (auto castOp = dyn_cast<arith::IndexCastUIOp>(defOp))
-    return computeDelta(castOp.getIn(), forOp, builder);
+    return record(computeDelta(castOp.getIn(), forOp, cache));
   if (auto castOp = dyn_cast<arith::IndexCastOp>(defOp))
-    return computeDelta(castOp.getIn(), forOp, builder);
+    return record(computeDelta(castOp.getIn(), forOp, cache));
 
-  return nullptr;
+  return record(nullptr);
 }
 
 // Get the per-iteration stride of `v`: tries accumulator analysis first
 // (for iter_arg-derived values with possibly loop-varying increment),
 // falls back to delta analysis (for IV-derived values, loop-invariant result).
-// getIterArgIncrement returns:
-//   nullopt        → not iter_arg-related, fall through to delta
-//   Some(Value())  → iter_arg found but decomposition failed, give up
-//   Some(non-null) → success
-static Value getStride(Value v, scf::ForOp forOp, OpBuilder &builder) {
-  if (auto result = getIterArgIncrement(v, forOp, builder))
-    return *result;
-  return computeDelta(v, forOp, builder);
+// Returns null if the stride cannot be determined.
+static StrideExprRef getStride(Value v, scf::ForOp forOp, DeltaCache &cache) {
+  StrideResult r = getIterArgIncrement(v, forOp);
+  if (r.status == StrideStatus::Ok)
+    return r.expr;
+  if (r.status == StrideStatus::Failed)
+    return nullptr;
+  return computeDelta(v, forOp, cache);
 }
 
 //===----------------------------------------------------------------------===//
@@ -481,65 +607,176 @@ static Value computeInitialPtr(Value base, Value strideOperand,
 
 // Combine per-operand strides into the final stride_new for the post-update op.
 // total = deltaBase + weight * deltaOffset; stride_new = total / weight.
-// Returns nullptr if stride is zero or weight doesn't divide evenly.
-// `strideOperandType` is needed for weight>1 to create the right integer type.
-static Value computeFinalStride(Value deltaBase, Value deltaOffset,
-                              int64_t weight, Type strideOperandType,
-                              Operation *op, scf::ForOp forOp,
-                              OpBuilder &builder) {
-  bool anyLoopVarying = !forOp.isDefinedOutsideOfLoop(deltaBase) ||
-                        !forOp.isDefinedOutsideOfLoop(deltaOffset);
-  auto setCombineIP = [&]() {
-    if (anyLoopVarying)
-      builder.setInsertionPoint(op);
-    else
-      builder.setInsertionPoint(forOp);
-  };
+// Returns null if stride is zero or weight doesn't divide evenly.  Purely
+// symbolic: a rejected candidate leaves no IR behind, and the weight scaling
+// is folded rather than emitted, so no `index` weight is ever multiplied
+// against a narrower stride operand.
+static StrideExprRef combineStride(StrideExprRef deltaBase,
+                                   StrideExprRef deltaOffset, int64_t weight) {
+  StrideExprRef total =
+      makeAdd(deltaBase, makeMul(deltaOffset, makeConst(weight)));
 
-  Value weightedDeltaOffset = deltaOffset;
-  if (weight != 1) {
-    if (auto co = getConstantIntValue(deltaOffset); co && *co != 0) {
-      setCombineIP();
-      weightedDeltaOffset = builder.create<arith::ConstantIndexOp>(
-          forOp.getLoc(), *co * weight);
-    } else if (auto co = getConstantIntValue(deltaOffset); co && *co == 0) {
-      // 0 * weight = 0
-    } else {
-      setCombineIP();
-      Value weightVal =
-          builder.create<arith::ConstantIndexOp>(forOp.getLoc(), weight);
-      weightedDeltaOffset =
-          builder.create<arith::MulIOp>(forOp.getLoc(), deltaOffset, weightVal);
-    }
-  }
-
-  Value stride;
-  auto cb = getConstantIntValue(deltaBase);
-  auto co = getConstantIntValue(weightedDeltaOffset);
-  if (cb && *cb == 0)
-    stride = weightedDeltaOffset;
-  else if (co && *co == 0)
-    stride = deltaBase;
-  else {
-    setCombineIP();
-    stride = builder.create<arith::AddIOp>(forOp.getLoc(), deltaBase,
-                                            weightedDeltaOffset);
-  }
-
-  if (auto constTotal = getConstantIntValue(stride);
-      constTotal && *constTotal == 0)
+  auto constTotal = foldConst(total);
+  if (constTotal && *constTotal == 0)
     return nullptr;
+  if (weight == 1)
+    return total;
 
-  if (weight != 1) {
-    auto constTotal = getConstantIntValue(stride);
-    if (!constTotal || *constTotal % weight != 0)
-      return nullptr;
-    setCombineIP();
-    unsigned bitWidth = strideOperandType.getIntOrFloatBitWidth();
-    return builder.create<arith::ConstantIntOp>(forOp.getLoc(),
-                                                *constTotal / weight, bitWidth);
+  // Block-stride ops encode the stride pre-scaled by `weight`, so the total
+  // must be known at compile time and divide evenly.
+  if (!constTotal || *constTotal % weight != 0)
+    return nullptr;
+  return makeConst(*constTotal / weight);
+}
+
+//===----------------------------------------------------------------------===//
+// Materialization
+//===----------------------------------------------------------------------===//
+
+// Can `v` be made available immediately before `insertPt`, cloning a pure
+// def-chain if needed?  Pure: inspects only, never mutates the IR.
+static bool canHoistBefore(Value v, Operation *insertPt, scf::ForOp forOp,
+                           DenseMap<Value, bool> &memo) {
+  if (forOp.isDefinedOutsideOfLoop(v) || isa<BlockArgument>(v))
+    return true;
+  Operation *defOp = v.getDefiningOp();
+  if (!defOp)
+    return true;
+  if (defOp->getBlock() != insertPt->getBlock())
+    return false;
+  // Already earlier in the block, so usable as-is: SSA guarantees its operands
+  // are defined even earlier.  This reasoning is only sound because analysis
+  // creates no IR — every value examined here predates the transform.
+  if (defOp->isBeforeInBlock(insertPt))
+    return true;
+  auto it = memo.find(v);
+  if (it != memo.end())
+    return it->second;
+  memo[v] = false;
+  if (!isPure(defOp))
+    return false;
+  for (Value operand : defOp->getOperands())
+    if (!canHoistBefore(operand, insertPt, forOp, memo))
+      return false;
+  memo[v] = true;
+  return true;
+}
+
+// Clone `v`'s def-chain before `insertPt` as needed.  Only valid after
+// canHoistBefore has approved `v`.
+static Value hoistBefore(Value v, Operation *insertPt, scf::ForOp forOp,
+                         OpBuilder &builder, DenseMap<Value, Value> &memo) {
+  if (forOp.isDefinedOutsideOfLoop(v) || isa<BlockArgument>(v))
+    return v;
+  Operation *defOp = v.getDefiningOp();
+  if (!defOp || defOp->getBlock() != insertPt->getBlock() ||
+      defOp->isBeforeInBlock(insertPt))
+    return v;
+  auto it = memo.find(v);
+  if (it != memo.end())
+    return it->second;
+
+  SmallVector<Value> newOperands;
+  for (Value operand : defOp->getOperands())
+    newOperands.push_back(hoistBefore(operand, insertPt, forOp, builder, memo));
+
+  builder.setInsertionPoint(insertPt);
+  Operation *cloned = builder.clone(*defOp);
+  for (auto [i, operand] : llvm::enumerate(newOperands))
+    cloned->setOperand(i, operand);
+  // Preserve which result was asked for; `v` need not be result 0.
+  Value res = cloned->getResult(cast<OpResult>(v).getResultNumber());
+  memo[v] = res;
+  return res;
+}
+
+// Rewrite `e` so that all of its leaves are available at `insertPt`.
+static StrideExprRef makeAvailableAt(const StrideExprRef &e,
+                                     Operation *insertPt, scf::ForOp forOp,
+                                     OpBuilder &builder,
+                                     DenseMap<Value, Value> &memo) {
+  switch (e->kind) {
+  case StrideExpr::Kind::Const:
+    return e;
+  case StrideExpr::Kind::Leaf: {
+    Value hv = hoistBefore(e->leaf, insertPt, forOp, builder, memo);
+    return hv == e->leaf ? e : makeLeaf(hv);
   }
-  return stride;
+  case StrideExpr::Kind::Cast:
+    return makeCast(e->castOp,
+                    makeAvailableAt(e->lhs, insertPt, forOp, builder, memo));
+  case StrideExpr::Kind::Add:
+    return makeAdd(makeAvailableAt(e->lhs, insertPt, forOp, builder, memo),
+                   makeAvailableAt(e->rhs, insertPt, forOp, builder, memo));
+  case StrideExpr::Kind::Sub:
+    return makeSub(makeAvailableAt(e->lhs, insertPt, forOp, builder, memo),
+                   makeAvailableAt(e->rhs, insertPt, forOp, builder, memo));
+  case StrideExpr::Kind::Mul:
+    return makeMul(makeAvailableAt(e->lhs, insertPt, forOp, builder, memo),
+                   makeAvailableAt(e->rhs, insertPt, forOp, builder, memo));
+  }
+  llvm_unreachable("unhandled StrideExpr kind");
+}
+
+// Constants are loop-invariant, so they are always emitted before the loop and
+// shared across every candidate in it.  Sharing matters beyond tidiness: the
+// rewrite groups ops by (base, stride) Value identity, so two candidates with
+// the same numeric stride must end up with the *same* Value to share an
+// iter_arg.
+using ConstCache = DenseMap<std::pair<int64_t, Type>, Value>;
+
+static Value materializeConst(int64_t c, Type ty, Location loc,
+                              scf::ForOp forOp, ConstCache &cache,
+                              OpBuilder &builder) {
+  if (!ty)
+    ty = builder.getIndexType();
+  auto key = std::make_pair(c, ty);
+  if (auto it = cache.find(key); it != cache.end())
+    return it->second;
+
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPoint(forOp);
+  Value v;
+  if (ty.isIndex())
+    v = builder.create<arith::ConstantIndexOp>(loc, c);
+  else
+    v = builder.create<arith::ConstantIntOp>(loc, c,
+                                             ty.getIntOrFloatBitWidth());
+  cache[key] = v;
+  return v;
+}
+
+// Emit `e` at the builder's current insertion point.  Sub-expressions are
+// emitted bottom-up, so every operand is created before its user and the
+// result dominates the insertion point by construction.
+static Value materialize(const StrideExprRef &e, Type wantType, Location loc,
+                         scf::ForOp forOp, ConstCache &cache,
+                         OpBuilder &builder) {
+  switch (e->kind) {
+  case StrideExpr::Kind::Const:
+    return materializeConst(e->constant, wantType, loc, forOp, cache, builder);
+  case StrideExpr::Kind::Leaf:
+    return e->leaf;
+  case StrideExpr::Kind::Cast: {
+    Value in = materialize(e->lhs, e->castOp->getOperand(0).getType(), loc,
+                           forOp, cache, builder);
+    Operation *cloned = builder.clone(*e->castOp);
+    cloned->setOperand(0, in);
+    return cloned->getResult(0);
+  }
+  case StrideExpr::Kind::Add:
+  case StrideExpr::Kind::Sub:
+  case StrideExpr::Kind::Mul: {
+    Value a = materialize(e->lhs, wantType, loc, forOp, cache, builder);
+    Value b = materialize(e->rhs, a.getType(), loc, forOp, cache, builder);
+    if (e->kind == StrideExpr::Kind::Add)
+      return builder.create<arith::AddIOp>(loc, a, b);
+    if (e->kind == StrideExpr::Kind::Sub)
+      return builder.create<arith::SubIOp>(loc, a, b);
+    return builder.create<arith::MulIOp>(loc, a, b);
+  }
+  }
+  llvm_unreachable("unhandled StrideExpr kind");
 }
 
 // Information about a post-update transformation to apply.
@@ -719,6 +956,9 @@ private:
 
   void processForOp(scf::ForOp forOp, OpBuilder &builder) {
     SmallVector<PostUpdateRewrite> rewrites;
+    // Shared across all candidates in this loop so equal strides map to one
+    // Value, which is what lets same-address ops share an iter_arg.
+    ConstCache constCache;
 
     for (Operation &op : *forOp.getBody()) {
       const PostUpdateOpInfo *info = getPostUpdateInfo(&op);
@@ -734,18 +974,49 @@ private:
       int64_t weight = info->weight;
 
       // Analyze each operand independently: accumulator (iter_arg) first,
-      // delta (IV/affine) fallback. Both return the per-iteration stride.
-      Value deltaBase = getStride(base, forOp, builder);
-      Value deltaOffset = getStride(strideOperand, forOp, builder);
+      // delta (IV/affine) fallback. Both return a symbolic per-iteration
+      // stride; no IR is created until the candidate is known to be viable.
+      DeltaCache deltaCache;
+      StrideExprRef deltaBase = getStride(base, forOp, deltaCache);
+      StrideExprRef deltaOffset = getStride(strideOperand, forOp, deltaCache);
 
       if (!deltaBase || !deltaOffset)
         continue;
 
-      Value strideNew = computeFinalStride(deltaBase, deltaOffset, weight,
-                                          strideOperand.getType(), &op,
-                                          forOp, builder);
-      if (!strideNew)
+      StrideExprRef total = combineStride(deltaBase, deltaOffset, weight);
+      if (!total)
         continue;
+
+      // Reject expressions whose subterms demand conflicting types.
+      Type strideType;
+      if (!exprType(total, strideType))
+        continue;
+      if (!strideType)
+        strideType = strideOperand.getType();
+
+      // A stride built only from loop-invariant leaves is materialized before
+      // the loop; otherwise it goes immediately before the candidate op.
+      SmallVector<Value> leaves;
+      collectLeaves(total, leaves);
+      bool allInvariant = llvm::all_of(
+          leaves, [&](Value l) { return forOp.isDefinedOutsideOfLoop(l); });
+
+      StrideExprRef finalExpr = total;
+      if (!allInvariant) {
+        // Every leaf must be usable at the candidate op.  Checked before any
+        // IR is created, so a rejected candidate leaves nothing behind.
+        DenseMap<Value, bool> canCache;
+        if (!llvm::all_of(leaves, [&](Value l) {
+              return canHoistBefore(l, &op, forOp, canCache);
+            }))
+          continue;
+        DenseMap<Value, Value> hoistMemo;
+        finalExpr = makeAvailableAt(total, &op, forOp, builder, hoistMemo);
+      }
+
+      builder.setInsertionPoint(allInvariant ? forOp.getOperation() : &op);
+      Value strideNew = materialize(finalExpr, strideType, op.getLoc(), forOp,
+                                    constCache, builder);
 
       Value initPtr =
           computeInitialPtr(base, strideOperand, weight, forOp, builder);

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/MathExtras.h"
 #include <memory>
 
 namespace mlir {
@@ -603,6 +604,11 @@ static Value materializeAtLoopEntry(Value v, scf::ForOp forOp,
   if (!defOp || !forOp->isAncestor(defOp))
     return nullptr;
 
+  // Cloning duplicates the op, so it must be safe to execute an extra time and
+  // its result must not depend on anything but its operands.
+  if (!isPure(defOp))
+    return nullptr;
+
   // Clone the defining op with operands materialized at loop entry.
   SmallVector<Value> newOperands;
   for (Value operand : defOp->getOperands()) {
@@ -615,7 +621,8 @@ static Value materializeAtLoopEntry(Value v, scf::ForOp forOp,
   Operation *cloned = builder.clone(*defOp);
   for (auto [i, operand] : llvm::enumerate(newOperands))
     cloned->setOperand(i, operand);
-  return cloned->getResult(0);
+  // Preserve which result was asked for; `v` need not be result 0.
+  return cloned->getResult(cast<OpResult>(v).getResultNumber());
 }
 
 // Compute the initial pointer, i.e. the address the op reaches on the first
@@ -840,6 +847,32 @@ static Value materializeConst(int64_t c, Type ty, Location loc,
                                              ty.getIntOrFloatBitWidth());
   cache[key] = v;
   return v;
+}
+
+// Check that every constant in `e` is representable in the type it would be
+// materialized as.  `stride_new` for block-stride ops is a narrow integer
+// (i16), and a stride that does not fit would otherwise become an out-of-range
+// arith.constant.  Pure, so an out-of-range candidate is rejected before any
+// IR is created.
+static bool constantsFitType(const StrideExprRef &e, Type wantType) {
+  switch (e->kind) {
+  case StrideExpr::Kind::Const: {
+    if (!wantType || wantType.isIndex())
+      return true; // index is 64-bit, always holds an int64_t
+    unsigned bitWidth = wantType.getIntOrFloatBitWidth();
+    return bitWidth >= 64 || llvm::isIntN(bitWidth, e->constant);
+  }
+  case StrideExpr::Kind::Leaf:
+    return true;
+  case StrideExpr::Kind::Cast:
+    return constantsFitType(e->lhs, e->castOp->getOperand(0).getType());
+  case StrideExpr::Kind::Add:
+  case StrideExpr::Kind::Sub:
+  case StrideExpr::Kind::Mul:
+    return constantsFitType(e->lhs, wantType) &&
+           constantsFitType(e->rhs, wantType);
+  }
+  return false;
 }
 
 // Emit `e` at the builder's current insertion point.  Sub-expressions are
@@ -1115,6 +1148,10 @@ private:
         continue;
       if (!strideType)
         strideType = strideOperand.getType();
+
+      // Reject strides whose constants do not fit the target operand type.
+      if (!constantsFitType(total, strideType))
+        continue;
 
       // A stride built only from loop-invariant leaves is materialized before
       // the loop; otherwise it goes immediately before the candidate op.

--- a/test/lit/vpto/soft_postupdate_accum-base-addptr.pto
+++ b/test/lit/vpto/soft_postupdate_accum-base-addptr.pto
@@ -1,0 +1,52 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path: base pointer is an iter_arg that advances via pto.addptr.
+// The vlds offset is constant 0, so all address advance comes from the base.
+// stride_new = base_increment = 64.
+
+// CHECK-LABEL: func.func @accum_base_addptr
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}}[%c64] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_base_addptr(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%ptr = %ub_in, %remaining = %c1024_i32)
+          -> (!pto.ptr<f32, ub>, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ptr[%c0] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%iv], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %next_ptr = pto.addptr %ptr, %c64 : !pto.ptr<f32, ub> -> !pto.ptr<f32, ub>
+        scf.yield %next_ptr, %next_rem : !pto.ptr<f32, ub>, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-both-iterargs.pto
+++ b/test/lit/vpto/soft_postupdate_accum-both-iterargs.pto
@@ -1,0 +1,54 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path: both base and offset are iter_args.
+// base advances by 32 via pto.addptr, offset advances by 32 via arith.addi.
+// total_delta = 32 + 1*32 = 64, stride_new = 64.
+
+// CHECK-LABEL: func.func @accum_both_iterargs
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}}[%c64] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_both_iterargs(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c32 = arith.constant 32 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%ptr = %ub_in, %off = %c0, %remaining = %c1024_i32)
+          -> (!pto.ptr<f32, ub>, index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ptr[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%iv], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %next_ptr = pto.addptr %ptr, %c32 : !pto.ptr<f32, ub> -> !pto.ptr<f32, ub>
+        %next_off = arith.addi %off, %c32 : index
+        scf.yield %next_ptr, %next_off, %next_rem : !pto.ptr<f32, ub>, index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-combined-stride-after-use.pto
+++ b/test/lit/vpto/soft_postupdate_accum-combined-stride-after-use.pto
@@ -1,0 +1,59 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path: the yield combines TWO loop-varying increments, both
+// defined after the candidate ops.  Combining them must not emit an add whose
+// own operands are still defined later in the block.
+// Per-iteration stride = (iv + 1) + 3 * iv.
+
+// CHECK-LABEL: func.func @accum_combined_stride_after_use
+// CHECK: scf.for
+// CHECK:   [[X:%[0-9]+]] = arith.addi
+// CHECK:   [[Y:%[0-9]+]] = arith.muli
+// CHECK:   [[STRIDE:%[0-9]+]] = arith.addi [[X]], [[Y]]
+// CHECK:   pto.vlds {{.*}}[[[STRIDE]]] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[[[STRIDE]]]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_combined_stride_after_use(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c3 = arith.constant 3 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c16 step %c1
+          iter_args(%off = %c0, %remaining = %c1024_i32) -> (index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%off], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %x = arith.addi %iv, %c1 : index
+        %y = arith.muli %iv, %c3 : index
+        %t = arith.addi %off, %x : index
+        %next_off = arith.addi %t, %y : index
+        scf.yield %next_off, %next_rem : index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-cross-iterarg-stride.pto
+++ b/test/lit/vpto/soft_postupdate_accum-cross-iterarg-stride.pto
@@ -1,0 +1,55 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path: yield = addi(%off, %stride) where %stride is another
+// iter_arg. decomposeLinear sees %stride as {0, %stride} (different block arg),
+// so increment = %stride — a loop-varying value from another iter_arg.
+
+// CHECK-LABEL: func.func @accum_cross_iterarg
+// CHECK: scf.for
+// CHECK-SAME: iter_args(
+// CHECK:   pto.vlds {{.*}}[%arg4] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[%arg4]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_cross_iterarg(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c16 step %c1
+          iter_args(%off = %c0, %stride = %c64, %remaining = %c1024_i32)
+          -> (index, index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%off], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %next_off = arith.addi %off, %stride : index
+        %next_stride = arith.addi %stride, %c1 : index
+        scf.yield %next_off, %next_stride, %next_rem : index, index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-lookthrough-offset.pto
+++ b/test/lit/vpto/soft_postupdate_accum-lookthrough-offset.pto
@@ -1,0 +1,53 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path with look-through: the offset operand is addi(%off, %c10),
+// NOT a direct BlockArgument. getIterArgIncrement traces through the addi
+// (skipping the loop-invariant %c10) to find iter_arg %off with increment 64.
+
+// CHECK-LABEL: func.func @accum_lookthrough
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}}[%c64] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[%c64]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_lookthrough(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%off = %c0, %remaining = %c1024_i32) -> (index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %shifted = arith.addi %off, %c10 : index
+        %vec = pto.vlds %ub_in[%shifted] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%shifted], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %next_off = arith.addi %off, %c64 : index
+        scf.yield %next_off, %next_rem : index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-multilevel-yield.pto
+++ b/test/lit/vpto/soft_postupdate_accum-multilevel-yield.pto
@@ -2,20 +2,27 @@
 
 // Accumulator path: yield expression is a multi-level chain where blockArg
 // is NOT a direct operand of the yield defining op.
-// yield = subi(addi(%off, 64), 4) → increment = 64 - 4 = 60.
+// yield = subi(addi(%off, 64), %iv) → increment = 64 - %iv.
 // The old single-level matching cannot handle this (yield defOp is subi,
 // not addi, and %off is not an operand of subi).
+//
+// The subtrahend is the induction variable rather than a constant on purpose:
+// with two constants the canonicalizer folds the whole chain into a single
+// arith.addi before this pass runs, so the subtraction path (makeSub in
+// decomposeLinear) would never be exercised.  Because 64 - %iv is loop-varying
+// it also cannot fold to a constant inside the pass, so the materialized
+// arith.subi below is direct evidence the Sub expression node was built.
 
 // CHECK-LABEL: func.func @accum_multilevel
 // CHECK: scf.for
-// CHECK:   pto.vlds {{.*}}[%c60] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
-// CHECK:   pto.vsts {{.*}}[%c60]{{.*}} -> !pto.ptr<f32,
+// CHECK:   [[STRIDE:%[0-9]+]] = arith.subi %c64,
+// CHECK:   pto.vlds {{.*}}[[[STRIDE]]] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[[[STRIDE]]]{{.*}} -> !pto.ptr<f32,
 // CHECK:   scf.yield
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @accum_multilevel(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
     %c0 = arith.constant 0 : index
-    %c4 = arith.constant 4 : index
     %c64 = arith.constant 64 : index
     %c1024 = arith.constant 1024 : index
     %c0_i64 = arith.constant 0 : i64
@@ -39,7 +46,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %vec = pto.vlds %ub_in[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
         pto.vsts %vec, %ub_out[%off], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
         %tmp = arith.addi %off, %c64 : index
-        %next = arith.subi %tmp, %c4 : index
+        %next = arith.subi %tmp, %iv : index
         scf.yield %next, %next_rem : index, i32
       }
     }

--- a/test/lit/vpto/soft_postupdate_accum-multilevel-yield.pto
+++ b/test/lit/vpto/soft_postupdate_accum-multilevel-yield.pto
@@ -1,0 +1,55 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path: yield expression is a multi-level chain where blockArg
+// is NOT a direct operand of the yield defining op.
+// yield = subi(addi(%off, 64), 4) → increment = 64 - 4 = 60.
+// The old single-level matching cannot handle this (yield defOp is subi,
+// not addi, and %off is not an operand of subi).
+
+// CHECK-LABEL: func.func @accum_multilevel
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}}[%c60] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[%c60]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_multilevel(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%off = %c0, %remaining = %c1024_i32) -> (index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%off], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %tmp = arith.addi %off, %c64 : index
+        %next = arith.subi %tmp, %c4 : index
+        scf.yield %next, %next_rem : index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-offset-nonconstant-stride.pto
+++ b/test/lit/vpto/soft_postupdate_accum-offset-nonconstant-stride.pto
@@ -1,0 +1,53 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path: offset is an iter_arg with non-constant stride (depends on IV).
+// offset advances by (iv + 1) each iteration — stride is loop-varying.
+// The delta path cannot handle this because stride_new is not loop-invariant.
+
+// CHECK-LABEL: func.func @accum_offset_nonconstant
+// CHECK: scf.for
+// CHECK:   [[STRIDE:%[0-9]+]] = arith.addi
+// CHECK:   pto.vlds {{.*}}[[[STRIDE]]] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[[[STRIDE]]]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_offset_nonconstant(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c16 step %c1
+          iter_args(%off = %c0, %remaining = %c1024_i32) -> (index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %s = arith.addi %iv, %c1 : index
+        %vec = pto.vlds %ub_in[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%off], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %next_off = arith.addi %off, %s : index
+        scf.yield %next_off, %next_rem : index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-stride-after-use.pto
+++ b/test/lit/vpto/soft_postupdate_accum-stride-after-use.pto
@@ -1,0 +1,53 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path: the increment is defined AFTER the ops that consume the
+// stride.  The stride must be re-materialized before the candidate op, not
+// left dangling at its original position (which would break SSA dominance).
+
+// CHECK-LABEL: func.func @accum_stride_after_use
+// CHECK: scf.for
+// CHECK:   [[STRIDE:%[0-9]+]] = arith.addi
+// CHECK:   pto.vlds {{.*}}[[[STRIDE]]] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[[[STRIDE]]]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_stride_after_use(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c16 step %c1
+          iter_args(%off = %c0, %remaining = %c1024_i32) -> (index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%off], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %s = arith.addi %iv, %c1 : index
+        %next_off = arith.addi %off, %s : index
+        scf.yield %next_off, %next_rem : index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-unchanged-iterarg.pto
+++ b/test/lit/vpto/soft_postupdate_accum-unchanged-iterarg.pto
@@ -1,0 +1,52 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Base is an iter_arg yielded unchanged (yield = blockArg, delta = 0).
+// Offset is IV (delta = step = 64). Total stride = 0 + 64 = 64.
+// Verifies that unchanged iter_arg returns a zero constant (not Value()),
+// allowing the optimization to proceed with the other operand's stride.
+
+// CHECK-LABEL: func.func @accum_unchanged
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}}[%c64] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[%c64]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_unchanged(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%ptr = %ub_in, %remaining = %c1024_i32)
+          -> (!pto.ptr<f32, ub>, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ptr[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%iv], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        scf.yield %ptr, %next_rem : !pto.ptr<f32, ub>, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_accum-vsstb-nonconstant-rs.pto
+++ b/test/lit/vpto/soft_postupdate_accum-vsstb-nonconstant-rs.pto
@@ -1,23 +1,27 @@
 // RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
 
-// Negative: pto.vsstb whose *base* advances by a loop-varying amount.
-// Rescaling delta(base) from addptr elements into 32-byte blocks is a division
-// by 32/sizeof(f32) = 8, which can only be proven exact for a compile-time
-// constant.  The increment here is %iv, so the vsstb must be left alone.
-// (delta(repeat_stride) needs no such proof -- it is never rescaled -- so a
-// non-constant repeat_stride increment IS supported; see
-// soft_postupdate_accum-vsstb-nonconstant-rs.pto.)
-// The vlds in the same loop is a plain delta candidate and is still rewritten.
+// pto.vsstb whose repeat_stride is an i16 iter_arg with a NON-constant
+// increment (%v = index_castui %iv, different every iteration).
+//
+// stride_new = (E/W)*delta(base) + delta(repeat_stride).  delta(base) is 0 and
+// delta(repeat_stride) is never rescaled, so the increment stays symbolic and
+// the rewrite is legal even though nothing here is a compile-time constant.
+// The increment is defined *after* the vsstb, so its def-chain is cloned ahead
+// of the op.
+//
+// Address check -- iv_n = 64n, rs_0 = 0, rs_{n+1} = rs_n + iv_n:
+//   original  32*rs_n  : 0, 0, 2048, 6144, ...
+//   post-update ptr_n  : 0, 0+32*0, 0+32*64, 2048+32*128, ...  (identical)
 
-// CHECK-LABEL: func.func @negative_vsstb_nonconstant_rs
+// CHECK-LABEL: func.func @accum_vsstb_nonconstant_rs
 // CHECK: scf.for
-// The vsstb keeps its original result-less form: the line ends at the mask
-// operand, with no "-> !pto.ptr" updated_base appended.
-// CHECK:   pto.vsstb {{.*}}!pto.mask<b32>{{$}}
+// The cloned increment precedes the vsstb and feeds its repeat_stride slot.
+// CHECK:   %[[INC:.*]] = arith.index_castui %{{.*}} : index to i16
+// CHECK:   pto.vsstb {{.*}}, %c2_i16, %[[INC]], {{.*}} -> !pto.ptr<f32,
 // CHECK:   scf.yield
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-  func.func @negative_vsstb_nonconstant_rs(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+  func.func @accum_vsstb_nonconstant_rs(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
     %c0 = arith.constant 0 : index
     %c64 = arith.constant 64 : index
     %c1024 = arith.constant 1024 : index
@@ -41,14 +45,15 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     pto.vecscope {
       scf.for %iv = %c0 to %c1024 step %c64
-          iter_args(%dst = %ub_out, %remaining = %c1024_i32) -> (!pto.ptr<f32, ub>, i32) {
+          iter_args(%rs = %c0_i16, %remaining = %c1024_i32) -> (i16, i32) {
         %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
         %vec = pto.vlds %ub_in[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
 
-        pto.vsstb %vec, %dst, %c2_i16, %c0_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+        pto.vsstb %vec, %ub_out, %c2_i16, %rs, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
 
-        %next_dst = pto.addptr %dst, %iv : <f32, ub> -> <f32, ub>
-        scf.yield %next_dst, %next_rem : !pto.ptr<f32, ub>, i32
+        %v = arith.index_castui %iv : index to i16
+        %next_rs = arith.addi %rs, %v : i16
+        scf.yield %next_rs, %next_rem : i16, i32
       }
     }
 

--- a/test/lit/vpto/soft_postupdate_accum-vsstb-rs-iterarg.pto
+++ b/test/lit/vpto/soft_postupdate_accum-vsstb-rs-iterarg.pto
@@ -1,0 +1,56 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Accumulator path for vsstb: repeat_stride is an iter_arg with constant increment.
+// rs starts at 0, advances by 2 each iteration. weight=32.
+// Only soIncr is active: stride_new = soIncr = 2 (i16).
+
+// CHECK-LABEL: func.func @accum_vsstb_rs
+// CHECK: scf.for
+// CHECK:   pto.vsstb {{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @accum_vsstb_rs(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c0_i16 = arith.constant 0 : i16
+    %c2_i16 = arith.constant 2 : i16
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%rs = %c0_i16, %remaining = %c1024_i32) -> (i16, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+
+        pto.vsstb %vec, %ub_out, %c2_i16, %rs, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+
+        %next_rs = arith.addi %rs, %c2_i16 : i16
+        scf.yield %next_rs, %next_rem : i16, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_inferred-vecscope.pto
+++ b/test/lit/vpto/soft_postupdate_inferred-vecscope.pto
@@ -1,0 +1,50 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// The input has NO hand-written pto.vecscope -- it is created later in the
+// pipeline by PTOInferVPTOVecScope.  This is how real kernels reach the pass,
+// so the rewrite must still happen.  Every other test in this suite writes the
+// vecscope by hand, which cannot catch a pass ordered before the inference.
+
+// CHECK-LABEL: func.func @inferred_vecscope
+// CHECK: pto.vecscope
+// CHECK:   scf.for
+// CHECK:     pto.vlds {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:     pto.vsts {{.*}} -> !pto.ptr<f32,
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @inferred_vecscope(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    scf.for %iv = %c0 to %c1024 step %c64
+        iter_args(%remaining = %c1024_i32) -> i32 {
+      %mask, %next = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+      %vec = pto.vlds %ub_in[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+      pto.vsts %vec, %ub_out[%iv], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+      scf.yield %next : i32
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_loop-same-base-different-offset.pto
+++ b/test/lit/vpto/soft_postupdate_loop-same-base-different-offset.pto
@@ -1,0 +1,50 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Two ops on the same base with the same per-iteration stride but DIFFERENT
+// offsets (%iv and %iv + 64).  They walk different address sequences, so they
+// must not share an iter_arg: the vsts has to start at %ub + 64, not at %ub.
+
+// CHECK-LABEL: func.func @same_base_different_offset
+// CHECK: [[INIT1:%[0-9]+]] = pto.addptr {{.*}}, %c64
+// CHECK: scf.for {{.*}} iter_args({{.*}}, [[P0:%[a-z0-9]+]] = {{.*}}, [[P1:%[a-z0-9]+]] = [[INIT1]])
+// CHECK:   pto.vlds [[P0]]{{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}, [[P1]]{{.*}} -> !pto.ptr<f32,
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @same_base_different_offset(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%remaining = %c1024_i32) -> i32 {
+        %mask, %next = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        %off2 = arith.addi %iv, %c64 : index
+        pto.vsts %vec, %ub[%off2], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        scf.yield %next : i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_mixed-accum-delta.pto
+++ b/test/lit/vpto/soft_postupdate_mixed-accum-delta.pto
@@ -1,0 +1,52 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Mixed analysis: base is iter_arg (addptr, increment=64), offset is IV (step=64).
+// Accumulator handles base, delta handles offset. Combined stride = 64 + 64 = 128.
+// vsts has constant base, so its stride is 64 (IV only).
+
+// CHECK-LABEL: func.func @mixed_accum_delta
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}}[%c128] {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   pto.vsts {{.*}}[%c64]{{.*}} -> !pto.ptr<f32,
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @mixed_accum_delta(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%ptr = %ub_in, %remaining = %c1024_i32)
+          -> (!pto.ptr<f32, ub>, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ptr[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%iv], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %next_ptr = pto.addptr %ptr, %c64 : !pto.ptr<f32, ub> -> !pto.ptr<f32, ub>
+        scf.yield %next_ptr, %next_rem : !pto.ptr<f32, ub>, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_negative-non-additive-yield.pto
+++ b/test/lit/vpto/soft_postupdate_negative-non-additive-yield.pto
@@ -5,9 +5,15 @@
 
 // CHECK-LABEL: func.func @negative_non_additive
 // CHECK: scf.for
-// CHECK:   pto.vlds {{.*}} -> !pto.vreg<64xf32>
-// CHECK-NOT: updated_base
+// Both ops keep their original form: each line ends at the original result
+// type, with no updated_base pointer appended.  The end-of-line anchors are
+// what make this negative test discriminating -- without them the CHECKs
+// also match the transformed "-> !pto.vreg<64xf32>, !pto.ptr<f32, ub>" and
+// "!pto.mask<b32> -> !pto.ptr<f32, ub>" forms.
+// CHECK:   pto.vlds {{.*}} -> !pto.vreg<64xf32>{{$}}
+// CHECK:   pto.vsts {{.*}}!pto.mask<b32>{{$}}
 // CHECK:   scf.yield
+// CHECK-NOT: updated_base
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @negative_non_additive(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {

--- a/test/lit/vpto/soft_postupdate_negative-non-additive-yield.pto
+++ b/test/lit/vpto/soft_postupdate_negative-non-additive-yield.pto
@@ -1,0 +1,51 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Negative test: offset is an iter_arg, but yield is NOT additive (yield = off * 2).
+// Neither accumulator nor delta analysis can handle this — op stays unchanged.
+
+// CHECK-LABEL: func.func @negative_non_additive
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}} -> !pto.vreg<64xf32>
+// CHECK-NOT: updated_base
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @negative_non_additive(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %c16 = arith.constant 16 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c16 step %c1
+          iter_args(%off = %c1, %remaining = %c1024_i32) -> (index, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%off] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %vec, %ub_out[%off], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %next_off = arith.muli %off, %c2 : index
+        scf.yield %next_off, %next_rem : index, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_negative-vsstb-nonconstant-stride.pto
+++ b/test/lit/vpto/soft_postupdate_negative-vsstb-nonconstant-stride.pto
@@ -1,0 +1,61 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Negative: pto.vsstb (weight=32) whose repeat_stride is an i16 iter_arg with a
+// NON-constant increment.  stride_new = total / 32 is not known at compile
+// time, so the vsstb must be left alone -- and in particular the weight must
+// not be multiplied against the i16 increment.
+// The vlds in the same loop is a plain delta candidate and is still rewritten.
+
+// CHECK-LABEL: func.func @negative_vsstb_nonconstant_rs
+// CHECK: scf.for
+// The vsstb keeps its original result-less form: the line ends at the mask
+// operand, with no "-> !pto.ptr" updated_base appended.
+// CHECK:   pto.vsstb {{.*}}!pto.mask<b32>{{$}}
+// CHECK:   scf.yield
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @negative_vsstb_nonconstant_rs(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c0_i16 = arith.constant 0 : i16
+    %c2_i16 = arith.constant 2 : i16
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%rs = %c0_i16, %remaining = %c1024_i32) -> (i16, i32) {
+        %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+
+        pto.vsstb %vec, %ub_out, %c2_i16, %rs, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+
+        %v = arith.index_castui %iv : index to i16
+        %next_rs = arith.addi %rs, %v : i16
+        scf.yield %next_rs, %next_rem : i16, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_negative-vsstb-stride-out-of-range.pto
+++ b/test/lit/vpto/soft_postupdate_negative-vsstb-stride-out-of-range.pto
@@ -1,0 +1,59 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Negative: stride_new would be 100000, which does not fit the i16
+// repeat_stride operand.  The candidate must be rejected rather than emit an
+// out-of-range arith.constant.
+
+// CHECK-LABEL: func.func @negative_vsstb_stride_out_of_range
+// CHECK: scf.for
+// The vsstb keeps its original result-less form: the line ends at the mask
+// operand, with no "-> !pto.ptr" updated_base appended.
+// CHECK:   pto.vsstb {{.*}}!pto.mask<b32>{{$}}
+// CHECK:   scf.yield
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @negative_vsstb_stride_out_of_range(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c100000 = arith.constant 100000 : index
+    %c1000000 = arith.constant 1000000 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c2_i16 = arith.constant 2 : i16
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      scf.for %iv = %c0 to %c1000000 step %c100000
+          iter_args(%remaining = %c1024_i32) -> i32 {
+        %mask, %next = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
+        %vec = pto.vlds %ub_in[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+
+        // repeat_stride = iv (varies per iteration), dest fixed
+        %rs = arith.index_castui %iv : index to i16
+        pto.vsstb %vec, %ub_out, %c2_i16, %rs, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+
+        scf.yield %next : i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_nested-loop.pto
+++ b/test/lit/vpto/soft_postupdate_nested-loop.pto
@@ -1,0 +1,52 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// Nested scf.for with candidates at both levels.  Loops must be rewritten
+// inner-to-outer: rewriting a loop erases it, so processing an enclosing loop
+// first would leave the inner loop's handle dangling.
+
+// CHECK-LABEL: func.func @nested_loops
+// CHECK: scf.for
+// CHECK:   pto.vlds {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+// CHECK:   scf.for
+// CHECK:     pto.vlds {{.*}} -> !pto.vreg<64xf32>, !pto.ptr<f32,
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @nested_loops(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c64 = arith.constant 64 : index
+    %c256 = arith.constant 256 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c32_i64 = arith.constant 32 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f32, ub>
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.vecscope {
+      scf.for %ivo = %c0 to %c256 step %c64 iter_args(%remo = %c1024_i32) -> (i32) {
+        %masko, %nro = pto.plt_b32 %remo : i32 -> !pto.mask<b32>, i32
+        %veco = pto.vlds %ub_in[%ivo] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+        pto.vsts %veco, %ub_out[%ivo], %masko : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+        %inner = scf.for %ivi = %c0 to %c256 step %c64 iter_args(%remi = %c1024_i32) -> (i32) {
+          %maski, %nri = pto.plt_b32 %remi : i32 -> !pto.mask<b32>, i32
+          %veci = pto.vlds %ub_in[%ivi] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+          pto.vsts %veci, %ub_out[%ivi], %maski : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+          scf.yield %nri : i32
+        }
+        scf.yield %inner : i32
+      }
+    }
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f32, ub>, !pto.ptr<f32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_vsstb-elemsize-f16.pto
+++ b/test/lit/vpto/soft_postupdate_vsstb-elemsize-f16.pto
@@ -1,0 +1,61 @@
+// RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
+
+// pto.vsstb repeat_stride is counted in 32-BYTE blocks, while pto.addptr takes
+// an offset in ELEMENTS.  The initial pointer therefore has to convert:
+//   addptr offset = rs_0 * (32 / sizeof(f16))  =  4 * 16  =  64
+// This file and its f32 twin differ only in element type, and must produce
+// DIFFERENT offsets -- a single hard-coded factor cannot satisfy both.
+//
+// dest is loop-invariant and rs advances by a constant 3 blocks per iteration,
+// so stride_new = (E/W)*0 + 3 = 3.
+
+// CHECK-LABEL: func.func @vsstb_elemsize_f16
+// CHECK: pto.addptr %{{.*}}, %c64 :
+// CHECK: scf.for
+// CHECK:   pto.vsstb {{.*}}, %c2_i16, %c3_i16, {{.*}} -> !pto.ptr<f16,
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsstb_elemsize_f16(%input: !pto.ptr<f16, gm>, %output: !pto.ptr<f16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c1024 = arith.constant 1024 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c2_i16 = arith.constant 2 : i16
+    %c3_i16 = arith.constant 3 : i16
+    %c4_i16 = arith.constant 4 : i16
+    %c32_i64 = arith.constant 32 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c1024_i32 = arith.constant 1024 : i32
+
+    %ub_in = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %ub_out = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f16, ub>
+
+    pto.mte_gm_ub %input, %ub_in, %c0_i64, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      // repeat_stride starts at 4 blocks, so the initial pointer is nonzero.
+      scf.for %iv = %c0 to %c1024 step %c64
+          iter_args(%rs = %c4_i16, %remaining = %c1024_i32) -> (i16, i32) {
+        %mask, %next_rem = pto.plt_b16 %remaining : i32 -> !pto.mask<b16>, i32
+        %vec = pto.vlds %ub_in[%iv] {dist = "NORM"} : !pto.ptr<f16, ub> -> !pto.vreg<128xf16>
+        pto.vsstb %vec, %ub_out, %c2_i16, %rs, %mask : !pto.vreg<128xf16>, !pto.ptr<f16, ub>, i16, i16, !pto.mask<b16>
+        %next_rs = arith.addi %rs, %c3_i16 : i16
+        scf.yield %next_rs, %next_rem : i16, i32
+      }
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_out, %output, %c128_i64
+      nburst(%c32_i64, %c128_i64, %c128_i64)
+      : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/lit/vpto/soft_postupdate_vsstb-elemsize-f32.pto
+++ b/test/lit/vpto/soft_postupdate_vsstb-elemsize-f32.pto
@@ -1,29 +1,28 @@
 // RUN: ptoas --pto-backend=vpto --pto-arch=a5 --enable-vpto-soft-postupdate --emit-vpto %s -o - | FileCheck %s
 
-// Negative: pto.vsstb whose *base* advances by a loop-varying amount.
-// Rescaling delta(base) from addptr elements into 32-byte blocks is a division
-// by 32/sizeof(f32) = 8, which can only be proven exact for a compile-time
-// constant.  The increment here is %iv, so the vsstb must be left alone.
-// (delta(repeat_stride) needs no such proof -- it is never rescaled -- so a
-// non-constant repeat_stride increment IS supported; see
-// soft_postupdate_accum-vsstb-nonconstant-rs.pto.)
-// The vlds in the same loop is a plain delta candidate and is still rewritten.
+// pto.vsstb repeat_stride is counted in 32-BYTE blocks, while pto.addptr takes
+// an offset in ELEMENTS.  The initial pointer therefore has to convert:
+//   addptr offset = rs_0 * (32 / sizeof(f32))  =  4 * 8  =  32
+// This file and its f16 twin differ only in element type, and must produce
+// DIFFERENT offsets -- a single hard-coded factor cannot satisfy both.
+//
+// dest is loop-invariant and rs advances by a constant 3 blocks per iteration,
+// so stride_new = (E/W)*0 + 3 = 3.
 
-// CHECK-LABEL: func.func @negative_vsstb_nonconstant_rs
+// CHECK-LABEL: func.func @vsstb_elemsize_f32
+// CHECK: pto.addptr %{{.*}}, %c32 :
 // CHECK: scf.for
-// The vsstb keeps its original result-less form: the line ends at the mask
-// operand, with no "-> !pto.ptr" updated_base appended.
-// CHECK:   pto.vsstb {{.*}}!pto.mask<b32>{{$}}
-// CHECK:   scf.yield
+// CHECK:   pto.vsstb {{.*}}, %c2_i16, %c3_i16, {{.*}} -> !pto.ptr<f32,
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-  func.func @negative_vsstb_nonconstant_rs(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
+  func.func @vsstb_elemsize_f32(%input: !pto.ptr<f32, gm>, %output: !pto.ptr<f32, gm>) attributes {pto.kernel} {
     %c0 = arith.constant 0 : index
     %c64 = arith.constant 64 : index
     %c1024 = arith.constant 1024 : index
     %c0_i64 = arith.constant 0 : i64
-    %c0_i16 = arith.constant 0 : i16
     %c2_i16 = arith.constant 2 : i16
+    %c3_i16 = arith.constant 3 : i16
+    %c4_i16 = arith.constant 4 : i16
     %c32_i64 = arith.constant 32 : i64
     %c128_i64 = arith.constant 128 : i64
     %c4096_i64 = arith.constant 4096 : i64
@@ -40,15 +39,14 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
 
     pto.vecscope {
+      // repeat_stride starts at 4 blocks, so the initial pointer is nonzero.
       scf.for %iv = %c0 to %c1024 step %c64
-          iter_args(%dst = %ub_out, %remaining = %c1024_i32) -> (!pto.ptr<f32, ub>, i32) {
+          iter_args(%rs = %c4_i16, %remaining = %c1024_i32) -> (i16, i32) {
         %mask, %next_rem = pto.plt_b32 %remaining : i32 -> !pto.mask<b32>, i32
         %vec = pto.vlds %ub_in[%iv] {dist = "NORM"} : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
-
-        pto.vsstb %vec, %dst, %c2_i16, %c0_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
-
-        %next_dst = pto.addptr %dst, %iv : <f32, ub> -> <f32, ub>
-        scf.yield %next_dst, %next_rem : !pto.ptr<f32, ub>, i32
+        pto.vsstb %vec, %ub_out, %c2_i16, %rs, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+        %next_rs = arith.addi %rs, %c3_i16 : i16
+        scf.yield %next_rs, %next_rem : i16, i32
       }
     }
 

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -2706,10 +2706,10 @@ static void prepareVPTOForEmission(PassManager &pm) {
   kernelModulePM.addNestedPass<func::FuncOp>(
       createVPTOExpandWrapperOpsPass());
   kernelModulePM.addPass(createCSEPass());
-  if (enableSoftPostUpdate)
-    kernelModulePM.addPass(pto::createVPTOSoftPostUpdatePass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTOInferVPTOVecScopePass());
+  if (enableSoftPostUpdate)
+    kernelModulePM.addPass(pto::createVPTOSoftPostUpdatePass());
   kernelModulePM.addPass(createLoopInvariantCodeMotionPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTONarrowVPTOLoopCountersPass());


### PR DESCRIPTION
Implement the accumulator analysis path for VPTOSoftPostUpdate (design doc step 2), and refactor the overall stride computation architecture.

### Changes

- Unified stride analysis: replace the mutually-exclusive accumulator/delta two-path design with getStride, which independently analyzes each operand — accumulator (iter_arg) first, delta (IV/affine) fallback — then combines via computeFinalStride.
- Recursive decomposeLinear: decompose yield expressions along addi/subi/muli/index_cast/addptr chains into blockArg * coeff + increment, requiring coeff == 1. Replaces single-level addi/addptr matching.
- getIterArgIncrement look-through: trace operands back through addi/subi/addptr with loop-invariant offset and index_cast to find the underlying iter_arg, applying collected type casts to the increment.
- Three-state return for getIterArgIncrement: nullopt (not iter_arg, try delta), Value() (iter_arg but decomposition failed, give up), Some(value) (success). Prevents treating unknown delta as zero.
- Zero constant for unchanged iter_arg: yield = blockArg correctly returns delta=0 instead of signaling failure.

### Tests

10 new lit tests covering: non-constant stride, base via addptr, both iter_args, cross-iter_arg stride, vsstb with iter_arg repeat_stride, multi-level yield chain, look-through offset, mixed accumulator+delta, unchanged iter_arg, non-additive yield (negative).