### PR TITLE
ci: pin PyPTO revision for simulator validation

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -116,7 +116,7 @@ jobs:
       VPTO_SIM_WORKSPACE: ${{ github.workspace }}/.work/vpto-sim-ci
       TILELANG_DSL_WORKSPACE: ${{ github.workspace }}/.work/tilelang-dsl-ci
       TILELANG_DSL_UT_WORKSPACE: ${{ github.workspace }}/.work/tilelang-dsl-ut-ci
-      PYPTO_REF: main
+      PYPTO_REF: ef6ce7cd8bd33b4c93b58dc34830a20b145736ac
       PYPTO_WORKSPACE: ${{ github.workspace }}/.work/pypto-ci
       PYPTO_RUN_WORKSPACE: ${{ github.workspace }}/.work/pypto-run-ci
       PTO_ISA_COMMIT: 016396b57e2c17093f1194e6acd89bb112b0ab24


### PR DESCRIPTION
## 问题

`vpto-sim-validation` 当前从 PyPTO `main` 拉取依赖，但同时硬编码运行 `TestManualWorkerExtraction::test_block_dim_override_runs`。PyPTO 提交 `937ebbb7afec` 删除了 `block_dim` 接口和该测试，导致 PTOAS 门禁在 pytest 收集阶段退出，尚未执行 PTOAS 编译或模拟器测试。

## 修改

将 `PYPTO_REF` 固定为 `ef6ce7cd8bd33b4c93b58dc34830a20b145736ac`，即上述破坏性变更的直接父提交。这样 CI 使用的 PyPTO 源码与门禁测试选择器保持一致，也避免后续 PyPTO `main` 漂移直接破坏 PTOAS PR 门禁。

## 验证

- `git diff --check`
- 使用 Python YAML 解析器检查 `ci_sim.yml`
- 确认固定 revision 中存在 `TestManualWorkerExtraction::test_block_dim_override_runs`