### PR TITLE
fix(emitc): rely on pto-inst for communication headers

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -13753,6 +13753,12 @@ struct EmitPTOManualPass
 	    builder.create<emitc::IncludeOp>(
 	        loc, "pto/pto-inst.hpp", /*is_standard_include=*/false);
         if (needsCommInclude) {
+	      builder.create<emitc::VerbatimOp>(
+	          loc, builder.getStringAttr(R"cpp(
+#ifndef PIPE_FIX
+#define PIPE_FIX static_cast<pipe_t>(10)
+#endif
+)cpp"));
 	      builder.create<emitc::IncludeOp>(
 	          loc, "pto/comm/pto_comm_inst.hpp", /*is_standard_include=*/false);
         }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -13753,12 +13753,6 @@ struct EmitPTOManualPass
 	    builder.create<emitc::IncludeOp>(
 	        loc, "pto/pto-inst.hpp", /*is_standard_include=*/false);
         if (needsCommInclude) {
-	      builder.create<emitc::VerbatimOp>(
-	          loc, builder.getStringAttr(R"cpp(
-#ifndef PIPE_FIX
-#define PIPE_FIX PIPE_M
-#endif
-)cpp"));
 	      builder.create<emitc::IncludeOp>(
 	          loc, "pto/comm/pto_comm_inst.hpp", /*is_standard_include=*/false);
         }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -13719,7 +13719,6 @@ struct EmitPTOManualPass
         bool needsEventIdArrayHelper = false;
         bool needsTRandomHelper = false;
         bool needsGlobalTensorDataHelper = false;
-        bool needsCommInclude = false;
         mop.walk([&](Operation *op) {
           if (isa<mlir::pto::DeclareEventIdArrayOp>(op))
             needsEventIdArrayHelper = true;
@@ -13735,15 +13734,6 @@ struct EmitPTOManualPass
           }
           if (isa<mlir::pto::PartitionViewOp>(op))
             needsGlobalTensorDataHelper = true;
-          if (isa<mlir::pto::BuildAsyncSessionOp, mlir::pto::TPutAsyncOp,
-                  mlir::pto::TGetAsyncOp, mlir::pto::TPrefetchAsyncOp,
-                  mlir::pto::WaitAsyncEventOp, mlir::pto::TestAsyncEventOp,
-                  mlir::pto::TPutOp,
-                  mlir::pto::TGetOp, mlir::pto::TNotifyOp, mlir::pto::TWaitOp,
-                  mlir::pto::TTestOp, mlir::pto::TBroadcastOp,
-                  mlir::pto::CommTGatherOp, mlir::pto::CommTScatterOp,
-                  mlir::pto::TReduceOp>(op))
-            needsCommInclude = true;
         });
 
 		    // 1. 插入头文件
@@ -13752,16 +13742,6 @@ struct EmitPTOManualPass
 	    builder.setInsertionPointToStart(mop.getBody());
 	    builder.create<emitc::IncludeOp>(
 	        loc, "pto/pto-inst.hpp", /*is_standard_include=*/false);
-        if (needsCommInclude) {
-	      builder.create<emitc::VerbatimOp>(
-	          loc, builder.getStringAttr(R"cpp(
-#ifndef PIPE_FIX
-#define PIPE_FIX static_cast<pipe_t>(10)
-#endif
-)cpp"));
-	      builder.create<emitc::IncludeOp>(
-	          loc, "pto/comm/pto_comm_inst.hpp", /*is_standard_include=*/false);
-        }
 	    builder.create<emitc::VerbatimOp>(
 	        loc, builder.getStringAttr("using namespace pto;"));
 

--- a/test/lit/pto/issue1086_comm_pipe_fix_alias.pto
+++ b/test/lit/pto/issue1086_comm_pipe_fix_alias.pto
@@ -6,10 +6,11 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --implicit-check-not='#define PIPE_FIX'
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --implicit-check-not='#define PIPE_FIX PIPE_M'
 
 // Regression for issue #1086: including the communication header must not
-// alias the system PIPE_FIX pipeline token to PIPE_M.
+// alias the system PIPE_FIX pipeline token to PIPE_M. Older A3 toolchains
+// still need the numeric pipeline fallback used by PTO-ISA communication code.
 
 module attributes {pto.target_arch = "a2a3"} {
   func.func @comm_then_fixpipe_store(
@@ -58,6 +59,9 @@ module attributes {pto.target_arch = "a2a3"} {
 }
 
 // CHECK: #include "pto/pto-inst.hpp"
+// CHECK: #ifndef PIPE_FIX
+// CHECK-NEXT: #define PIPE_FIX static_cast<pipe_t>(10)
+// CHECK-NEXT: #endif
 // CHECK: #include "pto/comm/pto_comm_inst.hpp"
 // CHECK-LABEL: AICORE void comm_then_fixpipe_store(
 // CHECK: pto::comm::TWAIT(

--- a/test/lit/pto/issue1086_comm_pipe_fix_alias.pto
+++ b/test/lit/pto/issue1086_comm_pipe_fix_alias.pto
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --implicit-check-not='#define PIPE_FIX'
+
+// Regression for issue #1086: including the communication header must not
+// alias the system PIPE_FIX pipeline token to PIPE_M.
+
+module attributes {pto.target_arch = "a2a3"} {
+  func.func @comm_then_fixpipe_store(
+      %signal_ptr: !pto.ptr<i32>,
+      %out_ptr: !pto.ptr<f32>)
+      attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c1_i32 = arith.constant 1 : i32
+
+    %signal_view = pto.make_tensor_view %signal_ptr,
+      shape = [%c1], strides = [%c1]
+      : !pto.tensor_view<1xi32>
+    %signal = pto.partition_view %signal_view,
+      offsets = [%c0], sizes = [%c1]
+      : !pto.tensor_view<1xi32> -> !pto.partition_tensor_view<1xi32>
+    pto.comm.twait(%signal, %c1_i32
+      : !pto.partition_tensor_view<1xi32>, i32) {cmp = #pto<wait_cmp ge>}
+
+    %lhs = pto.alloc_tile
+      : !pto.tile_buf<left, 32x32xf16, blayout=row_major, slayout=row_major>
+    %rhs = pto.alloc_tile
+      : !pto.tile_buf<right, 32x32xf16, blayout=row_major, slayout=col_major>
+    %acc = pto.alloc_tile
+      : !pto.tile_buf<acc, 32x32xf32, blayout=col_major, slayout=row_major, fractal=1024>
+    pto.tmatmul
+      ins(%lhs, %rhs
+        : !pto.tile_buf<left, 32x32xf16, blayout=row_major, slayout=row_major>,
+          !pto.tile_buf<right, 32x32xf16, blayout=row_major, slayout=col_major>)
+      outs(%acc
+        : !pto.tile_buf<acc, 32x32xf32, blayout=col_major, slayout=row_major, fractal=1024>)
+
+    %out_view = pto.make_tensor_view %out_ptr,
+      shape = [%c32, %c32], strides = [%c32, %c1]
+      : !pto.tensor_view<32x32xf32>
+    %out = pto.partition_view %out_view,
+      offsets = [%c0, %c0], sizes = [%c32, %c32]
+      : !pto.tensor_view<32x32xf32> -> !pto.partition_tensor_view<32x32xf32>
+    pto.tstore
+      ins(%acc
+        : !pto.tile_buf<acc, 32x32xf32, blayout=col_major, slayout=row_major, fractal=1024>)
+      outs(%out : !pto.partition_tensor_view<32x32xf32>)
+    return
+  }
+}
+
+// CHECK: #include "pto/pto-inst.hpp"
+// CHECK: #include "pto/comm/pto_comm_inst.hpp"
+// CHECK-LABEL: AICORE void comm_then_fixpipe_store(
+// CHECK: pto::comm::TWAIT(
+// CHECK: TMATMUL(
+// CHECK-NEXT: set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK: wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+// CHECK-NEXT: TSTORE(

--- a/test/lit/pto/issue1086_comm_pipe_fix_alias.pto
+++ b/test/lit/pto/issue1086_comm_pipe_fix_alias.pto
@@ -6,11 +6,11 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --implicit-check-not='#define PIPE_FIX PIPE_M'
+// RUN: ptoas --pto-arch=a3 --enable-insert-sync %s -o - 2>&1 | FileCheck %s --implicit-check-not='#define PIPE_FIX' --implicit-check-not='pto/comm/pto_comm_inst.hpp'
 
-// Regression for issue #1086: including the communication header must not
-// alias the system PIPE_FIX pipeline token to PIPE_M. Older A3 toolchains
-// still need the numeric pipeline fallback used by PTO-ISA communication code.
+// Regression for issue #1086: pto-inst.hpp exposes communication instructions
+// only in supported PTO compilation phases. Do not bypass that boundary with
+// a direct communication include or define the system PIPE_FIX pipeline token.
 
 module attributes {pto.target_arch = "a2a3"} {
   func.func @comm_then_fixpipe_store(
@@ -59,10 +59,6 @@ module attributes {pto.target_arch = "a2a3"} {
 }
 
 // CHECK: #include "pto/pto-inst.hpp"
-// CHECK: #ifndef PIPE_FIX
-// CHECK-NEXT: #define PIPE_FIX static_cast<pipe_t>(10)
-// CHECK-NEXT: #endif
-// CHECK: #include "pto/comm/pto_comm_inst.hpp"
 // CHECK-LABEL: AICORE void comm_then_fixpipe_store(
 // CHECK: pto::comm::TWAIT(
 // CHECK: TMATMUL(


### PR DESCRIPTION
## Summary

- stop emitting a generated `PIPE_FIX` macro for communication kernels
- remove the redundant direct `pto/comm/pto_comm_inst.hpp` include and rely on the phase-aware `pto/pto-inst.hpp` entry point used by PTO-ISA testcases
- retain the A3 regression that combines a communication op with a real `PIPE_M -> PIPE_FIX` dependency

## Root cause

BiSheng compiles CCE sources in separate host and device phases. PTO-ISA already accounts for this: `pto-inst.hpp` includes `pto_instr.hpp` only for `__CPU_SIM`, `__CCE_AICORE__`, or `__COSTMODEL`, and the device path then obtains communication instructions and the native CANN `PIPE_FIX` enumerator.

PTOAS bypassed that boundary by unconditionally emitting `pto/comm/pto_comm_inst.hpp`. The host phase therefore parsed `event.hpp` even though the host CANN pipe enum does not expose `PIPE_FIX`. The old compatibility macro also aliased `PIPE_FIX` to `PIPE_M`, collapsing real `PIPE_M -> PIPE_FIX` synchronization into `PIPE_M -> PIPE_M`.

## Validation

- focused lit coverage: 7 passed (`issue1086`, comm EmitC, A3 FIX-pipe selection, and related fence regressions)
- full lit suite: 1540 passed / 1 unsupported
- generated Issue #1086 C++ contains only `#include "pto/pto-inst.hpp"`; no generated `PIPE_FIX` macro or direct communication include remains
- the generated `set_flag` / `wait_flag(PIPE_M, PIPE_FIX, ...)` calls are preserved
- the complete generated C++ compiles with the A3 board BiSheng 15.0.5 / CANN 9.0.0 toolchain without any `PIPE_FIX` fallback

Closes #1086
