### PR TITLE
fix(vmi): lower vector-scalar ops directly

### DIFF
--- a/docs/isa/vmi-isa/03-eltwise-compute.md
+++ b/docs/isa/vmi-isa/03-eltwise-compute.md
@@ -329,9 +329,12 @@ scalar type must match the vector element type.
 
 - **syntax:**
   ```mlir
-  %r = pto.vmi.vshls %src, %scalar, %mask : !pto.vmi.vreg<L×T>, T, !pto.vmi.mask<L> -> !pto.vmi.vreg<L×T>
+  %r = pto.vmi.vshls %src, %shift, %mask : !pto.vmi.vreg<L×T>, i16, !pto.vmi.mask<L> -> !pto.vmi.vreg<L×T>
   ```
-- **datatypes:** `i8`–`i32`
+- **datatypes:** `T` is an integer type from 8 to 32 bits. The uniform shift
+  amount is a signless `i16` value independent of `T` and should be in the
+  range `[0, bitwidth(T))`. For `vshrs`, the signedness of `T` determines
+  whether the right shift is arithmetic or logical.
 - **lowering to `pto.mi`:**
   ```
   K × pto.vshls / pto.vshrs

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1161,7 +1161,8 @@ def VMIVcmpsOp : VMI_Op<"vcmps", [Pure]> {
   }];
 }
 
-class VMI_VecScalarOp<string mnemonic, string summaryText>
+class VMI_VecScalarOp<string mnemonic, string summaryText,
+                      Type scalarType = AnyType>
     : VMI_Op<mnemonic, [Pure]> {
   let summary = summaryText;
   let description = [{
@@ -1180,7 +1181,7 @@ class VMI_VecScalarOp<string mnemonic, string summaryText>
   }];
   let arguments = (ins
     VMI_VRegTypeConstraint:$src,
-    AnyType:$scalar,
+    scalarType:$scalar,
     VMI_MaskTypeConstraint:$mask,
     OptionalAttr<StrAttr>:$pmode
   );
@@ -1195,8 +1196,8 @@ def VMIAddSOp : VMI_VecScalarOp<"vadds", "VMI vector-scalar elementwise add">;
 def VMIMulSOp : VMI_VecScalarOp<"vmuls", "VMI vector-scalar elementwise multiply">;
 def VMIMaxSOp : VMI_VecScalarOp<"vmaxs", "VMI vector-scalar elementwise maximum">;
 def VMIMinSOp : VMI_VecScalarOp<"vmins", "VMI vector-scalar elementwise minimum">;
-def VMIShlSOp : VMI_VecScalarOp<"vshls", "VMI vector-scalar elementwise shift left">;
-def VMIShrSOp : VMI_VecScalarOp<"vshrs", "VMI vector-scalar elementwise shift right">;
+def VMIShlSOp : VMI_VecScalarOp<"vshls", "VMI vector-scalar elementwise shift left", I16>;
+def VMIShrSOp : VMI_VecScalarOp<"vshrs", "VMI vector-scalar elementwise shift right", I16>;
 
 def VMIvSelOp : VMI_Op<"vsel", [Pure]> {
   let summary = "VMI elementwise select";

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -1114,13 +1114,10 @@ def VMILowerUnifiedToLegacy : Pass<"vmi-lower-unified-to-legacy", "ModuleOp"> {
       C2: vcvt        →  legacy extf/truncf/fptosi/sitofp/extsi/extui/trunci
       C3: vload/vstore  →  legacy load/store variants
       C4: pset/pge    →  create_mask/create_group_mask
-      C5: vadds/vmaxs/vmins/vshls/vshrs
-          →  broadcast + legacy binary, discarding mask/pmode; vshrs selects
-             shrui for explicit unsigned elements and shrsi otherwise
       C6: vcadd/vcmax/vcmin  →  legacy reduce variants
 
     Ops NOT lowered (no legacy equivalent — require direct VMIToVPTO 1:N patterns):
-      plt, vmuls, vhist, vintlv, vdintlv, vselr,
+      plt, vadds, vmuls, vmaxs, vmins, vshls, vshrs, vhist, vintlv, vdintlv, vselr,
       vgather, vgatherb, vscatter,
       vexpdif, vaxpy, vlrelu, vprelu, vmull, vmula
   }];

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -2455,8 +2455,8 @@ verifyVMIVectorScalarOp(Operation *op, VMIVRegType srcType,
         "requires scalar type to match vector element type, got scalar ")
            << scalarType << " vs vector element " << eltTy;
 
-  if (failed(verifyAllSameVRegShapeAndLayout(
-          op, {srcType, resultType}, /*requireSameElement=*/true)))
+  if (failed(verifyAllSameVRegShapeAndLayout(op, {srcType, resultType},
+                                             /*requireSameElement=*/true)))
     return failure();
 
   if (failed(verifyMaskMatchesData(op, maskType, resultType)))
@@ -2482,9 +2482,20 @@ verifyVMIVectorScalarShiftOp(Operation *op, VMIVRegType srcType,
   if (!isVMIIntegerLikeType(eltTy))
     return op->emitOpError(
         "requires integer-like VMI element type for shift");
-
-  return verifyVMIVectorScalarOp(op, srcType, scalarType, resultType,
-                                 maskType, pmode);
+  if (!scalarType.isSignlessInteger(16))
+    return op->emitOpError("requires signless i16 shift amount");
+  if (failed(verifyAllSameVRegShapeAndLayout(op, {srcType, resultType},
+                                             /*requireSameElement=*/true)))
+    return failure();
+  if (failed(verifyMaskMatchesData(op, maskType, resultType)))
+    return failure();
+  if (pmode.has_value()) {
+    StringRef mode = pmode.value();
+    if (mode != "merge" && mode != "zero")
+      return op->emitOpError("unsupported pmode '")
+             << mode << "'; expected \"merge\" or \"zero\"";
+  }
+  return success();
 }
 
 LogicalResult VMIAddSOp::verify() {

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -577,8 +577,33 @@ struct LayoutSolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
-      if (auto vmuls = dyn_cast<VMIMulSOp>(op)) {
-        if (failed(unite(vmuls.getSrc(), vmuls.getResult(), op)))
+      if (auto vecScalar = dyn_cast<VMIAddSOp>(op)) {
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIMulSOp>(op)) {
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIMaxSOp>(op)) {
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIMinSOp>(op)) {
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIShlSOp>(op)) {
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIShrSOp>(op)) {
+        if (failed(unite(vecScalar.getSrc(), vecScalar.getResult(), op)))
           return WalkResult::interrupt();
         return WalkResult::advance();
       }

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -170,14 +170,13 @@ public:
 
 static bool isSameLayoutOp(Operation *op) {
   return isa<VMIAddFOp, VMIAddIOp, VMISubFOp, VMISubIOp, VMIMulFOp, VMIMulIOp,
-             VMIMulSOp, VMIVmullOp, VMIFmaOp, VMIDivFOp, VMIMinFOp, VMIMinIOp,
-             VMIMaxFOp, VMIMaxIOp, VMINegFOp,
-             VMIAbsFOp, VMIAbsIOp, VMISqrtOp, VMIExpOp, VMILnOp, VMIReluOp,
-             VMIFPToSIOp, VMISIToFPOp, VMIAndIOp, VMIOrIOp, VMIXOrIOp,
-             VMIShLIOp, VMIShRUIOp, VMIShRSIOp, VMINotOp, VMICmpFOp,
+             VMIAddSOp, VMIMulSOp, VMIMaxSOp, VMIMinSOp, VMIShlSOp, VMIShrSOp,
+             VMIVmullOp, VMIFmaOp, VMIDivFOp, VMIMinFOp, VMIMinIOp, VMIMaxFOp,
+             VMIMaxIOp, VMINegFOp, VMIAbsFOp, VMIAbsIOp, VMISqrtOp, VMIExpOp,
+             VMILnOp, VMIReluOp, VMIFPToSIOp, VMISIToFPOp, VMIAndIOp, VMIOrIOp,
+             VMIXOrIOp, VMIShLIOp, VMIShRUIOp, VMIShRSIOp, VMINotOp, VMICmpFOp,
              VMICmpIOp, VMISelectOp, VMIBitcastOp, VMIMaskAndOp, VMIMaskOrOp,
-             VMIMaskXOrOp,
-             VMIMaskNotOp, VMIActivePrefixIndexOp, VMICompressOp,
+             VMIMaskXOrOp, VMIMaskNotOp, VMIActivePrefixIndexOp, VMICompressOp,
              VMIExpandLoadOp>(op);
 }
 

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -55,13 +55,6 @@
 //   pge  → create_mask(N lanes)
 //   plt  → create_mask(min(rem, L))
 //
-// Category C5 — vector-scalar ops, one-step to legacy (5 ops):
-//   vadds/vmaxs/vmins/vshls/vshrs
-//     → broadcast scalar → legacy binary
-//   vshrs selects shrui for unsigned/signless elements and shrsi for
-//   explicitly signed elements.
-//   vmuls is kept unified for direct VMI-to-VPTO lowering.
-//
 // Category C3 — unified load/store (2 ops, dispatch by dist_mode/group):
 //   vload → load / deinterleave_load / group_load
 //   vstore → store / masked_store / interleave_store / group_store
@@ -85,8 +78,9 @@
 //   vprelu  → maxf + minf + mulf + addf
 //   Category C7/C8/C9 bypass mask/pmode synthesis here and skip pmode="merge".
 //
-// Category D — no legacy equivalent (explicitly skipped, 6 ops):
-//   vmuls vintlv vdintlv vselr vgatherb vmull
+// Category D — no legacy equivalent (explicitly skipped, 11 ops):
+//   vadds/vmuls/vmaxs/vmins/vshls/vshrs
+//   vintlv vdintlv vselr vgatherb vmull
 //
 //===----------------------------------------------------------------------===//
 
@@ -796,30 +790,6 @@ static LogicalResult lowerPge(VMIPgeOp op, OpBuilder &builder) {
 }
 
 //===----------------------------------------------------------------------===//
-// Category C5 helpers: vector-scalar ops (one-step to legacy)
-//===----------------------------------------------------------------------===//
-
-/// Lower a unified vector-scalar op (vadds, vmaxs, ...) to a legacy chain:
-///   %brc  = vmi.broadcast %scalar
-///   %raw  = legacy.op %src, %brc
-template <typename VecScalarOp>
-static LogicalResult
-lowerVecScalar(VecScalarOp op, OpBuilder &builder,
-               function_ref<Value(Location, Type, Value, Value)> createLegacy) {
-  Location loc = op.getLoc();
-  Type srcVmiType = op.getSrc().getType();
-  Value src = op.getSrc();
-  Value scalar = op.getScalar();
-
-  Value brc = builder.create<VMIBroadcastOp>(loc, srcVmiType, scalar)
-                  .getResult();
-  Value raw = createLegacy(loc, srcVmiType, src, brc);
-  op.getResult().replaceAllUsesWith(raw);
-  op->erase();
-  return success();
-}
-
-//===----------------------------------------------------------------------===//
 // Category C6 helpers: vcadd / vcmax / vcmin
 //===----------------------------------------------------------------------===//
 
@@ -1223,8 +1193,6 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
         isa<VMIvLoadOp, VMIvStoreOp>(op) ||
         // Category C4
         isa<VMIPsetOp, VMIPgeOp, VMIPltOp>(op) ||
-        // Category C5
-        isa<VMIAddSOp, VMIMaxSOp, VMIMinSOp, VMIShlSOp, VMIShrSOp>(op) ||
         // Category C6 — unified reduce (partial coverage)
         isa<VMIvcaddOp, VMIvcmaxOp, VMIvcminOp>(op) ||
         // Category C7 — fused multiply-add family → legacy fma
@@ -1236,11 +1204,12 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       worklist.push_back(op);
 
     // Category D — no legacy equivalent (require direct VMIToVPTO lowering):
-    //   plt, vmuls, vintlv, vdintlv, vselr, vgatherb, vmull
+    //   plt, vector-scalar ops, vintlv, vdintlv, vselr, vgatherb, vmull
     // These are intentionally NOT added to the worklist — they flow through
     // to VMIToVPTO which must provide direct 1:N lowering patterns.
-    if (isa<VMIMulSOp, VMIVintlvOp, VMIVdintlvOp, VMIVselrOp,
-            VMIVgatherbOp, VMIVmullOp>(op)) {
+    if (isa<VMIAddSOp, VMIMulSOp, VMIMaxSOp, VMIMinSOp, VMIShlSOp, VMIShrSOp,
+            VMIVintlvOp, VMIVdintlvOp, VMIVselrOp, VMIVgatherbOp, VMIVmullOp>(
+            op)) {
       op->emitRemark("VMI unified op has no legacy equivalent — "
                      "requires direct VMIToVPTO 1:N lowering");
     }
@@ -1366,65 +1335,6 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
 
     if (auto vop = dyn_cast<VMIvStoreOp>(op)) {
       (void)lowerVStore(vop, builder);
-      continue;
-    }
-
-    // ---- Category C5: vector-scalar ops ----
-
-    if (auto vop = dyn_cast<VMIAddSOp>(op)) {
-      Type elemType = getVMIElementType(vop.getSrc());
-      auto createLegacy = [&](Location loc, Type ty, Value lhs, Value rhs) -> Value {
-        if (isFloatType(elemType))
-          return builder.create<VMIAddFOp>(loc, ty, lhs, rhs).getResult();
-        return builder.create<VMIAddIOp>(loc, ty, lhs, rhs).getResult();
-      };
-      (void)lowerVecScalar(vop, builder, createLegacy);
-      continue;
-    }
-
-    if (auto vop = dyn_cast<VMIMaxSOp>(op)) {
-      Type elemType = getVMIElementType(vop.getSrc());
-      auto createLegacy = [&](Location loc, Type ty, Value lhs,
-                              Value rhs) -> Value {
-        if (isFloatType(elemType))
-          return builder.create<VMIMaxFOp>(loc, ty, lhs, rhs).getResult();
-        return builder.create<VMIMaxIOp>(loc, ty, lhs, rhs).getResult();
-      };
-      (void)lowerVecScalar(vop, builder, createLegacy);
-      continue;
-    }
-
-    if (auto vop = dyn_cast<VMIMinSOp>(op)) {
-      Type elemType = getVMIElementType(vop.getSrc());
-      auto createLegacy = [&](Location loc, Type ty, Value lhs,
-                              Value rhs) -> Value {
-        if (isFloatType(elemType))
-          return builder.create<VMIMinFOp>(loc, ty, lhs, rhs).getResult();
-        return builder.create<VMIMinIOp>(loc, ty, lhs, rhs).getResult();
-      };
-      (void)lowerVecScalar(vop, builder, createLegacy);
-      continue;
-    }
-
-    if (auto vop = dyn_cast<VMIShlSOp>(op)) {
-      auto createLegacy = [&](Location loc, Type ty, Value lhs,
-                              Value rhs) -> Value {
-        return builder.create<VMIShLIOp>(loc, ty, lhs, rhs).getResult();
-      };
-      (void)lowerVecScalar(vop, builder, createLegacy);
-      continue;
-    }
-
-    if (auto vop = dyn_cast<VMIShrSOp>(op)) {
-      Type elemType = getVMIElementType(vop.getSrc());
-      auto createLegacy = [&](Location loc, Type ty, Value lhs,
-                              Value rhs) -> Value {
-        auto intType = cast<IntegerType>(elemType);
-        if (!intType.isSigned())
-          return builder.create<VMIShRUIOp>(loc, ty, lhs, rhs).getResult();
-        return builder.create<VMIShRSIOp>(loc, ty, lhs, rhs).getResult();
-      };
-      (void)lowerVecScalar(vop, builder, createLegacy);
       continue;
     }
 

--- a/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
+++ b/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
@@ -231,9 +231,39 @@ struct MaskGranularitySolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
-      if (auto vmuls = dyn_cast<VMIMulSOp>(op)) {
-        if (failed(requestMaskUseForSource(vmuls.getMaskMutable(),
-                                           vmuls.getSrc(), op)))
+      if (auto vecScalar = dyn_cast<VMIAddSOp>(op)) {
+        if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
+                                           vecScalar.getSrc(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIMulSOp>(op)) {
+        if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
+                                           vecScalar.getSrc(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIMaxSOp>(op)) {
+        if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
+                                           vecScalar.getSrc(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIMinSOp>(op)) {
+        if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
+                                           vecScalar.getSrc(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIShlSOp>(op)) {
+        if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
+                                           vecScalar.getSrc(), op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto vecScalar = dyn_cast<VMIShrSOp>(op)) {
+        if (failed(requestMaskUseForSource(vecScalar.getMaskMutable(),
+                                           vecScalar.getSrc(), op)))
           return WalkResult::interrupt();
         return WalkResult::advance();
       }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8210,19 +8210,6 @@ struct OneToNVMIVecScalarOpPattern : OpConversionPattern<SourceOp> {
     if (failed(scalar) || failed(maybeResultTypes))
       return failure();
     Value scalarValue = *scalar;
-    if constexpr (std::is_same_v<TargetOp, VshlsOp> ||
-                  std::is_same_v<TargetOp, VshrsOp>) {
-      auto scalarType = dyn_cast<IntegerType>(scalarValue.getType());
-      if (!scalarType || scalarType.getWidth() != 16)
-        return rewriter.notifyMatchFailure(
-            op, "physical vector-scalar shift requires a 16-bit scalar");
-      if (!scalarType.isSignless())
-        scalarValue =
-            rewriter
-                .create<UnrealizedConversionCastOp>(
-                    op.getLoc(), TypeRange{rewriter.getI16Type()}, scalarValue)
-                .getResult(0);
-    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
         sourceParts.size() != resultTypes.size())
@@ -8235,13 +8222,7 @@ struct OneToNVMIVecScalarOpPattern : OpConversionPattern<SourceOp> {
          llvm::zip_equal(sourceParts, maskParts, resultTypes)) {
       auto vregType = dyn_cast<VRegType>(resultType);
       auto maskType = dyn_cast<MaskType>(mask.getType());
-      bool scalarTypeMatches =
-          vregType && vregType.getElementType() == scalarValue.getType();
-      if constexpr (std::is_same_v<TargetOp, VshlsOp> ||
-                    std::is_same_v<TargetOp, VshrsOp>)
-        scalarTypeMatches = scalarValue.getType().isSignlessInteger(16);
-      if (!vregType || !maskType || source.getType() != resultType ||
-          !scalarTypeMatches)
+      if (!vregType || !maskType || source.getType() != resultType)
         return rewriter.notifyMatchFailure(
             op, "physical vector-scalar part type mismatch");
       results.push_back(rewriter

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8209,6 +8209,20 @@ struct OneToNVMIVecScalarOpPattern : OpConversionPattern<SourceOp> {
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     if (failed(scalar) || failed(maybeResultTypes))
       return failure();
+    Value scalarValue = *scalar;
+    if constexpr (std::is_same_v<TargetOp, VshlsOp> ||
+                  std::is_same_v<TargetOp, VshrsOp>) {
+      auto scalarType = dyn_cast<IntegerType>(scalarValue.getType());
+      if (!scalarType || scalarType.getWidth() != 16)
+        return rewriter.notifyMatchFailure(
+            op, "physical vector-scalar shift requires a 16-bit scalar");
+      if (!scalarType.isSignless())
+        scalarValue =
+            rewriter
+                .create<UnrealizedConversionCastOp>(
+                    op.getLoc(), TypeRange{rewriter.getI16Type()}, scalarValue)
+                .getResult(0);
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
         sourceParts.size() != resultTypes.size())
@@ -8221,14 +8235,19 @@ struct OneToNVMIVecScalarOpPattern : OpConversionPattern<SourceOp> {
          llvm::zip_equal(sourceParts, maskParts, resultTypes)) {
       auto vregType = dyn_cast<VRegType>(resultType);
       auto maskType = dyn_cast<MaskType>(mask.getType());
+      bool scalarTypeMatches =
+          vregType && vregType.getElementType() == scalarValue.getType();
+      if constexpr (std::is_same_v<TargetOp, VshlsOp> ||
+                    std::is_same_v<TargetOp, VshrsOp>)
+        scalarTypeMatches = scalarValue.getType().isSignlessInteger(16);
       if (!vregType || !maskType || source.getType() != resultType ||
-          vregType.getElementType() != (*scalar).getType())
+          !scalarTypeMatches)
         return rewriter.notifyMatchFailure(
             op, "physical vector-scalar part type mismatch");
-      results.push_back(
-          rewriter
-              .create<TargetOp>(op.getLoc(), resultType, source, *scalar, mask)
-              .getResult());
+      results.push_back(rewriter
+                            .create<TargetOp>(op.getLoc(), resultType, source,
+                                              scalarValue, mask)
+                            .getResult());
     }
 
     replaceOpWithFlatConvertedValues(rewriter, op, results,
@@ -11331,8 +11350,12 @@ void populateVMIConversionPatterns(
       OneToNVMIBinaryOpPattern<VMISubIOp, VsubOp>,
       OneToNVMIBinaryOpPattern<VMIMulFOp, VmulOp>,
       OneToNVMIBinaryOpPattern<VMIMulIOp, VmulOp>,
+      OneToNVMIVecScalarOpPattern<VMIAddSOp, VaddsOp>,
       OneToNVMIVecScalarOpPattern<VMIMulSOp, VmulsOp>,
-      OneToNVMIVmullOpPattern,
+      OneToNVMIVecScalarOpPattern<VMIMaxSOp, VmaxsOp>,
+      OneToNVMIVecScalarOpPattern<VMIMinSOp, VminsOp>,
+      OneToNVMIVecScalarOpPattern<VMIShlSOp, VshlsOp>,
+      OneToNVMIVecScalarOpPattern<VMIShrSOp, VshrsOp>, OneToNVMIVmullOpPattern,
       OneToNVMIFmaOpPattern, OneToNVMIBinaryOpPattern<VMIDivFOp, VdivOp>,
       OneToNVMIBinaryOpPattern<VMIMinFOp, VminOp>,
       OneToNVMIBinaryOpPattern<VMIMinIOp, VminOp>,
@@ -12398,18 +12421,29 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     if (auto muli = dyn_cast<VMIMulIOp>(op))
       return emitMaskableUnsupported(
           op, "pto.vmi.muli", cast<VMIVRegType>(muli.getResult().getType()));
-    if (auto vmuls = dyn_cast<VMIMulSOp>(op)) {
-      if (vmuls.getPmode().has_value() && *vmuls.getPmode() == "merge") {
-        vmuls.emitError()
-            << kVMIDiagUnsupportedPrefix
-            << "pto.vmi.vmuls with pmode=merge requires an explicit "
-               "passthru lowering";
+    auto verifyVecScalar = [&](auto vecScalar, StringRef opName) -> WalkResult {
+      if (vecScalar.getPmode().has_value() &&
+          *vecScalar.getPmode() == "merge") {
+        vecScalar.emitError() << kVMIDiagUnsupportedPrefix << opName
+                              << " with pmode=merge requires an explicit "
+                                 "passthru lowering";
         return WalkResult::interrupt();
       }
       return emitMaskableUnsupported(
-          op, "pto.vmi.vmuls",
-          cast<VMIVRegType>(vmuls.getResult().getType()));
-    }
+          op, opName, cast<VMIVRegType>(vecScalar.getResult().getType()));
+    };
+    if (auto vecScalar = dyn_cast<VMIAddSOp>(op))
+      return verifyVecScalar(vecScalar, "pto.vmi.vadds");
+    if (auto vecScalar = dyn_cast<VMIMulSOp>(op))
+      return verifyVecScalar(vecScalar, "pto.vmi.vmuls");
+    if (auto vecScalar = dyn_cast<VMIMaxSOp>(op))
+      return verifyVecScalar(vecScalar, "pto.vmi.vmaxs");
+    if (auto vecScalar = dyn_cast<VMIMinSOp>(op))
+      return verifyVecScalar(vecScalar, "pto.vmi.vmins");
+    if (auto vecScalar = dyn_cast<VMIShlSOp>(op))
+      return verifyVecScalar(vecScalar, "pto.vmi.vshls");
+    if (auto vecScalar = dyn_cast<VMIShrSOp>(op))
+      return verifyVecScalar(vecScalar, "pto.vmi.vshrs");
     if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
       std::string reason;
       if (succeeded(checkSupportedVmullShape(vmull, &reason)))

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -614,7 +614,7 @@ lanes.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `source` | `VRegType` | Input vector |
-| `scalar` | `ScalarType` | Scalar operand (Python number or PTODSL scalar). Automatically coerced to the vector element type |
+| `scalar` | `ScalarType` | Scalar operand (Python number or PTODSL scalar). For `vshls` and `vshrs`, this is a signless `i16` shift amount; other operations coerce it to the vector element type |
 | `mask` | VMI mask | **Required.** Predicate mask gating lane participation |
 | `pmode` | `str` or `None` | Optional predicate mode: `"merge"` keeps predicate-inactive lanes at their prior value; `"zero"` writes 0 |
 
@@ -634,7 +634,9 @@ shifted = pto.vsubs(scores, row_max, col_mask)
 **Constraints**:
 - `mask` is always required for vector-scalar ops — unlike binary and unary
   ops, there is no mask-optional form.
-- `scalar` is coerced to match the element type of `source`.
+- `vshls` and `vshrs` coerce `scalar` to signless `i16`; its type is
+  independent of the source element type. Other vector-scalar ops coerce
+  `scalar` to match the element type of `source`.
 - `vsubs`, `vands`, `vors`, and `vxors` are PTODSL convenience spellings, not
   dedicated formal `pto.vmi` instructions in VMI v0.1.
 - `vdivs` is listed for symmetry with `vdiv`, but it is not currently surfaced

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -460,11 +460,16 @@ def _emit_unary(op_name: str, source, mask=None, *, pmode=None, loc=None, ip=Non
 
 def _emit_vec_scalar(op_name: str, source, scalar, mask, *, pmode=None, loc=None, ip=None):
     context = f"pto.vmi.{op_name}(...)"
+    scalar_value = (
+        coerce_scalar_to_type(scalar, IntegerType.get_signless(16), context=context)
+        if op_name in {"vshls", "vshrs"}
+        else _coerce_scalar_like_vmi_element(source, scalar, context=context)
+    )
     return _call_value(
         op_name,
         _type_of(source),
         _raw(source),
-        _coerce_scalar_like_vmi_element(source, scalar, context=context),
+        scalar_value,
         _required_mask(mask, context=context),
         pmode=pmode,
         loc=loc,

--- a/ptodsl/tests/test_vmi_vshr_signedness.py
+++ b/ptodsl/tests/test_vmi_vshr_signedness.py
@@ -49,6 +49,7 @@ def main() -> None:
     signed_text = vmi_vshr_signed_probe.compile().mlir_text()
     expect("pto.vmi.vshr" in signed_text, "signed probe must emit pto.vmi.vshr")
     expect("pto.vmi.vshrs" in signed_text, "signed probe must emit pto.vmi.vshrs")
+    expect(", i16," in signed_text, "signed probe must use an i16 shift amount")
     expect(
         "!pto.vmi.vreg<128xsi32>" in signed_text,
         "signed probe must preserve the explicit si32 VMI element type",
@@ -57,6 +58,7 @@ def main() -> None:
     unsigned_text = vmi_vshr_unsigned_probe.compile().mlir_text()
     expect("pto.vmi.vshr" in unsigned_text, "unsigned probe must emit pto.vmi.vshr")
     expect("pto.vmi.vshrs" in unsigned_text, "unsigned probe must emit pto.vmi.vshrs")
+    expect(", i16," in unsigned_text, "unsigned probe must use an i16 shift amount")
     expect(
         "!pto.vmi.vreg<128xui32>" in unsigned_text,
         "unsigned probe must preserve the explicit ui32 VMI element type",

--- a/test/lit/vmi_new/vmi_lower_vmaxs_vmins_integer.pto
+++ b/test/lit/vmi_new/vmi_lower_vmaxs_vmins_integer.pto
@@ -36,19 +36,23 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmaxs_integer(
-// CHECK: pto.vmi.broadcast
-// CHECK: pto.vmi.maxi
-// CHECK-NOT: pto.vmi.maxf
+// CHECK: pto.vmi.vmaxs
+// CHECK-NOT: pto.vmi.broadcast
+// CHECK-NOT: pto.vmi.maxi
 
 // CHECK-LABEL: func.func @vmins_integer(
-// CHECK: pto.vmi.broadcast
-// CHECK: pto.vmi.mini
-// CHECK-NOT: pto.vmi.minf
+// CHECK: pto.vmi.vmins
+// CHECK-NOT: pto.vmi.broadcast
+// CHECK-NOT: pto.vmi.mini
 
 // LOWER-LABEL: func.func @vmaxs_integer(
-// LOWER: pto.vmax
+// LOWER: pto.vmaxs
+// LOWER-NOT: pto.vdup
+// LOWER-NOT: pto.vmax {{.*}} : !pto.vreg
 // LOWER-NOT: pto.vmi.
 
 // LOWER-LABEL: func.func @vmins_integer(
-// LOWER: pto.vmin
+// LOWER: pto.vmins
+// LOWER-NOT: pto.vdup
+// LOWER-NOT: pto.vmin {{.*}} : !pto.vreg
 // LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_lower_vshrs_signedness.pto
+++ b/test/lit/vmi_new/vmi_lower_vshrs_signedness.pto
@@ -12,11 +12,11 @@
 module {
   func.func @vshrs_signed(
       %src: !pto.vmi.vreg<64xsi16, #pto.vmi.layout<contiguous>>,
-      %scalar: si16,
+      %scalar: i16,
       %mask: !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous>>)
       -> !pto.vmi.vreg<64xsi16, #pto.vmi.layout<contiguous>> {
     %result = pto.vmi.vshrs %src, %scalar, %mask
-        : !pto.vmi.vreg<64xsi16, #pto.vmi.layout<contiguous>>, si16,
+        : !pto.vmi.vreg<64xsi16, #pto.vmi.layout<contiguous>>, i16,
           !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous>>
         -> !pto.vmi.vreg<64xsi16, #pto.vmi.layout<contiguous>>
     return %result : !pto.vmi.vreg<64xsi16, #pto.vmi.layout<contiguous>>
@@ -36,11 +36,11 @@ module {
 
   func.func @vshrs_unsigned(
       %src: !pto.vmi.vreg<64xui16, #pto.vmi.layout<contiguous>>,
-      %scalar: ui16,
+      %scalar: i16,
       %mask: !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous>>)
       -> !pto.vmi.vreg<64xui16, #pto.vmi.layout<contiguous>> {
     %result = pto.vmi.vshrs %src, %scalar, %mask
-        : !pto.vmi.vreg<64xui16, #pto.vmi.layout<contiguous>>, ui16,
+        : !pto.vmi.vreg<64xui16, #pto.vmi.layout<contiguous>>, i16,
           !pto.vmi.mask<64xb16, #pto.vmi.layout<contiguous>>
         -> !pto.vmi.vreg<64xui16, #pto.vmi.layout<contiguous>>
     return %result : !pto.vmi.vreg<64xui16, #pto.vmi.layout<contiguous>>
@@ -78,7 +78,7 @@ module {
 // CHECK-NOT: pto.vmi.shrsi
 
 // LOWER-LABEL: func.func @vshrs_signed(
-// LOWER: unrealized_conversion_cast {{.*}} : si16 to i16
+// LOWER-NOT: unrealized_conversion_cast
 // LOWER: pto.vshrs {{.*}} : !pto.vreg<128xsi16>, i16, !pto.mask<b16> -> !pto.vreg<128xsi16>
 // LOWER-NOT: pto.vdup
 // LOWER-NOT: pto.vshr {{.*}} : !pto.vreg
@@ -90,7 +90,7 @@ module {
 // LOWER-NOT: pto.vshr {{.*}} : !pto.vreg
 
 // LOWER-LABEL: func.func @vshrs_unsigned(
-// LOWER: unrealized_conversion_cast {{.*}} : ui16 to i16
+// LOWER-NOT: unrealized_conversion_cast
 // LOWER: pto.vshrs {{.*}} : !pto.vreg<128xui16>, i16, !pto.mask<b16> -> !pto.vreg<128xui16>
 // LOWER-NOT: pto.vdup
 // LOWER-NOT: pto.vshr {{.*}} : !pto.vreg

--- a/test/lit/vmi_new/vmi_lower_vshrs_signedness.pto
+++ b/test/lit/vmi_new/vmi_lower_vshrs_signedness.pto
@@ -7,6 +7,7 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: pto-test-opt %s -vmi-lower-unified-to-legacy | FileCheck %s
+// RUN: pto-test-opt %s -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
 
 module {
   func.func @vshrs_signed(
@@ -58,20 +59,42 @@ module {
 }
 
 // CHECK-LABEL: func.func @vshrs_signed(
-// CHECK: pto.vmi.broadcast
-// CHECK: pto.vmi.shrsi
-// CHECK-NOT: pto.vmi.shrui
+// CHECK: pto.vmi.vshrs
+// CHECK-NOT: pto.vmi.broadcast
+// CHECK-NOT: pto.vmi.shrsi
 
 // CHECK-LABEL: func.func @vshrs_signless(
-// CHECK: pto.vmi.broadcast
-// CHECK: pto.vmi.shrui
-// CHECK-NOT: pto.vmi.shrsi
+// CHECK: pto.vmi.vshrs
+// CHECK-NOT: pto.vmi.broadcast
+// CHECK-NOT: pto.vmi.shrui
 
 // CHECK-LABEL: func.func @vshrs_unsigned(
-// CHECK: pto.vmi.broadcast
-// CHECK: pto.vmi.shrui
-// CHECK-NOT: pto.vmi.shrsi
+// CHECK: pto.vmi.vshrs
+// CHECK-NOT: pto.vmi.broadcast
+// CHECK-NOT: pto.vmi.shrui
 
 // CHECK-LABEL: func.func @vshr_signless(
 // CHECK: pto.vmi.shrui
 // CHECK-NOT: pto.vmi.shrsi
+
+// LOWER-LABEL: func.func @vshrs_signed(
+// LOWER: unrealized_conversion_cast {{.*}} : si16 to i16
+// LOWER: pto.vshrs {{.*}} : !pto.vreg<128xsi16>, i16, !pto.mask<b16> -> !pto.vreg<128xsi16>
+// LOWER-NOT: pto.vdup
+// LOWER-NOT: pto.vshr {{.*}} : !pto.vreg
+
+// LOWER-LABEL: func.func @vshrs_signless(
+// LOWER-NOT: unrealized_conversion_cast
+// LOWER: pto.vshrs {{.*}} : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.vreg<128xi16>
+// LOWER-NOT: pto.vdup
+// LOWER-NOT: pto.vshr {{.*}} : !pto.vreg
+
+// LOWER-LABEL: func.func @vshrs_unsigned(
+// LOWER: unrealized_conversion_cast {{.*}} : ui16 to i16
+// LOWER: pto.vshrs {{.*}} : !pto.vreg<128xui16>, i16, !pto.mask<b16> -> !pto.vreg<128xui16>
+// LOWER-NOT: pto.vdup
+// LOWER-NOT: pto.vshr {{.*}} : !pto.vreg
+
+// LOWER-LABEL: func.func @vshr_signless(
+// LOWER: pto.vshr
+// LOWER-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_vector_scalar_ops.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vector_scalar_ops.pto
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s --check-prefix=PIPELINE
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o /dev/null
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vector_scalar_f32(
+      %source: !pto.vmi.vreg<256xf32>,
+      %scalar: f32,
+      %mask: !pto.vmi.mask<256xpred>,
+      %dst: !pto.ptr<f32, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %added = pto.vmi.vadds %source, %scalar, %mask
+          : !pto.vmi.vreg<256xf32>, f32, !pto.vmi.mask<256xpred>
+          -> !pto.vmi.vreg<256xf32>
+      %multiplied = pto.vmi.vmuls %added, %scalar, %mask
+          : !pto.vmi.vreg<256xf32>, f32, !pto.vmi.mask<256xpred>
+          -> !pto.vmi.vreg<256xf32>
+      %maximum = pto.vmi.vmaxs %multiplied, %scalar, %mask
+          : !pto.vmi.vreg<256xf32>, f32, !pto.vmi.mask<256xpred>
+          -> !pto.vmi.vreg<256xf32>
+      %result = pto.vmi.vmins %maximum, %scalar, %mask
+          : !pto.vmi.vreg<256xf32>, f32, !pto.vmi.mask<256xpred>
+          -> !pto.vmi.vreg<256xf32>
+      pto.vmi.vstore %result, %dst[%c0]
+          : !pto.vmi.vreg<256xf32>, !pto.ptr<f32, ub>
+    }
+    return
+  }
+
+  func.func @vector_scalar_shift_i16(
+      %source: !pto.vmi.vreg<256xi16>,
+      %scalar: i16,
+      %mask: !pto.vmi.mask<256xpred>,
+      %dst: !pto.ptr<i16, ub>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    pto.vecscope {
+      %left = pto.vmi.vshls %source, %scalar, %mask
+          : !pto.vmi.vreg<256xi16>, i16, !pto.vmi.mask<256xpred>
+          -> !pto.vmi.vreg<256xi16>
+      %result = pto.vmi.vshrs %left, %scalar, %mask
+          : !pto.vmi.vreg<256xi16>, i16, !pto.vmi.mask<256xpred>
+          -> !pto.vmi.vreg<256xi16>
+      pto.vmi.vstore %result, %dst[%c0]
+          : !pto.vmi.vreg<256xi16>, !pto.ptr<i16, ub>
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vector_scalar_f32(
+// CHECK-COUNT-4: pto.vadds {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK-COUNT-4: pto.vmuls {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK-COUNT-4: pto.vmaxs {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK-COUNT-4: pto.vmins {{.*}} : !pto.vreg<64xf32>, f32, !pto.mask<b32> -> !pto.vreg<64xf32>
+
+// CHECK-LABEL: func.func @vector_scalar_shift_i16(
+// CHECK-COUNT-2: pto.vshls {{.*}} : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK-COUNT-2: pto.vshrs {{.*}} : !pto.vreg<128xi16>, i16, !pto.mask<b16> -> !pto.vreg<128xi16>
+// CHECK-NOT: pto.vdup
+// CHECK-NOT: pto.vadd {{.*}} : !pto.vreg
+// CHECK-NOT: pto.vmul {{.*}} : !pto.vreg
+// CHECK-NOT: pto.vmax {{.*}} : !pto.vreg
+// CHECK-NOT: pto.vmin {{.*}} : !pto.vreg
+// CHECK-NOT: pto.vshl {{.*}} : !pto.vreg
+// CHECK-NOT: pto.vshr {{.*}} : !pto.vreg
+// CHECK-NOT: pto.vmi.
+// CHECK-NOT: !pto.vmi.
+
+// PIPELINE-LABEL: func.func @vector_scalar_f32(
+// PIPELINE-COUNT-4: pto.vadds
+// PIPELINE-COUNT-4: pto.vmuls
+// PIPELINE-COUNT-4: pto.vmaxs
+// PIPELINE-COUNT-4: pto.vmins
+// PIPELINE-LABEL: func.func @vector_scalar_shift_i16(
+// PIPELINE-COUNT-2: pto.vshls
+// PIPELINE-COUNT-2: pto.vshrs
+// PIPELINE-NOT: pto.vdup
+// PIPELINE-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_vec_scalar_shift_type_invalid.pto
+++ b/test/lit/vmi_new/vmi_vec_scalar_shift_type_invalid.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it
+// under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file 2>&1 | FileCheck %s
+
+module {
+  func.func @vshrs_i32_shift_invalid(
+      %src: !pto.vmi.vreg<64xui32>,
+      %shift: i32,
+      %mask: !pto.vmi.mask<64xpred>) {
+    %result = "pto.vmi.vshrs"(%src, %shift, %mask)
+        : (!pto.vmi.vreg<64xui32>, i32, !pto.vmi.mask<64xpred>)
+        -> !pto.vmi.vreg<64xui32>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vshrs' op operand #1 must be 16-bit signless integer
+
+// -----
+
+module {
+  func.func @vshls_signed_shift_invalid(
+      %src: !pto.vmi.vreg<64xsi16>,
+      %shift: si16,
+      %mask: !pto.vmi.mask<64xpred>) {
+    %result = "pto.vmi.vshls"(%src, %shift, %mask)
+        : (!pto.vmi.vreg<64xsi16>, si16, !pto.vmi.mask<64xpred>)
+        -> !pto.vmi.vreg<64xsi16>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vshls' op operand #1 must be 16-bit signless integer


### PR DESCRIPTION
## 背景

除 `vmuls` 外，VMI vector-scalar op 目前会先展开为 `broadcast + vector-vector`，无法直接使用已有的 VPTO scalar micro-op。

此外，VMI `vshls/vshrs` 原先错误地要求 shift scalar 与 vector element type 相同；VPTO、micro-ISA、TileLang DSL、PTODSL VPTO op 和 CANN 接口实际统一使用 signless `i16` shift amount。

## 修改

- 让 `vadds`、`vmaxs`、`vmins`、`vshls`、`vshrs` 与 `vmuls` 一样保留 unified VMI 形式，并直接 1:N lowering 到对应 VPTO scalar op
- 补齐这些 op 的 layout propagation、layout assignment 和 mask granularity assignment
- 将 formal VMI `vshls/vshrs` 的 scalar operand 固定为 signless `i16`，由 PTODSL wrapper 将用户输入转换为该类型，移除 lowering 中的 shift 专用 cast
- 明确 `vshrs` 根据 source element signedness 选择算术或逻辑右移
- 统一 vector-scalar op 的 `pmode=merge` unsupported 诊断
- 同步 VMI/PTODSL 文档，并增加 direct lowering、scalar 类型约束、signedness、完整 PTOAS pipeline 和 VPTO LLVM emission 回归

## 验证

- `cmake --build build -j16 --target pto-test-opt PTOASPythonPackage`
- `llvm-lit -sv build/test/lit --filter 'vmi_new/'`：440 passed
- `PYTHONPATH="$PWD/build/python" python3 ptodsl/tests/test_vmi_vshr_signedness.py`
- `ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir test/lit/vmi_new/vmi_to_vpto_vector_scalar_ops.pto -o /dev/null`
- `git diff --check`
