### PR TITLE
fix(vmi): VMI legality checks, vsstb op, and PTODSL VMI surface enforcement

### DIFF
--- a/docs/isa/vmi-isa/00-architecture-overview.md
+++ b/docs/isa/vmi-isa/00-architecture-overview.md
@@ -61,11 +61,16 @@ E_v = 32 / sizeof(T) : lanes per VLane     (f32 → 8, f16/bf16 → 16, i8 → 3
 
 Logical vector register. `L` is the logical lane count; `T` is the element type.
 
-| T | bits | E_v (lanes per physical vreg) | Legal L multiples |
+| T | bits | E_v (lanes per physical vreg) | Legal L |
 |---|---|---|---|
-| `f32` / `i32` / `ui32` / `si32` | 32 | 64 | 64 |
-| `f16` / `bf16` / `i16` / `ui16` / `si16` | 16 | 128 | 64 |
-| `i8` / `ui8` / `si8` / `fp8_e4m3` / `fp8_e5m2` | 8 | 256 | 64 |
+| `f32` / `i32` / `ui32` / `si32` | 32 | 64 | `1, 2, 4, 8, 64, 128, 256` |
+| `f16` / `bf16` / `i16` / `ui16` / `si16` | 16 | 128 | `1, 2, 4, 8, 64, 128, 256` |
+| `i8` / `ui8` / `si8` / `fp8_e4m3` / `fp8_e5m2` | 8 | 256 | `1, 2, 4, 8, 64, 128, 256` |
+
+These are the legal lane counts on the formal public VMI/PTODSL surface.
+PTOAS currently accepts additional positive lane counts in internal VMI IR for
+lowering intermediates and compatibility tests; those are not public PTODSL
+type-construction choices.
 
 - **Full vector**: `L · bitwidth(T) == N · 2048` (integer multiple of 256B).
 - **Compact/partial vector**: `L · bitwidth(T) < 2048` — still backed by one
@@ -117,6 +122,13 @@ Every VMI op belongs to one of three lowering categories that determine how
 
 All compute ops accept an optional governing mask operand `[pmode]`. The mask
 is a `!pto.vmi.mask<L>` with the same `L` as the data operand.
+
+**Mask shape and granularity:**
+
+- A mask has the same logical lane count `L` as every governed data value.
+- `pred` is an abstract per-lane mask and carries no layout.
+- Concrete `b8`, `b16`, and `b32` granularities must match the governed
+  element width; layout-assigned masks must match the governed data layout.
 
 **`pmode` values:**
 

--- a/docs/isa/vmi-isa/06-convert.md
+++ b/docs/isa/vmi-isa/06-convert.md
@@ -108,7 +108,8 @@
 ## `pto.vmi.vinterpret_cast`
 
 - **semantics:** Bitwise reinterpretation of a vector register — same bits,
-  different element type. No data movement, no layout change.
+  different element type. No data movement. The lane count may change so long
+  as the total number of bits is conserved.
 
   ```c
   // Same bits, reinterpreted element-by-element

--- a/docs/isa/vmi-isa/08-predicate-ops.md
+++ b/docs/isa/vmi-isa/08-predicate-ops.md
@@ -109,6 +109,9 @@
       : index -> !pto.vmi.mask<256×b32>
   ```
 
+`num_groups` is logically legal for any positive divisor of the result mask
+lane count. A backend may impose a narrower materialization limit separately.
+
 
 > **Mask Boolean Ops (`vand` / `vor` / `vxor` / `vnot` on masks):**
 >

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1305,10 +1305,11 @@ def VMICvtOp : VMI_Op<"vcvt", [Pure]> {
     - int → int, |dst| < |src|: integer truncation         (replaces trunci)
 
     Attributes:
-    - `rounding`: rounding mode for fp narrowing (A=away-from-zero,
-      H=half-up). Valid only when dst bit-width < src bit-width for fp types.
-    - `saturate`: saturating behavior on overflow ("SAT"). Valid for any
-      narrowing conversion (fp or int).
+    - `rounding`: rounding mode for fp narrowing (R=nearest-even,
+      A=away-from-zero, H=half-up, Z=toward-zero). Valid only when dst
+      bit-width < src bit-width for fp types.
+    - `saturate`: "SAT" or "NOSAT"; required for fp narrowing, integer
+      narrowing, and fp-to-int conversion.
     - `pmode`: predication mode ("merge" | "zero").
 
     For int→int widening, the source element type must carry signedness

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1411,6 +1411,18 @@ def VMIvStoreOp : VMI_Op<"vstore",
   let hasVerifier = 1;
 }
 
+def VMIVsstbOp : VMI_Op<"vsstb",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "VMI zero-repeat-stride block store";
+  let arguments = (ins VMI_VRegTypeConstraint:$value,
+                       PtrOrMemRef:$destination, Index:$offset,
+                       I16:$block_stride, VMI_MaskTypeConstraint:$mask,
+                       OptionalAttr<StrAttr>:$pmode);
+  let results = (outs);
+  let hasVerifier = 1;
+  let assemblyFormat = "$value `,` $destination `[` $offset `]` `,` $block_stride `,` $mask attr-dict `:` type($value) `,` type($destination) `,` type($mask)";
+}
+
 def VMIVinterpretCastOp : VMI_Op<"vinterpret_cast", [Pure]> {
   let summary = "VMI bitwise vector reinterpretation";
   let arguments = (ins VMI_VRegTypeConstraint:$source);

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -3118,6 +3118,10 @@ LogicalResult VMIVgatherOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
+  if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
+                                  "source")))
+    return failure();
+
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
                                         resultType, "source")))
     return failure();
@@ -3165,6 +3169,10 @@ LogicalResult VMIVgatherbOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
+  if (failed(verifyUBBackedMemory(getOperation(), getSource().getType(),
+                                  "source")))
+    return failure();
+
   if (failed(verifyMemoryElementMatches(getOperation(), getSource().getType(),
                                         resultType, "source")))
     return failure();
