### PR TITLE
fix(ptodsl): accept max_regs as compatibility argument

### DIFF
--- a/docs/designs/ptodsl-simt-micro-op-api-design.md
+++ b/docs/designs/ptodsl-simt-micro-op-api-design.md
@@ -291,7 +291,7 @@ SIMT entry functions may carry an optional VPTO attribute:
 PTO-DSL exposes it through `@pto.simt`:
 
 ```python
-@pto.simt(max_threads=256)
+@pto.simt(max_threads=256, max_regs=48)
 def body(...):
     ...
 ```
@@ -305,9 +305,10 @@ func.func @body(...) attributes {
 }
 ```
 
-Lowering attaches the attribute to the generated specialized helper function,
-not to the authored Python symbol. Omitting the argument emits no explicit
-attribute and lets the backend default (1024) apply.
+Lowering attaches the `max_threads` attribute to the generated specialized helper
+function, not to the authored Python symbol. `max_regs` is accepted only for source
+compatibility and emits no attribute; the backend derives the register budget from
+`max_threads`.
 
 Validation:
 
@@ -430,10 +431,8 @@ Minimum Python/frontend tests:
    produces distinct helper functions and distinct traced bodies.
 8. `pto.simt_launch` callee attributes reference the actual generated helper
    symbols.
-9. `@pto.simt(max_threads=...)` emits `pto.simt_max_threads` on the generated
-   helper function. The register budget (`simt-max-registers`) is automatically
-   derived from `max_threads` by the backend according to the hardware resource
-   partition and is no longer a configurable attribute.
+9. `@pto.simt(max_threads=..., max_regs=...)` emits only `pto.simt_max_threads` on
+   the generated helper function; `max_regs` remains a no-op compatibility argument.
 
 Suggested lit/frontend assertions:
 

--- a/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
+++ b/ptodsl/docs/user_guide/03-kernel-entry-and-subkernels.md
@@ -964,7 +964,7 @@ Parameters are `Tile` references, typed UB pointers, and PTO scalars. The
 sub-kernel reads and writes individual elements through tile handles; results
 flow back to the caller via mutable tile parameters.
 
-**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None)`
+**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None, max_regs=None)`
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"kernel_entry.simt_signature","symbol":"kernel_entry_simt_signature_probe","compile":{"BLOCK":8}} -->
 ```python
@@ -1004,31 +1004,31 @@ in parallel, making it efficient for per-element operations.
 
 #### SIMT resource attributes
 
-An optional `max_threads` argument attaches a VPTO resource attribute
-to the generated `pto.simt_entry` helper.
+The optional `max_threads` argument attaches a VPTO resource attribute to the
+generated `pto.simt_entry` helper. `max_regs` is accepted for source compatibility
+but does not emit an attribute or otherwise affect code generation.
 
-**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None)`
+**Signature**: `@pto.simt(fn=None, *, name=None, target="a5", max_threads=None, max_regs=None)`
 
 **Parameters**:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `max_threads` | positive Python `int` | backend default `1024` | Compile-time launch envelope for this SIMT helper |
+| `max_regs` | positive Python `int` | `None` | Compatibility argument; accepted and validated but otherwise ignored |
 
 `max_threads` is not the launch size. The actual work-item count comes from the
-SIMT launch dimensions. The argument must be a Python integer known at trace
-time, greater than zero, and fit in signless `i32`. It is only valid on
-decorated SIMT helper functions, not inline `with pto.simt():` scopes.
+SIMT launch dimensions. Both arguments must be Python integers known at trace
+time, greater than zero, and fit in signless `i32`.
 
-The per-workitem register budget (`simt-max-registers`) is automatically
-derived from `max_threads` by the VPTO backend according to the hardware
-resource partition.
+The per-workitem register budget (`simt-max-registers`) is automatically derived
+from `max_threads` by the VPTO backend according to the hardware resource partition.
 
 **Example**:
 
 <!-- ptodsl-doc-test: {"mode":"compile","symbol":"kernel_entry_simt_resource_probe","compile":{}} -->
 ```python
-@pto.simt(max_threads=256)
+@pto.simt(max_threads=256, max_regs=48)
 def write_tid(dst: pto.ptr(pto.i32, "gm")):
     tid = pto.get_tid_x()
     idx = scalar.index_cast(tid)

--- a/ptodsl/ptodsl/_subkernels.py
+++ b/ptodsl/ptodsl/_subkernels.py
@@ -594,8 +594,10 @@ def simt(
     target: str = "a5",
     ast_rewrite: bool = True,
     max_threads: int | None = None,
+    max_regs: int | None = None,
 ):
     max_threads = _validate_simt_resource_attr("max_threads", max_threads)
+    _validate_simt_resource_attr("max_regs", max_regs)
     simt_inline_dims = None
     if fn is not None and not callable(fn):
         dims = (fn, *dims)

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -829,7 +829,7 @@ def simt_grouped_query_probe():
     pto.keep(grid_z, slot=8)
 
 
-@pto.simt(max_threads=256)
+@pto.simt(max_threads=256, max_regs=48)
 def simt_resource_attr_probe():
     pto.get_tid_x()
 
@@ -5158,12 +5158,21 @@ def main() -> None:
             r"func\.func @simt_resource_attr_probe__simt_\d+\(\) attributes \{pto\.simt_entry, pto\.simt_max_threads = 256 : i32\}",
             simt_resource_attr_text,
         ) is not None,
-        "@pto.simt(max_threads=...) should attach resource attrs to the helper function",
+        "@pto.simt(max_threads=..., max_regs=...) should only attach max_threads to the helper function",
+    )
+    expect(
+        "pto.simt_max_regs" not in simt_resource_attr_text,
+        "@pto.simt(max_regs=...) is accepted for compatibility but must not emit an attribute",
     )
     expect_raises(
         ValueError,
         lambda: pto.simt(max_threads=0)(lambda: None),
         "max_threads",
+    )
+    expect_raises(
+        TypeError,
+        lambda: pto.simt(max_regs=True)(lambda: None),
+        "max_regs",
     )
 
     def _enter_inline_simt_with_resource_attr():


### PR DESCRIPTION
## Summary

- restore `max_regs` as an accepted `@pto.simt` compatibility argument
- validate it with the existing positive-integer resource argument checks
- intentionally discard it before tracing so no `pto.simt_max_regs` attribute or codegen behavior is restored
- document the compatibility-only behavior

This is a scoped compatibility follow-up to #955 rather than a full revert.

## Validation

- `python3 -m py_compile ptodsl/ptodsl/_subkernels.py ptodsl/tests/test_jit_compile.py`
- `git diff --check`
- production-code search confirms there is no `simt_max_regs` field or `pto.simt_max_regs` emission

The full `ptodsl/tests/test_jit_compile.py` could not run in the local checkout because the existing build-tree Python environment does not provide `mlir.ir`.
