### PR TITLE
fix: use PIPE_ALL for vector GM fences

### DIFF
--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3125,9 +3125,10 @@ def FenceBarrierAllOp : PTO_Op<"fence.barrier_all"> {
     Memory fence for a visibility scope. Around signal/payload communication it
     can be used as the producer-side publish barrier or the consumer-side
     acquire barrier depending on placement. In EmitC, `scope = gm` and
-    `scope = all` conservatively drain MTE2, MTE3, and FIX before lowering to
-    `dsb(DSB_DDR)`, so users do not need to separately model those producer
-    pipe classes before a GM visibility fence.
+    `scope = all` drain all vector-kernel pipes with `PIPE_ALL` before lowering
+    to `dsb(DSB_DDR)`. Other kernel kinds conservatively drain MTE2, MTE3, and
+    FIX before the DDR barrier. Users therefore do not need to separately model
+    producer pipe classes before a GM visibility fence.
   }];
 
   let arguments = (ins PTO_FenceScopeAttr:$scope);

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5743,6 +5743,17 @@ static void emitConservativeGmFencePipeDrains(
   emitPipeBarrier(rewriter, loc, "PIPE_FIX");
 }
 
+static bool isInVectorKernel(Operation *op) {
+  for (Operation *parent = op->getParentOp(); parent;
+       parent = parent->getParentOp()) {
+    auto kernelKindAttr = parent->getAttrOfType<FunctionKernelKindAttr>(
+        FunctionKernelKindAttr::name);
+    if (kernelKindAttr)
+      return kernelKindAttr.getKernelKind() == FunctionKernelKind::Vector;
+  }
+  return false;
+}
+
 struct PTOBarrierToEmitC : public OpConversionPattern<pto::BarrierOp> {
   using OpConversionPattern<pto::BarrierOp>::OpConversionPattern;
 
@@ -5795,7 +5806,10 @@ struct PTOFenceToEmitC : public OpConversionPattern<FenceOp> {
         op.getScope().getScope() != pto::FenceScope::All)
       return rewriter.notifyMatchFailure(op, "unsupported fence scope");
 
-    emitConservativeGmFencePipeDrains(rewriter, op.getLoc());
+    if (isInVectorKernel(op))
+      emitPipeBarrier(rewriter, op.getLoc(), "PIPE_ALL");
+    else
+      emitConservativeGmFencePipeDrains(rewriter, op.getLoc());
     emitDsbDdr(rewriter, op.getLoc());
     rewriter.eraseOp(op);
     return success();

--- a/test/lit/pto/issue1026_vector_gm_fence_no_fix.pto
+++ b/test/lit/pto/issue1026_vector_gm_fence_no_fix.pto
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Regression for issue #1026: a vector GM fence after TPUT must not name
+// PIPE_FIX, which can hang a vector core after cross-rank communication.
+
+// RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s
+
+module {
+  func.func @vector_gm_fence_after_tput(
+      %dst_ptr: !pto.ptr<f32>,
+      %src_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c64 = arith.constant 64 : index
+
+    %dst_view = pto.make_tensor_view %dst_ptr,
+      shape = [%c1, %c64], strides = [%c64, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %dst = pto.partition_view %dst_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c64]
+      : !pto.tensor_view<?x?xf32>
+        -> !pto.partition_tensor_view<1x64xf32>
+
+    %src_view = pto.make_tensor_view %src_ptr,
+      shape = [%c1, %c64], strides = [%c64, %c1]
+      : !pto.tensor_view<?x?xf32>
+    %src = pto.partition_view %src_view,
+      offsets = [%c0, %c0], sizes = [%c1, %c64]
+      : !pto.tensor_view<?x?xf32>
+        -> !pto.partition_tensor_view<1x64xf32>
+
+    %stage = pto.alloc_tile :
+      !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+
+    pto.comm.tput(
+      %dst, %src,
+      buf(%stage)
+      : !pto.partition_tensor_view<1x64xf32>,
+        !pto.partition_tensor_view<1x64xf32>,
+        !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=64, v_row=1, v_col=64, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+      {atomicType = #pto<atomic_type atomic_none>}
+    pto.fence.barrier_all #pto.fence_scope<gm>
+    return
+  }
+}
+
+// CHECK-LABEL: AICORE void vector_gm_fence_after_tput(
+// CHECK:      pto::comm::TPUT(
+// CHECK-NOT:  pipe_barrier(PIPE_FIX);
+// CHECK:      pipe_barrier(PIPE_ALL);
+// CHECK-NEXT: dsb(DSB_DDR);
+// CHECK-NOT:  pipe_barrier(PIPE_FIX);
+// CHECK:      #endif // __DAV_VEC__

--- a/test/lit/pto/issue711_tnotify_mte_drain.pto
+++ b/test/lit/pto/issue711_tnotify_mte_drain.pto
@@ -10,7 +10,7 @@
 // TNotify release requires the producer side to drain local producer pipes
 // before the GM fence and before pto.comm.tnotify. PTOAS no longer runs the
 // historical MemoryConsistency analysis pass, so the explicit GM fence lowering
-// conservatively drains MTE2, MTE3, and FIX before dsb(DSB_DDR).
+// drains all vector-kernel pipes before dsb(DSB_DDR).
 
 // RUN: ptoas --pto-arch=a3 %s -o - 2>&1 | FileCheck %s
 
@@ -57,8 +57,8 @@ module {
     return
   }
 
-  // acc tstore -> tnotify: ACC->GM stores use the FIX pipe, so the release
-  // fence must be preceded by a FIX pipe drain.
+  // acc tstore -> tnotify: the vector-kernel release fence uses PIPE_ALL, so
+  // it does not name the cube-side FIX pipe explicitly.
   func.func @tnotify_drain_after_acc_tstore(
       %dst_ptr: !pto.ptr<f32>,
       %signal_ptr: !pto.ptr<i32>)
@@ -159,8 +159,8 @@ module {
     return
   }
 
-  // The explicit barrier_all conservatively drains MTE2, MTE3 and FIX, then
-  // completes the publish sequence with a DDR fence.
+  // The explicit barrier_all drains all vector-kernel pipes, then completes
+  // the publish sequence with a DDR fence.
   func.func @tnotify_after_existing_mte3_barrier_and_release(
       %src_ptr: !pto.ptr<f32>,
       %dst_ptr: !pto.ptr<f32>,
@@ -280,17 +280,13 @@ module {
 // CHECK:      pto::comm::NotifyOp{{.*}}= pto::comm::NotifyOp::Set;
 // CHECK:      TLOAD(
 // CHECK:      TSTORE(
-// CHECK:      pipe_barrier(PIPE_MTE2);
-// CHECK-NEXT: pipe_barrier(PIPE_MTE3);
-// CHECK-NEXT: pipe_barrier(PIPE_FIX);
+// CHECK:      pipe_barrier(PIPE_ALL);
 // CHECK-NEXT: dsb(DSB_DDR);
 // CHECK:      pto::comm::TNOTIFY(
 
 // CHECK-LABEL: AICORE void tnotify_drain_after_acc_tstore(
 // CHECK:      TSTORE
-// CHECK:      pipe_barrier(PIPE_MTE2);
-// CHECK-NEXT: pipe_barrier(PIPE_MTE3);
-// CHECK-NEXT: pipe_barrier(PIPE_FIX);
+// CHECK:      pipe_barrier(PIPE_ALL);
 // CHECK-NEXT: dsb(DSB_DDR);
 // CHECK:      pto::comm::TNOTIFY(
 
@@ -309,17 +305,13 @@ module {
 
 // CHECK-LABEL: AICORE void tnotify_after_existing_mte3_barrier_and_release(
 // CHECK:      TSTORE(
-// CHECK:      pipe_barrier(PIPE_MTE2);
-// CHECK-NEXT: pipe_barrier(PIPE_MTE3);
-// CHECK-NEXT: pipe_barrier(PIPE_FIX);
+// CHECK:      pipe_barrier(PIPE_ALL);
 // CHECK-NEXT: dsb(DSB_DDR);
 // CHECK:      pto::comm::TNOTIFY(
 
 // CHECK-LABEL: AICORE void tnotify_after_existing_mte3_barrier_and_fence(
 // CHECK:      TSTORE(
-// CHECK:      pipe_barrier(PIPE_MTE2);
-// CHECK-NEXT: pipe_barrier(PIPE_MTE3);
-// CHECK-NEXT: pipe_barrier(PIPE_FIX);
+// CHECK:      pipe_barrier(PIPE_ALL);
 // CHECK-NEXT: dsb(DSB_DDR);
 // CHECK:      pto::comm::TNOTIFY(
 


### PR DESCRIPTION
## Summary
- lower vector-kernel GM/ALL fences to pipe_barrier(PIPE_ALL) followed by dsb(DSB_DDR)
- retain the conservative MTE2/MTE3/FIX drain for non-vector kernels
- add a TPUT-to-fence regression for the device hang and update the existing TNotify fence expectations

## Validation
- LLVM 21.1.8: ptoas_runtime_staging build passed with -j1
- issue1026_vector_gm_fence_no_fix.pto: passed
- issue711_tnotify_mte_drain.pto: passed
- comm_p2p_emitc.pto: passed
- generated A3 vector C++ compiled with Bisheng for dav-c220-vec
- full lit was attempted; PTODSL daemon tests are unavailable because the local LLVM 21 build has MLIR_ENABLE_BINDINGS_PYTHON=OFF

Closes #1026