### PR TITLE
fix(ptodsl): allow MTE3 intra wait

### DIFF
--- a/ptodsl/docs/user_guide/10-sync-ops.md
+++ b/ptodsl/docs/user_guide/10-sync-ops.md
@@ -442,7 +442,7 @@ pto.set_intra_flag(pto.Pipe.MTE3, 0)
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `pipe` | `Pipe` | Waiting endpoint for the synchronization event. The public DSL accepts `Pipe.FIX` and `Pipe.V` here. |
+| `pipe` | `Pipe` | Waiting endpoint for the synchronization event. The public DSL accepts `Pipe.FIX`, `Pipe.MTE3`, and `Pipe.V` here. |
 | `event_id` | `int` or scalar expression | Physical event identifier to wait on (`0`–`31` for static IDs). |
 
 For A5 mixed C/V writeback code that must synchronize with both AIV subblocks, wait on both
@@ -454,8 +454,9 @@ the base event ID and `base_id + 16`.
 
 <!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"sync_ops.basic","symbol":"sync_ops_basic_probe","compile":{}} -->
 ```python
-# Vector-side endpoint waits for event ID0
-pto.wait_intra_flag(pto.Pipe.V, 0)
+# MTE3 waits for the Cube-to-UB handoff for each AIV subblock.
+with pto.for_(0, 2, step=1) as sid:
+    pto.wait_intra_flag(pto.Pipe.MTE3, sid * 16 + 6)
 ```
 
 ## 10.6 Synchronization in the authoring model

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -6140,7 +6140,7 @@ def wait_intra_flag(pipe, event_id):
     _validate_sync_pipe(
         pipe,
         context="wait_intra_flag(pipe, event_id)",
-        allowed=("PIPE_FIX", "PIPE_V"),
+        allowed=("PIPE_FIX", "PIPE_MTE3", "PIPE_V"),
     )
     event_operand = _sync_event_id_operand_in_range(
         event_id,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2951,6 +2951,8 @@ def public_sync_surface_probe():
     pto.wait_cross_flag(pto.Pipe.FIX, 0)
     pto.wait_intra_flag(pto.Pipe.V, dynamic_event)
     pto.wait_intra_flag(pto.Pipe.FIX, 20)
+    pto.wait_intra_flag(pto.Pipe.MTE3, dynamic_event)
+    pto.wait_intra_flag(pto.Pipe.MTE3, 31)
 
 
 @pto.jit(target="a5")
@@ -6320,6 +6322,8 @@ def main() -> None:
     expect("pto.sync.set <PIPE_FIX>, 4" in sync_surface_text, "set_intra_flag(Pipe.FIX, 4) should lower physical event ids through pto.sync.set")
     expect("pto.sync.wait <PIPE_V>, %c3" in sync_surface_text, "wait_intra_flag(Pipe.V, dynamic_event) should lower dynamic event ids through pto.sync.wait")
     expect("pto.sync.wait <PIPE_FIX>, 20" in sync_surface_text, "wait_intra_flag(Pipe.FIX, 20) should lower physical event ids through pto.sync.wait")
+    expect("pto.sync.wait <PIPE_MTE3>, %c3" in sync_surface_text, "wait_intra_flag(Pipe.MTE3, dynamic_event) should lower dynamic event ids through pto.sync.wait")
+    expect("pto.sync.wait <PIPE_MTE3>, 31" in sync_surface_text, "wait_intra_flag(Pipe.MTE3, 31) should lower the static physical event id through pto.sync.wait")
     expect(data_movement_surface_text.count("pto.mte_gm_ub") == 2, "public grouped GM->UB wrappers should lower to pto.mte_gm_ub")
     expect("pto.mte_ub_gm" in data_movement_surface_text, "public grouped UB->GM wrapper should lower to pto.mte_ub_gm")
     expect(

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -9,7 +9,7 @@
 import unittest
 import inspect
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import ptodsl._ops as _ops
 import ptodsl._pipe_namespace as _pipe_namespace
@@ -676,6 +676,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             (_ops.set_intra_flag, (pto.Pipe.MTE3, 32), {}, "set_intra_flag(..., event_id=...)", "[0, 31]"),
             (_ops.wait_intra_flag, (pto.Pipe.V, -2), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
             (_ops.wait_intra_flag, (pto.Pipe.FIX, 32), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
+            (_ops.wait_intra_flag, (pto.Pipe.MTE3, 32), {}, "wait_intra_flag(..., event_id=...)", "[0, 31]"),
         ]
 
         with patch.object(_ops._pto, "set_flag") as set_flag_op, \
@@ -705,7 +706,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             (_ops.set_cross_flag, (pto.Pipe.V, 0), "set_cross_flag(pipe, event_id)", "<PIPE_FIX>", "<PIPE_V>"),
             (_ops.wait_cross_flag, (pto.Pipe.MTE3, 0), "wait_cross_flag(pipe, event_id)", "<PIPE_FIX>", "<PIPE_MTE3>"),
             (_ops.set_intra_flag, (pto.Pipe.V, 0), "set_intra_flag(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE3>", "<PIPE_V>"),
-            (_ops.wait_intra_flag, (pto.Pipe.MTE3, 0), "wait_intra_flag(pipe, event_id)", "<PIPE_FIX>, <PIPE_V>", "<PIPE_MTE3>"),
+            (_ops.wait_intra_flag, (pto.Pipe.MTE2, 0), "wait_intra_flag(pipe, event_id)", "<PIPE_FIX>, <PIPE_MTE3>, <PIPE_V>", "<PIPE_MTE2>"),
         ]
 
         with patch.object(_ops._pto, "sync_set") as sync_set_op, \
@@ -723,17 +724,28 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         sync_wait_op.assert_not_called()
 
     def test_intra_sync_mixed_writeback_event_ranges(self):
+        dynamic_event = object()
+        dynamic_event_operand = object()
         with patch.object(_ops, "_pipe_attr", side_effect=lambda pipe: f"pipe:{pipe}") as pipe_attr, \
+             patch.object(_ops, "unwrap_surface_value", return_value=dynamic_event_operand) as unwrap_surface_value, \
              patch.object(_ops._pto, "sync_set") as sync_set_op, \
              patch.object(_ops._pto, "sync_wait") as sync_wait_op:
             _ops.set_intra_flag(pto.Pipe.FIX, 31)
             _ops.set_intra_flag(pto.Pipe.MTE3, 31)
             _ops.wait_intra_flag(pto.Pipe.FIX, 16)
             _ops.wait_intra_flag(pto.Pipe.V, 31)
+            _ops.wait_intra_flag(pto.Pipe.MTE3, 31)
+            _ops.wait_intra_flag(pto.Pipe.MTE3, dynamic_event)
 
-        self.assertEqual(pipe_attr.call_count, 4)
+        self.assertEqual(pipe_attr.call_count, 6)
         self.assertEqual(sync_set_op.call_count, 2)
-        self.assertEqual(sync_wait_op.call_count, 2)
+        sync_wait_op.assert_has_calls([
+            call(f"pipe:{pto.Pipe.FIX}", 16),
+            call(f"pipe:{pto.Pipe.V}", 31),
+            call(f"pipe:{pto.Pipe.MTE3}", 31),
+            call(f"pipe:{pto.Pipe.MTE3}", dynamic_event_operand),
+        ])
+        unwrap_surface_value.assert_called_once_with(dynamic_event)
 
     def test_pipe_namespace_and_buffer_helpers_are_exposed(self):
         names = [


### PR DESCRIPTION
## Summary
- Allow `pto.wait_intra_flag(pto.Pipe.MTE3, event_id)` for A5 intra-block synchronization.
- Cover static and dynamic MTE3 event IDs while retaining the static `[0, 31]` bound.
- Document the MTE3 writeback wait pattern.

## Tests
- `ptodsl/tests/test_vector_cube_ops.py -v`
- `ptodsl/tests/test_jit_compile.py`
- `ptodsl/tests/test_docs_as_test.py`
- `build-local-vpto/test/lit/vpto/intra_block_sync_vpto_llvm.pto`