### PR TITLE
docs: fix README runtime environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,17 @@ export WORKSPACE_DIR=$HOME/llvm-workspace
 export LLVM_SOURCE_DIR=$WORKSPACE_DIR/llvm-project
 export LLVM_BUILD_DIR=$LLVM_SOURCE_DIR/build-shared
 
-# PTOAS 源码与安装路径
+# PTOAS 源码路径
 export PTO_SOURCE_DIR=$WORKSPACE_DIR/PTOAS
-export PTO_INSTALL_DIR=$PTO_SOURCE_DIR/install
 # =======================================================
 
 # 创建工作目录
 mkdir -p $WORKSPACE_DIR
+
+# 推荐使用独立虚拟环境。后续 LLVM 和 PTOAS 构建必须使用同一个 Python。
+python3 -m venv "$WORKSPACE_DIR/.venv"
+source "$WORKSPACE_DIR/.venv/bin/activate"
+export PYTHON_BIN="$(command -v python3)"
 
 ```
 
@@ -71,7 +75,7 @@ mkdir -p $WORKSPACE_DIR
 * **Python**: 3.10+
 * **Python Packages**: `scikit-build-core`, `pybind11<3`, `nanobind`, `numpy`
 ```bash
-python3 -m pip install 'scikit-build-core>=0.12.2,<2' 'pybind11<3' nanobind numpy
+"$PYTHON_BIN" -m pip install 'scikit-build-core>=0.12.2,<2' 'pybind11<3' nanobind numpy
 
 ```
 
@@ -101,10 +105,10 @@ cmake -G Ninja -S llvm -B $LLVM_BUILD_DIR \
     -DBUILD_SHARED_LIBS=ON \
     -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
     -DLLVM_ENABLE_ASSERTIONS=ON \
-    -DPython3_EXECUTABLE=$(which python3) \
-    -DPython_EXECUTABLE=$(which python3) \
-    -Dpybind11_DIR=$(python3 -m pybind11 --cmakedir) \
-    -Dnanobind_DIR=$(python3 -m nanobind --cmake_dir) \
+    -DPython3_EXECUTABLE="$PYTHON_BIN" \
+    -DPython_EXECUTABLE="$PYTHON_BIN" \
+    -Dpybind11_DIR="$("$PYTHON_BIN" -m pybind11 --cmakedir)" \
+    -Dnanobind_DIR="$("$PYTHON_BIN" -m nanobind --cmake_dir)" \
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_TARGETS_TO_BUILD="host"
 
@@ -120,23 +124,35 @@ ninja -C $LLVM_BUILD_DIR
 ```bash
 # 1. 下载 PTOAS 源码
 cd $WORKSPACE_DIR
-git clone https://gitcode.com/cann/pto-as.git PTOAS
+git clone https://github.com/hw-native-sys/PTOAS.git PTOAS
 cd $PTO_SOURCE_DIR
 
 # 2. 安装到当前 Python 环境，并保留可增量构建的 build tree
-PYTHON_BIN=python3 \
+PYTHON_BIN="$PYTHON_BIN" \
 LLVM_BUILD_DIR="$LLVM_BUILD_DIR" \
 PTO_BUILD_DIR="$PTO_SOURCE_DIR/build" \
   ./quick_install.sh
 
-# 3. 后续可直接复用同一个 build tree
+# 3. 验证当前 shell 能找到安装后的命令
+command -v ptoas
+ptoas --version
+
+# 4. 后续可直接复用同一个 build tree
 ninja -C "$PTO_SOURCE_DIR/build" check-pto
 
 ```
 
 `quick_install.sh` 使用 editable install，并关闭 build isolation，避免把临时
 构建环境中的 pybind11 路径写入持久化 `CMakeCache.txt`。`ptoas` 会直接安装到
-`PYTHON_BIN` 对应的当前环境中。
+`PYTHON_BIN` 对应的当前环境中。激活上面创建的虚拟环境后，它的 `bin` 目录已经
+位于 `PATH` 中。
+
+如果明确选择不使用虚拟环境，并且 pip 将软件包安装到了用户目录，则还需要执行：
+
+```bash
+export PATH="$(python3 -m site --user-base)/bin:$PATH"
+hash -r
+```
 
 ### 3.4 Python 安装合同 (Python Distribution Contract)
 
@@ -146,17 +162,17 @@ ninja -C "$PTO_SOURCE_DIR/build" check-pto
 ```bash
 # 非 editable 的源码安装
 cd $PTO_SOURCE_DIR
