### PR TITLE
fix(vmi): lower compact reduction stores with point stores

### DIFF
--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -40,6 +40,9 @@
 //   vload  → dispatch by dist_mode/group/block_stride to
 //            load / deinterleave_load / group_broadcast_load{num_groups=1} / ...
 //   vstore → dispatch to store / masked_store / interleave_store / group_store / ...
+//   A full-active continuous store of a compact reduction result is normalized
+//   to a unit-stride group_store.  A full reduction is one logical group, so
+//   its producer is normalized to group=1 before legacy lowering.
 //   Skipped: dist_mode "unpack" (physical widening, no legacy equivalent).
 //
 // Category C4 — static mask creation (3 ops):
@@ -318,6 +321,35 @@ static bool isAllActiveSeed(Value seed) {
         return ia.getInt() >= maskTy.getElementCount();
   }
   return false;
+}
+
+/// Prepare a direct reduction result for a unit-stride group store.
+///
+/// Explicit grouped reductions already produce one scalar per group.  A full
+/// reduction has the same semantics as a one-group reduction; when the store
+/// is its only consumer, attach group=1 so the producer and store share the
+/// existing group-slot lowering.  The one-use condition avoids changing the
+/// representation expected by unrelated consumers.
+static bool prepareReductionForUnitStrideGroupStore(Value value,
+                                                    int64_t numGroups,
+                                                    OpBuilder &builder) {
+  Operation *producer = value.getDefiningOp();
+  if (!producer || !isa<VMIvcaddOp, VMIvcmaxOp, VMIvcminOp>(producer))
+    return false;
+
+  if (auto group = producer->getAttrOfType<IntegerAttr>("group"))
+    return group.getInt() == numGroups;
+
+  if (numGroups != 1 || !value.hasOneUse())
+    return false;
+
+  auto valueType = cast<VMIVRegType>(value.getType());
+  if (VMILayoutAttr layout = valueType.getLayoutAttr())
+    if (!layout.isGroupSlots() || layout.getNumGroups() != 1)
+      return false;
+
+  producer->setAttr("group", builder.getI64IntegerAttr(1));
+  return true;
 }
 
 /// Lower vcmp to cmpf/cmpi + mask_and.
@@ -645,6 +677,32 @@ static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
     if (values.empty())
       return failure();
     Value mask = op.getMask().empty() ? Value() : op.getMask().front();
+    auto valueType = cast<VMIVRegType>(values[0].getType());
+    int64_t numGroups = valueType.getElementCount();
+
+    // A compact reduction result contains one scalar per logical group.  A
+    // continuous store of those scalars is therefore a group_store with unit
+    // row stride, which lets the legacy lowering select point-store modes.
+    // Keep masked stores unchanged unless their mask is provably all-active:
+    // group_store writes every group and cannot preserve dynamic predication.
+    bool allActive = !mask || isAllActiveSeed(mask);
+    bool compact = numGroups > 0 && numGroups <= 8;
+
+    // Do not replace an explicitly assigned, incompatible representation;
+    // layout assignment will choose group slots when the type is unassigned.
+    bool layoutCompatible =
+        !valueType.getLayoutAttr() ||
+        (valueType.getLayoutAttr().isGroupSlots() &&
+         valueType.getLayoutAttr().getNumGroups() == numGroups);
+    if (compact && allActive && layoutCompatible &&
+        prepareReductionForUnitStrideGroupStore(values[0], numGroups,
+                                                builder)) {
+      Value unitStride = builder.create<arith::ConstantIndexOp>(loc, 1);
+      builder.create<VMIGroupStoreOp>(loc, values[0], dest, offset, unitStride,
+                                      builder.getI64IntegerAttr(numGroups));
+      op->erase();
+      return success();
+    }
     if (mask) {
       // Masked store path.
       builder.create<VMIMaskedStoreOp>(loc, values[0], dest, offset, mask);
@@ -1188,6 +1246,9 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
     }
   });
 
