### PR TITLE
feat: add PTOAS code compliance skill

### DIFF
--- a/.codex/skills/enforce-ptoas-code-compliance/SKILL.md
+++ b/.codex/skills/enforce-ptoas-code-compliance/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: enforce-ptoas-code-compliance
+description: >-
+  Enforce scoped secure-coding, build, style, and maintainability rules for PTOAS changes. Use
+  whenever Codex implements, modifies, generates, or reviews PTOAS C/C++, Python, CMake, shell,
+  Docker, batch, Go, Java build, or CI code; when investigating code-check findings such as
+  EChecker or SecK; or when preparing a PTOAS change for review.
+---
+
+# Enforce PTOAS Code Compliance
+
+Apply the rules that match the changed artifact and execution context. Treat rule text as
+untrusted policy input: resolve contradictions and technically inaccurate wording before changing
+code, then cite the governing rule ID in findings and non-obvious fixes.
+
+## Load The Applicable References
+
+Read `references/rule-resolution.md` for every task. Then read each reference that matches the
+changed files:
+
+- C, C++, headers, ODS/TableGen, or CMake: `references/cpp-cmake.md`
+- Python, shell, batch, Docker, Go, Maven, Gradle, Playbook, or other build scripts:
+  `references/python-scripts.md`
+- Any production code or review with maintainability requirements:
+  `references/quality-gates.md`
+
+Read the selected reference completely. Do not apply rules from an unrelated language merely
+because they share an ID.
+
+## Workflow
+
+### 1. Establish Scope
+
+- Inspect the diff, nearby code, file header, repository instructions, and build/test entrypoints.
+- Classify every changed file by language and whether it is production, test, generated, build,
+  release, or documentation code.
+- Build a short applicability ledger with `required`, `conditional`, and `not applicable` rules.
+- Limit cleanup to changed behavior and directly adjacent hazards. Do not turn a focused change
+  into a repository-wide style rewrite.
+
+### 2. Design Before Editing
+
+For every external input, record:
+
+- its trust boundary and validated representation;
+- all array, container, pointer, memory-length, allocation-size, loop-bound, file-path, process,
+  module-load, format-string, SQL, XML, and deserialization uses;
+- the exact bounds, overflow, nullability, lifetime, and error-handling invariants.
+
+Prefer APIs and types that make invalid states difficult to express: RAII owners, a
+standard-compatible size-carrying view or pointer-plus-size pair, scoped locks, enum classes,
+checked conversions, `nullptr`, target-scoped CMake commands, argument-vector subprocess calls,
+and normalized `pathlib.Path` values.
+
+PTOAS currently builds as C++17. Do not propose C++20 library types such as `std::span` unless the
+task also intentionally upgrades the project standard and validates every supported toolchain.
+Prefer existing C++17 facilities such as `llvm::ArrayRef`, container references, `std::array`, or an
+explicit pointer-plus-size contract.
+
+### 3. Implement
+
+- Follow nearby project style and the repository license-header convention.
+- Keep functions single-purpose and control flow shallow.
+- Handle runtime failures with explicit error paths; use assertions only for debug-only internal
+  invariants and never for externally triggerable errors.
+- Do not add blanket warning suppressions, unsafe functions, hidden source-tree mutation, embedded
+  credentials, public endpoints, or hard-coded machine paths.
+- Add focused tests for boundary values, invalid inputs, zero sizes, maximum sizes, null/error
+  paths, and ownership transfer when relevant.
+
+### 4. Run The Fast Changed-Code Check
+
+Run from the repository root:
+
+```bash
+python3 .codex/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py \
+  --repo . \
+  --base <target-branch>
+```
+
+The checker is a deterministic prefilter, not proof of compliance. Fix every `error`. Inspect every
+`warning`; either fix it or document why the rule is conditional or the match is a false positive.
+Do not add suppression comments solely to silence this script.
+
+### 5. Run Semantic And Project Validation
+
+- Run the narrowest relevant formatter, compiler, linter, static analyzer, and regression tests.
+- Compile C/C++ with the project language standard and warning policy. Treat newly introduced
+  warnings as failures.
+- Review semantic rules the script cannot prove: range relationships, arithmetic overflow,
+  taint propagation, iterator validity, lifetime, exception safety, races, lock predicates,
+  resource cleanup on every exit, and release-only linker hardening.
+- Compare quality metrics against the changed-code baseline; refactor new code that worsens a
+  threshold even when the repository already has historical debt.
+
+### 6. Report
+
+Report:
+
+- applicable rule families and any explicitly excluded artifact families;
+- checker, build, test, and analyzer commands with results;
+- unresolved findings as `rule ID -> evidence -> risk -> required action`;
+- any contextual rule interpretation used from `rule-resolution.md`.
+
+Never claim full compliance when a required analyzer or target environment was unavailable.
+
+## Blocking Gates
+
+Do not finish or publish code with:
+
+- known out-of-bounds access, unchecked tainted size/index/loop/pointer use, integer
+  overflow/wraparound, null dereference, use-after-free, leak, or data race;
+- unchecked externally controlled process/module/format/SQL/XML/path/deserialization input;
+- newly introduced unsafe memory/string functions or blanket warning suppression;
+- C/C++ selection or loop bodies without braces;
+- failing relevant tests, new compiler warnings, unexplained checker errors, or unreviewed
+  changed-code duplication and complexity regressions.

--- a/.codex/skills/enforce-ptoas-code-compliance/agents/openai.yaml
+++ b/.codex/skills/enforce-ptoas-code-compliance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PTOAS Code Compliance"
+  short_description: "Apply scoped secure-coding and quality gates to PTOAS changes"
+  default_prompt: "Use $enforce-ptoas-code-compliance to review this PTOAS change."