-pip install . --no-build-isolation
+"$PYTHON_BIN" -m pip install . --no-build-isolation
 
 # PTOAS / PTODSL 开发者的 editable 安装
 cd $PTO_SOURCE_DIR
-pip install -e . --no-build-isolation
+"$PYTHON_BIN" -m pip install -e . --no-build-isolation
 ```
 
 发布或 CI 产出的 `ptoas` wheel 也遵循同一合同：
 
 ```bash
-pip install /path/to/ptoas*.whl
+"$PYTHON_BIN" -m pip install /path/to/ptoas*.whl
 ```
 
 安装完成后，以下导入应直接可用：
@@ -188,17 +204,38 @@ from ptoas.mlir.dialects import pto as mlir_pto
 
 ## 4. 运行环境配置 (Runtime Environment)
 
-如果你已经通过 `pip install .`、`pip install -e .` 或 `pip install ptoas*.whl`
-完成安装，那么 `import ptodsl` / `from ptoas.mlir.dialects import pto` / `ptoas`
-都不应再依赖手动设置 `PYTHONPATH`。
-
-需要 CANN、Bisheng、simulator 或 NPU 时，在完成 PTOAS 安装后再加载
-CANN 自带的环境脚本。PTOAS 的 Python 包和 CLI 仍由当前 pip 环境提供，
-不需要手工添加 build/install tree 到 `PYTHONPATH` 或 `PATH`。
+每次打开新 shell 时，先恢复 3.0 中配置的路径变量并重新激活安装 PTOAS 的
+Python 环境。源码或 editable 安装会使用 LLVM 构建目录中的动态库，因此还需要
+将该目录加入动态库搜索路径：
 
 ```bash
-source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+# 先重新导出 WORKSPACE_DIR、LLVM_BUILD_DIR 等 3.0 中的路径变量
+source "$WORKSPACE_DIR/.venv/bin/activate"
+export PYTHON_BIN="$(command -v python3)"
+export LD_LIBRARY_PATH="$LLVM_BUILD_DIR/lib:${LD_LIBRARY_PATH:-}"
+
+command -v ptoas
 ptoas --version
+```
+
+发布 wheel 自带运行时依赖，不使用外部 LLVM build tree 时无需设置上述
+`LD_LIBRARY_PATH`。无论哪种安装方式，都不需要手工拼接 `PYTHONPATH`。
+
+需要 CANN、Bisheng、simulator 或 NPU 时，再加载 CANN 对外提供的环境脚本。
+常见安装位置如下，按实际环境选择一个：
+
+```bash
+source /usr/local/Ascend/cann/set_env.sh
+# 或
+source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
+```
+
+如果没有使用虚拟环境，请确认 Python 用户命令目录在 `PATH` 中：
+
+```bash
+export PATH="$(python3 -m site --user-base)/bin:$PATH"
+hash -r
+command -v ptoas
 ```
 
 ---
@@ -252,11 +289,11 @@ with Context() as ctx, Location.unknown():
 ```bash
 # 建议先进入支持的 PTOAS / PTODSL 安装环境
 cd $PTO_SOURCE_DIR
-pip install -e . --no-build-isolation
+"$PYTHON_BIN" -m pip install -e . --no-build-isolation
 
 # 运行python binding 测试
 cd $PTO_SOURCE_DIR/test/samples/MatMul/
