### PR TITLE
fix(vmi): generalize group broadcast selector lowering

### DIFF
--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1104,13 +1104,13 @@ def VMILowerUnifiedToLegacy : Pass<"vmi-lower-unified-to-legacy", "ModuleOp"> {
       C2: vcvt        →  legacy extf/truncf/fptosi/sitofp/extsi/extui/trunci
       C3: vload/vstore  →  legacy load/store variants
       C4: pset/pge    →  create_mask/create_group_mask
-      C5: vadds/vmuls/vmaxs/vmins/vshls/vshrs
+      C5: vadds/vmaxs/vmins/vshls/vshrs
           →  broadcast + legacy binary, discarding mask/pmode; vshrs selects
              shrui for explicit unsigned elements and shrsi otherwise
       C6: vcadd/vcmax/vcmin  →  legacy reduce variants
 
     Ops NOT lowered (no legacy equivalent — require direct VMIToVPTO 1:N patterns):
-      plt, vhist, vintlv, vdintlv, vselr,
+      plt, vmuls, vhist, vintlv, vdintlv, vselr,
       vgather, vgatherb, vscatter,
       vexpdif, vaxpy, vlrelu, vprelu, vmull, vmula
   }];

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -650,6 +650,11 @@ struct LayoutSolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
+      if (auto vmuls = dyn_cast<VMIMulSOp>(op)) {
+        if (failed(unite(vmuls.getSrc(), vmuls.getResult(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
       if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
         if (failed(constrainElementwiseBinary(vmull.getAMutable(),
                                               vmull.getBMutable(),

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -170,7 +170,7 @@ public:
 
 static bool isSameLayoutOp(Operation *op) {
   return isa<VMIAddFOp, VMIAddIOp, VMISubFOp, VMISubIOp, VMIMulFOp, VMIMulIOp,
-             VMIVmullOp, VMIFmaOp, VMIDivFOp, VMIMinFOp, VMIMinIOp,
+             VMIMulSOp, VMIVmullOp, VMIFmaOp, VMIDivFOp, VMIMinFOp, VMIMinIOp,
              VMIMaxFOp, VMIMaxIOp, VMINegFOp,
              VMIAbsFOp, VMIAbsIOp, VMISqrtOp, VMIExpOp, VMILnOp, VMIReluOp,
              VMIFPToSIOp, VMISIToFPOp, VMIAndIOp, VMIOrIOp, VMIXOrIOp,

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -52,11 +52,12 @@
 //   pge  → create_mask(N lanes)
 //   plt  → create_mask(min(rem, L))
 //
-// Category C5 — vector-scalar ops, one-step to legacy (6 ops):
-//   vadds/vmuls/vmaxs/vmins/vshls/vshrs
+// Category C5 — vector-scalar ops, one-step to legacy (5 ops):
+//   vadds/vmaxs/vmins/vshls/vshrs
 //     → broadcast scalar → legacy binary
 //   vshrs selects shrui for unsigned/signless elements and shrsi for
 //   explicitly signed elements.
+//   vmuls is kept unified for direct VMI-to-VPTO lowering.
 //
 // Category C3 — unified load/store (2 ops, dispatch by dist_mode/group):
 //   vload → load / deinterleave_load / group_load
@@ -81,8 +82,8 @@
 //   vprelu  → maxf + minf + mulf + addf
 //   Category C7/C8/C9 bypass mask/pmode synthesis here and skip pmode="merge".
 //
-// Category D — no legacy equivalent (explicitly skipped, 5 ops):
-//   vintlv vdintlv vselr vgatherb vmull
+// Category D — no legacy equivalent (explicitly skipped, 6 ops):
+//   vmuls vintlv vdintlv vselr vgatherb vmull
 //
 //===----------------------------------------------------------------------===//
 
@@ -740,7 +741,7 @@ static LogicalResult lowerPge(VMIPgeOp op, OpBuilder &builder) {
 // Category C5 helpers: vector-scalar ops (one-step to legacy)
 //===----------------------------------------------------------------------===//
 
-/// Lower a unified vector-scalar op (vadds, vmuls, ...) to a legacy chain:
+/// Lower a unified vector-scalar op (vadds, vmaxs, ...) to a legacy chain:
 ///   %brc  = vmi.broadcast %scalar
 ///   %raw  = legacy.op %src, %brc
 template <typename VecScalarOp>
@@ -1165,8 +1166,7 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
         // Category C4
         isa<VMIPsetOp, VMIPgeOp, VMIPltOp>(op) ||
         // Category C5
-        isa<VMIAddSOp, VMIMulSOp, VMIMaxSOp, VMIMinSOp, VMIShlSOp,
-            VMIShrSOp>(op) ||
+        isa<VMIAddSOp, VMIMaxSOp, VMIMinSOp, VMIShlSOp, VMIShrSOp>(op) ||
         // Category C6 — unified reduce (partial coverage)
         isa<VMIvcaddOp, VMIvcmaxOp, VMIvcminOp>(op) ||
         // Category C7 — fused multiply-add family → legacy fma
@@ -1178,10 +1178,10 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       worklist.push_back(op);
 
     // Category D — no legacy equivalent (require direct VMIToVPTO lowering):
-    //   plt, vintlv, vdintlv, vselr, vgatherb, vmull
+    //   plt, vmuls, vintlv, vdintlv, vselr, vgatherb, vmull
     // These are intentionally NOT added to the worklist — they flow through
     // to VMIToVPTO which must provide direct 1:N lowering patterns.
-    if (isa<VMIVintlvOp, VMIVdintlvOp, VMIVselrOp,
+    if (isa<VMIMulSOp, VMIVintlvOp, VMIVdintlvOp, VMIVselrOp,
             VMIVgatherbOp, VMIVmullOp>(op)) {
       op->emitRemark("VMI unified op has no legacy equivalent — "
                      "requires direct VMIToVPTO 1:N lowering");
@@ -1316,17 +1316,6 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
         if (isFloatType(elemType))
           return builder.create<VMIAddFOp>(loc, ty, lhs, rhs).getResult();
         return builder.create<VMIAddIOp>(loc, ty, lhs, rhs).getResult();
-      };
-      (void)lowerVecScalar(vop, builder, createLegacy);
-      continue;
-    }
-
-    if (auto vop = dyn_cast<VMIMulSOp>(op)) {
-      Type elemType = getVMIElementType(vop.getSrc());
-      auto createLegacy = [&](Location loc, Type ty, Value lhs, Value rhs) -> Value {
-        if (isFloatType(elemType))
-          return builder.create<VMIMulFOp>(loc, ty, lhs, rhs).getResult();
-        return builder.create<VMIMulIOp>(loc, ty, lhs, rhs).getResult();
       };
       (void)lowerVecScalar(vop, builder, createLegacy);
       continue;

--- a/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
+++ b/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
@@ -231,6 +231,12 @@ struct MaskGranularitySolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
+      if (auto vmuls = dyn_cast<VMIMulSOp>(op)) {
+        if (failed(requestMaskUseForSource(vmuls.getMaskMutable(),
+                                           vmuls.getSrc(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
       if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
         if (failed(requestMaskUse(vmull.getMaskMutable(), "b32", op)))
           return WalkResult::interrupt();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3145,83 +3145,6 @@ LogicalResult checkContiguousFullGroupChunks(
   return success();
 }
 
-LogicalResult checkFullGroupSlotSourceShape(
-    Operation *op, VMIVRegType type, int64_t groupSize, int64_t numGroups,
-    int64_t *lanesPerPart, int64_t *groupCount, PatternRewriter &rewriter) {
-  auto fail = [&](const Twine &message) {
-    return rewriter.notifyMatchFailure(op, message);
-  };
-
-  VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isGroupSlots() || layout.getNumGroups() != numGroups)
-    return fail("group slot op requires matching num_groups VMI layout");
-  if (type.getElementCount() != numGroups)
-    return fail("group slot op requires one logical lane per group");
-  FailureOr<int64_t> lanes = getDataLanesPerPart(type.getElementType());
-  if (failed(lanes))
-    return fail("group slot op requires known physical lanes per part");
-  if (groupSize <= 0)
-    return fail("group slot op requires positive derived group size");
-  if (*lanes % groupSize != 0 && groupSize % *lanes != 0)
-    return fail("group slot op requires group size to divide or be a "
-                "multiple of physical lanes per part");
-
-  *lanesPerPart = *lanes;
-  *groupCount = numGroups;
-  return success();
-}
-
-LogicalResult checkFullGroupBroadcastResultShape(
-    Operation *op, VMIVRegType type, int64_t groupSize, int64_t lanesPerPart,
-    int64_t *layoutFactor, int64_t *groupCount, PatternRewriter &rewriter) {
-  auto fail = [&](const Twine &message) {
-    return rewriter.notifyMatchFailure(op, message);
-  };
-
-  VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
-    return fail("group_broadcast result requires assigned VMI layout");
-  if (layout.isGroupSlots())
-    return fail("group_broadcast result requires a dense VMI layout");
-  bool laneStridedDense = layout.isDense() && layout.getLaneStride() > 1;
-  if (!laneStridedDense && failed(checkFullDataPhysicalChunks(type, nullptr)))
-    return fail("group_broadcast result requires full physical chunks");
-  FailureOr<int64_t> resultLanes = getDataLanesPerPart(type.getElementType());
-  if (failed(resultLanes) || *resultLanes != lanesPerPart)
-    return fail("group_broadcast result requires matching physical lanes");
-  if (groupSize <= 0 || type.getElementCount() % groupSize != 0)
-    return fail("group_broadcast result requires derived group size to evenly "
-                "divide lane count");
-  FailureOr<int64_t> factor = getDataLayoutFactor(type);
-  if (failed(factor))
-    return fail("group_broadcast result requires known layout factor");
-
-  if (*factor == 1) {
-    if (lanesPerPart % groupSize != 0 && groupSize % lanesPerPart != 0)
-      return fail("group_broadcast contiguous result requires group size to "
-                  "divide or be a multiple of physical lanes per part");
-  } else {
-    FailureOr<int64_t> blockElems = getVMILayoutBlockElems(type);
-    bool blockFragmentSmallGroup =
-        layout.isBlockDeinterleaved() && succeeded(blockElems) &&
-        groupSize < lanesPerPart && lanesPerPart % *blockElems == 0;
-    bool deinterleavedSmallGroup =
-        layout.isDeinterleaved() &&
-        groupSize < lanesPerPart && groupSize >= *factor &&
-        groupSize % *factor == 0 && lanesPerPart % (groupSize / *factor) == 0;
-    int64_t logicalSpanPerResultChunk = lanesPerPart * *factor;
-    if (!blockFragmentSmallGroup && !deinterleavedSmallGroup &&
-        (groupSize < lanesPerPart ||
-         groupSize % logicalSpanPerResultChunk != 0))
-      return fail("group_broadcast deinterleaved result requires every "
-                  "physical result chunk to stay within one logical group");
-  }
-
-  *layoutFactor = *factor;
-  *groupCount = type.getElementCount() / groupSize;
-  return success();
-}
-
 FailureOr<Value> createZeroVector(Location loc, VRegType type,
                                   PatternRewriter &rewriter) {
   FailureOr<Value> zero =
@@ -3287,78 +3210,6 @@ FailureOr<Value> createGroupSlotIndexVector(Location loc, VRegType indexType,
                       .getResult();
     result = rewriter.create<VselOp>(loc, indexType, splat, result, *laneMask)
                  .getResult();
-  }
-  return result;
-}
-
-FailureOr<Value> createMappedGroupSlotIndexVector(
-    Location loc, VMIVRegType resultVMIType, int64_t part, int64_t chunk,
-    VRegType indexType, int64_t groupSize, int64_t slots, int64_t &sourceChunk,
-    PatternRewriter &rewriter, int64_t slotLaneStride = 1) {
-  if (groupSize <= 0 || slots <= 0)
-    return failure();
-
-  int64_t lanesPerPart = indexType.getElementCount();
-  SmallVector<int64_t> slotByLane;
-  slotByLane.reserve(lanesPerPart);
-  std::optional<int64_t> resolvedSourceChunk;
-  for (int64_t lane = 0; lane < lanesPerPart; ++lane) {
-    FailureOr<bool> padding =
-        isPaddingLane(resultVMIType, part, chunk, lane);
-    if (failed(padding))
-      return failure();
-    if (*padding) {
-      slotByLane.push_back(0);
-      continue;
-    }
-    FailureOr<int64_t> logicalLane =
-        mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
-    if (failed(logicalLane))
-      return failure();
-    int64_t group = *logicalLane / groupSize;
-    int64_t candidateSourceChunk = group / slots;
-    if (resolvedSourceChunk && *resolvedSourceChunk != candidateSourceChunk)
-      return failure();
-    resolvedSourceChunk = candidateSourceChunk;
-    slotByLane.push_back((group % slots) * slotLaneStride);
-  }
-  if (!resolvedSourceChunk)
-    return failure();
-  sourceChunk = *resolvedSourceChunk;
-
-  FailureOr<Value> baseScalar = createScalarOffsetConstant(
-      loc, indexType.getElementType(), slotByLane.front(), rewriter);
-  FailureOr<MaskType> maskType =
-      getMaskTypeForVReg(indexType, rewriter.getContext());
-  FailureOr<Value> allMask = createAllTrueMaskForVReg(loc, indexType, rewriter);
-  if (failed(baseScalar) || failed(maskType) || failed(allMask))
-    return failure();
-
-  Value result = rewriter
-                     .create<VdupOp>(loc, indexType, *baseScalar, *allMask,
-                                     /*position=*/nullptr)
-                     .getResult();
-  int64_t rangeBegin = 0;
-  while (rangeBegin < lanesPerPart) {
-    int64_t slot = slotByLane[rangeBegin];
-    int64_t rangeEnd = rangeBegin + 1;
-    while (rangeEnd < lanesPerPart && slotByLane[rangeEnd] == slot)
-      ++rangeEnd;
-    if (rangeBegin != 0 || slot != slotByLane.front()) {
-      FailureOr<Value> slotScalar = createScalarOffsetConstant(
-          loc, indexType.getElementType(), slot, rewriter);
-      FailureOr<Value> laneMask =
-          createLaneRangeMask(loc, *maskType, rangeBegin, rangeEnd, rewriter);
-      if (failed(slotScalar) || failed(laneMask))
-        return failure();
-      Value splat = rewriter
-                        .create<VdupOp>(loc, indexType, *slotScalar, *allMask,
-                                        /*position=*/nullptr)
-                        .getResult();
-      result = rewriter.create<VselOp>(loc, indexType, splat, result, *laneMask)
-                   .getResult();
-    }
-    rangeBegin = rangeEnd;
   }
   return result;
 }
@@ -6426,299 +6277,240 @@ static LogicalResult lowerGroupBroadcastParts(
     Operation *op, ValueRange sourceParts, VMIVRegType sourceVMIType,
     VMIVRegType resultVMIType, TypeRange resultTypes, int64_t numGroups,
     ConversionPatternRewriter &rewriter, SmallVectorImpl<Value> &results) {
-  FailureOr<int64_t> groupSize =
-      getGroupSizeFromNumGroups(resultVMIType, numGroups);
-  if (failed(groupSize))
-    return rewriter.notifyMatchFailure(
-        op, "group_broadcast requires num_groups to evenly divide lane count");
-  int64_t lanesPerPart = 0;
-  int64_t groupCount = 0;
-  if (failed(checkFullGroupSlotSourceShape(op, sourceVMIType, *groupSize,
-                                           numGroups, &lanesPerPart,
-                                           &groupCount, rewriter)))
-    return failure();
-  int64_t resultLayoutFactor = 0;
-  int64_t resultGroupCount = 0;
-  if (failed(checkFullGroupBroadcastResultShape(
-          op, resultVMIType, *groupSize, lanesPerPart, &resultLayoutFactor,
-          &resultGroupCount, rewriter)))
-    return failure();
-  if (resultGroupCount != groupCount)
-    return rewriter.notifyMatchFailure(
-        op, "group_broadcast requires matching source/result group slots");
-
   if (sourceParts.empty() || resultTypes.empty())
     return rewriter.notifyMatchFailure(op, "group_broadcast arity mismatch");
+
+  std::string layoutReason;
+  VMILayoutSupport supports;
+  FailureOr<VMIGroupBroadcastLayoutFact> fact =
+      supports.getGroupBroadcastLayoutFactForLayouts(
+          sourceVMIType, resultVMIType, numGroups, &layoutReason);
+  if (failed(fact))
+    return rewriter.notifyMatchFailure(
+        op, Twine("group_broadcast requires a supported layout table row; ") +
+                layoutReason);
 
   auto firstSourceType = dyn_cast<VRegType>(sourceParts.front().getType());
   if (!firstSourceType)
     return rewriter.notifyMatchFailure(op,
                                        "group_broadcast source must be vreg");
+  if (llvm::any_of(sourceParts, [&](Value sourcePart) {
+        return sourcePart.getType() != firstSourceType;
+      }))
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast requires uniform physical source vreg types");
+  if (firstSourceType.getElementCount() != fact->lanesPerPart)
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast physical source lanes do not match the supported "
+            "layout row");
   unsigned indexBits =
       pto::getPTOStorageElemBitWidth(firstSourceType.getElementType());
   if (indexBits != 8 && indexBits != 16 && indexBits != 32)
     return rewriter.notifyMatchFailure(
         op, "group_broadcast requires 8/16/32-bit index elements");
-  auto indexElementType = IntegerType::get(rewriter.getContext(), indexBits);
+  auto indexElementType =
+      IntegerType::get(rewriter.getContext(), indexBits,
+                       IntegerType::SignednessSemantics::Unsigned);
+  auto indexScalarType = IntegerType::get(rewriter.getContext(), indexBits);
   auto indexType =
       VRegType::get(rewriter.getContext(), firstSourceType.getElementCount(),
                     indexElementType);
   FailureOr<Value> allMask =
-      createAllTrueMaskForVReg(op->getLoc(), firstSourceType, rewriter);
+      createAllTrueMaskForVReg(op->getLoc(), indexType, rewriter);
   if (failed(allMask))
     return rewriter.notifyMatchFailure(
         op, "failed to create group_broadcast all mask");
+
   VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
   VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-  FailureOr<int64_t> resultBlockElems =
-      getVMILayoutBlockElems(resultVMIType);
-  if (failed(resultBlockElems))
+  int64_t sourceSlots = sourceLayout.getSlots();
+  int64_t sourceLaneStride = sourceLayout.getLaneStride();
+  if (sourceSlots <= 0 || sourceLaneStride <= 0)
     return rewriter.notifyMatchFailure(
-        op, "group_broadcast requires a computable result block size");
-  int64_t selectionGroupSize = *groupSize;
-  if (resultLayoutFactor != 1 && resultLayout &&
-      resultLayout.isBlockDeinterleaved() &&
-      *groupSize < lanesPerPart)
-    selectionGroupSize = *resultBlockElems;
-  auto resolveLargeGroupSource = [&](int64_t group, int64_t chunksPerGroup,
-                                     int64_t &sourceChunk,
-                                     int64_t &baseGroupSlot) {
-    int64_t slots = sourceLayout.getSlots();
-    if (slots > 0) {
-      sourceChunk = group / slots;
-      baseGroupSlot = group % slots;
-      return;
+        op, "group_broadcast requires explicit positive source group slots");
+
+  enum class SelectorKind { Constant, LogicalRamp, VCGBlockRamp };
+  SelectorKind selectorKind;
+  int64_t selectorPeriod = 0;
+  if (fact->blockClass == VMIGroupBlockClass::FullPartMultiple) {
+    selectorKind = SelectorKind::Constant;
+  } else if (resultLayout.isContiguous() && resultLayout.getLaneStride() == 1) {
+    selectorKind = SelectorKind::LogicalRamp;
+    selectorPeriod = fact->groupSize;
+  } else if ((resultLayout.isContiguous() &&
+              resultLayout.getLaneStride() > 1) ||
+             resultLayout.isDeinterleaved() ||
+             resultLayout.isBlockDeinterleaved()) {
+    selectorKind = SelectorKind::VCGBlockRamp;
+    selectorPeriod = fact->vcgBlockElems;
+  } else {
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast layout table row has no selector lowering plan");
+  }
+
+  std::optional<int64_t> selectorShift;
+  std::optional<int64_t> sourceLaneStrideShift;
+  if (selectorKind != SelectorKind::Constant) {
+    selectorShift = getPowerOfTwoLog2(selectorPeriod);
+    sourceLaneStrideShift = getPowerOfTwoLog2(sourceLaneStride);
+    if (!selectorShift || !sourceLaneStrideShift)
+      return rewriter.notifyMatchFailure(
+          op, "group_broadcast ramp requires power-of-two selector period "
+              "and source lane stride");
+  }
+
+  Value sharedRamp;
+  llvm::DenseMap<int64_t, Value> selectorByBaseIndex;
+  auto getSelector = [&](int64_t baseSlot) -> FailureOr<Value> {
+    int64_t baseIndex = baseSlot * sourceLaneStride;
+    auto cached = selectorByBaseIndex.find(baseIndex);
+    if (cached != selectorByBaseIndex.end())
+      return cached->second;
+
+    if (selectorKind == SelectorKind::Constant) {
+      FailureOr<Value> baseScalar = createScalarOffsetConstant(
+          op->getLoc(), indexScalarType, baseIndex, rewriter);
+      if (failed(baseScalar))
+        return failure();
+      Value selector =
+          rewriter
+              .create<VdupOp>(op->getLoc(), indexType, *baseScalar, *allMask,
+                              /*position=*/nullptr)
+              .getResult();
+      selectorByBaseIndex.try_emplace(baseIndex, selector);
+      return selector;
     }
-    sourceChunk = group * chunksPerGroup;
-    baseGroupSlot = 0;
+
+    if (!sharedRamp) {
+      FailureOr<Value> zero = createScalarOffsetConstant(
+          op->getLoc(), indexScalarType, 0, rewriter);
+      if (failed(zero))
+        return failure();
+      sharedRamp =
+          rewriter.create<VciOp>(op->getLoc(), indexType, *zero, StringAttr{})
+              .getResult();
+      if (*selectorShift != 0) {
+        Value shift = createI16Constant(op->getLoc(), *selectorShift, rewriter);
+        sharedRamp = rewriter
+                         .create<VshrsOp>(op->getLoc(), indexType, sharedRamp,
+                                          shift, *allMask)
+                         .getResult();
+      }
+      if (*sourceLaneStrideShift != 0) {
+        Value shift =
+            createI16Constant(op->getLoc(), *sourceLaneStrideShift, rewriter);
+        sharedRamp = rewriter
+                         .create<VshlsOp>(op->getLoc(), indexType, sharedRamp,
+                                          shift, *allMask)
+                         .getResult();
+      }
+    }
+
+    Value selector = sharedRamp;
+    if (baseIndex != 0) {
+      FailureOr<Value> baseScalar = createScalarOffsetConstant(
+          op->getLoc(), indexScalarType, baseIndex, rewriter);
+      if (failed(baseScalar))
+        return failure();
+      selector = rewriter
+                     .create<VaddsOp>(op->getLoc(), indexType, selector,
+                                      *baseScalar, *allMask)
+                     .getResult();
+    }
+    selectorByBaseIndex.try_emplace(baseIndex, selector);
+    return selector;
   };
 
   results.clear();
   results.resize(resultTypes.size());
-  for (auto [flatIndex, resultType] : llvm::enumerate(resultTypes)) {
-    auto resultVRegType = dyn_cast<VRegType>(resultType);
-    if (!resultVRegType || resultVRegType != firstSourceType)
+  FailureOr<int64_t> resultLayoutFactor = getDataLayoutFactor(resultVMIType);
+  if (failed(resultLayoutFactor))
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast requires a computable result layout factor");
+
+  int64_t flatIndex = 0;
+  for (int64_t part = 0; part < *resultLayoutFactor; ++part) {
+    FailureOr<int64_t> chunks = *resultLayoutFactor == 1
+                                    ? FailureOr<int64_t>(resultTypes.size())
+                                    : getDataChunksInPart(resultVMIType, part);
+    if (failed(chunks))
       return rewriter.notifyMatchFailure(
-          op, "group_broadcast requires uniform physical vreg types");
-    int64_t sourceChunk = flatIndex;
-    int64_t baseGroupSlot = 0;
-    Value mappedGroupSlotIndex;
-    if (resultLayoutFactor == 1) {
-      bool laneStridedDense =
-          resultLayout && resultLayout.isDense() &&
-          resultLayout.getLaneStride() > 1;
-      if (laneStridedDense) {
-        VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-        int64_t slots = sourceLayout.getSlots();
-        if (slots <= 0) {
-          if (sourceParts.empty() ||
-              groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast lane-stride source requires explicit "
-                    "group_slots slots or derivable legacy slot count");
-          slots = groupCount / sourceParts.size();
-        }
-        FailureOr<Value> index = createMappedGroupSlotIndexVector(
-            op->getLoc(), resultVMIType, /*part=*/0, flatIndex, indexType,
-            *groupSize, slots, sourceChunk, rewriter,
-            sourceLayout.getLaneStride());
-        if (failed(index))
-          return rewriter.notifyMatchFailure(
-              op, "failed to create group_broadcast lane-stride group-slot "
-                  "index vector");
-        mappedGroupSlotIndex = *index;
-      } else if (*groupSize >= lanesPerPart) {
-        int64_t chunksPerGroup = *groupSize / lanesPerPart;
-        int64_t group = flatIndex / chunksPerGroup;
-        resolveLargeGroupSource(group, chunksPerGroup, sourceChunk,
-                                baseGroupSlot);
-      } else {
-        VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-        int64_t slots = sourceLayout.getSlots();
-        if (slots <= 0) {
-          if (sourceParts.empty() ||
-              groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast small-group source requires explicit "
-                    "group_slots slots or derivable legacy slot count");
-          slots = groupCount / sourceParts.size();
-        }
-        int64_t groupsPerResultChunk = lanesPerPart / *groupSize;
-        int64_t firstGroup = flatIndex * groupsPerResultChunk;
-        sourceChunk = firstGroup / slots;
-        baseGroupSlot = firstGroup % slots;
-      }
-    } else {
-      bool blockFragmentSmallGroup =
-          resultLayout && resultLayout.isBlockDeinterleaved() &&
-          *groupSize < lanesPerPart;
-      bool deinterleavedSmallGroup =
-          resultLayout && resultLayout.isDeinterleaved() &&
-          *groupSize < lanesPerPart;
-      if (blockFragmentSmallGroup) {
-        int64_t runningFlatIndex = 0;
-        bool found = false;
-        for (int64_t part = 0; part < resultLayoutFactor && !found; ++part) {
-          FailureOr<int64_t> chunks = getDataChunksInPart(resultVMIType, part);
-          if (failed(chunks))
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast failed to enumerate result chunks");
-          for (int64_t chunk = 0; chunk < *chunks;
-               ++chunk, ++runningFlatIndex) {
-            if (runningFlatIndex != static_cast<int64_t>(flatIndex))
-              continue;
-            int64_t groupsPerResultChunk =
-                lanesPerPart / *resultBlockElems;
-            int64_t firstGroup = chunk * groupsPerResultChunk;
-            int64_t slots = sourceLayout.getSlots();
-            if (slots <= 0) {
-              if (sourceParts.empty() ||
-                  groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-                return rewriter.notifyMatchFailure(
-                    op,
-                    "group_broadcast block-fragment source requires explicit "
-                    "group_slots slots or derivable legacy slot count");
-              slots = groupCount / sourceParts.size();
-            }
-            sourceChunk = firstGroup / slots;
-            baseGroupSlot = firstGroup % slots;
-            found = true;
-            break;
-          }
-        }
-        if (!found)
-          return rewriter.notifyMatchFailure(
-              op, "group_broadcast result chunk index is out of range");
-      } else if (deinterleavedSmallGroup) {
-        int64_t runningFlatIndex = 0;
-        bool found = false;
-        for (int64_t part = 0; part < resultLayoutFactor && !found; ++part) {
-          FailureOr<int64_t> chunks = getDataChunksInPart(resultVMIType, part);
-          if (failed(chunks))
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast failed to enumerate result chunks");
-          for (int64_t chunk = 0; chunk < *chunks;
-               ++chunk, ++runningFlatIndex) {
-            if (runningFlatIndex != static_cast<int64_t>(flatIndex))
-              continue;
-            int64_t slots = sourceLayout.getSlots();
-            if (slots <= 0) {
-              if (sourceParts.empty() ||
-                  groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-                return rewriter.notifyMatchFailure(
-                    op, "group_broadcast deinterleaved small-group source "
-                        "requires explicit group_slots slots or derivable "
-                        "legacy slot count");
-              slots = groupCount / sourceParts.size();
-            }
-            FailureOr<Value> index = createMappedGroupSlotIndexVector(
-                op->getLoc(), resultVMIType, part, chunk, indexType, *groupSize,
-                slots, sourceChunk, rewriter, sourceLayout.getLaneStride());
-            if (failed(index))
-              return rewriter.notifyMatchFailure(
-                  op,
-                  "failed to create group_broadcast mapped group-slot index "
-                  "vector");
-            mappedGroupSlotIndex = *index;
-            found = true;
-            break;
-          }
-        }
-        if (!found)
-          return rewriter.notifyMatchFailure(
-              op, "group_broadcast result chunk index is out of range");
-      } else {
-        int64_t runningFlatIndex = 0;
-        bool found = false;
-        for (int64_t part = 0; part < resultLayoutFactor && !found; ++part) {
-          FailureOr<int64_t> chunks = getDataChunksInPart(resultVMIType, part);
-          if (failed(chunks))
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast failed to enumerate result chunks");
-          for (int64_t chunk = 0; chunk < *chunks;
-               ++chunk, ++runningFlatIndex) {
-            if (runningFlatIndex != static_cast<int64_t>(flatIndex))
-              continue;
-            FailureOr<int64_t> firstLogical =
-                mapPhysicalLaneToLogical(resultVMIType, part, chunk, 0);
-            FailureOr<int64_t> lastLogical = mapPhysicalLaneToLogical(
-                resultVMIType, part, chunk, lanesPerPart - 1);
-            if (failed(firstLogical) || failed(lastLogical))
-              return rewriter.notifyMatchFailure(
-                  op, "group_broadcast failed to map result chunk lanes");
-            int64_t firstGroup = *firstLogical / *groupSize;
-            int64_t lastGroup = *lastLogical / *groupSize;
-            if (firstGroup != lastGroup)
-              return rewriter.notifyMatchFailure(
-                  op, "group_broadcast result chunk crosses logical groups");
-            int64_t chunksPerGroup = *groupSize / lanesPerPart;
-            resolveLargeGroupSource(firstGroup, chunksPerGroup, sourceChunk,
-                                    baseGroupSlot);
-            found = true;
-            break;
-          }
-        }
-        if (!found)
-          return rewriter.notifyMatchFailure(
-              op, "group_broadcast result chunk index is out of range");
-      }
-    }
-    if (*groupSize >= lanesPerPart) {
+          op, "group_broadcast failed to enumerate result chunks");
+    for (int64_t chunk = 0; chunk < *chunks; ++chunk, ++flatIndex) {
+      if (flatIndex >= static_cast<int64_t>(resultTypes.size()))
+        return rewriter.notifyMatchFailure(
+            op, "group_broadcast physical result count is too small");
+
+      Type resultType = resultTypes[flatIndex];
+      auto resultVRegType = dyn_cast<VRegType>(resultType);
+      if (!resultVRegType || resultVRegType != firstSourceType)
+        return rewriter.notifyMatchFailure(
+            op, "group_broadcast requires uniform physical vreg types");
+
+      FailureOr<int64_t> firstLogical =
+          mapPhysicalLaneToLogical(resultVMIType, part, chunk, 0);
+      if (failed(firstLogical))
+        return rewriter.notifyMatchFailure(
+            op, "group_broadcast failed to map the first result lane");
+      int64_t firstGroup = *firstLogical / fact->groupSize;
+      int64_t sourceChunk = firstGroup / sourceSlots;
+      int64_t baseSlot = firstGroup % sourceSlots;
       if (sourceChunk < 0 ||
           sourceChunk >= static_cast<int64_t>(sourceParts.size()))
         return rewriter.notifyMatchFailure(
             op, "group_broadcast source chunk is out of range");
-      if (sourceLayout.getSlots() > 1) {
-        FailureOr<Value> groupSlotIndex = createGroupSlotIndexVector(
-            op->getLoc(), indexType, selectionGroupSize, baseGroupSlot,
-            rewriter, sourceLayout.getLaneStride());
-        if (failed(groupSlotIndex))
+
+      // The support table selects one of the three affine selector forms.
+      // Check the table property against the canonical lane map so new table
+      // rows cannot silently reuse an incompatible lowering plan.
+      for (int64_t lane = 0; lane < fact->lanesPerPart; ++lane) {
+        FailureOr<bool> padding =
+            isPaddingLane(resultVMIType, part, chunk, lane);
+        if (failed(padding))
           return rewriter.notifyMatchFailure(
-              op, "failed to create group_broadcast group-slot index vector");
-        results[flatIndex] =
-            rewriter
-                .create<VselrOp>(op->getLoc(), resultType,
-                                 sourceParts[sourceChunk], *groupSlotIndex)
-                .getResult();
-      } else {
+              op, "group_broadcast failed to map result padding lanes");
+        if (*padding)
+          continue;
+        FailureOr<int64_t> logical =
+            mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
+        if (failed(logical))
+          return rewriter.notifyMatchFailure(
+              op, "group_broadcast failed to map a result lane");
+        int64_t actualGroup = *logical / fact->groupSize;
+        int64_t expectedGroup = firstGroup;
+        if (selectorKind != SelectorKind::Constant)
+          expectedGroup += lane / selectorPeriod;
+        if (actualGroup != expectedGroup ||
+            actualGroup / sourceSlots != sourceChunk)
+          return rewriter.notifyMatchFailure(
+              op, "group_broadcast layout table row does not match its "
+                  "selector lowering plan");
+      }
+
+      if (selectorKind == SelectorKind::Constant && sourceSlots == 1) {
         results[flatIndex] =
             rewriter
                 .create<VdupOp>(op->getLoc(), resultType,
                                 sourceParts[sourceChunk], *allMask,
                                 rewriter.getStringAttr("LOWEST"))
                 .getResult();
+        continue;
       }
-    } else {
-      bool blockFragmentSmallGroup =
-          resultLayout && resultLayout.isBlockDeinterleaved();
-      bool deinterleavedSmallGroup = resultLayout &&
-                                     resultLayout.isDeinterleaved();
-      if (resultLayoutFactor != 1 && !blockFragmentSmallGroup &&
-          !deinterleavedSmallGroup)
+
+      FailureOr<Value> selector = getSelector(baseSlot);
+      if (failed(selector))
         return rewriter.notifyMatchFailure(
-            op, "group_broadcast small-group deinterleaved result is not "
-                "supported");
-      if (sourceChunk < 0 ||
-          sourceChunk >= static_cast<int64_t>(sourceParts.size()))
-        return rewriter.notifyMatchFailure(
-            op, "group_broadcast source chunk is out of range");
-      FailureOr<Value> groupSlotIndex =
-          mappedGroupSlotIndex
-              ? FailureOr<Value>(mappedGroupSlotIndex)
-              : createGroupSlotIndexVector(op->getLoc(), indexType,
-                                           selectionGroupSize, baseGroupSlot,
-                                           rewriter,
-                                           sourceLayout.getLaneStride());
-      if (failed(groupSlotIndex))
-        return rewriter.notifyMatchFailure(
-            op, "failed to create group_broadcast group-slot index vector");
+            op, "failed to create group_broadcast selector ramp");
       results[flatIndex] =
           rewriter
               .create<VselrOp>(op->getLoc(), resultType,
-                               sourceParts[sourceChunk], *groupSlotIndex)
+                               sourceParts[sourceChunk], *selector)
               .getResult();
     }
   }
+  if (flatIndex != static_cast<int64_t>(resultTypes.size()))
+    return rewriter.notifyMatchFailure(
+        op, "group_broadcast physical result count is too large");
   return success();
 }
 
@@ -9735,320 +9527,27 @@ private:
 
 struct OneToNVMIGroupBroadcastOpPattern
     : OpConversionPattern<VMIGroupBroadcastOp> {
-  using OpConversionPattern<
-      VMIGroupBroadcastOp>::OpConversionPattern;
+  using OpConversionPattern<VMIGroupBroadcastOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(VMIGroupBroadcastOp op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto sourceVMIType = cast<VMIVRegType>(op.getSource().getType());
     auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
-    FailureOr<int64_t> groupSize = getGroupSizeFromNumGroups(
-        resultVMIType, op.getNumGroupsAttr().getInt());
-    if (failed(groupSize))
-      return rewriter.notifyMatchFailure(
-          op,
-          "group_broadcast requires num_groups to evenly divide lane count");
-    int64_t lanesPerPart = 0;
-    int64_t groupCount = 0;
-    if (failed(checkFullGroupSlotSourceShape(
-            op, sourceVMIType, *groupSize, op.getNumGroupsAttr().getInt(),
-            &lanesPerPart, &groupCount, rewriter)))
-      return failure();
-    int64_t resultLayoutFactor = 0;
-    int64_t resultGroupCount = 0;
-    if (failed(checkFullGroupBroadcastResultShape(
-            op, resultVMIType, *groupSize, lanesPerPart, &resultLayoutFactor,
-            &resultGroupCount, rewriter)))
-      return failure();
-    if (resultGroupCount != groupCount)
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast requires matching source/result group slots");
-
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     if (failed(maybe_resultTypes))
       return failure();
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.empty() || resultTypes.empty())
-      return rewriter.notifyMatchFailure(op, "group_broadcast arity mismatch");
-
-    auto firstSourceType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!firstSourceType)
-      return rewriter.notifyMatchFailure(op,
-                                         "group_broadcast source must be vreg");
-    unsigned indexBits =
-        pto::getPTOStorageElemBitWidth(firstSourceType.getElementType());
-    if (indexBits != 8 && indexBits != 16 && indexBits != 32)
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast requires 8/16/32-bit index elements");
-    auto indexElementType = IntegerType::get(rewriter.getContext(), indexBits);
-    auto indexType =
-        VRegType::get(rewriter.getContext(), firstSourceType.getElementCount(),
-                      indexElementType);
-    FailureOr<Value> allMask =
-        createAllTrueMaskForVReg(op.getLoc(), firstSourceType, rewriter);
-    if (failed(allMask))
-      return rewriter.notifyMatchFailure(
-          op, "failed to create group_broadcast all mask");
-    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
-    VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-    FailureOr<int64_t> resultBlockElems =
-        getVMILayoutBlockElems(resultVMIType);
-    if (failed(resultBlockElems))
-      return rewriter.notifyMatchFailure(
-          op, "group_broadcast requires a computable result block size");
-    int64_t selectionGroupSize = *groupSize;
-    if (resultLayoutFactor != 1 && resultLayout &&
-        resultLayout.isBlockDeinterleaved() &&
-        *groupSize < lanesPerPart)
-      selectionGroupSize = *resultBlockElems;
-    auto resolveLargeGroupSource = [&](int64_t group, int64_t chunksPerGroup,
-                                       int64_t &sourceChunk,
-                                       int64_t &baseGroupSlot) {
-      int64_t slots = sourceLayout.getSlots();
-      if (slots > 0) {
-        sourceChunk = group / slots;
-        baseGroupSlot = group % slots;
-        return;
-      }
-      sourceChunk = group * chunksPerGroup;
-      baseGroupSlot = 0;
-    };
-
     SmallVector<Value> results;
-    results.resize(resultTypes.size());
-    for (auto [flatIndex, resultType] : llvm::enumerate(resultTypes)) {
-      auto resultVRegType = dyn_cast<VRegType>(resultType);
-      if (!resultVRegType || resultVRegType != firstSourceType)
-        return rewriter.notifyMatchFailure(
-            op, "group_broadcast requires uniform physical vreg types");
-      int64_t sourceChunk = flatIndex;
-      int64_t baseGroupSlot = 0;
-      Value mappedGroupSlotIndex;
-      if (resultLayoutFactor == 1) {
-        bool laneStridedDense =
-            resultLayout && resultLayout.isDense() &&
-            resultLayout.getLaneStride() > 1;
-        if (laneStridedDense) {
-          VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-          int64_t slots = sourceLayout.getSlots();
-          if (slots <= 0) {
-            if (sourceParts.empty() ||
-                groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-              return rewriter.notifyMatchFailure(
-                  op, "group_broadcast lane-stride source requires explicit "
-                      "group_slots slots or derivable legacy slot count");
-            slots = groupCount / sourceParts.size();
-          }
-          FailureOr<Value> index = createMappedGroupSlotIndexVector(
-              op.getLoc(), resultVMIType, /*part=*/0, flatIndex, indexType,
-              *groupSize, slots, sourceChunk, rewriter,
-              sourceLayout.getLaneStride());
-          if (failed(index))
-            return rewriter.notifyMatchFailure(
-                op, "failed to create group_broadcast lane-stride group-slot "
-                    "index vector");
-          mappedGroupSlotIndex = *index;
-        } else if (*groupSize >= lanesPerPart) {
-          int64_t chunksPerGroup = *groupSize / lanesPerPart;
-          int64_t group = flatIndex / chunksPerGroup;
-          resolveLargeGroupSource(group, chunksPerGroup, sourceChunk,
-                                  baseGroupSlot);
-        } else {
-          VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
-          int64_t slots = sourceLayout.getSlots();
-          if (slots <= 0) {
-            if (sourceParts.empty() ||
-                groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-              return rewriter.notifyMatchFailure(
-                  op, "group_broadcast small-group source requires explicit "
-                      "group_slots slots or derivable legacy slot count");
-            slots = groupCount / sourceParts.size();
-          }
-          int64_t groupsPerResultChunk = lanesPerPart / *groupSize;
-          int64_t firstGroup = flatIndex * groupsPerResultChunk;
-          sourceChunk = firstGroup / slots;
-          baseGroupSlot = firstGroup % slots;
-        }
-      } else {
-        bool blockFragmentSmallGroup =
-            resultLayout && resultLayout.isBlockDeinterleaved() &&
-            *groupSize < lanesPerPart;
-        bool deinterleavedSmallGroup =
-            resultLayout && resultLayout.isDeinterleaved() &&
-            *groupSize < lanesPerPart;
-        if (blockFragmentSmallGroup) {
-          int64_t runningFlatIndex = 0;
-          bool found = false;
-          for (int64_t part = 0; part < resultLayoutFactor && !found; ++part) {
-            FailureOr<int64_t> chunks =
-                getDataChunksInPart(resultVMIType, part);
-            if (failed(chunks))
-              return rewriter.notifyMatchFailure(
-                  op, "group_broadcast failed to enumerate result chunks");
-            for (int64_t chunk = 0; chunk < *chunks;
-                 ++chunk, ++runningFlatIndex) {
-              if (runningFlatIndex != static_cast<int64_t>(flatIndex))
-                continue;
-              int64_t groupsPerResultChunk =
-                  lanesPerPart / *resultBlockElems;
-              int64_t firstGroup = chunk * groupsPerResultChunk;
-              int64_t slots = sourceLayout.getSlots();
-              if (slots <= 0) {
-                if (sourceParts.empty() ||
-                    groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-                  return rewriter.notifyMatchFailure(
-                      op,
-                      "group_broadcast block-fragment source requires explicit "
-                      "group_slots slots or derivable legacy slot count");
-                slots = groupCount / sourceParts.size();
-              }
-              sourceChunk = firstGroup / slots;
-              baseGroupSlot = firstGroup % slots;
-              found = true;
-              break;
-            }
-          }
-          if (!found)
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast result chunk index is out of range");
-        } else if (deinterleavedSmallGroup) {
-          int64_t runningFlatIndex = 0;
-          bool found = false;
-          for (int64_t part = 0; part < resultLayoutFactor && !found; ++part) {
-            FailureOr<int64_t> chunks =
-                getDataChunksInPart(resultVMIType, part);
-            if (failed(chunks))
-              return rewriter.notifyMatchFailure(
-                  op, "group_broadcast failed to enumerate result chunks");
-            for (int64_t chunk = 0; chunk < *chunks;
-                 ++chunk, ++runningFlatIndex) {
-              if (runningFlatIndex != static_cast<int64_t>(flatIndex))
-                continue;
-              int64_t slots = sourceLayout.getSlots();
-              if (slots <= 0) {
-                if (sourceParts.empty() ||
-                    groupCount % static_cast<int64_t>(sourceParts.size()) != 0)
-                  return rewriter.notifyMatchFailure(
-                      op, "group_broadcast deinterleaved small-group source "
-                          "requires explicit group_slots slots or derivable "
-                          "legacy slot count");
-                slots = groupCount / sourceParts.size();
-              }
-              FailureOr<Value> index = createMappedGroupSlotIndexVector(
-                  op.getLoc(), resultVMIType, part, chunk, indexType,
-                  *groupSize, slots, sourceChunk, rewriter,
-                  sourceLayout.getLaneStride());
-              if (failed(index))
-                return rewriter.notifyMatchFailure(
-                    op,
-                    "failed to create group_broadcast mapped group-slot index "
-                    "vector");
-              mappedGroupSlotIndex = *index;
-              found = true;
-              break;
-            }
-          }
-          if (!found)
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast result chunk index is out of range");
-        } else {
-          int64_t runningFlatIndex = 0;
-          bool found = false;
-          for (int64_t part = 0; part < resultLayoutFactor && !found; ++part) {
-            FailureOr<int64_t> chunks =
-                getDataChunksInPart(resultVMIType, part);
-            if (failed(chunks))
-              return rewriter.notifyMatchFailure(
-                  op, "group_broadcast failed to enumerate result chunks");
-            for (int64_t chunk = 0; chunk < *chunks;
-                 ++chunk, ++runningFlatIndex) {
-              if (runningFlatIndex != static_cast<int64_t>(flatIndex))
-                continue;
-              FailureOr<int64_t> firstLogical =
-                  mapPhysicalLaneToLogical(resultVMIType, part, chunk, 0);
-              FailureOr<int64_t> lastLogical = mapPhysicalLaneToLogical(
-                  resultVMIType, part, chunk, lanesPerPart - 1);
-              if (failed(firstLogical) || failed(lastLogical))
-                return rewriter.notifyMatchFailure(
-                    op, "group_broadcast failed to map result chunk lanes");
-              int64_t firstGroup = *firstLogical / *groupSize;
-              int64_t lastGroup = *lastLogical / *groupSize;
-              if (firstGroup != lastGroup)
-                return rewriter.notifyMatchFailure(
-                    op, "group_broadcast result chunk crosses logical groups");
-              int64_t chunksPerGroup = *groupSize / lanesPerPart;
-              resolveLargeGroupSource(firstGroup, chunksPerGroup, sourceChunk,
-                                      baseGroupSlot);
-              found = true;
-              break;
-            }
-          }
-          if (!found)
-            return rewriter.notifyMatchFailure(
-                op, "group_broadcast result chunk index is out of range");
-        }
-      }
-      if (*groupSize >= lanesPerPart) {
-        if (sourceChunk < 0 ||
-            sourceChunk >= static_cast<int64_t>(sourceParts.size()))
-          return rewriter.notifyMatchFailure(
-              op, "group_broadcast source chunk is out of range");
-        if (sourceLayout.getSlots() > 1) {
-          FailureOr<Value> groupSlotIndex = createGroupSlotIndexVector(
-              op.getLoc(), indexType, selectionGroupSize, baseGroupSlot,
-              rewriter, sourceLayout.getLaneStride());
-          if (failed(groupSlotIndex))
-            return rewriter.notifyMatchFailure(
-                op, "failed to create group_broadcast group-slot index vector");
-          results[flatIndex] =
-              rewriter
-                  .create<VselrOp>(op.getLoc(), resultType,
-                                   sourceParts[sourceChunk], *groupSlotIndex)
-                  .getResult();
-        } else {
-          results[flatIndex] =
-              rewriter
-                  .create<VdupOp>(op.getLoc(), resultType,
-                                  sourceParts[sourceChunk], *allMask,
-                                  rewriter.getStringAttr("LOWEST"))
-                  .getResult();
-        }
-      } else {
-        bool blockFragmentSmallGroup =
-            resultLayout && resultLayout.isBlockDeinterleaved();
-        bool deinterleavedSmallGroup = resultLayout &&
-                                       resultLayout.isDeinterleaved();
-        if (resultLayoutFactor != 1 && !blockFragmentSmallGroup &&
-            !deinterleavedSmallGroup)
-          return rewriter.notifyMatchFailure(
-              op, "group_broadcast small-group deinterleaved result is not "
-                  "supported");
-        if (sourceChunk < 0 ||
-            sourceChunk >= static_cast<int64_t>(sourceParts.size()))
-          return rewriter.notifyMatchFailure(
-              op, "group_broadcast source chunk is out of range");
-        FailureOr<Value> groupSlotIndex =
-            mappedGroupSlotIndex
-                ? FailureOr<Value>(mappedGroupSlotIndex)
-                : createGroupSlotIndexVector(op.getLoc(), indexType,
-                                             selectionGroupSize, baseGroupSlot,
-                                             rewriter,
-                                             sourceLayout.getLaneStride());
-        if (failed(groupSlotIndex))
-          return rewriter.notifyMatchFailure(
-              op, "failed to create group_broadcast group-slot index vector");
-        results[flatIndex] =
-            rewriter
-                .create<VselrOp>(op.getLoc(), resultType,
-                                 sourceParts[sourceChunk], *groupSlotIndex)
-                .getResult();
-      }
-    }
+    if (failed(lowerGroupBroadcastParts(
+            op, sourceParts, sourceVMIType, resultVMIType, resultTypes,
+            op.getNumGroupsAttr().getInt(), rewriter, results)))
+      return failure();
 
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
     return success();
   }
 };

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8092,6 +8092,56 @@ struct OneToNVMIBinaryOpPattern : OpConversionPattern<SourceOp> {
   }
 };
 
+template <typename SourceOp, typename TargetOp>
+struct OneToNVMIVecScalarOpPattern : OpConversionPattern<SourceOp> {
+  using OpConversionPattern<SourceOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      SourceOp op,
+      typename OpConversionPattern<SourceOp>::OneToNOpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (op.getPmode().has_value() && *op.getPmode() == "merge")
+      return rewriter.notifyMatchFailure(
+          op, "merge predicate mode requires an explicit passthru lowering");
+
+    ValueRange sourceParts = adaptor.getSrc();
+    FailureOr<Value> scalar =
+        getSingleValue(op, adaptor.getScalar(),
+                       "vector-scalar scalar must convert to one value",
+                       rewriter);
+    ValueRange maskParts = adaptor.getMask();
+    FailureOr<SmallVector<Type>> maybeResultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    if (failed(scalar) || failed(maybeResultTypes))
+      return failure();
+    SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
+    if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
+        sourceParts.size() != resultTypes.size())
+      return rewriter.notifyMatchFailure(
+          op, "physical vector-scalar arity mismatch");
+
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [source, mask, resultType] :
+         llvm::zip_equal(sourceParts, maskParts, resultTypes)) {
+      auto vregType = dyn_cast<VRegType>(resultType);
+      auto maskType = dyn_cast<MaskType>(mask.getType());
+      if (!vregType || !maskType || source.getType() != resultType ||
+          vregType.getElementType() != (*scalar).getType())
+        return rewriter.notifyMatchFailure(
+            op, "physical vector-scalar part type mismatch");
+      results.push_back(
+          rewriter
+              .create<TargetOp>(op.getLoc(), resultType, source, *scalar, mask)
+              .getResult());
+    }
+
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
+    return success();
+  }
+};
+
 struct OneToNVMIVmullOpPattern : OpConversionPattern<VMIVmullOp> {
   using OpConversionPattern<VMIVmullOp>::OpConversionPattern;
 
@@ -11185,7 +11235,9 @@ void populateVMIConversionPatterns(
       OneToNVMIBinaryOpPattern<VMISubFOp, VsubOp>,
       OneToNVMIBinaryOpPattern<VMISubIOp, VsubOp>,
       OneToNVMIBinaryOpPattern<VMIMulFOp, VmulOp>,
-      OneToNVMIBinaryOpPattern<VMIMulIOp, VmulOp>, OneToNVMIVmullOpPattern,
+      OneToNVMIBinaryOpPattern<VMIMulIOp, VmulOp>,
+      OneToNVMIVecScalarOpPattern<VMIMulSOp, VmulsOp>,
+      OneToNVMIVmullOpPattern,
       OneToNVMIFmaOpPattern, OneToNVMIBinaryOpPattern<VMIDivFOp, VdivOp>,
       OneToNVMIBinaryOpPattern<VMIMinFOp, VminOp>,
       OneToNVMIBinaryOpPattern<VMIMinIOp, VminOp>,
@@ -12251,6 +12303,18 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     if (auto muli = dyn_cast<VMIMulIOp>(op))
       return emitMaskableUnsupported(
           op, "pto.vmi.muli", cast<VMIVRegType>(muli.getResult().getType()));
+    if (auto vmuls = dyn_cast<VMIMulSOp>(op)) {
+      if (vmuls.getPmode().has_value() && *vmuls.getPmode() == "merge") {
+        vmuls.emitError()
+            << kVMIDiagUnsupportedPrefix
+            << "pto.vmi.vmuls with pmode=merge requires an explicit "
+               "passthru lowering";
+        return WalkResult::interrupt();
+      }
+      return emitMaskableUnsupported(
+          op, "pto.vmi.vmuls",
+          cast<VMIVRegType>(vmuls.getResult().getType()));
+    }
     if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
       std::string reason;
       if (succeeded(checkSupportedVmullShape(vmull, &reason)))

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_broadcast_reduce.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s32_broadcast_reduce.pto
@@ -50,16 +50,11 @@ module {
 // ASSIGN: %[[SCALED_SUM:.*]] = pto.vmi.group_reduce_addf %[[SCALED]]
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_reduce_s32_broadcast_reduce(
-// LOWER-DAG: %[[C2:.*]] = arith.constant 2 : i32
-// LOWER-DAG: %[[C4:.*]] = arith.constant 4 : i32
-// LOWER-DAG: %[[C6:.*]] = arith.constant 6 : i32
-// LOWER: pto.vselr
-// LOWER: pto.vdup %[[C2]]
-// LOWER: pto.vselr
-// LOWER: pto.vdup %[[C4]]
-// LOWER: pto.vselr
-// LOWER: pto.vdup %[[C6]]
-// LOWER: pto.vselr
+// LOWER: %[[IOTA:.*]] = pto.vci {{.*}} -> !pto.vreg<64xui32>
+// LOWER: %[[RAMP:.*]] = pto.vshrs %[[IOTA]], {{.*}}
+// LOWER-COUNT-4: pto.vselr {{.*}}, %[[RAMP]]
+// LOWER-NOT: pto.vsel {{.*}}
+// LOWER-NOT: pto.vdup
 // LOWER-COUNT-4: pto.vmul
 // LOWER: pto.vsts {{.*}}, %arg8[%arg9], {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_group_slots_fanout.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_slots_fanout.pto
@@ -54,9 +54,10 @@ module {
 // LOWER-LABEL: func.func @vmi_layout_assignment_group_slots_fanout(
 // LOWER: %[[FIRST_SUM:.*]] = pto.vadd {{.*}}, {{.*}}, {{.*}} : !pto.vreg<64xf32>
 // LOWER: pto.vsts %[[FIRST_SUM]], %arg4[%arg6], {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
-// LOWER: pto.vselr %[[FIRST_SUM]]
-// LOWER: pto.vdup {{.*}}
-// LOWER: pto.vselr %[[FIRST_SUM]]
+// LOWER: %[[IOTA:.*]] = pto.vci {{.*}} -> !pto.vreg<64xui32>
+// LOWER: %[[RAMP:.*]] = pto.vshrs %[[IOTA]], {{.*}}
+// LOWER-COUNT-2: pto.vselr %[[FIRST_SUM]], %[[RAMP]]
+// LOWER-NOT: pto.vsel {{.*}}
 // LOWER-COUNT-2: pto.vmul
 // LOWER: pto.vsts {{.*}}, %arg5[%arg6], {{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_group_broadcast_s32_deint2_small_group.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_broadcast_s32_deint2_small_group.pto
@@ -24,7 +24,10 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_group_broadcast_s32_lane_stride4_small_group(
+// CHECK: %[[IOTA:.*]] = pto.vci {{.*}} -> !pto.vreg<64xui32>
+// CHECK: %[[RAMP:.*]] = pto.vshrs %[[IOTA]], {{.*}}
 // CHECK-COUNT-4: pto.vselr
+// CHECK-NOT: pto.vsel {{.*}}
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_group_broadcast_selector_ramp.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_broadcast_selector_ramp.pto
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @group_broadcast_contiguous_two_block_multi_packet(
+      %source: !pto.vmi.vreg<16xf32, #pto.vmi.layout<num_groups = 16, slots = 8>>)
+      -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
+    %broadcast = pto.vmi.vbrc %source {group = 16}
+        : !pto.vmi.vreg<16xf32, #pto.vmi.layout<num_groups = 16, slots = 8>>
+        -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
+  }
+
+  func.func @group_broadcast_contiguous_four_block(
+      %source: !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>)
+      -> (!pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.vreg<64xui32>) {
+    %broadcast = pto.vmi.vbrc %source {group = 8}
+        : !pto.vmi.vreg<8xui32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<256xui32, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<256xui32, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.vreg<64xui32>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.vreg<64xui32>, !pto.vreg<64xui32>
+  }
+
+  func.func @group_broadcast_deinterleaved2_two_chunks_per_part(
+      %source: !pto.vmi.vreg<16xf32, #pto.vmi.layout<num_groups = 16, slots = 8>>)
+      -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
+    %broadcast = pto.vmi.vbrc %source {group = 16}
+        : !pto.vmi.vreg<16xf32, #pto.vmi.layout<num_groups = 16, slots = 8>>
+        -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>)
+        -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
+  }
+
+  func.func @group_broadcast_deinterleaved4(
+      %source: !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>)
+      -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
+    %broadcast = pto.vmi.vbrc %source {group = 8}
+        : !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>)
+        -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
+  }
+
+  func.func @group_broadcast_block_deinterleaved2_two_chunks_per_part(
+      %source: !pto.vmi.vreg<16xf32, #pto.vmi.layout<num_groups = 16, slots = 8>>)
+      -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
+    %broadcast = pto.vmi.vbrc %source {group = 16}
+        : !pto.vmi.vreg<16xf32, #pto.vmi.layout<num_groups = 16, slots = 8>>
+        -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<block_deinterleaved = 2>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<256xf32, #pto.vmi.layout<block_deinterleaved = 2>>)
+        -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
+  }
+
+  func.func @group_broadcast_source_lane_stride2(
+      %source: !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>)
+      -> !pto.vreg<64xf32> {
+    %broadcast = pto.vmi.vbrc %source {group = 8}
+        : !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+        -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<64xf32>
+    return %p0 : !pto.vreg<64xf32>
+  }
+
+  func.func @group_broadcast_i8_unsigned_ramp(
+      %source: !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>)
+      -> !pto.vreg<256xui8> {
+    %broadcast = pto.vmi.vbrc %source {group = 8}
+        : !pto.vmi.vreg<8xui8, #pto.vmi.layout<num_groups = 8, slots = 8>>
+        -> !pto.vmi.vreg<256xui8, #pto.vmi.layout<contiguous>>
+    %p0 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<256xui8, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<256xui8>
+    return %p0 : !pto.vreg<256xui8>
+  }
+
+  func.func @group_broadcast_full_slots1(
+      %source: !pto.vmi.vreg<2xf32, #pto.vmi.layout<num_groups = 2, slots = 1>>)
+      -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>) {
+    %broadcast = pto.vmi.vbrc %source {group = 2}
+        : !pto.vmi.vreg<2xf32, #pto.vmi.layout<num_groups = 2, slots = 1>>
+        -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%broadcast)
+        : (!pto.vmi.vreg<256xf32, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.vreg<64xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @group_broadcast_contiguous_two_block_multi_packet(
+// CHECK-SAME: %[[C_SRC0:arg[0-9]+]]: !pto.vreg<64xf32>, %[[C_SRC1:arg[0-9]+]]: !pto.vreg<64xf32>
+// CHECK: %[[C_IOTA:.*]] = pto.vci {{.*}} -> !pto.vreg<64xui32>
+// CHECK: %[[C_RAMP:.*]] = pto.vshrs %[[C_IOTA]], {{.*}}
+// CHECK-DAG: %[[C_BASE4:.*]] = pto.vadds %[[C_RAMP]], {{.*}}
+// CHECK-DAG: pto.vselr %[[C_SRC0]], %[[C_RAMP]]
+// CHECK-DAG: pto.vselr %[[C_SRC0]], %[[C_BASE4]]
+// CHECK-DAG: pto.vselr %[[C_SRC1]], %[[C_RAMP]]
+// CHECK-DAG: pto.vselr %[[C_SRC1]], %[[C_BASE4]]
+// CHECK-NOT: pto.vsel {{.*}}
+
+// CHECK-LABEL: func.func @group_broadcast_contiguous_four_block(
+// CHECK: %[[C4_IOTA:.*]] = pto.vci
+// CHECK: %[[C4_RAMP:.*]] = pto.vshrs %[[C4_IOTA]], {{.*}}
+// CHECK-DAG: %[[C4_BASE2:.*]] = pto.vadds %[[C4_RAMP]], {{.*}}
+// CHECK-DAG: %[[C4_BASE4:.*]] = pto.vadds %[[C4_RAMP]], {{.*}}
+// CHECK-DAG: %[[C4_BASE6:.*]] = pto.vadds %[[C4_RAMP]], {{.*}}
+// CHECK-DAG: pto.vselr {{.*}}, %[[C4_RAMP]]
+// CHECK-DAG: pto.vselr {{.*}}, %[[C4_BASE2]]
+// CHECK-DAG: pto.vselr {{.*}}, %[[C4_BASE4]]
+// CHECK-DAG: pto.vselr {{.*}}, %[[C4_BASE6]]
+// CHECK-NOT: pto.vsel {{.*}}
+
+// CHECK-LABEL: func.func @group_broadcast_deinterleaved2_two_chunks_per_part(
+// CHECK-SAME: %[[D2_SRC0:arg[0-9]+]]: !pto.vreg<64xf32>, %[[D2_SRC1:arg[0-9]+]]: !pto.vreg<64xf32>
+// CHECK: %[[D2_IOTA:.*]] = pto.vci
+// CHECK: %[[D2_RAMP:.*]] = pto.vshrs %[[D2_IOTA]], {{.*}}
+// CHECK: pto.vselr %[[D2_SRC0]], %[[D2_RAMP]]
+// CHECK: pto.vselr %[[D2_SRC1]], %[[D2_RAMP]]
+// CHECK: pto.vselr %[[D2_SRC0]], %[[D2_RAMP]]
+// CHECK: pto.vselr %[[D2_SRC1]], %[[D2_RAMP]]
+// CHECK-NOT: pto.vsel {{.*}}
+
+// CHECK-LABEL: func.func @group_broadcast_deinterleaved4(
+// CHECK: %[[D4_IOTA:.*]] = pto.vci
+// CHECK: %[[D4_RAMP:.*]] = pto.vshrs %[[D4_IOTA]], {{.*}}
+// CHECK-COUNT-4: pto.vselr {{.*}}, %[[D4_RAMP]]
+// CHECK-NOT: pto.vsel {{.*}}
+
+// CHECK-LABEL: func.func @group_broadcast_block_deinterleaved2_two_chunks_per_part(
+// CHECK-SAME: %[[BD2_SRC0:arg[0-9]+]]: !pto.vreg<64xf32>, %[[BD2_SRC1:arg[0-9]+]]: !pto.vreg<64xf32>
+// CHECK: %[[BD2_IOTA:.*]] = pto.vci
+// CHECK: %[[BD2_RAMP:.*]] = pto.vshrs %[[BD2_IOTA]], {{.*}}
+// CHECK: pto.vselr %[[BD2_SRC0]], %[[BD2_RAMP]]
+// CHECK: pto.vselr %[[BD2_SRC1]], %[[BD2_RAMP]]
+// CHECK: pto.vselr %[[BD2_SRC0]], %[[BD2_RAMP]]
+// CHECK: pto.vselr %[[BD2_SRC1]], %[[BD2_RAMP]]
+// CHECK-NOT: pto.vsel {{.*}}
+
+// CHECK-LABEL: func.func @group_broadcast_source_lane_stride2(
+// CHECK: %[[LS_IOTA:.*]] = pto.vci
+// CHECK: %[[LS_RAMP:.*]] = pto.vshrs %[[LS_IOTA]], {{.*}}
+// CHECK: %[[LS_SCALED:.*]] = pto.vshls %[[LS_RAMP]], {{.*}}
+// CHECK: pto.vselr {{.*}}, %[[LS_SCALED]]
+
+// CHECK-LABEL: func.func @group_broadcast_i8_unsigned_ramp(
+// CHECK: %[[I8_IOTA:.*]] = pto.vci {{.*}} -> !pto.vreg<256xui8>
+// CHECK: %[[I8_RAMP:.*]] = pto.vshrs %[[I8_IOTA]], {{.*}} : !pto.vreg<256xui8>
+// CHECK: pto.vselr {{.*}}, %[[I8_RAMP]]
+
+// CHECK-LABEL: func.func @group_broadcast_full_slots1(
+// CHECK-NOT: pto.vci
+// CHECK-COUNT-4: pto.vdup {{.*}}LOWEST
+// CHECK-NOT: pto.vselr
+// CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_vmuls.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vmuls.pto
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @vmuls_f32_single(
+      %source: !pto.vmi.vreg<64xf32>,
+      %scalar: f32,
+      %mask: !pto.vmi.mask<64xpred>) -> !pto.vmi.vreg<64xf32> {
+    %result = pto.vmi.vmuls %source, %scalar, %mask
+        : !pto.vmi.vreg<64xf32>, f32, !pto.vmi.mask<64xpred>
+        -> !pto.vmi.vreg<64xf32>
+    return %result : !pto.vmi.vreg<64xf32>
+  }
+
+  func.func @vmuls_f32_multichunk(
+      %source: !pto.vmi.vreg<256xf32>,
+      %scalar: f32,
+      %mask: !pto.vmi.mask<256xpred>) -> !pto.vmi.vreg<256xf32> {
+    %result = pto.vmi.vmuls %source, %scalar, %mask
+        : !pto.vmi.vreg<256xf32>, f32, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<256xf32>
+    return %result : !pto.vmi.vreg<256xf32>
+  }
+
+  func.func @vmuls_f32_deinterleaved(
+      %source: !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>,
+      %scalar: f32,
+      %mask: !pto.vmi.mask<256xb32, #pto.vmi.layout<deinterleaved = 2>>)
+      -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>> {
+    %result = pto.vmi.vmuls %source, %scalar, %mask
+        : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>,
+          f32,
+          !pto.vmi.mask<256xb32, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>
+    return %result
+        : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>
+  }
+
+  func.func @vmuls_f32_tail(
+      %source: !pto.vmi.vreg<100xf32>,
+      %scalar: f32,
+      %mask: !pto.vmi.mask<100xpred>) -> !pto.vmi.vreg<100xf32> {
+    %result = pto.vmi.vmuls %source, %scalar, %mask
+        : !pto.vmi.vreg<100xf32>, f32, !pto.vmi.mask<100xpred>
+        -> !pto.vmi.vreg<100xf32>
+    return %result : !pto.vmi.vreg<100xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @vmuls_f32_single(
+// CHECK: %[[SINGLE:.*]] = pto.vmuls {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: return %[[SINGLE]] : !pto.vreg<64xf32>
+
+// CHECK-LABEL: func.func @vmuls_f32_multichunk(
+// CHECK-COUNT-4: pto.vmuls {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+
+// CHECK-LABEL: func.func @vmuls_f32_deinterleaved(
+// CHECK-COUNT-4: pto.vmuls {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+
+// CHECK-LABEL: func.func @vmuls_f32_tail(
+// CHECK-COUNT-2: pto.vmuls {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK-NOT: pto.vdup
+// CHECK-NOT: pto.vmul {{.*}} : !pto.vreg
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_vmuls_merge_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vmuls_merge_invalid.pto
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto 2>&1 | FileCheck %s
+
+module {
+  func.func @vmuls_merge(
+      %source: !pto.vmi.vreg<64xf32>,
+      %scalar: f32,
+      %mask: !pto.vmi.mask<64xpred>) -> !pto.vmi.vreg<64xf32> {
+    %result = pto.vmi.vmuls %source, %scalar, %mask {pmode = "merge"}
+        : !pto.vmi.vreg<64xf32>, f32, !pto.vmi.mask<64xpred>
+        -> !pto.vmi.vreg<64xf32>
+    return %result : !pto.vmi.vreg<64xf32>
+  }
+}
+
+// CHECK: pto.vmi.vmuls with pmode=merge requires an explicit passthru lowering


### PR DESCRIPTION
## 背景

现有 `group_broadcast` lowering 针对不同 physical layout 分别构造 selector，包含较多按 lane 枚举和 `vdup`/`vsel` 拼装逻辑，难以完整覆盖 contiguous、deinterleaved、block-deinterleaved 以及 source lane stride 等组合。

Related to mouliangyu/PTOAS#566.

## 修改内容

- 基于 `VMILayoutSupport` 的 group-broadcast layout fact 统一选择 lowering 方案。
- 将 selector 归纳为 constant、logical ramp 和 VCG-block ramp 三种形式。
- 使用共享的 `vci` ramp，并通过 `vshrs`、`vshls` 和 `vadds` 构造不同 base slot 的 selector，替代逐段 `vdup`/`vsel` 拼装。
- 按 base index 缓存 selector，并保持相同 selector 可由后续 CSE 复用。
- 使用 canonical physical-to-logical lane mapping 校验 layout table 与 selector 公式一致，防止新增 table row 静默复用错误方案。
- 使用 unsigned 8/16/32-bit selector carrier，覆盖窄整数和 source lane-stride 场景。
- 保留 full-part、`slots=1` 场景的 `vdup LOWEST` 快速路径。
- 新增 contiguous、deinterleaved、block-deinterleaved、多 source chunk、lane stride 和 ui8 selector 的回归覆盖，并更新现有检查。

本修改不改变 `group_broadcast` 的 dense 结果语义。不同 physical result chunk 需要不同 selector 时仍分别生成 `vselr`；完全相同的结果由现有 CSE 合并。

## 验证

定向 lit 用例：

```text
-- Testing: 4 of 1391 tests, 4 workers --
Passed: 4
```

覆盖：

- `vmi_to_vpto_group_broadcast_selector_ramp`
- `vmi_to_vpto_group_broadcast_s32_deint2_small_group`
- `vmi_layout_assignment_group_reduce_s32_broadcast_reduce`
- `vmi_layout_assignment_group_slots_fanout`

完整 `check-pto` 在当前本地 build tree 中结果为 1257 passed / 134 failed；失败集中在已有 PTODSL daemon 的 MLIR Python 导入环境，以及与本修改无关的 VPTO/FileCheck 期望。上述 4 个本 PR 相关用例全部通过。