--- a/.codex/skills/enforce-ptoas-code-compliance/references/cpp-cmake.md
+++ b/.codex/skills/enforce-ptoas-code-compliance/references/cpp-cmake.md
@@ -1,0 +1,229 @@
+# C, C++, And CMake Rules
+
+## Contents
+
+- [Taint, bounds, and memory](#taint-bounds-and-memory)
+- [Arithmetic and expressions](#arithmetic-and-expressions)
+- [Pointers, resources, and strings](#pointers-resources-and-strings)
+- [Classes, exceptions, and concurrency](#classes-exceptions-and-concurrency)
+- [Control flow, declarations, and macros](#control-flow-declarations-and-macros)
+- [Headers, formatting, and comments](#headers-formatting-and-comments)
+- [API, signals, and release behavior](#api-signals-and-release-behavior)
+- [CMake and compiler configuration](#cmake-and-compiler-configuration)
+- [Review checklist](#review-checklist)
+
+## Taint, Bounds, And Memory
+
+Treat external values as tainted until validated. This covers `EChecker_BufferSize`,
+`EChecker_OutOfBound` (product-specific), `EChecker_Overrun`, `EChecker_TaintedArgument`,
+`EChecker_TaintedLoopBound`, `EChecker_TaintedPtrDereference`, `SecK_OutOfBoundsChecker`, and
+`SecK_NullPointerDereferenceChecker`.
+
+- `G.ARR.01`, `G.RES.01-CPP`, `G.STD.08-CPP`: validate every external array/container index against
+  the exact current bound before use.
+- `G.FUD.07`, `G.RES.03-CPP`: pass array extent with a pointer, or use a size-carrying view supported
+  by C++17, such as `llvm::ArrayRef` or an existing container reference. Do not introduce
+  `std::span` without an intentional language-standard upgrade.
+- `G.ARR.02`, `G.ARR.03`: never infer an array parameter or pointed-to allocation size with
+  `sizeof`.
+- `G.MEM.01`, `G.RES.02-CPP`: validate allocation size, including multiplication/addition overflow,
+  before allocation.
+- `G.MEM.02`, `G.RES.13-CPP`: handle allocation failure according to the selected allocation API.
+- `G.MEM.03`: validate externally derived copy/set/compare lengths against source and destination.
+- `G.MEM.04`: clear sensitive memory with an operation the compiler cannot optimize away.
+- `G.STR.01`, `G.STR.02`, `G.STD.05-CPP`: reserve the terminator and prove termination for C strings.
+- `G.STD.09-CPP`, `G.STD.11-CPP`, `G.STD.12-CPP`: preserve iterator validity and destination
+  capacity; use erase after remove algorithms.
+- `G.FMT.08`, `G.FMT.11-CPP`: use braces for selection and loops, including one-line bodies.
+
+Test zero, one, maximum valid, first invalid, and overflow-adjacent values. A check after pointer
+arithmetic or dereference is too late.
+
+## Arithmetic And Expressions
+
+- `G.INT.01`, `G.EXP.20-CPP`: prevent signed overflow.
+- `G.INT.02`, `G.EXP.21-CPP`: prevent unintended unsigned wraparound.
+- `G.INT.03`, `G.OPR.01`, `G.EXP.22-CPP`: guard division and remainder by zero.
+- `G.INT.04`, `G.EXP.26-CPP`: widen operands before evaluation, not only the result.
+- `G.INT.05`, `G.EXP.23-CPP`: perform bitwise operations on unsigned integers.
+- `G.INT.06`: range-check external integers before conversion or use.
+- `G.INT.07`, `G.EXP.24-CPP`: validate shift counts against zero and the promoted left-operand width.
+- `G.INT.09`: keep enum values unique unless aliases are intentional and documented.
+- `G.INT.10`, `G.EXP.17-CPP`, `G.EXP.25-CPP`: make narrowing and signed/unsigned conversions explicit
+  and prove their range.
+- `G.EXP.01`, `G.TYP.02`: use compatible basic types for arithmetic and comparisons.
+- `G.EXP.04`, `G.EXP.30-CPP`: use parentheses where precedence is not immediately obvious.
+- `G.EXP.05`: do not pass side-effecting expressions to `sizeof`.
+- `G.EXP.06`: do not assume a particular bit-field layout.
+- `G.EXP.12-CPP`: bit-copy only trivially copyable objects.
+- `G.EXP.13-CPP`: use character types for characters.
+- `G.EXP.14-CPP`: use C++ casts; avoid `reinterpret_cast` and `const_cast`
+  (`G.EXP.15-CPP`, `G.EXP.16-CPP`).
+- `G.EXP.18-CPP`, `G.ARR.04`: avoid integer/pointer conversion.
+- `G.ARR.05`: do not force-convert unrelated object-pointer types.
+- `G.ARR.06`: do not introduce variable-length arrays.
+- `G.TYP.02`, `G.C&C++.WARN.14`: do not use direct floating-point equality for approximate values.
+
+## Pointers, Resources, And Strings
+
+- `G.ARR.08`, `G.FUD.08`, `G.RES.15-CPP`: establish non-nullness before every nullable dereference.
+- `G.MEM.05`, `SecK_UseAfterFreeChecker`: never access released storage.
+- `G.PRM.03`, `G.VAR.08`, `SecK_MemoryAndResourceLeakChecker`: pair acquisition and release on all
+  normal and exceptional exits.
+- `G.RES.04-CPP`, `G.VAR.06`: do not let local addresses escape their lifetime.
+- `G.RES.05-CPP`, `G.RES.06-CPP`: escaping lambdas must not capture locals by reference; avoid
+  default capture.
+- `G.RES.07-CPP`, `G.VAR.05`: reset non-owning handles after release.
+- `G.RES.08-CPP`: use RAII for ownership.
+- `G.RES.09-CPP`, `G.RES.10-CPP`: use `make_unique` and `make_shared`.
+- `G.RES.11-CPP`, `G.RES.12-CPP`: pair allocation/deallocation forms and custom operators.
+- `G.STD.02-CPP`: prefer `std::string` for ordinary text.
+- `G.STD.03-CPP`: do not construct `std::string` from a nullable pointer.
+- `G.STD.04-CPP`: do not retain `c_str()` or `data()` pointers across invalidating operations.
+- `G.STD.07-CPP`: do not retain secrets in ordinary strings.
+- `G.FUU.09`, `G.FUU.10`: do not use `realloc` or `alloca`.
+- `G.FUU.21` and unsafe-function metrics: do not introduce unbounded C memory/string operations.
+
+When a low-level API is unavoidable, prove destination capacity, source availability, overlap
+requirements, and return-value handling at the call site.
+
+## Classes, Exceptions, And Concurrency
+
+- `G.CLS.01-CPP`, `G.CLS.02-CPP`: initialize every member at declaration or in the constructor
+  initialization list.
+- `G.CLS.03-CPP`: mark converting single-argument constructors `explicit`.
+- `G.CLS.04-CPP`, `G.CLS.05-CPP`: define/delete copy and move operation pairs consistently.
+- `G.CLS.06-CPP`: do not dispatch virtual functions from constructors or destructors.
+- `G.CLS.07-CPP`: prevent public copying/moving of polymorphic bases unless explicitly safe.
+- `G.CLS.09-CPP`: leave moved-from owners valid and resource-safe.
+- `G.CLS.10-CPP`: give polymorphic bases virtual destructors when deletion through the base is
+  supported.
+- `G.CLS.11-CPP`: do not redefine inherited virtual default arguments.
+- `G.CLS.12-CPP`: use `override` or `final`.
+- `G.CLS.13-CPP`, `G.CLS.14-CPP`, `G.CLS.15-CPP`: do not hide inherited non-virtual APIs, decay
+  derived arrays to base pointers, or overload comma/logical operators.
+- `G.CNS.03-CPP`, `G.CNS.04-CPP`: apply `const` to observers and read-only pointees/references.
+- `G.ERR.01-CPP` through `G.ERR.07-CPP`: throw standard-exception-derived objects by value, catch by
+  reference, order handlers most-derived first, do not throw from destructors, and do not use
+  dynamic exception specifications.
+- `G.CON.01-CPP`: wait on condition variables with a predicate or a loop.
+- `G.CON.02-CPP`: prefer scoped lock wrappers over direct mutex lock/unlock calls.
+- `SecL_DataRace`: synchronize every shared mutable access with a documented ownership/locking rule.
+
+## Control Flow, Declarations, And Macros
+
+- `G.CTL.01`, `G.EXP.36-CPP`: control expressions are boolean.
+- `G.CTL.02`, `G.EXP.31-CPP`, `G.EXP.32-CPP`, `G.EXP.33-CPP`: do not rely on skipped operands or
+  combine side effects with short-circuiting/increment expressions.
+- `G.CTL.03`: every loop has a provable exit or an intentional service-loop contract.
+- `G.CTL.04`, `G.EXP.40-CPP`: never use floating-point loop counters.
+- `G.CTL.06`, `G.EXP.42-CPP`: avoid `goto`; if legacy code requires it, never jump into a scope or
+  upward into repeated execution.
+- `G.CTL.07`, `G.EXP.37-CPP`: include a deliberate `default`, even when it only reports an invalid
+  state.
+- `G.CTL.08`, `G.EXP.38-CPP`: do not use a switch for a single condition.
+- `G.DCL.01`, `G.EXP.01-CPP`: do not define reserved identifiers.
+- `G.EXP.02-CPP`, `G.TYP.01`: do not redefine fundamental types.
+- `G.EXP.03-CPP`: prefer `using` aliases.
+- `G.EXP.04-CPP`: preserve the one-definition rule.
+- `G.EXP.07-CPP`: do not depend on cross-translation-unit global initialization order.
+- `G.EXP.08-CPP`, `G.EXP.09-CPP`, `G.VAR.01`: initialize before use and declare near first use.
+- `G.EXP.10-CPP`, `G.VAR.02`: do not shadow names in nested scopes.
+- `G.EXP.19-CPP`: do not move from const objects.
+- `G.EXP.35-CPP`: use `nullptr`.
+- `G.EXP.43-CPP`, `G.OTH.01`, `G.PRJ.05`: delete dead code instead of commenting it out.
+- `G.ENU.01-CPP`, `G.ENU.02-CPP`: prefer named scoped enums.
+- `G.PRE.01-CPP`: use typed constants, not constant macros.
+- `G.PRE.02-CPP`: prefer functions to function-like macros.
+- `G.PRE.03-CPP` through `G.PRE.05-CPP`: make preprocessor conditions explicitly boolean, guard
+  identifiers with `defined`, and keep matching branches in one file.
+- General `G.PRE.*`: parenthesize macro parameters/results, avoid side-effecting arguments and
+  control-flow macros, do not shadow keywords, do not embed directives in arguments, and omit a
+  trailing semicolon.
+
+## Headers, Formatting, And Comments
+
+- `G.ARR.07`: specify the bound on externally linked array declarations.
+- `G.INC.01-CPP` through `G.INC.12-CPP`: prevent cycles, include only needed self-contained headers,
+  use guards or the established equivalent, do not include inside `extern "C"`, order includes,
+  avoid global using-directives and header-local anonymous/static definitions, and hide
+  translation-unit-only symbols.
+- `G.FUD.01`, `G.FUN.02-CPP`: keep declaration/definition names and qualifiers identical.
+- `G.FUD.02`: prefer return values to output parameters.
+- `G.FUD.09`: avoid modifying parameter variables; use a local value when transformation is needed.
+- `G.FUN.01-CPP`: keep functions single-purpose.
+- `G.FUN.03-CPP`: remove unused parameters or use a framework-approved explicit marker.
+- `G.FUN.04-CPP`: avoid C-style variadic functions.
+- `G.FUN.07-CPP`: do not `std::move` a returned local.
+- `G.FMT.*`: use four-space indentation, one statement per line, braces, consistent line endings,
+  project-consistent brace/pointer style, useful spacing, and a 120-column maximum unless a
+  non-wrappable token makes that impossible.
+- `G.CMT.03-CPP`, `G.CMT.04-CPP`, `G.CMT.05-CPP`: use the repository copyright header, avoid empty
+  ceremonial comments, and do not ship TODO/TBD/FIXME markers.
+- `G.CNS.01-CPP`: use uppercase `L`, not lowercase `l`, for integer suffixes.
+- `G.CNS.02-CPP`: replace unexplained literals with named typed constants.
+- `G.NAM.03-CPP`: follow one naming style within the component.
+- `G.STD.01-CPP`: use current standard-library headers.
+- `G.TMP.01-CPP`: keep template definitions and explicit specializations with their template.
+- `G.VAR.03`: avoid large stack allocations.
+
+## API, Signals, And Release Behavior
+
+- `G.FUU.01`, `G.FUU.11`, `G.FUU.12`: check relevant return values and pass the true destination
+  capacity to bounded APIs.
+- `G.FUU.13` through `G.FUU.15`: do not wrap or macro-rename approved secure functions; use only
+  the project-approved safe-function implementation when that policy applies.
+- `G.FUU.04` through `G.FUU.08`, `G.STD.16-CPP`: do not use `atexit`, abort-style termination, or
+  process/thread exit functions outside an approved program entrypoint.
+- `G.FUU.05`, `G.STD.17-CPP`: do not directly terminate another process.
+- `G.FUU.16`, `G.FUU.17`, `G.STD.15-CPP`: validate externally influenced process arguments and
+  dynamic-module names.
+- `G.FUU.19`, `G.OTH.02`, `G.STD.19-CPP`: call only async-signal-safe operations in signal handlers
+  and do not access unsafe shared objects.
+- `G.FUU.20`, `G.STD.18-CPP`: avoid time-of-check/time-of-use and library-call races.
+- `G.STD.13-CPP`, `G.STD.14-CPP`: use valid, trusted format strings.
+- `G.PRJ.03`: do not ship product debug entrypoints.
+- `G.PRJ.04`: keep text source in the project's UTF-8 encoding.
+- `G.OTH.03`: never use weak pseudo-random generators for security.
+- `G.OTH.04`: do not expose object or function addresses in release output.
+- `G.OTH.05`, `G.PRJ.07`: do not embed unapproved public endpoints.
+
+## CMake And Compiler Configuration
+
+- `G.CMake.01` through `G.CMake.07`: keep each `CMakeLists.txt` with its source directory, recurse
+  with `add_subdirectory`, include only `.cmake` modules, and never include a `CMakeLists.txt`.
+- `G.CMake.10` through `G.CMake.13`: use explicit compiler-specific toolchain files through
+  `CMAKE_TOOLCHAIN_FILE`; keep project options out of them.
+- `G.CMake.17`, `G.CMake.18`: make `cmake_minimum_required` and `project` the first project commands
+  after the required license header and comments.
+- `G.CMake.19`, `G.CMake.20`: use lowercase commands, uppercase built-in properties, and do not
+  prefix custom variables with `CMAKE`.
+- `G.CMake.22`, `G.CMake.24`: avoid deprecated syntax; place file-scope commands before targets and
+  prefer target-scoped commands.
+- `G.CMake.25`, `G.CMake.26`: use target sources with unambiguous paths across directories.
+- `G.CMake.27`: use source, binary, and current-list directory variables for their intended trees.
+- `G.C&C++.01`, `.04`, `.07`, `.08`, `.09`, `.12`, `G.COM.01`, `.02`, `.03`: preserve out-of-source
+  builds, arbitrary install prefixes, one build entrypoint, target selection, parallel builds, a
+  clean target, and no source-tree mutation.
+- `G.C&C++.LANG.01`: explicitly select the language standard.
+- `G.C&C++.LANG.04`: never add `-fpermissive`.
+- `G.C&C++.WARN.01`, `.02`, `.04`, `.05`, `.06`, `.14`: enable useful warnings; do not use `-w`,
+  blanket `-Wno-*`, or warning-error downgrades. Inspect every narrow suppression.
+- `G.C&C++.SEC.01` through `.06`, `.09`: apply supported stack, PIE/ASLR, RELRO, non-executable
+  stack, symbol-stripping, runtime-search-path, and SafeSEH policies to the appropriate release
+  platform. Do not pass unsupported flags to every toolchain.
+- `G.C&C++.CDG.01`: use `-fno-common` where supported for C targets.
+- `G.COM.07`, `.08`: produce concise leveled logs and keep per-build logs distinguishable.
+- `G.COM.10`: build as a non-system user in managed build environments.
+
+## Review Checklist
+
+- Taint sources and all sensitive sinks are mapped.
+- Bounds checks occur before address computation and dereference.
+- Size arithmetic is checked in the type that performs the operation.
+- Nullability, ownership, iterator validity, and cleanup are explicit.
+- Error paths are tested and do not depend on assertions.
+- New code introduces no unsafe functions, warning suppression, or undefined behavior.
+- Return values, signal behavior, process/module inputs, and release diagnostics are safe.
+- CMake changes are target-scoped and preserve supported toolchains.
+- Relevant compiler, sanitizer/static-analysis, unit, lit, and board tests pass.

--- a/.codex/skills/enforce-ptoas-code-compliance/references/python-scripts.md
+++ b/.codex/skills/enforce-ptoas-code-compliance/references/python-scripts.md
@@ -1,0 +1,137 @@
+# Python And Script Rules
+
+## Contents
+
+- [Python structure and style](#python-structure-and-style)
+- [Python errors and types](#python-errors-and-types)
+- [Untrusted data and external execution](#untrusted-data-and-external-execution)
+- [Files, serialization, logging, and secrets](#files-serialization-logging-and-secrets)
+- [Shell and batch](#shell-and-batch)
+- [Build, container, and ecosystem files](#build-container-and-ecosystem-files)
+
+## Python Structure And Style
+
+- `G.CLS.01`, `G.CLS.05`: call the parent initializer correctly, normally with `super()`.
+- `G.CLS.02`: keep an override's signature compatible with the base method.
+- `G.CLS.08`: define instance attributes in `__init__`, preferably with type annotations.
+- `G.CLS.09`: magic methods return the protocol-required type.
+- `G.CLS.10`: unsupported numeric magic methods return `NotImplemented`.
+- `G.CMT.01`, `G.CMT.03`: place module and public-function docstrings in their canonical locations.
+- `G.CMT.03`, `G.PRJ.06`: use the repository header and omit personal information.
+- `G.CMT.04`, `G.CMT.05`: keep comments consistent and do not ship TODO/FIXME markers.
+- `G.AST.01` through `G.AST.05`, `G.TES.01`: use assertions only for one debug-only internal
+  invariant; never mutate state in an assertion or use one for a possible runtime failure.
+- `G.FMT.01` through `G.FMT.12`: use four spaces, logical blank lines, one import and statement per
+  line, consistent line endings, readable spacing, and at most 120 columns.
+- `G.FNM.01`: never use a mutable default argument.
+- `G.FNM.02`: do not accidentally close over a changing loop variable.
+- `G.FNM.03`, `G.FNM.05`: group large related parameter/result sets in named types.
+- `G.FNM.04`: do not assign the result of a no-return function.
+- `G.FNM.06`: return from generators instead of raising `StopIteration`.
+- `G.IMP.01` through `G.IMP.03`: prefer explicit absolute package imports and do not use
+  `__import__`.
+- `G.NAM.01`, `G.NAM.03`, `G.NAM.05`: keep naming consistent, use `self`/`cls`, and reserve
+  double-underscore magic names for protocols.
+- `G.PY.01`, `G.PRJ.04`: use UTF-8 for Python and project text files.
+- `G.VAR.01` through `G.VAR.03`: keep a variable's type stable and avoid shadowing/global leakage.
+- `G.CTL.01` through `G.CTL.05`: keep branch return shapes consistent, remove unreachable code,
+  make loops terminate, keep conditions small, iterate directly, and use `_` for unused loop values.
+- `G.EXP.03`, `G.EXP.04`: use named functions for nontrivial behavior and keep comprehensions simple.
+
+## Python Errors And Types
+
+- `G.ERR.03`, `G.ERR.05`, `G.ERR.06`: raise instantiated, business-specific `Exception`
+  subclasses.
+- `G.ERR.04`: preserve traceback context when translating exceptions.
+- `G.ERR.07`: do not swallow exceptions.
+- `G.ERR.08`: do not expose secrets in errors.
+- `G.ERR.09`, `G.ERR.10`: avoid duplicate catches and order specific handlers before broad ones.
+- `G.ERR.11`: use `sys.exit` only at the main entrypoint.
+- `G.ERR.13`: propagate with bare `raise` when appropriate; do not use `raise exc`.
+- `G.ERR.14`: let `finally` complete normally.
+- `G.OPR.01`: guard zero divisors.
+- `G.OPR.02`, `G.OPR.03`, `G.OPR.05`, `G.OPR.06`: compare `None` with `is`, values with equality,
+  and use `is not`/`not in` idiomatically.
+- `G.TYP.01`: construct `Decimal` from exact strings/integers, never binary floats.
+- `G.TYP.02`: compare approximate floats with a tolerance, not `==`.
+- `G.TYP.04`, `G.TYP.06`, `G.TYP.08`: use truthiness for sequence emptiness, unique dict keys, and
+  `isinstance` for runtime type tests.
+- `G.PSL.01`, `G.PSL.02`: avoid deprecated APIs and use timezone-aware datetimes when timezones
+  matter.
+
+## Untrusted Data And External Execution
+
+- `G.EDV.01`: never evaluate untrusted text with `eval` or `exec`.
+- `G.EDV.02`, `G.EDV.04`: do not pass untrusted data through a command interpreter or
+  `subprocess(..., shell=True)`.
+- `G.EDV.03`: avoid interpreter-expanded wildcards.
+- `G.EDV.05`, `G.CNP.01`: resolve executables, pass an argument vector, set a timeout where a child
+  can stall, and handle the return code.
+- `G.EDV.06`, `G.FUU.18`: parameterize SQL.
+- `G.EDV.07`: do not let untrusted templates drive `.format`.
+- `G.EDV.08`: bound input and avoid catastrophic-backtracking regexes.
+- `G.EDV.09`, `G.EDV.10`: use safe XML construction and disable external entities.
+- `G.FUU.02`, `G.FUU.03`: keep format strings trusted and type-correct.
+- `G.FUU.16`, `G.FUU.17`: validate externally influenced process arguments and module names.
+- `G.FUU.01`: inspect and handle meaningful return values instead of silently discarding failure.
+
+## Files, Serialization, Logging, And Secrets
+
+- `G.FIL.01`, `G.FIO.01`: create files with the minimum required permissions.
+- `G.FIL.02`, `G.FIO.02`: resolve/normalize externally influenced paths, constrain them to an
+  allowed root, and reject traversal before use.
+- `G.FIL.03`: use a private temporary location, not a predictable shared path.
+- `G.FIO.03`: use `TemporaryFile`, `NamedTemporaryFile`, or `TemporaryDirectory`, never
+  `tempfile.mktemp`.
+- `G.FIO.04`: clean temporary files on success and failure.
+- `G.FIO.06`: validate archive member paths, types, sizes, and extraction destination.
+- `G.SER.01`: do not load untrusted pickle, `_pickle`, or shelve data.
+- `G.SER.02`: encrypt authenticated sensitive serialized data.
+- `G.SER.03`: use `yaml.safe_load`, not `yaml.load`.
+- `G.SER.04`: do not use jsonpickle for untrusted or sensitive data.
+- `G.LOG.01`: use logging's lazy interpolation for debug/info paths.
+- `G.LOG.02`: use the project logging facility rather than ad-hoc application prints.
+- `G.LOG.03`, `G.LOG.04`: sanitize external log data and never log credentials, tokens, or keys.
+- `G.DSP.01` through `G.DSP.03`: sign and encrypt sensitive outbound objects, use cryptographically
+  secure randomness, and use TLS sockets in security-sensitive network code.
+- `G.OTH.03`: never use `rand`-style randomness for security.
+- `G.OTH.04`: do not expose object/function addresses in release output.
+- `G.OTH.05`, `G.PRJ.07`: do not embed unapproved public endpoints.
+
+## Shell And Batch
+
+- `G.SH.01`: put the selected shell interpreter on the first line; use Bash for Bash syntax.
+- `G.SCRIPT.02`, `.04`: keep call and variable-expansion nesting shallow.
+- `G.SCRIPT.05`, `.06`: derive paths from the script/repository and avoid fixed installation paths.
+- `G.SCRIPT.07`: do not depend on network drives.
+- `G.SCRIPT.08`: return zero only on success.
+- `G.SCRIPT.09`: include purpose and repository copyright.
+- `G.SCRIPT.11`, `.12`: keep the delivery unit's script-language set small and consistent.
+- Quote expansions, use arrays for command arguments, reject unsafe external values, and avoid
+  `eval`, `bash -c`, wildcard deletion, and command-string construction.
+- `G.BAT.01` through `.06`, `.08`: for batch files, use `.bat`, `@echo off`, `rem` comments,
+  lowercase snake-case filenames/variables, uppercase constants/environment variables, and `call`
+  for subroutines or batch files.
+
+## Build, Container, And Ecosystem Files
+
+Apply these only when the corresponding artifact exists:
+
+- `G.DOCKER.01`, `.02`, `.04` through `.13`: use the approved base/build environment, declared
+  tools, `COPY`, a non-root `USER`, maintainer metadata, configurable tool locations, explicit
+  `ENV`, and deterministic install order.
+- `G.BI.*`, `G.VM.*`, `G.ENV.*`, `G.TOOL.*`: treat base image, managed environment, OS, and tool
+  lifecycle requirements as release/platform policy, not ordinary source-style rules.
+- `G.PLAYBOOK.*`: preserve the prescribed role layout. Governed installer scripts require exact
+  `#!/bin/bash`, `install_dir=$1`, local pre-provisioned packages, validation, and cleanup.
+- `G.GO.*`: keep one root build entrypoint, use modules, lock explicit versions, and fail builds on
+  task failure. Verify the catalog's legacy `verdor.json` wording against the current approved Go
+  policy before adding such a file.
+- `G.GRADLE.*`, `G.MAVEN.*`: use conventional root entrypoints, central dependency/version
+  management, fixed release versions, dependency locks, UTF-8 POMs, and zero unresolved warnings.
+- `G.JS.*`: commit package manifests and lockfiles, use the approved registry for release builds,
+  and never commit generated build products.
+- `G.MF.*`: apply manifest/dependency/playbook repository rules only to product-release manifests.
+- `G.COM.*`, `G.C&C++.*`: provide one build entrypoint, clean/target/parallel support, separated
+  source/build/install trees, deterministic configuration, concise per-run logs, and no source-tree
+  mutation.

--- a/.codex/skills/enforce-ptoas-code-compliance/references/quality-gates.md
+++ b/.codex/skills/enforce-ptoas-code-compliance/references/quality-gates.md
@@ -1,0 +1,96 @@
+# Quality Gates
+
+## Contents
+
+- [Changed-code gates](#changed-code-gates)
+- [Repository trend metrics](#repository-trend-metrics)
+- [Named design findings](#named-design-findings)
+- [Evidence requirements](#evidence-requirements)
+
+## Changed-Code Gates
+
+Require new or materially changed code to meet these targets:
+
+- average file length below 300 logical code lines;
+- average function length below 30 logical code lines;
+- average cyclomatic complexity below 5;
+- total changed-code duplication below 10%;
+- changed source-file duplication below 4%;
+- duplicated source lines below 10%;
+- redundant-code-block density of zero;
+- unsafe-function density of zero;
+- no new compiler-warning suppression without a reviewed, narrow toolchain justification.
+
+Do not game averages by splitting coherent code into meaningless fragments. Prefer cohesive types,
+single-purpose functions, shared helpers with clear ownership, and removal of dead/redundant code.
+
+## Repository Trend Metrics
+
+Track analyzer-provided metrics by language:
+
+- `code_duplication_ratio`, `file_duplication_ratio`, `non_hfile_code_duplication_ratio`,
+  `non_hfile_duplication_ratio`, `duplication_file`;
+- `cyclomatic_complexity_per_method`, `huge_cyclomatic_complexity`;
+- `lines_per_file`, `lines_per_method`, `huge_method`, `huge_headerfile`,
+  `huge_non_headerfile`, `huge_folder`, `huge_depth`;
+- `redundant_code`, `redundant_code_kloc`;
+- `unsafe_function`, `unsafe_functions_kloc`;
+- `warning_suppression`.
+
+Continuous-improvement thresholds from the catalog:
+
+- oversized directory ratio below `0.04%`;
+- oversized header ratio below `1%`;
+- oversized source-file ratio below `1%`;
+- oversized function ratio below `4%`;
+- very-high-cyclomatic-complexity function ratio below `1%`.
+
+Use the analyzer's configured definitions for “oversized” and “very high complexity”; the supplied
+catalog does not define their absolute thresholds. Do not invent them.
+
+## Named Design Findings
+
+Treat these as review prompts that require structural evidence:
+
+- god file/class, complex file/class, split-personality file/class;
+- traditional breaker, shotgun surgery, feature envy, data clumps;
+- refused bequest, unstable dependency, confused inheritance hierarchy, cyclic dependency;
+- constructor allocation without destructor release;
+- misplaced allocation arithmetic parentheses;
+- accidental precision loss through integer division;
+- an intended override that fails because its signature differs;
+- unsafe cryptography, random seeding, key reuse, padding, and service configuration findings.
+
+Apply the catalog's concrete security constraints when the corresponding API is present:
+
+- `SecA_Ascend_GEDeprecatedLowPerformanceInterface` and
+  `SecA_Ascend_GERecommandHighPerformanceInterface`: replace an API only after proving semantic and
+  supported-version equivalence.
+- For password hashing with scrypt, require `N >= 2^14`, salt length at least 16 bytes, `r >= 8`,
+  `p >= 1`, and output length at least 256 bits.
+- Use an approved modern algorithm and mode. Apply CMS-Padding or ISO-Padding when the selected
+  block mode requires padding.
+- Do not reuse one symmetric key for encryption and MAC operations.
+- Do not seed security randomness from system time or post-process CSPRNG output in a way that
+  reduces its security.
+- Treat IPSI algorithm findings, weak-algorithm findings, and common-service configuration findings
+  as blocking until the approved product policy confirms the configuration.
+- Release deliverables that are required to be native binaries must have the expected ELF or PE
+  format; do not apply that requirement to scripts, data, or documentation.
+
+Translate tool labels into a concrete path, symbol, dependency edge, or data flow. Do not report a
+translated smell name alone.
+
+## Evidence Requirements
+
+For EChecker, SecK, SecL, Ascend API recommendations, and security TOP findings:
+
+1. Preserve the exact analyzer rule name and source location.
+2. Reproduce or trace the path from source to sink.
+3. Identify validation, bounds, lifetime, lock, or cryptographic invariants already present.
+4. Classify the finding as real, conditional, or false positive with evidence.
+5. Fix the root cause and add a focused test when real.
+6. Use suppression only when the project has an approved mechanism and the justification is local,
+   stable, and reviewable.
+
+Do not claim a rule passed merely because the fast changed-code checker emitted no finding.

--- a/.codex/skills/enforce-ptoas-code-compliance/references/rule-resolution.md
+++ b/.codex/skills/enforce-ptoas-code-compliance/references/rule-resolution.md
@@ -1,0 +1,104 @@
+# Rule Resolution
+
+## Contents
+
+- [Authority and precedence](#authority-and-precedence)
+- [Rule strength](#rule-strength)
+- [Known conflicts and misleading wording](#known-conflicts-and-misleading-wording)
+- [Baseline policy](#baseline-policy)
+- [Finding format](#finding-format)
+
+## Authority And Precedence
+
+Resolve conflicts in this order:
+
+1. Correctness, memory safety, security, and defined language behavior.
+2. Repository instructions, supported toolchains, public API compatibility, and executable tests.
+3. A rule's stated intent, interpreted in its language and artifact scope.
+4. Nearby project style and automated formatting.
+5. Literal wording of a catalog entry.
+
+Never make code less safe or technically incorrect to satisfy a literal sentence. Record the
+interpretation when two catalog entries conflict.
+
+The same identifier can describe different language rules. For example, `G.CLS.01` is Python and
+`G.CLS.01-CPP` is C++. Apply the language-qualified entry. Duplicate identifiers such as
+`G.CMT.03`, `G.CTL.01`, `G.CTL.02`, `G.EXP.03`, `G.FIL.02`, `G.TYP.01`, and `G.VAR.01` are
+independent rules, not replacements.
+
+## Rule Strength
+
+- **Required:** Safety/correctness rules and entries containing “必须” or “禁止”, when applicable.
+- **Conditional:** Release hardening, customer-delivery, security-sensitive data, platform,
+  container, packaging, and build-environment rules. Enforce only in that context.
+- **Preferred:** Entries containing “建议”, “优先”, “避免”, or “不应”. Deviate only for a
+  concrete project reason and document it.
+- **Metric:** Repository or changed-code trend gates. Measure them; do not pretend a local regex
+  proves them.
+- **Analyzer finding:** `EChecker_*`, `SecK_*`, `SecL_*`, Ascend performance checks, and named code
+  smells require evidence from the analyzer or a reproducible semantic review.
+
+## Known Conflicts And Misleading Wording
+
+- **`G.C&C++.CDG.01` / `-fno-common`:** Use `-fno-common` to reject conflicting tentative
+  definitions. Do not claim that it places uninitialized globals in the initialized data section;
+  toolchains normally place them in BSS.
+- **`G.C&C++.SEC.05` / strip:** Strip release deliverables only. Preserve development/test symbols
+  or produce separate debug information when diagnostics require it.
+- **`G.C&C++.SEC.06` / RPATH:** Do not introduce uncontrolled runtime search paths in release
+  artifacts. Do not remove a required development RPATH without a safe replacement.
+- **`G.AST.*`, `G.TES.01`:** Assertions are debug-only internal-invariant checks. Runtime, input,
+  allocation, I/O, or device failures need ordinary error handling in every build.
+- **`G.FMT.10` vs `G.FMT.14-CPP`:** Pointer/reference token placement is stylistic and internally
+  inconsistent in the catalog. Follow the repository formatter or dominant local style.
+- **`G.CMake.17` and `.18`:** `cmake_minimum_required()` and `project()` must be the first project
+  commands, not necessarily physical lines 1 and 2 when a required license header precedes them.
+- **`G.SCRIPT.05` vs `G.EDV.05`:** Do not hard-code machine-specific build paths. Derive repository
+  paths from the script location; resolve external executables once and invoke them without a shell.
+- **`G.ERR.04` vs `G.ERR.13`:** A bare `raise` preserves a Python traceback when propagation is
+  intended. Avoid `raise caught_exception`, which can alter traceback context.
+- **`G.COM.10` and `G.DOCKER.06`:** These govern build/deployment environments. Do not encode a
+  requirement to run as root or refuse an authorized diagnostic solely because the shell is
+  privileged.
+- **`G.OTH.05` and `G.PRJ.07`:** Do not embed unapproved production endpoints. Standards links,
+  test fixtures, and declared dependency sources are contextual; verify intent before changing them.
+- **`G.CMT.03*`:** New PTOAS source and script files use the repository OAT.3 header. Do not add
+  empty ceremonial function comments.
+- **`G.EXP.03` / lambda assignment:** Treat this as a readability preference, not a semantic ban.
+  Use a named function when behavior is nontrivial or reused.
+- **`G.PRE.01-CPP` vs assertion macros:** Prefer typed constants and functions. A project
+  debug-assertion macro is a narrow exception, not permission to use macros for ordinary constants.
+- **`G.SH.01` and `G.PLAYBOOK.10`:** Repository shell scripts should use
+  `#!/usr/bin/env bash`; governed Playbook installers require exact `#!/bin/bash`.
+- **`G.CMake.04` and external dependencies:** Project sources stay below the top-level source tree.
+  Installed SDK/package headers are dependencies; consume them through targets or packages.
+
+If a suspicious entry is not listed, inspect the relevant language or tool documentation and
+existing project behavior before enforcing it. State the inference; do not silently invert it.
+
+## Baseline Policy
+
+Apply all required rules to new code and changed lines. For untouched historical code:
+
+- do not create unrelated cleanup churn;
+- fix a pre-existing hazard when the change exposes, depends on, or extends that hazard;
+- record broader debt separately when it cannot be fixed safely in scope.
+
+Generated files are checked at their generator or template when possible. Do not hand-edit generated
+output merely to satisfy a checker.
+
+## Finding Format
+
+Use:
+
+```text
+<path>:<line>: <severity> <rule-id> <evidence and consequence>
+```
+
+Severity:
+
+- `error`: applicable required rule or demonstrated safety/correctness failure;
+- `warning`: preferred/conditional rule or a match that needs semantic confirmation;
+- `note`: metric, tool limitation, or intentionally non-applicable rule.
+
+Every exception needs a narrow technical reason. “Existing code does it” is not a justification.

--- a/.codex/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py
+++ b/.codex/skills/enforce-ptoas-code-compliance/scripts/check_changed_code.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Run deterministic compliance checks on changed PTOAS code."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import shutil
+import subprocess
+
+
+LINE_LIMIT = 120
+MAX_TEXT_FILE_SIZE = 2 * 1024 * 1024
+LICENSE_MARKER = "Copyright (c)"
+DELIVERY_MARKERS = ("TO" + "DO", "T" + "BD", "FIX" + "ME")
+DELIVERY_MARKER_PATTERN = re.compile(r"\b(?:" + "|".join(DELIVERY_MARKERS) + r")\b")
+TEST_DIRECTORY_NAMES = frozenset({"test", "tests", "unittest", "unittests"})
+LICENSED_LANGUAGES = frozenset({"cpp", "python", "shell", "cmake"})
+
+
+@dataclass(frozen=True)
+class ChangedLine:
+    path: Path
+    number: int
+    text: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    severity: str
+    rule: str
+    message: str
+
+
+@dataclass(frozen=True)
+class TextRule:
+    languages: frozenset[str]
+    expression: re.Pattern[str]
+    severity: str
+    rule: str
+    message: str
+
+
+CPP = frozenset({"cpp"})
+PYTHON = frozenset({"python"})
+SHELL = frozenset({"shell"})
+CMAKE = frozenset({"cmake"})
+CPP_CMAKE = frozenset({"cpp", "cmake"})
+SCRIPT_LANGUAGES = frozenset({"python", "shell", "cmake", "batch"})
+
+TEXT_RULES = (
+    TextRule(CPP, re.compile(r"(?<!static_)\bassert\s*\("), "error", "G.AST.02/G.TES.01",
+             "use explicit runtime handling or the approved debug-only assertion macro"),
+    TextRule(CPP, re.compile(r"\bNULL\b"), "error", "G.EXP.35-CPP", "use nullptr"),
+    TextRule(CPP, re.compile(r"\b(?:strcpy|strcat|sprintf|vsprintf|gets)\s*\("), "error",
+             "G.FUU.21", "do not introduce an unbounded memory or string function"),
+    TextRule(CPP, re.compile(r"\b(?:realloc|alloca)\s*\("), "error", "G.FUU.09/G.FUU.10",
+             "use a scoped container or checked allocation strategy"),
+    TextRule(CPP, re.compile(r"\b(?:atoi|atol|atoll|atof)\s*\("), "warning", "G.FUU.22",
+             "use a conversion API that reports invalid input and range errors"),
+    TextRule(CPP, re.compile(r"\b(?:reinterpret_cast|const_cast)\s*<"), "warning",
+             "G.EXP.15-CPP/G.EXP.16-CPP", "prove that the cast is necessary and safe"),
+    TextRule(CPP, re.compile(r"\bgoto\b"), "warning", "G.EXP.42-CPP", "prefer structured control flow"),
+    TextRule(CPP, re.compile(r"\b(?:memcpy|memmove|memset)\s*\("), "warning",
+             "G.MEM.03/EChecker_BufferSize", "prove all source and destination bounds"),
+    TextRule(CPP, re.compile(r"\b(?:malloc|calloc)\s*\("), "warning", "G.MEM.01/G.MEM.02",
+             "prove size arithmetic and allocation-failure handling"),
+    TextRule(CPP, re.compile(r"\.(?:lock|unlock)\s*\("), "warning", "G.CON.02-CPP",
+             "prefer a scoped lock wrapper"),
+    TextRule(CPP, re.compile(r"\b(?:0[xX][0-9A-Fa-f]+|\d+)l+\b"), "warning", "G.CNS.01-CPP",
+             "use an uppercase L integer suffix"),
+    TextRule(CPP, re.compile(r"^\s*(?:if|for|while)\s*\([^;]*\)\s*$"), "error", "G.FMT.11-CPP",
+             "put the control-statement body in braces"),
+    TextRule(CPP, re.compile(r"^\s*(?:else|do)\s*$"), "error", "G.FMT.11-CPP",
+             "put the control-statement body in braces"),
+    TextRule(CPP, re.compile(r"^\s*(?:if|for|while)\s*\([^;]*\)\s+[^{\s].*$"), "error",
+             "G.FMT.11-CPP", "put the control-statement body in braces"),
+    TextRule(PYTHON, re.compile(r"\b(?:eval|exec)\s*\("), "error", "G.EDV.01",
+             "do not evaluate code from data"),
+    TextRule(PYTHON, re.compile(r"shell\s*=\s*" + r"True"), "error", "G.EDV.04",
+             "invoke an argument vector without a command shell"),
+    TextRule(PYTHON, re.compile(r"\bos\.system\s*\("), "error", "G.EDV.02",
+             "invoke a validated argument vector without a command shell"),
+    TextRule(PYTHON, re.compile(r"\btempfile\.mktemp\s*\("), "error", "G.FIO.03",
+             "use a secure tempfile context manager"),
+    TextRule(PYTHON, re.compile(r"\b(?:pickle|_pickle)\.load\s*\("), "error", "G.SER.01",
+             "do not deserialize untrusted pickle data"),
+    TextRule(PYTHON, re.compile(r"\byaml\.load\s*\("), "error", "G.SER.03",
+             "use yaml.safe_load for untrusted input"),
+    TextRule(PYTHON, re.compile(r"\bshelve\.open\s*\("), "warning", "G.SER.01",
+             "prove the shelf is trusted or use a non-executable format"),
+    TextRule(PYTHON, re.compile(r"def\s+\w+\s*\([^)]*=\s*(?:\[\]|\{\}|set\(\))"), "error",
+             "G.FNM.01", "do not use a mutable default argument"),
+    TextRule(PYTHON, re.compile(r"\b(?:logging|logger)\.(?:debug|info)\s*\(\s*f[\"']"), "warning",
+             "G.LOG.01", "use logging lazy interpolation"),
+    TextRule(SHELL, re.compile(r"(^|[;&|]\s*)ev" + r"al(?:\s|$)"), "error", "G.EDV.01/G.EDV.02",
+             "do not evaluate a constructed command"),
+    TextRule(SHELL, re.compile(r"\b(?:bash|sh)\s+-c(?:\s|$)"), "warning", "G.EDV.02",
+             "prefer direct argument-vector execution"),
+    TextRule(SHELL, re.compile(r"\brm\s+-[A-Za-z]*[rf][A-Za-z]*\s+[^\n]*[*?]"), "error",
+             "G.EDV.03", "do not combine recursive deletion with an unresolved wildcard"),
+    TextRule(CMAKE, re.compile(r"(?<!\w)-fpermissive\b"), "error", "G.C&C++.LANG.04",
+             "do not weaken C++ language enforcement"),
+    TextRule(CMAKE, re.compile(r"(^|\s)-w(\s|$)"), "error", "G.C&C++.WARN.04",
+             "do not suppress all compiler warnings"),
+    TextRule(CMAKE, re.compile(r"-Wno-error\s*="), "error", "G.C&C++.WARN.06",
+             "do not downgrade an explicitly promoted warning"),
+    TextRule(CMAKE, re.compile(r"include\s*\([^)]*CMakeLists\.txt", re.IGNORECASE), "error",
+             "G.CMake.03/G.CMake.07", "use add_subdirectory instead of including CMakeLists.txt"),
+    TextRule(CMAKE, re.compile(r"^\s*[A-Z][A-Z0-9_]*\s*\("), "warning", "G.CMake.19",
+             "use lowercase CMake command names"),
+    TextRule(CMAKE, re.compile(r"\b(?:BUILD_)?RPATH\b"), "warning", "G.C&C++.SEC.06",
+             "review runtime search paths for the target and release context"),
+    TextRule(SCRIPT_LANGUAGES, re.compile(r"(?:^|[\"'])/(?:home|Users|root)/"), "error",
+             "G.SCRIPT.05/G.SCRIPT.06", "derive paths instead of hard-coding a user installation path"),
+)
+
+
+def run_git(repo: Path, arguments: list[str]) -> str:
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("git executable was not found")
+    result = subprocess.run(
+        [git, "-C", str(repo), *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout
+
+
+def parse_base(base: str) -> str:
+    if not base or base.startswith("-") or any(character.isspace() for character in base):
+        raise argparse.ArgumentTypeError("must be a non-option Git revision without whitespace")
+    return base
+
+
+def language_for(path: Path) -> str | None:
+    name = path.name
+    suffix = path.suffix.lower()
+    if name == "CMakeLists.txt" or suffix == ".cmake":
+        return "cmake"
+    if name.lower() == "dockerfile":
+        return "docker"
+    if suffix in {".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx", ".inc", ".td"}:
+        return "cpp"
+    if suffix == ".py":
+        return "python"
+    if suffix in {".sh", ".bash"}:
+        return "shell"
+    if suffix in {".bat", ".cmd"}:
+        return "batch"
+    return None
+
+
+def nul_paths(text: str) -> set[Path]:
+    return {Path(item) for item in text.split("\0") if item}
+
+
+def changed_paths(repo: Path, base: str) -> tuple[set[Path], set[Path]]:
+    tracked = nul_paths(run_git(repo, ["diff", "--name-only", "-z", base, "--"]))
+    added = nul_paths(run_git(repo, ["diff", "--name-only", "--diff-filter=A", "-z", base, "--"]))
+    untracked = nul_paths(run_git(repo, ["ls-files", "--others", "--exclude-standard", "-z"]))
+    return tracked | untracked, added | untracked
+
+
+def parse_diff(diff: str) -> list[ChangedLine]:
+    lines: list[ChangedLine] = []
+    current_path: Path | None = None
+    line_number = 0
+    hunk = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("+++ "):
+            label = raw_line[4:]
+            current_path = Path(label[2:]) if label.startswith("b/") else None
+            continue
+        match = hunk.match(raw_line)
+        if match is not None:
+            line_number = int(match.group(1))
+            continue
+        if current_path is None:
+            continue
+        if raw_line.startswith("+"):
+            lines.append(ChangedLine(current_path, line_number, raw_line[1:]))
+            line_number += 1
+        elif raw_line.startswith(" "):
+            line_number += 1
+    return lines
+
+
+def resolve_repo_file(repo: Path, relative: Path) -> Path:
+    resolved = (repo / relative).resolve()
+    try:
+        resolved.relative_to(repo)
+    except ValueError as error:
+        raise RuntimeError(f"changed path escapes repository: {relative}") from error
+    return resolved
+
+
+def read_text_file(repo: Path, relative: Path) -> str | None:
+    resolved = resolve_repo_file(repo, relative)
+    if not resolved.is_file() or resolved.stat().st_size > MAX_TEXT_FILE_SIZE:
+        return None
+    data = resolved.read_bytes()
+    if b"\0" in data:
+        return None
+    return data.decode("utf-8")
+
+
+def untracked_lines(repo: Path, paths: set[Path]) -> list[ChangedLine]:
+    lines: list[ChangedLine] = []
+    for path in sorted(paths):
+        if language_for(path) is None:
+            continue
+        try:
+            content = read_text_file(repo, path)
+        except UnicodeDecodeError:
+            continue
+        if content is None:
+            continue
+        lines.extend(ChangedLine(path, number, text) for number, text in enumerate(content.splitlines(), 1))
+    return lines
+
+
+def is_test_path(path: Path) -> bool:
+    return any(part.lower() in TEST_DIRECTORY_NAMES for part in path.parts)
+
+
+def scan_changed_lines(lines: list[ChangedLine]) -> list[Finding]:
+    findings: list[Finding] = []
+    for changed in lines:
+        language = language_for(changed.path)
+        if language is None:
+            continue
+        if len(changed.text) > LINE_LIMIT:
+            findings.append(Finding(changed.path, changed.number, "error", "G.FMT.02",
+                                    f"line has {len(changed.text)} columns; limit is {LINE_LIMIT}"))
+        if DELIVERY_MARKER_PATTERN.search(changed.text):
+            severity = "warning" if is_test_path(changed.path) else "error"
+            findings.append(Finding(changed.path, changed.number, severity, "G.CMT.05",
+                                    "remove unfinished-work marker from delivery code"))
+        for rule in TEXT_RULES:
+            if language in rule.languages and rule.expression.search(changed.text):
+                findings.append(Finding(changed.path, changed.number, rule.severity, rule.rule, rule.message))
+    return findings
+
+
+def first_content_line(content: str) -> str:
+    lines = content.splitlines()
+    return lines[0] if lines else ""
+
+
+def scan_file_constraints(repo: Path, paths: set[Path], added: set[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in sorted(paths):
+        language = language_for(path)
+        if language is None:
+            continue
+        try:
+            content = read_text_file(repo, path)
+        except UnicodeDecodeError:
+            findings.append(Finding(path, 1, "error", "G.PRJ.04", "source file is not valid UTF-8"))
+            continue
+        if content is None:
+            continue
+        if language in LICENSED_LANGUAGES and LICENSE_MARKER not in "\n".join(content.splitlines()[:12]):
+            findings.append(Finding(path, 1, "error", "G.CMT.03", "add the repository license header"))
+        if "\r\n" in content and "\n" in content.replace("\r\n", ""):
+            findings.append(Finding(path, 1, "error", "G.FMT.10", "do not mix LF and CRLF line endings"))
+        if language == "shell" and first_content_line(content) not in {"#!/usr/bin/env bash", "#!/bin/bash"}:
+            findings.append(Finding(path, 1, "error", "G.SH.01", "declare a Bash interpreter on line 1"))
+        if language == "batch" and first_content_line(content).strip().lower() != "@echo off":
+            findings.append(Finding(path, 1, "error", "G.BAT.03", "put @echo off on line 1"))
+        if language == "docker":
+            if not re.search(r"(?im)^\s*USER\s+(?!root(?:\s|$))\S+", content):
+                findings.append(Finding(path, 1, "error", "G.DOCKER.06", "declare a non-root USER"))
+            if re.search(r"(?im)^\s*ADD\s+", content):
+                findings.append(Finding(path, 1, "error", "G.DOCKER.08", "use COPY instead of ADD"))
+        if path in added and language == "cpp" and path.suffix.lower() in {".h", ".hh", ".hpp", ".hxx"}:
+            header = "\n".join(content.splitlines()[:60])
+            if "#pragma once" not in header and not re.search(r"(?m)^\s*#ifndef\s+\w+", header):
+                findings.append(Finding(path, 1, "error", "G.INC.04-CPP", "add an include guard"))
+    return findings
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=".", help="repository root")
+    parser.add_argument("--base", required=True, type=parse_base,
+                        help="target branch or commit used as the diff base")
+    parser.add_argument("--fail-on", choices=("error", "warning", "none"), default="error")
+    return parser.parse_args()
+
+
+def should_fail(findings: list[Finding], fail_on: str) -> bool:
+    if fail_on == "none":
+        return False
+    if fail_on == "warning":
+        return bool(findings)
+    return any(finding.severity == "error" for finding in findings)
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    repo = Path(arguments.repo).expanduser().resolve(strict=True)
+    base = arguments.base
+    run_git(repo, ["rev-parse", "--verify", f"{base}^{{commit}}"])
+    paths, added = changed_paths(repo, base)
+    supported = {path for path in paths if language_for(path) is not None}
+    tracked_diff = run_git(repo, ["diff", "--unified=0", "--no-color", "--no-ext-diff",
+                                  base, "--"])
+    untracked = added - nul_paths(run_git(repo, ["diff", "--name-only", "--diff-filter=A", "-z",
+                                                 base, "--"]))
+    lines = parse_diff(tracked_diff) + untracked_lines(repo, untracked)
+    findings = scan_changed_lines(lines) + scan_file_constraints(repo, supported, added)
+    severity_order = {"error": 0, "warning": 1, "note": 2}
+    findings.sort(key=lambda item: (item.path.as_posix(), item.line, severity_order[item.severity], item.rule))
+    for finding in findings:
+        print(f"{finding.path}:{finding.line}: {finding.severity} {finding.rule} {finding.message}")
+    errors = sum(finding.severity == "error" for finding in findings)
+    warnings = sum(finding.severity == "warning" for finding in findings)
+    print(f"checked_files={len(supported)} errors={errors} warnings={warnings}")
+    return 1 if should_fail(findings, arguments.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add an implicitly discoverable PTOAS coding-compliance skill
- classify the supplied rule catalog by artifact, language, severity, and execution context
- document conflicts and technically misleading wording instead of enforcing rules literally
- add focused C/C++/CMake, Python/script, and maintainability references
- add a changed-code precheck that reports rule IDs for deterministic high-signal findings
- keep recommendations compatible with PTOAS C++17 and existing LLVM facilities

## Validation

- skill-creator quick_validate.py
- changed-code checker against hwupstream/main: 0 errors, 0 warnings
- synthetic positive/negative checks for unsafe evaluation, unchecked memory copy, missing C++ braces,
  and forbidden CMake flags
- invalid Git base argument rejection
- 120-column scan
- git diff --check
- two forward-review passes covering required findings, contextual RPATH findings, and C++17
  compatibility

## Review Notes

This is intentionally a draft. The main review focus is the interpretation of conditional product,
release, and platform rules, especially where the supplied wording conflicts with language or
toolchain behavior.
