### PR TITLE
fix(vmi): support table-driven group_store assignment and vsstb lowering

### DIFF
--- a/docs/designs/vmi-implementation-manual.md
+++ b/docs/designs/vmi-implementation-manual.md
@@ -3110,23 +3110,30 @@ pto.vmi.group_load / pto.vmi.group_store:
       destination[offset + g * row_stride + i] = value[g * S + i]
     row_stride is an index operand, measured in elements, and may be dynamic.
     Tail/valid-lane information is not an attr; it must be represented by a
-    mask in the producing/consuming computation. The current direct
-    group_load/group_store path is for full physical chunks.
+    mask in the producing/consuming computation. Direct group_store also
+    supports a contiguous tail when each logical group is exactly one 32B
+    block; lowering creates a prefix predicate for the final physical vreg.
   layout assignment:
     group_load result natural layout is contiguous
     group_store value use is requested as contiguous
   current direct lowering:
     source/value element width must be maskable by b8/b16/b32
-    layout must be contiguous with full physical chunks
-    num_groups must evenly divide N, and the derived group size S must be a
-    multiple of the physical lanes
-    per part, so every physical chunk belongs to exactly one group
-    lower each physical chunk with pto.vlds/pto.vsts at:
+    for contiguous group_store with S equal to one 32B VCG block and a static
+    positive 32B-aligned row_stride:
+      block_stride = row_stride / S, measured in 32B blocks
+      lower each physical vreg with pto.vsstb and repeat_stride = 0
+      the physical-part base is offset + first_group_in_part * row_stride
+      block_stride must fit the 16-bit pto.vsstb control field
+    for contiguous full physical chunks, num_groups must evenly divide N and S
+    must be a multiple of the physical lanes per part; lower each chunk with
+    pto.vlds/pto.vsts at:
       offset + group * row_stride + chunk_in_group * lanes_per_part
+    deinterleaved=2 full chunks lower through pto.vstsx2
   unsupported cases:
-    derived group size splitting a physical chunk, because this needs partial-vreg
-    lane insertion/extraction or a gather/scatter plan
-    partial/tail physical chunks
+    derived group sizes smaller than one 32B block or between one block and a
+    full physical vreg, because these need partial-vreg extraction or a more
+    general gather/scatter plan
+    dynamic or non-32B-aligned row_stride for the one-block pto.vsstb path
     GM-backed direct vector load/store paths not already accepted by the normal
     VMI memory access plan
 

--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -39,6 +39,10 @@ struct VMIStoreLayoutFact {
   VMILayoutAttr valueLayout;
 };
 