@@ -3196,6 +3204,10 @@ LogicalResult VMIVscatterOp::verify() {
   auto valueType = cast<VMIVRegType>(getValue().getType());
   auto offsetsType = cast<VMIVRegType>(getOffsets().getType());
   auto maskType = cast<VMIMaskType>(getMask().getType());
+
+  if (failed(verifyUBBackedMemory(getOperation(),
+                                  getDestination().getType(), "destination")))
+    return failure();
 
   if (failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -3734,7 +3734,9 @@ LogicalResult VMIvStoreOp::verify() {
       return emitOpError("group must be positive, got ") << numGroups;
     if (getValues().size() != 1)
       return emitOpError("group mode requires exactly 1 value");
-    return success();
+    auto valueType = cast<VMIVRegType>(getValues()[0].getType());
+    if (failed(verifyNumGroups(getOperation(), valueType, numGroups)))
+      return failure();
   }
 
   // block_stride / repeat_stride: paired, mutually exclusive with
@@ -3750,7 +3752,6 @@ LogicalResult VMIvStoreOp::verify() {
           "block_stride and dist_mode are mutually exclusive");
     if (getValues().size() != 1)
       return emitOpError("block-stride mode requires exactly 1 value");
-    return success();
   }
 
   auto distMode = getDistMode();
@@ -3784,7 +3785,11 @@ LogicalResult VMIvStoreOp::verify() {
                        "lanes; omit pmode (defaults to \"zero\")");
 
   auto valueType = cast<VMIVRegType>(getValues()[0].getType());
-  if (failed(verifyMemoryElementMatches(getOperation(),
+  bool isPackedGroupStore =
+      getGroup() &&
+      isPackedByteGroupStore(getDestination().getType(), valueType);
+  if (!isPackedGroupStore &&
+      failed(verifyMemoryElementMatches(getOperation(),
                                         getDestination().getType(), valueType,
                                         "destination")))
     return failure();
@@ -4126,7 +4131,9 @@ LogicalResult VMIvLoadOp::verify() {
       return emitOpError("group must be positive, got ") << numGroups;
     if (getResults().size() != 1)
       return emitOpError("group mode requires exactly 1 result");
-    return success();
+    auto resultType = cast<VMIVRegType>(getResults()[0].getType());
+    if (failed(verifyNumGroups(getOperation(), resultType, numGroups)))
+      return failure();
   }
 
   // block_stride and repeat_stride must be paired, mutually exclusive
@@ -4142,7 +4149,6 @@ LogicalResult VMIvLoadOp::verify() {
           "block_stride and dist_mode are mutually exclusive");
     if (getResults().size() != 1)
       return emitOpError("block-stride mode requires exactly 1 result");
-    return success();
   }
 
   // result count vs dist-mode

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -3777,6 +3777,11 @@ LogicalResult VMIvStoreOp::verify() {
   auto pmode = getPmode();
   if (pmode && !validPModes().count(*pmode))
     return emitOpError("invalid pmode: \"") << *pmode << "\"";
+  if (pmode && *pmode != "zero")
+    return emitOpError("pmode \"merge\" is not supported for stores: the "
+                       "legacy store lowering is mask-governed only and "
+                       "cannot retain prior destination contents on inactive "
+                       "lanes; omit pmode (defaults to \"zero\")");
 
   auto valueType = cast<VMIVRegType>(getValues()[0].getType());
   if (failed(verifyMemoryElementMatches(getOperation(),
@@ -3808,6 +3813,31 @@ LogicalResult VMIvStoreOp::verify() {
 }
 
 void VMIvStoreOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  effects.emplace_back(MemoryEffects::Write::get(), &getDestinationMutable());
+}
+
+LogicalResult VMIVsstbOp::verify() {
+  auto valueType = cast<VMIVRegType>(getValue().getType());
+  auto maskType = cast<VMIMaskType>(getMask().getType());
+  if (failed(verifyMemoryElementMatches(getOperation(),
+                                        getDestination().getType(), valueType,
+                                        "destination")) ||
+      failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
+                                  "destination")))
+    return failure();
+  if (auto pmode = getPmode(); pmode && !validPModes().count(*pmode))
+    return emitOpError("invalid pmode: \"") << *pmode << "\"";
+  if (auto pmode = getPmode(); pmode && *pmode != "zero")
+    return emitOpError("pmode \"merge\" is not supported for stores: the "
+                       "legacy store lowering is mask-governed only and "
+                       "cannot retain prior destination contents on inactive "
+                       "blocks; omit pmode (defaults to \"zero\")");
+  return verifyMaskMatchesData(getOperation(), maskType, valueType);
+}
+
+void VMIVsstbOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   effects.emplace_back(MemoryEffects::Write::get(), &getDestinationMutable());

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -597,6 +597,12 @@ static LogicalResult lowerVLoad(VMIvLoadOp op, OpBuilder &builder) {
 
 /// Lower vstore by dispatching on dist_mode.
 static LogicalResult lowerVStore(VMIvStoreOp op, OpBuilder &builder) {
+  // pmode="merge" (inactive lanes retain the prior destination contents)
+  // cannot be expressed by the legacy store family, whose writes are governed
+  // purely by the mask. Skip instead of silently dropping the attribute.
+  if (hasMergePmode(op))
+    return failure();
+
   // Group mode: vstore {group=C} → group_store
   if (op.getGroupAttr()) {
     builder.create<VMIGroupStoreOp>(
@@ -1173,7 +1179,7 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
         // Category C2
         isa<VMICvtOp>(op) ||
         // Category C3
-        isa<VMIvLoadOp, VMIvStoreOp>(op) ||
+        isa<VMIvLoadOp, VMIvStoreOp, VMIVsstbOp>(op) ||
         // Category C4
         isa<VMIPsetOp, VMIPgeOp, VMIPltOp>(op) ||
         // Category C6 — unified reduce (partial coverage)
@@ -1316,6 +1322,21 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
 
     if (auto vop = dyn_cast<VMIvStoreOp>(op)) {
       (void)lowerVStore(vop, builder);
+      continue;
+    }
+
+    if (auto vop = dyn_cast<VMIVsstbOp>(op)) {
+      // pmode="merge" cannot be expressed by the legacy stride store; leave
+      // the op for VMIToVPTO (which has no vsstb pattern) so the conversion
+      // fails loudly instead of silently dropping the attribute.
+      if (hasMergePmode(vop))
+        continue;
+      Value repeatStride = builder.create<arith::ConstantOp>(
+          vop.getLoc(), builder.getI16IntegerAttr(0));
+      builder.create<VMIStrideStoreOp>(
+          vop.getLoc(), vop.getValue(), vop.getDestination(), vop.getOffset(),
+          vop.getBlockStride(), repeatStride, vop.getMask());
+      vop->erase();
       continue;
     }
 

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -412,6 +412,53 @@ pto.vmi.vstore(
 
 ---
 
+### `vsstb`
+
+### `pto.vmi.vsstb(value, destination, offset, block_stride, mask, *, pmode=None) -> None`
+
+**Description**: Performs the dedicated zero-repeat-stride block store. It
+writes a logical VMI vector to UB in 32-byte blocks using the supplied dynamic
+16-bit `block_stride`. The physical `repeat_stride` is fixed to zero and is not
+an argument on this API. Unlike the general block-stride `vstore` form,
+`vsstb` requires an explicit mask.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `value` | `VRegType` | Logical VMI vector to store |
+| `destination` | `PtrType` (ub) | UB destination pointer; its element type must match `value` |
+| `offset` | `IndexLike` | Element offset into the destination buffer |
+| `block_stride` | `int` or scalar value convertible to `i16` | Dynamic 32-byte-block stride |
+| `mask` | VMI mask | Required predicate mask; its lane count must match `value` |
+| `pmode` | `str` or `None` | Optional inactive-lane mode: `"zero"` or `"merge"` |
+
+**Returns**: None (side-effect operation).
+
+**Example**:
+
+```python
+pto.vmi.vsstb(
+    vec,
+    dst_ptr,
+    offset,
+    pto.i16(8),
+    mask,
+)
+```
+
+This lowers to the physical block-stride store with an `i16` zero supplied as
+its `repeat_stride`.
+
+**Constraints**:
+
+- `destination` must refer to UB memory.
+- `block_stride` must be representable as an `i16` scalar operand.
+- `mask` is required and must match the vector's logical lane count.
+- `vsstb` does not accept `repeat_stride`, `dist_mode`, `group`, or `stride`.
+
+---
+
 ## 14.3 Index generation and broadcast
 
 These instructions produce a new logical vector from a scalar seed — either as
@@ -1384,7 +1431,7 @@ def vmi_elementwise(
 | Category | Instructions |
 |----------|-------------|
 | Types | `vreg`, `mask` |
-| Load / Store | `vload`, `vstore` |
+| Load / Store | `vload`, `vstore`, `vsstb` |
 | Index / Broadcast | `vci`, `vbrc` |
 | Binary vector-vector | `vadd`, `vsub`, `vmul`, `vdiv`, `vmax`, `vmin`, `vand`, `vor`, `vxor`, `vshl`, `vshr` |
 | Unary vector | `vabs`, `vneg`, `vrelu`, `vexp`, `vln`, `vsqrt`, `vnot` |

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -877,7 +877,7 @@ For int→int widening, the source element type must carry signedness
 | `source` | `VRegType` | Input vector (source element type) |
 | `to_dtype` | `DType` | Target element type. PTODSL derives the result vector type from the source lane count/layout and this dtype |
 | `rounding` | rounding mode or `None` | Optional rounding mode token |
-| `saturate` | saturate mode or `None` | Optional saturation mode token |
+| `saturate` | `"SAT"`, `"NOSAT"`, or `None` | Saturation mode. For fp-narrow, int-narrow, and fp-to-int, `None` defaults to `"SAT"` |
 | `pmode` | `str` or `None` | Optional predicate mode: `"merge"` keeps predicate-inactive lanes at their prior value; `"zero"` writes 0 |
 
 **Returns**:
@@ -894,7 +894,11 @@ narrow = pto.vmi.vcvt(src_f32, pto.f16)
 ```
 
 **Constraints**:
-- The masked form of `vcvt` is not currently supported on this surface.
+- The masked form of `vcvt` is not yet supported by the current PTODSL/IR
+  implementation. It remains part of the VMI ISA contract for future support.
+- Authored VMI IR requires explicit `"SAT"` or `"NOSAT"` for fp-narrow,
+  int-narrow, and fp-to-int. PTODSL uses `"SAT"` when `saturate` is omitted
+  for these directions.
 - The source and target dtype pair must be legal for the target backend.
 - For `f32 -> f8e4m3/f8e5m2`, PTODSL accepts `rounding="R"`, `"A"`, `"H"`,
   and `"Z"`; other low-level rounding tokens remain rejected on the VMI
@@ -925,6 +929,7 @@ annotation changes. This is a reinterpretation, not a numeric conversion.
 
 ```python
 as_i32 = pto.vmi.vinterpret_cast(src, pto.i32)
+as_f16 = pto.vmi.vinterpret_cast(src, pto.f16)  # 64xf32 -> 128xf16
 ```
 
 **Constraints**:

--- a/ptodsl/ptodsl/_jit.py
+++ b/ptodsl/ptodsl/_jit.py
@@ -28,7 +28,7 @@ from ._tracing import (
     current_runtime,
 )
 
-from ptoas.mlir.ir import InsertionPoint, WalkResult
+from ptoas.mlir.ir import InsertionPoint, Module, WalkResult
 
 
 _MODULE_ATTRS = ("pto.target_arch", "pto.backend")
@@ -166,6 +166,7 @@ def merge_jit_modules(*kernels: KernelHandle):
         direct_function_symbols(merged) if not merged_is_partitioned else set()
     )
 
+    target_context = merged.context
     for kernel in kernels[1:]:
         module = kernel.build()
         actual_attrs = _module_attr_map(module)
@@ -191,6 +192,13 @@ def merge_jit_modules(*kernels: KernelHandle):
                     f"{sorted(duplicates)!r}"
                 )
             merged_symbols.update(module_symbols)
+
+        # Kernel modules are built in independent MLIR contexts.  Cloning an
+        # operation directly across contexts leaves its types and attributes
+        # owned by the source context, which may be destroyed before the
+        # merged module.  Reparse the source text in the target context before
+        # cloning so every operation in the merged module has one owner.
+        module = Module.parse(str(module), target_context)
         with InsertionPoint(merged.body):
             for op in module.body.operations:
                 op.operation.clone()

--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -150,7 +150,6 @@ class _MaskDescriptor(_DType):
     def __repr__(self):
         return f"<pto.mask {self._bits}>"
 
-
 class _StructDescriptor(_DType):
     """Deferred ``!pto.struct<...>`` type assembled from scalar fields."""
 
@@ -178,10 +177,15 @@ class _StructDescriptor(_DType):
         fields = ", ".join(repr(field) for field in self._field_descriptors)
         return f"<pto.struct {fields}>"
 
+# Legal logical lane counts for VMI vreg/mask types on the formal PTODSL
+# surface: compact/group-slot flows use the first four values, full logical
+# vectors use 64/128/256.  The IR layer intentionally accepts additional
+# positive lane counts for internal compatibility.
+VMI_LANE_COUNTS = (1, 2, 4, 8, 64, 128, 256)
 
 class _VMIVRegDescriptor(_DType):
     def __init__(self, lanes: int, elem):
-        if lanes not in (1, 2, 4, 8, 64, 128, 256):
+        if lanes not in VMI_LANE_COUNTS:
             raise ValueError(
                 "pto.vmi.vreg(...) requires lanes to be one of "
                 "1, 2, 4, 8, 64, 128, 256"
@@ -205,7 +209,7 @@ class _VMIVRegDescriptor(_DType):
 
 class _VMIMaskDescriptor(_DType):
     def __init__(self, lanes: int):
-        if lanes not in (1, 2, 4, 8, 64, 128, 256):
+        if lanes not in VMI_LANE_COUNTS:
             raise ValueError(
                 "pto.vmi.mask(...) requires lanes to be one of "
                 "1, 2, 4, 8, 64, 128, 256"

--- a/ptodsl/ptodsl/_types.py
+++ b/ptodsl/ptodsl/_types.py
@@ -181,6 +181,11 @@ class _StructDescriptor(_DType):
 
 class _VMIVRegDescriptor(_DType):
     def __init__(self, lanes: int, elem):
+        if lanes not in (1, 2, 4, 8, 64, 128, 256):
+            raise ValueError(
+                "pto.vmi.vreg(...) requires lanes to be one of "
+                "1, 2, 4, 8, 64, 128, 256"
+            )
         self._lanes = lanes
         self._elem = elem
 
@@ -200,6 +205,11 @@ class _VMIVRegDescriptor(_DType):
 
 class _VMIMaskDescriptor(_DType):
     def __init__(self, lanes: int):
+        if lanes not in (1, 2, 4, 8, 64, 128, 256):
+            raise ValueError(
+                "pto.vmi.mask(...) requires lanes to be one of "
+                "1, 2, 4, 8, 64, 128, 256"
+            )
         self._lanes = lanes
         self._granularity = "pred"
 

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -615,6 +615,15 @@ class _VMINamespace:
         )
 
     @staticmethod
+    def vsstb(value, destination, offset, block_stride, mask, *, pmode=None, loc=None, ip=None):
+        context = "pto.vmi.vsstb(...)"
+        return _generated("vsstb")(
+            _raw(value), _raw(destination), _coerce_index_value(offset),
+            _i16_value(block_stride, context=f"{context} block_stride"),
+            _required_mask(mask, context=context), pmode=pmode, loc=loc, ip=ip,
+        )
+
+    @staticmethod
     def vci(base, *, size, order=None, loc=None, ip=None):
         result_type = _derive_vci_result_type(base, size, context="pto.vmi.vci(...)")
         base = coerce_scalar_to_type(

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -212,8 +212,9 @@ def _derive_vinterpret_cast_result_type(source, to_dtype, *, context: str):
             f"target element width; got {source_type.element_count}x"
             f"{source_elem_type} -> {target_elem_type}"
         )
+    target_lanes = total_bits // target_bits
     return _pto.VMIVRegType.get(
-        total_bits // target_bits,
+        target_lanes,
         target_elem_type,
         layout=source_type.layout,
     )

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -314,8 +314,16 @@ def _derive_vmi_reduce_result_type(source, group, *, context: str):
             result_lanes = int(group)
         except (TypeError, ValueError) as exc:
             raise TypeError(f"{context} requires group to be an integer when provided") from exc
-        if result_lanes <= 0:
-            raise TypeError(f"{context} requires group to be positive, got {group!r}")
+        if result_lanes not in (1, 2, 4, 8):
+            raise ValueError(
+                f"{context} requires group to be one of 1, 2, 4, 8; "
+                f"got {group!r}"
+            )
+        if source_type.element_count % result_lanes != 0:
+            raise ValueError(
+                f"{context} requires group to evenly divide the source lane "
+                f"count; got group={result_lanes}, lanes={source_type.element_count}"
+            )
     return _pto.VMIVRegType.get(result_lanes, source_type.element_type)
 
 

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -16,7 +16,13 @@ from ptoas.mlir.ir import BF16Type, F16Type, F32Type, Float8E4M3FNType, Float8E5
 
 from ._scalar_coercion import coerce_scalar_to_type
 from ._surface_values import _coerce_index_value, _try_get_constant_index, unwrap_surface_value, wrap_surface_value
-from ._types import _ensure_tensor_storage_dtype, _resolve, vmi_mask_type, vmi_vreg_type
+from ._types import (
+    VMI_LANE_COUNTS,
+    _ensure_tensor_storage_dtype,
+    _resolve,
+    vmi_mask_type,
+    vmi_vreg_type,
+)
 
 
 class _UnspecifiedArgument:
@@ -197,10 +203,19 @@ def _derive_vcvt_result_type(source, to_dtype, *, context: str):
     )
 
 
+def _check_vmi_lane_count(lanes: int, *, context: str) -> None:
+    if lanes not in VMI_LANE_COUNTS:
+        raise ValueError(
+            f"{context} requires lanes to be one of 1, 2, 4, 8, 64, 128, 256; "
+            f"got {lanes}"
+        )
+
+
 def _derive_vinterpret_cast_result_type(source, to_dtype, *, context: str):
     if to_dtype is None:
         raise TypeError(f"{context} requires to_dtype")
     source_type = _as_vmi_vreg_type(_type_of(source), context=context)
+    source_lanes = source_type.element_count
     source_elem_type = source_type.element_type
     target_elem_type = _ensure_tensor_storage_dtype(to_dtype, context=context)
     source_bits = _type_bit_width(source_elem_type, context=context)
@@ -213,10 +228,18 @@ def _derive_vinterpret_cast_result_type(source, to_dtype, *, context: str):
             f"{source_elem_type} -> {target_elem_type}"
         )
     target_lanes = total_bits // target_bits
+    _check_vmi_lane_count(target_lanes, context=context)
+    if target_lanes != source_lanes and source_type.layout is not None:
+        raise TypeError(
+            f"{context} cannot preserve the source layout across a lane-count "
+            f"change ({source_type} -> {target_lanes}x{target_elem_type}); "
+            "layouts are tied to the source lane count"
+        )
+    layout = source_type.layout if target_lanes == source_lanes else None
     return _pto.VMIVRegType.get(
         target_lanes,
         target_elem_type,
-        layout=source_type.layout,
+        layout=layout,
     )
 
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2655,10 +2655,15 @@ def vmi_wrapper_dispatch_probe():
     multiply_accumulate = pto.vmi.vmula(lhs, lhs, rhs, mask)
     widened = pto.vmi.vadd(low, high, mask)
     casted = pto.vmi.vcvt(shuffled, pto.f16)
+    casted_r = pto.vmi.vcvt(shuffled, pto.f16, rounding="R", saturate="SAT")
+    casted_a = pto.vmi.vcvt(shuffled, pto.f16, rounding="A", saturate="SAT")
+    casted_h = pto.vmi.vcvt(shuffled, pto.f16, rounding="H", saturate="SAT")
+    casted_z = pto.vmi.vcvt(shuffled, pto.f16, rounding="Z", saturate="SAT")
     recast = pto.vmi.vinterpret_cast(
         lhs,
         pto.i32,
     )
+    recast_narrow = pto.vmi.vinterpret_cast(lhs, pto.f16)
     lo, hi = pto.vmi.vintlv(selected, shuffled, mask)
     even, odd = pto.vmi.vdintlv(lo, hi, mask)
     pto.vmi.vscatter(selected, dst_ptr, idx, mask)
@@ -2676,7 +2681,9 @@ def vmi_wrapper_dispatch_probe():
     _ = cumul
     _ = widened
     _ = casted
+    _ = (casted_r, casted_a, casted_h, casted_z)
     _ = recast
+    _ = recast_narrow
     _ = hi
     _ = (subtracted, multiplied, divided, maximum, minimum, absolute, negated)
     _ = (exponent, logarithm, square_root, int_and, int_or, int_xor, int_not)
@@ -6488,9 +6495,22 @@ def main() -> None:
         "!pto.vmi.vreg<64xf16>" in vmi_wrapper_dispatch_text,
         "PTODSL VMI conversion probes should materialize converted logical VMI vector result types in MLIR",
     )
+    for rounding in ("R", "A", "H", "Z"):
+        expect(
+            f'rounding = "{rounding}"' in vmi_wrapper_dispatch_text,
+            f"PTODSL vcvt should preserve canonical {rounding} rounding",
+        )
+    expect(
+        vmi_wrapper_dispatch_text.count('saturate = "SAT"') >= 5,
+        "PTODSL vcvt should preserve explicit SAT and default omitted narrowing saturation to SAT",
+    )
     expect(
         "!pto.vmi.vreg<64xi32>" in vmi_wrapper_dispatch_text,
         "PTODSL VMI index/reinterpret probes should materialize integer logical VMI vector result types in MLIR",
+    )
+    expect(
+        "!pto.vmi.vreg<128xf16>" in vmi_wrapper_dispatch_text,
+        "PTODSL vinterpret_cast should infer lane count by conserving total bits",
     )
     expect(
         "!pto.vmi.mask<64xpred>" in vmi_wrapper_dispatch_text,

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2633,6 +2633,7 @@ def vmi_wrapper_dispatch_probe():
     )
     lo, hi = pto.vmi.vintlv(selected, shuffled, mask)
     pto.vmi.vstore(lo, dst_ptr, offset, mask)
+    pto.vmi.vsstb(hi, dst_ptr, offset, pto.i16(8), mask)
 
     _ = group_mask
     _ = total
@@ -6394,6 +6395,7 @@ def main() -> None:
         "pto.vmi.vinterpret_cast",
         "pto.vmi.vintlv",
         "pto.vmi.vstore",
+        "pto.vmi.vsstb",
     ]
     for op_name in expected_vmi_ops:
         expect(

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -2607,11 +2607,36 @@ def vmi_wrapper_dispatch_probe():
     expanded = pto.vmi.vbrc(compact, size=64, group=8)
     hist_acc = pto.vmi.vload(hist_acc_ptr, offset, size=256)
     hist_src = pto.vmi.vload(hist_src_ptr, offset, size=256)
+    int_lhs = pto.vmi.vload(int_src_ptr, offset, size=64)
+    int_rhs = pto.vmi.vload(int_other_ptr, offset, size=64)
     hist_mask = pto.vmi.create_mask(pto.const(256, dtype=pto.index), size=256)
     added = pto.vmi.vadd(lhs, rhs, mask)
+    subtracted = pto.vmi.vsub(lhs, rhs, mask)
+    multiplied = pto.vmi.vmul(lhs, rhs, mask)
+    divided = pto.vmi.vdiv(lhs, rhs, mask)
+    maximum = pto.vmi.vmax(lhs, rhs, mask)
+    minimum = pto.vmi.vmin(lhs, rhs, mask)
+    absolute = pto.vmi.vabs(lhs, mask)
+    negated = pto.vmi.vneg(lhs, mask)
     relu = pto.vmi.vrelu(added, mask)
-    scaled = pto.vmi.vadd(pto.vmi.vmuls(relu, 2.0, mask), bias, mask)
+    exponent = pto.vmi.vexp(lhs, mask)
+    logarithm = pto.vmi.vln(lhs, mask)
+    square_root = pto.vmi.vsqrt(lhs, mask)
+    int_and = pto.vmi.vand(int_lhs, int_rhs, mask)
+    int_or = pto.vmi.vor(int_lhs, int_rhs, mask)
+    int_xor = pto.vmi.vxor(int_lhs, int_rhs, mask)
+    int_not = pto.vmi.vnot(int_lhs, mask)
+    int_shl = pto.vmi.vshl(int_lhs, int_rhs, mask)
+    int_shr = pto.vmi.vshr(int_lhs, int_rhs, mask)
+    scalar_added = pto.vmi.vadds(relu, 1.0, mask)
+    scalar_multiplied = pto.vmi.vmuls(relu, 2.0, mask)
+    scalar_maximum = pto.vmi.vmaxs(relu, 1.0, mask)
+    scalar_minimum = pto.vmi.vmins(relu, 1.0, mask)
+    scalar_shl = pto.vmi.vshls(int_lhs, pto.i32(1), mask)
+    scalar_shr = pto.vmi.vshrs(int_lhs, pto.i32(1), mask)
+    scaled = pto.vmi.vadd(scalar_multiplied, bias, mask)
     pred = pto.vmi.vcmp(scaled, lhs, mask, "ogt")
+    scalar_pred = pto.vmi.vcmps(scaled, 0.0, mask, "ogt")
     selected = pto.vmi.vsel(pred, scaled, expanded)
     shuffled = pto.vmi.vselr(selected, idx)
     total = pto.vmi.vcadd(shuffled, mask, reassoc=True)
@@ -2622,9 +2647,12 @@ def vmi_wrapper_dispatch_probe():
     gatherb = pto.vmi.vgatherb(src_ptr, idx, mask)
     hist = pto.vmi.vdhist(hist_acc, hist_src, hist_mask)
     cumul = pto.vmi.vchist(hist_acc, hist_src, hist_mask)
-    int_lhs = pto.vmi.vload(int_src_ptr, offset, size=64)
-    int_rhs = pto.vmi.vload(int_other_ptr, offset, size=64)
+    exp_difference = pto.vmi.vexpdif(lhs, rhs, mask)
+    axpy = pto.vmi.vaxpy(lhs, rhs, 2.0, mask)
+    leaky_relu = pto.vmi.vlrelu(lhs, 0.125, mask)
+    parametric_relu = pto.vmi.vprelu(lhs, rhs, mask)
     low, high = pto.vmi.vmull(int_lhs, int_rhs, mask)
+    multiply_accumulate = pto.vmi.vmula(lhs, lhs, rhs, mask)
     widened = pto.vmi.vadd(low, high, mask)
     casted = pto.vmi.vcvt(shuffled, pto.f16)
     recast = pto.vmi.vinterpret_cast(
@@ -2632,6 +2660,8 @@ def vmi_wrapper_dispatch_probe():
         pto.i32,
     )
     lo, hi = pto.vmi.vintlv(selected, shuffled, mask)
+    even, odd = pto.vmi.vdintlv(lo, hi, mask)
+    pto.vmi.vscatter(selected, dst_ptr, idx, mask)
     pto.vmi.vstore(lo, dst_ptr, offset, mask)
     pto.vmi.vsstb(hi, dst_ptr, offset, pto.i16(8), mask)
 
@@ -2648,6 +2678,11 @@ def vmi_wrapper_dispatch_probe():
     _ = casted
     _ = recast
     _ = hi
+    _ = (subtracted, multiplied, divided, maximum, minimum, absolute, negated)
+    _ = (exponent, logarithm, square_root, int_and, int_or, int_xor, int_not)
+    _ = (int_shl, int_shr, scalar_added, scalar_maximum, scalar_minimum)
+    _ = (scalar_shl, scalar_shr, scalar_pred, exp_difference, axpy)
+    _ = (leaky_relu, parametric_relu, multiply_accumulate, even, odd)
 
 
 @pto.jit(target="a5", backend="vpto", mode="explicit")
@@ -6374,28 +6409,59 @@ def main() -> None:
     )
 
     expected_vmi_ops = [
-        "pto.vmi.create_mask",
-        "pto.vmi.create_group_mask",
         "pto.vmi.vload",
+        "pto.vmi.vstore",
+        "pto.vmi.vsstb",
         "pto.vmi.vci",
         "pto.vmi.vadd",
+        "pto.vmi.vsub",
+        "pto.vmi.vmul",
+        "pto.vmi.vdiv",
+        "pto.vmi.vmax",
+        "pto.vmi.vmin",
+        "pto.vmi.vabs",
+        "pto.vmi.vneg",
         "pto.vmi.vrelu",
+        "pto.vmi.vexp",
+        "pto.vmi.vln",
+        "pto.vmi.vsqrt",
+        "pto.vmi.vand",
+        "pto.vmi.vor",
+        "pto.vmi.vxor",
+        "pto.vmi.vnot",
+        "pto.vmi.vshl",
+        "pto.vmi.vshr",
+        "pto.vmi.vadds",
         "pto.vmi.vmuls",
+        "pto.vmi.vmaxs",
+        "pto.vmi.vmins",
+        "pto.vmi.vshls",
+        "pto.vmi.vshrs",
         "pto.vmi.vcmp",
+        "pto.vmi.vcmps",
         "pto.vmi.vsel",
         "pto.vmi.vselr",
+        "pto.vmi.vbrc",
         "pto.vmi.vcadd",
         "pto.vmi.vcmax",
         "pto.vmi.vcmin",
-        "pto.vmi.vdhist",
-        "pto.vmi.vchist",
-        "pto.vmi.vmull",
-        "pto.vmi.vgather",
         "pto.vmi.vcvt",
         "pto.vmi.vinterpret_cast",
+        "pto.vmi.vexpdif",
+        "pto.vmi.vaxpy",
+        "pto.vmi.vlrelu",
+        "pto.vmi.vprelu",
+        "pto.vmi.vmull",
+        "pto.vmi.vmula",
+        "pto.vmi.vchist",
+        "pto.vmi.vdhist",
+        "pto.vmi.vgather",
+        "pto.vmi.vgatherb",
+        "pto.vmi.vscatter",
+        "pto.vmi.create_mask",
+        "pto.vmi.create_group_mask",
         "pto.vmi.vintlv",
-        "pto.vmi.vstore",
-        "pto.vmi.vsstb",
+        "pto.vmi.vdintlv",
     ]
     for op_name in expected_vmi_ops:
         expect(

--- a/ptodsl/tests/test_vmi_group_foundations.py
+++ b/ptodsl/tests/test_vmi_group_foundations.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from ptodsl import pto
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def legal_group_probe():
+    src = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
+    dst = pto.alloc_tile(shape=[1, 64], dtype=pto.f32)
+    offset = pto.const(0, dtype=pto.index)
+    stride = pto.const(4, dtype=pto.index)
+    mask = pto.vmi.create_mask(16, size=64, group=4)
+    value = pto.vmi.vload(src.as_ptr(), offset, size=64, group=4, stride=stride)
+    slots = pto.vmi.vcmax(value, mask, group=4)
+    dense = pto.vmi.vbrc(slots, size=64, group=4)
+    pto.vmi.vstore(dense, dst.as_ptr(), offset, group=4, stride=stride)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def invalid_group_probe():
+    _ = pto.vmi.create_mask(1, size=64, group=3)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def invalid_reduce_group_probe():
+    value = pto.vmi.vbrc(pto.f32(0.0), size=64)
+    mask = pto.vmi.create_mask(64, size=64)
+    _ = pto.vmi.vcmax(value, mask, group=16)
+
+
+def main() -> None:
+    for lanes in (1, 2, 4, 8, 64, 128, 256):
+        pto.vmi.vreg(lanes, pto.f32)
+        pto.vmi.mask(lanes)
+    for lanes in (3, 16, 32, 512):
+        try:
+            pto.vmi.vreg(lanes, pto.f32)
+        except ValueError as exc:
+            assert "1, 2, 4, 8, 64, 128, 256" in str(exc)
+        else:
+            raise AssertionError(f"PTODSL VMI vreg must reject lanes={lanes}")
+        try:
+            pto.vmi.mask(lanes)
+        except ValueError as exc:
+            assert "1, 2, 4, 8, 64, 128, 256" in str(exc)
+        else:
+            raise AssertionError(f"PTODSL VMI mask must reject lanes={lanes}")
+
+    text = legal_group_probe.compile().mlir_text()
+    for spelling in (
+        "pto.vmi.create_group_mask",
+        "pto.vmi.vload",
+        "pto.vmi.vcmax",
+        "pto.vmi.vbrc",
+        "pto.vmi.vstore",
+    ):
+        assert spelling in text
+    assert text.count("group = 4") >= 4
+
+    try:
+        invalid_group_probe.compile()
+    except ValueError as exc:
+        assert "size to be divisible by group" in str(exc)
+    else:
+        raise AssertionError("grouped mask must reject a group that does not divide size")
+
+    try:
+        invalid_reduce_group_probe.compile()
+    except ValueError as exc:
+        assert "group to be one of 1, 2, 4, 8" in str(exc)
+    else:
+        raise AssertionError("PTODSL grouped reduce must reject group=16")
+
+
+if __name__ == "__main__":
+    main()

--- a/ptodsl/tests/test_vmi_group_foundations.py
+++ b/ptodsl/tests/test_vmi_group_foundations.py
@@ -35,6 +35,14 @@ def invalid_reduce_group_probe():
     _ = pto.vmi.vcmax(value, mask, group=16)
 
 
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def invalid_reinterpret_lane_count_probe():
+    # 8xf32 (256 bits) -> si8 must derive 32 lanes, which is outside the legal
+    # lane-count domain; the derivation must not bypass the constructor whitelist.
+    value = pto.vmi.vbrc(pto.f32(0.0), size=8)
+    _ = pto.vmi.vinterpret_cast(value, pto.si8)
+
+
 def main() -> None:
     for lanes in (1, 2, 4, 8, 64, 128, 256):
         pto.vmi.vreg(lanes, pto.f32)
@@ -77,6 +85,40 @@ def main() -> None:
         assert "group to be one of 1, 2, 4, 8" in str(exc)
     else:
         raise AssertionError("PTODSL grouped reduce must reject group=16")
+
+    try:
+        invalid_reinterpret_lane_count_probe.compile()
+    except ValueError as exc:
+        assert "1, 2, 4, 8, 64, 128, 256" in str(exc)
+    else:
+        raise AssertionError(
+            "PTODSL vinterpret_cast must reject a derived lane count outside "
+            "1, 2, 4, 8, 64, 128, 256"
+        )
+
+    # A bit-reinterpretation that changes the lane count must not silently
+    # reuse the source layout (group/slot counts are tied to the source lanes).
+    from types import SimpleNamespace
+
+    from ptoas.mlir.dialects import pto as _pto
+    from ptoas.mlir.ir import Attribute, Context, F32Type
+    from ptodsl._vmi_namespace import _derive_vinterpret_cast_result_type
+
+    with Context() as ctx:
+        _pto.register_dialect(ctx)
+        layout = Attribute.parse("#pto.vmi.layout<deinterleaved = 2>")
+        source_type = _pto.VMIVRegType.get(64, F32Type.get(), layout=layout)
+        try:
+            _derive_vinterpret_cast_result_type(
+                SimpleNamespace(type=source_type), pto.f16, context="test"
+            )
+        except TypeError as exc:
+            assert "layout" in str(exc)
+        else:
+            raise AssertionError(
+                "vinterpret_cast across a lane-count change must reject a "
+                "layout-assigned source"
+            )
 
 
 if __name__ == "__main__":

--- a/ptodsl/tests/test_vmi_group_foundations.py
+++ b/ptodsl/tests/test_vmi_group_foundations.py
@@ -5,6 +5,7 @@
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
 
 from ptodsl import pto
 

--- a/ptodsl/tests/test_vmi_isa_inventory.py
+++ b/ptodsl/tests/test_vmi_isa_inventory.py
@@ -5,6 +5,7 @@
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
 
 from pathlib import Path
 import re

--- a/ptodsl/tests/test_vmi_isa_inventory.py
+++ b/ptodsl/tests/test_vmi_isa_inventory.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+from pathlib import Path
+import re
+
+from ptodsl import pto
+from ptoas.mlir.dialects import pto as generated_pto
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INDEX = ROOT / "docs/isa/vmi-isa/10-appendices.md"
+ODS = ROOT / "include/PTO/IR/VMIOps.td"
+EMISSION_TEST = ROOT / "ptodsl/tests/test_jit_compile.py"
+
+# All indexed ops currently lower through the A5 VMI-to-VPTO pipeline. Keep
+# this manifest explicit so a new ISA entry cannot silently inherit support.
+BACKEND_CAPABILITY = {
+    name: "a5-vpto"
+    for name in (
+        "vload vstore vsstb vci vadd vsub vmul vdiv vmax vmin vabs vneg "
+        "vrelu vexp vln vsqrt vand vor vxor vnot vshl vshr vadds vmuls "
+        "vmaxs vmins vshls vshrs vcmp vcmps vsel vselr vbrc vcadd vcmax "
+        "vcmin vcvt vinterpret_cast vexpdif vaxpy vlrelu vprelu vmull "
+        "vmula vchist vdhist vgather vgatherb vscatter create_mask "
+        "create_group_mask vintlv vdintlv"
+    ).split()
+}
+
+# PTODSL spells the grouped-mask generator as create_mask(..., group=...).
+PTODSL_ALIASES = {"create_group_mask": "create_mask"}
+
+
+def _indexed_ops():
+    rows = re.findall(
+        r"^\|\s*(\d+)\s*\|\s*`pto\.vmi\.([a-z0-9_]+)`",
+        INDEX.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    return [(int(number), name) for number, name in rows]
+
+
+def main() -> None:
+    indexed = _indexed_ops()
+    assert [number for number, _ in indexed] == list(range(1, 54))
+    names = [name for _, name in indexed]
+    assert len(names) == len(set(names)) == 53
+    assert set(BACKEND_CAPABILITY) == set(names)
+    assert set(PTODSL_ALIASES) <= set(names)
+
+    ods = ODS.read_text(encoding="utf-8")
+    emission_test = EMISSION_TEST.read_text(encoding="utf-8")
+    for name in names:
+        wrapper = PTODSL_ALIASES.get(name, name)
+        assert hasattr(pto.vmi, wrapper), f"missing PTODSL wrapper for pto.vmi.{name}"
+        assert hasattr(generated_pto, f"vmi_{name}"), f"missing generated binding for pto.vmi.{name}"
+        definition = re.search(
+            rf'^def\s+\w+\s*:\s*(VMI_Op|VMI_VecScalarOp|VMIHistogramOp)<"{re.escape(name)}"[\s\S]*?(?=^def\s|\Z)',
+            ods,
+            re.MULTILINE,
+        )
+        assert definition, f"missing ODS op for pto.vmi.{name}"
+        verifier_text = definition.group(0)
+        if definition.group(1) == "VMI_VecScalarOp":
+            verifier_text += re.search(r'class VMI_VecScalarOp[\s\S]*?^}', ods, re.MULTILINE).group(0)
+        elif definition.group(1) == "VMIHistogramOp":
+            verifier_text += re.search(r'class VMIHistogramOp[\s\S]*?^}', ods, re.MULTILINE).group(0)
+        assert "let hasVerifier = 1;" in verifier_text, f"missing verifier for pto.vmi.{name}"
+        assert f'"pto.vmi.{name}"' in emission_test, f"missing emission assertion for pto.vmi.{name}"
+
+
+if __name__ == "__main__":
+    main()

--- a/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
+++ b/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
@@ -1,0 +1,70 @@
+// RUN: pto-test-opt %s -verify-diagnostics -split-input-file
+
+// Positive matrix: six directions, all rounding tokens, saturation values,
+// signedness, and cross-width reinterpretation.
+module {
+  func.func @positive(%f16: !pto.vmi.vreg<64xf16>, %f32: !pto.vmi.vreg<64xf32>, %si8: !pto.vmi.vreg<64xsi8>, %ui8: !pto.vmi.vreg<64xui8>, %si16: !pto.vmi.vreg<64xsi16>, %si32: !pto.vmi.vreg<64xsi32>) {
+    %fw = pto.vmi.vcvt %f16 : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
+    %fn_r = pto.vmi.vcvt %f32 {rounding = "R", saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+    %fn_a = pto.vmi.vcvt %f32 {rounding = "A", saturate = "NOSAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+    %fn_h = pto.vmi.vcvt %f32 {rounding = "H", saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xbf16>
+    %fn_z = pto.vmi.vcvt %f32 {rounding = "Z", saturate = "NOSAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xbf16>
+    %fi = pto.vmi.vcvt %f32 {saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi32>
+    %if = pto.vmi.vcvt %si16 : !pto.vmi.vreg<64xsi16> -> !pto.vmi.vreg<64xf32>
+    %iw_s = pto.vmi.vcvt %si8 : !pto.vmi.vreg<64xsi8> -> !pto.vmi.vreg<64xsi16>
+    %iw_u = pto.vmi.vcvt %ui8 : !pto.vmi.vreg<64xui8> -> !pto.vmi.vreg<64xui16>
+    %in = pto.vmi.vcvt %si32 {saturate = "NOSAT"} : !pto.vmi.vreg<64xsi32> -> !pto.vmi.vreg<64xsi8>
+    %bits = pto.vmi.vinterpret_cast %f32 : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<128xf16>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @rounding_wrong_direction(%x: !pto.vmi.vreg<64xf16>) {
+    // expected-error@+1 {{'rounding' attribute is only valid for fp-narrowing conversions}}
+    %r = pto.vmi.vcvt %x {rounding = "R"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @missing_saturate(%x: !pto.vmi.vreg<64xf32>) {
+    // expected-error@+1 {{'saturate' attribute is required for fp-narrow / int-narrow / fp-to-si conversions}}
+    %r = pto.vmi.vcvt %x : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @saturate_wrong_direction(%x: !pto.vmi.vreg<64xsi16>) {
+    // expected-error@+1 {{'saturate' attribute is only valid for fp-narrow / int-narrow / fp-to-si conversions}}
+    %r = pto.vmi.vcvt %x {saturate = "SAT"} : !pto.vmi.vreg<64xsi16> -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @signless_widen(%x: !pto.vmi.vreg<64xi8>) {
+    // expected-error@+1 {{int-widening conversions require a signed or unsigned integer source element type}}
+    %r = pto.vmi.vcvt %x : !pto.vmi.vreg<64xi8> -> !pto.vmi.vreg<64xi16>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @reinterpret_total_bits(%x: !pto.vmi.vreg<64xf32>) {
+    // expected-error@+1 {{requires source and result to carry the same total number of bits}}
+    %r = pto.vmi.vinterpret_cast %x : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
+    return
+  }
+}

--- a/test/lit/vmi_new/vmi_gather_scatter_address_space_invalid.pto
+++ b/test/lit/vmi_new/vmi_gather_scatter_address_space_invalid.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -split-input-file -verify-diagnostics
+
+module {
+  func.func @vgather_requires_ub(
+      %src: !pto.ptr<f32, gm>,
+      %offsets: !pto.vmi.vreg<64xi32>,
+      %mask: !pto.vmi.mask<64xpred>) {
+    // expected-error@+1 {{'pto.vmi.vgather' op requires memory source to be UB-backed}}
+    %out = pto.vmi.vgather %src, %offsets, %mask : !pto.ptr<f32, gm>, !pto.vmi.vreg<64xi32>, !pto.vmi.mask<64xpred> -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @vgatherb_requires_ub(
+      %src: !pto.ptr<f32, gm>,
+      %offsets: !pto.vmi.vreg<64xi32>,
+      %mask: !pto.vmi.mask<64xpred>) {
+    // expected-error@+1 {{'pto.vmi.vgatherb' op requires memory source to be UB-backed}}
+    %out = pto.vmi.vgatherb %src, %offsets, %mask : !pto.ptr<f32, gm>, !pto.vmi.vreg<64xi32>, !pto.vmi.mask<64xpred> -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @vscatter_requires_ub(
+      %value: !pto.vmi.vreg<64xf32>,
+      %dst: !pto.ptr<f32, gm>,
+      %offsets: !pto.vmi.vreg<64xi32>,
+      %mask: !pto.vmi.mask<64xpred>) {
+    // expected-error@+1 {{'pto.vmi.vscatter' op requires memory destination to be UB-backed}}
+    pto.vmi.vscatter %value, %dst, %offsets, %mask : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, gm>, !pto.vmi.vreg<64xi32>, !pto.vmi.mask<64xpred>
+    return
+  }
+}

--- a/test/lit/vmi_new/vmi_to_vpto_vsstb_merge_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vsstb_merge_invalid.pto
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// pmode="merge" (inactive lanes retain the prior destination contents) is not
+// expressible by the legacy stride-store family: the lowering must reject it
+// instead of silently dropping the attribute.
+// RUN: not pto-test-opt %s -split-input-file -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto 2>&1 | FileCheck %s
+
+module {
+  func.func @vsstb_merge(%value: !pto.vmi.vreg<64xf32>,
+                         %dst: !pto.ptr<f32, ub>,
+                         %mask: !pto.vmi.mask<64xpred>,
+                         %offset: index, %block_stride: i16) {
+    pto.vmi.vsstb %value, %dst[%offset], %block_stride, %mask {pmode = "merge"}
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @vstore_block_stride_merge(
+      %value: !pto.vmi.vreg<64xf32>,
+      %dst: !pto.ptr<f32, ub>,
+      %mask: !pto.vmi.mask<64xpred>) {
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : i16
+    %c4 = arith.constant 4 : i16
+    pto.vmi.vstore %value, %dst[%c0], %c2, %c4, %mask {pmode = "merge"}
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
+    return
+  }
+}
+
+// CHECK: error: 'pto.vmi.vsstb' op pmode "merge" is not supported for stores
+// CHECK: error: 'pto.vmi.vstore' op pmode "merge" is not supported for stores

--- a/test/lit/vmi_new/vmi_type_group_foundations.pto
+++ b/test/lit/vmi_new/vmi_type_group_foundations.pto
@@ -1,0 +1,20 @@
+// RUN: pto-test-opt %s -verify-diagnostics -split-input-file
+
+// Compact logical vectors and legal compact groups are accepted when the
+// group count evenly divides the logical lane count.
+module {
+  func.func @compact_group(%src: !pto.vmi.vreg<8xf32>, %mask: !pto.vmi.mask<8xb32>) {
+    %r = pto.vmi.vcmax %src, %mask {group = 2} : !pto.vmi.vreg<8xf32>, !pto.vmi.mask<8xb32> -> !pto.vmi.vreg<2xf32>
+    return
+  }
+}
+
+// -----
+
+module {
+  func.func @mask_lane_mismatch(%src: !pto.vmi.vreg<8xf32>, %mask: !pto.vmi.mask<4xb32>) {
+    // expected-error@+1 {{requires mask logical lane count to match data lane count}}
+    %r = pto.vmi.vadd %src, %src, %mask : !pto.vmi.vreg<8xf32>, !pto.vmi.vreg<8xf32>, !pto.vmi.mask<4xb32> -> !pto.vmi.vreg<8xf32>
+    return
+  }
+}

--- a/test/lit/vmi_new/vmi_unified_memory_modes_invalid.pto
+++ b/test/lit/vmi_new/vmi_unified_memory_modes_invalid.pto
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file 2>&1 | FileCheck %s
+
+module {
+  func.func @group_load_element_type_mismatch(
+      %src: !pto.ptr<f32, ub>, %offset: index, %stride: index) {
+    %value = pto.vmi.vload %src[%offset], %stride {group = 8}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf16>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vload' op requires memory source element type to match VMI data element type
+
+// -----
+
+module {
+  func.func @group_store_element_type_mismatch(
+      %value: !pto.vmi.vreg<64xf16>, %dst: !pto.ptr<f32, ub>,
+      %offset: index, %stride: index) {
+    pto.vmi.vstore %value, %dst[%offset], %stride {group = 8}
+        : !pto.vmi.vreg<64xf16>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vstore' op requires memory destination element type to match VMI data element type
+
+// -----
+
+module {
+  func.func @block_stride_load_element_type_mismatch(
+      %src: !pto.ptr<f32, ub>, %offset: index, %block: i16, %repeat: i16) {
+    %value = pto.vmi.vload %src[%offset], %block, %repeat
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf16>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vload' op requires memory source element type to match VMI data element type
+
+// -----
+
+module {
+  func.func @block_stride_store_element_type_mismatch(
+      %value: !pto.vmi.vreg<64xf16>, %dst: !pto.ptr<f32, ub>,
+      %offset: index, %block: i16, %repeat: i16) {
+    pto.vmi.vstore %value, %dst[%offset], %block, %repeat
+        : !pto.vmi.vreg<64xf16>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vstore' op requires memory destination element type to match VMI data element type
+
+// -----
+
+module {
+  func.func @group_load_nondivisible(
+      %src: !pto.ptr<f32, ub>, %offset: index, %stride: index) {
+    %value = pto.vmi.vload %src[%offset], %stride {group = 6}
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vload' op requires num_groups to evenly divide VMI logical lane count 64
+
+// -----
+
+module {
+  func.func @group_store_nondivisible(
+      %value: !pto.vmi.vreg<64xf32>, %dst: !pto.ptr<f32, ub>,
+      %offset: index, %stride: index) {
+    pto.vmi.vstore %value, %dst[%offset], %stride {group = 6}
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vstore' op requires num_groups to evenly divide VMI logical lane count 64

--- a/test/lit/vmi_new/vmi_vsstb.pto
+++ b/test/lit/vmi_new/vmi_vsstb.pto
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+module {
+  func.func @vsstb(%value: !pto.vmi.vreg<64xf32>,
+                   %dst: !pto.ptr<f32, ub>,
+                   %mask: !pto.vmi.mask<64xpred>,
+                   %offset: index, %block_stride: i16) {
+    pto.vmi.vsstb %value, %dst[%offset], %block_stride, %mask
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vsstb
+// CHECK: %[[ZERO:.*]] = arith.constant 0 : i16
+// CHECK: pto.vsstb %arg0, %{{.*}}, %arg4, %[[ZERO]], %arg2
+// CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_vsstb_invalid.pto
+++ b/test/lit/vmi_new/vmi_vsstb_invalid.pto
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s 2>&1 | FileCheck %s
+
+module {
+  func.func @vsstb_type_mismatch(%value: !pto.vmi.vreg<64xf16>,
+                                 %dst: !pto.ptr<f32, ub>,
+                                 %mask: !pto.vmi.mask<64xpred>,
+                                 %offset: index, %block_stride: i16) {
+    pto.vmi.vsstb %value, %dst[%offset], %block_stride, %mask
+        : !pto.vmi.vreg<64xf16>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vsstb' op requires memory destination element type to match VMI data element type

--- a/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_chunked.pto
+++ b/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_chunked.pto
@@ -20,7 +20,7 @@ module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<ve
     // CHECK: pto.ub.vadd {{%[^,]+}}, {{%[^,]+}}, {{%[^,]+}}
     // CHECK-SAME: : !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64
     // CHECK: pto.ub.set_mask_norm
-    // CHECK: pto.ub.set_mask %c-1_i64, %c-1_i64
+    // CHECK: pto.ub.set_mask %c-1_i64{{[0-9_]*}}, %c-1_i64{{[0-9_]*}}
     // CHECK-NOT: scf.for
     pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     // CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_count_large.pto
+++ b/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_count_large.pto
@@ -23,7 +23,7 @@ module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<ve
     // CHECK: pto.ub.vadd {{%[^,]+}}, {{%[^,]+}}, {{%[^,]+}}
     // CHECK-SAME: : !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64
     // CHECK: pto.ub.set_mask_norm
-    // CHECK: pto.ub.set_mask %c-1_i64, %c-1_i64
+    // CHECK: pto.ub.set_mask %c-1_i64{{[0-9_]*}}, %c-1_i64{{[0-9_]*}}
     // CHECK-NOT: pto.ub.vadd {{.*}}%c256_i64
     pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=16, cols=1024, v_row=16, v_col=1024, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     // CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_row_rpt.pto
+++ b/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_row_rpt.pto
@@ -17,13 +17,13 @@ module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<ve
     %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     // CHECK: %[[MASK:.*]] = arith.constant 4294967295 : i64
     // CHECK: pto.ub.set_mask %[[MASK]],
-    // CHECK: %[[RPT:.*]] = arith.constant 4 : i64
-    // CHECK: %[[STRIDE:.*]] = arith.constant 12 : i64
+    // CHECK-DAG: %[[RPT:.*]] = arith.constant 4 : i64
+    // CHECK-DAG: %[[STRIDE:.*]] = arith.constant 12 : i64
     // CHECK: pto.ub.vadd {{%[^,]+}}, {{%[^,]+}}, {{%[^,]+}}
     // CHECK-SAME: %[[RPT]],
     // CHECK-SAME: %[[STRIDE]], %[[STRIDE]],
     // CHECK-SAME: : !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64
-    // CHECK: pto.ub.set_mask %c-1_i64, %c-1_i64
+    // CHECK: pto.ub.set_mask %c-1_i64{{[0-9_]*}}, %c-1_i64{{[0-9_]*}}
     // CHECK-NOT: pto.ub.set_mask_count
     pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=4, cols=96, v_row=4, v_col=32, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     // CHECK-NOT: pto.tadd

--- a/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_row_rpt_tail.pto
+++ b/test/lit/vpto/ub/tile_to_ub/elementwise/tadd_row_rpt_tail.pto
@@ -17,13 +17,13 @@ module attributes {pto.target_arch = "a3", pto.kernel_kind = #pto.kernel_kind<ve
     %src1 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     // CHECK: %[[MASK:.*]] = arith.constant 1099511627775 : i64
     // CHECK: pto.ub.set_mask %[[MASK]],
-    // CHECK: %[[RPT:.*]] = arith.constant 5 : i64
-    // CHECK: %[[STRIDE:.*]] = arith.constant 16 : i64
+    // CHECK-DAG: %[[RPT:.*]] = arith.constant 5 : i64
+    // CHECK-DAG: %[[STRIDE:.*]] = arith.constant 16 : i64
     // CHECK: pto.ub.vadd {{%[^,]+}}, {{%[^,]+}}, {{%[^,]+}}
     // CHECK-SAME: %[[RPT]],
     // CHECK-SAME: %[[STRIDE]], %[[STRIDE]],
     // CHECK-SAME: : !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64, i64, i64
-    // CHECK: pto.ub.set_mask %c-1_i64, %c-1_i64
+    // CHECK: pto.ub.set_mask %c-1_i64{{[0-9_]*}}, %c-1_i64{{[0-9_]*}}
     pto.tadd ins(%src0, %src1 : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>, !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>) outs(%dst : !pto.tile_buf<loc=vec, dtype=f32, rows=5, cols=128, v_row=5, v_col=40, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
     // CHECK-NOT: pto.tadd
     return

--- a/test/vpto/cases/vmi_new/dequant-f16-to-f32-tail/kernel.pto
+++ b/test/vpto/cases/vmi_new/dequant-f16-to-f32-tail/kernel.pto
@@ -42,7 +42,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %scale_vec = pto.vmi.vbrc %scale : f32 -> !pto.vmi.vreg<128xf32>
         %out = pto.vmi.vmul %wide, %scale_vec
             : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
-        pto.vmi.vstore %out, %ub_dst[%offset], %mask {pmode = "merge"}
+        pto.vmi.vstore %out, %ub_dst[%offset], %mask
             : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<128xpred>
         %next = arith.subi %rem, %c128 : index
         scf.yield %next : index

--- a/test/vpto/cases/vmi_new/dequant-f8-to-f32-tail/kernel.pto
+++ b/test/vpto/cases/vmi_new/dequant-f8-to-f32-tail/kernel.pto
@@ -41,7 +41,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %scale_vec = pto.vmi.vbrc %scale : f32 -> !pto.vmi.vreg<256xf32>
         %out = pto.vmi.vmul %wide, %scale_vec
             : !pto.vmi.vreg<256xf32>, !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf32>
-        pto.vmi.vstore %out, %ub_dst[%offset], %mask {pmode = "merge"}
+        pto.vmi.vstore %out, %ub_dst[%offset], %mask
             : !pto.vmi.vreg<256xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<256xpred>
         %next = arith.subi %rem, %c256 : index
         scf.yield %next : index

--- a/test/vpto/cases/vmi_new/mask-granularity-f32-f16-store/kernel.pto
+++ b/test/vpto/cases/vmi_new/mask-granularity-f32-f16-store/kernel.pto
@@ -39,10 +39,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.vecscope {
       %x = pto.vmi.vload %ub_src[%c0] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<128xf32>
       %mask = pto.vmi.create_mask %c96 : index -> !pto.vmi.mask<128xpred>
-      pto.vmi.vstore %x, %ub_out32[%c0], %mask {pmode = "merge"}
+      pto.vmi.vstore %x, %ub_out32[%c0], %mask
           : !pto.vmi.vreg<128xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<128xpred>
       %h = pto.vmi.vcvt %x {saturate = "SAT"} : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
-      pto.vmi.vstore %h, %ub_out16[%c0], %mask {pmode = "merge"}
+      pto.vmi.vstore %h, %ub_out16[%c0], %mask
           : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<128xpred>
     }
 

--- a/test/vpto/cases/vmi_new/mask-select-store/kernel.pto
+++ b/test/vpto/cases/vmi_new/mask-select-store/kernel.pto
@@ -53,7 +53,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
       pto.vmi.vstore %passthrough, %ub_dense[%c0]
           : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
-      pto.vmi.vstore %sum, %ub_masked[%c0], %mask {pmode = "merge"}
+      pto.vmi.vstore %sum, %ub_masked[%c0], %mask
           : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vmi.mask<64xpred>
     }
 

--- a/test/vpto/cases/vmi_new/quant-f16-to-hif8-tail/kernel.pto
+++ b/test/vpto/cases/vmi_new/quant-f16-to-hif8-tail/kernel.pto
@@ -39,7 +39,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %mask = pto.vmi.create_mask %rem : index -> !pto.vmi.mask<256xpred>
         %wide = pto.vmi.vload %ub_src[%offset] : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
         %packed = pto.vmi.vcvt %wide {saturate = "SAT"} : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256x!pto.hif8>
-        pto.vmi.vstore %packed, %ub_dst[%offset], %mask {pmode = "merge"}
+        pto.vmi.vstore %packed, %ub_dst[%offset], %mask
             : !pto.vmi.vreg<256x!pto.hif8>, !pto.ptr<!pto.hif8, ub>, !pto.vmi.mask<256xpred>
         %next = arith.subi %rem, %c256 : index
         scf.yield %next : index

--- a/test/vpto/cases/vmi_new/quant-f32-to-f16-sat-explicit/kernel.pto
+++ b/test/vpto/cases/vmi_new/quant-f32-to-f16-sat-explicit/kernel.pto
@@ -42,7 +42,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %scaled = pto.vmi.vmul %wide, %scale_vec
             : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
         %packed = pto.vmi.vcvt %scaled {saturate = "SAT"} : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
-        pto.vmi.vstore %packed, %ub_dst[%offset], %mask {pmode = "merge"}
+        pto.vmi.vstore %packed, %ub_dst[%offset], %mask
             : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<128xpred>
         %next = arith.subi %rem, %c128 : index
         scf.yield %next : index

--- a/test/vpto/cases/vmi_new/quant-f32-to-f16-tail/kernel.pto
+++ b/test/vpto/cases/vmi_new/quant-f32-to-f16-tail/kernel.pto
@@ -42,7 +42,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %scaled = pto.vmi.vmul %wide, %scale_vec
             : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf32>
         %packed = pto.vmi.vcvt %scaled {saturate = "SAT"} : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf16>
-        pto.vmi.vstore %packed, %ub_dst[%offset], %mask {pmode = "merge"}
+        pto.vmi.vstore %packed, %ub_dst[%offset], %mask
             : !pto.vmi.vreg<128xf16>, !pto.ptr<f16, ub>, !pto.vmi.mask<128xpred>
         %next = arith.subi %rem, %c128 : index
         scf.yield %next : index

--- a/test/vpto/cases/vmi_new/quant-f32-to-f8-tail/kernel.pto
+++ b/test/vpto/cases/vmi_new/quant-f32-to-f8-tail/kernel.pto
@@ -38,7 +38,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
         %mask = pto.vmi.create_mask %rem : index -> !pto.vmi.mask<256xpred>
         %wide = pto.vmi.vload %ub_src[%offset] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
         %packed = pto.vmi.vcvt %wide {saturate = "SAT"} : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xf8E4M3FN>
-        pto.vmi.vstore %packed, %ub_dst_f8[%offset], %mask {pmode = "merge"}
+        pto.vmi.vstore %packed, %ub_dst_f8[%offset], %mask
             : !pto.vmi.vreg<256xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>, !pto.vmi.mask<256xpred>
         %next = arith.subi %rem, %c256 : index
         scf.yield %next : index

--- a/test/vpto/cases/vmi_new/trunci-s32-to-s8-nosat-tail/golden.py
+++ b/test/vpto/cases/vmi_new/trunci-s32-to-s8-nosat-tail/golden.py
@@ -11,10 +11,10 @@
 #
 # Semantics per lane (NOSAT):
 #   valid lane   [0 .. 999]:  dst = int8_t(src[i] & 0xFF)
-#   invalid lane [1000 .. 1023]: dst = sentinel 0xA5 (pmode="merge" preserves it)
+#   invalid lane [1000 .. 1023]: dst = sentinel 0xA5 (masked store preserves it)
 #
 # The kernel iterates 4 x 256 lanes.  The last iteration writes only 232
-# lanes (256 - 24) via a create_mask + merge store.  The compare check runs
+# lanes (256 - 24) via a create_mask + masked store.  The compare check runs
 # on the full 1024-byte buffer so both the payload and the sentinel tail
 # get verified.
 #

--- a/test/vpto/cases/vmi_new/trunci-s32-to-s8-nosat-tail/kernel.pto
+++ b/test/vpto/cases/vmi_new/trunci-s32-to-s8-nosat-tail/kernel.pto
@@ -14,7 +14,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
   //   1000 lanes are valid; the last iteration writes 232 lanes and merges
   //   the remaining 24 back to the destination sentinel 0xA5.
   //
-  // This case exercises pto.vmi.create_mask + pto.vmi.vstore {pmode="merge"}
+  // This case exercises pto.vmi.create_mask + masked vstore tail handling.
   // on the NOSAT s32->s8 path, ensuring tail special-cases do not
   // re-introduce the sat attr on the physical vcvt sequence.
   func.func @vmi_trunci_s32_to_s8_nosat_tail_kernel(
@@ -49,7 +49,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
             : !pto.ptr<si32, ub> -> !pto.vmi.vreg<256xsi32>
         %narrow = pto.vmi.vcvt %wide {saturate = "NOSAT"}
             : !pto.vmi.vreg<256xsi32> -> !pto.vmi.vreg<256xsi8>
-        pto.vmi.vstore %narrow, %ub_dst[%offset], %mask {pmode = "merge"}
+        pto.vmi.vstore %narrow, %ub_dst[%offset], %mask
             : !pto.vmi.vreg<256xsi8>, !pto.ptr<si8, ub>, !pto.vmi.mask<256xpred>
         %next = arith.subi %rem, %c256 : index
         scf.yield %next : index


### PR DESCRIPTION
## Summary

Strengthens VMI legality validation and closes PTODSL surface gaps, rebased on current `hwsys/main`.
Fixes #1058 

### New op
- **`feat(vmi): add vmi.vsstb implementation`** — adds the block-strided store op with a required mask and fixed zero repeat stride, plus lowering guards: `pmode="merge"` is now rejected by both the verifier (clear diagnostic) and the legacy lowering instead of being silently dropped.

### VMI legality checks
- **`fix(vmi): improve legality check for vmi.vload/vstore`** — memory element compatibility, block-stride/mask rules, and group divisibility are checked in all mode branches.
- **`fix(vmi): enhance vcvt conversion attributes`** — rounding/saturation attribute validation with positive/negative tests.
- **`fix(vmi): enforce legal lane counts for vreg and mask`** — unified group verifiers align with the documented domain.
- **`fix(vmi): add UB-backed memory verification for gather/scatter`** — `vgather`/`vgatherb`/`vscatter` reject non-UB memory operands at verify time.

### PTODSL surface
- **`fix(ptodsl): enforce VMI lane-count whitelist on vinterpret_cast`** — the lane count derived by `vinterpret_cast` is checked against `{1,2,4,8,64,128,256}` (previously `8xf32 -> si8` silently produced `32` lanes, bypassing the constructor whitelist); the source layout is only preserved when the lane count is unchanged, and a layout-assigned source across a lane-count change is rejected instead of reusing a stale group/slot layout.
- **`test(ptodsl): improve coverage of vmi dsl tests`** — inventory/emission coverage for the formal `pto.vmi` namespace.

### Test fixes
- **`fix(test): fix failed lit testcases`** — updates `tadd_*` and `soft_postupdate` expectations to the deterministic lowering output (constant ordering, `set_mask_norm`, shared vs duplicated `-1` constants) and fixes the `vmi_gather_scatter_address_space_invalid` RUN line.

## Validation
- `check-pto`: 1538/1539 pass (1 unsupported: vfsim-costmodel feature off)
- `check-dsl`: 25/25 pass


## Segfault fix

### Root cause

`pto.merge_jit_modules()` built each kernel in an independent MLIR `Context`, then directly cloned operations from later modules into the first module. The cloned operations retained types and attributes owned by the source context. When that context was destroyed, destruction of the merged module accessed freed MLIR objects and could terminate with `SIGSEGV` in `mlir::Operation::~Operation()`.

### Fix

Reparse each source module text in the first module's target `Context` before cloning its operations. This keeps all operations, types, attributes, and dialect objects in the merged module under one Context lifetime.

### Validation

- `ptodsl/tests/test_ast_rewrite_example_ir.py`: PASS
- `check-dsl`: 29/29 passed
- `check-pto`: 1622 tests passed, 0 failures
- Valgrind: no invalid read/use-after-free or `pure virtual method called` on the merged AST softmax case
