### PR TITLE
perf(vmi): prioritize one-chunk cast layouts

### DIFF
--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -65,6 +65,11 @@ enum class VMICastLayoutPort {
   Result,
 };
 
+enum class VMICastLayoutPriority {
+  Normal,
+  High,
+};
+
 enum class VMIInterleaveLayoutPort {
   Lhs,
   Rhs,
@@ -78,6 +83,7 @@ struct VMICastLayoutFact {
   VMILayoutAttr resultLayout;
   int64_t sourceBits = 0;
   int64_t resultBits = 0;
+  VMICastLayoutPriority priority = VMICastLayoutPriority::Normal;
 };
 
 struct VMIMaskGranularityCastLayoutFact {

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -62,6 +62,7 @@ enum class DataLayoutSeedPhase {
   GroupSlotLoad,
   GroupBroadcast,
   GroupBroadcastLoad,
+  CompactCast,
   GroupStore,
   Cast,
   WeakReduce,
@@ -261,6 +262,12 @@ struct LayoutSolver {
 
   VMILayoutAttr getContiguousLayout() {
     return VMILayoutAttr::getContiguous(ctx);
+  }
+
+  DataLayoutSeedPhase getCastSeedPhase(const VMICastLayoutFact &fact) {
+    return fact.priority == VMICastLayoutPriority::High
+               ? DataLayoutSeedPhase::CompactCast
+               : DataLayoutSeedPhase::Cast;
   }
 
   VMILayoutAttr getPreferredDenseStoreLayout(VMIVRegType type) {
@@ -1059,7 +1066,7 @@ struct LayoutSolver {
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         if (succeeded(fact)) {
           if (failed(setPreferredLayout(extf.getResult(), fact->resultLayout,
-                                        op, DataLayoutSeedPhase::Cast)))
+                                        op, getCastSeedPhase(*fact))))
             return WalkResult::interrupt();
         }
         return WalkResult::advance();
@@ -1072,7 +1079,7 @@ struct LayoutSolver {
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         if (succeeded(fact)) {
           if (failed(setPreferredLayout(extsi.getResult(), fact->resultLayout,
-                                        op, DataLayoutSeedPhase::Cast)))
+                                        op, getCastSeedPhase(*fact))))
             return WalkResult::interrupt();
         }
         return WalkResult::advance();
@@ -1085,7 +1092,7 @@ struct LayoutSolver {
             supports.getPreferredCastLayoutFact(sourceType, resultType);
         if (succeeded(fact)) {
           if (failed(setPreferredLayout(extui.getResult(), fact->resultLayout,
-                                        op, DataLayoutSeedPhase::Cast)))
+                                        op, getCastSeedPhase(*fact))))
             return WalkResult::interrupt();
         }
         return WalkResult::advance();
@@ -1100,8 +1107,12 @@ struct LayoutSolver {
         if (succeeded(fact)) {
           resultLayout = fact->resultLayout;
         }
+        DataLayoutSeedPhase phase =
+            succeeded(fact)
+                ? getCastSeedPhase(*fact)
+                : DataLayoutSeedPhase::Cast;
         if (failed(setPreferredLayout(truncf.getResult(), resultLayout, op,
-                                      DataLayoutSeedPhase::Cast)))
+                                      phase)))
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
@@ -1115,8 +1126,12 @@ struct LayoutSolver {
         if (succeeded(fact)) {
           resultLayout = fact->resultLayout;
         }
+        DataLayoutSeedPhase phase =
+            succeeded(fact)
+                ? getCastSeedPhase(*fact)
+                : DataLayoutSeedPhase::Cast;
         if (failed(setPreferredLayout(trunci.getResult(), resultLayout, op,
-                                      DataLayoutSeedPhase::Cast)))
+                                      phase)))
           return WalkResult::interrupt();
         return WalkResult::advance();
       }

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -168,6 +168,16 @@ static bool matchesElementCountPattern(ElementCountPattern pattern,
   return false;
 }
 
