### PR TITLE
build: aggregate static LLVM into the wheel compiler DSO

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -38,7 +38,7 @@ concurrency:
 env:
   LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
   LLVM_REF: feature-vpto-llvm21
-  LLVM_CACHE_FLAVOR: llvm21-vpto-release-hardening-v1
+  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v1
 
 jobs:
   build_wheel:
@@ -148,7 +148,7 @@ jobs:
         run: |
           echo "WORKSPACE_DIR=/llvm-workspace" >> $GITHUB_ENV
           echo "LLVM_SOURCE_DIR=/llvm-workspace/llvm-project" >> $GITHUB_ENV
-          echo "LLVM_BUILD_DIR=/llvm-workspace/llvm-project/build-release" >> $GITHUB_ENV
+          echo "LLVM_BUILD_DIR=/llvm-workspace/llvm-project/build-wheel-static" >> $GITHUB_ENV
           echo "PTO_SOURCE_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "PTO_BUILD_DIR=$GITHUB_WORKSPACE/build-release" >> $GITHUB_ENV
 
@@ -166,7 +166,7 @@ jobs:
         id: cache-llvm
         uses: actions/cache/restore@v4
         with:
-          path: /llvm-workspace/llvm-project/build-release
+          path: /llvm-workspace/llvm-project/build-wheel-static
           key: llvm-${{ steps.llvm-source.outputs.sha }}-manylinux_2_34-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Prepare LLVM source
@@ -187,7 +187,12 @@ jobs:
           cd $LLVM_SOURCE_DIR
           cmake -C "$PTO_SOURCE_DIR/cmake/LinuxHardeningCache.cmake" -G Ninja -S llvm -B $LLVM_BUILD_DIR \
             -DLLVM_ENABLE_PROJECTS="mlir;clang" \
-            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DLLVM_BUILD_LLVM_DYLIB=OFF \
+            -DLLVM_LINK_LLVM_DYLIB=OFF \
+            -DMLIR_LINK_MLIR_DYLIB=OFF \
+            -DLLVM_ENABLE_PIC=ON \
+            -DMLIR_INSTALL_AGGREGATE_OBJECTS=ON \
             -DLLVM_ENABLE_ASSERTIONS=OFF \
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DPython3_EXECUTABLE=${PY_PATH}/bin/python \
@@ -203,7 +208,7 @@ jobs:
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: /llvm-workspace/llvm-project/build-release
+          path: /llvm-workspace/llvm-project/build-wheel-static
           key: llvm-${{ steps.llvm-source.outputs.sha }}-manylinux_2_34-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Build PTOAS
@@ -233,15 +238,15 @@ jobs:
           export PTO_WHEEL_DIST_DIR=$PTO_SOURCE_DIR/build/wheel-dist
           export PTO_WHEELHOUSE=$GITHUB_WORKSPACE/wheelhouse
           mkdir -p "$PTO_WHEELHOUSE"
-          # The raw wheel intentionally keeps package-relative RPATHs. Give
-          # auditwheel the external LLVM build only while resolving and
-          # bundling its shared dependencies.
+          # Static LLVM/MLIR is embedded in PTOASCompiler. Keep the build-tree
+          # path available only for incidental non-LLVM shared dependencies.
           export LD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
           auditwheel repair --plat manylinux_2_34_${{ matrix.arch }} "$PTO_WHEEL_DIST_DIR"/ptoas*.whl -w "$PTO_WHEELHOUSE"
 
       - name: Test wheel installation
         run: |
-          PTO_TEST_WHEEL_PATH="$GITHUB_WORKSPACE/wheelhouse/ptoas*.whl" \
+          PTO_EXPECT_STATIC_LLVM=1 \
+            PTO_TEST_WHEEL_PATH="$GITHUB_WORKSPACE/wheelhouse/ptoas*.whl" \
             bash $PTO_SOURCE_DIR/docker/test_wheel_imports.sh
 
       - name: Upload wheel artifact
@@ -285,14 +290,12 @@ jobs:
           test -f "$TEST_DIR/extracted/ptodsl/__init__.py"
           test -d "$TEST_DIR/extracted/ptoas/_runtime/share/ptoas/TileOps"
           test "$(cat "$TEST_DIR/extracted/.ptoas-python-version")" = "3.11"
-          found_core=
-          for core in "$TEST_DIR"/extracted/ptoas/_core*.so; do
-            if [ -f "$core" ]; then
-              found_core=1
-              break
-            fi
-          done
-          test -n "$found_core"
+          compgen -G "$TEST_DIR/extracted/ptoas/_core*.so" >/dev/null
+          compgen -G "$TEST_DIR/extracted/ptoas/mlir/_mlir_libs/libPTOASCompiler*" >/dev/null
+          ! compgen -G "$TEST_DIR/extracted/ptoas/mlir/_mlir_libs/libPTOASPythonCAPI*" >/dev/null
+
+          python "$PTO_SOURCE_DIR/docker/validate_installed_native_dependencies.py" \
+            "$TEST_DIR/extracted/ptoas" --expect-static-llvm
 
           env -u PYTHONPATH -u DYLD_LIBRARY_PATH -u LD_LIBRARY_PATH \
             "$TEST_DIR/extracted/bin/ptoas" --version

--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -12,6 +12,7 @@ on:
   push:
     tags-ignore:
       - '**'
+  pull_request:
   # Nightly build & publish (UTC time, offset from Linux workflow).
   schedule:
     - cron: "40 17 * * *"
@@ -37,7 +38,7 @@ concurrency:
 env:
   LLVM_REPO: https://github.com/vpto-dev/llvm-project.git
   LLVM_REF: feature-vpto-llvm21
-  LLVM_CACHE_FLAVOR: llvm21-vpto-release-v1
+  LLVM_CACHE_FLAVOR: llvm21-vpto-wheel-static-pic-v1
 
 jobs:
   build_wheel:
@@ -146,7 +147,7 @@ jobs:
         run: |
           echo "WORKSPACE_DIR=${RUNNER_TEMP}/llvm-workspace" >> $GITHUB_ENV
           echo "LLVM_SOURCE_DIR=${RUNNER_TEMP}/llvm-workspace/llvm-project" >> $GITHUB_ENV
-          echo "LLVM_BUILD_DIR=${RUNNER_TEMP}/llvm-workspace/llvm-project/build-release" >> $GITHUB_ENV
+          echo "LLVM_BUILD_DIR=${RUNNER_TEMP}/llvm-workspace/llvm-project/build-wheel-static" >> $GITHUB_ENV
           echo "PTO_SOURCE_DIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
           echo "PTO_BUILD_DIR=$GITHUB_WORKSPACE/build-release" >> $GITHUB_ENV
 
@@ -164,7 +165,7 @@ jobs:
         id: cache-llvm
         uses: actions/cache/restore@v4
         with:
