### PR TITLE
fix(emitc): 在 DCCI 前物化 CMO tensor 地址

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -74,6 +74,7 @@ jobs:
               - 'lib/PTO/Transforms/CMakeLists.txt'
               - 'lib/PTO/Transforms/ExpandTileOp.cpp'
               - 'lib/PTO/Transforms/FoldTileBufIntrinsics.cpp'
+              - 'lib/PTO/Transforms/PTOToEmitC.cpp'
               - 'lib/PTO/Transforms/*VPTO*'
               - 'lib/PTO/Transforms/**/*VPTO*'
 

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -4512,15 +4512,28 @@ static Value castToGMBytePointer(ConversionPatternRewriter &rewriter,
   return rewriter.create<emitc::CastOp>(loc, targetTy, value).getResult();
 }
 
-static Value materializeTensorViewDataPointer(
+static Value materializeGlobalTensorDataPointer(
     ConversionPatternRewriter &rewriter, Location loc, Value value,
     Type sourceType) {
-  auto tvTy = dyn_cast<pto::TensorViewType>(sourceType);
-  if (!tvTy)
+  Type loweredType = value.getType();
+  if (auto lvalueTy = dyn_cast<emitc::LValueType>(loweredType))
+    loweredType = lvalueTy.getValueType();
+  if (!isEmitCGlobalTensorLikeType(loweredType))
+    return value;
+
+  Type elemType;
+  if (auto tvTy = dyn_cast<pto::TensorViewType>(sourceType))
+    elemType = tvTy.getElementType();
+  else if (auto partitionTy =
+               dyn_cast<pto::PartitionTensorViewType>(sourceType))
+    elemType = partitionTy.getElementType();
+  else if (auto memrefTy = dyn_cast<MemRefType>(sourceType))
+    elemType = memrefTy.getElementType();
+  else
     return value;
 
   auto *ctx = rewriter.getContext();
-  std::string elemTypeStr = getElemTypeStringForGT(tvTy.getElementType());
+  std::string elemTypeStr = getElemTypeStringForGT(elemType);
   auto ptrTy = emitc::PointerType::get(
       emitc::OpaqueType::get(ctx, "__gm__ " + elemTypeStr));
   return rewriter
@@ -7022,6 +7035,8 @@ struct PTOCmoCacheInvalidToEmitC
       return rewriter.notifyMatchFailure(op, "unsupported CMO invalidate space");
     if (op.getAddr()) {
       Value addr = peelUnrealized(adaptor.getAddr());
+      addr = materializeGlobalTensorDataPointer(
+          rewriter, op.getLoc(), addr, op.getAddr().getType());
       emitInvalidateGmCacheSingleLine(rewriter, op.getLoc(), addr);
     } else {
       emitInvalidateGmCacheAll(rewriter, op.getLoc());
@@ -7195,7 +7210,7 @@ struct PTOInitializeL2G2LPipeToEmitC
         cast<Type>(getTypeConverter()->convertType(op.getPipe().getType()));
 
     Value gmAddr = peelUnrealized(adaptor.getGmAddr());
-    gmAddr = materializeTensorViewDataPointer(
+    gmAddr = materializeGlobalTensorDataPointer(
         rewriter, op.getLoc(), gmAddr, op.getGmAddr().getType());
     Value localAddr =
         op.getLocalAddr() ? peelUnrealized(adaptor.getLocalAddr()) : Value();
@@ -14608,8 +14623,14 @@ struct EmitPTOManualPass
             needsEventIdArrayHelper = true;
           if (isa<mlir::pto::TRandomOp>(op))
             needsTRandomHelper = true;
-          if (isa<mlir::pto::PartitionViewOp>(op))
-            needsGlobalTensorDataHelper = true;
+          if (auto cmo = dyn_cast<mlir::pto::CmoCacheInvalidOp>(op)) {
+            if (cmo.getAddr())
+              needsGlobalTensorDataHelper = true;
+          }
+          if (auto init = dyn_cast<mlir::pto::InitializeL2G2LPipeOp>(op)) {
+            if (isa<mlir::pto::TensorViewType>(init.getGmAddr().getType()))
+              needsGlobalTensorDataHelper = true;
+          }
           if (isa<mlir::pto::BuildAsyncSessionOp, mlir::pto::TPutAsyncOp,
                   mlir::pto::TGetAsyncOp, mlir::pto::TPrefetchAsyncOp,
                   mlir::pto::WaitAsyncEventOp, mlir::pto::TestAsyncEventOp,
@@ -14719,15 +14740,6 @@ static AICORE inline void ptoas_auto_sync_tail(
     break;
   }
 }
-
-#if defined(__CPU_SIM) || defined(__CCE_AICORE__) || defined(__COSTMODEL)
-template <typename Element, typename Shape, typename Stride,
-          pto::Layout TensorLayout>
-static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(
-    pto::GlobalTensor<Element, Shape, Stride, TensorLayout> &tensor) {
-  dcci((__gm__ void*)tensor.data(), cache_line_t::SINGLE_CACHE_LINE);
-}
-#endif
 
 template <typename Ptr>
 static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {

--- a/test/lit/pto/issue995_cmo_partition_view_emitc.pto
+++ b/test/lit/pto/issue995_cmo_partition_view_emitc.pto
@@ -52,21 +52,19 @@ module {
   }
 }
 
-// CHECK: #if defined(__CPU_SIM) || defined(__CCE_AICORE__) || defined(__COSTMODEL)
-// CHECK-NEXT: template <typename Element, typename Shape, typename Stride,
-// CHECK-NEXT:           pto::Layout TensorLayout>
-// CHECK-NEXT: static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(
-// CHECK-NEXT:     pto::GlobalTensor<Element, Shape, Stride, TensorLayout> &tensor) {
-// CHECK-NEXT:   dcci((__gm__ void*)tensor.data(), cache_line_t::SINGLE_CACHE_LINE);
-// CHECK-NEXT: }
-// CHECK-NEXT: #endif
+// CHECK: template <typename Tensor>
+// CHECK-NEXT: static AICORE inline auto PTOAS__GLOBAL_TENSOR_DATA(Tensor &tensor)
+// CHECK-NOT: pto::GlobalTensor<Element
+// CHECK: template <typename Ptr>
+// CHECK-NEXT: static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
 
 // CHECK-LABEL: AICORE void single_line_ptr(
 // CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE({{[_A-Za-z][_A-Za-z0-9]*}});
 
 // CHECK-LABEL: AICORE void single_line_partition_view(
 // CHECK: GlobalTensor<float, {{.*}}> [[PVIEW:[_A-Za-z][_A-Za-z0-9]*]] = GlobalTensor<float, {{.*}}>(
-// CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE([[PVIEW]]);
+// CHECK: __gm__ float* [[PVIEW_DATA:[_A-Za-z][_A-Za-z0-9]*]] = PTOAS__GLOBAL_TENSOR_DATA([[PVIEW]]);
+// CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE([[PVIEW_DATA]]);
 
 // CHECK-LABEL: AICORE void single_line_partition_view_nonzero_offset(
 // CHECK-DAG: const int64_t [[COL_OFFSET:[_A-Za-z][_A-Za-z0-9]*]] = 2;
@@ -74,4 +72,5 @@ module {
 // CHECK-DAG: const int64_t [[ROW_STRIDE:[_A-Za-z][_A-Za-z0-9]*]] = 32;
 // CHECK-DAG: const int64_t [[ONE:[_A-Za-z][_A-Za-z0-9]*]] = 1;
 // CHECK: GlobalTensor<float, {{.*}}> [[OFFSET_PVIEW:[_A-Za-z][_A-Za-z0-9]*]] = GlobalTensor<float, {{.*}}>({{[_A-Za-z][_A-Za-z0-9]*}} + (([[ZERO]] + [[ONE]] * [[ROW_STRIDE]]) + [[COL_OFFSET]] * [[ONE]]),
-// CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE([[OFFSET_PVIEW]]);
+// CHECK: __gm__ float* [[OFFSET_DATA:[_A-Za-z][_A-Za-z0-9]*]] = PTOAS__GLOBAL_TENSOR_DATA([[OFFSET_PVIEW]]);
+// CHECK: PTOAS__DCCI_SINGLE_CACHE_LINE([[OFFSET_DATA]]);


### PR DESCRIPTION
## 背景

#1001 为 CMO 的 partition view 输入增加了具体的 `pto::GlobalTensor` DCCI 重载。Bisheng 在 fat-object 的 host parse 阶段不会暴露该类型，因此会在尚未进入 device 编译前报错。#1007 通过预处理保护先解决了 host parse 问题；本 PR 在此基础上进一步消除 DCCI helper 对具体 tensor 类型的依赖。

## 修改

- 在 PTO → EmitC lowering 中识别实际降成 `GlobalTensor` 的 CMO 地址，并先通过 `PTOAS__GLOBAL_TENSOR_DATA` 物化成 GM 指针。
- 将现有地址物化逻辑泛化到 tensor view、partition tensor view 和前置 pass 生成的 memref，同时支持 EmitC lvalue 表示。
- 删除具体的 `pto::GlobalTensor` DCCI 重载，只保留指针版本；raw pointer 路径保持不变。
- 更新 #995 回归测试，覆盖 raw pointer、零 offset partition view、非零 offset partition view，并检查不再生成具体类型重载。
- 将 `PTOToEmitC.cpp` 加入 VPTO SIM 门禁 path filter，避免 EmitC lowering 修改再次跳过 fat-object 编译验证。

## 验证

- LLVM 21 独立 build tree 全量构建通过。
- 相关 lit：4/4 通过（#995 CMO EmitC、signal payload cache consistency、CMO invalid case、#872 release case）。
- CANN 9.0.0 + PTO-ISA `016396b57e2c17093f1194e6acd89bb112b0ab24`：`micro-op/backend/mixed-external-vadd` 在 `COMPILE_ONLY=1` 下完成 fatobj、launch object 和 kernel so 链接。
- #995 含非零 partition offset 的生成 C++ 经 Bisheng `-dc -c` 成功生成 fatobj。
