### PR TITLE
feat(ptodsl): 新增运行时标量及 builtin vector 的公共浮点类型转换接口

### DIFF
--- a/ptodsl/ptodsl/_scalar_adaptation.py
+++ b/ptodsl/ptodsl/_scalar_adaptation.py
@@ -232,6 +232,14 @@ def _coerce_float_like(value, target_type):
     if value.type == target_type:
         return value
 
+    source_shape = _float_shape(value.type)
+    target_shape = _float_shape(target_type)
+    if source_shape != target_shape:
+        raise TypeError(
+            "cannot coerce floating-point values with different shapes: "
+            f"{value.type} and {target_type}"
+        )
+
     source_width = _float_bytewidth(value.type)
     target_width = _float_bytewidth(target_type)
     if source_width < target_width:
@@ -244,7 +252,15 @@ def _coerce_float_like(value, target_type):
     )
 
 
+def _float_shape(type_obj):
+    if VectorType.isinstance(type_obj):
+        return tuple(VectorType(type_obj).shape)
+    return ()
+
+
 def _float_bytewidth(type_obj):
+    if VectorType.isinstance(type_obj):
+        return _float_bytewidth(VectorType(type_obj).element_type)
     if BF16Type.isinstance(type_obj) or F16Type.isinstance(type_obj):
         return 2
     if F32Type.isinstance(type_obj):

--- a/ptodsl/ptodsl/scalar.py
+++ b/ptodsl/ptodsl/scalar.py
@@ -79,6 +79,41 @@ def select(cond, true_val, false_val):
     ).result)
 
 
