### PR TITLE
fix(emitc): hide GlobalTensor helper from host parse

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -14720,12 +14720,14 @@ static AICORE inline void ptoas_auto_sync_tail(
   }
 }
 
+#if defined(__CPU_SIM) || defined(__CCE_AICORE__) || defined(__COSTMODEL)
 template <typename Element, typename Shape, typename Stride,
           pto::Layout TensorLayout>
 static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(
     pto::GlobalTensor<Element, Shape, Stride, TensorLayout> &tensor) {
   dcci((__gm__ void*)tensor.data(), cache_line_t::SINGLE_CACHE_LINE);
 }
+#endif
 
 template <typename Ptr>
 static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {

--- a/test/lit/pto/issue995_cmo_partition_view_emitc.pto
+++ b/test/lit/pto/issue995_cmo_partition_view_emitc.pto
@@ -52,12 +52,14 @@ module {
   }
 }
 
-// CHECK: template <typename Element, typename Shape, typename Stride,
+// CHECK: #if defined(__CPU_SIM) || defined(__CCE_AICORE__) || defined(__COSTMODEL)
+// CHECK-NEXT: template <typename Element, typename Shape, typename Stride,
 // CHECK-NEXT:           pto::Layout TensorLayout>
 // CHECK-NEXT: static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(
 // CHECK-NEXT:     pto::GlobalTensor<Element, Shape, Stride, TensorLayout> &tensor) {
 // CHECK-NEXT:   dcci((__gm__ void*)tensor.data(), cache_line_t::SINGLE_CACHE_LINE);
 // CHECK-NEXT: }
+// CHECK-NEXT: #endif
 
 // CHECK-LABEL: AICORE void single_line_ptr(
 // CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE({{[_A-Za-z][_A-Za-z0-9]*}});


### PR DESCRIPTION
## Summary

- guard the `GlobalTensor`-specific single-cache-line DCCI helper with the same type-availability conditions used by `pto-inst.hpp`
- keep the generic pointer helper visible to the Bisheng host-side parse
- extend the issue #995 EmitC regression test to require the preprocessor guard

## Root cause

PR #1001 emitted a `pto::GlobalTensor<...>` overload into every generated C++ translation unit. Bisheng's `-xcce` host-side parse does not define `__CCE_AICORE__`, so `pto-inst.hpp` does not include `pto_tile.hpp` and `pto::GlobalTensor` is unavailable. This made nearly every generated A3/A5 kernel fail before device compilation.

The overload is now visible only when `pto_tile.hpp` is visible:

```cpp
#if defined(__CPU_SIM) || defined(__CCE_AICORE__) || defined(__COSTMODEL)
```

The AICore path therefore retains the `.data()` fix for partition tensor views while the host parse no longer sees an unavailable device type.

## Validation

- LLVM/MLIR 21.1.8 Release build of `ptoas_runtime_staging`: PASS
- targeted lit tests: 3/3 PASS
  - `pto/issue995_cmo_partition_view_emitc.pto`
  - `pto/signal_payload_cache_consistency.pto`
  - `pto/issue872_tput_tnotify_release.pto`
- generated A3 C++ contains the guarded overload and preserves the generic pointer overload
- A3 `/run all abs` board validation: PASS (`status=OK`, `stage=run`)

Follow-up fix for the A3/A5 board regression introduced by #1001.
