### PR TITLE
feat(vmi): 支持 width-changing vinterpret_cast

### DIFF
--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -440,6 +440,13 @@ public:
   getBitcastLayoutFact(VMIBitcastOp op,
                        std::string *reason = nullptr) const;
 
+  FailureOr<SmallVector<VMIBitcastLayoutFact, 4>>
+  getBitcastLayoutFactsForLayout(VMIVRegType sourceType,
+                                 VMIVRegType resultType,
+                                 VMICastLayoutPort port,
+                                 VMILayoutAttr layout,
+                                 std::string *reason = nullptr) const;
+
   LogicalResult getBitcastSupport(VMIBitcastOp op,
                                   std::string *reason = nullptr) const;
 

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -175,7 +175,7 @@ static bool isSameLayoutOp(Operation *op) {
              VMIMaxIOp, VMINegFOp, VMIAbsFOp, VMIAbsIOp, VMISqrtOp, VMIExpOp,
              VMILnOp, VMIReluOp, VMIFPToSIOp, VMISIToFPOp, VMIAndIOp, VMIOrIOp,
              VMIXOrIOp, VMIShLIOp, VMIShRUIOp, VMIShRSIOp, VMINotOp, VMICmpFOp,
-             VMICmpIOp, VMISelectOp, VMIBitcastOp, VMIMaskAndOp, VMIMaskOrOp,
+             VMICmpIOp, VMISelectOp, VMIMaskAndOp, VMIMaskOrOp,
              VMIMaskXOrOp, VMIMaskNotOp, VMIActivePrefixIndexOp, VMICompressOp,
              VMIExpandLoadOp>(op);
 }
@@ -245,6 +245,47 @@ public:
       return relations;
     }
     return failure();
+  }
+};
+
+class VMIBitcastTransfer final : public VMILayoutTransfer {
+public:
+  FailureOr<SmallVector<VMILayoutRelation, 4>>
+  query(Operation *op, Value changedValue, VMILayoutAttr changedLayout,
+        const VMILayoutPropagator &propagator,
+        OpOperand *changedOperand) const override {
+    auto bitcast = dyn_cast<VMIBitcastOp>(op);
+    if (!bitcast)
+      return failure();
+
+    auto sourceType = dyn_cast<VMIVRegType>(bitcast.getSource().getType());
+    auto resultType = dyn_cast<VMIVRegType>(bitcast.getResult().getType());
+    if (!sourceType || !resultType)
+      return failure();
+
+    VMICastLayoutPort port;
+    if (changedOperand == &bitcast.getSourceMutable() ||
+        changedValue == bitcast.getSource()) {
+      port = VMICastLayoutPort::Source;
+    } else if (changedValue == bitcast.getResult()) {
+      port = VMICastLayoutPort::Result;
+    } else {
+      return failure();
+    }
+
+    VMILayoutSupport supports;
+    FailureOr<SmallVector<VMIBitcastLayoutFact, 4>> facts =
+        supports.getBitcastLayoutFactsForLayout(sourceType, resultType, port,
+                                                changedLayout);
+    if (failed(facts) || facts->empty())
+      return failure();
+
+    SmallVector<VMILayoutRelation, 4> relations;
+    for (const VMIBitcastLayoutFact &fact : *facts)
+      relations.push_back(makeRelation(SmallVector<VMILayoutFact, 4>{
+          operandFact(bitcast.getSourceMutable(), fact.sourceLayout),
+          valueFact(bitcast.getResult(), fact.resultLayout)}));
+    return relations;
   }
 };
 