+struct VMIGroupStoreLayoutFact {
+  VMILayoutAttr valueLayout;
+};
+
 struct VMIMaskedStoreLayoutFact {
   VMILayoutAttr valueLayout;
   VMILayoutAttr maskLayout;
@@ -310,6 +314,25 @@ public:
   FailureOr<VMIGroupSlotLayoutFact>
   getGroupStoreLayoutFact(VMIVRegType valueType, int64_t numGroups,
                           std::string *reason = nullptr) const;
+
+  FailureOr<VMIGroupStoreLayoutFact>
+  getGroupStoreLayoutFact(VMIGroupStoreOp op, VMIVRegType valueType,
+                          std::string *reason = nullptr) const;
+
+  FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>>
+  getGroupStoreLayoutFactsForLayout(VMIGroupStoreOp op,
+                                    VMIVRegType valueType,
+                                    VMILayoutAttr layout,
+                                    std::string *reason = nullptr) const;
+
+  FailureOr<VMIGroupStoreLayoutFact>
+  getPreferredGroupStoreLayoutFact(VMIGroupStoreOp op, VMIVRegType valueType,
+                                   std::string *reason = nullptr) const;
+
+  FailureOr<VMIGroupStoreLayoutFact>
+  getHighPriorityGroupStoreLayoutFact(VMIGroupStoreOp op,
+                                      VMIVRegType valueType,
+                                      std::string *reason = nullptr) const;
 
   FailureOr<VMIGroupReduceLayoutFact>
   getPreferredGroupReduceLayoutFact(VMIVRegType sourceType, int64_t numGroups,

--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -39,10 +39,6 @@ struct VMIStoreLayoutFact {
   VMILayoutAttr valueLayout;
 };
 
-struct VMIGroupStoreLayoutFact {
-  VMILayoutAttr valueLayout;
-};
-
 struct VMIMaskedStoreLayoutFact {
   VMILayoutAttr valueLayout;
   VMILayoutAttr maskLayout;
@@ -113,6 +109,14 @@ enum class VMIGroupBlockClass {
   TwoBlock,
   FourBlock,
   FullPartMultiple,
+};
+
+struct VMIGroupStoreLayoutFact {
+  VMILayoutAttr valueLayout;
+  VMIGroupBlockClass blockClass = VMIGroupBlockClass::OneBlock;
+  int64_t groupSize = 0;
+  int64_t lanesPerPart = 0;
+  int64_t vcgBlockElems = 0;
 };
 
 struct VMIGroupReduceLayoutFact {

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -25,7 +25,6 @@
 #include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 
 namespace mlir {
@@ -63,10 +62,12 @@ enum class DataLayoutSeedPhase {
   GroupSlotLoad,
   GroupBroadcast,
   GroupBroadcastLoad,
+  GroupStore,
   Cast,
   WeakReduce,
   Store,
   Other,
+  GroupStoreFallback,
   SeedEnd,
 };
 
@@ -87,10 +88,6 @@ struct MaskUseRequest {
   OpOperand *operand;
   VMILayoutAttr layout;
   DataLayoutSeedPhase phase = DataLayoutSeedPhase::Other;
-};
-
-struct GroupStoreUseRequest {
-  VMIGroupStoreOp store;
 };
 
 static std::optional<int64_t> getConstantIndexValue(Value value) {
@@ -446,76 +443,6 @@ struct LayoutSolver {
            << " requires constant positive row_stride divisible by 8 f32 "
               "elements for the block8 stride plan; stable gather fallback is "
               "not implemented";
-  }
-
-  VMILayoutAttr getPreferredGroupStoreUseLayout(
-      Value value, int64_t numGroups, Value rowStride,
-      llvm::function_ref<VMILayoutAttr(Value)> getKnownLayout) {
-    auto type = dyn_cast<VMIVRegType>(value.getType());
-    if (!type)
-      return getContiguousLayout();
-    if (VMILayoutAttr existing = type.getLayoutAttr())
-      if (existing.isGroupSlots() && existing.getSlots() > 0)
-        return existing;
-    VMILayoutAttr known = getKnownLayout(value);
-    if (known && known.isGroupSlots() && known.getNumGroups() == numGroups &&
-        known.getSlots() > 0)
-      return known;
-    if (known && known.isDeinterleaved()) {
-      if (known.getFactor() == 2)
-        return known;
-      if (known.getFactor() == 4)
-        return VMILayoutAttr::getDeinterleaved(ctx, /*factor=*/2);
-    }
-    if (auto castOp = value.getDefiningOp()) {
-      if (isa<VMIExtFOp, VMIExtSIOp, VMIExtUIOp, VMITruncFOp, VMITruncIOp>(
-              castOp) &&
-          castOp->getNumOperands() == 1 && castOp->getNumResults() == 1) {
-        auto sourceType =
-            dyn_cast<VMIVRegType>(castOp->getOperand(0).getType());
-        auto resultType = dyn_cast<VMIVRegType>(castOp->getResult(0).getType());
-        if (sourceType && resultType) {
-          VMILayoutAttr sourceLayout = getKnownLayout(castOp->getOperand(0));
-          if (!sourceLayout)
-            sourceLayout = getDataLayout(castOp->getOperand(0));
-          VMILayoutSupport supports;
-          FailureOr<VMICastLayoutFact> fact =
-              supports.getCastLayoutFactForSourceLayout(sourceType, resultType,
-                                                        sourceLayout);
-          if (succeeded(fact) && fact->resultLayout.isGroupSlots() &&
-              fact->resultLayout.getNumGroups() == numGroups &&
-              fact->resultLayout.getSlots() > 0)
-            return fact->resultLayout;
-        }
-      }
-    }
-    VMILayoutAttr solved = getDataLayout(value);
-    if (solved && solved.isGroupSlots() && solved.getNumGroups() == numGroups &&
-        solved.getSlots() > 0)
-      return solved;
-    if (value.getDefiningOp<VMIGroupReduceAddFOp>() ||
-        value.getDefiningOp<VMIGroupReduceMaxFOp>() ||
-        value.getDefiningOp<VMIGroupReduceMinFOp>() ||
-        value.getDefiningOp<VMIGroupReduceAddIOp>() ||
-        value.getDefiningOp<VMIGroupReduceMaxIOp>() ||
-        value.getDefiningOp<VMIGroupReduceMinIOp>())
-      return getPreferredGroupSlotsLayout(type, numGroups);
-    if (type.getElementCount() == numGroups) {
-      std::optional<int64_t> stride = getConstantIndexValue(rowStride);
-      bool packedSlots =
-          stride && *stride == 1 && static_cast<int64_t>(numGroups) >= 8;
-      return VMILayoutAttr::getGroupSlots(ctx, numGroups, packedSlots ? 8 : 1);
-    }
-    if (auto load = value.getDefiningOp<VMIGroupSlotLoadOp>())
-      return getPreferredGroupSlotLoadLayout(load);
-    return getContiguousLayout();
-  }
-
-  VMILayoutAttr getPreferredGroupStoreUseLayout(Value value, int64_t numGroups,
-                                                Value rowStride) {
-    return getPreferredGroupStoreUseLayout(
-        value, numGroups, rowStride,
-        [&](Value knownValue) { return getDataLayout(knownValue); });
   }
 
   VMILayoutAttr getDataLayout(Value value) {
@@ -1287,8 +1214,24 @@ struct LayoutSolver {
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMIGroupStoreOp>(op)) {
-        addDataValue(store.getValue());
-        groupStoreUseRequests.push_back(GroupStoreUseRequest{store});
+        auto valueType = cast<VMIVRegType>(store.getValue().getType());
+        VMILayoutSupport supports;
+        VMILayoutAttr highPriorityLayout;
+        FailureOr<VMIGroupStoreLayoutFact> highPriorityFact =
+            supports.getHighPriorityGroupStoreLayoutFact(store, valueType);
+        if (succeeded(highPriorityFact)) {
+          highPriorityLayout = highPriorityFact->valueLayout;
+          requestDataUse(store.getValueMutable(), highPriorityLayout,
+                         /*late=*/false, DataLayoutSeedPhase::GroupStore);
+        }
+
+        FailureOr<VMIGroupStoreLayoutFact> preferredFact =
+            supports.getPreferredGroupStoreLayoutFact(store, valueType);
+        if (succeeded(preferredFact) &&
+            preferredFact->valueLayout != highPriorityLayout)
+          requestDataUse(store.getValueMutable(), preferredFact->valueLayout,
+                         /*late=*/false,
+                         DataLayoutSeedPhase::GroupStoreFallback);
         return WalkResult::advance();
       }
       if (auto store = dyn_cast<VMIMaskedStoreOp>(op)) {
@@ -1864,19 +1807,6 @@ struct LayoutSolver {
                               static_cast<DataLayoutSeedPhase>(phase))))
         return failure();
 
-    for (GroupStoreUseRequest request : groupStoreUseRequests) {
-      VMIGroupStoreOp store = request.store;
-      VMILayoutAttr layout = getPreferredGroupStoreUseLayout(
-          store.getValue(), store.getNumGroupsAttr().getInt(),
-          store.getRowStride(), [&](Value value) {
-            return propagator.getRequestedOrCurrentLayout(value);
-          });
-      if (failed(propagator.request(store.getValueMutable(), layout)))
-        return failure();
-    }
-    if (failed(propagator.run()))
-      return failure();
-
     for (DataUseRequest request : dataUseRequests)
       if (request.late &&
           failed(propagator.request(*request.operand, request.layout)))
@@ -1961,7 +1891,6 @@ struct LayoutSolver {
   SmallVector<MaskNode> maskNodes;
   SmallVector<DataLayoutSeed> dataLayoutSeeds;
   SmallVector<DataUseRequest> dataUseRequests;
-  SmallVector<GroupStoreUseRequest> groupStoreUseRequests;
   SmallVector<MaskUseRequest> maskUseRequests;
 };
 

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -660,6 +660,34 @@ public:
   }
 };
 
+class VMIGroupStoreTransfer final : public VMILayoutTransfer {
+public:
+  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
+        const VMILayoutPropagator &propagator,
+        OpOperand *changedOperand) const override {
+    auto store = dyn_cast<VMIGroupStoreOp>(op);
+    if (!store || changedValue != store.getValue())
+      return failure();
+
+    auto valueType = dyn_cast<VMIVRegType>(store.getValue().getType());
+    if (!valueType)
+      return failure();
+
+    VMILayoutSupport supports;
+    FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>> facts =
+        supports.getGroupStoreLayoutFactsForLayout(store, valueType,
+                                                   changedLayout);
+    if (failed(facts) || facts->empty())
+      return failure();
+    SmallVector<VMILayoutRelation, 4> relations;
+    for (const VMIGroupStoreLayoutFact &fact : *facts)
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+          operandFact(store.getValueMutable(), fact.valueLayout)}));
+    return relations;
+  }
+};
+
 class VMIMaskedLoadTransfer final : public VMILayoutTransfer {
 public:
   FailureOr<SmallVector<VMILayoutRelation, 4>>
@@ -750,6 +778,7 @@ const VMILayoutTransfer *getTransfer(Operation *op) {
   static VMIInterleaveTransfer interleaveTransfer;
   static VMIGatherTransfer gatherTransfer;
   static VMIStoreTransfer storeTransfer;
+  static VMIGroupStoreTransfer groupStoreTransfer;
   static VMIMaskedLoadTransfer maskedLoadTransfer;
   static VMIMaskedStoreTransfer maskedStoreTransfer;
 
@@ -784,6 +813,8 @@ const VMILayoutTransfer *getTransfer(Operation *op) {
     return &castTransfer;
   if (isa<VMIStoreOp>(op))
     return &storeTransfer;
+  if (isa<VMIGroupStoreOp>(op))
+    return &groupStoreTransfer;
   if (isa<VMIMaskedLoadOp>(op))
     return &maskedLoadTransfer;
   if (isa<VMIMaskedStoreOp>(op))

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -683,6 +683,32 @@ static constexpr GroupSlotMemoryLayoutPattern kGroupSlotMemoryLayoutPatterns[] =
         {gs(8, 4)},
 };
 
+enum class GroupStoreLayoutPriority {
+  LegalOnly,
+  Fallback,
+  High,
+};
+
+struct GroupStoreLayoutPattern {
+  ElementBitsPattern elementBits;
+  GroupBlockPattern block;
+  GroupMemoryPattern memory = memAny();
+  LayoutPattern valueLayout;
+  GroupStoreLayoutPriority priority = GroupStoreLayoutPriority::LegalOnly;
+};
+
+static constexpr GroupStoreLayoutPattern kGroupStoreLayoutPatterns[] = {
+    // One 32B block per group requires packed contiguous values for the
+    // block-strided store path when row_stride preserves 32B alignment.
+    {bits<8, 16, 32>(), gb(1), memBlockAligned(), c(),
+     GroupStoreLayoutPriority::High},
+    // Full physical group chunks use ordinary contiguous stores.
+    {bits<8, 16, 32>(), gbFull(), memAny(), c(),
+     GroupStoreLayoutPriority::Fallback},
+    // Two-part deinterleaved values can be stored directly with vstsx2.
+    {bits<8, 16, 32>(), gbFull(2), memAny(), d(2)},
+};
+
 struct GroupBroadcastLoadLayoutPattern {
   GroupBlockPattern block;
   ElementBitsPattern elementBits;
@@ -951,6 +977,19 @@ static bool matchesGroupBlockPattern(GroupBlockPattern pattern,
   if (pattern.denominator <= 0 || numerator % pattern.denominator != 0)
     return false;
   return key.groupSize == numerator / pattern.denominator;
+}
+
+static bool matchesGroupStoreLayoutPattern(
+    const GroupStoreLayoutPattern &pattern, VMIVRegType valueType,
+    GroupLayoutKey key, std::optional<int64_t> rowStride) {
+  unsigned elementBits =
+      pto::getPTOStorageElemBitWidth(valueType.getElementType());
+  return elementBits != 0 &&
+         matchesElementBitsPattern(pattern.elementBits,
+                                   valueType.getElementType()) &&
+         matchesGroupBlockPattern(pattern.block, key) &&
+         matchesGroupLoadMemoryPattern(pattern.memory, rowStride,
+                                       key.groupSize, elementBits);
 }
 
 static FailureOr<GroupLayoutKey>
@@ -2338,6 +2377,193 @@ FailureOr<VMIGroupSlotLayoutFact> VMILayoutSupport::getGroupStoreLayoutFact(
     return fail("value layout does not match a supported group_store table "
                 "row");
   return VMIGroupSlotLayoutFact{layout, numGroups, layout.getSlots()};
+}
+
+FailureOr<VMIGroupStoreLayoutFact> VMILayoutSupport::getGroupStoreLayoutFact(
+    VMIGroupStoreOp op, VMIVRegType valueType, std::string *reason) const {
+  auto fail = [&](const Twine &message) -> FailureOr<VMIGroupStoreLayoutFact> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  VMILayoutAttr layout = valueType.getLayoutAttr();
+  if (!layout)
+    return fail("requires assigned value layout");
+
+  int64_t numGroups = op.getNumGroupsAttr().getInt();
+  if (layout.isGroupSlots()) {
+    if (failed(getGroupStoreLayoutFact(valueType, numGroups, reason)))
+      return failure();
+    return VMIGroupStoreLayoutFact{layout};
+  }
+
+  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0)
+    return fail("group_store requires known element bit width");
+
+  FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
+      valueType, numGroups,
+      "group_store layout table has no row for this group size", reason);
+  if (failed(key))
+    return failure();
+
+  std::optional<int64_t> rowStride =
+      getConstantIndexValue(op.getRowStride());
+  for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+      continue;
+    if (!matchesLayoutPattern(valueType.getContext(), pattern.valueLayout,
+                              layout))
+      continue;
+    return VMIGroupStoreLayoutFact{layout};
+  }
+
+  return fail("value layout, group size, and row_stride do not match a "
+              "supported group_store table row");
+}
+
+FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>>
+VMILayoutSupport::getGroupStoreLayoutFactsForLayout(
+    VMIGroupStoreOp op, VMIVRegType valueType, VMILayoutAttr layout,
+    std::string *reason) const {
+  auto fail = [&](const Twine &message)
+      -> FailureOr<SmallVector<VMIGroupStoreLayoutFact, 4>> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  if (!layout)
+    return fail("requires assigned group_store value layout");
+
+  MLIRContext *ctx = valueType.getContext();
+  auto sourceType = VMIVRegType::get(ctx, valueType.getElementCount(),
+                                    valueType.getElementType(), layout);
+  if (succeeded(getGroupStoreLayoutFact(op, sourceType, nullptr)))
+    return SmallVector<VMIGroupStoreLayoutFact, 4>{{layout}};
+
+  FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
+      valueType, op.getNumGroupsAttr().getInt(),
+      "group_store layout table has no row for this group size", reason);
+  if (failed(key))
+    return failure();
+
+  std::optional<int64_t> rowStride =
+      getConstantIndexValue(op.getRowStride());
+  SmallVector<VMIGroupStoreLayoutFact, 4> facts;
+  for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+      continue;
+
+    VMILayoutAttr useLayout =
+        materializeLayoutPattern(ctx, pattern.valueLayout);
+    bool duplicate = llvm::any_of(
+        facts, [&](const VMIGroupStoreLayoutFact &fact) {
+          return fact.valueLayout == useLayout;
+        });
+    if (!useLayout || duplicate)
+      continue;
+
+    auto useType = VMIVRegType::get(ctx, valueType.getElementCount(),
+                                   valueType.getElementType(), useLayout);
+    if (failed(getEnsureLayoutFact(sourceType, useType, nullptr)))
+      continue;
+    facts.push_back(VMIGroupStoreLayoutFact{useLayout});
+  }
+
+  if (facts.empty())
+    return fail("value layout cannot be used directly or materialized to a "
+                "supported group_store layout table row");
+  return facts;
+}
+
+FailureOr<VMIGroupStoreLayoutFact>
+VMILayoutSupport::getPreferredGroupStoreLayoutFact(
+    VMIGroupStoreOp op, VMIVRegType valueType, std::string *reason) const {
+  auto fail = [&](const Twine &message) -> FailureOr<VMIGroupStoreLayoutFact> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  MLIRContext *ctx = valueType.getContext();
+  int64_t numGroups = op.getNumGroupsAttr().getInt();
+  if (valueType.getElementCount() == numGroups) {
+    std::optional<int64_t> rowStride =
+        getConstantIndexValue(op.getRowStride());
+    bool packedSlots =
+        rowStride && *rowStride == 1 && static_cast<int64_t>(numGroups) >= 8;
+    VMILayoutAttr layout =
+        VMILayoutAttr::getGroupSlots(ctx, numGroups, packedSlots ? 8 : 1);
+    auto assignedType = VMIVRegType::get(
+        ctx, valueType.getElementCount(), valueType.getElementType(), layout);
+    if (succeeded(getGroupStoreLayoutFact(op, assignedType, nullptr)))
+      return VMIGroupStoreLayoutFact{layout};
+  }
+
+  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0)
+    return fail("group_store requires known element bit width");
+  FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
+      valueType, numGroups,
+      "group_store preferred layout table has no row for this group size",
+      reason);
+  if (failed(key))
+    return failure();
+
+  std::optional<int64_t> rowStride =
+      getConstantIndexValue(op.getRowStride());
+  const GroupStoreLayoutPattern *selected = nullptr;
+  for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
+    if (pattern.priority == GroupStoreLayoutPriority::LegalOnly)
+      continue;
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+      continue;
+    if (!selected || static_cast<unsigned>(pattern.priority) >
+                         static_cast<unsigned>(selected->priority))
+      selected = &pattern;
+  }
+  if (selected)
+    return VMIGroupStoreLayoutFact{
+        materializeLayoutPattern(ctx, selected->valueLayout)};
+
+  return fail("value type, group size, and row_stride do not match a "
+              "preferred group_store table row");
+}
+
+FailureOr<VMIGroupStoreLayoutFact>
+VMILayoutSupport::getHighPriorityGroupStoreLayoutFact(
+    VMIGroupStoreOp op, VMIVRegType valueType, std::string *reason) const {
+  auto fail = [&](const Twine &message) -> FailureOr<VMIGroupStoreLayoutFact> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  if (pto::getPTOStorageElemBitWidth(valueType.getElementType()) == 0)
+    return fail("group_store requires known element bit width");
+  FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
+      valueType, op.getNumGroupsAttr().getInt(),
+      "high-priority group_store layout table has no row for this group size",
+      reason);
+  if (failed(key))
+    return failure();
+
+  std::optional<int64_t> rowStride =
+      getConstantIndexValue(op.getRowStride());
+  for (const GroupStoreLayoutPattern &pattern : kGroupStoreLayoutPatterns) {
+    if (pattern.priority != GroupStoreLayoutPriority::High)
+      continue;
+    if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
+      continue;
+    VMILayoutAttr layout = materializeLayoutPattern(valueType.getContext(),
+                                                    pattern.valueLayout);
+    if (!layout)
+      continue;
+    return VMIGroupStoreLayoutFact{layout};
+  }
+
+  return fail("value type, group size, and row_stride do not match a "
+              "high-priority group_store table row");
 }
 
 LogicalResult getGroupReduceAddSupportImpl(VMIVRegType sourceType,

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -1052,6 +1052,18 @@ static VMIGroupBroadcastLayoutFact materializeGroupBroadcastLayoutFact(
   return fact;
 }
 
+static VMIGroupStoreLayoutFact materializeGroupStoreLayoutFact(
+    MLIRContext *ctx, const GroupStoreLayoutPattern &pattern,
+    GroupLayoutKey key) {
+  VMIGroupStoreLayoutFact fact;
+  fact.valueLayout = materializeLayoutPattern(ctx, pattern.valueLayout);
+  fact.blockClass = getGroupBlockClassFromPattern(pattern.block);
+  fact.groupSize = key.groupSize;
+  fact.lanesPerPart = key.lanesPerPart;
+  fact.vcgBlockElems = key.vcgBlockElems;
+  return fact;
+}
+
 static VMIInterleaveLayoutFact materializeInterleaveLayoutFact(
     MLIRContext *ctx, const InterleaveLayoutPattern &pattern,
     InterleaveLayoutKey key) {
@@ -2415,7 +2427,10 @@ FailureOr<VMIGroupStoreLayoutFact> VMILayoutSupport::getGroupStoreLayoutFact(
     if (!matchesLayoutPattern(valueType.getContext(), pattern.valueLayout,
                               layout))
       continue;
-    return VMIGroupStoreLayoutFact{layout};
+    VMIGroupStoreLayoutFact fact =
+        materializeGroupStoreLayoutFact(valueType.getContext(), pattern, *key);
+    fact.valueLayout = layout;
+    return fact;
   }
 
   return fail("value layout, group size, and row_stride do not match a "
@@ -2439,8 +2454,10 @@ VMILayoutSupport::getGroupStoreLayoutFactsForLayout(
   MLIRContext *ctx = valueType.getContext();
   auto sourceType = VMIVRegType::get(ctx, valueType.getElementCount(),
                                     valueType.getElementType(), layout);
-  if (succeeded(getGroupStoreLayoutFact(op, sourceType, nullptr)))
-    return SmallVector<VMIGroupStoreLayoutFact, 4>{{layout}};
+  FailureOr<VMIGroupStoreLayoutFact> directFact =
+      getGroupStoreLayoutFact(op, sourceType, nullptr);
+  if (succeeded(directFact))
+    return SmallVector<VMIGroupStoreLayoutFact, 4>{*directFact};
 
   FailureOr<GroupLayoutKey> key = buildGroupLayoutKey(
       valueType, op.getNumGroupsAttr().getInt(),
@@ -2468,7 +2485,10 @@ VMILayoutSupport::getGroupStoreLayoutFactsForLayout(
                                    valueType.getElementType(), useLayout);
     if (failed(getEnsureLayoutFact(sourceType, useType, nullptr)))
       continue;
-    facts.push_back(VMIGroupStoreLayoutFact{useLayout});
+    VMIGroupStoreLayoutFact fact =
+        materializeGroupStoreLayoutFact(ctx, pattern, *key);
+    fact.valueLayout = useLayout;
+    facts.push_back(fact);
   }
 
   if (facts.empty())
@@ -2523,8 +2543,7 @@ VMILayoutSupport::getPreferredGroupStoreLayoutFact(
       selected = &pattern;
   }
   if (selected)
-    return VMIGroupStoreLayoutFact{
-        materializeLayoutPattern(ctx, selected->valueLayout)};
+    return materializeGroupStoreLayoutFact(ctx, *selected, *key);
 
   return fail("value type, group size, and row_stride do not match a "
               "preferred group_store table row");
@@ -2555,11 +2574,11 @@ VMILayoutSupport::getHighPriorityGroupStoreLayoutFact(
       continue;
     if (!matchesGroupStoreLayoutPattern(pattern, valueType, *key, rowStride))
       continue;
-    VMILayoutAttr layout = materializeLayoutPattern(valueType.getContext(),
-                                                    pattern.valueLayout);
-    if (!layout)
+    VMIGroupStoreLayoutFact fact = materializeGroupStoreLayoutFact(
+        valueType.getContext(), pattern, *key);
+    if (!fact.valueLayout)
       continue;
-    return VMIGroupStoreLayoutFact{layout};
+    return fact;
   }
 
   return fail("value type, group size, and row_stride do not match a "

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -1791,6 +1791,48 @@ static bool isCompactSmallGroupStore(VMILayoutAttr layout,
          rowStride && *rowStride == 1;
 }
 
+struct OneBlockGroupStorePlan {
+  int64_t groupSize = 0;
+  int64_t groupsPerPart = 0;
+  int64_t blockStride = 0;
+};
+
+FailureOr<OneBlockGroupStorePlan> getOneBlockGroupStorePlan(
+    VMIGroupStoreOp op, VMIVRegType valueType,
+    const VMIGroupStoreLayoutFact &fact, std::string *reason) {
+  auto fail = [&](const Twine &message)
+      -> FailureOr<OneBlockGroupStorePlan> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  VMILayoutAttr layout = valueType.getLayoutAttr();
+  if (fact.blockClass != VMIGroupBlockClass::OneBlock || !layout ||
+      !layout.isContiguous())
+    return fail("one-block group_store requires contiguous layout");
+  if (fact.groupSize <= 0 || fact.groupSize != fact.vcgBlockElems ||
+      fact.lanesPerPart <= 0 ||
+      fact.lanesPerPart % fact.groupSize != 0)
+    return fail("one-block group_store requires one 32B group per VCG block");
+  if (!isa<PtrType>(op.getDestination().getType()))
+    return fail("one-block group_store requires !pto.ptr destination");
+
+  std::optional<int64_t> rowStride =
+      getConstantIndexValue(op.getRowStride());
+  if (!rowStride || *rowStride <= 0 || *rowStride % fact.groupSize != 0)
+    return fail("one-block group_store requires a constant positive row_stride "
+                "aligned to 32B blocks");
+
+  int64_t blockStride = *rowStride / fact.groupSize;
+  if (blockStride > 0xffff)
+    return fail("one-block group_store block_stride exceeds the 16-bit vsstb "
+                "control field");
+
+  return OneBlockGroupStorePlan{
+      fact.groupSize, fact.lanesPerPart / fact.groupSize, blockStride};
+}
+
 LogicalResult
 checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
@@ -1847,22 +1889,29 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
     return success();
   }
 
-  FailureOr<int64_t> groupSize = getGroupSizeFromNumGroups(
-      valueType, op.getNumGroupsAttr().getInt(), reason);
-  if (failed(groupSize))
+  VMILayoutSupport supports;
+  FailureOr<VMIGroupStoreLayoutFact> fact =
+      supports.getGroupStoreLayoutFact(op, valueType, reason);
+  if (failed(fact))
     return failure();
   if (failed(checkSupportedStoreShape(valueType,
                                       op.getDestination(),
                                       op.getDestination().getType(), reason)))
     return failure();
-  if (succeeded(checkSupportedGroupChunkShape(valueType, *groupSize, reason)))
+  if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
+    if (failed(getOneBlockGroupStorePlan(op, valueType, *fact, reason)))
+      return failure();
+    return success();
+  }
+  if (succeeded(
+          checkSupportedGroupChunkShape(valueType, fact->groupSize, reason)))
     return success();
 
   int64_t lanesPerPart = 0;
   int64_t groupCount = 0;
   int64_t chunksPerGroupPerPart = 0;
   return checkDeinterleaved2GroupStoreChunkShape(
-      valueType, *groupSize, &lanesPerPart, &groupCount,
+      valueType, fact->groupSize, &lanesPerPart, &groupCount,
       &chunksPerGroupPerPart, reason);
 }
 
@@ -7675,21 +7724,67 @@ struct OneToNVMIGroupStoreOpPattern
       return success();
     }
 
+    VMILayoutSupport supports;
+    FailureOr<VMIGroupStoreLayoutFact> fact =
+        supports.getGroupStoreLayoutFact(op, valueVMIType);
+    if (failed(fact))
+      return rewriter.notifyMatchFailure(
+          op, "group_store layout does not match the support table");
+
+    if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
+      FailureOr<OneBlockGroupStorePlan> plan =
+          getOneBlockGroupStorePlan(op, valueVMIType, *fact, nullptr);
+      if (failed(plan))
+        return rewriter.notifyMatchFailure(
+            op, "failed to build one-block group_store vsstb plan");
+
+      ValueRange valueParts = adaptor.getValue();
+      int64_t numGroups = op.getNumGroupsAttr().getInt();
+      if (static_cast<int64_t>(valueParts.size()) !=
+          ceilDivNonNegative(numGroups, plan->groupsPerPart))
+        return rewriter.notifyMatchFailure(
+            op, "one-block group_store physical arity mismatch");
+
+      Value blockStride = rewriter.create<arith::ConstantIntOp>(
+          op.getLoc(), plan->blockStride, 16);
+      Value repeatStride =
+          rewriter.create<arith::ConstantIntOp>(op.getLoc(), 0, 16);
+      for (auto [part, value] : llvm::enumerate(valueParts)) {
+        auto vregType = dyn_cast<VRegType>(value.getType());
+        if (!vregType)
+          return rewriter.notifyMatchFailure(
+              op, "one-block group_store value must be vreg");
+        FailureOr<Value> mask = createContiguousStoreMask(
+            op.getLoc(), valueVMIType, part, vregType, rewriter);
+        if (failed(mask))
+          return rewriter.notifyMatchFailure(
+              op, "failed to create one-block group_store mask");
+
+        Value partOffset = createGroupChunkOffset(
+            op.getLoc(), *offset, *rowStride, part * plan->groupsPerPart,
+            /*inGroupLaneOffset=*/0, rewriter);
+        Value base = rewriter
+                         .create<AddPtrOp>(op.getLoc(), (*destination).getType(),
+                                           *destination, partOffset)
+                         .getResult();
+        rewriter.create<VsstbOp>(op.getLoc(), /*updated_base=*/Type{}, value,
+                                 base, blockStride, repeatStride, *mask);
+      }
+
+      rewriter.eraseOp(op);
+      return success();
+    }
+
     int64_t lanesPerPart = 0;
     int64_t groupCount = 0;
     int64_t chunksPerGroup = 0;
