### PR TITLE
Fix tile arith.select aliases in autosync

### DIFF
--- a/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIRTranslator.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/SyncSolverIRTranslator.cpp
@@ -13,6 +13,7 @@
 
 #include "PTO/IR/PTO.h"
 #include "../Utils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -80,7 +81,10 @@ llvm::SmallVector<Value> IRTranslator::tracebackMemValsStep(Value val) {
     return out;
   }
 
-  if (auto addPtr = dyn_cast<pto::AddPtrOp>(defOp)) {
+  if (auto select = dyn_cast<arith::SelectOp>(defOp)) {
+    out.push_back(select.getTrueValue());
+    out.push_back(select.getFalseValue());
+  } else if (auto addPtr = dyn_cast<pto::AddPtrOp>(defOp)) {
     out.push_back(addPtr.getPtr());
   } else if (auto intToPtr = dyn_cast<pto::IntToPtrOp>(defOp)) {
     if (auto ptrToInt = intToPtr.getAddr().getDefiningOp<pto::PtrToIntOp>())

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -357,6 +357,10 @@ void PTOIRTranslator::RecursionIR(Region *region) {
     else if (auto bitcast = dyn_cast<pto::BitcastOp>(op)) {
       UpdateAliasBufferInfo(bitcast.getResult(), bitcast.getSrc());
     }
+    else if (auto select = dyn_cast<arith::SelectOp>(op)) {
+      UpdateAliasBufferInfo(select.getResult(), select.getTrueValue());
+      UpdateAliasBufferInfo(select.getResult(), select.getFalseValue());
+    }
 
     // --- Case C: 控制流 (SCF) ---
     else if (auto forOp = dyn_cast<scf::ForOp>(op)) {

--- a/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
+++ b/lib/PTO/Transforms/InsertSync/PTOIRTranslator.cpp
@@ -82,6 +82,18 @@ static pto::AddressSpace getTileAddressSpace(pto::TileBufType type) {
   return pto::AddressSpace::MAT;
 }
 
+static void
+appendUniqueMemInfo(SmallVectorImpl<std::unique_ptr<BaseMemInfo>> &infos,
+                    std::unique_ptr<BaseMemInfo> candidate) {
+  if (!candidate)
+    return;
+  if (llvm::any_of(infos, [&](const std::unique_ptr<BaseMemInfo> &info) {
+        return info && *info == *candidate;
+      }))
+    return;
+  infos.emplace_back(std::move(candidate));
+}
+
 } // namespace
 
 static bool getConstIndexValue(Value value, int64_t &out) {
@@ -829,17 +841,12 @@ void PTOIRTranslator::UpdateAliasBufferInfo(Value result, Value source) {
 
   auto &resultMemInfoVec = buffer2MemInfoMap_[result];
   for (auto &parentInfo : buffer2MemInfoMap_[source])
-    resultMemInfoVec.emplace_back(parentInfo->clone(result));
+    appendUniqueMemInfo(resultMemInfoVec, parentInfo->clone(result));
 }
 
 void PTOIRTranslator::UpdateConservativeAliasBufferInfo(Value result,
                                                         Value source) {
-  if (!result || !source) return;
-  if (!buffer2MemInfoMap_.contains(source)) return;
-
-  auto &resultMemInfoVec = buffer2MemInfoMap_[result];
-  for (auto &parentInfo : buffer2MemInfoMap_[source])
-    resultMemInfoVec.emplace_back(parentInfo->clone(result));
+  UpdateAliasBufferInfo(result, source);
 }
 
 LogicalResult PTOIRTranslator::UpdateIntToPtrOpMemInfo(pto::IntToPtrOp op) {

--- a/test/lit/pto/arith_select_tile_sync.pto
+++ b/test/lit/pto/arith_select_tile_sync.pto
@@ -13,10 +13,31 @@
 // RUN:   | FileCheck %s --check-prefix=GSS
 
 module attributes {pto.target_arch = "a3"} {
-  func.func @arith_select_tile_sync(
+  func.func @arith_select_tile_read_sync(
       %cond: i1,
       %src0: !pto.partition_tensor_view<16x16xf32>,
-      %src1: !pto.partition_tensor_view<16x16xf32>,
+      %dst: !pto.partition_tensor_view<16x16xf32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %addr0 = arith.constant 0 : i64
+    %addr1 = arith.constant 1024 : i64
+    %addr2 = arith.constant 2048 : i64
+    %a = pto.alloc_tile addr = %addr0 : !pto.tile_buf<vec, 16x16xf32>
+    %seed = pto.alloc_tile addr = %addr1 : !pto.tile_buf<vec, 16x16xf32>
+    %b = pto.alloc_tile addr = %addr2 : !pto.tile_buf<vec, 16x16xf32>
+
+    pto.tload ins(%src0 : !pto.partition_tensor_view<16x16xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x16xf32>)
+    pto.tabs ins(%seed : !pto.tile_buf<vec, 16x16xf32>)
+             outs(%b : !pto.tile_buf<vec, 16x16xf32>)
+    %selected = arith.select %cond, %a, %b : !pto.tile_buf<vec, 16x16xf32>
+    pto.tstore ins(%selected : !pto.tile_buf<vec, 16x16xf32>)
+               outs(%dst : !pto.partition_tensor_view<16x16xf32>)
+    return
+  }
+
+  func.func @arith_select_tile_write_sync(
+      %cond: i1,
+      %src: !pto.partition_tensor_view<16x16xf32>,
       %dst: !pto.partition_tensor_view<16x16xf32>)
       attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
     %addr0 = arith.constant 0 : i64
@@ -24,29 +45,45 @@ module attributes {pto.target_arch = "a3"} {
     %a = pto.alloc_tile addr = %addr0 : !pto.tile_buf<vec, 16x16xf32>
     %b = pto.alloc_tile addr = %addr1 : !pto.tile_buf<vec, 16x16xf32>
 
-    pto.tload ins(%src0 : !pto.partition_tensor_view<16x16xf32>)
-              outs(%a : !pto.tile_buf<vec, 16x16xf32>)
-    pto.tload ins(%src1 : !pto.partition_tensor_view<16x16xf32>)
-              outs(%b : !pto.tile_buf<vec, 16x16xf32>)
     %selected = arith.select %cond, %a, %b : !pto.tile_buf<vec, 16x16xf32>
-    pto.tstore ins(%selected : !pto.tile_buf<vec, 16x16xf32>)
+    pto.tload ins(%src : !pto.partition_tensor_view<16x16xf32>)
+              outs(%selected : !pto.tile_buf<vec, 16x16xf32>)
+    pto.tstore ins(%b : !pto.tile_buf<vec, 16x16xf32>)
                outs(%dst : !pto.partition_tensor_view<16x16xf32>)
     return
   }
 }
 
-// INSERT-LABEL: func.func @arith_select_tile_sync
-// INSERT: pto.tload
+// INSERT-LABEL: func.func @arith_select_tile_read_sync
 // INSERT: pto.tload
 // INSERT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// INSERT: pto.tabs
+// INSERT: pto.set_flag[<PIPE_V>, <PIPE_MTE3>,
 // INSERT: arith.select
+// INSERT-DAG: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// INSERT-DAG: pto.wait_flag[<PIPE_V>, <PIPE_MTE3>,
+// INSERT-NEXT: pto.tstore
+
+// INSERT-LABEL: func.func @arith_select_tile_write_sync
+// INSERT: arith.select
+// INSERT: pto.tload
+// INSERT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
 // INSERT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
 // INSERT-NEXT: pto.tstore
 
-// GSS-LABEL: func.func @arith_select_tile_sync
-// GSS: pto.tload
+// GSS-LABEL: func.func @arith_select_tile_read_sync
 // GSS: pto.tload
 // GSS: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// GSS: pto.tabs
+// GSS: pto.set_flag[<PIPE_V>, <PIPE_MTE3>,
 // GSS: arith.select
+// GSS-DAG: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// GSS-DAG: pto.wait_flag[<PIPE_V>, <PIPE_MTE3>,
+// GSS-NEXT: pto.tstore
+
+// GSS-LABEL: func.func @arith_select_tile_write_sync
+// GSS: arith.select
+// GSS: pto.tload
+// GSS: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
 // GSS: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
 // GSS-NEXT: pto.tstore

--- a/test/lit/pto/arith_select_tile_sync.pto
+++ b/test/lit/pto/arith_select_tile_sync.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-insert-sync \
+// RUN:   --emit-pto-ir %s 2>&1 | FileCheck %s --check-prefix=INSERT
+// RUN: ptoas --pto-arch=a3 --pto-level=level3 --enable-graph-sync-solver \
+// RUN:   --graph-sync-solver-event-id-max=8 --emit-pto-ir %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=GSS
+
+module attributes {pto.target_arch = "a3"} {
+  func.func @arith_select_tile_sync(
+      %cond: i1,
+      %src0: !pto.partition_tensor_view<16x16xf32>,
+      %src1: !pto.partition_tensor_view<16x16xf32>,
+      %dst: !pto.partition_tensor_view<16x16xf32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %addr0 = arith.constant 0 : i64
+    %addr1 = arith.constant 1024 : i64
+    %a = pto.alloc_tile addr = %addr0 : !pto.tile_buf<vec, 16x16xf32>
+    %b = pto.alloc_tile addr = %addr1 : !pto.tile_buf<vec, 16x16xf32>
+
+    pto.tload ins(%src0 : !pto.partition_tensor_view<16x16xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x16xf32>)
+    pto.tload ins(%src1 : !pto.partition_tensor_view<16x16xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x16xf32>)
+    %selected = arith.select %cond, %a, %b : !pto.tile_buf<vec, 16x16xf32>
+    pto.tstore ins(%selected : !pto.tile_buf<vec, 16x16xf32>)
+               outs(%dst : !pto.partition_tensor_view<16x16xf32>)
+    return
+  }
+}
+
+// INSERT-LABEL: func.func @arith_select_tile_sync
+// INSERT: pto.tload
+// INSERT: pto.tload
+// INSERT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// INSERT: arith.select
+// INSERT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// INSERT-NEXT: pto.tstore
+
+// GSS-LABEL: func.func @arith_select_tile_sync
+// GSS: pto.tload
+// GSS: pto.tload
+// GSS: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// GSS: arith.select
+// GSS: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// GSS-NEXT: pto.tstore

--- a/test/lit/pto/arith_select_tile_sync.pto
+++ b/test/lit/pto/arith_select_tile_sync.pto
@@ -13,7 +13,28 @@
 // RUN:   | FileCheck %s --check-prefix=GSS
 
 module attributes {pto.target_arch = "a3"} {
-  func.func @arith_select_tile_read_sync(
+  func.func @arith_select_tile_same_pipe_read_sync(
+      %cond: i1,
+      %src0: !pto.partition_tensor_view<16x16xf32>,
+      %src1: !pto.partition_tensor_view<16x16xf32>,
+      %dst: !pto.partition_tensor_view<16x16xf32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<vector>} {
+    %addr0 = arith.constant 0 : i64
+    %addr1 = arith.constant 1024 : i64
+    %a = pto.alloc_tile addr = %addr0 : !pto.tile_buf<vec, 16x16xf32>
+    %b = pto.alloc_tile addr = %addr1 : !pto.tile_buf<vec, 16x16xf32>
+
+    pto.tload ins(%src0 : !pto.partition_tensor_view<16x16xf32>)
+              outs(%a : !pto.tile_buf<vec, 16x16xf32>)
+    pto.tload ins(%src1 : !pto.partition_tensor_view<16x16xf32>)
+              outs(%b : !pto.tile_buf<vec, 16x16xf32>)
+    %selected = arith.select %cond, %a, %b : !pto.tile_buf<vec, 16x16xf32>
+    pto.tstore ins(%selected : !pto.tile_buf<vec, 16x16xf32>)
+               outs(%dst : !pto.partition_tensor_view<16x16xf32>)
+    return
+  }
+
+  func.func @arith_select_tile_cross_pipe_read_sync(
       %cond: i1,
       %src0: !pto.partition_tensor_view<16x16xf32>,
       %dst: !pto.partition_tensor_view<16x16xf32>)
@@ -54,7 +75,15 @@ module attributes {pto.target_arch = "a3"} {
   }
 }
 
-// INSERT-LABEL: func.func @arith_select_tile_read_sync
+// INSERT-LABEL: func.func @arith_select_tile_same_pipe_read_sync
+// INSERT: pto.tload
+// INSERT: pto.tload
+// INSERT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// INSERT: arith.select
+// INSERT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// INSERT-NEXT: pto.tstore
+
+// INSERT-LABEL: func.func @arith_select_tile_cross_pipe_read_sync
 // INSERT: pto.tload
 // INSERT: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
 // INSERT: pto.tabs
@@ -71,7 +100,15 @@ module attributes {pto.target_arch = "a3"} {
 // INSERT: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
 // INSERT-NEXT: pto.tstore
 
-// GSS-LABEL: func.func @arith_select_tile_read_sync
+// GSS-LABEL: func.func @arith_select_tile_same_pipe_read_sync
+// GSS: pto.tload
+// GSS: pto.tload
+// GSS: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// GSS: arith.select
+// GSS: pto.wait_flag[<PIPE_MTE2>, <PIPE_MTE3>,
+// GSS-NEXT: pto.tstore
+
+// GSS-LABEL: func.func @arith_select_tile_cross_pipe_read_sync
 // GSS: pto.tload
 // GSS: pto.set_flag[<PIPE_MTE2>, <PIPE_MTE3>,
 // GSS: pto.tabs

--- a/test/lit/pto/multi_tile_dyn_slot_conservative_sync.pto
+++ b/test/lit/pto/multi_tile_dyn_slot_conservative_sync.pto
@@ -9,13 +9,11 @@
 // RUN: ptoas --enable-insert-sync %s 2>/dev/null > /dev/null
 
 // Smoke test that the dynamic-slot path still compiles end-to-end through
-// PTOResolveBufferSelect (arith.select chain) + InsertSync. The
-// PTOIRTranslator now sees the arith.select on memref values and
-// conservatively aliases both branches via
-// `UpdateConservativeAliasBufferInfo`, ensuring sync analysis never
-// silently drops a real dependency just because the slot index is a
-// runtime SSA. We don't FileCheck specific flag patterns here -- only
-// that the pipeline runs to a clean exit code.
+// InsertSync and the later PTOResolveBufferSelect lowering. InsertSync runs
+// before PTOResolveBufferSelect, so it models the dynamic slot at
+// `pto.multi_tile_get` rather than seeing the lowering-time arith.select chain.
+// We don't FileCheck specific flag patterns here -- only that the pipeline runs
+// to a clean exit code.
 
 module {
   func.func @dyn_slot_compiles(


### PR DESCRIPTION
## Summary

- Restore tile `arith.select` alias propagation in both autosync engines so dependencies through selected tile buffers are not dropped.
- Record the regression source: the old `arith.select` handling lived in `PTOIRTranslator::RecursionIR` behind a `MemRefType` gate and was removed by `22d4f58` (`Remove memref compatibility from sync analysis`) instead of being re-gated for tile types.
- Close the planner/sync asymmetry: legacy and modern memplanners kept unioning select roots, but InsertSync and GraphSyncSolver were blind to tile-native select aliases.
- Deduplicate legacy alias meminfo propagation to avoid exponential growth through repeated cheap alias ops.
- Strengthen regression coverage so reads through a select require waits for both candidate producers, and writes through a select update both candidate aliases.

## Validation

- Remote A3 build: `cmake --build build-pr1082 -j16` passed.
- Remote related lit: `llvm-lit -v build-pr1082/test/lit --filter 'arith_select_tile_sync|multi_tile_dyn_slot_conservative_sync|ptr_roundtrip_scalar_sync|multi_tile_alias_slot_dyn_event_id'` passed, 4 tests.
- Remote full lit: `cmake --build build-pr1082 --target check-pto -j16` passed, 1532 passed / 1533 discovered / 1 unsupported / 0 failures.