-python3 ./tmatmulk.py > ./tmatmulk.pto
+"$PYTHON_BIN" ./tmatmulk.py > ./tmatmulk.pto
 
 # 运行ptoas 测试
 ptoas ./tmatmulk.pto -o ./tmatmulk.cpp
@@ -270,6 +307,9 @@ ptoas ./tmatmulk.pto -o ./tmatmulk.cpp
 
 
 ```bash
+# 以下相对路径均以仓库根目录为起点
+cd "$PTO_SOURCE_DIR"
+
 # 1) 生成 npu_validation 测试目录（会在当前 sample 目录下创建 npu_validation/）
 # A2/A3 示例：
 python3 test/npu_validation/scripts/generate_testcase.py \

--- a/README.md
+++ b/README.md
@@ -133,13 +133,6 @@ LLVM_BUILD_DIR="$LLVM_BUILD_DIR" \
 PTO_BUILD_DIR="$PTO_SOURCE_DIR/build" \
   ./quick_install.sh
 
-# 3. 验证当前 shell 能找到安装后的命令
-command -v ptoas
-ptoas --version
-
-# 4. 后续可直接复用同一个 build tree
-ninja -C "$PTO_SOURCE_DIR/build" check-pto
-
 ```
 
 `quick_install.sh` 使用 editable install，并关闭 build isolation，避免把临时
@@ -147,12 +140,7 @@ ninja -C "$PTO_SOURCE_DIR/build" check-pto
 `PYTHON_BIN` 对应的当前环境中。激活上面创建的虚拟环境后，它的 `bin` 目录已经
 位于 `PATH` 中。
 
-如果明确选择不使用虚拟环境，并且 pip 将软件包安装到了用户目录，则还需要执行：
-
-```bash
-export PATH="$(python3 -m site --user-base)/bin:$PATH"
-hash -r
-```
+安装完成后，必须先按第 4 节配置运行环境，再执行 `ptoas` 或 `check-pto`。
 
 ### 3.4 Python 安装合同 (Python Distribution Contract)
 
@@ -218,6 +206,12 @@ command -v ptoas
 ptoas --version
 ```
 
+源码开发者完成上述配置后，可以复用安装时保留的 build tree 运行测试：
+
+```bash
+ninja -C "$PTO_SOURCE_DIR/build" check-pto
+```
+
 发布 wheel 自带运行时依赖，不使用外部 LLVM build tree 时无需设置上述
 `LD_LIBRARY_PATH`。无论哪种安装方式，都不需要手工拼接 `PYTHONPATH`。
 
@@ -230,12 +224,15 @@ source /usr/local/Ascend/cann/set_env.sh
 source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
 ```
 
-如果没有使用虚拟环境，请确认 Python 用户命令目录在 `PATH` 中：
+如果没有使用虚拟环境，并且 pip 将软件包安装到了用户目录，请在运行 `ptoas`
+之前先配置 `PATH`，然后同样设置上述 `LD_LIBRARY_PATH`：
 
 ```bash
 export PATH="$(python3 -m site --user-base)/bin:$PATH"
 hash -r
+export LD_LIBRARY_PATH="$LLVM_BUILD_DIR/lib:${LD_LIBRARY_PATH:-}"
 command -v ptoas
+ptoas --version
 ```
 
 ---

--- a/README_en.md
+++ b/README_en.md
@@ -127,13 +127,6 @@ PYTHON_BIN="$PYTHON_BIN" \
 LLVM_BUILD_DIR="$LLVM_BUILD_DIR" \
 PTO_BUILD_DIR="$PTO_SOURCE_DIR/build" \
   ./quick_install.sh
