### PR TITLE
chore(ci): skip macOS wheel build for pull requests

### DIFF
--- a/.github/workflows/build_wheel_mac.yml
+++ b/.github/workflows/build_wheel_mac.yml
@@ -12,9 +12,10 @@ on:
   push:
     tags-ignore:
       - '**'
-  pull_request:
-  # Nightly build & publish (UTC time, offset from Linux workflow).
+  # macOS wheels are intentionally not built on pull requests (expensive
+  # macOS runners); nightly/release/manual runs still build and publish them.
   schedule:
+    # Nightly build & publish (UTC time, offset from Linux workflow).
     - cron: "40 17 * * *"
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Stop building macOS wheels on pull requests. The `Build Wheel (macOS)` workflow currently triggers on every PR (`pull_request:`), which spins up expensive macOS runners (2 archs) for a build that is not needed to validate a PR.

This restores the earlier trigger policy from `011056103` ("ci: restore macOS wheel trigger policy"), which had removed the `pull_request` trigger; it was inadvertently re-added in `03bc04e16`.

## Change

- Remove the `pull_request:` trigger from `.github/workflows/build_wheel_mac.yml`.
- macOS wheels are still built on:
  - `push` (non-tag)
  - `schedule` (nightly)
  - `workflow_dispatch` (manual)
  - `release`

## Verification

- YAML parses correctly; workflow triggers are `push / schedule / workflow_dispatch / release` (no `pull_request`).