### PR TITLE
ci: temporarily run TileLang DSL ST in smoke mode

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -704,8 +704,7 @@ jobs:
           echo "PTO_DSL_ST_LLVM_DIR=${PTO_DSL_ST_LLVM_DIR}" >> "${GITHUB_ENV}"
 
       - name: Run TileLang DSL CI
-        # Temporarily run unmaintained TileLang ST only as a PR smoke test.
-        if: ${{ github.event_name == 'pull_request' }}
+        # Temporarily keep unmaintained TileLang ST in smoke mode for every trigger.
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -704,26 +704,18 @@ jobs:
           echo "PTO_DSL_ST_LLVM_DIR=${PTO_DSL_ST_LLVM_DIR}" >> "${GITHUB_ENV}"
 
       - name: Run TileLang DSL CI
-        # Temporarily skip unmaintained TileLang ST on nightly runs. PR smoke
-        # and manually dispatched full validation remain enabled.
-        if: ${{ github.event_name != 'schedule' }}
+        # Temporarily run unmaintained TileLang ST only as a PR smoke test.
+        if: ${{ github.event_name == 'pull_request' }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p "${TILELANG_DSL_WORKSPACE}"
           export LLVM_BUILD_DIR="${LLVM_DIR}"
           export MLIR_PYTHON_ROOT="${MLIR_PYTHONPATH}"
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
-            PTOAS_BIN="${PTOAS_BIN}" \
-            bash test/tilelang_st/script/run_ci.sh -r sim -v a5 --jobs 64 --smoke \
-              2>&1 | tee "${TILELANG_DSL_WORKSPACE}/run_ci.log"
-          else
-            ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
-            PTOAS_BIN="${PTOAS_BIN}" \
-            bash test/tilelang_st/script/run_ci.sh -r sim -v a5 --jobs 64 \
-              2>&1 | tee "${TILELANG_DSL_WORKSPACE}/run_ci.log"
-          fi
+          ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
+          PTOAS_BIN="${PTOAS_BIN}" \
+          bash test/tilelang_st/script/run_ci.sh -r sim -v a5 --jobs 64 --smoke \
+            2>&1 | tee "${TILELANG_DSL_WORKSPACE}/run_ci.log"
 
       - name: Restore PTODSL LLVM build cache
         id: ptodsl-llvm-cache

--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -10,9 +10,8 @@ name: ci-sim
 
 on:
   pull_request:
-  # Nightly self-hosted simulator validation (GitHub cron is UTC).
-  schedule:
-    - cron: "0 14 * * *"
+  # Nightly runs are temporarily disabled until TileLang ST has an active maintainer.
+  # Keep manual dispatch available for on-demand full simulator validation.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -10,8 +10,9 @@ name: ci-sim
 
 on:
   pull_request:
-  # Nightly runs are temporarily disabled until TileLang ST has an active maintainer.
-  # Keep manual dispatch available for on-demand full simulator validation.
+  # Nightly self-hosted simulator validation (GitHub cron is UTC).
+  schedule:
+    - cron: "0 14 * * *"
   workflow_dispatch:
 
 permissions:
@@ -703,6 +704,9 @@ jobs:
           echo "PTO_DSL_ST_LLVM_DIR=${PTO_DSL_ST_LLVM_DIR}" >> "${GITHUB_ENV}"
 
       - name: Run TileLang DSL CI
+        # Temporarily skip unmaintained TileLang ST on nightly runs. PR smoke
+        # and manually dispatched full validation remain enabled.
+        if: ${{ github.event_name != 'schedule' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## 背景

`ci-sim` 每日定时验证目前长期失败且缺少 TileLang ST 维护者。最近 15 次 scheduled run 全部失败；抽查最近 5 次，均失败在 `Run TileLang DSL CI`。

继续让这项无人维护的 ST 阻断 nightly，只会占用排障注意力并掩盖同一 workflow 中其他 simulator 验证的状态。

## 修改

- 将 `Run TileLang DSL CI` 暂时统一为 smoke validation。
- 保留整条 `ci-sim` 每日调度，VPTO、TileLib ST、PTODSL ST 等其他 nightly 验证继续执行。
- PR、scheduled 和 `workflow_dispatch` 三种触发都会执行 TileLang DSL smoke。
- 删除按事件切换全量模式的分支，唯一保留的调用固定带 `--smoke`；手动触发 main 也不会执行全量验证。
- 在 step 旁记录暂停原因；TileLang ST 恢复维护后再显式恢复全量入口。

## 验证

- `git diff --check`
- 对修改前后的 `.github/workflows/ci_sim.yml` 分别运行 `actionlint`，诊断一致：仅存在主分支已有的自托管 runner `label-1` 未登记和 `if: ${{ true }}` 两项问题，本 PR 未新增 lint 诊断。