@@ -765,6 +806,7 @@ public:
 const VMILayoutTransfer *getTransfer(Operation *op) {
   static VMISameLayoutTransfer sameLayoutTransfer;
   static VMICastTransfer castTransfer;
+  static VMIBitcastTransfer bitcastTransfer;
   static VMIMaskGranularityCastTransfer maskGranularityCastTransfer;
   static VMIFreeResultLayoutTransfer freeResultLayoutTransfer;
   static VMILoadTransfer loadTransfer;
@@ -804,6 +846,8 @@ const VMILayoutTransfer *getTransfer(Operation *op) {
     return &interleaveTransfer;
   if (isa<VMIGatherOp>(op))
     return &gatherTransfer;
+  if (isa<VMIBitcastOp>(op))
+    return &bitcastTransfer;
   if (isSameLayoutOp(op))
     return &sameLayoutTransfer;
   if (isa<VMIEnsureMaskGranularityOp>(op))

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -2842,6 +2842,57 @@ VMILayoutSupport::getBitcastLayoutFact(VMIBitcastOp op,
   return VMIBitcastLayoutFact{sourceLayout, resultLayout};
 }
 
+FailureOr<SmallVector<VMIBitcastLayoutFact, 4>>
+VMILayoutSupport::getBitcastLayoutFactsForLayout(
+    VMIVRegType sourceType, VMIVRegType resultType, VMICastLayoutPort port,
+    VMILayoutAttr layout, std::string *reason) const {
+  auto fail = [&](const Twine &message)
+      -> FailureOr<SmallVector<VMIBitcastLayoutFact, 4>> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  if (!layout)
+    return fail("requires an assigned bitcast query layout");
+
+  unsigned sourceElementBits =
+      pto::getPTOStorageElemBitWidth(sourceType.getElementType());
+  unsigned resultElementBits =
+      pto::getPTOStorageElemBitWidth(resultType.getElementType());
+  if (sourceElementBits == 0 || resultElementBits == 0)
+    return fail("requires source and result with known storage element width");
+
+  if (sourceElementBits == resultElementBits)
+    return SmallVector<VMIBitcastLayoutFact, 4>{
+        VMIBitcastLayoutFact{layout, layout}};
+
+  int64_t numGroups = layout.isGroupSlots() ? layout.getNumGroups() : 0;
+  MLIRContext *ctx = sourceType.getContext();
+  SmallVector<VMIBitcastLayoutFact, 4> facts;
+  for (const WidthChangingBitcastLayoutPattern &pattern :
+       kWidthChangingBitcastLayoutPatterns) {
+    VMILayoutAttr candidate =
+        materializeLayoutPattern(ctx, pattern.layout, numGroups);
+    if (!candidate)
+      continue;
+    if (port == VMICastLayoutPort::Source && candidate != layout)
+      continue;
+    if (port == VMICastLayoutPort::Result && candidate != layout)
+      continue;
+    facts.push_back(VMIBitcastLayoutFact{candidate, candidate});
+  }
+
+  if (facts.empty()) {
+    if (port == VMICastLayoutPort::Source)
+      return fail(
+          "requires a legal width-changing bitcast source layout relation");
+    return fail(
+        "requires a legal width-changing bitcast result layout relation");
+  }
+  return facts;
+}
+
 LogicalResult VMILayoutSupport::getBitcastSupport(VMIBitcastOp op,
                                                   std::string *reason) const {
   return getBitcastLayoutFact(op, reason);

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -866,7 +866,7 @@ annotation changes. This is a reinterpretation, not a numeric conversion.
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `source` | `VRegType` | Input vector |
-| `to_dtype` | `DType` | **Required.** Target element type. PTODSL keeps the source lane count/layout and reinterprets each lane at the new type |
+| `to_dtype` | `DType` | **Required.** Target element type. PTODSL preserves the vector's total bit footprint and derives the target lane count |
 
 **Returns**:
 
@@ -883,7 +883,8 @@ as_i32 = pto.vmi.vinterpret_cast(src, pto.i32)
 **Constraints**:
 - `to_dtype` is always required — PTODSL must not guess a reinterpretation
   target element type.
-- The source and target element widths must match.
+- The target lane count is `source_lanes * source_element_bits /
+  target_element_bits`; this value must be integral.
 
 ---
 
@@ -1310,7 +1311,8 @@ surface no longer asks you to spell the full result type manually.
 - `vload` with `dist_mode="unpack"` requires `to_dtype` to derive the widened
   element type.
 - `vcvt` requires `to_dtype`.
-- `vinterpret_cast` requires `to_dtype`.
+- `vinterpret_cast` requires `to_dtype`; its lane count is derived by
+  preserving the source vector's total bit footprint.
 - `vgatherb` is inferred from the source pointer element type and the mask.
 
 ---

--- a/ptodsl/ptodsl/_vmi_namespace.py
+++ b/ptodsl/ptodsl/_vmi_namespace.py
@@ -205,13 +205,15 @@ def _derive_vinterpret_cast_result_type(source, to_dtype, *, context: str):
     target_elem_type = _ensure_tensor_storage_dtype(to_dtype, context=context)
     source_bits = _type_bit_width(source_elem_type, context=context)
     target_bits = _type_bit_width(target_elem_type, context=context)
-    if source_bits != target_bits:
+    total_bits = source_type.element_count * source_bits
+    if total_bits % target_bits != 0:
         raise TypeError(
-            f"{context} requires source and target element widths to match; got "
+            f"{context} requires the source bit count to be divisible by the "
+            f"target element width; got {source_type.element_count}x"
             f"{source_elem_type} -> {target_elem_type}"
         )
     return _pto.VMIVRegType.get(
-        source_type.element_count,
+        total_bits // target_bits,
         target_elem_type,
         layout=source_type.layout,
     )

--- a/ptodsl/tests/test_jit_diagnostics.py
+++ b/ptodsl/tests/test_jit_diagnostics.py
@@ -112,9 +112,9 @@ def vmi_vinterpret_cast_missing_dtype_probe():
 
 
 @pto.jit(target="a5")
-def vmi_vinterpret_cast_width_mismatch_probe():
-    src = pto.vmi.vbrc(pto.f32(0.0), size=64)
-    _ = pto.vmi.vinterpret_cast(src, to_dtype=pto.f16)
+def vmi_vinterpret_cast_footprint_mismatch_probe():
+    src = pto.vmi.vbrc(pto.f16(0.0), size=1)
+    _ = pto.vmi.vinterpret_cast(src, to_dtype=pto.f32)
 
 
 @pto.jit(target="a5")
@@ -721,10 +721,10 @@ def main() -> None:
         "requires to_dtype",
     )
     expect_raises(
-        vmi_vinterpret_cast_width_mismatch_probe.compile,
+        vmi_vinterpret_cast_footprint_mismatch_probe.compile,
         TypeError,
         "pto.vmi.vinterpret_cast(...)",
-        "element widths to match",
+        "source bit count to be divisible",
     )
     expect_raises(
         vmi_create_mask_group_mismatch_probe.compile,

--- a/ptodsl/tests/test_vmi_bf16_group8_carrier.py
+++ b/ptodsl/tests/test_vmi_bf16_group8_carrier.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+from ptodsl import pto
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def vmi_bf16_group8_carrier_probe():
+    src_tile = pto.alloc_tile(shape=[1, 256], dtype=pto.bf16)
+    offset = pto.const(0, dtype=pto.index)
+    mask = pto.vmi.create_mask(256, size=256)
+    zero = pto.vmi.vbrc(pto.bf16(0.0), size=256)
+    source = pto.vmi.vload(src_tile.as_ptr(), offset, size=256)
+    source_f32 = pto.vmi.vcvt(source, to_dtype=pto.f32)
+    mask_f32 = pto.vmi.create_mask(256, size=256)
+    maximum = pto.vmi.vcmax(source_f32, mask_f32, group=8)
+    low, high = pto.vmi.vintlv(zero, source, mask)
+    low_f32 = pto.vmi.vinterpret_cast(low, to_dtype=pto.f32)
+    high_f32 = pto.vmi.vinterpret_cast(high, to_dtype=pto.f32)
+    _ = maximum
+    _ = low_f32
+    _ = high_f32
+
+
+def main() -> None:
+    text = vmi_bf16_group8_carrier_probe.compile().mlir_text()
+    expect(
+        "!pto.vmi.vreg<256xbf16>" in text,
+        "carrier probe must preserve the 256-lane BF16 source",
+    )
+    expect(
+        "pto.vmi.vcmax" in text and "{group = 8 : i64}" in text,
+        "carrier probe must emit one surface group=8 maximum",
+    )
+    expect(
+        "-> !pto.vmi.vreg<8xf32>" in text,
+        "explicit BF16-to-F32 conversion followed by group=8 maximum must "
+        "infer an 8xf32 result",
+    )
+    expect(
+        text.count("!pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<128xf32>") == 2,
+        "both BF16 carrier halves must reinterpret to 128xf32 by total bits",
+    )
+    print("ptodsl_vmi_bf16_group8_carrier: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/lit/vmi_new/opt/per_block_bf16_group8_quant_vmi_opt.pto
+++ b/test/lit/vmi_new/opt/per_block_bf16_group8_quant_vmi_opt.pto
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s | FileCheck %s --check-prefix=VPTO --implicit-check-not=pto.vmi. --implicit-check-not='!pto.vmi' --implicit-check-not=pto.vdintlv --implicit-check-not=pto.vsldb --implicit-check-not=pto.vsstb --implicit-check-not=pto.vcmax --implicit-check-not=pto.vldsx2 --implicit-check-not='pto.vcvt ' --implicit-check-not=pto.vcgmax --implicit-check-not='pto.vmax ' --implicit-check-not=pto.vpack --implicit-check-not=pto.vselr --implicit-check-not='pto.vmul ' --implicit-check-not=pto.vintlv --implicit-check-not=pto.vbitcast --implicit-check-not='pto.vsts '
+
+// Optimization guard for the per-block BF16 group=8 quant path. Two adjacent
+// 128-column strips form one 256-lane value with eight 32-lane groups. Keep the
+// BF16-to-F32 conversion and reduction on deinterleaved layouts, broadcast the
+// eight scale slots directly in registers, and preserve the width-changing
+// carrier reinterpretation needed by the final PK4_B32 stores.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @per_block_bf16_group8_quant_vmi_opt(
+      %src: !pto.ptr<bf16, ub>,
+      %dst: !pto.ptr<f8E4M3FN, ub>,
+      %off: index) attributes {pto.kernel} {
+    %c128 = arith.constant 128 : index
+    %c256 = arith.constant 256 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %off128 = arith.addi %off, %c128 : index
+    %mask = pto.vmi.create_mask %c256
+        : index -> !pto.vmi.mask<256xpred>
+    %zero = pto.vmi.vbrc %cst : bf16 -> !pto.vmi.vreg<256xbf16>
+    %x = pto.vmi.vload %src[%off]
+        : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+    %x_f32 = pto.vmi.vcvt %x
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf32>
+    %mask_f32 = pto.vmi.create_mask %c256
+        : index -> !pto.vmi.mask<256xpred>
+    %amax = pto.vmi.vcmax %x_f32, %mask_f32 {group = 8}
+        : !pto.vmi.vreg<256xf32>, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<8xf32>
+    %scale = pto.vmi.vcvt %amax {rounding = "R", saturate = "NOSAT"}
+        : !pto.vmi.vreg<8xf32> -> !pto.vmi.vreg<8xbf16>
+    %scale256 = pto.vmi.vbrc %scale {group = 8}
+        : !pto.vmi.vreg<8xbf16> -> !pto.vmi.vreg<256xbf16>
+    %qbf16 = pto.vmi.vmul %x, %scale256, %mask
+        : !pto.vmi.vreg<256xbf16>, !pto.vmi.vreg<256xbf16>,
+          !pto.vmi.mask<256xpred> -> !pto.vmi.vreg<256xbf16>
+    %low, %high = pto.vmi.vintlv %zero, %qbf16, %mask
+        : !pto.vmi.vreg<256xbf16>, !pto.vmi.vreg<256xbf16>,
+          !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<256xbf16>, !pto.vmi.vreg<256xbf16>
+    %low32 = pto.vmi.vinterpret_cast %low
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<128xf32>
+    %high32 = pto.vmi.vinterpret_cast %high
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<128xf32>
+    %low8 = pto.vmi.vcvt %low32 {rounding = "R", saturate = "SAT"}
+        : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf8E4M3FN>
+    %high8 = pto.vmi.vcvt %high32 {rounding = "R", saturate = "SAT"}
+        : !pto.vmi.vreg<128xf32> -> !pto.vmi.vreg<128xf8E4M3FN>
+    pto.vmi.vstore %low8, %dst[%off]
+        : !pto.vmi.vreg<128xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
+    pto.vmi.vstore %high8, %dst[%off128]
+        : !pto.vmi.vreg<128xf8E4M3FN>, !pto.ptr<f8E4M3FN, ub>
+    return
+  }
+}
+
+// ASSIGN-LABEL: func.func @per_block_bf16_group8_quant_vmi_opt(
+// ASSIGN: %[[X:.*]] = pto.vmi.load
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[X_F32:.*]] = pto.vmi.extf %[[X]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 4>>
+// ASSIGN: %[[AMAX:.*]] = pto.vmi.group_reduce_maxf %[[X_F32]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<8xf32, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// ASSIGN: %[[SCALE_LS2:.*]] = pto.vmi.truncf %[[AMAX]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<8xbf16, #pto.vmi.layout<num_groups = 8, slots = 8, lane_stride = 2>>
+// ASSIGN: %[[SCALE:.*]] = pto.vmi.ensure_layout %[[SCALE_LS2]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<8xbf16, #pto.vmi.layout<num_groups = 8, slots = 8>>
+// ASSIGN-NOT: pto.vmi.store
+// ASSIGN-NOT: pto.vmi.load
+// ASSIGN: %[[SCALE256:.*]] = pto.vmi.group_broadcast %[[SCALE]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[Q:.*]] = pto.vmi.mulf %[[X]], %[[SCALE256]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[Q_C:.*]] = pto.vmi.ensure_layout %[[Q]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[LOW:.*]], %[[HIGH:.*]] = pto.vmi.vintlv
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<deinterleaved = 2>>, !pto.vmi.vreg<256xbf16, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[LOW_C:.*]] = pto.vmi.ensure_layout %[[LOW]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>>
+// ASSIGN: pto.vmi.bitcast %[[LOW_C]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[HIGH_C:.*]] = pto.vmi.ensure_layout %[[HIGH]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>>
+// ASSIGN: pto.vmi.bitcast %[[HIGH_C]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+
+// VPTO-LABEL: func.func @per_block_bf16_group8_quant_vmi_opt(
+// VPTO: pto.vldsx2 {{.*}}, "DINTLV_B16"
+// VPTO-COUNT-2: pto.vcvt {{.*}} {part = "EVEN"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+// VPTO-COUNT-2: pto.vcvt {{.*}} {part = "ODD"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xf32>
+// VPTO-COUNT-3: pto.vmax {{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32>
+// VPTO: pto.vcgmax
+// VPTO: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "NOSAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xbf16>
+// VPTO: pto.vbitcast {{.*}} : !pto.vreg<128xbf16> -> !pto.vreg<64xui32>
+// VPTO: pto.vpack {{.*}}, "LOWER" : !pto.vreg<64xui32> -> !pto.vreg<128xui16>
+// VPTO: pto.vbitcast {{.*}} : !pto.vreg<128xui16> -> !pto.vreg<128xbf16>
+// VPTO: pto.vselr
+// VPTO-COUNT-2: pto.vmul {{.*}} : !pto.vreg<128xbf16>, !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<128xbf16>
+// VPTO: %[[Q_LOW:.*]], %[[Q_HIGH:.*]] = pto.vintlv
+// VPTO: %[[LOW0:.*]], %[[LOW1:.*]] = pto.vintlv {{.*}}, %[[Q_LOW]]
+// VPTO-COUNT-2: pto.vbitcast {{.*}} : !pto.vreg<128xbf16> -> !pto.vreg<64xf32>
+// VPTO: %[[HIGH0:.*]], %[[HIGH1:.*]] = pto.vintlv {{.*}}, %[[Q_HIGH]]
+// VPTO-COUNT-2: pto.vbitcast {{.*}} : !pto.vreg<128xbf16> -> !pto.vreg<64xf32>
+// VPTO-COUNT-4: pto.vcvt {{.*}} {part = "P0", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<256xf8E4M3FN>
+// VPTO-NOT: part = "P1"
+// VPTO-NOT: part = "P2"
+// VPTO-NOT: part = "P3"
+// VPTO-NOT: pto.vor
+// VPTO-COUNT-4: pto.vsts {{.*}} {dist = "PK4_B32"}
+// VPTO-NOT: pto.vsts

--- a/test/lit/vmi_new/vmi_layout_assignment_vintlv_width_changing_bitcast.pto
+++ b/test/lit/vmi_new/vmi_layout_assignment_vintlv_width_changing_bitcast.pto
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under
+// the terms and conditions of CANN Open Software License Agreement Version 2.0
+// (the "License"). Please refer to the License for details. You may not use
+// this file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON
+// AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS
+// FOR A PARTICULAR PURPOSE. See LICENSE in the root of the software repository
+// for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER
+
+module {
+  func.func @vmi_layout_assignment_vintlv_width_changing_bitcast(
+      %zero: !pto.vmi.vreg<256xbf16>,
+      %acc: !pto.vmi.vreg<256xbf16>,
+      %mask: !pto.vmi.mask<256xpred>)
+      -> (!pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>) {
+    %low, %high = pto.vmi.vintlv %zero, %acc, %mask
+        : !pto.vmi.vreg<256xbf16>, !pto.vmi.vreg<256xbf16>,
+          !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<256xbf16>, !pto.vmi.vreg<256xbf16>
+    %low_f32 = pto.vmi.vinterpret_cast %low
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<128xf32>
+    %high_f32 = pto.vmi.vinterpret_cast %high
+        : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<128xf32>
+    return %low_f32, %high_f32
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xf32>
+  }
+}
+
+// ASSIGN-LABEL: func.func @vmi_layout_assignment_vintlv_width_changing_bitcast(
+// ASSIGN: %[[LOW:.*]], %[[HIGH:.*]] = pto.vmi.vintlv
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<deinterleaved = 2>>, !pto.vmi.vreg<256xbf16, #pto.vmi.layout<deinterleaved = 2>>
+// ASSIGN: %[[LOW_C:.*]] = pto.vmi.ensure_layout %[[LOW]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[LOW_F32:.*]] = pto.vmi.bitcast %[[LOW_C]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[HIGH_C:.*]] = pto.vmi.ensure_layout %[[HIGH]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<256xbf16, #pto.vmi.layout<contiguous>>
+// ASSIGN: %[[HIGH_F32:.*]] = pto.vmi.bitcast %[[HIGH_C]]
+// ASSIGN-SAME: -> !pto.vmi.vreg<128xf32, #pto.vmi.layout<contiguous>>
+
+// LOWER-LABEL: func.func @vmi_layout_assignment_vintlv_width_changing_bitcast(
+// LOWER: pto.vintlv
+// LOWER-COUNT-2: pto.vbitcast
+// LOWER: pto.vintlv
+// LOWER-COUNT-2: pto.vbitcast
+// LOWER-NOT: pto.vmi.
+// LOWER-NOT: !pto.vmi.
+// LOWER-NOT: unrealized_conversion_cast


### PR DESCRIPTION
## 背景

量化场景使用 256-lane BF16 向量承载中间结果。归约阶段应先通过普通 `vcvt` 显式转换为 256-lane FP32，再执行现有的 `group=8` FP32 reduction；尾部 FP8 打包则需要将 256-lane BF16 carrier 按总 bit footprint reinterpret 为 128-lane FP32。

现有 `vinterpret_cast` surface 固定保留 lane 数，layout propagation 也把 bitcast 当作普通 same-layout op，因此无法表达这种 width-changing reinterpret。

来源问题：[`learning-chip/vmi-demo#31`](https://github.com/learning-chip/vmi-demo/pull/31) 及其中的 [`quant/remain_gap/PTOAS_ASKS.md`](https://github.com/learning-chip/vmi-demo/blob/quant_remain/quant/remain_gap/PTOAS_ASKS.md)。本 PR 完成该问题所需的 PTOAS 编译/codegen 路径；产品 8192×2048 真机结果由下游采用新写法后复测。

## 正确写法

`vcmax` 保持同类型 reduction，不使用 mixed-type `to_dtype`。BF16 累积完成后显式转换一次，scale 直接从 group slots 广播回 256 lanes；FP8 打包前的 reinterpret 按总 bit footprint 改变 lane 数：

```python
amax_bf16 = ...  # 256-lane BF16 accumulation
amax_f32 = pto.vmi.vcvt(amax_bf16, to_dtype=pto.f32)
mask_f32 = pto.vmi.create_mask(256, size=256)
amax = pto.vmi.vcmax(amax_f32, mask_f32, group=8)

scale_bf16 = ...  # 8 BF16 group slots
scale_256 = pto.vmi.vbrc(scale_bf16, group=8)
quant_bf16 = pto.vmi.vmul(source_bf16, scale_256, mask_bf16)

low_bf16, high_bf16 = pto.vmi.vintlv(zero_bf16, quant_bf16, mask_bf16)
low_f32 = pto.vmi.vinterpret_cast(low_bf16, to_dtype=pto.f32)
high_f32 = pto.vmi.vinterpret_cast(high_bf16, to_dtype=pto.f32)
```

对应逻辑类型为：

```text
256xbf16 -> vcvt -> 256xf32 -> vcmax(group=8) -> 8xf32
8xbf16   -> vbrc(group=8) -> 256xbf16
256xbf16 -> vinterpret_cast -> 128xf32
```

## 修改内容

- 让 `pto.vmi.vinterpret_cast` 按总 bit footprint 推导目标 lane 数，即 `source_lanes * source_bits / target_bits`，并在结果不整除时给出诊断。
- 为 bitcast 增加独立的 layout transfer，通过表驱动声明 width-changing bitcast 当前支持 contiguous layout；必要时由 layout assignment 插入 `ensure_layout`。
- 在 `test/lit/vmi_new/opt/per_block_bf16_group8_quant_vmi_opt.pto` 增加完整优化监控：既检查 layout assignment 的 256-lane/group=8 传播，也检查端到端 VPTO 的 reduction、寄存器广播、carrier reinterpret 和 PK4 store 指令形态。
- 更新 PTODSL 用户文档与类型诊断测试。

本 PR **不** 给 `vcmax` 增加 `to_dtype`，也不新增 BF16 输入、FP32 输出的 mixed-type verifier 或专用 reduction lowering。类型转换在 surface 上保持显式。

## Codegen

显式转换后的 group=8 reduction 使用现有通用路径，生成：

```text
4 x vcvt    128xbf16 -> 64xf32 (EVEN/ODD)
3 x vmax    合并四个物理 FP32 chunk
1 x vcgmax  完成 group=8 reduction
1 x vpack + 1 x vselr  将 8 个 scale slots 在寄存器中广播
2 x vmul    对两个 BF16 物理向量执行量化乘法
3 x vintlv + 4 x vbitcast + 4 x P0 vcvt + 4 x PK4_B32 vsts
```

监控同时禁止 `vdintlv`、`vsldb`、`vsstb`、`vcmax`、额外的上述关键指令以及任何残留 VMI op/type，避免 case 只验证“能 lower”却漏掉性能形态退化。

公平 `PK4_B32` CA-model 对比中，CCE 为 32144 cycles；本 PR 的显式 final-cast VMI 路径为 31502 cycles，VMI 快 642 cycles（约 2.0%）。原 carrier reinterpret 专用路径为 31659 cycles；显式转换路径还可再减少 157 cycles。随机 BF16 输入的 FP8 与 scale 输出完全一致。

## 支持边界

- width-changing `vinterpret_cast` 必须保持总 bit footprint。
- 当前 layout 表仅声明 contiguous carrier reinterpret；其他输入 layout 由 assignment 转为 contiguous，无法合法转换时仍会报错。
- group=8 reduction 继续使用现有同类型语义；本 PR 不扩大 reduction 的 dtype 组合。

## 验证

```text
cmake --build build-main-llvm21 -j16 --target pto-test-opt
  passed

Focused VMI lit
  vmi_layout_assignment_vintlv_width_changing_bitcast: passed
  per_block_bf16_group8_quant_vmi_opt (layout assignment): passed
  per_block_bf16_group8_quant_vmi_opt (end-to-end VPTO): passed

PTODSL
  ptodsl_jit_diagnostics: passed
  ptodsl_vmi_bf16_group8_carrier: passed

git diff --check
  passed
```

完整 lit 在当前 build tree 中仍被既有 `ptoas` Python wrapper 导入错误阻塞，失败统一为 `ImportError: dynamic module does not define module export function (PyInit_ptoas)`；本 PR 直接覆盖的 `pto-test-opt` 与 PTODSL 聚焦测试均通过。