-          path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-release
+          path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-wheel-static
           key: llvm-${{ steps.llvm-source.outputs.sha }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Prepare LLVM source
@@ -185,7 +186,12 @@ jobs:
           cd $LLVM_SOURCE_DIR
           cmake -G Ninja -S llvm -B $LLVM_BUILD_DIR \
             -DLLVM_ENABLE_PROJECTS="mlir;clang" \
-            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DLLVM_BUILD_LLVM_DYLIB=OFF \
+            -DLLVM_LINK_LLVM_DYLIB=OFF \
+            -DMLIR_LINK_MLIR_DYLIB=OFF \
+            -DLLVM_ENABLE_PIC=ON \
+            -DMLIR_INSTALL_AGGREGATE_OBJECTS=ON \
             -DLLVM_ENABLE_ASSERTIONS=OFF \
             -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
             -DPython3_EXECUTABLE=$(which python) \
@@ -201,7 +207,7 @@ jobs:
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-release
+          path: ${{ runner.temp }}/llvm-workspace/llvm-project/build-wheel-static
           key: llvm-${{ steps.llvm-source.outputs.sha }}-${{ steps.runner-meta.outputs.label }}-${{ matrix.arch }}-${{ matrix.python }}-${{ env.LLVM_CACHE_FLAVOR }}
 
       - name: Build PTOAS
@@ -262,9 +268,8 @@ jobs:
           echo "delocate dependency summary:"
           delocate-listdeps "${wheels[0]}" || true
 
-          # The raw wheel intentionally keeps package-relative RPATHs. Give
-          # delocate the external LLVM build only while resolving and bundling
-          # its shared dependencies.
+          # Static LLVM/MLIR is embedded in PTOASCompiler. Keep the build-tree
+          # path available only for incidental non-LLVM shared dependencies.
           export DYLD_LIBRARY_PATH="${LLVM_BUILD_DIR}/lib${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}"
           delocate-wheel \
             --require-archs "${REQUIRED_ARCH}" \
@@ -316,7 +321,8 @@ jobs:
 
       - name: Test wheel installation
         run: |
-          PTO_TEST_WHEEL_PATH="$GITHUB_WORKSPACE/wheelhouse/ptoas*.whl" \
+          PTO_EXPECT_STATIC_LLVM=1 \
+            PTO_TEST_WHEEL_PATH="$GITHUB_WORKSPACE/wheelhouse/ptoas*.whl" \
             bash $PTO_SOURCE_DIR/docker/test_wheel_imports.sh
 
       - name: Upload wheel artifact
@@ -359,14 +365,12 @@ jobs:
           test -f "$TEST_DIR/extracted/ptodsl/__init__.py"
           test -d "$TEST_DIR/extracted/ptoas/_runtime/share/ptoas/TileOps"
           test "$(cat "$TEST_DIR/extracted/.ptoas-python-version")" = "3.11"
-          found_core=
-          for core in "$TEST_DIR"/extracted/ptoas/_core*.so; do
-            if [ -f "$core" ]; then
-              found_core=1
-              break
-            fi
-          done
-          test -n "$found_core"
+          compgen -G "$TEST_DIR/extracted/ptoas/_core*.so" >/dev/null
+          compgen -G "$TEST_DIR/extracted/ptoas/mlir/_mlir_libs/libPTOASCompiler*" >/dev/null
+          ! compgen -G "$TEST_DIR/extracted/ptoas/mlir/_mlir_libs/libPTOASPythonCAPI*" >/dev/null
+
+          python "$PTO_SOURCE_DIR/docker/validate_installed_native_dependencies.py" \
+            "$TEST_DIR/extracted/ptoas" --expect-static-llvm
 
           env -u PYTHONPATH -u DYLD_LIBRARY_PATH -u LD_LIBRARY_PATH \
             "$TEST_DIR/extracted/bin/ptoas" --version

--- a/cmake/RelocatePTOASCompilerArchive.cmake.in
+++ b/cmake/RelocatePTOASCompilerArchive.cmake.in
@@ -31,7 +31,7 @@ endif()
 
 set(_ptoas_known_native_files
   "${_ptoas_package_root}/$<TARGET_FILE_NAME:PTOASPythonCore>"
-  "${_ptoas_mlir_lib_root}/$<TARGET_FILE_NAME:PTOASPythonCAPI>"
+  "${_ptoas_mlir_lib_root}/$<TARGET_FILE_NAME:PTOASCompiler>"
 )
 foreach(_ptoas_native IN LISTS _ptoas_known_native_files)
   if(NOT EXISTS "${_ptoas_native}")
@@ -148,7 +148,7 @@ foreach(_ptoas_dependency IN LISTS _ptoas_resolved_dependencies)
   endif()
 
   get_filename_component(_ptoas_dependency_name "${_ptoas_dependency_real}" NAME)
-  if(_ptoas_dependency_name MATCHES "^libPTOASPythonCAPI")
+  if(_ptoas_dependency_name MATCHES "^libPTOASCompiler")
     continue()
   endif()
   file(INSTALL "${_ptoas_dependency}"

--- a/docker/test_wheel_imports.sh
+++ b/docker/test_wheel_imports.sh
@@ -100,6 +100,13 @@ echo "Testing ptodsl public imports..."
 
 echo "Testing installed ptoas console entry..."
 "$PYTHON_BIN" -c "from ptoas import _core; print(f'ptoas native extension imported successfully from {_core.__file__}')"
+PTOAS_PACKAGE_ROOT="$($PYTHON_BIN -c 'from pathlib import Path; from ptoas import _core; print(Path(_core.__file__).parent)')"
+NATIVE_DEPENDENCY_ARGS=("${PTOAS_PACKAGE_ROOT}")
+if [[ "${PTO_EXPECT_STATIC_LLVM:-0}" == "1" ]]; then
+  NATIVE_DEPENDENCY_ARGS+=(--expect-static-llvm)
+fi
+"$PYTHON_BIN" "${REPO_ROOT}/docker/validate_installed_native_dependencies.py" \
+  "${NATIVE_DEPENDENCY_ARGS[@]}"
 PTOAS_VERSION_OUTPUT="$(ptoas --version | tr -d '\r')"
 echo "${PTOAS_VERSION_OUTPUT}"
 EXPECTED_PTOAS_CLI_VERSION="${PTOAS_CLI_VERSION:-${PTOAS_VERSION:-}}"

--- a/docker/validate_installed_native_dependencies.py
+++ b/docker/validate_installed_native_dependencies.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Validate the installed PTOAS native dependency ownership boundary."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+COMPILER_LIBRARY_PREFIX = "libPTOASCompiler"
+OBSOLETE_LIBRARY_PREFIX = "libPTOASPythonCAPI"
+EXTERNAL_IMPLEMENTATION_PATTERN = re.compile(
+    r"^lib(?:LLVM|MLIR|PTOIR|PTOTransforms)"
+)
+
+
+def _dependencies(binary: Path) -> set[str]:
+    if sys.platform == "darwin":
+        output = subprocess.run(
+            ["otool", "-L", str(binary)],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        lines = output.splitlines()[1:]
+        return {Path(line.strip().split(" ", 1)[0]).name for line in lines}
+
+    output = subprocess.run(
+        ["readelf", "-d", str(binary)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    return set(re.findall(r"Shared library: \[([^]]+)\]", output))
+
+
+def _native_extensions(package_root: Path) -> list[Path]:
+    mlir_native_root = package_root / "mlir" / "_mlir_libs"
+    candidates = list(package_root.glob("_core*.so"))
+    candidates.extend(package_root.glob("_core*.dylib"))
+    candidates.extend(mlir_native_root.glob("_*.so"))
+    candidates.extend(mlir_native_root.glob("_*.dylib"))
+    return sorted(path for path in candidates if path.is_file())
+
+
+def validate(package_root: Path, expect_static_llvm: bool) -> None:
+    mlir_native_root = package_root / "mlir" / "_mlir_libs"
+    compiler_libraries = sorted(
+        path
+        for path in mlir_native_root.glob(f"{COMPILER_LIBRARY_PREFIX}*")
+        if path.is_file()
+    )
+    if len(compiler_libraries) != 1:
+        raise SystemExit(
+            f"expected exactly one {COMPILER_LIBRARY_PREFIX} under "
+            f"{mlir_native_root}, found {compiler_libraries}"
+        )
+    if any(mlir_native_root.glob(f"{OBSOLETE_LIBRARY_PREFIX}*")):
+        raise SystemExit(
+            f"obsolete {OBSOLETE_LIBRARY_PREFIX} remains under {mlir_native_root}"
+        )
+
+    extensions = _native_extensions(package_root)
+    if not extensions:
+        raise SystemExit(f"no PTOAS native extensions found under {package_root}")
+
+    failures: list[str] = []
+    for extension in extensions:
+        dependencies = _dependencies(extension)
+        if not any(dep.startswith(COMPILER_LIBRARY_PREFIX) for dep in dependencies):
+            failures.append(f"{extension}: does not resolve {COMPILER_LIBRARY_PREFIX}")
+        if expect_static_llvm:
+            external = sorted(
+                dep
+                for dep in dependencies
+                if EXTERNAL_IMPLEMENTATION_PATTERN.match(dep)
+            )
+            if external:
+                failures.append(
+                    f"{extension}: directly depends on static-profile external "
+                    f"implementation libraries {external}"
+                )
+
+    if expect_static_llvm:
+        compiler_dependencies = _dependencies(compiler_libraries[0])
+        external = sorted(
+            dep
+            for dep in compiler_dependencies
+            if EXTERNAL_IMPLEMENTATION_PATTERN.match(dep)
+        )
+        if external:
+            failures.append(
+                f"{compiler_libraries[0]}: static profile still depends on {external}"
+            )
+
+    if failures:
+        raise SystemExit("native dependency validation failed:\n  " + "\n  ".join(failures))
+
+    profile = "static LLVM" if expect_static_llvm else "shared LLVM"
+    print(
+        f"validated {len(extensions)} native extensions and "
+        f"{COMPILER_LIBRARY_PREFIX} ownership ({profile} profile)"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate an installed PTOAS native dependency graph."
+    )
+    parser.add_argument("package_root", type=Path)
+    parser.add_argument("--expect-static-llvm", action="store_true")
+    args = parser.parse_args()
+    validate(args.package_root.resolve(), args.expect_static_llvm)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/validate_wheel_payload.py
+++ b/docker/validate_wheel_payload.py
@@ -34,10 +34,12 @@ NATIVE_MODULE_PATHS = {
     for suffix in importlib.machinery.EXTENSION_SUFFIXES
 }
 MLIR_NATIVE_MODULE_PREFIX = "ptoas/mlir/_mlir_libs/"
-COMMON_CAPI_LIBRARY_PATHS = {
-    f"{MLIR_NATIVE_MODULE_PREFIX}libPTOASPythonCAPI{suffix}"
-    for suffix in (".so", ".dylib")
-}
+PTOAS_COMPILER_LIBRARY_PREFIX = (
+    f"{MLIR_NATIVE_MODULE_PREFIX}libPTOASCompiler"
+)
+OBSOLETE_COMMON_CAPI_PREFIX = (
+    f"{MLIR_NATIVE_MODULE_PREFIX}libPTOASPythonCAPI"
+)
 MLIR_NATIVE_MODULE_PATHS = {
     f"{MLIR_NATIVE_MODULE_PREFIX}_mlir{suffix}"
     for suffix in importlib.machinery.EXTENSION_SUFFIXES
@@ -115,11 +117,22 @@ def validate_wheel_payload(wheel: Path) -> None:
                 f"found {mlir_native_modules}"
             )
 
-        common_capi_libraries = sorted(COMMON_CAPI_LIBRARY_PATHS & names)
-        if len(common_capi_libraries) != 1:
+        compiler_libraries = sorted(
+            name for name in names if name.startswith(PTOAS_COMPILER_LIBRARY_PREFIX)
+        )
+        if len(compiler_libraries) != 1:
             raise SystemExit(
-                "wheel must contain exactly one PTOAS MLIR common CAPI library, "
-                f"found {common_capi_libraries}"
+                "wheel must contain exactly one PTOAS compiler library, "
+                f"found {compiler_libraries}"
+            )
+
+        obsolete_common_capi = sorted(
+            name for name in names if name.startswith(OBSOLETE_COMMON_CAPI_PREFIX)
+        )
+        if obsolete_common_capi:
+            raise SystemExit(
+                "wheel contains the obsolete PTOAS Python CAPI library: "
+                f"{obsolete_common_capi}"
             )
 
         site_initializers = sorted(SITE_INITIALIZER_PATHS & names)

--- a/docs/designs/ptoas-compiler-dso-wheel-linking.md
+++ b/docs/designs/ptoas-compiler-dso-wheel-linking.md
@@ -1,0 +1,684 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+# PTOAS Compiler DSO and Wheel Linking Design
+
+## Status
+
+This design is **implemented**. Development and normal regression builds keep
+the shared LLVM/MLIR SDK profile; Linux and macOS wheel workflows select the
+static PIC SDK profile described below.
+
+The central rule is:
+
+> PTOAS has one CMake target graph and one package-owned compiler DSO. Local
+> development and normal regression CI supply that graph with a shared
+> LLVM/MLIR SDK; wheel workflows supply it with a static PIC LLVM/MLIR SDK.
+
+The SDK profile changes the implementation behind the same imported CMake
+target names. It must not introduce a second, wheel-only list of LLVM or MLIR
+libraries.
+
+## Motivation
+
+Before this design, the Linux and macOS wheel workflows built LLVM with
+`BUILD_SHARED_LIBS=ON`. The Python extensions and `PTOASPythonCAPI` therefore
+referred to a large graph of small LLVM/MLIR component libraries. Wheel repair
+had to discover, inspect, copy, rewrite, and often sign that entire graph.
+
+This is especially expensive on macOS. Recent successful runs observed roughly
+42 minutes for arm64 and 72 minutes for x86_64 in `delocate-wheel`. In the same
+runs, an approximately 6.3 MB raw wheel became approximately 19 MB after
+repair. These are observations rather than committed performance thresholds,
+but they identify the shape of the problem.
+
+The dependency closure also includes libraries that do not describe the
+intended PTOAS distribution boundary, for example:
+
+```text
+libMLIRMlirOptMain.dylib
+libMLIRAffineTransformOps.dylib
+libMLIRAMDGPUTransforms.dylib
+...
+```
+
+The problem is not the existence of a `.dylib` or `.so`. PTOAS needs a shared
+native boundary because `_core`, MLIR's generated `_mlir` modules, and
+`_site_initialize_0` must use one MLIR runtime. The problem is exposing the
+fine-grained LLVM/MLIR component graph as hundreds of runtime dependencies.
+
+The implemented distribution boundary is one project-owned
+`libPTOASCompiler.{so,dylib}`. In wheel builds, the linker's ordinary static
+archive selection pulls the needed LLVM/MLIR implementation into that DSO. In
+development builds, the same DSO continues to depend on shared LLVM/MLIR
+components, retaining fast incremental links and the existing debugging model.
+
+## Goals
+
+1. Install exactly one project-owned compiler DSO named `PTOASCompiler`.
+2. Make all PTOAS Python native modules use the MLIR runtime owned by that DSO.
+3. Use static PIC LLVM/MLIR only for Linux and macOS wheel builds.
+4. Keep local development, normal CI, simulator CI, and the development Docker
+   image on shared LLVM/MLIR.
+5. Keep one semantic CMake dependency graph in PTOAS. Select static versus
+   shared implementations by selecting the LLVM SDK profile.
+6. Let the static linker select archive members from CMake targets. Do not
+   enumerate installed library paths or copy dependencies by hand.
+7. Continue to run `auditwheel` and `delocate` for platform policy checks and
+   any remaining non-system dependencies.
+8. Preserve the standalone compiler archive, built from the same PTOAS targets
+   as the wheel.
+
+## Non-Goals
+
+- Requiring `-dead_strip`, `--gc-sections`, LTO, or a custom linker in the
+  first implementation.
+- Applying `--whole-archive` or `-all_load` to all LLVM/MLIR libraries.
+- Treating upstream's all-inclusive `libMLIR` as PTOAS's final distribution
+  boundary. It does not include the PTOAS compiler implementation and does not
+  by itself enforce a single runtime across PTOAS extensions.
+- Creating a wheel-only list of LLVM/MLIR components in workflow YAML or
+  `CMAKE_ARGS`.
+- Providing a stable external ABI for `PTOASCompiler` in the first version.
+- Changing development and ordinary regression builds to static LLVM/MLIR.
+- Removing wheel repair or replacing it with project-owned dependency-copying
+  logic.
+
+## Previous Native Topology
+
+The previous targets were split between
+`lib/Bindings/Python/CMakeLists.txt` and `tools/ptoas/CMakeLists.txt`:
+
+```text
+PTOASPythonCAPI (shared)
+├── embedded MLIR Python CAPI objects
+└── shared LLVM/MLIR component dependencies
+
+generated _mlir modules ───────► PTOASPythonCAPI
+_site_initialize_0 ────────────► PTOASPythonCAPI
+
+_core
+├── NativeModule.cpp
+├── PTOModule.cpp
+├── ptoas_runtime_objects
+│   ├── ptoas.cpp
+│   ├── driver.cpp
+│   ├── VPTOHostStubEmission.cpp
+│   ├── ObjectEmission.cpp
+│   └── TilelangDaemon.cpp
+├── PTOCAPI
+└── PTOASPythonCAPI
+```
+
+`ptoas_runtime_objects` carries the compiler's LLVM/MLIR link dependencies,
+while MLIR's Python CAPI objects live in `PTOASPythonCAPI`. Consequently,
+changing LLVM to static without changing this ownership boundary could embed
+independent MLIR implementations in multiple Python modules.
+
+## Implemented Native Topology
+
+Evolve the existing MLIR common CAPI DSO into the compiler ownership boundary:
+
+```text
+PTOASCompiler (shared)
+├── embedded MLIR Python CAPI objects
+├── embedded PTOCAPI objects
+├── embedded PTOIR and PTOTransforms objects
+├── embedded ptobc_lib objects
+├── PTOASCompilerImplementation objects
+│   ├── current ptoas_runtime_objects sources
+│   └── PTOModule.cpp
+└── required LLVM/MLIR CMake targets
+
+generated _mlir modules ───────► PTOASCompiler
+_site_initialize_0 ────────────► PTOASCompiler
+_core (NativeModule.cpp only) ─► PTOASCompiler
+```
+
+The installed location remains the private MLIR native directory because all
+generated MLIR modules already know how to resolve their common CAPI there:
+
+```text
+ptoas/mlir/_mlir_libs/libPTOASCompiler.so       # Linux
+ptoas/mlir/_mlir_libs/libPTOASCompiler.dylib    # macOS
+```
+
+`libPTOASPythonCAPI` is no longer installed. `PTOASCompiler` replaces it as
+both the AddMLIRPython common CAPI and the PTOAS compiler implementation DSO.
+The package-private target deliberately has no CMake `VERSION` or `SOVERSION`:
+otherwise a wheel archive dereferences both the versioned file and its symlink
+and stores the same DSO twice. The DSO still has the unversioned
+`libPTOASCompiler` SONAME/install name used by the extensions in that wheel.
+
+### Why `PTOModule.cpp` Belongs in the DSO
+
+If `_core` retained `PTOModule.cpp`, the DSO would need to export a broad set of
+MLIR and PTO C++ symbols used by the binding implementation. Moving it into
+`PTOASCompiler` lets `_core` remain a thin Python entry point. The cross-target
+surface can initially be limited to bridge functions equivalent to:
+
+```cpp
+namespace mlir::pto {
+PTOAS_COMPILER_EXPORT int runPTOAS(int argc, char **argv);
+}
+
+namespace mlir::pto::python {
+PTOAS_COMPILER_EXPORT void
+populatePTODialectBindings(pybind11::module_ &module);
+}
+```
+
+These declarations need a small visibility header and platform export macro.
+For version 1 they are an internal, same-build C++ ABI between artifacts in one
+wheel. A stable public C API can be designed separately if external consumers
+need one.
+
+This bridge intentionally depends on pybind11 and therefore makes
+`PTOASCompiler` a package-internal implementation library, not a reusable
+public SDK library. `PTOModule.cpp` must be compiled with RTTI and exceptions
+enabled, matching the current pybind11 extension translation unit. The target
+must also acquire pybind11's headers and Python link contract without adding a
+second Python module initializer. A future public compiler ABI should be a
+separate C API layered over this implementation.
+
+Python extensions conventionally leave CPython API symbols to be resolved by
+the interpreter. Moving pybind11 code into this private DSO therefore requires
+one deliberate exception to `add_mlir_aggregate`'s Linux `-z defs` default and
+pybind11's normal macOS dynamic-lookup link option. Do not link a release wheel
+to an absolute `libpython` or Python framework merely to satisfy that check.
+Instead, audit the final undefined-symbol set and allow only the expected
+CPython API in addition to platform runtime symbols.
+
+## One PTOAS Graph, Two LLVM SDK Profiles
+
+PTOAS always links logical CMake targets such as `MLIRIR`, `MLIRParser`,
+`MLIRMlirOptMain`, and `LLVMOption`. It never names their `.a`, `.so`, or
+`.dylib` files. The LLVM build determines what implementation those targets
+represent.
+
+### Shared Development Profile
+
+This remains the default for:
+
+- local editable and developer builds;
+- `.github/workflows/ci.yml`;
+- `.github/workflows/ci_sim.yml`;
+- `docker/Dockerfile`;
+- `docker/Dockerfile.dev`;
+- other normal regression configurations.
+
+The relevant setting when building the LLVM SDK remains:
+
+```cmake
+-DBUILD_SHARED_LIBS=ON
+```
+
+PTOAS itself still creates `PTOASCompiler` explicitly as `SHARED`; the SDK's
+`BUILD_SHARED_LIBS` value does not change that. Its private runtime dependencies
+are the shared LLVM/MLIR component libraries from the developer SDK.
+PTOAS-owned compiler and C API objects are embedded in the DSO in both
+profiles. This preserves the current LLVM rebuild and incremental link
+behavior without exposing separate PTOAS implementation DSOs.
+
+### Static Wheel Profile
+
+Only `.github/workflows/build_wheel.yml` and
+`.github/workflows/build_wheel_mac.yml` build and consume this LLVM SDK. The
+following are arguments to the LLVM source-tree configure, not a new PTOAS
+mode switch:
+
+```cmake
+-DBUILD_SHARED_LIBS=OFF
+-DLLVM_BUILD_LLVM_DYLIB=OFF
+-DLLVM_LINK_LLVM_DYLIB=OFF
+-DMLIR_LINK_MLIR_DYLIB=OFF
+-DLLVM_ENABLE_PIC=ON
+-DMLIR_INSTALL_AGGREGATE_OBJECTS=ON
+```
+
+The pinned LLVM 21 tree defines these options; `LLVM_ENABLE_PIC` and
+`MLIR_INSTALL_AGGREGATE_OBJECTS` already default to `ON`, but wheel workflows
+set them explicitly because they are part of the distribution contract. The
+required contract is: LLVM/MLIR component targets are static and
+position-independent; PTOAS does not silently redirect them to an upstream
+LLVM or MLIR dylib. `MLIR_INSTALL_AGGREGATE_OBJECTS` is required only when
+PTOAS consumes an installed LLVM SDK. The current workflows consume its build
+tree, but keeping the option explicit makes an installed SDK equivalent.
+
+When `PTOASCompiler` links those same target names, ordinary archive member
+selection embeds the referenced implementation in the project DSO. The Python
+extensions then have one direct PTOAS runtime dependency rather than direct
+dependencies on the external LLVM build tree.
+
+Static and shared LLVM SDKs must use separate build directories and cache keys.
+Before enabling the profile, both wheel workflows must bump
+`LLVM_CACHE_FLAVOR`, for example to `llvm21-vpto-wheel-static-v1`. Reusing a
+cache produced with `BUILD_SHARED_LIBS=ON` is invalid even when the source SHA
+is identical.
+
+The resulting matrix is:
+
+| Property | Development and normal CI | Wheel workflows |
+| --- | --- | --- |
+| PTOAS target graph | One common graph | The same graph |
+| `PTOASCompiler` | Shared DSO | Shared DSO |
+| PTOAS compiler objects | Embedded | Embedded |
+| LLVM/MLIR components | Shared dependencies | Static PIC members in the DSO |
+| Wheel repair | Not applicable | Policy check and residual dependencies |
+
+## Concrete CMake Changes
+
+### 1. Extend the AddMLIRPython Common CAPI Target
+
+In `lib/Bindings/Python/CMakeLists.txt`, rename the existing target while
+retaining MLIR's standard source collection and module wiring:
+
+```cmake
+add_mlir_python_common_capi_library(PTOASCompiler
+  INSTALL_COMPONENT PTOAS_Python
+  INSTALL_DESTINATION "ptoas/mlir/_mlir_libs"
+  OUTPUT_DIRECTORY "${PTOAS_MLIR_PYTHON_PACKAGE_DIR}/_mlir_libs"
+  RELATIVE_INSTALL_ROOT "../../../"
+  DECLARED_HEADERS
+    MLIRPythonCAPI.HeaderSources
+  DECLARED_SOURCES
+    ${PTOAS_MLIR_PYTHON_SOURCE_SETS}
+    PTOASPythonSources
+  EMBED_LIBS
+    MLIRCAPITransforms
+    PTOCAPI
+    PTOIR
+    PTOTransforms
+    ptobc_lib
+    PTOASCompilerImplementation
+)
+
+set_property(TARGET PTOASCompiler PROPERTY LINKER_LANGUAGE CXX)
+
+add_mlir_python_modules(PTOAS_Python
+  # Existing arguments remain unchanged.
+  COMMON_CAPI_LINK_LIBS
+    PTOASCompiler
+)
+```
+
+Using `add_mlir_python_common_capi_library` remains important: it is the
+upstream mechanism that creates an `add_mlir_aggregate(... SHARED ...)`,
+collects the selected Python CAPI objects, and wires the generated `_mlir` and
+site-initializer modules to one common runtime. `PTOCAPI` is already declared
+with `add_mlir_public_c_api_library`, so it is aggregation-capable and belongs
+in `EMBED_LIBS`; adding it only through `target_link_libraries` would leave its
+C API in a separate shared library under a downstream shared configuration.
+
+Add `ENABLE_AGGREGATION` to the existing `PTOIR` and `PTOTransforms`
+declarations before naming them in `EMBED_LIBS`. This embeds those
+project-owned objects in both profiles while their LLVM/MLIR dependencies
+continue to follow the selected SDK. This is a short list of PTOAS ownership
+roots, not a wheel-specific enumeration of upstream libraries.
+
+Likewise, convert `ptobc_lib` from a plain static library to a non-installed
+`add_mlir_library(... OBJECT ENABLE_AGGREGATION ...)` target and embed it. Its
+source list remains unchanged. This prevents its public `PTOIR` dependency
+from reintroducing a separate PTOIR DSO after the outer aggregate has embedded
+PTOIR.
+
+`PTOASCompilerImplementation` is declared later under `tools/ptoas`. MLIR's
+`add_mlir_aggregate` explicitly supports this in-tree target ordering through
+deferred generator expressions, so `lib` can continue to precede `tools` in
+the top-level build.
+
+### 2. Make the Compiler Implementation Aggregation-Capable
+
+In `tools/ptoas/CMakeLists.txt`, evolve the current
+`ptoas_runtime_objects` target into a non-installed aggregation root. The
+source list remains authoritative. The object target receives compile settings,
+while its link dependencies are passed when the aggregation root is created:
+
+```cmake
+add_mlir_library(PTOASCompilerImplementation
+  OBJECT
+  ENABLE_AGGREGATION
+  DISABLE_INSTALL
+  ${PTOAS_RUNTIME_SOURCES}
+  "${CMAKE_SOURCE_DIR}/lib/Bindings/Python/PTOModule.cpp"
+  LINK_LIBS PUBLIC
+  ${PTOAS_RUNTIME_LINK_LIBS}
+)
+
+ptoas_configure_runtime_compile_target(
+  obj.PTOASCompilerImplementation)
+```
+
+`add_mlir_library(... OBJECT ...)` creates
+`obj.PTOASCompilerImplementation`, which owns compilation, plus a normal
+library target that carries its link interface. Applying the current compile
+definitions only to the latter would not configure the object files. The
+split is:
+
+- `ptoas_configure_runtime_compile_target` owns release-version/default-path
+  definitions and generated-header dependencies;
+- `PTOAS_RUNTIME_LINK_LIBS` owns the existing single dependency list and is
+  supplied to `add_mlir_library`;
+- the object target also receives
+  `MLIR_PYTHON_PACKAGE_PREFIX=ptoas.mlir.` because `PTOModule.cpp` moved out of
+  the original extension target's directory.
+
+`add_mlir_library(... ENABLE_AGGREGATION ...)` publishes the implementation's
+object files and filtered transitive link dependencies to `PTOASCompiler`.
+Dependencies already embedded by the outer aggregate, including `PTOIR` and
+`PTOTransforms`, are removed from its runtime link interface. This is why a
+plain object library plus a raw `target_link_libraries(PTOASCompiler ...)`
+should not be the final design: those raw usage requirements could reintroduce
+an embedded project library as a separate DSO in the shared profile.
+
+`PTOAS_RUNTIME_LINK_LIBS` remains the single authoritative LLVM/MLIR component
+list. Pass it through `add_mlir_library(... LINK_LIBS ...)` when creating the
+aggregation root: adding dependencies later with `target_link_libraries` does
+not retroactively place them in `MLIR_AGGREGATE_DEPS`. Do not copy that list to
+`lib/Bindings/Python/CMakeLists.txt` or either wheel workflow.
+
+Any PTOAS static or object target that is linked into `PTOASCompiler` must have
+`POSITION_INDEPENDENT_CODE ON` when the corresponding LLVM/MLIR helper does not
+already guarantee it.
+
+The implementation still links the logical `ptobc_lib` target. Aggregate
+filtering, rather than a second dependency list, ensures that its objects and
+transitive dependencies enter the final DSO exactly once.
+
+Apply per-source compile options to `PTOModule.cpp` after
+the MLIR helper creates the object target: it must retain
+`-frtti -fexceptions` (or the MSVC equivalent), while the LLVM-based compiler
+sources retain LLVM's normal compile mode. Link
+`obj.PTOASCompilerImplementation` privately to `pybind11::module`, not merely
+`pybind11::headers`: the object compilation needs both pybind11 and Python
+include usage requirements. Link `PTOASCompiler` privately to the same target
+for Python's platform link contract, including macOS dynamic lookup.
+`PTOASCompiler` does not become a Python module or gain a `PyInit_*` entry. On
+Linux, add a scoped `-z undefs` override for the aggregate's default `-z defs`,
+then validate the remaining undefined symbols as described above.
+
+### 3. Make `_core` a Thin Entry Point
+
+`PTOASPythonCore` retains only `NativeModule.cpp` as a source and links the
+common DSO:
+
+```cmake
+add_mlir_python_extension(PTOASPythonCore _core
+  # Existing install and Python binding arguments remain unchanged.
+  SOURCES
+    NativeModule.cpp
+  LINK_LIBS
+    PTOASCompiler
+)
+```
+
+`NativeModule.cpp` calls only the exported compiler and PTO binding bridges.
+It must not link `PTOASCompilerImplementation`, `PTOCAPI`, `PTOIR`,
+`PTOTransforms`, or LLVM/MLIR components directly.
+
+This arrangement does not create cyclic CMake subdirectories: the common DSO
+is declared under `lib` with a deferred reference to the implementation target
+declared later under `tools`. It also avoids creating a second implementation
+target for wheel builds.
+
+### 4. Control Symbol Visibility
+
+`PTOASCompiler` should default to hidden C/C++ symbol visibility, while the
+MLIR Python C API and the narrow PTOAS bridges retain their required exports.
+`add_mlir_public_c_api_library` already compiles C API objects with hidden
+visibility plus `MLIR_CAPI_BUILDING_LIBRARY`; preserve that mechanism. Add
+explicit visibility only for the two PTOAS bridges and avoid a blanket export
+list.
+
+This is where PTOAS deliberately differs from a single Python extension such
+as Triton's `libtriton`: the generated AddMLIRPython modules require the MLIR C
+API to remain exported from the common DSO. The export surface is therefore
+"MLIR/PTO C API plus two private bridges", not only one `PyInit_*` symbol.
+
+On Linux, validate the dynamic symbol table with `readelf --dyn-syms`. On
+macOS, validate it with `nm -gU`. A version script or exported-symbols list is
+optional follow-up work if CMake visibility properties do not produce a small
+enough surface.
+
+## Static Selection and Wheel Size
+
+The first size-control mechanism is normal static archive selection:
+
+```text
+PTOASCompiler undefined references
+              │
+              ▼
+linker extracts only satisfying members from LLVM/MLIR archives
+              │
+              ▼
+one package-owned compiler DSO
+```
+
+There is no project-maintained file or symbol allowlist. There is also no
+global `--whole-archive`, `-all_load`, or `-force_load` over LLVM/MLIR, because
+that would defeat archive selection and can greatly increase wheel size.
+
+Static registration is the exception that needs explicit testing. Prefer
+explicit dialect, pass, translation, and target registration roots. If one
+specific upstream archive relies on static constructors and its members are
+otherwise unreferenced, retain only that archive with a narrowly scoped
+whole-archive mechanism and document why it is required.
+
+Dead stripping and LTO are follow-up optimizations, not correctness
+requirements. After the baseline static profile works, linker maps can show
+which archive members entered `PTOASCompiler`. Only then should the project
+evaluate `-dead_strip`, `--gc-sections`, thin LTO, or further registration
+reduction against measured wheel size and link cost.
+
+## Workflow Changes
+
+The PTOAS configure and build command remains structurally identical in every
+workflow. It receives `LLVM_DIR` and `MLIR_DIR` from the selected SDK and does
+not receive a wheel-specific dependency list.
+
+The following producers remain shared:
+
+```text
+local development
+.github/workflows/ci.yml
+.github/workflows/ci_sim.yml
+docker/Dockerfile
+docker/Dockerfile.dev
+```
+
+The following producers switch their LLVM build and cache to static PIC:
+
+```text
+.github/workflows/build_wheel.yml
+.github/workflows/build_wheel_mac.yml
+```
+
+`auditwheel repair` and `delocate-wheel` remain in place. Their work should
+become small because LLVM/MLIR components are no longer external dependencies,
+but they still provide platform policy validation and relocate any legitimate
+third-party shared dependencies.
+
+## Installation and Standalone Archive
+
+`_core` already uses an install RPATH that includes
+`ptoas/mlir/_mlir_libs`, and AddMLIRPython supplies the corresponding layout
+for generated modules. Preserve that contract while replacing the common DSO
+name.
+
+Update `cmake/RelocatePTOASCompilerArchive.cmake.in` in the same change:
+
+- replace `$<TARGET_FILE_NAME:PTOASPythonCAPI>` with
+  `$<TARGET_FILE_NAME:PTOASCompiler>`;
+- replace the dependency exclusion matching `libPTOASPythonCAPI` with
+  `libPTOASCompiler`;
+- continue discovering generated AddMLIRPython modules from their owned
+  install directory;
+- continue deriving external dependencies from binary metadata rather than a
+  handwritten library list.
+
+Update `docker/validate_wheel_payload.py` and any native payload tests to
+require `PTOASCompiler` and reject the obsolete DSO.
+
+The archive and wheel must use the same native targets. Packaging may still
+stage or relocate those targets differently, but it must not compile a second
+compiler implementation.
+
+## Required Invariants
+
+Every supported build must satisfy:
+
+1. Exactly one installed `libPTOASCompiler` exists in the PTOAS package.
+2. No installed `libPTOASPythonCAPI` exists.
+3. `_core`, generated `_mlir` modules, and `_site_initialize_0` resolve
+   `PTOASCompiler`.
+4. Python-created MLIR objects and PTOAS compiler code use one MLIR runtime.
+5. The compiler archive and wheel originate from the same PTOAS CMake targets.
+6. Static and shared LLVM SDK build trees and cache keys never overlap.
+
+For the static wheel profile, additionally:
+
+1. Package extensions do not directly depend on external `libLLVM*`,
+   `libMLIR*`, `libPTOIR*`, or `libPTOTransforms*` shared libraries.
+2. `PTOASCompiler` does not depend on external LLVM/MLIR component shared
+   libraries.
+3. A static library is not accidentally bundled as a separate wheel payload
+   file.
+
+AddMLIRPython's generated extensions may still privately embed archive members
+from upstream-declared `PRIVATE_LINK_LIBS`, currently `LLVMSupport`. Upstream
+defines these as hidden, extension-local support code. This exception must not
+include MLIR CAPI, IR, context, dialect, pass, or PTOAS compiler implementation
+objects: those remain owned by `PTOASCompiler`. It is also not a wheel payload
+copy list and must not produce an additional shared-library dependency.
+
+For the shared development profile, LLVM/MLIR component dependencies are
+allowed, but they must occur below the common `PTOASCompiler` ownership
+boundary rather than being independently linked into `_core`.
+
+## Validation Plan
+
+### Target and Dependency Graph
+
+- Configure both profiles and inspect the generated link commands.
+- Assert that all Python native modules link `PTOASCompiler`.
+- Assert that `_core` has no direct compiler or LLVM/MLIR implementation
+  libraries.
+- Inspect raw and repaired wheels with `readelf -d` on Linux and `otool -L` on
+  macOS.
+- Reject project-external `libLLVM*`, `libMLIR*`, `libPTOIR*`, and
+  `libPTOTransforms*` dependencies in static-profile wheel binaries.
+- Permit only upstream-declared, hidden `PRIVATE_LINK_LIBS` objects in generated
+  extensions; verify that MLIR CAPI/runtime objects are not duplicated there.
+- Inspect loader resolution from a clean environment, not from the LLVM build
+  directory.
+
+### Functional Coverage
+
+- Import `ptoas`, `ptoas._core`, `ptoas.mlir.ir`, all packaged MLIR dialects,
+  and `ptoas.mlir.dialects.pto` in different orders.
+- Parse and print representative MLIR modules.
+- Construct PTO types, attributes, and enums through the Python bindings.
+- Exercise the Python CLI, installed `ptoas` launcher, and compiler paths.
+- Run the existing wheel import/compiler suite and standalone archive suite.
+- Cover both Linux architectures and both macOS architectures built by the
+  release matrix.
+- Run the same behavior checks against a shared-profile editable build to
+  protect developer workflows.
+
+### Measurements
+
+Record before and after values for:
+
+- cold LLVM SDK build time;
+- PTOAS link time and peak memory;
+- raw and repaired wheel size;
+- uncompressed native payload size;
+- number of packaged DSOs and their direct dependency count;
+- wheel repair time on every release architecture.
+
+The first rollout is accepted based on correctness, a materially smaller
+runtime dependency graph, and no material wheel-size regression. Do not set a
+hard repair-time target until at least two uncached runs establish stable
+baselines.
+
+## Risks and Mitigations
+
+### Missing Static Registration
+
+Normal archive selection can omit code reachable only through static
+constructors. Use explicit registration roots and functional tests. Apply
+whole-archive semantics only to a proven, narrowly identified archive.
+
+### Duplicate MLIR Runtime
+
+An extension can accidentally retain a direct static MLIR dependency. Make
+binary dependency checks and cross-module Python object tests release gates.
+
+### Hidden Required Symbols
+
+Default-hidden visibility can hide the common C API or PTOAS bridge exports.
+Use explicit export macros and inspect the dynamic symbol table on both
+platforms.
+
+### Static Link Resource Cost
+
+Static LLVM/MLIR can increase link time and peak memory. Limit this profile to
+wheel workflows, cache the LLVM SDK independently, avoid LTO initially, and
+measure the final link.
+
+### Unexpected Wheel Size
+
+Broad registration roots or whole-archive flags can retain too much code. Use
+the linker map to identify the responsible archives, then reduce roots or
+narrow the exceptional retention. Do not replace this analysis with a manual
+copy allowlist.
+
+## Rollout
+
+1. Rename and extend the common DSO to `PTOASCompiler`, move the compiler and
+   PTO binding implementation into it, and thin `_core` while LLVM remains
+   shared everywhere.
+2. Validate local development, normal CI, simulator CI, wheel behavior, and
+   the standalone archive against the new ownership boundary.
+3. Add independent static-PIC LLVM cache profiles to the two wheel workflows
+   only.
+4. Add binary dependency assertions, switch wheel builds to the static SDK,
+   and compare size and repair time with the recorded baseline.
+5. Inspect linker maps and consider dead stripping or LTO only if the measured
+   result justifies the additional complexity.
+
+Keeping step 1 separate from step 3 makes failures attributable: first prove
+the single-runtime ownership change, then change how its implementation is
+linked.
+
+## Industry Reference Patterns
+
+No referenced project is an exact template for PTOAS, but several established
+patterns support the individual choices in this design:
+
+- [IREE compiler Python bindings](https://github.com/iree-org/iree/blob/main/compiler/bindings/python/CMakeLists.txt)
+  link tools and Python-facing code through the project-owned
+  `iree_compiler_API_Impl` boundary.
+- [Triton's top-level CMake](https://github.com/triton-lang/triton/blob/main/CMakeLists.txt)
+  builds one `libtriton` shared Python library, links its compiler and
+  LLVM/MLIR targets privately, clears transitive interface libraries, and
+  constrains exports. Its LLVM discovery also requests `llvm-config
+  --link-static`, making static LLVM a deliberate distribution input rather
+  than a copied runtime component graph.
+- [TVM's LLVM integration](https://github.com/apache/tvm/blob/main/cmake/utils/FindLLVM.cmake)
+  supports LLVM as a build-selected compiler implementation behind a small
+  number of project-owned runtime/compiler libraries.
+- [torch-mlir's Python CMake](https://github.com/llvm/torch-mlir/blob/main/python/CMakeLists.txt)
+  and [CIRCT's Python CMake](https://github.com/llvm/circt/blob/main/lib/Bindings/Python/CMakeLists.txt)
+  use `add_mlir_python_common_capi_library` so generated extension modules
+  share one native MLIR runtime.
+
+These references support project ownership, a common MLIR runtime, and
+build-profile selection. They do **not** establish a universal requirement to
+enable `-dead_strip`, LTO, or fully static development builds. Those remain
+project-specific optimizations driven by measurement.

--- a/docs/designs/ptoas-mlir-namespace-and-native-isolation.md
+++ b/docs/designs/ptoas-mlir-namespace-and-native-isolation.md
@@ -489,10 +489,14 @@ _mlir.so ──► libPTOASCompiler.so
 _core.so ──► libPTOASCompiler.so
 ```
 
-That is a separate architectural change requiring a deliberate exported API
-boundary and symbol-visibility policy. It is not a prerequisite for the
-namespace migration because repaired wheels already isolate external shared
-libraries with package-local, content-derived names.
+The follow-on implementation, including the shared development SDK and static
+wheel SDK profiles, is specified in
+`docs/designs/ptoas-compiler-dso-wheel-linking.md`.
+
+That architectural change now provides the exported bridge and symbol-
+visibility policy described there. This section is retained as the historical
+namespace-migration baseline; the follow-on design supersedes its native DSO
+topology.
 
 ## Public API Migration
 

--- a/include/PTO/Compiler/CompilerApi.h
+++ b/include/PTO/Compiler/CompilerApi.h
@@ -6,19 +6,17 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-#ifndef PTOAS_LIB_BINDINGS_PYTHON_PTOMODULE_H
-#define PTOAS_LIB_BINDINGS_PYTHON_PTOMODULE_H
+#ifndef PTO_COMPILER_COMPILERAPI_H
+#define PTO_COMPILER_COMPILERAPI_H
 
-#include "PTO/Compiler/CompilerApi.h"
-#include "pybind11/pybind11.h"
+#if defined(_WIN32)
+#if defined(PTOAS_COMPILER_BUILDING_LIBRARY)
+#define PTOAS_COMPILER_EXPORT __declspec(dllexport)
+#else
+#define PTOAS_COMPILER_EXPORT __declspec(dllimport)
+#endif
+#else
+#define PTOAS_COMPILER_EXPORT __attribute__((visibility("default")))
+#endif
 
-namespace mlir::pto::python {
-
-/// Adds PTO dialect types, attributes, enums, and registration helpers to the
-/// project-owned ptoas._core extension module through PTOASCompiler.
-PTOAS_COMPILER_EXPORT void
-populatePTODialectBindings(pybind11::module_ &module);
-
-} // namespace mlir::pto::python
-
-#endif // PTOAS_LIB_BINDINGS_PYTHON_PTOMODULE_H
+#endif // PTO_COMPILER_COMPILERAPI_H

--- a/lib/Bindings/Python/CMakeLists.txt
+++ b/lib/Bindings/Python/CMakeLists.txt
@@ -99,10 +99,11 @@ set(PTOAS_MLIR_PYTHON_SOURCE_SETS
   MLIRPythonSources.Dialects.scf
 )
 
-# Keep one common CAPI DSO for the upstream MLIR Python package. PTOAS owns a
-# single ptoas._core extension, built in tools/ptoas, which links this common
-# CAPI and contains both the PTO dialect implementation and compiler driver.
-add_mlir_python_common_capi_library(PTOASPythonCAPI
+# Keep the MLIR Python CAPI and PTOAS compiler implementation in one package-
+# owned DSO. Generated extensions and the thin ptoas._core entry point all
+# resolve this target, so Python-created and compiler-created IR share one
+# native MLIR runtime.
+add_mlir_python_common_capi_library(PTOASCompiler
   INSTALL_COMPONENT PTOAS_Python
   INSTALL_DESTINATION "ptoas/mlir/_mlir_libs"
   OUTPUT_DIRECTORY "${PTOAS_MLIR_PYTHON_PACKAGE_DIR}/_mlir_libs"
@@ -117,11 +118,21 @@ add_mlir_python_common_capi_library(PTOASPythonCAPI
   # the missing direct dependency until upstream Core declares it itself.
   EMBED_LIBS
     MLIRCAPITransforms
+    PTOCAPI
+    PTOIR
+    PTOTransforms
+    ptobc_lib
+    PTOASCompilerImplementation
 )
 # Imported MLIR aggregate objects do not expose a source language from which
 # CMake can infer the linker driver. The common CAPI is C++, matching MLIR's
 # own in-tree target.
-set_property(TARGET PTOASPythonCAPI PROPERTY LINKER_LANGUAGE CXX)
+set_property(TARGET PTOASCompiler PROPERTY LINKER_LANGUAGE CXX)
+# This is a package-private same-build boundary, not an LLVM-style SDK ABI.
+# Avoid installing both a versioned file and its symlink: wheel archives
+# dereference the symlink and would otherwise store the DSO twice.
+set_property(TARGET PTOASCompiler PROPERTY VERSION)
+set_property(TARGET PTOASCompiler PROPERTY SOVERSION)
 
 add_mlir_python_modules(PTOAS_Python
   ROOT_PREFIX "${PTOAS_MLIR_PYTHON_PACKAGE_DIR}"
@@ -130,7 +141,7 @@ add_mlir_python_modules(PTOAS_Python
     ${PTOAS_MLIR_PYTHON_SOURCE_SETS}
     PTOASPythonSources
   COMMON_CAPI_LINK_LIBS
-    PTOASPythonCAPI
+    PTOASCompiler
 )
 
 # AddMLIRPython deliberately resets each generated target's install RPATH to

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -8,8 +8,9 @@
 
 //===- DialectPTO.cpp -----------------------------------------------------===//
 //
-// Python bindings for the PTO dialect types in the project-owned ptoas._core
-// extension. The public Python facade remains ptoas.mlir.dialects.pto.
+// Python bindings for the PTO dialect types embedded in PTOASCompiler. The
+// thin ptoas._core entry point calls this implementation, while the public
+// Python facade remains ptoas.mlir.dialects.pto.
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/PTO/IR/CMakeLists.txt
+++ b/lib/PTO/IR/CMakeLists.txt
@@ -13,6 +13,8 @@
 
 # [关键] 库名重命名为 PTOIR，避免与 LLVM 里的 PTODialect/MLIRPTODialect 冲突
 add_mlir_dialect_library(PTOIR
+  ENABLE_AGGREGATION
+
   PTO.cpp
   VPTO.cpp
   VMI.cpp

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -11,7 +11,19 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
+set(_ptoas_transforms_private_link_libs)
+if(TARGET vfsim::native_core)
+  list(APPEND _ptoas_transforms_private_link_libs
+    $<BUILD_INTERFACE:vfsim::native_core>)
+endif()
+if(TARGET vfsim::ir_planner)
+  list(APPEND _ptoas_transforms_private_link_libs
+    $<BUILD_INTERFACE:vfsim::ir_planner>)
+endif()
+
 add_mlir_dialect_library(PTOTransforms
+  ENABLE_AGGREGATION
+
   TileFusion/FusionAnalysis.cpp
   TileFusion/FusionOpSemantics.cpp
   TileFusion/PTOPreFusionAnalysis.cpp
@@ -128,7 +140,8 @@ add_mlir_dialect_library(PTOTransforms
   LINK_COMPONENTS
   Analysis
 
-  LINK_LIBS PUBLIC
+  LINK_LIBS
+  PUBLIC
   PTOIR
   MLIRIR
   MLIRPass
@@ -152,6 +165,8 @@ add_mlir_dialect_library(PTOTransforms
   MLIRConvertToLLVMPass
   MLIRTargetLLVMIRExport
   MLIRToLLVMIRTranslationRegistration
+  PRIVATE
+  ${_ptoas_transforms_private_link_libs}
 )
 
 install(TARGETS PTOTransforms
@@ -168,18 +183,18 @@ target_include_directories(PTOTransforms INTERFACE
   $<INSTALL_INTERFACE:include>
 )
 
-if(TARGET vfsim::native_core)
-  target_link_libraries(PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::native_core>)
-  if(TARGET obj.PTOTransforms)
-    target_link_libraries(obj.PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::native_core>)
-  endif()
+if(TARGET vfsim::native_core AND TARGET obj.PTOTransforms)
+  # Preserve the simulator target's compile usage requirements on the object
+  # library; its link dependency is already captured in aggregation metadata.
+  target_link_libraries(obj.PTOTransforms PRIVATE
+    $<BUILD_INTERFACE:vfsim::native_core>)
 endif()
 
 if(TARGET vfsim::ir_planner)
-  target_link_libraries(PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::ir_planner>)
   target_compile_definitions(PTOTransforms PRIVATE PTO_ENABLE_VFSIM_IR_PLANNER=1)
   if(TARGET obj.PTOTransforms)
-    target_link_libraries(obj.PTOTransforms PRIVATE $<BUILD_INTERFACE:vfsim::ir_planner>)
+    target_link_libraries(obj.PTOTransforms PRIVATE
+      $<BUILD_INTERFACE:vfsim::ir_planner>)
     target_compile_definitions(obj.PTOTransforms PRIVATE PTO_ENABLE_VFSIM_IR_PLANNER=1)
   endif()
 endif()

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3659,7 +3659,8 @@ FailureOr<SmallVector<Value>> materializeLaneStrideToContiguous(
   results.reserve(resultTypes.size());
   for (auto [resultIndex, resultType] : llvm::enumerate(resultTypes)) {
     size_t sourceBegin = resultIndex * laneStride;
-    size_t sourceEnd = std::min(sourceBegin + laneStride, sourceParts.size());
+    size_t sourceEnd =
+        std::min<size_t>(sourceBegin + laneStride, sourceParts.size());
     SmallVector<Value> currentLevel;
     currentLevel.reserve(sourceEnd - sourceBegin);
     for (Value source : sourceParts.slice(sourceBegin, sourceEnd - sourceBegin)) {

--- a/tools/ptoas/CMakeLists.txt
+++ b/tools/ptoas/CMakeLists.txt
@@ -53,7 +53,7 @@ foreach(_ptoas_wrapper IN ITEMS
   )
 endforeach()
 
-function(ptoas_configure_runtime_target target_name)
+function(ptoas_configure_runtime_compile_target target_name)
   target_compile_definitions(${target_name} PRIVATE
     PTOAS_RELEASE_VERSION="${PTOAS_CLI_VERSION}"
     # Source-tree defaults for TileLib expansion. These let ptoas run directly
@@ -65,50 +65,91 @@ function(ptoas_configure_runtime_target target_name)
     PTOAS_DEFAULT_TILEOPS_PKG_PATH="${CMAKE_SOURCE_DIR}/lib"
     ${ARGN}
   )
-  target_link_libraries(${target_name} PUBLIC
-    PTOIR
-    PTOTransforms
-    ptobc_lib
-    MLIRMlirOptMain
-    MLIRBufferizationTransforms
-    MLIRArithTransforms
-    MLIRTensorTransforms
-    MLIRFuncTransforms
-    MLIRIR
-    MLIRParser
-    MLIRPass
-    MLIREmitCDialect
-    MLIRSCFDialect
-    MLIRGPUDialect
-    MLIRTransforms
-    MLIRTargetCpp
-    MLIRAffineDialect
-    MLIRArithDialect
-    MLIRTensorDialect
-    MLIRControlFlowDialect
-    MLIRBufferizationDialect
-    MLIRFuncDialect
-    MLIRFuncInlinerExtension
-    MLIRLLVMIRTransforms
-    MLIRSupport
-    LLVMOption
-    MLIRTransformUtils
-  )
   add_dependencies(${target_name}
     PTOOpsIncGen
   )
 endfunction()
 
-# Keep the LLVM-based driver sources under LLVM's RTTI/exception compile mode.
-# The pybind11 translation unit must retain the Python extension's normal RTTI
-# and exception mode, so it is compiled by the module target separately.
-add_library(ptoas_runtime_objects OBJECT ${PTOAS_RUNTIME_SOURCES})
-llvm_update_compile_flags(ptoas_runtime_objects)
-ptoas_configure_runtime_target(ptoas_runtime_objects)
+set(PTOAS_RUNTIME_LINK_LIBS
+  PTOIR
+  PTOTransforms
+  ptobc_lib
+  MLIRMlirOptMain
+  MLIRBufferizationTransforms
+  MLIRArithTransforms
+  MLIRTensorTransforms
+  MLIRFuncTransforms
+  MLIRIR
+  MLIRParser
+  MLIRPass
+  MLIREmitCDialect
+  MLIRSCFDialect
+  MLIRGPUDialect
+  MLIRTransforms
+  MLIRTargetCpp
+  MLIRAffineDialect
+  MLIRArithDialect
+  MLIRTensorDialect
+  MLIRControlFlowDialect
+  MLIRBufferizationDialect
+  MLIRFuncDialect
+  MLIRFuncInlinerExtension
+  MLIRLLVMIRTransforms
+  MLIRSupport
+  LLVMOption
+  MLIRTransformUtils
+)
 
-# Build the single PTOAS-owned Python extension. It contains both the compiler
-# driver and PTO dialect bindings, while linking MLIR's shared common CAPI so
-# Python-created MLIR objects and the compiler use the same MLIR runtime.
+# This aggregation root owns all compiler and PTO Python binding objects. The
+# final shared library is declared earlier as PTOASCompiler; AddMLIR resolves
+# this forward target relationship during generation.
+add_mlir_library(PTOASCompilerImplementation
+  OBJECT
+  ENABLE_AGGREGATION
+  EXCLUDE_FROM_LIBMLIR
+  DISABLE_INSTALL
+  PARTIAL_SOURCES_INTENDED
+
+  ${PTOAS_RUNTIME_SOURCES}
+  "${CMAKE_SOURCE_DIR}/lib/Bindings/Python/PTOModule.cpp"
+
+  LINK_LIBS PUBLIC
+  ${PTOAS_RUNTIME_LINK_LIBS}
+)
+ptoas_configure_runtime_compile_target(obj.PTOASCompilerImplementation)
+target_compile_definitions(obj.PTOASCompilerImplementation PRIVATE
+  "MLIR_PYTHON_PACKAGE_PREFIX=ptoas.mlir."
+  PTOAS_COMPILER_BUILDING_LIBRARY=1
+)
+target_include_directories(PTOASCompilerImplementation PRIVATE
+  "${CMAKE_SOURCE_DIR}/lib/Bindings/Python"
+)
+target_link_libraries(obj.PTOASCompilerImplementation PRIVATE pybind11::module)
+
+# LLVM normally disables RTTI and exceptions. Retain the Python binding
+# contract only for its translation unit while leaving compiler sources on the
+# standard LLVM flags.
+if(MSVC)
+  set_property(SOURCE "${CMAKE_SOURCE_DIR}/lib/Bindings/Python/PTOModule.cpp"
+    APPEND PROPERTY COMPILE_OPTIONS /EHsc /GR)
+elseif(LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL)
+  set_property(SOURCE "${CMAKE_SOURCE_DIR}/lib/Bindings/Python/PTOModule.cpp"
+    APPEND PROPERTY COMPILE_OPTIONS -frtti -fexceptions)
+endif()
+
+# PTOModule.cpp references the CPython API. As with a regular extension, those
+# symbols are supplied by the interpreter at load time rather than libpython.
+target_link_libraries(PTOASCompiler PRIVATE pybind11::module)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT LLVM_USE_SANITIZER)
+  target_link_options(PTOASCompiler PRIVATE "LINKER:-z,undefs")
+endif()
+set_target_properties(PTOASCompiler PROPERTIES
+  CXX_VISIBILITY_PRESET hidden
+  VISIBILITY_INLINES_HIDDEN YES
+)
+
+# Build the single PTOAS-owned Python extension as a thin entry point. Compiler,
+# PTO dialect, and MLIR CAPI implementation all live in PTOASCompiler.
 set(PTOAS_BUILD_PYTHON_PACKAGE_DIR "${CMAKE_BINARY_DIR}/python/ptoas")
 add_mlir_python_extension(PTOASPythonCore _core
   INSTALL_COMPONENT PTOAS_Python
@@ -117,11 +158,8 @@ add_mlir_python_extension(PTOASPythonCore _core
   PYTHON_BINDINGS_LIBRARY pybind11
   SOURCES
     NativeModule.cpp
-    "${CMAKE_SOURCE_DIR}/lib/Bindings/Python/PTOModule.cpp"
   LINK_LIBS
-    ptoas_runtime_objects
-    PTOCAPI
-    PTOASPythonCAPI
+    PTOASCompiler
 )
 target_compile_definitions(PTOASPythonCore PRIVATE
   "MLIR_PYTHON_PACKAGE_PREFIX=ptoas.mlir."

--- a/tools/ptoas/ptoas.h
+++ b/tools/ptoas/ptoas.h
@@ -10,6 +10,7 @@
 #define PTOAS_H
 
 #include "ObjectEmission.h"
+#include "PTO/Compiler/CompilerApi.h"
 #include "PTO/Transforms/VPTOLLVMEmitter.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
@@ -126,7 +127,7 @@ void registerPTOASPassesAndCLOptions();
 void loadPTOASDialects(MLIRContext &context);
 
 // Reusable driver entry shared by the Python extension and standalone CLI.
-int runPTOAS(int argc, char **argv);
+PTOAS_COMPILER_EXPORT int runPTOAS(int argc, char **argv);
 
 // Attach textual-.pto SSA name hints (function args, block args, op results)
 // to the parsed module's Locations as debug metadata. Called by the driver

--- a/tools/ptobc/CMakeLists.txt
+++ b/tools/ptobc/CMakeLists.txt
@@ -16,25 +16,23 @@
 # NOTE: Do NOT call cmake_minimum_required()/project() or find_package() here.
 # PTOAS top-level already configures LLVM/MLIR and exports PTOAS:: targets.
 
-add_library(ptobc_lib STATIC
+add_mlir_library(ptobc_lib
+  OBJECT
+  ENABLE_AGGREGATION
+  EXCLUDE_FROM_LIBMLIR
+  DISABLE_INSTALL
+
   src/leb128.cpp
   src/ptobc_format.cpp
   src/mlir_helpers.cpp
   src/mlir_encode.cpp
   src/canonical_printer.cpp
   src/ptobc_decode_print.cpp
-)
 
-target_include_directories(ptobc_lib PUBLIC
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/generated
-)
+  LINK_COMPONENTS
+  Support
 
-# MLIR/LLVM deps
-llvm_map_components_to_libnames(PTObc_LLVM_LIBS Support)
-
-target_link_libraries(ptobc_lib PUBLIC
-  ${PTObc_LLVM_LIBS}
+  LINK_LIBS PUBLIC
   PTOIR
   MLIRIR
   MLIRParser
@@ -43,6 +41,20 @@ target_link_libraries(ptobc_lib PUBLIC
   MLIRArithDialect
   MLIRSCFDialect
 )
+
+target_include_directories(ptobc_lib PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/generated
+)
+
+# ptobc reports malformed input through C++ exceptions. add_mlir_library
+# applies LLVM's default no-exceptions flags, so restore the existing ptobc
+# compilation contract on the object target used by the aggregate.
+if(MSVC)
+  target_compile_options(obj.ptobc_lib PRIVATE /EHsc)
+elseif(LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL)
+  target_compile_options(obj.ptobc_lib PRIVATE -fexceptions)
+endif()
 
 add_executable(ptobc
   src/main.cpp


### PR DESCRIPTION
## 背景

当前 wheel 使用动态 LLVM/MLIR 构建，`auditwheel`/`delocate` 需要遍历并搬运大量组件动态库。该依赖图在 macOS 上尤其昂贵，wheel repair 经常成为整条构建链路的主要耗时，也使发布 wheel 包含大量独立 LLVM/MLIR 动态库。

## 修改

- 将 MLIR Python common CAPI 扩展为包内唯一的 `PTOASCompiler` DSO：
  - 聚合 PTO CAPI、IR、Transforms、ptobc 和 compiler driver；
  - 将 `_core` 收敛为只包含 Python 入口的薄模块；
  - 通过显式导出宏暴露 `_core` 所需的两个内部 bridge；
  - 去掉包内 DSO 的版本化文件名，避免 wheel 同时存入实体文件和 symlink 副本。
- 保持一套 PTOAS CMake target graph，通过 LLVM SDK 配置选择链接方式：
  - 开发环境和普通门禁继续使用动态 LLVM/MLIR；
  - Linux/macOS wheel 使用 static PIC LLVM/MLIR，将所需实现链接进 `PTOASCompiler`。
- 增加 wheel/安装树依赖检查：
  - 要求包内恰好存在一个 `libPTOASCompiler`；
  - 拒绝旧的 `libPTOASPythonCAPI`；
  - 静态 wheel 中拒绝 native extension 或 `PTOASCompiler` 继续直接依赖 LLVM/MLIR/PTO 实现动态库。
- 更新 standalone compiler archive 的 relocation 逻辑，并补充完整设计文档和既有 namespace 设计的衔接说明。
- 重新开启 macOS wheel 的 PR 触发，PR 使用 Python 3.11 x x86_64/aarch64 精简矩阵验证静态链接和 repair 表现。
- 修正最新主线 lane-stride pack 代码在 Apple libc++ 下的 `std::min` 类型推导问题，使 macOS wheel 能编译该路径。

## Wheel 体积

本地使用与 wheel workflow 相同的 static PIC LLVM 配置构建 Linux x86_64 wheel，并与当前发布 wheel 比较：

| 产物 | 大小 | 相对当前发布 wheel |
| --- | ---: | ---: |
| 当前发布 wheel | 80,439,451 bytes | - |
| static LLVM raw wheel | 34,338,435 bytes | -57.31% |
| `auditwheel repair` 后 | 34,707,899 bytes | -56.85% |

- repair 后 wheel 减少 45,731,552 bytes，约 43.4 MiB。
- wheel 内没有独立的 `libLLVM*`/`libMLIR*`；LLVM/MLIR 所需实现聚合到一个 `libPTOASCompiler.so`。
- `libPTOASCompiler.so` 未压缩大小为 119,203,184 bytes，在 wheel 中压缩为 32,886,852 bytes。
- 本机 Conda GCC 15 只能 repair 为 `manylinux_2_39_x86_64`；正式 workflow 使用的 `manylinux_2_34` 精确体积仍以 CI 产物为准，但本地结果已经覆盖静态链接、依赖收集和压缩后的完整链路。

## 本地验证

- 使用与 CI 对齐的 LLVM revision 构建完整 static PIC LLVM/MLIR/Clang SDK，启用 ccache 和 32 路并行。
- 使用该 SDK 构建 PTOAS static LLVM wheel，并成功链接聚合 `libPTOASCompiler.so`。
- 通过 wheel payload 检查和 static LLVM native dependency 检查：4 个 native extension 均只由 `libPTOASCompiler` 持有 PTOAS/LLVM 实现，不再直接依赖 LLVM/MLIR/PTO 实现动态库。
- 对 raw wheel 和 repair 后 wheel分别执行隔离 venv 安装验证：
  - `ptoas.mlir.ir`、PTO dialect、`ptodsl` 和 `_core` 导入成功；
  - `ptoas --version` 成功；
  - 清空 `PYTHONPATH` 和动态库环境后，PTODSL compile-only probe 及 PTOAS CLI smoke 成功。
- 共享 LLVM profile 下继续构建 `PTOASPythonPackage` 和 `ptobc`，验证开发环境链接方式不变。
- 最新主线 rebase 后重新编译 `obj.PTOTransforms` 和聚合 `libPTOASCompiler.so`，验证 macOS 可移植性修复不影响 Linux 构建。
- 通过 YAML、shell、Python 语法和 `git diff --check` 检查。

## CI 验证边界

- Linux/macOS wheel workflow 负责验证正式 manylinux/macOS 构建环境、两个架构的 static LLVM 最终链接、repair 和安装 smoke。
- 本地没有 macOS 环境，因此 macOS dylib 体积和 `delocate` 实际耗时以本 PR workflow 为准。