+def cast(value, dtype):
+    """Cast a runtime scalar or builtin vector to ``dtype``.
+
+    For builtin vectors, a scalar ``dtype`` denotes the destination element
+    type and the source vector shape is preserved.  An explicit ``pto.Vec``
+    descriptor is also accepted when its shape matches the source.
+    """
+    raw_value = unwrap_surface_value(value)
+    target_type = _resolve(dtype)
+    source_is_vector = hasattr(raw_value, "type") and VectorType.isinstance(raw_value.type)
+    target_is_vector = VectorType.isinstance(target_type)
+
+    if source_is_vector:
+        source_vector_type = VectorType(raw_value.type)
+        if target_is_vector:
+            target_vector_type = VectorType(target_type)
+            if tuple(source_vector_type.shape) != tuple(target_vector_type.shape):
+                raise TypeError(
+                    "scalar.cast(vector, dtype) requires the destination vector shape "
+                    f"to match the source: got {target_type}, expected shape "
+                    f"{tuple(source_vector_type.shape)}"
+                )
+        else:
+            target_type = VectorType.get(list(source_vector_type.shape), target_type)
+    elif target_is_vector:
+        raise TypeError(
+            "scalar.cast(scalar, dtype) cannot produce a vector; "
+            "use pto.Vec(..., init=value) to broadcast"
+        )
+
+    return wrap_surface_value(
+        coerce_scalar_to_type(value, target_type, context="scalar.cast(...)")
+    )
+
+
 def max(lhs, rhs):
     """Runtime scalar maximum across float / integer / index values."""
     return wrap_surface_value(emit_runtime_max(

--- a/ptodsl/ptodsl/scalar.py
+++ b/ptodsl/ptodsl/scalar.py
@@ -360,6 +360,7 @@ def _element_bytewidth(elem_type):
 __all__ = [
     "muli", "addi", "subi",
     "index_cast",
+    "cast",
     "select",
     "max", "min", "exp", "log", "sqrt", "abs",
     "load", "store",

--- a/ptodsl/tests/test_scalar_cast.py
+++ b/ptodsl/tests/test_scalar_cast.py
@@ -35,6 +35,10 @@ def vector_float_cast_shape_mismatch_probe():
     _ = scalar.cast(value, pto.Vec(pto.f32, 8))
 
 
+def test_scalar_cast_is_public():
+    assert "cast" in scalar.__all__
+
+
 def test_scalar_float_cast():
     text = scalar_float_cast_probe.compile().mlir_text()
     assert "arith.extf" in text
@@ -63,6 +67,7 @@ def test_vector_float_cast_rejects_shape_mismatch():
 
 
 def main():
+    test_scalar_cast_is_public()
     test_scalar_float_cast()
     test_vector_float_cast_preserves_shape()
     test_vector_float_cast_rejects_shape_mismatch()

--- a/ptodsl/tests/test_scalar_cast.py
+++ b/ptodsl/tests/test_scalar_cast.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import pytest
+
+from ptodsl import pto, scalar
+
+
+@pto.jit(target="a5")
+def scalar_float_cast_probe():
+    data = pto.alloc_tile(shape=[1, 16], dtype=pto.f16, valid_shape=[1, 1])
+    value = scalar.load(data[0, 0])
+    widened = scalar.cast(value, pto.f32)
+    narrowed = scalar.cast(widened, pto.f16)
+    scalar.store(narrowed, data[0, 0])
+
+
+@pto.jit(target="a5")
+def vector_float_cast_probe():
+    data = pto.alloc_tile(shape=[1, 16], dtype=pto.f16, valid_shape=[1, 8])
+    ptr = data.as_ptr()
+    value = scalar.load(ptr, 0, contiguous=4)
+    widened = scalar.cast(value, pto.f32)
+    narrowed = scalar.cast(widened, pto.Vec(pto.f16, 4))
+    scalar.store(narrowed, ptr, 4)
+
+
+@pto.jit(target="a5")
+def vector_float_cast_shape_mismatch_probe():
+    data = pto.alloc_tile(shape=[1, 16], dtype=pto.f16, valid_shape=[1, 8])
+    value = scalar.load(data.as_ptr(), 0, contiguous=4)
+    _ = scalar.cast(value, pto.Vec(pto.f32, 8))
+
+
+def test_scalar_float_cast():
+    text = scalar_float_cast_probe.compile().mlir_text()
+    assert "arith.extf" in text
+    assert "arith.truncf" in text
+    assert "f16 to f32" in text
+    assert "f32 to f16" in text
+
+
+def test_vector_float_cast_preserves_shape():
+    text = vector_float_cast_probe.compile().mlir_text()
+    assert "arith.extf" in text
+    assert "arith.truncf" in text
+    assert "vector<4xf16> to vector<4xf32>" in text
+    assert "vector<4xf32> to vector<4xf16>" in text
+
+
+def test_vector_float_cast_rejects_shape_mismatch():
+    with pytest.raises(TypeError, match="destination vector shape"):
+        vector_float_cast_shape_mismatch_probe.compile()

--- a/ptodsl/tests/test_scalar_cast.py
+++ b/ptodsl/tests/test_scalar_cast.py
@@ -6,8 +6,6 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-import pytest
-
 from ptodsl import pto, scalar
 
 
@@ -54,5 +52,21 @@ def test_vector_float_cast_preserves_shape():
 
 
 def test_vector_float_cast_rejects_shape_mismatch():
-    with pytest.raises(TypeError, match="destination vector shape"):
+    try:
         vector_float_cast_shape_mismatch_probe.compile()
+    except TypeError as error:
+        assert "destination vector shape" in str(error)
+    else:
+        raise AssertionError(
+            "scalar.cast must reject a mismatched destination vector shape"
+        )
+
+
+def main():
+    test_scalar_float_cast()
+    test_vector_float_cast_preserves_shape()
+    test_vector_float_cast_rejects_shape_mismatch()
+    print("ptodsl_scalar_cast: PASS")
+
+if __name__ == "__main__":
+    main()

--- a/test/dsl-st/scalar_cast.py
+++ b/test/dsl-st/scalar_cast.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""End-to-end SIMT coverage for the public ``scalar.cast`` API.
+
+The SIMT body exercises both per-thread runtime scalars and lane-local builtin
+vectors returned by ``scalar.load(..., contiguous=VEC)``.
+"""
+
+import numpy as np
+
+from common import auto_main, golden_output_case
+from ptodsl import pto, scalar
+
+
+VEC = 4
+THREADS = 32
+ELEMENTS = THREADS * (1 + VEC)
+
+
+@pto.simt
+def scalar_cast_simt_body(
+    input_ptr: pto.ptr(pto.f32, "gm"),
+    output_ptr: pto.ptr(pto.f32, "gm"),
+) -> None:
+    tid = pto.get_tid_x()
+    idx = scalar.index_cast(tid)
+
+    scalar_value = scalar.load(input_ptr, idx)
+    narrowed_scalar = scalar.cast(scalar_value, pto.f16)
+    widened_scalar = scalar.cast(narrowed_scalar, pto.f32)
+    scalar.store(widened_scalar, output_ptr, idx)
+
+    vector_base = THREADS + idx * VEC
+    vector_value = scalar.load(input_ptr, vector_base, contiguous=VEC)
+    narrowed_vector = scalar.cast(vector_value, pto.f16)
+    widened_vector = scalar.cast(narrowed_vector, pto.Vec(pto.f32, VEC))
+    scalar.store(widened_vector, output_ptr, vector_base)
+
+
+@pto.jit(
+    name="scalar_cast_simt_f32_f16_round_trip",
+    kernel_kind="vector",
+    target="a5",
+    mode="explicit",
+    insert_sync=False,
+)
+def scalar_cast_simt_f32_f16_round_trip(
+    input_ptr: pto.ptr(pto.f32, "gm"),
+    output_ptr: pto.ptr(pto.f32, "gm"),
+) -> None:
+    scalar_cast_simt_body[THREADS, 1, 1](input_ptr, output_ptr)
+    pto.pipe_barrier(pto.Pipe.ALL)
+
+
+def make_inputs():
+    input_data = np.linspace(
+        -3.25,
+        3.25,
+        num=ELEMENTS,
+        dtype=np.float32,
+    )
+    input_data += np.float32(0.0013)
+    return [input_data]
+
+
+def make_expected(input_data):
+    return input_data.astype(np.float16).astype(np.float32)
+
+
+CASES = [
+    golden_output_case(
+        "scalar_cast_simt_f32_f16_round_trip",
+        scalar_cast_simt_f32_f16_round_trip,
+        inputs=make_inputs,
+        expected=make_expected,
+        rtol=0.0,
+        atol=0.0,
+    ),
+]
+
+
+auto_main(globals())


### PR DESCRIPTION
## 背景

TileLang PTO 后端在生成 PTODSL 代码时，需要对运行时浮点标量和 builtin vector 进行升精度或降精度转换。

此前 PTODSL 没有提供对应的公共接口，下游只能在生成代码中直接导入并调用 MLIR Python API，例如：

```python
from mlir.dialects import arith
from mlir.ir import VectorType
```

这种方式会将 PTOAS/PTODSL 的内部实现细节泄漏到下游，要求运行环境必须直接提供可导入的 `mlir` Python 包，也会使 PTOAS 后续通过 wheel 独立分发时产生不必要的依赖风险。

本 PR 在 PTODSL 公共接口中新增运行时浮点类型转换能力，使下游只依赖 `pto` API，不再直接操作 MLIR 类型和算子。

## 修改内容

### 1. 新增公共接口 `scalar.cast`

新增：

```python
scalar.cast(value, dtype)
```

该接口用于转换运行时标量或一维 builtin vector 的浮点元素类型，并返回标准 PTODSL surface value。

示例：

```python
value_f32 = scalar.cast(value_f16, pto.F32)
value_f16 = scalar.cast(value_f32, pto.F16)
```

### 2. 支持一维 builtin vector 的元素类型转换

当输入是 builtin vector、目标参数是标量 dtype 时，接口会保留原有 vector 长度，仅替换元素类型。例如：

```text
vector<4xf16> -> vector<4xf32>
vector<4xf32> -> vector<4xf16>
```

接口也支持显式传入 `pto.Vec(dtype, size)` 作为目标类型，但目标 vector 长度必须与输入一致。

### 3. 完善浮点转换 lowering

扩展内部浮点类型适配逻辑：

- 升精度转换生成 `arith.extf`；
- 降精度转换生成 `arith.truncf`；
- scalar 与 vector 统一复用浮点位宽判断逻辑；
- vector 转换前校验源类型和目标类型的 shape；
- 转换结果通过现有 wrapper 返回，不向调用方暴露 MLIR 对象。

### 4. 增加非法用法检查

以下情况会抛出明确的 `TypeError`：

- 将运行时 scalar 隐式广播为 vector；
- 输入 vector 与目标 `pto.Vec` 的长度不一致；
- 输入和目标类型的 shape 不兼容。

这样可以在 PTODSL 构图阶段尽早暴露错误，避免生成难以定位的非法 MLIR。

## 接口语义

| 输入 | 目标 dtype | 结果 |
| --- | --- | --- |
| scalar `f16` | `pto.F32` | scalar `f32` |
| scalar `f32` | `pto.F16` | scalar `f16` |
| `vector<Nxf16>` | `pto.F32` | `vector<Nxf32>` |
| `vector<Nxf32>` | `pto.F16` | `vector<Nxf16>` |
| `vector<Nxf16>` | `pto.Vec(pto.F32, N)` | `vector<Nxf32>` |
| scalar | `pto.Vec(...)` | 报错，不进行隐式广播 |
| `vector<NxT>` | `pto.Vec(..., M)`，且 `N != M` | 报错 |

## 测试补充

新增 `ptodsl/tests/test_scalar_cast.py`，覆盖：

- scalar `f16 -> f32 -> f16`；
- builtin vector `vector<4xf16> -> vector<4xf32> -> vector<4xf16>`；
- 对生成 IR 中 `arith.extf` 和 `arith.truncf` 的检查；
- vector shape 保持检查；
- vector 长度不匹配时的异常检查。

## 验证结果

基于提交 `b1e40cab166578bb5aa12885bc1b8d1f4fd992ba` 完成以下验证：

- 新增单元测试：`3 passed`；
- 既有 `ptodsl/tests/test_jit_compile.py`：通过；
- PTOAS CMake/Ninja 编译及安装：通过；
- 成功生成并安装 PTOAS wheel：
  `ptoas-0.55-cp310-cp310-linux_x86_64.whl`；
- PTODSL `MatMul`、`Abs` 编译冒烟测试：通过；
- TileKernels Engram Gate PTO 后端测试：`24 passed, 24 deselected`；
- 对 Gate 新生成代码进行检查：
  - 直接引用 `mlir.dialects`：0 处；
  - 直接引用 `mlir.ir`：0 处；
  - 使用 `scalar.cast`：78 处。

Gate 验证日志：

```text
/data/zyc/log/zyc_PTO_scalar_cast_gate_b1e40cab.log
```

## 兼容性与影响

- 本次修改只新增公共接口，不改变现有接口语义；
- MLIR 方言、类型判断和转换算子继续封装在 PTOAS/PTODSL 内部；
- 下游生成代码不再需要显式导入 `mlir` Python 包；
- 有利于 PTOAS 后续以 wheel 形式独立安装和分发；
- 非法 shape 转换会更早给出明确错误。