-
-# 3. Verify that the current shell resolves the installed command.
-command -v ptoas
-ptoas --version
-
-# 4. Reuse the same build tree for subsequent test or development builds.
-ninja -C "$PTO_SOURCE_DIR/build" check-pto
 ```
 
 `quick_install.sh` uses an editable install with build isolation disabled so a
@@ -142,13 +135,8 @@ temporary build environment's pybind11 path is not persisted in
 owns `PYTHON_BIN`. Activating the virtual environment created above puts its
 `bin` directory on `PATH`.
 
-If you intentionally install outside a virtual environment and pip uses the
-user installation scheme, add its command directory to `PATH`:
-
-```bash
-export PATH="$(python3 -m site --user-base)/bin:$PATH"
-hash -r
-```
+After installation, configure the runtime environment in section 4 before
+running either `ptoas` or `check-pto`.
 
 ### 3.4 Step 3: Supported Python Install Flows
 
@@ -210,6 +198,13 @@ command -v ptoas
 ptoas --version
 ```
 
+Source developers can reuse the retained build tree after completing the
+runtime setup above:
+
+```bash
+ninja -C "$PTO_SOURCE_DIR/build" check-pto
+```
+
 Release wheels carry their runtime dependencies and do not require this
 `LD_LIBRARY_PATH` when no external LLVM build tree is used. Neither installation
 flow requires manually assembling `PYTHONPATH`.
@@ -223,13 +218,16 @@ source /usr/local/Ascend/cann/set_env.sh
 source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
 ```
 
-Without a virtual environment, make sure the Python user command directory is
-on `PATH`:
+Without a virtual environment, if pip uses the user installation scheme, set
+`PATH` before running `ptoas` and then configure the same `LD_LIBRARY_PATH`
+shown above:
 
 ```bash
 export PATH="$(python3 -m site --user-base)/bin:$PATH"
 hash -r
+export LD_LIBRARY_PATH="$LLVM_BUILD_DIR/lib:${LD_LIBRARY_PATH:-}"
 command -v ptoas
+ptoas --version
 ```
 
 ---

--- a/README_en.md
+++ b/README_en.md
@@ -52,13 +52,17 @@ export WORKSPACE_DIR=$HOME/llvm-workspace
 export LLVM_SOURCE_DIR=$WORKSPACE_DIR/llvm-project
 export LLVM_BUILD_DIR=$LLVM_SOURCE_DIR/build-shared
 
-# PTOAS source and install paths
+# PTOAS source path
 export PTO_SOURCE_DIR=$WORKSPACE_DIR/PTOAS
-export PTO_INSTALL_DIR=$PTO_SOURCE_DIR/install
 # =============================================================
 
 # Create the workspace directory
 mkdir -p $WORKSPACE_DIR
+
+# Use an isolated environment. LLVM and PTOAS must use the same Python.
+python3 -m venv "$WORKSPACE_DIR/.venv"
+source "$WORKSPACE_DIR/.venv/bin/activate"
+export PYTHON_BIN="$(command -v python3)"
 ```
 
 ### 3.1 Prerequisites
@@ -70,7 +74,7 @@ mkdir -p $WORKSPACE_DIR
 * **Python Packages**: `scikit-build-core`, `pybind11<3`, `nanobind`, `numpy`
 
 ```bash
-python3 -m pip install "scikit-build-core>=0.12.2,<2" "pybind11<3" nanobind numpy
+"$PYTHON_BIN" -m pip install "scikit-build-core>=0.12.2,<2" "pybind11<3" nanobind numpy
 ```
 
 > **Note**: The current LLVM/MLIR Python bindings are not compatible with `pybind11` 3.x.
@@ -95,7 +99,11 @@ cmake -G Ninja -S llvm -B $LLVM_BUILD_DIR \
     -DLLVM_ENABLE_PROJECTS="mlir;clang" \
     -DBUILD_SHARED_LIBS=ON \
     -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
-    -DPython3_EXECUTABLE=$(which python3) \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DPython3_EXECUTABLE="$PYTHON_BIN" \
+    -DPython_EXECUTABLE="$PYTHON_BIN" \
+    -Dpybind11_DIR="$("$PYTHON_BIN" -m pybind11 --cmakedir)" \
+    -Dnanobind_DIR="$("$PYTHON_BIN" -m nanobind --cmake_dir)" \
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_TARGETS_TO_BUILD="host"
 
