### PR TITLE
fix(ptodsl): refactor vecscope inference and support pto.vecscope context manager

### DIFF
--- a/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
+++ b/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
@@ -16,10 +16,14 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Pass/Pass.h"
 
+#include <optional>
+
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace mlir {
@@ -56,7 +60,19 @@ struct ResultlessScopePlan {
   SmallVector<Operation *, 16> moveOps;
 };
 
+struct LogicalScopePlan {
+  size_t begin = 0;
+  size_t end = 0;
+  ResultlessScopePlan plan;
+};
+
+using SegmentRematCache =
+    llvm::DenseMap<Value, llvm::DenseMap<Operation *, Value>>;
+
 static VPTOInferenceOpClass classifyOperationForInference(Operation *op);
+static LogicalResult
+buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
+                         EscapingMovedValue &escapingValue);
 static LogicalResult inferVecScopesInRegion(Region &region,
                                             MLIRContext *context);
 
@@ -74,12 +90,6 @@ static bool isExplicitVectorScopeCarrier(Operation *op) {
 
 static bool isForbiddenInsideInferredVectorScope(Operation *op) {
   return isa<pto::VbitsortOp, pto::Vmrgsort4Op>(op);
-}
-
-static bool isCloneableMaskProducer(Operation *op) {
-  return isa<pto::PsetB8Op, pto::PsetB16Op, pto::PsetB32Op, pto::PgeB8Op,
-             pto::PgeB16Op, pto::PgeB32Op, pto::PltB8Op, pto::PltB16Op,
-             pto::PltB32Op>(op);
 }
 
 static bool isVectorScopeBoundaryOperation(Operation *op) {
@@ -118,6 +128,16 @@ static bool isSafeScalarOperation(Operation *op) {
   if (isa<func::CallOp>(op))
     return false;
   if (isPTOOperation(op) && !isMemoryEffectFree(op))
+    return false;
+  return isMemoryEffectFree(op);
+}
+
+static bool isRematerializableVecScopeProducer(Operation *op) {
+  if (!op || op->getNumRegions() != 0)
+    return false;
+  if (op->hasTrait<OpTrait::IsTerminator>())
+    return false;
+  if (isa<func::CallOp>(op))
     return false;
   return isMemoryEffectFree(op);
 }
@@ -258,57 +278,204 @@ static Operation *getAncestorInBlock(Operation *op, Block &block) {
   return nullptr;
 }
 
-static bool isUseBeforeInBlock(OpOperand *lhs, OpOperand *rhs, Block &block) {
-  Operation *lhsAncestor = getAncestorInBlock(lhs->getOwner(), block);
-  Operation *rhsAncestor = getAncestorInBlock(rhs->getOwner(), block);
-  if (!lhsAncestor || !rhsAncestor || lhsAncestor == rhsAncestor)
-    return false;
-  return lhsAncestor->isBeforeInBlock(rhsAncestor);
-}
+static FailureOr<Operation *>
+cloneVecScopeProducerForUse(
+    Value value, Operation *user, Operation *logicalScopeAnchor,
+    SegmentRematCache &cache, MLIRContext *context,
+    llvm::DenseMap<Operation *, Operation *> &clones) {
+  auto result = dyn_cast<OpResult>(value);
+  if (!result)
+    return failure();
 
-static void keepEarliestUseFirst(SmallVectorImpl<OpOperand *> &uses,
-                                 Block &block) {
-  if (uses.size() < 2)
-    return;
-
-  unsigned earliest = 0;
-  for (unsigned i = 1, e = uses.size(); i < e; ++i) {
-    if (isUseBeforeInBlock(uses[i], uses[earliest], block))
-      earliest = i;
+  if (auto cacheIt = cache.find(value); cacheIt != cache.end()) {
+    auto anchorIt = cacheIt->second.find(logicalScopeAnchor);
+    if (anchorIt != cacheIt->second.end())
+      return anchorIt->second.getDefiningOp();
   }
-  if (earliest != 0)
-    std::swap(uses.front(), uses[earliest]);
-}
 
-static void cloneSharedMaskProducers(Block &block, MLIRContext *context) {
-  IRRewriter rewriter(context);
-  SmallVector<Operation *, 32> ops;
-  for (Operation &op : block)
-    ops.push_back(&op);
+  Operation *producer = result.getOwner();
+  auto existing = clones.find(producer);
+  if (existing != clones.end())
+    return existing->second;
 
-  for (Operation *op : ops) {
-    if (!isCloneableMaskProducer(op))
+  if (!isRematerializableVecScopeProducer(producer))
+    return failure();
+
+  IRMapping mapping;
+  for (Value operand : producer->getOperands()) {
+    if (!isVecScopeType(operand.getType()))
       continue;
 
-    for (OpResult result : op->getOpResults()) {
-      if (!isa<pto::MaskType>(result.getType()) || result.use_empty())
+    FailureOr<Operation *> clonedOperandProducer =
+        cloneVecScopeProducerForUse(operand, user, logicalScopeAnchor, cache,
+                                    context, clones);
+    if (failed(clonedOperandProducer))
+      return failure();
+
+    auto operandResult = cast<OpResult>(operand);
+    mapping.map(operand, (*clonedOperandProducer)
+                             ->getResult(operandResult.getResultNumber()));
+  }
+
+  IRRewriter rewriter(context);
+  rewriter.setInsertionPoint(user);
+  Operation *clone = rewriter.clone(*producer, mapping);
+  clones.try_emplace(producer, clone);
+  cache[value][logicalScopeAnchor] = clone->getResult(result.getResultNumber());
+  return clone;
+}
+
+static void collectGreedyLogicalScopePlans(
+    ArrayRef<Operation *> ops, SmallVectorImpl<LogicalScopePlan> &plans) {
+  plans.clear();
+
+  for (size_t begin = 0; begin < ops.size();) {
+    size_t bestEnd = begin;
+    ResultlessScopePlan bestPlan;
+
+    for (size_t end = ops.size(); end > begin; --end) {
+      ArrayRef<Operation *> candidate = ops.slice(begin, end - begin);
+      if (!hasVectorOperation(candidate))
         continue;
 
-      SmallVector<OpOperand *, 8> uses;
-      for (OpOperand &use : result.getUses())
-        uses.push_back(&use);
-      if (uses.size() < 2)
-        continue;
-
-      keepEarliestUseFirst(uses, block);
-      for (OpOperand *use : ArrayRef<OpOperand *>(uses).drop_front()) {
-        Operation *user = use->getOwner();
-        rewriter.setInsertionPoint(user);
-        Operation *clone = rewriter.clone(*op);
-        use->set(clone->getResult(result.getResultNumber()));
+      ResultlessScopePlan plan;
+      EscapingMovedValue candidateEscapingValue;
+      if (succeeded(
+              buildResultlessScopePlan(candidate, plan, candidateEscapingValue))) {
+        bestEnd = end;
+        bestPlan = std::move(plan);
+        break;
       }
     }
+
+    if (bestEnd == begin) {
+      ++begin;
+      continue;
+    }
+
+    plans.push_back(LogicalScopePlan{begin, bestEnd, std::move(bestPlan)});
+    begin = bestEnd;
   }
+}
+
+static void assignLogicalScopeAnchorsForCluster(
+    ArrayRef<Operation *> ops,
+    llvm::DenseMap<Operation *, Operation *> &logicalScopeAnchors) {
+  SmallVector<LogicalScopePlan, 8> plans;
+  collectGreedyLogicalScopePlans(ops, plans);
+
+  llvm::DenseMap<Operation *, Operation *> scopeAnchorByMovedOp;
+  for (const LogicalScopePlan &plan : plans) {
+    if (plan.plan.moveOps.empty())
+      continue;
+    Operation *scopeAnchor = plan.plan.moveOps.front();
+    for (Operation *movedOp : plan.plan.moveOps)
+      scopeAnchorByMovedOp[movedOp] = scopeAnchor;
+  }
+
+  Operation *currentNonScopeAnchor = nullptr;
+  for (Operation *op : ops) {
+    auto scopeIt = scopeAnchorByMovedOp.find(op);
+    if (scopeIt != scopeAnchorByMovedOp.end()) {
+      logicalScopeAnchors[op] = scopeIt->second;
+      currentNonScopeAnchor = nullptr;
+      continue;
+    }
+
+    if (!currentNonScopeAnchor)
+      currentNonScopeAnchor = op;
+    logicalScopeAnchors[op] = currentNonScopeAnchor;
+  }
+}
+
+static llvm::DenseMap<Operation *, Operation *>
+computeLogicalScopeAnchors(Block &block) {
+  llvm::DenseMap<Operation *, Operation *> logicalScopeAnchors;
+  SmallVector<Operation *, 32> pending;
+
+  auto flush = [&]() {
+    if (pending.empty())
+      return;
+    assignLogicalScopeAnchorsForCluster(pending, logicalScopeAnchors);
+    pending.clear();
+  };
+
+  for (Operation &op : block) {
+    switch (classifyOperationForInference(&op)) {
+    case VPTOInferenceOpClass::Vector:
+    case VPTOInferenceOpClass::SafeScalar:
+      pending.push_back(&op);
+      break;
+    case VPTOInferenceOpClass::Boundary:
+      flush();
+      break;
+    }
+  }
+  flush();
+  return logicalScopeAnchors;
+}
+
+static LogicalResult rematerializeEscapingValueForUserSegments(
+    Value value, const llvm::SmallPtrSetImpl<Operation *> &movedOps,
+    Block &block, SegmentRematCache &cache, MLIRContext *context) {
+  auto result = dyn_cast<OpResult>(value);
+  if (!result)
+    return failure();
+
+  llvm::DenseMap<Operation *, Operation *> logicalScopeAnchors =
+      computeLogicalScopeAnchors(block);
+  llvm::DenseMap<Operation *, SmallVector<OpOperand *, 4>> usesBySegment;
+
+  for (OpOperand &use : result.getUses()) {
+    Operation *user = use.getOwner();
+    if (isUserInsideCluster(user, movedOps))
+      continue;
+
+    Operation *ancestor = getAncestorInBlock(user, block);
+    if (!ancestor)
+      return failure();
+
+    auto anchorIt = logicalScopeAnchors.find(ancestor);
+    if (anchorIt == logicalScopeAnchors.end())
+      return failure();
+
+    usesBySegment[anchorIt->second].push_back(&use);
+  }
+
+  if (usesBySegment.empty())
+    return failure();
+
+  for (auto &entry : usesBySegment) {
+    Operation *logicalScopeAnchor = entry.first;
+    SmallVectorImpl<OpOperand *> &uses = entry.second;
+    Value replacement;
+    if (auto cacheIt = cache.find(value); cacheIt != cache.end()) {
+      auto anchorIt = cacheIt->second.find(logicalScopeAnchor);
+      if (anchorIt != cacheIt->second.end())
+        replacement = anchorIt->second;
+    }
+
+    if (!replacement) {
+      if (!logicalScopeAnchor)
+        return failure();
+
+      llvm::DenseMap<Operation *, Operation *> clones;
+      FailureOr<Operation *> clonedProducer =
+          cloneVecScopeProducerForUse(value, logicalScopeAnchor,
+                                      logicalScopeAnchor, cache, context,
+                                      clones);
+      if (failed(clonedProducer))
+        return failure();
+
+      replacement = (*clonedProducer)->getResult(result.getResultNumber());
+      cache[value][logicalScopeAnchor] = replacement;
+    }
+
+    for (OpOperand *use : uses)
+      use->set(replacement);
+  }
+
+  return success();
 }
 
 static bool findEscapingMovedResult(
@@ -490,8 +657,117 @@ static LogicalResult wrapGreedySubclusters(ArrayRef<Operation *> ops,
   return success();
 }
 
+static FailureOr<bool> fixOneEscapingSubcluster(ArrayRef<Operation *> ops,
+                                                SegmentRematCache &cache,
+                                                MLIRContext *context) {
+  for (size_t begin = 0; begin < ops.size();) {
+    size_t bestEnd = begin;
+    EscapingMovedValue escapingValue;
+    bool sawEscapingMovedResult = false;
+    size_t escapingCandidateBegin = begin;
+    size_t escapingCandidateEnd = begin;
+
+    for (size_t end = ops.size(); end > begin; --end) {
+      ArrayRef<Operation *> candidate = ops.slice(begin, end - begin);
+      if (!hasVectorOperation(candidate))
+        continue;
+
+      ResultlessScopePlan ignoredPlan;
+      EscapingMovedValue candidateEscapingValue;
+      if (succeeded(buildResultlessScopePlan(candidate, ignoredPlan,
+                                             candidateEscapingValue))) {
+        bestEnd = end;
+        break;
+      }
+
+      if (!sawEscapingMovedResult && candidateEscapingValue.producer) {
+        escapingValue = candidateEscapingValue;
+        sawEscapingMovedResult = true;
+        escapingCandidateBegin = begin;
+        escapingCandidateEnd = end;
+      }
+    }
+
+    if (bestEnd == begin) {
+      if (classifyOperationForInference(ops[begin]) ==
+              VPTOInferenceOpClass::Vector &&
+          sawEscapingMovedResult && escapingValue.requiresDiagnostic) {
+        ArrayRef<Operation *> escapingCandidate =
+            ops.slice(escapingCandidateBegin,
+                      escapingCandidateEnd - escapingCandidateBegin);
+        llvm::SmallPtrSet<Operation *, 16> movedOps =
+            computeMovedOpsForResultlessScope(escapingCandidate);
+        Block *block = ops.front()->getBlock();
+        if (!block)
+          return false;
+
+        if (succeeded(rematerializeEscapingValueForUserSegments(
+                escapingValue.value, movedOps, *block, cache, context)))
+          return true;
+        return false;
+      }
+      ++begin;
+      continue;
+    }
+
+    begin = bestEnd;
+  }
+
+  return false;
+}
+
+static LogicalResult repairEscapingSubclusters(Block &block,
+                                               MLIRContext *context) {
+  constexpr unsigned kMaxRepairIterations = 256;
+  SegmentRematCache cache;
+  for (unsigned iteration = 0; iteration < kMaxRepairIterations; ++iteration) {
+    bool changedInIteration = false;
+    SmallVector<Operation *, 32> pending;
+    SmallVector<Operation *, 32> ops;
+    for (Operation &op : block)
+      ops.push_back(&op);
+
+    auto flush = [&]() -> FailureOr<bool> {
+      FailureOr<bool> changed =
+          fixOneEscapingSubcluster(pending, cache, context);
+      pending.clear();
+      return changed;
+    };
+
+    for (Operation *op : ops) {
+      switch (classifyOperationForInference(op)) {
+      case VPTOInferenceOpClass::Vector:
+      case VPTOInferenceOpClass::SafeScalar:
+        pending.push_back(op);
+        break;
+      case VPTOInferenceOpClass::Boundary: {
+        FailureOr<bool> changed = flush();
+        if (failed(changed))
+          return failure();
+        changedInIteration |= *changed;
+        break;
+      }
+      }
+      if (changedInIteration)
+        break;
+    }
+
+    if (changedInIteration)
+      continue;
+
+    FailureOr<bool> changed = flush();
+    if (failed(changed))
+      return failure();
+    if (!*changed)
+      return success();
+  }
+
+  return failure();
+}
+
 static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
-  cloneSharedMaskProducers(block, context);
+  if (failed(repairEscapingSubclusters(block, context)))
+    return failure();
 
   SmallVector<Operation *, 16> pending;
 

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -649,6 +649,8 @@ everything available in auto — tiles, Tile Ops, sub-kernels — and additional
 gain access to MTE ops, explicit synchronization, and pointer manipulation.
 When you need precise control over individual instructions and phase ordering,
 you can drop below the tile abstraction without leaving the `@pto.jit` entry.
+When you want to delineate an authored vector interval directly in the public
+PTODSL surface, use `with pto.vecscope():` inside an explicit-mode kernel body.
 
 The richer type surface also applies to sub-kernels: in auto mode, a
 sub-kernel's parameters are restricted to `Tile` and PTO scalar types; in

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -20,7 +20,7 @@ class PTODSLAstRewriteError(SyntaxError):
     """Raised when AST rewrite sees unsupported Python control flow."""
 
 
-def rewrite_jit_function(fn):
+def rewrite_jit_function(fn, *, static_bindings=None):
     """Return a function whose Python if/for control flow lowers to PTODSL APIs."""
     try:
         source = inspect.getsource(fn)
@@ -42,6 +42,7 @@ def rewrite_jit_function(fn):
     closure_vars = inspect.getclosurevars(fn)
     static_env = dict(fn.__globals__)
     static_env.update(closure_vars.nonlocals)
+    static_env.update(static_bindings or {})
     _inject_closure_defaults(function_def, closure_vars.nonlocals)
     _sanitize_signature_for_exec(function_def)
     function_def = _ConditionalExpressionNormalizer().visit(function_def)
@@ -312,10 +313,10 @@ class _SlotInfoVisitor(ast.NodeVisitor):
 
     def visit_Subscript(self, node):
         if isinstance(node.ctx, ast.Load):
-            self.loads.update(_resolve_subscript_slots(node, self._static_iters, require_static=False))
+            self.loads.update(_resolve_subscript_slots(node, self._static_env, self._static_iters, require_static=False))
             return
         if isinstance(node.ctx, (ast.Store, ast.Del)):
-            slots = _resolve_subscript_slots(node, self._static_iters, require_static=True)
+            slots = _resolve_subscript_slots(node, self._static_env, self._static_iters, require_static=True)
             if slots:
                 self.stores.update(slots)
             else:
@@ -325,7 +326,7 @@ class _SlotInfoVisitor(ast.NodeVisitor):
 
     def visit_AugAssign(self, node):
         if isinstance(node.target, ast.Subscript):
-            slots = _resolve_subscript_slots(node.target, self._static_iters, require_static=True)
+            slots = _resolve_subscript_slots(node.target, self._static_env, self._static_iters, require_static=True)
             if slots:
                 self.loads.update(slots)
                 self.stores.update(slots)
@@ -337,7 +338,7 @@ class _SlotInfoVisitor(ast.NodeVisitor):
 
     def visit_For(self, node):
         if _is_pto_attr_call(node.iter, "static_range") and isinstance(node.target, ast.Name):
-            values = _try_eval_static_range(node.iter, self._static_env)
+            values = _try_eval_static_range(node.iter, self._static_env, self._static_iters)
             if values is None:
                 for stmt in node.body:
                     self.visit(stmt)
@@ -399,7 +400,7 @@ def _slot_live_before_stmt(stmt, live_after, static_env, static_iters) -> set[_S
         )
     if isinstance(stmt, ast.For):
         if _is_pto_attr_call(stmt.iter, "static_range") and isinstance(stmt.target, ast.Name):
-            values = _try_eval_static_range(stmt.iter, static_env)
+            values = _try_eval_static_range(stmt.iter, static_env, static_iters)
             if values is not None:
                 next_static_iters = dict(static_iters)
                 next_static_iters[stmt.target.id] = values
@@ -467,10 +468,10 @@ def _simple_name_targets(target) -> set[str]:
     return set()
 
 
-def _resolve_subscript_slots(node, static_iters, *, require_static) -> set[_SubscriptSlot]:
+def _resolve_subscript_slots(node, static_env, static_iters, *, require_static) -> set[_SubscriptSlot]:
     if not isinstance(node.value, ast.Name):
         return set()
-    index_values = _static_index_values(node.slice, static_iters)
+    index_values = _static_index_values(node.slice, static_env, static_iters)
     if index_values is None:
         return set()
     return {
@@ -479,16 +480,11 @@ def _resolve_subscript_slots(node, static_iters, *, require_static) -> set[_Subs
     }
 
 
-def _static_index_values(node, static_iters):
-    if isinstance(node, ast.Constant) and isinstance(node.value, int) and not isinstance(node.value, bool):
-        return (node.value,)
-    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-        values = _static_index_values(node.operand, static_iters)
-        if values is not None and len(values) == 1:
-            return (-values[0],)
-    if isinstance(node, ast.Name) and node.id in static_iters:
-        return tuple(static_iters[node.id])
-    return None
+def _static_index_values(node, static_env, static_iters):
+    try:
+        return _eval_static_int_values(node, static_env, static_iters)
+    except PTODSLAstRewriteError:
+        return None
 
 
 def _unsupported_subscript_store_message(node) -> str:
@@ -502,11 +498,11 @@ def _unsupported_subscript_store_message(node) -> str:
     )
 
 
-def _try_eval_static_range(call, static_env):
+def _try_eval_static_range(call, static_env, static_iters=None):
     if not _is_pto_attr_call(call, "static_range") or call.keywords:
         return None
     try:
-        values = [_eval_static_int(arg, static_env) for arg in call.args]
+        values = [_eval_static_int(arg, static_env, static_iters) for arg in call.args]
     except PTODSLAstRewriteError:
         return None
     if len(values) == 1:
@@ -518,31 +514,50 @@ def _try_eval_static_range(call, static_env):
     return None
 
 
-def _eval_static_int(node, static_env) -> int:
+def _eval_static_int(node, static_env, static_iters=None) -> int:
+    values = _eval_static_int_values(node, static_env, static_iters or {})
+    if len(values) != 1:
+        raise PTODSLAstRewriteError("static integer expression must resolve to one value")
+    return values[0]
+
+
+def _eval_static_int_values(node, static_env, static_iters) -> tuple[int, ...]:
     if isinstance(node, ast.Constant) and isinstance(node.value, int) and not isinstance(node.value, bool):
-        return node.value
+        return (node.value,)
     if isinstance(node, ast.Name):
+        if node.id in static_iters:
+            return tuple(static_iters[node.id])
         value = static_env.get(node.id, _MISSING_GLOBAL)
         if isinstance(value, int) and not isinstance(value, bool):
-            return value
+            return (value,)
         raise PTODSLAstRewriteError("static value is not an integer")
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.UAdd):
-        return +_eval_static_int(node.operand, static_env)
+        return tuple(+value for value in _eval_static_int_values(node.operand, static_env, static_iters))
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-        return -_eval_static_int(node.operand, static_env)
+        return tuple(-value for value in _eval_static_int_values(node.operand, static_env, static_iters))
     if isinstance(node, ast.BinOp):
-        lhs = _eval_static_int(node.left, static_env)
-        rhs = _eval_static_int(node.right, static_env)
-        if isinstance(node.op, ast.Add):
-            return lhs + rhs
-        if isinstance(node.op, ast.Sub):
-            return lhs - rhs
-        if isinstance(node.op, ast.Mult):
-            return lhs * rhs
-        if isinstance(node.op, ast.FloorDiv):
-            return lhs // rhs
-        if isinstance(node.op, ast.Mod):
-            return lhs % rhs
+        lhs_values = _eval_static_int_values(node.left, static_env, static_iters)
+        rhs_values = _eval_static_int_values(node.right, static_env, static_iters)
+        values = []
+        seen = set()
+        for lhs in lhs_values:
+            for rhs in rhs_values:
+                if isinstance(node.op, ast.Add):
+                    value = lhs + rhs
+                elif isinstance(node.op, ast.Sub):
+                    value = lhs - rhs
+                elif isinstance(node.op, ast.Mult):
+                    value = lhs * rhs
+                elif isinstance(node.op, ast.FloorDiv):
+                    value = lhs // rhs
+                elif isinstance(node.op, ast.Mod):
+                    value = lhs % rhs
+                else:
+                    raise PTODSLAstRewriteError("unsupported static integer expression")
+                if value not in seen:
+                    seen.add(value)
+                    values.append(value)
+        return tuple(values)
     raise PTODSLAstRewriteError("unsupported static integer expression")
 
 
@@ -741,7 +756,7 @@ class _SlotCarryRewriter(ast.NodeTransformer):
 
     def visit_For(self, node):
         if _is_pto_attr_call(node.iter, "static_range") and isinstance(node.target, ast.Name):
-            values = _try_eval_static_range(node.iter, self._static_env)
+            values = _try_eval_static_range(node.iter, self._static_env, self._static_iters)
             old = self._static_iters.get(node.target.id)
             if values is not None:
                 self._static_iters[node.target.id] = values
@@ -758,7 +773,7 @@ class _SlotCarryRewriter(ast.NodeTransformer):
         return self.generic_visit(node)
 
     def visit_Subscript(self, node):
-        slots = _resolve_subscript_slots(node, self._static_iters, require_static=False)
+        slots = _resolve_subscript_slots(node, self._static_env, self._static_iters, require_static=False)
         if slots and len({slot.base for slot in slots}) == 1:
             base = next(iter(slots)).base
             if base in self._slot_maps and slots <= set(self._slot_maps[base]["slots"]):
@@ -1070,7 +1085,7 @@ class _ControlFlowRewriter:
         if _is_pto_attr_call(stmt.iter, "static_range"):
             next_static_iters = dict(static_iters)
             if isinstance(stmt.target, ast.Name):
-                values = _try_eval_static_range(stmt.iter, self._static_env)
+                values = _try_eval_static_range(stmt.iter, self._static_env, static_iters)
                 if values is not None:
                     next_static_iters[stmt.target.id] = values
             stmt.body = self.rewrite_block(

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -22,6 +22,7 @@ Public API
 """
 
 from ._bootstrap import make_context  # noqa: F401
+from ._diagnostics import explicit_mode_required_with_context_error
 from ._runtime_index_ops import coerce_runtime_index
 from ._scalar_coercion import coerce_scalar_to_type
 from ._surface_types import const_expr
@@ -34,10 +35,19 @@ from mlir.ir import InsertionPoint
 
 # ── vecscope ──────────────────────────────────────────────────────────────────
 
+def _require_explicit_mode(surface: str):
+    session = current_session()
+    if session is None:
+        return
+    current_module_spec = getattr(session, "current_function_module_spec", session.module_spec)
+    if getattr(current_module_spec, "mode", None) != "explicit":
+        raise explicit_mode_required_with_context_error(surface, current_module_spec)
+
 class _VecScopeCM:
     """Context manager for ``pto.vecscope { … }``."""
 
     def __enter__(self):
+        _require_explicit_mode("pto.vecscope()")
         self._op = _pto.VecScopeOp()
         self._block = self._op.body.blocks.append()
         self._ip = InsertionPoint(self._block)

--- a/ptodsl/ptodsl/_diagnostics.py
+++ b/ptodsl/ptodsl/_diagnostics.py
@@ -487,9 +487,6 @@ def unsupported_public_surface_error(name: str) -> AttributeError:
             "Use pto.alloc_tile(shape=..., dtype=..., memory_space=..., valid_shape=..., addr=...) "
             "to author tiles, and keep explicit tile-type construction inside internal implementation code only."
         ),
-        "vecscope": (
-            "Use @pto.tileop for named single-core helpers, or inline compute code with `with pto.tileop():`."
-        ),
         "as_ptr": (
             "Use tile.as_ptr(), view.as_ptr(), or partition.as_ptr() on the authored object itself "
             "instead of the removed pto.as_ptr(...) helper."

--- a/ptodsl/ptodsl/_kernel_compilation.py
+++ b/ptodsl/ptodsl/_kernel_compilation.py
@@ -83,13 +83,21 @@ class KernelCompiler:
         self._callback = callback
         self._kernel_identity = id(callback)
         self._ast_rewrite = ast_rewrite
-        self._trace_callback = None
+        self._trace_callback_cache = {}
         self._compiled_cache = {}
 
-    def tracing_callback(self):
-        if self._trace_callback is None:
-            self._trace_callback = rewrite_jit_function(self._callback) if self._ast_rewrite else self._callback
-        return self._trace_callback
+    def tracing_callback(self, constexpr_bindings=None):
+        if not self._ast_rewrite:
+            return self._callback
+        cache_key = tuple(
+            (name, constexpr_bindings[name])
+            for name in sorted(constexpr_bindings or {})
+        )
+        cached = self._trace_callback_cache.get(cache_key)
+        if cached is None:
+            cached = rewrite_jit_function(self._callback, static_bindings=constexpr_bindings)
+            self._trace_callback_cache[cache_key] = cached
+        return cached
 
     def compile(self, **constexpr_bindings):
         if self._module_spec.entry is False:
@@ -112,7 +120,7 @@ class KernelCompiler:
         if cached is not None:
             return cached
 
-        callback = self.tracing_callback()
+        callback = self.tracing_callback(normalized_bindings)
         runtime = SignatureTracingRuntime(
             self._module_spec,
             self._kernel_signature,

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -152,6 +152,7 @@ from ._ops import (             # noqa: F401
 
 # ── Control flow ──────────────────────────────────────────────────────────────
 from ._control_flow import (    # noqa: F401
+    vecscope,
     for_, if_, yield_,
     static_range,
     LoopHandle, BranchHandle,
@@ -184,6 +185,6 @@ PAT = MaskPattern
 
 
 def __getattr__(name):
-    if name in {"ukernel", "tile_buf_type", "vecscope", "as_ptr", "vbrc_load", "vsts_1pt", "constexpr", "copy_ubuf_to_ubuf", "tensor_spec", "TensorSpec"}:
+    if name in {"ukernel", "tile_buf_type", "as_ptr", "vbrc_load", "vsts_1pt", "constexpr", "copy_ubuf_to_ubuf", "tensor_spec", "TensorSpec"}:
         raise unsupported_public_surface_error(name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -1370,6 +1370,52 @@ def ast_runtime_for_static_slot_carry_probe(cols: pto.i32):
     _ = total
 
 
+_STATIC_SLOT_GLOBAL_INDEX = 2
+
+
+@pto.jit(target="a5")
+def ast_runtime_for_static_slot_global_index_probe(cols: pto.i32):
+    zero = pto.const(0, dtype=pto.index)
+    accs = [zero for _ in pto.static_range(4)]
+
+    for c in range(cols):
+        accs[_STATIC_SLOT_GLOBAL_INDEX] = accs[_STATIC_SLOT_GLOBAL_INDEX] + c
+
+    total = zero
+    for h in pto.static_range(4):
+        total = total + accs[h]
+    _ = total
+
+
+@pto.jit(target="a5")
+def ast_runtime_for_static_slot_binop_index_probe(cols: pto.i32):
+    zero = pto.const(0, dtype=pto.index)
+    accs = [zero for _ in pto.static_range(5)]
+
+    for c in range(cols):
+        for h in pto.static_range(4):
+            accs[h + 1] = accs[h + 1] + c
+
+    total = zero
+    for h in pto.static_range(5):
+        total = total + accs[h]
+    _ = total
+
+
+@pto.jit(target="a5")
+def ast_runtime_for_static_slot_constexpr_index_probe(cols: pto.i32, *, SLOT: pto.const_expr = 2):
+    zero = pto.const(0, dtype=pto.index)
+    accs = [zero for _ in pto.static_range(4)]
+
+    for c in range(cols):
+        accs[SLOT] = accs[SLOT] + c
+
+    total = zero
+    for h in pto.static_range(4):
+        total = total + accs[h]
+    _ = total
+
+
 @pto.jit(target="a5")
 def ast_runtime_for_dynamic_slot_store_error_probe(cols: pto.i32):
     zero = pto.const(0, dtype=pto.index)
@@ -5502,6 +5548,35 @@ def main() -> None:
         "iter_args(" in ast_runtime_for_static_slot_carry_text
         and "scf.yield" in ast_runtime_for_static_slot_carry_text,
         "static subscript slot carry should lower through scf.for iter_args",
+    )
+    ast_runtime_for_static_slot_global_index_text = ast_runtime_for_static_slot_global_index_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_runtime_for_static_slot_global_index_text,
+        "AST-rewritten runtime for global static subscript slot carry specialization",
+    )
+    expect(
+        ast_runtime_for_static_slot_global_index_text.count("scf.for") == 1,
+        "module-global static slot indices should lower through the authored runtime loop",
+    )
+    ast_runtime_for_static_slot_binop_index_text = ast_runtime_for_static_slot_binop_index_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        ast_runtime_for_static_slot_binop_index_text,
+        "AST-rewritten runtime for BinOp static subscript slot carry specialization",
+    )
+    expect(
+        ast_runtime_for_static_slot_binop_index_text.count("scf.for") == 1,
+        "BinOp static slot indices should lower through the authored runtime loop",
+    )
+    ast_runtime_for_static_slot_constexpr_index_text = (
+        ast_runtime_for_static_slot_constexpr_index_probe.compile(SLOT=2).mlir_text()
+    )
+    expect_parse_roundtrip_and_verify(
+        ast_runtime_for_static_slot_constexpr_index_text,
+        "AST-rewritten runtime for constexpr static subscript slot carry specialization",
+    )
+    expect(
+        ast_runtime_for_static_slot_constexpr_index_text.count("scf.for") == 1,
+        "constexpr static slot indices should lower through the authored runtime loop",
     )
     expect_raises(
         PTODSLAstRewriteError,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3304,6 +3304,17 @@ def vdup_surface_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def vecscope_surface_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    ub_f32 = pto.castptr(zero_u64, pto.ptr(pto.f32, "ub"))
+    zero = pto.const(0)
+    with pto.vecscope():
+        mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
+        vec_f32 = pto.vlds(ub_f32, zero)
+        pto.vsts(vec_f32, ub_f32, zero, mask32_full)
+
+
+@pto.jit(target="a5", mode="explicit")
 def vdup_surface_invalid_scalar_position_probe():
     mask32_full = pto.pset_b32(pto.MaskPattern.ALL)
     _ = pto.vdup(pto.f32(0), mask32_full, pto.PositionMode.HIGHEST)
@@ -3473,6 +3484,12 @@ def auto_mode_explicit_surface_violation_probe():
     gm_src = pto.castptr(zero_u64, pto.ptr(pto.f16, "gm"))
     ub_dst = pto.castptr(zero_u64, pto.ptr(pto.f16, "ub"))
     pto.mte_gm_ub(gm_src, ub_dst, 0, 256, nburst=(8, 256, 256))
+
+
+@pto.jit(target="a5")
+def auto_mode_vecscope_violation_probe():
+    with pto.vecscope():
+        pass
 
 
 @pto.jit(target="a5")
@@ -3653,7 +3670,7 @@ def main() -> None:
     expect(not hasattr(pto, "get_buf_dyn"), "pto.get_buf_dyn should not remain on the public pto namespace")
     expect(not hasattr(pto, "rls_buf_dyn"), "pto.rls_buf_dyn should not remain on the public pto namespace")
     expect(not hasattr(pto, "tile_buf_type"), "pto.tile_buf_type should not remain on the public pto namespace")
-    expect(not hasattr(pto, "vecscope"), "pto.vecscope should not remain on the public pto namespace")
+    expect(hasattr(pto, "vecscope"), "pto.vecscope should be exported from the public pto namespace")
     expect(not hasattr(pto, "as_ptr"), "pto.as_ptr should not remain on the public pto namespace")
     expect(not hasattr(pto, "vbrc_load"), "pto.vbrc_load should not remain on the public pto namespace")
     expect(not hasattr(pto, "vsts_1pt"), "pto.vsts_1pt should not remain on the public pto namespace")
@@ -3669,10 +3686,9 @@ def main() -> None:
         "pto.tile_buf_type is not a supported PTODSL public interface" in str(removed_tile_buf_type),
         "removed pto.tile_buf_type should diagnose the authored alloc_tile replacement",
     )
-    removed_vecscope = expect_raises(AttributeError, lambda: getattr(pto, "vecscope"))
     expect(
-        "pto.vecscope is not a supported PTODSL public interface" in str(removed_vecscope),
-        "removed pto.vecscope should diagnose the public SIMD replacements",
+        callable(pto.vecscope),
+        "pto.vecscope should expose the public vecscope context manager",
     )
     removed_as_ptr = expect_raises(AttributeError, lambda: getattr(pto, "as_ptr"))
     expect(
@@ -4772,6 +4788,23 @@ def main() -> None:
     expect(
         __file__ in str(auto_mode_violation),
         "auto-mode DMA violation should preserve the authored source file",
+    )
+    auto_mode_vecscope_violation = expect_raises(
+        RuntimeError,
+        auto_mode_vecscope_violation_probe.compile,
+        '@pto.jit(mode="explicit")',
+    )
+    expect(
+        "auto-mode contract violation" in str(auto_mode_vecscope_violation),
+        "auto-mode vecscope use should be diagnosed as an auto-mode contract violation",
+    )
+    expect(
+        "pto.vecscope()" in str(auto_mode_vecscope_violation),
+        "auto-mode vecscope violation should identify the explicit-only surface",
+    )
+    expect(
+        "auto_mode_vecscope_violation_probe" in str(auto_mode_vecscope_violation),
+        "auto-mode vecscope violation should identify the authored kernel name",
     )
     merged_cross_mode_text = str(pto.merge_jit_modules(host_vec_copy.compile(), host_vec_copy_explicit.compile()))
     expect_parse_roundtrip_and_verify(merged_cross_mode_text, "merged cross-mode PTODSL container")
@@ -6124,6 +6157,8 @@ def main() -> None:
     expect_parse_roundtrip_and_verify(low_precision_vcvt_surface_text, "low-precision vcvt surface specialization")
     vdup_surface_text = vdup_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(vdup_surface_text, "public vdup surface specialization")
+    vecscope_surface_text = vecscope_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(vecscope_surface_text, "public vecscope surface specialization")
     vmulscvt_surface_text = vmulscvt_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(vmulscvt_surface_text, "public vmulscvt surface specialization")
     vmula_surface_text = vmula_surface_probe.compile().mlir_text()
@@ -6461,6 +6496,9 @@ def main() -> None:
     expect("f32, !pto.mask<b32> -> !pto.vreg<64xf32>" in vdup_surface_text, "vdup(scalar_f32, mask_b32) should infer an f32 vector result type")
     expect(vdup_surface_text.count('position = "LOWEST"') >= 1, "vdup(vec, mask) should default position to LOWEST")
     expect('position = "HIGHEST"' in vdup_surface_text, "vdup(vec, mask, PositionMode.HIGHEST) should preserve the authored position")
+    expect(vecscope_surface_text.count("pto.vecscope") == 1, "pto.vecscope() should lower exactly one vecscope region")
+    expect("pto.vlds" in vecscope_surface_text, "public vecscope body should allow vector loads")
+    expect("pto.vsts" in vecscope_surface_text, "public vecscope body should allow vector stores")
     expect("pto.vmulscvt" in vmulscvt_surface_text, "vmulscvt(...) should lower to pto.vmulscvt")
     expect('\"A\"' in vmulscvt_surface_text, "vmulscvt(..., rnd=VcvtRoundMode.A) should preserve the authored round token")
     expect('\"EVEN\"' in vmulscvt_surface_text, "vmulscvt(..., part=PartMode.EVEN) should preserve the authored part token")

--- a/test/lit/vpto/auto_vecscope_infer_revert_cse_mask.pto
+++ b/test/lit/vpto/auto_vecscope_infer_revert_cse_mask.pto
@@ -1,0 +1,38 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+// Protects rematerialization of a CSE'd vecscope mask producer across a boundary.
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @auto_vecscope_infer_revert_cse_mask() {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c0_i64 = arith.constant 0 : i64
+    %cst = arith.constant 1.000000e+00 : f32
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+
+    %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %vec0 = pto.vlds %ub[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %sum0 = pto.vadds %vec0, %cst, %mask : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+    pto.vsts %sum0, %ub[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    pto.barrier #pto.pipe<PIPE_ALL>
+    %vec1 = pto.vlds %ub[%c64] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %sum1 = pto.vadds %vec1, %cst, %mask : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+    pto.vsts %sum1, %ub[%c64], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    return
+  }
+  }
+}
+
+// CHECK-LABEL: func.func @auto_vecscope_infer_revert_cse_mask
+// CHECK: pto.vecscope {
+// CHECK: pto.pset_b32
+// CHECK: pto.vlds
+// CHECK: pto.vadds
+// CHECK: pto.vsts
+// CHECK: }
+// CHECK: pto.barrier
+// CHECK: pto.vecscope {
+// CHECK: pto.pset_b32
+// CHECK: pto.vlds
+// CHECK: pto.vadds
+// CHECK: pto.vsts

--- a/test/lit/vpto/auto_vecscope_infer_revert_cse_vdup.pto
+++ b/test/lit/vpto/auto_vecscope_infer_revert_cse_vdup.pto
@@ -1,0 +1,36 @@
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+// Protects rematerialization of a CSE'd vecscope-typed producer across a boundary.
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @auto_vecscope_infer_revert_cse_vdup() {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %zero = builtin.unrealized_conversion_cast %c0_i32 : i32 to ui32
+    %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui32, ub>
+
+    %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %init = pto.vdup %zero, %mask : ui32, !pto.mask<b32> -> !pto.vreg<64xui32>
+    %sum0 = pto.vadd %init, %init, %mask : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+    pto.vsts %sum0, %ub[%c0], %mask : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+    pto.barrier #pto.pipe<PIPE_ALL>
+    %sum1 = pto.vadd %init, %init, %mask : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.mask<b32> -> !pto.vreg<64xui32>
+    pto.vsts %sum1, %ub[%c64], %mask : !pto.vreg<64xui32>, !pto.ptr<ui32, ub>, !pto.mask<b32>
+    return
+  }
+  }
+}
+
+// CHECK-LABEL: func.func @auto_vecscope_infer_revert_cse_vdup
+// CHECK: pto.vecscope {
+// CHECK: pto.vdup
+// CHECK: pto.vadd
+// CHECK: pto.vsts
+// CHECK: }
+// CHECK: pto.barrier
+// CHECK: pto.vecscope {
+// CHECK: pto.vdup
+// CHECK: pto.vadd
+// CHECK: pto.vsts

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -2698,14 +2698,12 @@ static void prepareVPTOForEmission(PassManager &pm) {
       pto::createPTOUnrollSIMTForPass());
   kernelModulePM.addPass(createSCCPPass());
   kernelModulePM.addPass(createCanonicalizerPass());
-  kernelModulePM.addPass(createCSEPass());
   kernelModulePM.addPass(pto::createVPTOPtrNormalizePass());
   kernelModulePM.addPass(pto::createVPTOPtrCastCleanupPass());
   kernelModulePM.addPass(pto::createVPTONormalizeEquivalentVcvtPass());
   kernelModulePM.addPass(createReconcileUnrealizedCastsPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       createVPTOExpandWrapperOpsPass());
-  kernelModulePM.addPass(createCSEPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTOInferVPTOVecScopePass());
   if (enableSoftPostUpdate)


### PR DESCRIPTION
## What's changed
- refactor vecscope inference to fix leaked variables after vecscope inference
- remove some unnessary CSE pass
- support more static value type IV in static_range
- support pto.vecscope context manager in explicit mode