-    FailureOr<int64_t> groupSize =
-        getGroupSizeFromNumGroups(valueVMIType, op.getNumGroupsAttr().getInt());
-    if (failed(groupSize))
-      return rewriter.notifyMatchFailure(
-          op, "group_store requires num_groups to evenly divide lane count");
 
     int64_t d2LanesPerPart = 0;
     int64_t d2GroupCount = 0;
     int64_t d2ChunksPerGroupPerPart = 0;
     std::string d2Reason;
     if (succeeded(checkDeinterleaved2GroupStoreChunkShape(
-            valueVMIType, *groupSize, &d2LanesPerPart, &d2GroupCount,
+            valueVMIType, fact->groupSize, &d2LanesPerPart, &d2GroupCount,
             &d2ChunksPerGroupPerPart, &d2Reason))) {
       std::optional<std::string> dist =
           getX2MemoryDistToken(valueVMIType.getElementType(), "INTLV");
@@ -7734,7 +7829,7 @@ struct OneToNVMIGroupStoreOpPattern
       return success();
     }
 
-    if (failed(checkContiguousFullGroupChunks(op, valueVMIType, *groupSize,
+    if (failed(checkContiguousFullGroupChunks(op, valueVMIType, fact->groupSize,
                                               &lanesPerPart, &groupCount,
                                               &chunksPerGroup, rewriter)))
       return failure();
@@ -12632,9 +12727,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
         return WalkResult::advance();
       store.emitError()
           << kVMIDiagUnsupportedPrefix
-          << "pto.vmi.group_store requires contiguous full value chunks, a "
-             "supported UB destination, and num_groups deriving a group size "
-             "aligned to physical chunks ("
+          << "pto.vmi.group_store requires a supported UB destination and a "
+             "table-supported value layout lowering through one-block vsstb, "
+             "full-chunk vsts, or deinterleaved vstsx2 ("
           << reason << ")";
       return WalkResult::interrupt();
     }

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -3655,8 +3655,35 @@ static FailureOr<StringRef> buildVldsx2Callee(MLIRContext *context,
       .getValue();
 }
 
-static StringRef buildVsldbCallee(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.vsldb").getValue();
+static FailureOr<StringRef>
+buildBlockStridedMemoryCallee(MLIRContext *context, Type vectorType,
+                              StringRef stem, bool post) {
+  Type elementType = getElementTypeFromVectorLike(vectorType);
+  auto lanes = getElementCountFromVectorLike(vectorType);
+  if (!elementType || !lanes)
+    return failure();
+
+  std::string element;
+  if (auto intType = dyn_cast<IntegerType>(elementType))
+    element = "i" + std::to_string(intType.getWidth());
+  else if (isLowpPayloadElementType(elementType))
+    element = "i8";
+  else
+    element = getMemoryElementTypeFragment(elementType);
+  if (element.empty())
+    return failure();
+
+  return StringAttr::get(context,
+                         "llvm.hivm." + stem.str() +
+                             std::string(post ? ".post" : "") + ".v" +
+                             std::to_string(*lanes) + element)
+      .getValue();
+}
+
+static FailureOr<StringRef> buildVsldbCallee(MLIRContext *context,
+                                              Type resultType) {
+  return buildBlockStridedMemoryCallee(context, resultType, "vsldb",
+                                       /*post=*/false);
 }
 
 static FailureOr<StringRef> buildVstsCallee(MLIRContext *context, Type valueType) {
@@ -3681,12 +3708,9 @@ static FailureOr<StringRef> buildVstsx2Callee(MLIRContext *context, Type valueTy
       .getValue();
 }
 
-static StringRef buildVsstbCallee(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.vsstb").getValue();
-}
-
-static StringRef buildVsstbPostCallee(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.vsstb.post").getValue();
+static FailureOr<StringRef> buildVsstbCallee(MLIRContext *context,
+                                             Type valueType, bool post) {
+  return buildBlockStridedMemoryCallee(context, valueType, "vsstb", post);
 }
 
 static Type getVgather2SourceElementType(Type sourceType) {
@@ -6783,7 +6807,10 @@ public:
     Type callResultType = getPayloadABIType(
         op.getResult().getType(), resultType, rewriter.getContext());
 
-    StringRef calleeName = buildVsldbCallee(op.getContext());
+    FailureOr<StringRef> calleeName =
+        buildVsldbCallee(op.getContext(), op.getResult().getType());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported vsldb signature");
     Value zeroValue = getI32Constant(rewriter, op.getLoc(), 0);
     SmallVector<Value> args{adaptor.getSource(), packedStride, zeroValue,
                             adaptor.getMask()};
@@ -6791,9 +6818,9 @@ public:
         TypeRange{adaptor.getSource().getType(), packedStride.getType(),
                   zeroValue.getType(), adaptor.getMask().getType()},
         TypeRange{callResultType});
-    auto call = rewriter.create<func::CallOp>(op.getLoc(), calleeName,
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               TypeRange{callResultType}, args);
-    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     Value result = castFromPayloadABI(
         op.getLoc(), call.getResult(0), op.getResult().getType(), resultType,
         rewriter);
@@ -7080,9 +7107,10 @@ public:
       return rewriter.notifyMatchFailure(op, "unsupported vsstb result count");
     }
 
-    StringRef calleeName = usePostIntrinsic
-                               ? buildVsstbPostCallee(op.getContext())
-                               : buildVsstbCallee(op.getContext());
+    FailureOr<StringRef> calleeName = buildVsstbCallee(
+        op.getContext(), op.getValue().getType(), usePostIntrinsic);
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported vsstb signature");
     Value zeroValue = getI32Constant(rewriter, op.getLoc(), usePostIntrinsic ? 1 : 0);
     Value value = castToPayloadABI(
         op.getLoc(), adaptor.getValue(), op.getValue().getType(), rewriter);
@@ -7093,9 +7121,9 @@ public:
                   packedStride.getType(), zeroValue.getType(),
                   adaptor.getMask().getType()},
         resultTypes);
-    auto call = rewriter.create<func::CallOp>(op.getLoc(), calleeName,
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               resultTypes, args);
-    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     if (usePostIntrinsic)
       rewriter.replaceOp(op, call.getResults());
     else

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -3701,8 +3701,35 @@ static FailureOr<StringRef> buildVldsx2Callee(MLIRContext *context,
   return buildMemoryLaneTypedCallee(context, resultType, "vldsx2", "");
 }
 
-static StringRef buildVsldbCallee(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.vsldb").getValue();
+static FailureOr<StringRef>
+buildBlockStridedMemoryCallee(MLIRContext *context, Type vectorType,
+                              StringRef stem, bool post) {
+  Type elementType = getElementTypeFromVectorLike(vectorType);
+  auto lanes = getElementCountFromVectorLike(vectorType);
+  if (!elementType || !lanes)
+    return failure();
+
+  std::string element;
+  if (auto intType = dyn_cast<IntegerType>(elementType))
+    element = "i" + std::to_string(intType.getWidth());
+  else if (isLowpPayloadElementType(elementType))
+    element = "i8";
+  else
+    element = getMemoryElementTypeFragment(elementType);
+  if (element.empty())
+    return failure();
+
+  return StringAttr::get(context,
+                         "llvm.hivm." + stem.str() +
+                             std::string(post ? ".post" : "") + ".v" +
+                             std::to_string(*lanes) + element)
+      .getValue();
+}
+
+static FailureOr<StringRef> buildVsldbCallee(MLIRContext *context,
+                                              Type resultType) {
+  return buildBlockStridedMemoryCallee(context, resultType, "vsldb",
+                                       /*post=*/false);
 }
 
 static FailureOr<StringRef> buildVstsCallee(MLIRContext *context, Type valueType) {
@@ -3720,12 +3747,9 @@ static FailureOr<StringRef> buildVstsx2Callee(MLIRContext *context, Type valueTy
   return buildMemoryLaneTypedCallee(context, valueType, "vstsx2", "");
 }
 
-static StringRef buildVsstbCallee(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.vsstb").getValue();
-}
-
-static StringRef buildVsstbPostCallee(MLIRContext *context) {
-  return StringAttr::get(context, "llvm.hivm.vsstb.post").getValue();
+static FailureOr<StringRef> buildVsstbCallee(MLIRContext *context,
+                                             Type valueType, bool post) {
+  return buildBlockStridedMemoryCallee(context, valueType, "vsstb", post);
 }
 
 static Type getVgather2SourceElementType(Type sourceType) {
@@ -7382,7 +7406,10 @@ public:
     Type callResultType = getPayloadABIType(
         op.getResult().getType(), resultType, rewriter.getContext());
 
-    StringRef calleeName = buildVsldbCallee(op.getContext());
+    FailureOr<StringRef> calleeName =
+        buildVsldbCallee(op.getContext(), op.getResult().getType());
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported vsldb signature");
     Value zeroValue = getI32Constant(rewriter, op.getLoc(), 0);
     SmallVector<Value> args{adaptor.getSource(), packedStride, zeroValue,
                             adaptor.getMask()};
@@ -7390,9 +7417,9 @@ public:
         TypeRange{adaptor.getSource().getType(), packedStride.getType(),
                   zeroValue.getType(), adaptor.getMask().getType()},
         TypeRange{callResultType});
-    auto call = rewriter.create<func::CallOp>(op.getLoc(), calleeName,
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               TypeRange{callResultType}, args);
-    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     Value result = castFromPayloadABI(
         op.getLoc(), call.getResult(0), op.getResult().getType(), resultType,
         rewriter);
@@ -7679,9 +7706,10 @@ public:
       return rewriter.notifyMatchFailure(op, "unsupported vsstb result count");
     }
 
-    StringRef calleeName = usePostIntrinsic
-                               ? buildVsstbPostCallee(op.getContext())
-                               : buildVsstbCallee(op.getContext());
+    FailureOr<StringRef> calleeName = buildVsstbCallee(
+        op.getContext(), op.getValue().getType(), usePostIntrinsic);
+    if (failed(calleeName))
+      return rewriter.notifyMatchFailure(op, "unsupported vsstb signature");
     Value zeroValue = getI32Constant(rewriter, op.getLoc(), usePostIntrinsic ? 1 : 0);
     Value value = castToPayloadABI(
         op.getLoc(), adaptor.getValue(), op.getValue().getType(), rewriter);
@@ -7692,9 +7720,9 @@ public:
                   packedStride.getType(), zeroValue.getType(),
                   adaptor.getMask().getType()},
         resultTypes);
-    auto call = rewriter.create<func::CallOp>(op.getLoc(), calleeName,
+    auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               resultTypes, args);
-    state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     if (usePostIntrinsic)
       rewriter.replaceOp(op, call.getResults());
     else

--- a/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s12_invalid.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_reduce_s12_invalid.pto
@@ -15,7 +15,7 @@ module {
       %dst: !pto.ptr<f32, ub>,
       %off: index) {
     %c1 = arith.constant 1 : index
-    // CHECK: VMI-LAYOUT-CONTRACT: cannot materialize requested VMI operand layout #pto.vmi.layout<num_groups = 8>
+    // CHECK: VMI-LAYOUT-CONTRACT: cannot materialize requested VMI operand layout #pto.vmi.layout<num_groups = 8, slots = 8>
     %sum = pto.vmi.vcadd %source, %mask
         {group = 8, reassoc}
         : !pto.vmi.vreg<96xf32>, !pto.vmi.mask<96xpred>

--- a/test/lit/vmi_new/vmi_layout_assignment_group_store_truncf_contiguous.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_group_store_truncf_contiguous.pto
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-layout-assignment | FileCheck %s
+
+module {
+  func.func @vmi_layout_assignment_group_store_truncf_contiguous(
+      %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<bf16, ub>, %off: index) {
+    %c1024 = arith.constant 1024 : index
+    %value = pto.vmi.load %src[%off]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
+    %narrow = pto.vmi.truncf %value {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xbf16>
+    pto.vmi.group_store %narrow, %dst[%off], %c1024
+        {num_groups = 8 : i64}
+        : !pto.vmi.vreg<128xbf16>, !pto.ptr<bf16, ub>
+    return
+  }
+
+  func.func @vmi_layout_assignment_group_store_d4_to_d2(
+      %value: !pto.vmi.vreg<512xf32, #pto.vmi.layout<deinterleaved = 4>>,
+      %dst: !pto.ptr<f32, ub>, %off: index) {
+    %c512 = arith.constant 512 : index
+    pto.vmi.group_store %value, %dst[%off], %c512
+        {num_groups = 2 : i64}
+        : !pto.vmi.vreg<512xf32, #pto.vmi.layout<deinterleaved = 4>>,
+          !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_layout_assignment_group_store_truncf_contiguous(
+// CHECK: %[[VALUE:.*]] = pto.vmi.load
+// CHECK-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// CHECK: %[[NARROW:.*]] = pto.vmi.truncf %[[VALUE]]
+// CHECK-SAME: !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>> -> !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>
+// CHECK-NOT: pto.vmi.ensure_layout
+// CHECK: pto.vmi.group_store %[[NARROW]]
+// CHECK-SAME: !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>, !pto.ptr<bf16, ub>
+
+// CHECK-LABEL: func.func @vmi_layout_assignment_group_store_d4_to_d2(
+// CHECK-SAME: %[[D4:.*]]: !pto.vmi.vreg<512xf32, #pto.vmi.layout<deinterleaved = 4>>
+// CHECK: %[[D2:.*]] = pto.vmi.ensure_layout %[[D4]]
+// CHECK-SAME: -> !pto.vmi.vreg<512xf32, #pto.vmi.layout<deinterleaved = 2>>
+// CHECK: pto.vmi.group_store %[[D2]]
+// CHECK-SAME: !pto.vmi.vreg<512xf32, #pto.vmi.layout<deinterleaved = 2>>, !pto.ptr<f32, ub>

--- a/test/lit/vmi_new/vmi_to_vpto_group_store_vsstb.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_store_vsstb.pto
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @group_store_one_block_bf16(
+      %value: !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>,
+      %dst: !pto.ptr<bf16, ub>, %off: index) {
+    %c1024 = arith.constant 1024 : index
+    pto.vmi.group_store %value, %dst[%off], %c1024
+        {num_groups = 8 : i64}
+        : !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>,
+          !pto.ptr<bf16, ub>
+    return
+  }
+
+  func.func @group_store_one_block_f32_two_parts(
+      %value: !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>,
+      %dst: !pto.ptr<f32, ub>, %off: index) {
+    %c256 = arith.constant 256 : index
+    pto.vmi.group_store %value, %dst[%off], %c256
+        {num_groups = 16 : i64}
+        : !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>,
+          !pto.ptr<f32, ub>
+    return
+  }
+
+  func.func @group_store_one_block_bf16_tail(
+      %value: !pto.vmi.vreg<80xbf16, #pto.vmi.layout<contiguous>>,
+      %dst: !pto.ptr<bf16, ub>, %off: index) {
+    %c512 = arith.constant 512 : index
+    pto.vmi.group_store %value, %dst[%off], %c512
+        {num_groups = 5 : i64}
+        : !pto.vmi.vreg<80xbf16, #pto.vmi.layout<contiguous>>,
+          !pto.ptr<bf16, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @group_store_one_block_bf16(
+// CHECK: %[[BS64:.*]] = arith.constant 64 : i16
+// CHECK: %[[RS0:.*]] = arith.constant 0 : i16
+// CHECK: %[[ALL16:.*]] = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+// CHECK: %[[BASE16:.*]] = pto.addptr
+// CHECK: pto.vsstb %arg0, %[[BASE16]], %[[BS64]], %[[RS0]], %[[ALL16]] : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, i16, i16, !pto.mask<b16>
+
+// CHECK-LABEL: func.func @group_store_one_block_f32_two_parts(
+// CHECK: %[[ROW_STRIDE:.*]] = arith.constant 256 : index
+// CHECK: %[[BS32:.*]] = arith.constant 32 : i16
+// CHECK: %[[RS0_2:.*]] = arith.constant 0 : i16
+// CHECK: pto.vsstb %arg0, %{{.*}}, %[[BS32]], %[[RS0_2]], %{{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+// CHECK: %[[GROUP8:.*]] = arith.constant 8 : index
+// CHECK: %[[PART_DELTA:.*]] = arith.muli %[[ROW_STRIDE]], %[[GROUP8]] : index
+// CHECK: %[[PART_OFFSET:.*]] = arith.addi %arg3, %[[PART_DELTA]] : index
+// CHECK: %[[PART_BASE:.*]] = pto.addptr %arg2, %[[PART_OFFSET]] : <f32, ub> -> <f32, ub>
+// CHECK: pto.vsstb %arg1, %[[PART_BASE]], %[[BS32]], %[[RS0_2]], %{{.*}} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+
+// CHECK-LABEL: func.func @group_store_one_block_bf16_tail(
+// CHECK: %[[BS32_TAIL:.*]] = arith.constant 32 : i16
+// CHECK: %[[RS0_TAIL:.*]] = arith.constant 0 : i16
+// CHECK: %[[ACTIVE80:.*]] = arith.constant 80 : i32
+// CHECK: %[[TAIL_MASK:.*]], %{{.*}} = pto.plt_b16 %[[ACTIVE80]] : i32 -> !pto.mask<b16>, i32
+// CHECK: pto.vsstb %arg0, %{{.*}}, %[[BS32_TAIL]], %[[RS0_TAIL]], %[[TAIL_MASK]] : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, i16, i16, !pto.mask<b16>
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+// CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_group_store_vsstb_stride_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_group_store_vsstb_stride_invalid.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -vmi-to-vpto 2>&1 | FileCheck %s
+
+module {
+  func.func @group_store_one_block_stride_overflow(
+      %value: !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>,
+      %dst: !pto.ptr<bf16, ub>, %off: index) {
+    %c1048576 = arith.constant 1048576 : index
+    pto.vmi.group_store %value, %dst[%off], %c1048576
+        {num_groups = 8 : i64}
+        : !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>,
+          !pto.ptr<bf16, ub>
+    return
+  }
+}
+
+// CHECK: VMI-UNSUPPORTED:
+// CHECK-SAME: pto.vmi.group_store
+// CHECK-SAME: block_stride exceeds the 16-bit vsstb control field

--- a/test/lit/vpto/vreg_low_precision_memory_vpto_llvm.pto
+++ b/test/lit/vpto/vreg_low_precision_memory_vpto_llvm.pto
@@ -82,9 +82,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 // CHECK-LABEL: define void @lowp_x2_and_block_mix_aiv
 // CHECK: call { <256 x i8>, <256 x i8> } @llvm.hivm.vldsx2.v256f4e1m2x2
 // CHECK: call void @llvm.hivm.vstsx2.v256f4e1m2x2
-// CHECK: call <256 x i8> @llvm.hivm.vsldb
-// CHECK: call void @llvm.hivm.vsstb
-// CHECK: call void @llvm.hivm.vsstb
+// CHECK: call <256 x i8> @llvm.hivm.vsldb.v256i8
+// CHECK: call void @llvm.hivm.vsstb.v256i8
+// CHECK: call void @llvm.hivm.vsstb.v256i8
 
 // CHECK-LABEL: define void @lowp_unaligned_state_mix_aiv
 // CHECK: call <32 x i8> @llvm.hivm.vldas

--- a/test/lit/vpto/vsldb_typed_callee_vpto_llvm.pto
+++ b/test/lit/vpto/vsldb_typed_callee_vpto_llvm.pto
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+// RUN: ptoas --cann-output-version=9.0.0-beta.1 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vsldb_bf16(%src: !pto.ptr<bf16, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1_i16 = arith.constant 1 : i16
+    pto.vecscope {
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      %value = pto.vsldb %src, %c1_i16, %c0_i16, %mask : !pto.ptr<bf16, ub>, i16, i16, !pto.mask<b16> -> !pto.vreg<128xbf16>
+      pto.vsts %value, %src[%c0], %mask : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
+    }
+    return
+  }
+
+  func.func @vsldb_hif8(%src: !pto.ptr<!pto.hif8, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1_i16 = arith.constant 1 : i16
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %value = pto.vsldb %src, %c1_i16, %c0_i16, %mask : !pto.ptr<!pto.hif8, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
+      pto.vsts %value, %src[%c0], %mask : !pto.vreg<256x!pto.hif8>, !pto.ptr<!pto.hif8, ub>, !pto.mask<b8>
+    }
+    return
+  }
+
+  func.func @vsldb_f8e4m3(%src: !pto.ptr<f8E4M3FN, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i16 = arith.constant 0 : i16
+    %c1_i16 = arith.constant 1 : i16
+    pto.vecscope {
+      %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %value = pto.vsldb %src, %c1_i16, %c0_i16, %mask : !pto.ptr<f8E4M3FN, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256xf8E4M3FN>
+      pto.vsts %value, %src[%c0], %mask : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
+    }
+    return
+  }
+}
+
+// CHECK-DAG: declare <128 x bfloat> @llvm.hivm.vsldb.v128bf16
+// CHECK-DAG: declare <256 x i8> @llvm.hivm.vsldb.v256i8
+// CHECK: call <128 x bfloat> @llvm.hivm.vsldb.v128bf16
+// CHECK-COUNT-2: call <256 x i8> @llvm.hivm.vsldb.v256i8

--- a/test/lit/vpto/vsstb_typed_callee_vpto_llvm.pto
+++ b/test/lit/vpto/vsstb_typed_callee_vpto_llvm.pto
@@ -1,5 +1,5 @@
 // Copyright (c) 2026 Huawei Technologies Co., Ltd.
-// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
 // CANN Open Software License Agreement Version 2.0 (the "License").
 // Please refer to the License for details. You may not use this file except in compliance with the License.
 // THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
@@ -9,18 +9,16 @@
 // RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
-  func.func @vsstb_with_updated_base(%value: !pto.vreg<64xf32>, %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+  func.func @vsstb_bf16(%value: !pto.vreg<128xbf16>, %dst: !pto.ptr<bf16, ub>) attributes {pto.kernel} {
     %c2_i16 = arith.constant 2 : i16
-    %c4_i16 = arith.constant 4 : i16
+    %c0_i16 = arith.constant 0 : i16
     pto.vecscope {
-      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
-      %next = pto.vsstb %value, %dst, %c2_i16, %c4_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32> -> !pto.ptr<f32, ub>
-      pto.vsstb %value, %next, %c2_i16, %c4_i16, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, i16, i16, !pto.mask<b32>
+      %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+      pto.vsstb %value, %dst, %c2_i16, %c0_i16, %mask : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, i16, i16, !pto.mask<b16>
     }
     return
   }
 }
 
-// CHECK-LABEL: llvm.func @vsstb_with_updated_base_mix_aiv
-// CHECK: llvm.call @llvm.hivm.vsstb.post.v64f32
-// CHECK: llvm.call @llvm.hivm.vsstb.v64f32
+// CHECK-LABEL: llvm.func @vsstb_bf16_mix_aiv
+// CHECK: llvm.call @llvm.hivm.vsstb.v128bf16

--- a/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/compare.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/compare.py
@@ -23,6 +23,7 @@ SEGMENT_NAMES = (
     "vldsx2/vstsx2 low",
     "vldsx2/vstsx2 high",
     "vsldb/vsstb hif8",
+    "vlds/vsstb/vsldb bf16",
     "vldas/vldus f8e5m2",
     "vstus/vstas f4e2m1x2",
 )

--- a/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/golden.py
+++ b/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/golden.py
@@ -19,7 +19,7 @@ import numpy as np
 
 SEED = 37
 VECTOR_BYTES = 256
-TOTAL_BYTES = 10 * VECTOR_BYTES
+TOTAL_BYTES = 11 * VECTOR_BYTES
 
 
 def generate(output_dir: Path, seed: int) -> None:
@@ -39,10 +39,12 @@ def generate(output_dir: Path, seed: int) -> None:
     # The b8 block load/store pair observes the next 32-byte block after a
     # same-stride roundtrip, matching the existing block-layout instruction contract.
     golden[7 * VECTOR_BYTES:8 * VECTOR_BYTES] = data[7 * VECTOR_BYTES + 32:8 * VECTOR_BYTES + 32]
+    # Exercise the typed bf16 vsstb intrinsic with contiguous 32-byte blocks.
+    golden[8 * VECTOR_BYTES:9 * VECTOR_BYTES] = data[8 * VECTOR_BYTES:9 * VECTOR_BYTES]
     # vldus starts from an explicitly unaligned base.
-    golden[8 * VECTOR_BYTES:9 * VECTOR_BYTES] = data[8 * VECTOR_BYTES + 1:9 * VECTOR_BYTES + 1]
+    golden[9 * VECTOR_BYTES:10 * VECTOR_BYTES] = data[9 * VECTOR_BYTES + 1:10 * VECTOR_BYTES + 1]
     # vstus/vstas makes only the explicit state-store offset bytes visible here.
-    golden[9 * VECTOR_BYTES:9 * VECTOR_BYTES + 3] = data[9 * VECTOR_BYTES:9 * VECTOR_BYTES + 3]
+    golden[10 * VECTOR_BYTES:10 * VECTOR_BYTES + 3] = data[10 * VECTOR_BYTES:10 * VECTOR_BYTES + 3]
     output_dir.mkdir(parents=True, exist_ok=True)
     data.tofile(output_dir / "v1.bin")
     np.zeros((TOTAL_BYTES,), dtype=np.uint8).tofile(output_dir / "v2.bin")

--- a/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/kernel.pto
+++ b/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/kernel.pto
@@ -2,7 +2,7 @@
 // case: micro-op/vector-load-store/vreg-low-precision-ldst
 // family: vector-load-store
 // target_ops: pto.vlds, pto.vsts, pto.vldsx2, pto.vstsx2, pto.vsldb, pto.vsstb, pto.vldas, pto.vldus, pto.vstus, pto.vstas
-// scenarios: low-precision-vreg, raw-byte-roundtrip, full-mask, x2-roundtrip, block-roundtrip, unaligned-load, state-store
+// scenarios: low-precision-vreg, raw-byte-roundtrip, full-mask, x2-roundtrip, hif8-and-bf16-block-roundtrip, unaligned-load, state-store
 // -----------------------------------------------------------------------------
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @vreg_low_precision_ldst_kernel_2d(%arg0: !pto.ptr<ui8, gm>,
@@ -14,16 +14,18 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %c1024 = arith.constant 1024 : index
     %c1280 = arith.constant 1280 : index
     %c1792 = arith.constant 1792 : index
-    %c2048 = arith.constant 2048 : index
     %c2304 = arith.constant 2304 : index
+    %c2560 = arith.constant 2560 : index
     %c1 = arith.constant 1 : index
+    %c0_i16 = arith.constant 0 : i16
     %c1_i16 = arith.constant 1 : i16
     %c3_i32 = arith.constant 3 : i32
     %c0_i64 = arith.constant 0 : i64
-    %c10_i64 = arith.constant 10 : i64
+    %c11_i64 = arith.constant 11 : i64
     %c256_i64 = arith.constant 256 : i64
     %c4096_i64 = arith.constant 4096 : i64
     %c8192_i64 = arith.constant 8192 : i64
+    %c12288_i64 = arith.constant 12288 : i64
     %false = arith.constant false
 
     %ub_in_u8 = pto.castptr %c0_i64 : i64 -> !pto.ptr<ui8, ub>
@@ -35,16 +37,19 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %ub_out_f8e5 = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f8E5M2, ub>
     %ub_in_hif8 = pto.castptr %c0_i64 : i64 -> !pto.ptr<!pto.hif8, ub>
     %ub_out_hif8 = pto.castptr %c4096_i64 : i64 -> !pto.ptr<!pto.hif8, ub>
+    %ub_in_bf16 = pto.castptr %c0_i64 : i64 -> !pto.ptr<bf16, ub>
+    %ub_out_bf16 = pto.castptr %c4096_i64 : i64 -> !pto.ptr<bf16, ub>
+    %ub_scratch_bf16 = pto.castptr %c12288_i64 : i64 -> !pto.ptr<bf16, ub>
     %ub_in_f4e1 = pto.castptr %c0_i64 : i64 -> !pto.ptr<!pto.f4E1M2x2, ub>
     %ub_out_f4e1 = pto.castptr %c4096_i64 : i64 -> !pto.ptr<!pto.f4E1M2x2, ub>
     %ub_in_f4e2 = pto.castptr %c0_i64 : i64 -> !pto.ptr<!pto.f4E2M1x2, ub>
     %ub_out_f4e2 = pto.castptr %c4096_i64 : i64 -> !pto.ptr<!pto.f4E2M1x2, ub>
 
     pto.mte_gm_ub %arg0, %ub_in_u8, %c0_i64, %c256_i64
-      nburst(%c10_i64, %c256_i64, %c256_i64)
+      nburst(%c11_i64, %c256_i64, %c256_i64)
       : !pto.ptr<ui8, gm>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64
     pto.mte_gm_ub %arg1, %ub_out_u8, %c0_i64, %c256_i64
-      nburst(%c10_i64, %c256_i64, %c256_i64)
+      nburst(%c11_i64, %c256_i64, %c256_i64)
       : !pto.ptr<ui8, gm>, !pto.ptr<ui8, ub>, i64, i64, i64, i64, i64
 
     pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
@@ -52,6 +57,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 
     pto.vecscope {
       %mask = pto.pset_b8 "PAT_ALL" : !pto.mask<b8>
+      %mask_b16 = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
 
       %f8e4 = pto.vlds %ub_in_f8e4[%c0] : !pto.ptr<f8E4M3FN, ub> -> !pto.vreg<256xf8E4M3FN>
       pto.vsts %f8e4, %ub_out_f8e4[%c0], %mask : !pto.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.mask<b8>
@@ -80,14 +86,20 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
       %block_roundtrip = pto.vsldb %ub_scratch_hif8, %c1_i16, %c1_i16, %mask : !pto.ptr<!pto.hif8, ub>, i16, i16, !pto.mask<b8> -> !pto.vreg<256x!pto.hif8>
       pto.vsts %block_roundtrip, %ub_out_hif8[%c1792], %mask : !pto.vreg<256x!pto.hif8>, !pto.ptr<!pto.hif8, ub>, !pto.mask<b8>
 
-      %unaligned_base = pto.addptr %ub_in_f8e5, %c2048 : !pto.ptr<f8E5M2, ub> -> !pto.ptr<f8E5M2, ub>
+      %block_bf16 = pto.vlds %ub_in_bf16[%c1024] : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+      pto.vsstb %block_bf16, %ub_scratch_bf16, %c1_i16, %c0_i16, %mask_b16 : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, i16, i16, !pto.mask<b16>
+      pto.mem_bar "VST_VLD"
+      %block_bf16_roundtrip = pto.vsldb %ub_scratch_bf16, %c1_i16, %c0_i16, %mask_b16 : !pto.ptr<bf16, ub>, i16, i16, !pto.mask<b16> -> !pto.vreg<128xbf16>
+      pto.vsts %block_bf16_roundtrip, %ub_out_bf16[%c1024], %mask_b16 : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
+
+      %unaligned_base = pto.addptr %ub_in_f8e5, %c2304 : !pto.ptr<f8E5M2, ub> -> !pto.ptr<f8E5M2, ub>
       %unaligned_src = pto.addptr %unaligned_base, %c1 : !pto.ptr<f8E5M2, ub> -> !pto.ptr<f8E5M2, ub>
       %load_align = pto.vldas %unaligned_src : !pto.ptr<f8E5M2, ub> -> !pto.align
       %unaligned, %next_align = pto.vldus %unaligned_src, %load_align : !pto.ptr<f8E5M2, ub>, !pto.align -> !pto.vreg<256xf8E5M2>, !pto.align
-      pto.vsts %unaligned, %ub_out_f8e5[%c2048], %mask : !pto.vreg<256xf8E5M2>, !pto.ptr<f8E5M2, ub>, !pto.mask<b8>
+      pto.vsts %unaligned, %ub_out_f8e5[%c2304], %mask : !pto.vreg<256xf8E5M2>, !pto.ptr<f8E5M2, ub>, !pto.mask<b8>
 
-      %state_store_dst = pto.addptr %ub_out_f4e2, %c2304 : !pto.ptr<!pto.f4E2M1x2, ub> -> !pto.ptr<!pto.f4E2M1x2, ub>
-      %state_store_value = pto.vlds %ub_in_f4e2[%c2304] : !pto.ptr<!pto.f4E2M1x2, ub> -> !pto.vreg<256x!pto.f4E2M1x2>
+      %state_store_dst = pto.addptr %ub_out_f4e2, %c2560 : !pto.ptr<!pto.f4E2M1x2, ub> -> !pto.ptr<!pto.f4E2M1x2, ub>
+      %state_store_value = pto.vlds %ub_in_f4e2[%c2560] : !pto.ptr<!pto.f4E2M1x2, ub> -> !pto.vreg<256x!pto.f4E2M1x2>
       %store_align = pto.init_align : !pto.align
       %updated_store_align = pto.vstus %store_align, %c3_i32, %state_store_value, %state_store_dst : !pto.align, i32, !pto.vreg<256x!pto.f4E2M1x2>, !pto.ptr<!pto.f4E2M1x2, ub> -> !pto.align
       pto.vstas %updated_store_align, %state_store_dst, %c3_i32 : !pto.align, !pto.ptr<!pto.f4E2M1x2, ub>, i32
@@ -96,7 +108,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
     pto.mte_ub_gm %ub_out_u8, %arg1, %c256_i64
-      nburst(%c10_i64, %c256_i64, %c256_i64)
+      nburst(%c11_i64, %c256_i64, %c256_i64)
       : !pto.ptr<ui8, ub>, !pto.ptr<ui8, gm>, i64, i64, i64, i64
     pto.barrier #pto.pipe<PIPE_ALL>
     return

--- a/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/main.cpp
+++ b/test/vpto/cases/micro-op/vector-load-store/vreg-low-precision-ldst/main.cpp
@@ -35,7 +35,7 @@ void LaunchVreg_low_precision_ldst_kernel_2d(uint8_t *v1, uint8_t *v2,
                                              void *stream);
 
 int main() {
-  constexpr size_t fileSize = 10 * 256 * sizeof(uint8_t);
+  constexpr size_t fileSize = 11 * 256 * sizeof(uint8_t);
 
   uint8_t *v1Host = nullptr;
   uint8_t *v2Host = nullptr;


### PR DESCRIPTION
## 背景

`pto.vmi.group_store` 的 layout 请求此前没有完整接入 layout support/propagation 表，assignment 中还保留了单独的手写选择逻辑。同时，一个 logical group 恰好对应 32B VCG block 的连续布局无法直接 lower，导致 ND→NZ 等场景不能使用 block-strided store。

## 修改内容

- 将 `group_store` 的 direct、preferred 和 high-priority layout fact 统一纳入 `VMILayoutSupport` 表，并注册 propagation transfer，使 assignment 通过标准 seed phase 和 relation 传播选择布局。
- 移除 assignment 中读取当前 layout、检查 producer 类型的手写 `group_store` 选择逻辑，保留高优先级请求与普通 fallback 的既有优先级框架。
- 为 one-block `group_store` 构造通用 lowering plan：
  - 每个 logical group 必须恰好为一个 32B VCG block；
  - static positive `row_stride` 必须按 32B block 对齐；
  - 由 `row_stride / group_size` 生成 `block_stride`，并检查 16-bit control field；
  - 使用 `pto.vsstb`、`repeat_stride = 0` 和连续 tail predicate 完成单 part/多 part 写出。
- 保留已有 full-chunk `vsts` 与 deinterleaved=2 `vstsx2` lowering 路径。
- 为 CANN 9.0.0-beta.1 与 9.0.0+ 两套 VPTO LLVM emitter 生成类型化的 `vsldb`/`vsstb`/`vsstb.post` callee；FP8、HiF8 和 packed FP4 按真实 LLVM payload ABI 使用 `v256i8`。
- 更新 VMI 实现文档，并增加 layout assignment、one-block/tail/stride-overflow lowering、typed intrinsic 和 runtime 回归覆盖。

## 验证

- Focused lit：6/6 通过
  - `vmi_to_vpto_group_store_vsstb.pto`
  - `vmi_to_vpto_group_store_vsstb_stride_invalid.pto`
  - `vsldb_typed_callee_vpto_llvm.pto`
  - `vsstb_typed_callee_vpto_llvm.pto`
  - `vreg_low_precision_memory_vpto_llvm.pto`
  - `vsstb_post_update_result_vpto_llvm.pto`
- CANN 9.1.0 simulator：`vreg-low-precision-ldst` runtime compare passed。
- CANN 9.0.0-beta.1 simulator：同一 runtime case compare passed。
- CANN 9.1.0 `msprof op simulator`：`CastNd2nzKernel_case3_bf16_M_64_N_128` BF16 byte-exact ND `[64,128]` → NZ `[8,64,16]` golden passed，指令记录确认执行 `RV_VSSTB`。
- `git diff --check` 通过。