+  // Process consumers before producers.  Besides avoiding stale producer
+  // uses, this lets a compact reduction-result vstore normalize a full
+  // reduction to group=1 before the reduction itself is lowered.
   for (Operation *op : llvm::reverse(worklist)) {
     if (!op->getBlock())
       continue;

--- a/test/lit/vmi_new/vmi_layout_assignment_dense_store_group_slots.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_dense_store_group_slots.pto
@@ -6,11 +6,13 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: not pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto 2>&1 | FileCheck %s
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
 
-// group_reduce_addf→vcadd, store→vstore.  Error comes from layout validation on old op.
+// A continuous store of a compact grouped reduction is normalized to a
+// unit-stride group_store instead of requiring a dense register layout.
 module {
-  func.func @vmi_layout_assignment_dense_store_group_slots_invalid(
+  func.func @vmi_layout_assignment_dense_store_group_slots(
       %source: !pto.vmi.vreg<64xf32>,
       %mask: !pto.vmi.mask<64xpred>,
       %dst: !pto.ptr<f32, ub>,
@@ -18,12 +20,19 @@ module {
     %sum = pto.vmi.vcadd %source, %mask {group = 8, reassoc}
         : !pto.vmi.vreg<64xf32>, !pto.vmi.mask<64xpred>
         -> !pto.vmi.vreg<8xf32>
-    // CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.store operand #0 has type
-    // CHECK-SAME: #pto.vmi.layout<num_groups = 8, slots = 8>
-    // CHECK-SAME: requires
-    // CHECK-SAME: #pto.vmi.layout<contiguous>
     pto.vmi.vstore %sum, %dst[%off]
         : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
     return
   }
 }
+
+// ASSIGN-LABEL: func.func @vmi_layout_assignment_dense_store_group_slots(
+// ASSIGN: %[[SUM:.*]] = pto.vmi.group_reduce_addf
+// ASSIGN-SAME: -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// ASSIGN: pto.vmi.group_store %[[SUM]]
+// ASSIGN-SAME: {num_groups = 8 : i64}
+
+// LOWER-LABEL: func.func @vmi_layout_assignment_dense_store_group_slots(
+// LOWER: pto.vcgadd
+// LOWER: pto.vsts
+// LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_layout_assignment_widen_dense_reduce_multi_consumer.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_widen_dense_reduce_multi_consumer.pto
@@ -7,14 +7,12 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
-// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER --implicit-check-not=pto.vdintlv
 
 module {
   func.func @vmi_layout_assignment_widen_dense_reduce_multi_consumer(
       %src: !pto.ptr<f16, ub>,
-      %k1: !pto.vmi.vreg<128xf32>,
-      %init0: !pto.vmi.vreg<1xf32>,
-      %init1: !pto.vmi.vreg<1xf32>,
+      %rhs: !pto.ptr<f32, ub>,
       %out0: !pto.ptr<f32, ub>,
       %out1: !pto.ptr<f32, ub>,
       %off: index) {
@@ -24,6 +22,8 @@ module {
         : !pto.ptr<f16, ub> -> !pto.vmi.vreg<128xf16>
     %w = pto.vmi.vcvt %a
         : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xf32>
+    %k1 = pto.vmi.vload %rhs[%off] {dist_mode = "continuous"}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
     %t1 = pto.vmi.vmul %w, %k1
         : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
         -> !pto.vmi.vreg<128xf32>
@@ -43,36 +43,37 @@ module {
 }
 
 // ASSIGN-LABEL: func.func @vmi_layout_assignment_widen_dense_reduce_multi_consumer(
-// ASSIGN-SAME: %[[B:arg[0-9]+]]: !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
-// ASSIGN-SAME: %arg2: !pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>
-// ASSIGN-SAME: %arg3: !pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>
 // ASSIGN: %[[A:.*]] = pto.vmi.load
-// ASSIGN-SAME: -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
 // ASSIGN: %[[W:.*]] = pto.vmi.extf %[[A]]
-// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[B:.*]] = pto.vmi.load
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
 // ASSIGN: %[[T1:.*]] = pto.vmi.mulf %[[W]], %[[B]]
-// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
 // ASSIGN: %[[MASK:.*]] = pto.vmi.create_mask
-// ASSIGN-SAME: -> !pto.vmi.mask<128xb32, #pto.vmi.layout<contiguous>>
-// ASSIGN: %[[ZERO0:.*]] = {{.*}}pto.vmi.constant{{.*}}
-// ASSIGN: %[[R0:.*]] = pto.vmi.reduce_addf %[[T1]], %[[ZERO0]], %[[MASK]]
-// ASSIGN-SAME: -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>
-// ASSIGN: pto.vmi.store %[[R0]]
-// ASSIGN: %[[ZERO1:.*]] = {{.*}}pto.vmi.constant{{.*}}
-// ASSIGN: %[[R:.*]] = pto.vmi.reduce_addf %[[W]], %[[ZERO1]], %[[MASK]]
-// ASSIGN-SAME: -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<contiguous>>
-// ASSIGN: pto.vmi.store %[[R]]
+// ASSIGN-SAME: -> !pto.vmi.mask<128xb32, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[R0:.*]] = pto.vmi.group_reduce_addf %[[T1]], %[[MASK]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<num_groups = 1, slots = 1>>
+// ASSIGN: pto.vmi.group_store %[[R0]]
+// ASSIGN: %[[R:.*]] = pto.vmi.group_reduce_addf %[[W]], %[[MASK]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<num_groups = 1, slots = 1>>
+// ASSIGN: pto.vmi.group_store %[[R]]
 
 // LOWER-LABEL: func.func @vmi_layout_assignment_widen_dense_reduce_multi_consumer(
 // LOWER: pto.vlds
 // LOWER: pto.vcvt
 // LOWER: pto.vcvt
+// LOWER: pto.vldsx2 {{.*}}, "DINTLV_B32"
 // LOWER: pto.vmul
-// LOWER: pto.vcadd
+// LOWER: pto.vmul
 // LOWER: pto.vadd
+// LOWER: pto.vcadd
+// LOWER: pto.vdup
 // LOWER: pto.vsts
-// LOWER: pto.vcadd
 // LOWER: pto.vadd
+// LOWER: pto.vcadd
+// LOWER: pto.vdup
 // LOWER: pto.vsts
 // LOWER-NOT: pto.vmi.
 // LOWER-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_continuous_reduce_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_continuous_reduce_store.pto
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+
+module {
+  func.func @continuous_reduce_store_1(
+      %source: !pto.vmi.vreg<64xf32>,
+      %reduce_mask: !pto.vmi.mask<64xpred>,
+      %dst: !pto.ptr<f32, ub>, %off: index) {
+    %store_mask = pto.vmi.pset "PAT_ALL" : !pto.vmi.mask<1xpred>
+    %sum = pto.vmi.vcadd %source, %reduce_mask {reassoc}
+        : !pto.vmi.vreg<64xf32>, !pto.vmi.mask<64xpred>
+        -> !pto.vmi.vreg<1xf32>
+    pto.vmi.vstore %sum, %dst[%off], %store_mask
+        : !pto.vmi.vreg<1xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<1xpred>
+    return
+  }
+
+  func.func @continuous_reduce_store_2(
+      %source: !pto.vmi.vreg<128xf32>,
+      %mask: !pto.vmi.mask<128xpred>,
+      %dst: !pto.ptr<f32, ub>, %off: index) {
+    %max = pto.vmi.vcmax %source, %mask {group = 2}
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.mask<128xpred>
+        -> !pto.vmi.vreg<2xf32>
+    pto.vmi.vstore %max, %dst[%off]
+        : !pto.vmi.vreg<2xf32>, !pto.ptr<f32, ub>
+    return
+  }
+
+  func.func @continuous_reduce_store_4(
+      %source: !pto.vmi.vreg<256xf32>,
+      %mask: !pto.vmi.mask<256xpred>,
+      %dst: !pto.ptr<f32, ub>, %off: index) {
+    %min = pto.vmi.vcmin %source, %mask {group = 4}
+        : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<4xf32>
+    pto.vmi.vstore %min, %dst[%off]
+        : !pto.vmi.vreg<4xf32>, !pto.ptr<f32, ub>
+    return
+  }
+
+  func.func @continuous_reduce_store_8(
+      %source: !pto.vmi.vreg<512xf32>,
+      %mask: !pto.vmi.mask<512xpred>,
+      %dst: !pto.ptr<f32, ub>, %off: index) {
+    %sum = pto.vmi.vcadd %source, %mask {group = 8, reassoc}
+        : !pto.vmi.vreg<512xf32>, !pto.vmi.mask<512xpred>
+        -> !pto.vmi.vreg<8xf32>
+    pto.vmi.vstore %sum, %dst[%off]
+        : !pto.vmi.vreg<8xf32>, !pto.ptr<f32, ub>
+    return
+  }
+
+  func.func @dynamic_mask_keeps_masked_store(
+      %source: !pto.vmi.vreg<64xf32>,
+      %reduce_mask: !pto.vmi.mask<64xpred>,
+      %store_mask: !pto.vmi.mask<1xpred>,
+      %dst: !pto.ptr<f32, ub>, %off: index) {
+    %sum = pto.vmi.vcadd %source, %reduce_mask {reassoc}
+        : !pto.vmi.vreg<64xf32>, !pto.vmi.mask<64xpred>
+        -> !pto.vmi.vreg<1xf32>
+    pto.vmi.vstore %sum, %dst[%off], %store_mask
+        : !pto.vmi.vreg<1xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<1xpred>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @continuous_reduce_store_1(
+// ASSIGN: %[[SUM1:.*]] = pto.vmi.group_reduce_addf
+// ASSIGN-SAME: {num_groups = 1 : i64, reassoc}
+// ASSIGN-SAME: -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<num_groups = 1, slots = 1>>
+// ASSIGN: pto.vmi.group_store %[[SUM1]]
+// ASSIGN-SAME: {num_groups = 1 : i64}
+
+// ASSIGN-LABEL: func.func @continuous_reduce_store_2(
+// ASSIGN: %[[MAX2:.*]] = pto.vmi.group_reduce_maxf
+// ASSIGN: pto.vmi.group_store %[[MAX2]]
+// ASSIGN-SAME: {num_groups = 2 : i64}
+
+// ASSIGN-LABEL: func.func @continuous_reduce_store_4(
+// ASSIGN: %[[MIN4:.*]] = pto.vmi.group_reduce_minf
+// ASSIGN: pto.vmi.group_store %[[MIN4]]
+// ASSIGN-SAME: {num_groups = 4 : i64}
+
+// ASSIGN-LABEL: func.func @continuous_reduce_store_8(
+// ASSIGN: %[[SUM8:.*]] = pto.vmi.group_reduce_addf
+// ASSIGN: pto.vmi.group_store %[[SUM8]]
+// ASSIGN-SAME: {num_groups = 8 : i64}
+
+// ASSIGN-LABEL: func.func @dynamic_mask_keeps_masked_store(
+// ASSIGN: pto.vmi.reduce_addf
+// ASSIGN: pto.vmi.masked_store
+// ASSIGN-NOT: pto.vmi.group_store
+
+// LOWER-LABEL: func.func @continuous_reduce_store_1(
+// LOWER: pto.vcadd
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
+
+// LOWER-LABEL: func.func @continuous_reduce_store_2(
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
+// LOWER: pto.vsts {{.*}} {dist = "1PT_B32"}
+
+// LOWER-LABEL: func.func @continuous_reduce_store_4(
+// LOWER-COUNT-4: pto.vsts {{.*}} {dist = "1PT_B32"}
+
+// LOWER-LABEL: func.func @continuous_reduce_store_8(
+// LOWER-COUNT-8: pto.vsts {{.*}} {dist = "1PT_B32"}
+
+// LOWER-LABEL: func.func @dynamic_mask_keeps_masked_store(
+// LOWER: pto.vsts
+// LOWER-NOT: {dist = "1PT_B32"}

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf_store.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf_store.pto
@@ -47,8 +47,12 @@ module {
 // ASSIGN-SAME: -> !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous, lane_stride = 2>>
 // ASSIGN: pto.vmi.masked_store %[[NARROW]]
 // ASSIGN-SAME: !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous, lane_stride = 2>>
-// ASSIGN: pto.vmi.reduce_addf %[[SUM]], {{.*}}, %[[MASK32]]
+// ASSIGN: %[[REDUCE:.*]] = pto.vmi.group_reduce_addf %[[SUM]], %[[MASK32]]
+// ASSIGN-SAME: {num_groups = 1 : i64, reassoc}
 // ASSIGN-SAME: !pto.vmi.mask<64xb32, #pto.vmi.layout<contiguous>>
+// ASSIGN-SAME: -> !pto.vmi.vreg<1xf32, #pto.vmi.layout<num_groups = 1, slots = 1>>
+// ASSIGN: pto.vmi.group_store %[[REDUCE]]
+// ASSIGN-SAME: {num_groups = 1 : i64}
 
 // LOWER-LABEL: func.func @vmi_to_vpto_reduce_addf_store(
 // LOWER-SAME: %[[SRC:[^,]+]]: !pto.vreg<64xf32>
@@ -61,10 +65,5 @@ module {
 // LOWER: %[[ALL:.*]] = pto.pset_b32 "PAT_ALL"
 // LOWER: %[[SUM:.*]] = pto.vadd %[[SRC]], %[[RHS]], %[[ALL]]
 // LOWER: pto.vsts {{.*}}, %[[DST_BF16]][%[[OFF]]], {{.*}} {dist = "PK_B32"}
-// LOWER: %[[VL1:.*]] = pto.pge_b32 "PAT_VL1" : !pto.mask<b32>
 // LOWER: %[[REDUCED:.*]] = pto.vcadd %[[SUM]], %[[REDUCE_MASK]]
-// LOWER: %[[REDUCED_SUM:.*]] = pto.vadd %[[REDUCED]], {{.*}}, %[[VL1]]
-// LOWER: %[[ONE:.*]] = arith.constant 1 : i32
-// LOWER: %[[PREFIX:.*]], %{{.*}} = pto.plt_b32 %[[ONE]]
-// LOWER: %[[MASKED:.*]] = pto.pand %[[STORE_MASK]], %[[PREFIX]]
-// LOWER: pto.vsts %[[REDUCED_SUM]], %[[DST]][%[[OFF]]], %[[MASKED]]
+// LOWER: pto.vsts %[[REDUCED]], %[[DST]][%[[OFF]]], {{.*}} {dist = "1PT_B32"}


### PR DESCRIPTION
## What

- Normalize full-active continuous stores of compact `vcadd`/`vcmax`/`vcmin` results to unit-stride `group_store`.
- Treat a full reduction as `group = 1` when its only consumer is the store, allowing the existing group-slot lowering to emit `1PT_B32` directly.
- Reuse the same path for explicit grouped reductions with 2, 4, or 8 compact results.
- Preserve ordinary masked-store lowering when the store predicate is dynamic, since point stores cannot represent dynamic predication.

## Why

A direct `1 x T -> 1` reduction followed by `vstore` previously lowered through neutral-init materialization, an extra vector add, predicate construction, and a masked store. The compact result can instead use the existing group-store representation and lower to `vcadd` plus `1PT_B32` store.

The layout regression test now uses memory-backed operands, allowing layout assignment to select a direct `DINTLV_B32` load for multi-part widening/reduction flows instead of introducing an artificial conversion at a VMI register function argument.

## Tests

- `cmake --build build-main-llvm21 --target pto-test-opt -j2`
- `llvm-lit -sv build-main-llvm21/test/lit/vmi_new` (438/438 passed)

Closes #1022.

The focused reproducer and performance context are in #1013.
