### PR TITLE
feat(ptodsl): expose pto.vsqz lane compaction (issue #977)

### DIFF
--- a/ptodsl/docs/user_guide/08-compute-operations.md
+++ b/ptodsl/docs/user_guide/08-compute-operations.md
@@ -2015,6 +2015,62 @@ These ops rearrange data between vector registers without touching UB memory.
 They are useful for switching between interleaved layouts (`x0, y0, x1, y1,
 ...`) and split layouts (`x...`, `y...`) inside `@pto.simd`.
 
+#### `pto.vsqz(vec: VRegType, mask: MaskType) -> VRegType`
+
+**Description**: Compact the active lanes of a vector register toward the
+front while preserving their relative order. Lanes are scanned from low to
+high; lanes for which `mask` is `true` are kept, and the kept elements are
+moved to the lowest result lanes in their original source order. The trailing
+lanes that are no longer occupied are zero-filled according to the underlying
+ISA specification. This is a register compaction: it reorganizes vector
+contents but does not itself perform any store.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `vec` | `VRegType` | Source vector register |
+| `mask` | `MaskType` | Lane predicate selecting the elements to compact |
+
+**Returns**:
+
+| Return Value | Type | Description |
+|--------------|------|-------------|
+| `result` | `VRegType` | Compacted vector; same `VRegType` as `vec` |
+
+**Constraints**:
+- The result `VRegType` is identical to the input `vec` `VRegType`; the result
+  type is inferred from `vec` and cannot be supplied separately.
+- The relative order of the active lanes is preserved.
+- Trailing lanes that are not filled by active elements are zero-filled per
+  the underlying ISA semantics.
+- Low-precision vregs are outside the general-purpose compute/rearrangement
+  surface; `vsqz` does not accept them.
+- `vsqz` is register compaction only — it does not execute a store. There is
+  no `mode` or `stored` parameter; the underlying PTOAS emitter determines
+  store hints (such as for `pto.vstur`) from surrounding user code, not from
+  `vsqz` arguments.
+
+**Example** — compact the active lanes of a row, then store the dense prefix to
+a UB base through the alignment-coupled store chain. `vsqz` only compacts the
+register; the dense store must be performed with `pto.vstur` (the required
+consumer that lets the VPTO LLVM emitter set `VSQZ #st=1`), followed by
+`pto.vstar` to flush the trailing bytes. Do **not** feed the compacted vector
+back to `pto.vsts(..., mask)` with the original mask — the original mask selects
+source lanes, not the compacted positions, so it would write the surviving
+elements to the wrong destinations.
+
+<!-- ptodsl-doc-test: {"mode":"compile_fragment","fixture":"compute_ops.vector_compute","symbol":"compute_ops_vector_probe","compile":{"BLOCK":128}} -->
+```python
+compacted = pto.vsqz(s_row, col_mask)
+store_base = pto.addptr(out_tile.as_ptr(), pto.const(0, dtype=pto.index))
+align0 = pto.init_align()
+align1 = pto.vstur(align0, compacted, store_base, pto.PostUpdate.ON)
+pto.vstar(align1, store_base)
+```
+
+---
+
 #### `pto.vintlv(lhs: VRegType, rhs: VRegType) -> tuple[VRegType, VRegType]`
 
 **Description**: Interleave two vectors lane-by-lane and return the result as a
@@ -2105,7 +2161,7 @@ even_lanes, odd_lanes = pto.vdintlv(packed_low, packed_high)
 | Compare/select | `vcmp`, `vcmps`, `vsel` |
 | Conversion | `vcvt`, `vpack`, `vbitcast`, `pbitcast` |
 | Index generation | `vci` |
-| Rearrangement | `vintlv`, `vdintlv` |
+| Rearrangement | `vsqz`, `vintlv`, `vdintlv` |
 
 ---
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -2009,6 +2009,11 @@ def vnot(inp, mask):
     return _emit_unary_vec_op(_pto.VnotOp, inp, mask)
 
 
+def vsqz(inp, mask):
+    """``pto.vsqz`` - compact active lanes to the front while preserving order."""
+    return _emit_unary_vec_op(_pto.VsqzOp, inp, mask)
+
+
 def vexpdif(inp, ref, mask, part: str = "ODD"):
     """``pto.vexpdif`` – ``exp(inp - ref)`` selecting ODD or EVEN lanes."""
     _reject_low_precision_vreg_operands(inp, ref, context="pto.vexpdif(...)")

--- a/ptodsl/ptodsl/pto.py
+++ b/ptodsl/ptodsl/pto.py
@@ -107,7 +107,7 @@ from ._ops import (             # noqa: F401
     vadd, vsub, vmul, vdiv, vmax, vmin,
     vand, vor, vxor, vshl, vshr, vshls, vshrs,
     vcmax, vcadd, vcmin, vdup, vexpdif,
-    vexp, vln, vsqrt, vabs, vneg, vrec, vrsqrt, vrelu, vnot,
+    vexp, vln, vsqrt, vabs, vneg, vrec, vrsqrt, vrelu, vnot, vsqz,
     vcgmax, vcgadd, vcgmin, vcpadd,
     vtrc, vprelu, vintlv, vdintlv, vselr,
     chistv2,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2081,6 +2081,13 @@ def public_vector_surface_probe(inp_tile: pto.Tile, out_tile: pto.Tile, stats_ti
     s_shifted = pto.vsub(s_row, row_max_broadcast, col_mask)
     p_row = pto.vexp(s_shifted, col_mask)
     row_sum = pto.vcgadd(p_row, col_mask)
+    # Register-level probe: only assert that pto.vsqz emits the op. The
+    # compacted result is intentionally discarded here — a real compress_store
+    # would consume it via pto.init_align + pto.vstur(POST_UPDATE) + pto.vstar
+    # (see docs/user_guide/08-compute-operations.md). This probe deliberately
+    # does NOT chain a masked pto.vsts, because the original col_mask selects
+    # source lanes, not compacted positions, and would scatter the survivors.
+    _ = pto.vsqz(p_row, col_mask)
     pto.vsts(p_row, out_tile[row, 0:], col_mask)
     pto.vsts(row_max, stats_tile.as_ptr(), row, col_mask, dist="1PT_B32")
     pto.vsts(row_sum, stats_tile.as_ptr(), row + 1, col_mask, dist="1PT_B32")
@@ -6423,6 +6430,7 @@ def main() -> None:
     expect("pto.vexp" in public_surface_text, "vexp(...) should lower to pto.vexp")
     expect("pto.vcgmax" in public_surface_text, "vcgmax(...) should lower to pto.vcgmax")
     expect("pto.vcgadd" in public_surface_text, "vcgadd(...) should lower to pto.vcgadd")
+    expect("pto.vsqz" in public_surface_text, "vsqz(...) should lower to pto.vsqz")
     expect("pto.vadds" in public_surface_text, "vsubs(...) should lower via scalar negation plus pto.vadds")
     expect("pto.mte_l1_l0a" in public_surface_text, "mte_l1_l0a(...) should lower to pto.mte_l1_l0a")
     expect("start(" not in public_surface_text, "mte_l1_l0a/l0b start_row/start_col should lower as operands")

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -86,6 +86,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         names = [
             "vsub", "vmin", "vand", "vor", "vxor", "vshl", "vshr",
             "vln", "vsqrt", "vabs", "vneg", "vrec", "vrsqrt", "vrelu", "vnot",
+            "vsqz",
             "vcmin", "vcgmin", "vcpadd",
             "vadds", "vmuls", "vmaxs", "vmins", "vlrelu", "vshls", "vshrs", "vands", "vors", "vxors",
             "vaxpy", "vmula", "vci", "vaddrelu", "vsubrelu", "vsel",
@@ -257,6 +258,25 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             self.assertIs(_ops.vsubrelu(vec, rhs, mask), relu_vec)
             vsub.assert_called_once_with(vec, rhs, mask)
             vrelu.assert_called_once_with(sub_vec, mask)
+
+    def test_vsqz_dispatches_to_generated_op_with_source_type(self):
+        inp = SimpleNamespace(type="vec_ty")
+        mask = SimpleNamespace(type="mask_ty")
+        result = object()
+
+        with patch.object(
+            _ops, "unwrap_surface_value", side_effect=_identity
+        ), patch.object(
+            _ops, "wrap_surface_value", side_effect=_identity
+        ), patch.object(
+            _ops._pto,
+            "VsqzOp",
+            return_value=SimpleNamespace(result=result),
+        ) as op_ctor:
+            output = _ops.vsqz(inp, mask)
+
+        self.assertIs(output, result)
+        op_ctor.assert_called_once_with("vec_ty", inp, mask)
 
     def test_vcgmin_and_vsel_dispatch_correctly(self):
         vec = SimpleNamespace(type="vec_ty")


### PR DESCRIPTION
## Summary

Adds the `pto.vsqz(inp, mask)` lane-compaction wrapper to the PTODSL public surface, addressing #977.

`vsqz` compacts the active lanes of a vector register toward the front while preserving their relative order; trailing lanes are zero-filled per the underlying ISA spec. This is a PTODSL-surface-only change — the PTOAS TableGen op `PTO_VsqzOp`, its verifier, and the LLVM emitters already exist and are unchanged.

## Public API

```python
compacted = pto.vsqz(vec, mask)   # -> VRegType (same as vec)
```

Corresponding MLIR (observed in generated IR):

```
%8 = pto.vsqz %6, %mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
```

The result type is inferred from `vec` (via the shared `_emit_unary_vec_op` helper used by `vnot`/`vexp`/`vcmax`/`vcpadd`); there is no `result_type` parameter and no special mask validation. Low-precision vreg rejection is inherited from the shared helper. No `mode`/`stored`/`target`/`dist` parameters are exposed — `vsqz` is register compaction only and does not itself perform a store.

## Changed files (PTODSL surface only)

- `ptodsl/ptodsl/_ops.py` — add `vsqz(inp, mask)` delegating to `_emit_unary_vec_op(_pto.VsqzOp, inp, mask)`.
- `ptodsl/ptodsl/pto.py` — export `vsqz` on the public namespace.
- `ptodsl/tests/test_vector_cube_ops.py` — add `"vsqz"` to the namespace test and a dispatch test asserting the full `VsqzOp` constructor args `("vec_ty", inp, mask)`.
- `ptodsl/tests/test_jit_compile.py` — add `_ = pto.vsqz(p_row, col_mask)` to `public_vector_surface_probe` (result discarded; only asserts `pto.vsqz` is emitted) and an `expect("pto.vsqz" in public_surface_text, ...)` in `main()`. The probe intentionally does **not** chain a masked `pto.vsts` — see the review-response comment for why that was an illegal usage.
- `ptodsl/docs/user_guide/08-compute-operations.md` — new `vsqz` subsection in 8.2.8 (before `vintlv`) showing the correct compress-store chain (`vsqz → addptr → init_align → vstur(POST_UPDATE) → vstar`); 8.2.9 quick-reference Rearrangement row updated.

No changes to TableGen (`include/PTO/IR/VPTOOps.td`), the verifier (`lib/PTO/IR/VPTO.cpp`), lowering (`lib/PTO/Transforms/**`), `test/lit/**`, or `test/vpto/**`.

## Verification

Verified on a real PTOAS build environment (x86_64, `ptoas` Python bindings + MLIR core, base `456ebb4b`). All `vsqz`-relevant paths pass:

| Check | Result |
|-------|--------|
| `pytest test_vector_cube_ops.py` (mock dispatch + namespace) | **PASS** — 41 passed, 122 subtests |
| `public_surface_exports_probe.verify()` + `.compile().mlir_text()` + `Module.parse` round-trip + `operation.verify()` + `"pto.vsqz" in text` | **PASS** |
| `test_docs_as_test.py` `run_compile_fragment_block` for the `vsqz` doc snippet incl. the full `vstur` compress-store chain (fixture `compute_ops.vector_compute`) | **PASS** |

Generated MLIR line confirms the type contract (`vreg<64xf32> -> vreg<64xf32>`):

```
%8 = pto.vsqz %6, %mask : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
```

A detailed review-response comment (see issuecomment-5127800309) documents the two issues found in review and how they were fixed (illegal `vsts` after `vsqz` in docs; probe scope).

## Notes

- The branch is based on `456ebb4b` (PR #1030 merge); the current `upstream/main` head is `4eb5ea7` (PR #1054). A clean rebase onto `4eb5ea7` was performed locally (no textual conflicts), but the newer base requires a rebuilt `ptoas` Python package (`ptoas.mlir` namespace, introduced by PR #1016 "standardize-python-packaging") that was not available in the verification environment. The functional `vsqz` change itself is base-agnostic and verified on `456ebb4b`. The 5 touched files have no semantic conflict with #1016's packaging changes; rebase/merge once CI/build catches up.
- `vpto-sim-validation` currently fails on a2a3sim with `Runtime 'tensormap_and_ringbuffer' is not available for platform 'a2a3sim'` (registered as `~ensormap_and_ringbuffer`) in `tests/st/runtime/ops/test_elementwise.py::test_tile_add[64]`, deep in the PyPTO runtime layer (`simpler_setup.runtime_builder.get_binaries`) — no PTODSL/MLIR/vsqz frame in the traceback, same test passes on a5sim and for `test_tile_add[128]` on a2a3sim. This is a CI runner infrastructure issue, not introduced by this PR. (CI health-probe: #1066.)
- No NPU on-device test (out of scope for this PTODSL-surface task).
- Resolves #977.
