### PR TITLE
fix(ci): restore parallel TileLib ST and watchdog labels

### DIFF
--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -874,7 +874,9 @@ jobs:
           TILELIB_ST_OUTPUT_ROOT="${TILELIB_ST_WORKSPACE}/tilelib-st-a5" \
           ASCEND_HOME_PATH="${ASCEND_HOME_PATH}" \
           PTOAS_BIN="${PTO_DSL_ST_PTOAS_BIN}" \
-          scripts/sim_dsl.sh test/tilelib-st/run_tilelib_st.py -- test/tilelib-st/a5 \
+          "${PTO_DSL_ST_PYTHON_BIN}" -m pytest \
+            -n "${TILELIB_ST_JOBS:-16}" --dist=worksteal -v \
+            test/tilelib-st/test_tilelib_st.py \
             2>&1 | tee "${TILELIB_ST_WORKSPACE}/tilelib-st-a5.log"
 
       - name: Run PTODSL ST CI

--- a/.github/workflows/ci_sim.yml
+++ b/.github/workflows/ci_sim.yml
@@ -904,7 +904,10 @@ jobs:
             ${{ env.TILELIB_ST_WORKSPACE }}/run_ci.log
             ${{ env.TILELIB_ST_WORKSPACE }}/ptodsl-dsl-st.log
             ${{ env.TILELIB_ST_WORKSPACE }}/tilelib-st-a5.log
-            ${{ env.TILELIB_ST_WORKSPACE }}/tilelib-st-a5/**
+            ${{ env.TILELIB_ST_WORKSPACE }}/tilelib-st-a5/logs/*.log
+            ${{ env.TILELIB_ST_WORKSPACE }}/tilelib-st-a5/cases/*/example.exitcode
+            ${{ env.TILELIB_ST_WORKSPACE }}/tilelib-st-a5/cases/*/run_example.sh
+            ${{ env.TILELIB_ST_WORKSPACE }}/tilelib-st-a5/cases/*/msprof.stdout.log
             ${{ env.TILELIB_ST_WORKSPACE }}/ptodsl-python-probe.log
           if-no-files-found: warn
 

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -22,12 +22,14 @@ jobs:
   warn-slow-ci-sim:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-22.04
-    continue-on-error: true
     permissions:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      # The warning targets a pull request. Request PR write permission as well
+      # as issues write so both the ci-slow label and conversation comment can
+      # be updated by GITHUB_TOKEN under restrictive repository defaults.
+      pull-requests: write
     env:
       SOFT_TIMEOUT_MINUTES: ${{ vars.CI_SIM_SOFT_TIMEOUT_MINUTES || '90' }}
       PR_CONTEXT_DIR: pr-context


### PR DESCRIPTION
## 背景

PR #1028 已经将 TileLib ST 改为按 case 使用 `pytest-xdist` 并行调度，但后续 CI workflow 修改重新使用了串行 `run_tilelib_st.py` 入口。当前 154 个 case 因此共享一个 simulator 会话串行执行；最近一次串行门禁中的 `Run TileLib ST CI` 用时约 59 分钟。

同一次门禁超过 watchdog 的 90 分钟软预算后，watchdog 虽然正确识别了慢运行，却在给 PR 添加 `ci-slow` label 时因为 `GITHUB_TOKEN` 只有 pull-request read 权限而收到 403。该 job 的 `continue-on-error` 又让 Watchdog workflow 最终显示为 success，没有留下 label 或评论。

## 修改

- 恢复 TileLib ST 的 pytest 入口，使用 16 路 `pytest-xdist --dist=worksteal` 调度独立 case。
- 保留当前 `TILELIB_ST_WORKSPACE`、PTODSL Python、PTOAS 和日志路径配置。
- 将 TileLib artifact 从整个 case simulator 工作目录收敛为聚合日志、每 case 日志、退出码、复现脚本和 msprof stdout，避免并行输出产生百万级临时文件上传。
- 为慢 CI 告警 job 同时授予 `issues: write` 和 `pull-requests: write`，使 `GITHUB_TOKEN` 可以更新 PR 的 `ci-slow` label 和 Conversation 评论。
- 移除 watchdog job 的 `continue-on-error`，使 watchdog 自身的权限或脚本错误在独立 workflow 中可见；该 workflow 不是 `ci-sim` required check，不会改变原门禁结果。

## 验证

- `.github/workflows/ci_sim.yml` 和 `.github/workflows/watchdog.yml` 通过 PyYAML 解析。
- TileLib ST Python 文件通过 `py_compile`。
- 使用 CI 同款 PTODSL Python、pytest 9.1.1 和 pytest-xdist 3.8.0：154 个 case 收集成功。
- `pytest --collect-only -n 16 --dist=worksteal test/tilelib-st/test_tilelib_st.py` 通过。
- PR CI 中 154 个 TileLib ST case 全部通过，并行运行时间为 9 分 18 秒。
- 根据该次 CI 实际输出验证 artifact 收敛：上传文件从 1,101,864 个降至 616 个，约 2.6 MB。
- `git diff --check` 通过。

后续 CI 出现的 exit 143 已确认来自宿主机 OOM：PR #1105 的 TileLib simulator 与 PR #1104 的 PTOAS 编译等任务同时运行，runner 所在 tmux scope 使用 `OOMPolicy=stop`，action 子进程成为 OOM victim 后连带关闭了整个 runner。该宿主机部署问题不通过降低本 PR 的 TileLib 并行度处理。

说明：`workflow_run` 会从默认分支加载 watchdog，因此新的 PR 写权限需要在本 PR 合入后，由下一次 PR `ci-sim` 完成事件做端到端验证。

Follow-up to #1028 and #1031.
