### PR TITLE
fix(ptodsl): tolerate inaccessible include paths

### DIFF
--- a/ptodsl/ptodsl/_runtime/toolchain.py
+++ b/ptodsl/ptodsl/_runtime/toolchain.py
@@ -85,7 +85,11 @@ def ascend_driver_path() -> Path:
 
 
 def _append_include_flag(flags: list[str], path: Path) -> None:
-    if not path.is_dir():
+    try:
+        is_dir = path.is_dir()
+    except OSError:
+        return
+    if not is_dir:
         return
     flag = f"-I{path}"
     if flag not in flags:

--- a/ptodsl/tests/test_runtime_toolchain.py
+++ b/ptodsl/tests/test_runtime_toolchain.py
@@ -17,6 +17,26 @@ from ptodsl._runtime import native_build, toolchain
 
 
 class RuntimeToolchainTest(unittest.TestCase):
+    def test_include_flag_skips_inaccessible_directory(self):
+        flags = []
+        inaccessible = Path("/inaccessible/include")
+        error = PermissionError(13, "Permission denied", str(inaccessible))
+
+        with mock.patch.object(Path, "is_dir", side_effect=error):
+            toolchain._append_include_flag(flags, inaccessible)
+
+        self.assertEqual(flags, [])
+
+    def test_include_flag_adds_accessible_directory_once(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            include_dir = Path(temp_dir)
+            flags = []
+
+            toolchain._append_include_flag(flags, include_dir)
+            toolchain._append_include_flag(flags, include_dir)
+
+            self.assertEqual(flags, [f"-I{include_dir}"])
+
     def test_a2_a3_use_c220_aicore_arch(self):
         self.assertEqual(
             toolchain.aicore_arch_for_kernel_kind("vector", "a3"), "dav-c220-vec"


### PR DESCRIPTION
## Summary

- handle filesystem errors while probing candidate native include directories
- skip inaccessible include paths consistently with missing paths
- preserve normal include flag generation and de-duplication

## Testing

- `python ptodsl/tests/test_runtime_toolchain.py` (7 tests passed)
- `python -m unittest discover -s ptodsl/tests -p 'test_*.py'` (131 tests passed)
- `git diff --check`

Closes #1034