@@ -110,24 +118,37 @@ Clone the PTOAS source and build against the LLVM 21 you just compiled.
 ```bash
 # 1. Clone PTOAS
 cd $WORKSPACE_DIR
-git clone https://gitcode.com/cann/pto-as.git PTOAS
+git clone https://github.com/hw-native-sys/PTOAS.git PTOAS
 cd $PTO_SOURCE_DIR
 
 # 2. Install into the current Python environment while keeping a persistent,
 #    incrementally reusable build tree.
-PYTHON_BIN=python3 \
+PYTHON_BIN="$PYTHON_BIN" \
 LLVM_BUILD_DIR="$LLVM_BUILD_DIR" \
 PTO_BUILD_DIR="$PTO_SOURCE_DIR/build" \
   ./quick_install.sh
 
-# 3. Reuse the same build tree for subsequent test or development builds.
+# 3. Verify that the current shell resolves the installed command.
+command -v ptoas
+ptoas --version
+
+# 4. Reuse the same build tree for subsequent test or development builds.
 ninja -C "$PTO_SOURCE_DIR/build" check-pto
 ```
 
 `quick_install.sh` uses an editable install with build isolation disabled so a
 temporary build environment's pybind11 path is not persisted in
 `CMakeCache.txt`. The `ptoas` command is installed into the environment that
-owns `PYTHON_BIN`.
+owns `PYTHON_BIN`. Activating the virtual environment created above puts its
+`bin` directory on `PATH`.
+
+If you intentionally install outside a virtual environment and pip uses the
+user installation scheme, add its command directory to `PATH`:
+
+```bash
+export PATH="$(python3 -m site --user-base)/bin:$PATH"
+hash -r
+```
 
 ### 3.4 Step 3: Supported Python Install Flows
 
@@ -136,15 +157,15 @@ If you want to use Python bindings or PTODSL, prefer the repository-root
 
 ```bash
 # 1) Released or CI-built wheel: installs PTOAS + PTODSL together
-pip install /path/to/ptoas*.whl
+"$PYTHON_BIN" -m pip install /path/to/ptoas*.whl
 
 # 2) Non-editable source install from the repository root
 cd $PTO_SOURCE_DIR
-pip install . --no-build-isolation
+"$PYTHON_BIN" -m pip install . --no-build-isolation
 
 # 3) Editable install for PTOAS / PTODSL developers
 cd $PTO_SOURCE_DIR
-pip install -e . --no-build-isolation
+"$PYTHON_BIN" -m pip install -e . --no-build-isolation
 ```
 
 After installation, the following imports should work directly:
@@ -167,14 +188,55 @@ from ptoas.mlir.dialects import pto as mlir_pto
 If you previously ran `pip install -e .` without the flag and your build is now broken, fix the existing `CMakeCache.txt` with:
 
 ```bash
-cmake -B build -Dpybind11_DIR=$(python3 -m pybind11 --cmakedir)
+cmake -B build -Dpybind11_DIR="$("$PYTHON_BIN" -m pybind11 --cmakedir)"
 ```
 
 ---
 
-## 4. Usage
+## 4. Runtime Environment
 
