### PR TITLE
fix(ptodsl): preserve default TileOp C/V split intent

### DIFF
--- a/docs/designs/issue-1004-tileop-default-kernel-kind.md
+++ b/docs/designs/issue-1004-tileop-default-kernel-kind.md
@@ -1,0 +1,223 @@
+# Issue #1004：TileOp 默认 Kernel Kind 设计
+
+## 状态
+
+本文是 [hw-native-sys/PTOAS#1004](https://github.com/hw-native-sys/PTOAS/issues/1004)
+的拟议实现设计。它只描述默认 TileOp 路径：不新增 `mixed` kernel kind，也不要求
+用户选择物理计算核类型。
+
+## 问题
+
+`@pto.jit(..., backend="vpto")` 保留 `"vector"` 作为实际生效的默认
+`kernel_kind`，以便 native build 路径沿用原有的 host 编译配置选择。decorator 同时
+记录调用者是否传入过该参数：
+
+```python
+@pto.jit(target="a5", backend="vpto")
+def kernel():
+    ...
+```
+
+对此形式，前端生成：
+
+```text
+KernelModuleSpec.kernel_kind          == "vector"
+KernelModuleSpec.kernel_kind_explicit == False
+```
+
+这两个字段的含义不同：前者是内部的实际默认值；后者是判断 PTO IR 是否包含用户
+编写的物理计算核约束所需的来源信息。
+
+当前 `_apply_child_module_attrs` 会为每个 VPTO child 写入
+`pto.kernel_kind = #pto.kernel_kind<vector>`。它把内部默认值变成了显式 IR 契约。
+PTOAS 随后物化 Vector TileOp section 和 Cube TileOp section 时，
+`VPTOSplitCVModule` 会正确拒绝 Cube section，因为它与已显式标为 Vector 的 child
+冲突。失败发生在 VPTO emission 之前。
+
+## 目标
+
+标准的公开编程模型应为：
+
+```python
+@pto.jit(target="a5", backend="vpto")
+def gemm_epilogue(...):
+    # kernel 编排位于这里。
+    with pto.tileop():
+        # Vector 单核计算。
+        ...
+    with pto.tileop():
+        # Cube 单核计算。
+        ...
+```
+
+用户不写 `kernel_kind="vector"`、`kernel_kind="cube"`、section hint 或
+`kernel_kind="mixed"`。PTOAS 推导每个 TileOp 的单一计算域，物化相应 section，并将
+mixed entry 拆分为 Vector 和 Cube backend child。
+
+修改必须保留 `KernelModuleSpec` 中的默认值 `"vector"`，因为 native build 仍会使用
+该值；但不能再把默认值序列化为用户编写的 VPTO IR intent。
+
+## 非目标
+
+- 不向 PTODSL 或 PTO IR 添加 `kernel_kind="mixed"`。
+- 不添加公开的 TileOp section 或物理计算核 hint。
+- 不修改 TileOp 单核推导、section ABI，或 `VPTOSplitCVModule` 的无 kind 拆分算法。
+- 不为手写 orchestration kernel 中的 raw MTE、flag/sync 或任意 raw VPTO 指令序列
+  推导 C/V 归属。TileOp 有意将 MTE 和跨 pipe 同步留在调用者中；此类推导有独立的
+  正确性契约，必须单独提案。
+- 不在本修改中删除已有的显式 kind 支持。它仍是向后兼容的高级路径，但新的 TileOp
+  文档和示例不能要求使用它。
+
+## 现有流水线契约
+
+相关职责已经存在：
+
+1. `@pto.jit` 使用私有默认 sentinel，计算实际生效的 `kernel_kind`，并记录
+   `kernel_kind_explicit`。
+2. PTODSL tracing 生成 TileOp helper 时不预先选择 section kind。
+3. PTOAS 在 backend pipeline 之前运行 `PTOMaterializeTileOpSectionsPass`，再运行
+   `PTONormalizeUncoveredTileSectionsPass`。前一个 pass 验证单一纯 TileOp 计算域，并
+   物化 `pto.section.vector` 或 `pto.section.cube`。
+4. `VPTOSplitCVModule` 针对每种 section kind 克隆一次无 kind module，移除相反的
+   section，并且只在生成的 backend child 上设置 `pto.kernel_kind`。
+5. `VPTONormalizeContainer` 接收 VPTO lowering 所需的规范 child module。
+
+唯一错误的衔接位于第 1 步与第 4 步之间：默认值过早地写在 child-module 边界。
+
+```text
+默认 @pto.jit
+  -> 实际 kind="vector", explicit=False
+  -> 不带 pto.kernel_kind 的 VPTO child
+  -> TileOp section 物化
+  -> 无 kind 的 C/V section 拆分
+  -> vector child + cube child，分别带有生成的 pto.kernel_kind
+```
+
+## 拟议修改
+
+只修改 `ptodsl/ptodsl/_tracing/module_builder.py::_apply_child_module_attrs`。
+
+当前 VPTO 条件将每个有效实际 kind 都视为用户编写的 kind。修正后的 VPTO 条件必须
+要求其来源是显式的：
+
+```python
+if (
+    spec.kernel_kind in {"cube", "vector"}
+    and (
+        (spec.backend == "vpto" and spec.kernel_kind_explicit)
+        or (spec.backend == "emitc" and not spec.entry)
+    )
+):
+    child_op.attributes["pto.kernel_kind"] = Attribute.parse(
+        f"#pto.kernel_kind<{spec.kernel_kind}>"
+    )
+```
+
+`_build_backend_partitioned_module` 中已有的 function-level 条件，会为普通 entry
+检查 `spec.kernel_kind_explicit`。child-level 条件必须与其一致，以保持“实际默认值”与
+“用户编写的 IR 约束”之间的唯一事实来源。
+
+本 issue 不需要 C++ pass 修改。特别是不能放宽
+`verifyExplicitKernelKindMatchesSections`：一个真正显式单 kind module 中包含相反
+section，仍必须被诊断为无效。
+
+## IR 示例
+
+### PTOAS 物化 section 前的默认 TileOp entry
+
+VPTO child 带有 backend 路由元数据，但不带物理 kind：
+
+```mlir
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
+    func.func @kernel() attributes {pto.entry} {
+      // pto.tileop.helper 函数和/或 inline TileOp 调用
+      return
+    }
+  }
+}
+```
+
+### TileOp 物化与 C/V 拆分后
+
+外层 container 对每个推导出的 kind 有一个 child。只有这些生成的 child 带有 kind：
+
+```mlir
+module attributes {pto.target_arch = "a5"} {
+  module attributes {
+    pto.backend = "vpto",
+    pto.kernel_kind = #pto.kernel_kind<vector>,
+    pto.target_arch = "a5"
+  } { ... vector 代码 ... }
+  module attributes {
+    pto.backend = "vpto",
+    pto.kernel_kind = #pto.kernel_kind<cube>,
+    pto.target_arch = "a5"
+  } { ... cube 代码 ... }
+}
+```
+
+这是现有的规范 VPTO 输入形态。VPTO emitter 与 host stub 生成不需要感知新的 mixed
+类型。
+
+## 兼容性
+
+- 默认 `@pto.jit` 在内部继续保留实际 `kernel_kind="vector"`；native build 的选择
+  不变。
+- 显式 `kernel_kind="vector"` 与 `kernel_kind="cube"` 为兼容而继续接受，并保留
+  当前的显式 IR 行为。
+- 默认纯 Vector 或纯 Cube TileOp 保持有效；其物理 kind 由 PTOAS 推导，而非用户断言。
+- 默认 mixed TileOp entry 在其推导出的各 section 分别有效时变为有效。
+- 显式 kind 与相反的推导 section 组合时，继续产生现有冲突诊断。编译器不得为满足
+  自相矛盾的显式声明而静默丢弃用户代码。
+
+## 测试计划
+
+后续实现 PR 必须在两个层级添加聚焦覆盖。
+
+### PTODSL tracing 回归
+
+新增一个合法、最小的默认 `@pto.jit(backend="vpto")` fixture，其中包含一个 Vector
+TileOp 和一个 Cube TileOp。断言生成的 backend child：
+
+- 包含 `pto.backend = "vpto"`；
+- 在经过 PTOAS 处理前不包含 `pto.kernel_kind`；以及
+- 其私有 module spec/cache signature 保留实际 `"vector"` 和
+  `kernel_kind_explicit=False`。
+
+该测试证明前端没有将默认值序列化为 intent，且不得要求用户传入 `kernel_kind`。
+
+### PTOAS 端到端回归
+
+通过以下命令编译 trace 后的 IR：
+
+```text
+ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto <input> -o -
+```
+
+检查结果恰有一个 Vector child 与一个 Cube child；每个 child 必须带有生成的匹配
+`pto.kernel_kind`、包含自身的 section body，且不残留 `pto.section.*`。现有
+`test/lit/vpto/section_sugar_mixed.pto` 覆盖 splitter 的 raw IR 契约；新测试必须覆盖
+导致 #1004 的 PTODSL 默认 child 契约。
+
+还应保留或新增：
+
+- 默认纯 Vector TileOp：一个 Vector child；
+- 默认纯 Cube TileOp：一个 Cube child；
+- 显式 Vector 加 Cube section：冲突诊断；
+- 显式 Cube 加 Vector section：冲突诊断。
+
+issue POC 可以有意省略 `pto.vecscope`；它足以证明此前的 split 失败，但不是端到端
+成功用例。正向回归必须使用通过 verifier 的 Vector TileOp，确保后续 vector
+verification 失败不会掩盖 split 正确性。
+
+## 验收标准
+
+1. 文档中的默认 TileOp 示例从不写 `kernel_kind`。
+2. PTODSL tracing 完成后的 IR，其 VPTO child 不包含由默认值导出的
+   `pto.kernel_kind`。
+3. PTOAS 能够推导并将一个有效的默认 C/V TileOp entry 拆分为恰好两个规范 child
+   module。
+4. native build 的实际默认值仍为 `"vector"`。
+5. 显式且矛盾的 kind/section 输入仍产生带位置的诊断。
+6. 不引入公开的 `mixed` kind、section hint 或新的 TileOp 参数。

--- a/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
+++ b/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
@@ -62,33 +62,38 @@ static bool isExplicitSection(Operation *op) {
   return isa<SectionCubeOp, SectionVectorOp>(op);
 }
 
-static bool isTileLikeOp(Operation *op) {
-  if (!op)
-    return false;
-  return isa<OpPipeInterface>(op) &&
-         op->getName().getStringRef().starts_with("pto.t");
-}
-
-static bool isPipeLikeOp(Operation *op) {
-  return op && isa<OpPipeInterface>(op);
-}
-
 static bool isRawVPTOVectorTransientType(Type type) {
   return isa<VRegType, MaskType, AlignType>(type);
 }
 
-static bool isRawVPTOVectorLikeOp(Operation *op) {
-  if (!op)
-    return false;
+// Raw VPTO micro-instructions predate OpPipeInterface. Prefer their ODS
+// instruction-class interfaces, then retain type evidence for out-of-tree
+// operations that have not adopted the markers yet.
+static std::optional<InferredSectionKind>
+inferRawVPTOComputeKind(Operation *op) {
+  if (isa<CubeMicroOpInterface>(op))
+    return InferredSectionKind::Cube;
+  if (isa<VectorMicroOpInterface>(op))
+    return InferredSectionKind::Vector;
+  if (isa<MadSemanticOpInterface, MadRawOpInterface>(op))
+    return InferredSectionKind::Cube;
+
   for (Value operand : op->getOperands()) {
     if (isRawVPTOVectorTransientType(operand.getType()))
-      return true;
+      return InferredSectionKind::Vector;
   }
   for (Value result : op->getResults()) {
     if (isRawVPTOVectorTransientType(result.getType()))
-      return true;
+      return InferredSectionKind::Vector;
   }
-  return false;
+  return std::nullopt;
+}
+
+static bool isTileLikeOp(Operation *op) {
+  if (!op)
+    return false;
+  return op->getName().getStringRef().starts_with("pto.t") ||
+         inferRawVPTOComputeKind(op).has_value();
 }
 
 static bool hasAnySection(func::FuncOp funcOp) {
@@ -338,6 +343,8 @@ classifyTStoreBySourceAddressSpace(Operation *op) {
 }
 
 static std::optional<InferredSectionKind> classifyTileOp(Operation *op) {
+  if (std::optional<InferredSectionKind> kind = inferRawVPTOComputeKind(op))
+    return kind;
   if (std::optional<InferredSectionKind> kind = classifyTileOpByName(op))
     return kind;
   if (std::optional<InferredSectionKind> kind = classifyInternalPipeTileOp(op))
@@ -372,17 +379,15 @@ static void inspectModuleKindOperation(Operation *op, ModuleKindSummary &summary
   if (isExplicitSection(op))
     return;
 
-  if (isPipeLikeOp(op)) {
+  if (isTileLikeOp(op)) {
     if (std::optional<InferredSectionKind> kind = classifyTileOp(op)) {
       if (*kind == InferredSectionKind::Vector)
         ++summary.vectorCount;
       else
         ++summary.cubeCount;
-    } else if (isTileLikeOp(op)) {
+    } else {
       summary.ambiguousOps.push_back(op);
     }
-  } else if (isRawVPTOVectorLikeOp(op)) {
-    ++summary.vectorCount;
   }
 
   for (Region &region : op->getRegions()) {

--- a/lib/PTO/Transforms/VPTOSplitCVModule.cpp
+++ b/lib/PTO/Transforms/VPTOSplitCVModule.cpp
@@ -244,6 +244,31 @@ static ModuleOp cloneModuleForKind(ModuleOp source, FunctionKernelKind kind,
   return cloned;
 }
 
+// PTODSL and raw VPTO inputs may use an outer routing module that contains one
+// untyped kernel module. Split that child in its parent instead of cloning the
+// routing module: VPTO's downstream nested pass pipeline expects each direct
+// child of the container to be a kernel-kind module with direct functions.
+static LogicalResult splitNestedSectionModule(ModuleOp child) {
+  if (!hasCVSections(child))
+    return success();
+  if (failed(verifyNoNestedSections(child)) ||
+      failed(verifySectionSplitCandidatesUseSections(child)))
+    return failure();
+
+  bool needVector = hasSectionKind(child, FunctionKernelKind::Vector);
+  bool needCube = hasSectionKind(child, FunctionKernelKind::Cube);
+  if (!needVector && !needCube)
+    return success();
+
+  OpBuilder builder(child);
+  if (needVector)
+    cloneModuleForKind(child, FunctionKernelKind::Vector, builder);
+  if (needCube)
+    cloneModuleForKind(child, FunctionKernelKind::Cube, builder);
+  child.erase();
+  return success();
+}
+
 static LogicalResult materializeExplicitKernelKindSections(ModuleOp module) {
   auto kindAttr = module->getAttrOfType<FunctionKernelKindAttr>(
       FunctionKernelKindAttr::name);
@@ -259,6 +284,19 @@ static LogicalResult materializeExplicitKernelKindSections(ModuleOp module) {
 static LogicalResult splitCVModule(ModuleOp module) {
   if (hasKernelKind(module))
     return materializeExplicitKernelKindSections(module);
+
+  SmallVector<ModuleOp> untypedSectionChildren;
+  for (ModuleOp child : module.getOps<ModuleOp>()) {
+    if (!hasKernelKind(child) && hasCVSections(child))
+      untypedSectionChildren.push_back(child);
+  }
+  if (!untypedSectionChildren.empty()) {
+    for (ModuleOp child : untypedSectionChildren)
+      if (failed(splitNestedSectionModule(child)))
+        return failure();
+    return success();
+  }
+
   if (hasKernelKindChildModule(module)) {
     for (ModuleOp child : module.getOps<ModuleOp>()) {
       if (!hasKernelKind(child))

--- a/ptodsl/ptodsl/_tracing/module_builder.py
+++ b/ptodsl/ptodsl/_tracing/module_builder.py
@@ -77,7 +77,10 @@ def _apply_child_module_attrs(child_op, spec: KernelModuleSpec) -> None:
     child_op.attributes["pto.backend"] = StringAttr.get(spec.backend)
     if (
         spec.kernel_kind in {"cube", "vector"}
-        and (spec.backend == "vpto" or (spec.backend == "emitc" and not spec.entry))
+        and (
+            (spec.backend == "vpto" and spec.kernel_kind_explicit)
+            or (spec.backend == "emitc" and not spec.entry)
+        )
     ):
         child_op.attributes["pto.kernel_kind"] = Attribute.parse(
             f"#pto.kernel_kind<{spec.kernel_kind}>"

--- a/ptodsl/tests/test_flash_attention_demo_compile.py
+++ b/ptodsl/tests/test_flash_attention_demo_compile.py
@@ -65,8 +65,8 @@ def main() -> None:
     expect(
         'pto.backend = "vpto"' in wrapper_text
         and 'pto.target_arch = "a5"' in wrapper_text
-        and 'pto.kernel_kind = #pto.kernel_kind<vector>' in wrapper_text,
-        "flash attention wrapper compile should encode the VPTO backend directly on the child module",
+        and 'pto.kernel_kind = #pto.kernel_kind<' not in wrapper_text,
+        "flash attention wrapper compile should encode VPTO routing without asserting a physical kind",
     )
     expect("func.func @materialize_tile_bounds" in wrapper_text, "wrapper compile should emit the SIMT helper function")
     expect("pto.store_vfsimt_info" in wrapper_text, "wrapper compile should materialize SIMT caller metadata setup")
@@ -98,8 +98,8 @@ def main() -> None:
     expect(
         'pto.backend = "vpto"' in specialized_text
         and 'pto.target_arch = "a5"' in specialized_text
-        and 'pto.kernel_kind = #pto.kernel_kind<vector>' in specialized_text,
-        "direct compile should encode the VPTO backend directly on the child module",
+        and 'pto.kernel_kind = #pto.kernel_kind<' not in specialized_text,
+        "direct compile should encode VPTO routing without asserting a physical kind",
     )
     expect("!pto.tile_buf<mat, 64x128xf32" in specialized_text, "BLOCK_Q=64 specialization should change the physical Q tile shape")
     expect("func.call @materialize_tile_bounds" in specialized_text, "direct compile should still route SIMT helpers through func.call")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -4149,14 +4149,14 @@ def main() -> None:
     expect(
         'pto.backend = "vpto"' in default_text
         and 'pto.target_arch = "a5"' in default_text
-        and 'pto.kernel_kind = #pto.kernel_kind<vector>' in default_text,
-        "primary VPTO child module should carry PTOAS-facing backend metadata directly on the child module",
+        and 'pto.kernel_kind = #pto.kernel_kind<' not in default_text,
+        "default VPTO child module should preserve backend metadata without serializing the internal vector default as authored kernel kind",
     )
     expect(
         'pto.backend = "vpto"' in explicit_text
         and 'pto.target_arch = "a5"' in explicit_text
-        and 'pto.kernel_kind = #pto.kernel_kind<vector>' in explicit_text,
-        "explicit specialization child module should keep the same VPTO child metadata shape",
+        and 'pto.kernel_kind = #pto.kernel_kind<' not in explicit_text,
+        "explicit-mode specialization should not serialize the default vector kind as authored intent",
     )
     expect(
         "ptodsl.compile_options" not in default_text,
@@ -4317,8 +4317,8 @@ def main() -> None:
     )
     expect(
         kernel_module_call_text.count('pto.backend = "vpto"') >= 2
-        and kernel_module_call_text.count('pto.kernel_kind = #pto.kernel_kind<vector>') >= 2,
-        "entry-plus-helper specialization should materialize separate child modules for caller and callee",
+        and 'pto.kernel_kind = #pto.kernel_kind<' not in kernel_module_call_text,
+        "default entry-plus-helper specialization should materialize separate VPTO children without asserting a physical kind",
     )
     ast_rewrite_kernel_module_text = entry_calls_ast_rewrite_kernel_module_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(
@@ -4362,8 +4362,8 @@ def main() -> None:
     expect(
         'pto.backend = "vpto"' in mixed_backend_text
         and 'pto.target_arch = "a5"' in mixed_backend_text
-        and 'pto.kernel_kind = #pto.kernel_kind<vector>' in mixed_backend_text,
-        "mixed-backend callee child should preserve the callee's VPTO backend through child pto.backend metadata",
+        and 'pto.kernel_kind = #pto.kernel_kind<' not in mixed_backend_text,
+        "default mixed-backend VPTO callee child should preserve backend metadata without asserting a physical kind",
     )
     expect(
         "pto.tload" in mixed_backend_text and "pto.tstore" in mixed_backend_text,
@@ -4960,9 +4960,13 @@ def main() -> None:
         and "pto.section.vector {" not in explicit_vector_inline_tileop_text,
         "inline pto.tileop() scopes should defer physical section materialization to PTOAS",
     )
-
     INLINE_SUBKERNEL_SCOPE_OBSERVATIONS.clear()
     inline_subkernel_scope_text = inline_subkernel_scope_probe.compile(TRACE_TOKEN=1).mlir_text()
+    expect(
+        'pto.backend = "vpto"' in inline_subkernel_scope_text
+        and 'pto.kernel_kind = #pto.kernel_kind<' not in inline_subkernel_scope_text,
+        "default inline TileOp entries should leave physical section selection to PTOAS",
+    )
     expect_parse_roundtrip_and_verify(inline_subkernel_scope_text, "inline subkernel scope specialization")
     expect(
         INLINE_SUBKERNEL_SCOPE_OBSERVATIONS == [

--- a/test/lit/vpto/raw_uncovered_cv_sections.pto
+++ b/test/lit/vpto/raw_uncovered_cv_sections.pto
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s
+
+// Raw VPTO micro-op instruction classes are sufficient to infer C/V sections
+// without an authored pto.kernel_kind or pto.section.* wrapper.
+module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
+  module attributes {pto.backend = "vpto", pto.target_arch = "a5"} {
+    func.func @raw_uncovered_cv() attributes {pto.entry} {
+      %c0 = arith.constant 0 : index
+      %c16 = arith.constant 16 : i64
+      %zero = arith.constant 0 : i64
+
+      %ub = pto.castptr %zero : i64 -> !pto.ptr<f32, ub>
+      %vec = pto.vlds %ub[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      pto.vsts %vec, %ub[%c0], %mask
+        : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+
+      %lhs = pto.castptr %zero : i64 -> !pto.ptr<f16, l0a>
+      %rhs = pto.castptr %zero : i64 -> !pto.ptr<f16, l0b>
+      %acc = pto.castptr %zero : i64 -> !pto.ptr<f32, l0c>
+      pto.mad %lhs, %rhs, %acc, %c16, %c16, %c16
+        : !pto.ptr<f16, l0a>, !pto.ptr<f16, l0b>,
+          !pto.ptr<f32, l0c>, i64, i64, i64
+      return
+    }
+  }
+}
+
+// CHECK: module attributes {
+// CHECK-SAME: pto.backend = "vpto"
+// CHECK-SAME: pto.target_arch = "a5"
+// CHECK: module attributes {
+// CHECK-SAME: pto.kernel_kind = #pto.kernel_kind<vector>
+// CHECK: func.func @raw_uncovered_cv
+// CHECK: pto.vlds
+// CHECK: pto.vsts
+// CHECK-NOT: pto.mad_raw
+// CHECK-NOT: pto.section
+// CHECK: module attributes {
+// CHECK-SAME: pto.kernel_kind = #pto.kernel_kind<cube>
+// CHECK: func.func @raw_uncovered_cv
+// CHECK: pto.mad_raw
+// CHECK-NOT: pto.vlds
+// CHECK-NOT: pto.vsts
+// CHECK-NOT: pto.section


### PR DESCRIPTION
## Summary
- document and implement the default TileOp C/V split path for #1004
- retain the internal VPTO vector build default without serializing it as authored `pto.kernel_kind`
- preserve explicit VPTO `kernel_kind="vector"` / `"cube"` and existing EmitC helper metadata behavior
- cover default entries, explicit mode, inline TileOps, mixed-backend callees, and flash-attention tracing

## Validation
- `PYTHONPATH=build-local-vpto/python:/Users/jimmychou/work/ptoas/llvm-workspace/llvm-project/build-shared/tools/mlir/python_packages/mlir_core /Users/jimmychou/work/ptoas/.venv-ptoas-local/bin/python ptodsl/tests/test_jit_compile.py`
- `PYTHONPATH=build-local-vpto/python:/Users/jimmychou/work/ptoas/llvm-workspace/llvm-project/build-shared/tools/mlir/python_packages/mlir_core /Users/jimmychou/work/ptoas/.venv-ptoas-local/bin/python ptodsl/tests/test_flash_attention_demo_compile.py`
- `/Users/jimmychou/work/ptoas/llvm-workspace/llvm-project/build-shared/bin/llvm-lit -v build-local-vpto/test/lit/vpto/section_sugar_mixed.pto`
- `git diff --check`

Fixes #1004