### PR TITLE
[CI-probe] docs-only touch to exercise vpto-sim-validation (not for merge)

### DIFF
--- a/ptodsl/docs/developer_guide/tilelib-debugging-playbook.md
+++ b/ptodsl/docs/developer_guide/tilelib-debugging-playbook.md
@@ -190,3 +190,5 @@ The fix was in the specialization design, not in the row-arg template:
 
 This pattern can affect any PTODSL template that bakes `ViewSpec` metadata into
 the rendered helper body.
+
+<!-- CI health-probe: this file is unchanged in behavior; touched only to exercise the vpto-sim-validation path filter. -->


### PR DESCRIPTION
## Purpose

This is a **CI health-probe PR**, not intended for merge. It exists to answer one question:

**Is the `vpto-sim-validation` job itself healthy on current `main`?**

## Context

On PR #1063 (`feat(ptodsl): expose pto.vsqz`), the `vpto-sim-validation` job failed with:

```
ValueError: Runtime 'tensormap_and_ringbuffer' is not available for platform 'a2a3sim'.
Available runtimes for a2a3sim: ~ensormap_and_ringbuffer, ~ost_build_graph
```

The failure was in `tests/st/runtime/ops/test_elementwise.py::test_tile_add[64]`, deep in the PyPTO runtime layer (`simpler_setup.runtime_builder.get_binaries`), with no PTODSL/MLIR/vsqz frame in the traceback. The same test passed on `a5sim` and passed for `test_tile_add[128]` on `a2a3sim`. The error string suggests the a2a3sim runner's `simpler_setup` runtime registry has a corrupted name (`tensormap...` registered as `~ensormap...`).

This PR isolates the pipeline: a **docs-only, behavior-neutral change** under `ptodsl/docs/` that hits the `ptodsl/**` path filter (so `detect-vpto-sim-changes` sets `should_run=true` and `vpto-sim-validation` actually runs), without touching any code, IR, or the vsqz work.

## What the result means

- If `vpto-sim-validation` **passes** here → the pipeline is healthy and the #1063 failure was a transient a2a3sim-runner issue (consistent with the analysis above). #1063 needs no code change.
- If `vpto-sim-validation` **fails the same way** here → the pipeline itself is broken on `main`, independent of any PR. This is a CI infrastructure issue for maintainers.

## Expected outcome

Only `vpto-sim-validation` + `license-header-check` + `detect-vpto-sim-changes` matter for this probe. **Do not merge.** Close after the result is observed.
