### PR TITLE
feat: 支持 tput/tget 动态分区 shape

### DIFF
--- a/docs/PTO_IR_manual.md
+++ b/docs/PTO_IR_manual.md
@@ -10201,7 +10201,7 @@ This section documents PTO communication primitives. PTOAS currently exposes:
 
 ##### `pto.comm.tput` - Synchronous Remote Write
 
-**Summary:** Lowers to `pto::comm::TPUT(...)` and copies data from local GM to remote GM through a VEC staging tile.
+**Summary:** Copies data synchronously from local GM to remote GM through a VEC staging tile.
 
 **Arguments:**
 
@@ -10214,9 +10214,29 @@ This section documents PTO communication primitives. PTOAS currently exposes:
 
 **Constraints & Verification:**
 
-- `dst` / `src` must be GM-shaped values with positive static shapes.
-- `dst` and `src` must have the same element type and static shape.
-- `ping` / `pong` must be local VEC tile-like values whose element type matches `src`.
+- `dst` / `src` must be GM-shaped values. Static dimensions must be positive.
+- Dynamic dimensions are supported only when both operands are
+  `pto.partition_tensor_view` values.
+- `dst` and `src` must have the same element type and identical static/dynamic
+  shape signatures. Corresponding dynamic extents must be equal at runtime.
+- Runtime extents must be nonnegative, and each partition range must remain
+  within its backing tensor view. A zero extent denotes an empty transfer.
+- `ping` / `pong` must be local VEC tile-like values whose element type matches
+  `src`. Their physical `rows` / `cols` must be positive static values.
+- Staging `v_row` / `v_col` values must be positive and may be static or
+  dynamic. If a transfer enters the chunked path, a static `v_row` / `v_col`
+  must exactly divide the corresponding logical row / column extent. Use
+  dynamic valid dimensions when a partial final chunk is possible.
+- When `pong` is present, it must have the same type as `ping`.
+
+**Semantics:**
+
+For every logical index in the common `src` / `dst` shape, the operation reads
+the local `src` element and writes the corresponding remote `dst` element.
+`atomic_none` performs a normal write; an atomic mode such as `atomic_add`
+combines the source value with the destination according to that mode. The
+staging bundle may divide the logical range into chunks but does not change the
+logical transfer extent.
 
 **Examples:**
 