-### 4.1 Command-Line Interface (CLI)
+In every new shell, restore the path variables from section 3.0 and reactivate
+the Python environment that owns the PTOAS installation. Source and editable
+installs use shared libraries from the external LLVM build tree, so add that
+directory to the runtime library search path:
+
+```bash
+# Re-export WORKSPACE_DIR, LLVM_BUILD_DIR, and the other paths from section 3.0.
+source "$WORKSPACE_DIR/.venv/bin/activate"
+export PYTHON_BIN="$(command -v python3)"
+export LD_LIBRARY_PATH="$LLVM_BUILD_DIR/lib:${LD_LIBRARY_PATH:-}"
+
+command -v ptoas
+ptoas --version
+```
+
+Release wheels carry their runtime dependencies and do not require this
+`LD_LIBRARY_PATH` when no external LLVM build tree is used. Neither installation
+flow requires manually assembling `PYTHONPATH`.
+
+Load CANN's public environment setup only when CANN, Bisheng, the simulator, or
+an NPU is required. Select the path that exists in your environment:
+
+```bash
+source /usr/local/Ascend/cann/set_env.sh
+# or
+source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh
+```
+
+Without a virtual environment, make sure the Python user command directory is
+on `PATH`:
+
+```bash
+export PATH="$(python3 -m site --user-base)/bin:$PATH"
+hash -r
+command -v ptoas
+```
+
+---
+
+## 5. Usage
+
+### 5.1 Command-Line Interface (CLI)
 
 ```bash
 # Parse and print PTO IR
@@ -193,7 +255,7 @@ ptoas test/lit/pto/empty_func.pto --pto-level=level3 -o outputfile.cpp
 ptoas --version
 ```
 
-### 4.2 Python API
+### 5.2 Python API
 
 In a supported `ptoas` install environment, both the PTO Dialect and PTODSL
 can be imported directly.
@@ -211,28 +273,31 @@ with Context() as ctx, Location.unknown():
     print("PTODSL imported successfully!", jit_pto, scalar)
 ```
 
-### 4.3 Running Tests
+### 5.3 Running Tests
 
 ```bash
 # Recommended: enter a supported PTOAS / PTODSL install environment first
 cd $PTO_SOURCE_DIR
-pip install -e . --no-build-isolation
+"$PYTHON_BIN" -m pip install -e . --no-build-isolation
 
 # Run Python binding tests
 cd $PTO_SOURCE_DIR/test/samples/MatMul/
-python3 ./tmatmulk.py > ./tmatmulk.pto
+"$PYTHON_BIN" ./tmatmulk.py > ./tmatmulk.pto
 
 # Run ptoas tests
 ptoas ./tmatmulk.pto -o ./tmatmulk.cpp
 ```
 
-### 4.4 On-Board Validation
+### 5.4 On-Board Validation
 
-This flow generates NPU validation test cases from the `.cpp` files produced by ptoas (under `test/samples/`) and runs them on an NPU. The example below reuses `MatMul/tmatmulk.cpp` generated in section 4.3.
+This flow generates NPU validation test cases from the `.cpp` files produced by ptoas (under `test/samples/`) and runs them on an NPU. The example below reuses `MatMul/tmatmulk.cpp` generated in section 5.3.
 
 > For compile-only validation on a machine without an NPU card, see [docs/no_npu_compile_only_guide_zh.md](docs/no_npu_compile_only_guide_zh.md).
 
 ```bash
+# The relative paths below start at the repository root.
+cd "$PTO_SOURCE_DIR"
+
 # 1) Generate the npu_validation test directory
 #    (creates npu_validation/ under the current sample directory)
 


### PR DESCRIPTION
## Summary

- use one activated virtual environment and Python executable throughout the LLVM and PTOAS build
- verify the installed `ptoas` command and document the Python user-bin fallback
- restore the LLVM shared-library search path required by source/editable installs
- replace the circular CANN environment bootstrap and keep the Chinese and English instructions aligned
- make the sample and NPU-validation commands safe to run consecutively from the documented working directories

## Validation

- `bash -n` over every Bash code block in `README.md` and `README_en.md`
- `git diff --check`
- fresh virtual environment plus fresh PTOAS build tree using `quick_install.sh`
- fresh-shell `command -v ptoas` and `ptoas --version` (`ptoas 0.55`)
- imports of `ptodsl` and `ptoas.mlir.dialects.pto`
- CLI compilation of `test/lit/pto/empty_func.pto`
- MatMul PTO/CPP generation and A3/A5 NPU-validation testcase generation

## Validation note

The current main branch has an unrelated macOS-only `std::min` type-deduction failure in `VMIToVPTO.cpp`. A local-only cast was used to let the clean editable build continue through packaging validation, then reverted. This PR contains only the two README files.