+static bool matchesPhysicalChunkCountPattern(
+    PhysicalChunkCountPattern pattern, int64_t chunkCount) {
+  if (chunkCount <= 0)
+    return false;
+  for (int64_t i = 0; i < pattern.count; ++i)
+    if (pattern.values[i] == chunkCount)
+      return true;
+  return false;
+}
+
 static bool matchesMaskGranularityPattern(MaskGranularityPattern pattern,
                                           StringRef granularity) {
   uint8_t mask = granularity == "b8"    ? 1u << 0
@@ -402,6 +412,15 @@ struct PreferredCastLayoutPattern {
   LayoutPattern resultLayout;
 };
 
+struct HighPriorityCastLayoutPattern {
+  ElementBitsPattern sourceBits;
+  ElementBitsPattern resultBits;
+  PhysicalChunkCountPattern sourceChunks;
+  PhysicalChunkCountPattern resultChunks;
+  LayoutPattern sourceLayout;
+  LayoutPattern resultLayout;
+};
+
 struct LegalCastLayoutPattern {
   ElementBitsPattern sourceBits;
   ElementBitsPattern resultBits;
@@ -450,6 +469,19 @@ static constexpr PreferredCastLayoutPattern
         {bits<16>(), bits<8>(), 0, c(), ls(2)},
         {bits<32>(), bits<16>(), 0, c(), ls(2)},
         {bits<32>(), bits<8>(), 0, c(), ls(4)},
+};
+
+static constexpr HighPriorityCastLayoutPattern
+    kHighPriorityCastLayoutPatterns[] = {
+        // One-chunk widening relations.
+        {bits<8>(), bits<16>(), chunk<1>(), chunk<1>(), ls(2), c()},
+        {bits<16>(), bits<32>(), chunk<1>(), chunk<1>(), ls(2), c()},
+        {bits<8>(), bits<32>(), chunk<1>(), chunk<1>(), ls(4), c()},
+
+        // One-chunk narrowing relations.
+        {bits<16>(), bits<8>(), chunk<1>(), chunk<1>(), c(), ls(2)},
+        {bits<32>(), bits<16>(), chunk<1>(), chunk<1>(), c(), ls(2)},
+        {bits<32>(), bits<8>(), chunk<1>(), chunk<1>(), c(), ls(4)},
 };
 
 static constexpr LegalCastLayoutPattern kLegalCastLayoutPatterns[] = {
@@ -884,12 +916,7 @@ struct InterleaveLayoutKey {
 
 static bool matchesPhysicalChunkCountPattern(
     PhysicalChunkCountPattern pattern, InterleaveLayoutKey key) {
-  if (key.physicalChunkCount <= 0)
-    return false;
-  for (int64_t i = 0; i < pattern.count; ++i)
-    if (pattern.values[i] == key.physicalChunkCount)
-      return true;
-  return false;
+  return matchesPhysicalChunkCountPattern(pattern, key.physicalChunkCount);
 }
 
 static bool matchesInterleaveLayoutPattern(
@@ -1409,13 +1436,68 @@ static std::pair<int64_t, int64_t> getCastElementBits(VMIVRegType sourceType,
 static VMICastLayoutFact makeCastLayoutFact(int64_t sourceBits,
                                             int64_t resultBits,
                                             VMILayoutAttr sourceLayout,
-                                            VMILayoutAttr resultLayout) {
+                                            VMILayoutAttr resultLayout,
+                                            VMICastLayoutPriority priority =
+                                                VMICastLayoutPriority::Normal) {
   VMICastLayoutFact fact;
   fact.sourceBits = sourceBits;
   fact.resultBits = resultBits;
   fact.sourceLayout = sourceLayout;
   fact.resultLayout = resultLayout;
+  fact.priority = priority;
   return fact;
+}
+
+static FailureOr<VMICastLayoutFact>
+getHighPriorityCastLayoutFactImpl(VMIVRegType sourceType,
+                                  VMIVRegType resultType,
+                                  bool allowLaneStrideNarrowing,
+                                  std::string *reason) {
+  auto [sourceBits, resultBits] = getCastElementBits(sourceType, resultType);
+  if (!allowLaneStrideNarrowing && sourceBits > resultBits)
+    return failure();
+
+  MLIRContext *ctx = sourceType.getContext();
+  std::optional<VMICastLayoutFact> selected;
+  for (const HighPriorityCastLayoutPattern &pattern :
+       kHighPriorityCastLayoutPatterns) {
+    if (!matchesElementBitsPattern(pattern.sourceBits, sourceBits) ||
+        !matchesElementBitsPattern(pattern.resultBits, resultBits))
+      continue;
+
+    VMILayoutAttr sourceLayout =
+        materializeLayoutPattern(ctx, pattern.sourceLayout);
+    VMILayoutAttr resultLayout =
+        materializeLayoutPattern(ctx, pattern.resultLayout);
+    auto assignedSourceType = VMIVRegType::get(
+        ctx, sourceType.getElementCount(), sourceType.getElementType(),
+        sourceLayout);
+    auto assignedResultType = VMIVRegType::get(
+        ctx, resultType.getElementCount(), resultType.getElementType(),
+        resultLayout);
+    FailureOr<int64_t> sourceArity = getVMIPhysicalArity(assignedSourceType);
+    FailureOr<int64_t> resultArity = getVMIPhysicalArity(assignedResultType);
+    if (failed(sourceArity) || failed(resultArity) ||
+        !matchesPhysicalChunkCountPattern(pattern.sourceChunks,
+                                          *sourceArity) ||
+        !matchesPhysicalChunkCountPattern(pattern.resultChunks,
+                                          *resultArity))
+      continue;
+    if (selected) {
+      if (reason)
+        *reason = "high-priority cast layout table has ambiguous matching rows";
+      return failure();
+    }
+    selected = makeCastLayoutFact(sourceBits, resultBits, sourceLayout,
+                                  resultLayout,
+                                  VMICastLayoutPriority::High);
+  }
+  if (!selected) {
+    if (reason)
+      *reason = "requires a matching high-priority cast layout table row";
+    return failure();
+  }
+  return *selected;
 }
 
 static int64_t getMaskGranularityBits(StringRef granularity) {
@@ -1493,6 +1575,11 @@ getPreferredLaneStrideNarrowCastLayoutFactImpl(VMIVRegType sourceType,
 
 FailureOr<VMICastLayoutFact> VMILayoutSupport::getPreferredCastLayoutFact(
     VMIVRegType sourceType, VMIVRegType resultType, std::string *reason) const {
+  FailureOr<VMICastLayoutFact> highPriorityFact =
+      getHighPriorityCastLayoutFactImpl(sourceType, resultType,
+                                        preferLaneStrideNarrowing, reason);
+  if (succeeded(highPriorityFact))
+    return highPriorityFact;
   if (preferLaneStrideNarrowing) {
     FailureOr<VMICastLayoutFact> laneStrideFact =
         getPreferredLaneStrideNarrowCastLayoutFactImpl(sourceType, resultType,

--- a/test/lit/vmi_new/opt/fa4_vsstb_cast_layout_opt.pto
+++ b/test/lit/vmi_new/opt/fa4_vsstb_cast_layout_opt.pto
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s | FileCheck %s --check-prefix=VPTO --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi'
+
+// FA4 narrows four one-chunk f32 streams before block-strided stores. Prefer
+// the one-chunk c -> ls2 cast relation before group_store requests contiguous
+// values, then materialize ls2 -> c on the narrower f16 side.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @fa4_vsstb_cast_layout_opt(
+      %src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f16, ub>, %off: index) {
+    %c16 = arith.constant 16 : index
+    %c64 = arith.constant 64 : index
+    %c128 = arith.constant 128 : index
+    %c192 = arith.constant 192 : index
+    %c1024 = arith.constant 1024 : index
+    %c1040 = arith.constant 1040 : index
+    %c2064 = arith.constant 2064 : index
+
+    %x0 = pto.vmi.load %src[%off]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    %x1 = pto.vmi.load %src[%c64]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    %x2 = pto.vmi.load %src[%c128]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    %x3 = pto.vmi.load %src[%c192]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+
+    %h0 = pto.vmi.truncf %x0 {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+    %h1 = pto.vmi.truncf %x1 {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+    %h2 = pto.vmi.truncf %x2 {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+    %h3 = pto.vmi.truncf %x3 {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+
+    pto.vmi.group_store %h0, %dst[%off], %c2064 {num_groups = 4 : i64}
+        : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>
+    pto.vmi.group_store %h1, %dst[%c16], %c2064 {num_groups = 4 : i64}
+        : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>
+    pto.vmi.group_store %h2, %dst[%c1024], %c2064 {num_groups = 4 : i64}
+        : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>
+    pto.vmi.group_store %h3, %dst[%c1040], %c2064 {num_groups = 4 : i64}
+        : !pto.vmi.vreg<64xf16>, !pto.ptr<f16, ub>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @fa4_vsstb_cast_layout_opt(
+// ASSIGN-COUNT-4: pto.vmi.load
+// ASSIGN-SAME: -> !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN-COUNT-4: pto.vmi.truncf
+// ASSIGN-SAME: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>> -> !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+// ASSIGN-COUNT-4: pto.vmi.ensure_layout
+// ASSIGN-SAME: !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>> -> !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous>>
+
+// VPTO-LABEL: func.func @fa4_vsstb_cast_layout_opt(
+// VPTO-NOT: pto.vdintlv
+// VPTO-COUNT-4: pto.vcvt {{.*}} {part = "EVEN"
+// VPTO-NOT: part = "ODD"
+// VPTO-NOT: pto.vor
+// VPTO: pto.vpack {{.*}}, "LOWER"
+// VPTO: pto.vsstb
+// VPTO: pto.vpack {{.*}}, "LOWER"
+// VPTO: pto.vsstb
+// VPTO: pto.vpack {{.*}}, "LOWER"
+// VPTO: pto.vsstb
+// VPTO: pto.vpack {{.*}}, "LOWER"
+// VPTO: pto.vsstb


### PR DESCRIPTION
## 背景

FA4 的四路 `f32 -> f16` 窄化结果随后进入 `group_store`。原有 layout seed 顺序会先满足 `group_store` 的 contiguous 要求，使上游 `f32` load 选择双 chunk layout，最终产生额外的 `vdintlv`/`vor`。

对于 source/result 都只占一个物理 chunk 的 cast，优先选择 `c <-> ls(2|4)` 不会增加 chunk 数，可以把 layout 转换放到窄类型一侧并 lower 为 `vpack`，避免上述额外指令。

Fixes mouliangyu/PTOAS#567

该 issue 中的额外 ASU 算址已由已合入的 hw-native-sys/PTOAS#1054 修复：stateless stride store 发射 resultless 普通 `vsstb`，由 Bisheng 自动形成 post-update 指针递推。本 PR 补齐剩余的 layout/instruction-selection 问题。

## 修改

- 为 cast layout fact 增加 `Normal`/`High` 优先级。
- 通过显式表项枚举 source/result 均为单 chunk 的 widening/narrowing `c <-> ls(2|4)` 关系，并在 layout assignment 中让这些表项早于 `group_store` 生效。
- 多 chunk cast 仍保持普通 cast 优先级，不改变原有选择。
- 新增 FA4 `opt` 回归，监控 assignment 中的 `c -> ls2 -> c` 形态以及最终 `4 x vcvt(EVEN) + 4 x vpack(LOWER) + 4 x vsstb`，同时禁止 `vdintlv`、ODD `vcvt` 和 `vor`。

## 验证

- `cmake --build build --target pto-test-opt PTOASPythonCore -j 16`
- 定向 FA4 与多 chunk 边界用例：2/2 通过
- `vmi_new`：442/442 通过
- 完整 lit：1434 passed，1 unsupported；5 个既有基线失败（1 个 soft-postupdate 检查、4 个 TileLib `tadd` 检查），未新增失败