@@ -10228,11 +10248,36 @@ pto.comm.tput(%dst, %src, buf(%ping) : !pto.partition_tensor_view<128xf32>, !pto
 pto.comm.tput(%dst, %src, buf(%ping, %pong) : !pto.partition_tensor_view<128xf32>, !pto.partition_tensor_view<128xf32>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {atomicType = #pto<atomic_type atomic_add>}
 ```
 
+For a variable-size transfer, construct both partitions with the same runtime
+extent and use dynamic staging valid dimensions when the extent may require a
+partial final chunk:
+
+```mlir
+%dst_part = pto.partition_view %dst_view,
+  offsets = [%c0, %c0], sizes = [%rows, %c4096]
+  : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<?x4096xi8>
+%src_part = pto.partition_view %src_view,
+  offsets = [%c0, %c0], sizes = [%rows, %c4096]
+  : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<?x4096xi8>
+%stage = pto.alloc_tile addr = %c0_i64
+  valid_row = %c1 valid_col = %c4096
+  : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096,
+                  v_row=?, v_col=?, blayout=row_major,
+                  slayout=none_box, fractal=512, pad=0>
+pto.comm.tput(%dst_part, %src_part, buf(%stage)
+  : !pto.partition_tensor_view<?x4096xi8>,
+    !pto.partition_tensor_view<?x4096xi8>,
+    !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096,
+                  v_row=?, v_col=?, blayout=row_major,
+                  slayout=none_box, fractal=512, pad=0>)
+  {atomicType = #pto<atomic_type atomic_none>}
+```
+
 ---
 
 ##### `pto.comm.tget` - Synchronous Remote Read
 
-**Summary:** Lowers to `pto::comm::TGET(...)` and copies data from remote GM to local GM through a VEC staging tile.
+**Summary:** Copies data synchronously from remote GM to local GM through a VEC staging tile.
 
 **Arguments:**
 
@@ -10245,8 +10290,17 @@ pto.comm.tput(%dst, %src, buf(%ping, %pong) : !pto.partition_tensor_view<128xf32
 
 **Constraints & Verification:**
 
-- Same GM/global-like and staging constraints as `pto.comm.tput`.
-- `dst` and `src` must have the same element type and static shape.
+- The GM/global-like, dynamic partition, runtime extent, zero-length, and
+  staging constraints are the same as for `pto.comm.tput`.
+- `dst` and `src` must have the same element type and identical static/dynamic
+  shape signatures.
+
+**Semantics:**
+
+For every logical index in the common `src` / `dst` shape, the operation reads
+the remote `src` element and writes the corresponding local `dst` element. The
+staging bundle may divide the logical range into chunks but does not change the
+logical transfer extent.
 
 **Examples:**
 

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3934,8 +3934,14 @@ static bool isCommGlobalLikeType(Type ty) {
   return isa<pto::TensorViewType, pto::PartitionTensorViewType>(ty);
 }
 
-static LogicalResult verifyCommGlobalLike(Operation *op, Value value,
-                                          StringRef name) {
+enum class CommGlobalShapePolicy {
+  StaticOnly,
+  AllowDynamicPartitionView,
+};
+
+static LogicalResult verifyCommGlobalLike(
+    Operation *op, Value value, StringRef name,
+    CommGlobalShapePolicy policy = CommGlobalShapePolicy::StaticOnly) {
   Type ty = value.getType();
   if (!isCommGlobalLikeType(ty))
     return op->emitOpError()
@@ -3944,10 +3950,23 @@ static LogicalResult verifyCommGlobalLike(Operation *op, Value value,
   SmallVector<int64_t, 4> shape = getShapeVec(ty);
   if (shape.empty())
     return op->emitOpError() << "expects " << name << " to have rank >= 1";
+
+  bool opAllowsDynamic =
+      policy == CommGlobalShapePolicy::AllowDynamicPartitionView;
+  bool isAllowedDynamicType = isa<pto::PartitionTensorViewType>(ty);
   for (int64_t dim : shape) {
-    if (dim == ShapedType::kDynamic || dim <= 0)
-      return op->emitOpError() << "expects " << name
-                               << " to have a positive static shape";
+    if (dim == ShapedType::kDynamic) {
+      if (!opAllowsDynamic)
+        return op->emitOpError()
+               << "does not support dynamic dimensions on " << name;
+      if (!isAllowedDynamicType)
+        return op->emitOpError() << "allows dynamic dimensions on " << name
+                                 << " only for partition_tensor_view";
+      continue;
+    }
+    if (dim <= 0)
+      return op->emitOpError() << "expects every static dimension of " << name
+                               << " to be positive";
   }
   return success();
 }
@@ -16299,8 +16318,12 @@ LogicalResult TGetAsyncOp::verify() {
 }
 
 LogicalResult TPutOp::verify() {
-  if (failed(verifyCommGlobalLike(*this, getDst(), "dst")) ||
-      failed(verifyCommGlobalLike(*this, getSrc(), "src")) ||
+  if (failed(verifyCommGlobalLike(
+          *this, getDst(), "dst",
+          CommGlobalShapePolicy::AllowDynamicPartitionView)) ||
+      failed(verifyCommGlobalLike(
+          *this, getSrc(), "src",
+          CommGlobalShapePolicy::AllowDynamicPartitionView)) ||
       failed(verifyCommStagingTileLike(*this, getPing(), "ping")) ||
       failed(verifyCommPingPongSameType(*this, getPing(), getPong(), "ping",
                                         "pong")))
@@ -16308,15 +16331,20 @@ LogicalResult TPutOp::verify() {
   if (getElemTy(getDst().getType()) != getElemTy(getSrc().getType()))
     return emitOpError("expects src and dst to have the same element type");
   if (getShapeVec(getDst().getType()) != getShapeVec(getSrc().getType()))
-    return emitOpError("expects src and dst to have the same static shape");
+    return emitOpError(
+        "expects src and dst to have the same static/dynamic shape signature");
   if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType()))
     return emitOpError("expects staging tile element type to match src/dst");
   return success();
 }
 
 LogicalResult TGetOp::verify() {
-  if (failed(verifyCommGlobalLike(*this, getDst(), "dst")) ||
-      failed(verifyCommGlobalLike(*this, getSrc(), "src")) ||
+  if (failed(verifyCommGlobalLike(
+          *this, getDst(), "dst",
+          CommGlobalShapePolicy::AllowDynamicPartitionView)) ||
+      failed(verifyCommGlobalLike(
+          *this, getSrc(), "src",
+          CommGlobalShapePolicy::AllowDynamicPartitionView)) ||
       failed(verifyCommStagingTileLike(*this, getPing(), "ping")) ||
       failed(verifyCommPingPongSameType(*this, getPing(), getPong(), "ping",
                                         "pong")))
@@ -16324,7 +16352,8 @@ LogicalResult TGetOp::verify() {
   if (getElemTy(getDst().getType()) != getElemTy(getSrc().getType()))
     return emitOpError("expects src and dst to have the same element type");
   if (getShapeVec(getDst().getType()) != getShapeVec(getSrc().getType()))
-    return emitOpError("expects src and dst to have the same static shape");
+    return emitOpError(
+        "expects src and dst to have the same static/dynamic shape signature");
   if (getElemTy(getPing().getType()) != getElemTy(getSrc().getType()))
     return emitOpError("expects staging tile element type to match src/dst");
   return success();

--- a/test/lit/pto/comm_dynamic_async_scope_invalid.pto
+++ b/test/lit/pto/comm_dynamic_async_scope_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @dynamic_async_p2p(
+      %dst: !pto.partition_tensor_view<?xf32>,
+      %src: !pto.partition_tensor_view<?xf32>,
+      %session: !pto.async_session) {
+    %event = pto.comm.tput_async(%dst, %src, %session : !pto.partition_tensor_view<?xf32>, !pto.partition_tensor_view<?xf32>, !pto.async_session) -> !pto.async_event
+    return
+  }
+}
+
+// CHECK: error: 'pto.comm.tput_async' op expects dst to have a static shape

--- a/test/lit/pto/comm_dynamic_collective_scope_invalid.pto
+++ b/test/lit/pto/comm_dynamic_collective_scope_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @dynamic_collective(
+      %src: !pto.partition_tensor_view<?x128xf32>,
+      %peer: !pto.partition_tensor_view<?x128xf32>,
+      %stage: !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {
+    pto.comm.tbroadcast(%src, recv(%stage), group(%peer) : !pto.partition_tensor_view<?x128xf32>, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.partition_tensor_view<?x128xf32>) {root = 0 : i32}
+    return
+  }
+}
+
+// CHECK: error: 'pto.comm.tbroadcast' op does not support dynamic dimensions on src

--- a/test/lit/pto/comm_dynamic_signal_scope_invalid.pto
+++ b/test/lit/pto/comm_dynamic_signal_scope_invalid.pto
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @dynamic_signal(
+      %signal: !pto.partition_tensor_view<?xi32>, %value: i32) {
+    pto.comm.tnotify(%signal, %value : !pto.partition_tensor_view<?xi32>, i32) {notifyOp = #pto<notify_op set>}
+    return
+  }
+}
+
+// CHECK: error: 'pto.comm.tnotify' op does not support dynamic dimensions on signal

--- a/test/lit/pto/comm_p2p_dynamic_partition_emitc.pto
+++ b/test/lit/pto/comm_p2p_dynamic_partition_emitc.pto
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 %s -o - 2>&1 | FileCheck %s --check-prefix=EMITC
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --mlir-print-ir-after=pto-resolve-buffer-select %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=NATIVE
+
+module {
+  func.func @comm_p2p_dynamic_partition(
+      %dst_ptr: !pto.ptr<i8>, %src_ptr: !pto.ptr<i8>, %runtime_rows: i32) {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c4096 = arith.constant 4096 : index
+    %rows = arith.index_cast %runtime_rows : i32 to index
+    %dst_view = pto.make_tensor_view %dst_ptr, shape = [%c32, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xi8>
+    %src_view = pto.make_tensor_view %src_ptr, shape = [%c32, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xi8>
+    %dst = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%rows, %c4096] : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<?x4096xi8>
+    %src = pto.partition_view %src_view, offsets = [%c0, %c0], sizes = [%rows, %c4096] : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<?x4096xi8>
+    %stage = pto.alloc_tile addr = %c0_i64 valid_row = %c1 valid_col = %c4096 : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.comm.tput(%dst, %src, buf(%stage) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {atomicType = #pto<atomic_type atomic_none>}
+    pto.comm.tget(%dst, %src, buf(%stage) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+
+  // A static valid shape remains legal. At runtime its row/column values must
+  // divide the transfer shape whenever the transfer enters the chunked path.
+  func.func @comm_p2p_dynamic_partition_static_valid(
+      %dst_ptr: !pto.ptr<i8>, %src_ptr: !pto.ptr<i8>, %runtime_rows: i32) {
+    %c0_i64 = arith.constant 0 : i64
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c4096 = arith.constant 4096 : index
+    %rows = arith.index_cast %runtime_rows : i32 to index
+    %dst_view = pto.make_tensor_view %dst_ptr, shape = [%c32, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xi8>
+    %src_view = pto.make_tensor_view %src_ptr, shape = [%c32, %c4096], strides = [%c4096, %c1] {layout = #pto.layout<nd>} : !pto.tensor_view<?x?xi8>
+    %dst = pto.partition_view %dst_view, offsets = [%c0, %c0], sizes = [%rows, %c4096] : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<?x4096xi8>
+    %src = pto.partition_view %src_view, offsets = [%c0, %c0], sizes = [%rows, %c4096] : !pto.tensor_view<?x?xi8> -> !pto.partition_tensor_view<?x4096xi8>
+    %stage = pto.alloc_tile addr = %c0_i64 : !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    pto.comm.tput(%dst, %src, buf(%stage) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {atomicType = #pto<atomic_type atomic_none>}
+    return
+  }
+}
+
+// EMITC: pto::Shape<1, 1, 1, -1, 4096>
+// EMITC-SAME: ({{[^,]+}}, {{[^,]+}}, {{[^,]+}}, {{[^,]+}}, {{[^)]+}})
+// EMITC: pto::Stride<-1, -1, -1, -1, -1>
+// EMITC-SAME: ({{[^,]+}}, {{[^,]+}}, {{[^,]+}}, {{[^,]+}}, {{[^)]+}})
+// EMITC: GlobalTensor<int8_t, pto::Shape<1, 1, 1, -1, 4096>, pto::Stride<-1, -1, -1, -1, -1>, pto::Layout::ND>
+// EMITC: pto::comm::TPUT(
+// EMITC: pto::comm::TGET(
+
+// NATIVE: IR Dump After PTOResolveBufferSelect
+// NATIVE-LABEL: func.func @comm_p2p_dynamic_partition
+// NATIVE: %[[ROWS:.*]] = arith.index_cast
+// NATIVE: %[[DST:.*]] = pto.partition_view {{.*}} sizes = [%[[ROWS]], %c4096]
+// NATIVE: %[[SRC:.*]] = pto.partition_view {{.*}} sizes = [%[[ROWS]], %c4096]
+// NATIVE: pto.comm.tput(%[[DST]], %[[SRC]], buf(
+// NATIVE-SAME: !pto.partition_tensor_view<?x4096xi8>
+// NATIVE: pto.comm.tget(%[[DST]], %[[SRC]], buf(
+// NATIVE-SAME: !pto.partition_tensor_view<?x4096xi8>
+// NATIVE-NOT: memref.subview

--- a/test/lit/pto/comm_p2p_dynamic_partition_verify_invalid.pto
+++ b/test/lit/pto/comm_p2p_dynamic_partition_verify_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @shape_signature_mismatch(
+      %dst: !pto.partition_tensor_view<?x4096xi8>,
+      %src: !pto.partition_tensor_view<?x2048xi8>,
+      %stage: !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {
+    pto.comm.tput(%dst, %src, buf(%stage) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x2048xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {atomicType = #pto<atomic_type atomic_none>}
+    return
+  }
+}
+
+// CHECK: error: 'pto.comm.tput' op expects src and dst to have the same static/dynamic shape signature

--- a/test/lit/pto/comm_p2p_dynamic_tensor_view_invalid.pto
+++ b/test/lit/pto/comm_p2p_dynamic_tensor_view_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @direct_dynamic_tensor_view(
+      %dst: !pto.tensor_view<?x4096xi8>,
+      %src: !pto.tensor_view<?x4096xi8>,
+      %stage: !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {
+    pto.comm.tget(%dst, %src, buf(%stage) : !pto.tensor_view<?x4096xi8>, !pto.tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}
+
+// CHECK: error: 'pto.comm.tget' op allows dynamic dimensions on dst only for partition_tensor_view

--- a/test/lit/pto/comm_p2p_nonpositive_static_invalid.pto
+++ b/test/lit/pto/comm_p2p_nonpositive_static_invalid.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --pto-arch=a3 --emit-pto-ir %s 2>&1 | FileCheck %s
+
+module {
+  func.func @nonpositive_static_dimension(
+      %dst: !pto.partition_tensor_view<0x4096xi8>,
+      %src: !pto.partition_tensor_view<0x4096xi8>,
+      %stage: !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {
+    pto.comm.tput(%dst, %src, buf(%stage) : !pto.partition_tensor_view<0x4096xi8>, !pto.partition_tensor_view<0x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=1, v_col=4096, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {atomicType = #pto<atomic_type atomic_none>}
+    return
+  }
+}
+
+// CHECK: error: 'pto.comm.tput' op expects every static dimension of dst to be positive

--- a/tools/ptobc/testdata/comm_p2p_dynamic_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/comm_p2p_dynamic_v0_roundtrip.pto
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+module {
+  func.func @comm_p2p_dynamic_v0(
+      %dst: !pto.partition_tensor_view<?x4096xi8>,
+      %src: !pto.partition_tensor_view<?x4096xi8>,
+      %ping: !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>,
+      %pong: !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {
+    pto.comm.tput(%dst, %src, buf(%ping) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {atomicType = #pto<atomic_type atomic_none>}
+    pto.comm.tput(%dst, %src, buf(%ping, %pong) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>) {atomicType = #pto<atomic_type atomic_add>}
+    pto.comm.tget(%dst, %src, buf(%ping) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.comm.tget(%dst, %src, buf(%ping, %pong) : !pto.partition_tensor_view<?x4096xi8>, !pto.partition_tensor_view<?x4096xi8>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=i8, rows=1, cols=4096, v_row=?, v_col=?, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    return
+  }
+}

--- a/tools/ptobc/tests/CMakeLists.txt
+++ b/tools/ptobc/tests/CMakeLists.txt
@@ -113,6 +113,14 @@ add_test(NAME ptobc_tstore_fp_v0_encode
     ${CMAKE_CURRENT_LIST_DIR}/tstore_fp_v0_encode.sh
 )
 
+add_test(NAME ptobc_comm_p2p_dynamic_v0_encode
+  COMMAND ${CMAKE_COMMAND} -E env
+    PTOBC_BIN=$<TARGET_FILE:ptobc>
+    PTOAS_BIN=${CMAKE_BINARY_DIR}/tools/ptoas/ptoas
+    TESTDATA_DIR=${PTObc_TESTDATA_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/comm_p2p_dynamic_v0_encode.sh
+)
+
 add_test(NAME ptobc_tdequant_v0_encode
   COMMAND ${CMAKE_COMMAND} -E env
     PTOBC_BIN=$<TARGET_FILE:ptobc>

--- a/tools/ptobc/tests/comm_p2p_dynamic_v0_encode.sh
+++ b/tools/ptobc/tests/comm_p2p_dynamic_v0_encode.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+set -euo pipefail
+
+PTOBC_BIN=${PTOBC_BIN:-}
+if [[ -z "${PTOBC_BIN}" ]]; then
+  echo "error: PTOBC_BIN not set" >&2
+  exit 2
+fi
+
+PTOAS_BIN=${PTOAS_BIN:-}
+if [[ -z "${PTOAS_BIN}" ]]; then
+  echo "error: PTOAS_BIN not set" >&2
+  exit 2
+fi
+
+TESTDATA_DIR=${TESTDATA_DIR:-}
+if [[ -z "${TESTDATA_DIR}" ]]; then
+  echo "error: TESTDATA_DIR not set" >&2
+  exit 2
+fi
+
+IN="${TESTDATA_DIR}/comm_p2p_dynamic_v0_roundtrip.pto"
+OUT_DIR=${OUT_DIR:-"${PWD}/ptobc_comm_p2p_dynamic_out"}
+mkdir -p "${OUT_DIR}"
+
+BC="${OUT_DIR}/comm_p2p_dynamic_v0_roundtrip.ptobc"
+ROUNDTRIP="${OUT_DIR}/comm_p2p_dynamic_v0_roundtrip.roundtrip.pto"
+
+"${PTOBC_BIN}" encode "${IN}" -o "${BC}"
+"${PTOBC_BIN}" decode "${BC}" -o "${ROUNDTRIP}"
+
+[[ $(grep -Fc "pto.comm.tput(" "${ROUNDTRIP}") -eq 2 ]]
+[[ $(grep -Fc "pto.comm.tget(" "${ROUNDTRIP}") -eq 2 ]]
+grep -F "!pto.partition_tensor_view<?x4096xi8>" "${ROUNDTRIP}" >/dev/null
+grep -F "atomic_add" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.comm.tput(%0, %1, buf(%2, %3)" "${ROUNDTRIP}" >/dev/null
+grep -F "pto.comm.tget(%0, %1, buf(%2, %3)" "${ROUNDTRIP}" >/dev/null
+
+"${PTOAS_BIN}" --pto-arch=a3 --emit-pto-ir "${ROUNDTRIP}" -o /dev/null


### PR DESCRIPTION
## 当前状态

设计和实现已完成，并已合并最新 `main`（`71894b5db8df35bc41436605890100380e26af8d`）解决冲突。PR 已迁移到当前 tile-native 通信链路，不再依赖已删除的 `PTOViewToMemref` / decoded-memref bypass。

## 实现内容

- 为 `verifyCommGlobalLike()` 增加显式 `CommGlobalShapePolicy`：默认继续要求静态 shape，仅同步 `pto.comm.tput/tget` 的 `dst/src` 使用 `AllowDynamicPartitionView`。
- 动态维只对 `!pto.partition_tensor_view` 开放；直接动态 `tensor_view` 仍由 verifier 拒绝，静态维仍必须大于 `0`。
- `dst/src` 继续要求元素类型相同、静态/动态 shape 签名完全相同，并更新对应诊断。
- signal、collective、async P2P 和 VEC staging tile 物理 `rows/cols` 均保持原有静态约束。
- 复用主线现有 `PTOPartitionViewToEmitC -> buildRuntimeGlobalTensor -> PTOP2PCommToEmitC` 链路，不修改 P2P lowering、ptobc schema 或 pto-isa。

## 合并 main 后的迁移

- `PTOCommType` 已采用 tile-native `tensor_view/partition_tensor_view/tile_buf` operand；旧的直接动态 memref 负例已移除。
- pass-seam 回归从已删除的 `pto-view-to-memref` 改为 `pto-resolve-buffer-select`，检查动态 size 保留在 `pto.partition_view`，且中间 IR 不退回 `memref.subview`。
- EmitC 回归按主线真实 descriptor 更新：`Shape<1, 1, 1, -1, 4096>` 配合 `Stride<-1, -1, -1, -1, -1>` 的五个运行时参数。
- 用户手册已同步更新为 tile-native 架构；实现约束由手册和回归测试固定。
- ptobc round-trip 已收紧为精确检查 `tput/tget` operand 顺序和可选 pong。

## 测试覆盖

- 动态 `partition_view<?x4096xi8>` 的 `tput/tget` 正向 EmitC 和 tile-native pass seam。
- 动态与静态 staging valid shape。
- shape 签名不一致、直接动态 `tensor_view`、非正数静态维。
- signal、collective、async P2P 未被意外放宽。
- PTO-BC v0 encode/decode round-trip，含 ping-pong、`atomic_add`，并把解码结果重新交给 PTOAS。

## 验证结果

- `CCACHE_DISABLE=1 ninja -C build PTOASPythonPackage ptobc`：通过。
- 定向通信 lit：8/8 passed。
- `ctest --test-dir build -R '^ptobc_comm_p2p_dynamic_v0_encode$' --output-on-failure`：1/1 passed。
- `ninja -C build check-pto`：1539 tests，1538 passed，1 unsupported，0 failed。
- 仓库 license-header checker：通过。
- `git diff --check`：通过。
- 与最新 `main` 的 merge-tree：无冲突。

当前没有匹配的 CANN 设备编译环境，因此生成 C++ 的设备侧仅编译验证仍作为有环境时的补充验证项；EmitC 的 runtime `Shape/Stride/GlobalTensor/TPUT/TGET` 形态已由 lit 固定。

Closes #1069
