### PR TITLE
VMI execution bug: 1-lane vstore alignment fault error

### DIFF
--- a/docs/repro/narrow_lane_store/.gitignore
+++ b/docs/repro/narrow_lane_store/.gitignore
@@ -1,0 +1,3 @@
+outputs/
+__pycache__/
+*.pyc

--- a/docs/repro/narrow_lane_store/BUG_REPORT.md
+++ b/docs/repro/narrow_lane_store/BUG_REPORT.md
@@ -1,0 +1,60 @@
+# Bug report — 1-lane `vstore` needs 32-byte aligned UB address
+
+Audience: PTOAS maintainers.
+Tag / tree: `vmi-v0.1.3` (this worktree).
+
+## Problem
+
+A 1-lane `vstore` whose destination is 4-byte aligned but **not** 32-byte
+aligned faults the vector cores:
+
+```
+RuntimeError: aclrtLaunchKernelWithHostArgs failed ... ACL error 507035
+[Error]: The vector core execution is abnormal.
+```
+
+The AscendC peer stores to the same packed addresses with
+`vsts(..., dist="ONEPT_B32")` and is fine.
+
+The failure mode is especially nasty: the fault can poison the process so the
+*next* unrelated kernel fails, and the traceback points somewhere innocent.
+
+## Minimal algorithm
+
+```text
+for k in 0..7:
+    vstore(val[k], out_ub[k], mask=1-lane)   # packed (8,) f32
+```
+
+For odd `k`, `&out_ub[k]` is only 4-byte aligned. That faults on VMI.
+
+## Fixtures
+
+| Fixture | Role | Expected on current build |
+|---------|------|---------------------------|
+| `fixtures/faulting_vmi.py` | Packed 1-lane stores | **FAIL** launch (ACL 507035) |
+| `fixtures/padded_workaround_vmi.py` | `(B, 8)` padded slots | **PASS** numeric |
+| `fixtures/reference_asc_cce.asc` | AscendC `ONEPT_B32` peer | **PASS** compile |
+
+## Ask
+
+Either:
+
+1. Support 1-lane `vstore` to 4-byte-aligned UB addresses (matching AscendC
+   `ONEPT_B32`), or
+2. Emit a **build-time diagnostic** when a 1-lane store target is not 32-byte
+   aligned, instead of a deferred device fault.
+
+## Criteria
+
+1. `faulting_vmi.py` launches without ACL 507035 and returns `out == vals`, or
+2. Compiling a misaligned 1-lane store fails loudly at build time with a clear
+   message naming the alignment requirement.
+
+Until then, the padded `(B, 8)` layout in `padded_workaround_vmi.py` remains
+the working path (32 bytes of UB per row, no runtime cost beyond the pad).
+
+## Non-goals
+
+- Frontend / TileLang emission (this package is hand-written pure ptodsl)
+- Changing AscendC `ONEPT_B32` semantics

--- a/docs/repro/narrow_lane_store/BUG_REPORT.md
+++ b/docs/repro/narrow_lane_store/BUG_REPORT.md
@@ -9,21 +9,24 @@ A 1-lane `vstore` whose destination is 4-byte aligned but **not** 32-byte
 aligned faults the vector cores:
 
 ```
-RuntimeError: aclrtLaunchKernelWithHostArgs failed ... ACL error 507035
+RuntimeError: ... device error type 3, error code is 507035
 [Error]: The vector core execution is abnormal.
 ```
 
 The AscendC peer stores to the same packed addresses with
-`vsts(..., dist="ONEPT_B32")` and is fine.
+`vsts(..., dist="ONEPT_B32")` and is fine. The same 1-lane `vstore` into a
+`(B, 8)` padded layout (32-byte slot per row) is exact.
 
 The failure mode is especially nasty: the fault can poison the process so the
 *next* unrelated kernel fails, and the traceback points somewhere innocent.
+Isolate each launch in its own process.
 
 ## Minimal algorithm
 
 ```text
+# input staged as (B, 8) so every 1-lane *load* is aligned
 for k in 0..7:
-    vstore(val[k], out_ub[k], mask=1-lane)   # packed (8,) f32
+    vstore(val[k, 0], out_ub[k], mask=1-lane)   # packed (8,) f32  ← faults
 ```
 
 For odd `k`, `&out_ub[k]` is only 4-byte aligned. That faults on VMI.

--- a/docs/repro/narrow_lane_store/README.md
+++ b/docs/repro/narrow_lane_store/README.md
@@ -9,13 +9,13 @@ Branch: `repro/narrow-store-align`. Details: [`BUG_REPORT.md`](BUG_REPORT.md).
 ## Algorithm
 
 ```text
-# faulting (packed)
+# faulting (packed destination; input staged padded so loads stay aligned)
 for k in 0..7:
-    vstore(val[k], out_ub[k], mask=1)          # out_ub: (8,) f32
+    vstore(val[k, 0], out_ub[k], mask=1)       # out_ub: (8,) f32
 
-# workaround (padded)
+# workaround (padded destination; GM out is also (B, 8), host checks col 0)
 for k in 0..7:
-    vstore(val[k], pad_ub[k, 0], mask=1)       # pad_ub: (8, 8) f32
+    vstore(val[k, 0], pad_ub[k, 0], mask=1)    # pad_ub: (8, 8) f32
 ```
 
 | Fixture | Role | Expected on current build |
@@ -51,6 +51,10 @@ source scripts/env.sh
 ```
 
 Results: `outputs/check_narrow_lane_store/results.txt`.
+
+Run the two VMI fixtures in **separate processes** (the check script does);
+a 507035 fault can poison the NPU context for later launches in the same
+process.
 
 ## How to read the result
 

--- a/docs/repro/narrow_lane_store/README.md
+++ b/docs/repro/narrow_lane_store/README.md
@@ -1,0 +1,62 @@
+# Narrow 1-lane store — 32-byte alignment fault
+
+A 1-lane `vstore` to a 4-byte-aligned (but not 32-byte-aligned) UB address
+faults the vector cores. AscendC `vsts(..., ONEPT_B32)` at the same address is
+fine. This package is a self-contained bug report and numeric repro for PTOAS.
+
+Branch: `repro/narrow-store-align`. Details: [`BUG_REPORT.md`](BUG_REPORT.md).
+
+## Algorithm
+
+```text
+# faulting (packed)
+for k in 0..7:
+    vstore(val[k], out_ub[k], mask=1)          # out_ub: (8,) f32
+
+# workaround (padded)
+for k in 0..7:
+    vstore(val[k], pad_ub[k, 0], mask=1)       # pad_ub: (8, 8) f32
+```
+
+| Fixture | Role | Expected on current build |
+|---------|------|---------------------------|
+| `fixtures/faulting_vmi.py` | Packed 1-lane stores | **FAIL** launch (ACL 507035) |
+| `fixtures/padded_workaround_vmi.py` | 32-byte padded slots | **PASS** numeric |
+| `fixtures/reference_asc_cce.asc` | AscendC peer | **PASS** (`bisheng`) |
+
+## Layout
+
+```text
+narrow_lane_store/
+  BUG_REPORT.md
+  README.md
+  fixtures/
+  scripts/
+  outputs/          # produced by check script (gitignored)
+```
+
+## Prerequisites
+
+- CANN toolkit with `bisheng` and Ascend headers (`ASCEND_HOME_PATH`)
+- A Python env with `ptodsl`
+- An NPU device for the numeric check (`NPU_TEST_DEVICE`, default `npu:1`)
+
+## Run
+
+From this directory:
+
+```bash
+source scripts/env.sh
+./scripts/check_narrow_lane_store.sh
+```
+
+Results: `outputs/check_narrow_lane_store/results.txt`.
+
+## How to read the result
+
+- **faulting COMPILE PASS + LAUNCH FAIL (507035)** together with **padded
+  NUMERIC PASS** is the bug this package reports.
+- If faulting also passes numerically, the criteria in
+  [`BUG_REPORT.md`](BUG_REPORT.md) are met.
+- If the host has no NPU / driver, the script records `LAUNCH SKIP` and still
+  scores the compile side.

--- a/docs/repro/narrow_lane_store/fixtures/faulting_vmi.py
+++ b/docs/repro/narrow_lane_store/fixtures/faulting_vmi.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Faulting VMI fixture: 1-lane vstore into a packed (B,) float32 UB buffer.
+
+For odd k the destination is 4-byte aligned but not 32-byte aligned. Current
+builds fault the vector cores (ACL 507035).
+"""
+
+import os
+
+import numpy as np
+from ptodsl import pto
+
+_B = 8
+_DEVICE = os.environ.get("NPU_TEST_DEVICE", "npu:1")
+
+
+@pto.jit(
+    name="narrow_lane_store_packed",
+    kernel_kind="vector",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+)
+def narrow_lane_store_packed(
+    val_gm: pto.ptr(pto.f32, "gm"),
+    out_gm: pto.ptr(pto.f32, "gm"),
+):
+    c0 = pto.const(0)
+    c1 = pto.const(1)
+    c_b = pto.const(_B)
+    shape = [c1, c1, c1, c1, c_b]
+    strides = [c_b, c_b, c_b, c_b, c1]
+    off = [c0, c0, c0, c0, c0]
+
+    val_view = pto.make_tensor_view(val_gm, shape=shape, strides=strides)
+    out_view = pto.make_tensor_view(out_gm, shape=shape, strides=strides)
+    val_part = pto.partition_view(val_view, offsets=off, sizes=shape)
+    out_part = pto.partition_view(out_view, offsets=off, sizes=shape)
+
+    val_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
+    out_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
+    pto.tile.load(val_part, val_ub)
+
+    one = pto.vmi.create_mask(1, size=1)
+    for k in range(_B):
+        src = pto.vmi.vload(
+            pto.addptr(val_ub.as_ptr(), k),
+            pto.const(0, dtype=pto.index),
+            size=1,
+        )
+        pto.vmi.vstore(
+            src,
+            pto.addptr(out_ub.as_ptr(), k),
+            pto.const(0, dtype=pto.index),
+            one,
+        )
+
+    pto.tile.store(out_ub, out_part)
+
+
+def run_numeric(device=None):
+    import torch
+    import torch_npu  # noqa: F401
+
+    device = device or _DEVICE
+    if not torch.npu.is_available() or torch.npu.device_count() < 1:
+        raise RuntimeError("NPU not available")
+    torch.npu.set_device(device)
+    vals = (np.arange(_B, dtype=np.float32) + 1.0) * 10.0
+    a = torch.from_numpy(vals).to(device)
+    out = torch.full((_B,), float("nan"), dtype=torch.float32, device=device)
+    stream = torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+    compiled = narrow_lane_store_packed.compile()
+    compiled[1, stream](a.data_ptr(), out.data_ptr())
+    torch.npu.synchronize()
+    got = out.cpu().numpy()
+    return {"ok": bool(np.allclose(got, vals)), "got": got.tolist()}
+
+
+if __name__ == "__main__":
+    print(narrow_lane_store_packed.compile().mlir_text()[:400])

--- a/docs/repro/narrow_lane_store/fixtures/faulting_vmi.py
+++ b/docs/repro/narrow_lane_store/fixtures/faulting_vmi.py
@@ -8,8 +8,10 @@
 
 """Faulting VMI fixture: 1-lane vstore into a packed (B,) float32 UB buffer.
 
-For odd k the destination is 4-byte aligned but not 32-byte aligned. Current
-builds fault the vector cores (ACL 507035).
+Input is staged as (B, 8) so every 1-lane *load* address is 32-byte aligned.
+Only the destination of the 1-lane *store* is packed — for odd k that address
+is 4-byte aligned but not 32-byte aligned. Current builds fault the vector
+cores (ACL 507035).
 """
 
 import os
@@ -18,6 +20,7 @@ import numpy as np
 from ptodsl import pto
 
 _B = 8
+_ALIGN = 8
 _DEVICE = os.environ.get("NPU_TEST_DEVICE", "npu:1")
 
 
@@ -32,37 +35,33 @@ def narrow_lane_store_packed(
     val_gm: pto.ptr(pto.f32, "gm"),
     out_gm: pto.ptr(pto.f32, "gm"),
 ):
-    c0 = pto.const(0)
-    c1 = pto.const(1)
-    c_b = pto.const(_B)
-    shape = [c1, c1, c1, c1, c_b]
-    strides = [c_b, c_b, c_b, c_b, c1]
-    off = [c0, c0, c0, c0, c0]
+    ub = pto.castptr(pto.const(0, dtype=pto.i64), pto.ptr(pto.f32, "ub"))
+    pad_in = ub
+    out_ub = pto.addptr(ub, _B * _ALIGN)
+    in_bytes = _B * _ALIGN * 4
+    out_bytes = _B * 4
 
-    val_view = pto.make_tensor_view(val_gm, shape=shape, strides=strides)
-    out_view = pto.make_tensor_view(out_gm, shape=shape, strides=strides)
-    val_part = pto.partition_view(val_view, offsets=off, sizes=shape)
-    out_part = pto.partition_view(out_view, offsets=off, sizes=shape)
-
-    val_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
-    out_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
-    pto.tile.load(val_part, val_ub)
+    pto.mte_gm_ub(val_gm, pad_in, 0, in_bytes, nburst=(1, in_bytes, in_bytes))
+    pto.set_flag("MTE2", "V", event_id=0)
+    pto.wait_flag("MTE2", "V", event_id=0)
 
     one = pto.vmi.create_mask(1, size=1)
     for k in range(_B):
         src = pto.vmi.vload(
-            pto.addptr(val_ub.as_ptr(), k),
+            pto.addptr(pad_in, k * _ALIGN),
             pto.const(0, dtype=pto.index),
             size=1,
         )
         pto.vmi.vstore(
             src,
-            pto.addptr(out_ub.as_ptr(), k),
+            pto.addptr(out_ub, k),
             pto.const(0, dtype=pto.index),
             one,
         )
 
-    pto.tile.store(out_ub, out_part)
+    pto.set_flag("V", "MTE3", event_id=0)
+    pto.wait_flag("V", "MTE3", event_id=0)
+    pto.mte_ub_gm(out_ub, out_gm, out_bytes, nburst=(1, out_bytes, out_bytes))
 
 
 def run_numeric(device=None):
@@ -74,7 +73,9 @@ def run_numeric(device=None):
         raise RuntimeError("NPU not available")
     torch.npu.set_device(device)
     vals = (np.arange(_B, dtype=np.float32) + 1.0) * 10.0
-    a = torch.from_numpy(vals).to(device)
+    pad = np.zeros((_B, _ALIGN), dtype=np.float32)
+    pad[:, 0] = vals
+    a = torch.from_numpy(pad).to(device)
     out = torch.full((_B,), float("nan"), dtype=torch.float32, device=device)
     stream = torch.npu.current_stream()._as_parameter_  # noqa: SLF001
     compiled = narrow_lane_store_packed.compile()

--- a/docs/repro/narrow_lane_store/fixtures/padded_workaround_vmi.py
+++ b/docs/repro/narrow_lane_store/fixtures/padded_workaround_vmi.py
@@ -9,6 +9,7 @@
 """Working VMI workaround: 1-lane vstore into a (B, 8) padded UB buffer.
 
 Each row gets its own 32-byte slot, so destination [k, 0] is always aligned.
+GM in/out are also (B, 8); the host checks column 0.
 """
 
 import os
@@ -32,49 +33,32 @@ def narrow_lane_store_padded(
     val_gm: pto.ptr(pto.f32, "gm"),
     out_gm: pto.ptr(pto.f32, "gm"),
 ):
-    c0 = pto.const(0)
-    c1 = pto.const(1)
-    c_b = pto.const(_B)
-    shape = [c1, c1, c1, c1, c_b]
-    strides = [c_b, c_b, c_b, c_b, c1]
-    off = [c0, c0, c0, c0, c0]
+    ub = pto.castptr(pto.const(0, dtype=pto.i64), pto.ptr(pto.f32, "ub"))
+    pad_in = ub
+    pad_out = pto.addptr(ub, _B * _ALIGN)
+    nbytes = _B * _ALIGN * 4
 
-    val_view = pto.make_tensor_view(val_gm, shape=shape, strides=strides)
-    out_view = pto.make_tensor_view(out_gm, shape=shape, strides=strides)
-    val_part = pto.partition_view(val_view, offsets=off, sizes=shape)
-    out_part = pto.partition_view(out_view, offsets=off, sizes=shape)
-
-    val_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
-    pad_ub = pto.alloc_tile(shape=[_B, _ALIGN], dtype=pto.f32)
-    out_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
-    pto.tile.load(val_part, val_ub)
+    pto.mte_gm_ub(val_gm, pad_in, 0, nbytes, nburst=(1, nbytes, nbytes))
+    pto.set_flag("MTE2", "V", event_id=0)
+    pto.wait_flag("MTE2", "V", event_id=0)
 
     one = pto.vmi.create_mask(1, size=1)
     for k in range(_B):
         src = pto.vmi.vload(
-            pto.addptr(val_ub.as_ptr(), k),
+            pto.addptr(pad_in, k * _ALIGN),
             pto.const(0, dtype=pto.index),
             size=1,
         )
         pto.vmi.vstore(
             src,
-            pto.addptr(pad_ub.as_ptr(), k * _ALIGN),
-            pto.const(0, dtype=pto.index),
-            one,
-        )
-        back = pto.vmi.vload(
-            pto.addptr(pad_ub.as_ptr(), k * _ALIGN),
-            pto.const(0, dtype=pto.index),
-            size=1,
-        )
-        pto.vmi.vstore(
-            back,
-            pto.addptr(out_ub.as_ptr(), k),
+            pto.addptr(pad_out, k * _ALIGN),
             pto.const(0, dtype=pto.index),
             one,
         )
 
-    pto.tile.store(out_ub, out_part)
+    pto.set_flag("V", "MTE3", event_id=0)
+    pto.wait_flag("V", "MTE3", event_id=0)
+    pto.mte_ub_gm(pad_out, out_gm, nbytes, nburst=(1, nbytes, nbytes))
 
 
 def run_numeric(device=None):
@@ -86,13 +70,15 @@ def run_numeric(device=None):
         raise RuntimeError("NPU not available")
     torch.npu.set_device(device)
     vals = (np.arange(_B, dtype=np.float32) + 1.0) * 10.0
-    a = torch.from_numpy(vals).to(device)
-    out = torch.full((_B,), float("nan"), dtype=torch.float32, device=device)
+    pad = np.zeros((_B, _ALIGN), dtype=np.float32)
+    pad[:, 0] = vals
+    a = torch.from_numpy(pad).to(device)
+    out = torch.full((_B, _ALIGN), float("nan"), dtype=torch.float32, device=device)
     stream = torch.npu.current_stream()._as_parameter_  # noqa: SLF001
     compiled = narrow_lane_store_padded.compile()
     compiled[1, stream](a.data_ptr(), out.data_ptr())
     torch.npu.synchronize()
-    got = out.cpu().numpy()
+    got = out.cpu().numpy()[:, 0]
     return {"ok": bool(np.allclose(got, vals)), "got": got.tolist()}
 
 

--- a/docs/repro/narrow_lane_store/fixtures/padded_workaround_vmi.py
+++ b/docs/repro/narrow_lane_store/fixtures/padded_workaround_vmi.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+"""Working VMI workaround: 1-lane vstore into a (B, 8) padded UB buffer.
+
+Each row gets its own 32-byte slot, so destination [k, 0] is always aligned.
+"""
+
+import os
+
+import numpy as np
+from ptodsl import pto
+
+_B = 8
+_ALIGN = 8  # float32 elems per 32-byte slot
+_DEVICE = os.environ.get("NPU_TEST_DEVICE", "npu:1")
+
+
+@pto.jit(
+    name="narrow_lane_store_padded",
+    kernel_kind="vector",
+    target="a5",
+    backend="vpto",
+    mode="explicit",
+)
+def narrow_lane_store_padded(
+    val_gm: pto.ptr(pto.f32, "gm"),
+    out_gm: pto.ptr(pto.f32, "gm"),
+):
+    c0 = pto.const(0)
+    c1 = pto.const(1)
+    c_b = pto.const(_B)
+    shape = [c1, c1, c1, c1, c_b]
+    strides = [c_b, c_b, c_b, c_b, c1]
+    off = [c0, c0, c0, c0, c0]
+
+    val_view = pto.make_tensor_view(val_gm, shape=shape, strides=strides)
+    out_view = pto.make_tensor_view(out_gm, shape=shape, strides=strides)
+    val_part = pto.partition_view(val_view, offsets=off, sizes=shape)
+    out_part = pto.partition_view(out_view, offsets=off, sizes=shape)
+
+    val_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
+    pad_ub = pto.alloc_tile(shape=[_B, _ALIGN], dtype=pto.f32)
+    out_ub = pto.alloc_tile(shape=[1, _B], dtype=pto.f32)
+    pto.tile.load(val_part, val_ub)
+
+    one = pto.vmi.create_mask(1, size=1)
+    for k in range(_B):
+        src = pto.vmi.vload(
+            pto.addptr(val_ub.as_ptr(), k),
+            pto.const(0, dtype=pto.index),
+            size=1,
+        )
+        pto.vmi.vstore(
+            src,
+            pto.addptr(pad_ub.as_ptr(), k * _ALIGN),
+            pto.const(0, dtype=pto.index),
+            one,
+        )
+        back = pto.vmi.vload(
+            pto.addptr(pad_ub.as_ptr(), k * _ALIGN),
+            pto.const(0, dtype=pto.index),
+            size=1,
+        )
+        pto.vmi.vstore(
+            back,
+            pto.addptr(out_ub.as_ptr(), k),
+            pto.const(0, dtype=pto.index),
+            one,
+        )
+
+    pto.tile.store(out_ub, out_part)
+
+
+def run_numeric(device=None):
+    import torch
+    import torch_npu  # noqa: F401
+
+    device = device or _DEVICE
+    if not torch.npu.is_available() or torch.npu.device_count() < 1:
+        raise RuntimeError("NPU not available")
+    torch.npu.set_device(device)
+    vals = (np.arange(_B, dtype=np.float32) + 1.0) * 10.0
+    a = torch.from_numpy(vals).to(device)
+    out = torch.full((_B,), float("nan"), dtype=torch.float32, device=device)
+    stream = torch.npu.current_stream()._as_parameter_  # noqa: SLF001
+    compiled = narrow_lane_store_padded.compile()
+    compiled[1, stream](a.data_ptr(), out.data_ptr())
+    torch.npu.synchronize()
+    got = out.cpu().numpy()
+    return {"ok": bool(np.allclose(got, vals)), "got": got.tolist()}
+
+
+if __name__ == "__main__":
+    print(narrow_lane_store_padded.compile().mlir_text()[:400])

--- a/docs/repro/narrow_lane_store/fixtures/reference_asc_cce.asc
+++ b/docs/repro/narrow_lane_store/fixtures/reference_asc_cce.asc
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// AscendC peer: 1-lane stores into a packed float32 buffer via vsts ONEPT_B32.
+// Same addresses that fault under VMI are fine here.
+// Compiles with bisheng --cce-aicore-only (see README).
+
+#include "kernel_operator.h"
+
+namespace {
+constexpr int B = 8;
+}
+
+__simd_vf__ inline void vf_narrow_store(__ubuf__ float* val,
+                                        __ubuf__ float* out) {
+  vector_bool one = pset_b32(PAT_VL1);
+  vector_f32 t0, t1, t2, t3, t4, t5, t6, t7;
+  vlds(t0, val, 0, NORM);
+  vlds(t1, val, 1, NORM);
+  vlds(t2, val, 2, NORM);
+  vlds(t3, val, 3, NORM);
+  vlds(t4, val, 4, NORM);
+  vlds(t5, val, 5, NORM);
+  vlds(t6, val, 6, NORM);
+  vlds(t7, val, 7, NORM);
+  vsts(t0, out, 0, ONEPT_B32, one);
+  vsts(t1, out, 1, ONEPT_B32, one);
+  vsts(t2, out, 2, ONEPT_B32, one);
+  vsts(t3, out, 3, ONEPT_B32, one);
+  vsts(t4, out, 4, ONEPT_B32, one);
+  vsts(t5, out, 5, ONEPT_B32, one);
+  vsts(t6, out, 6, ONEPT_B32, one);
+  vsts(t7, out, 7, ONEPT_B32, one);
+}
+
+extern "C" __global__ __vector__ void ref_narrow_lane_store(
+    __gm__ float* /*gm_val*/, __gm__ float* /*gm_out*/) {
+  AscendC::InitSocState();
+  __ubuf__ float* ub = (__ubuf__ float*)0;
+  __ubuf__ float* val = ub;
+  __ubuf__ float* out = ub + B;
+  vf_narrow_store(val, out);
+}

--- a/docs/repro/narrow_lane_store/scripts/check_narrow_lane_store.sh
+++ b/docs/repro/narrow_lane_store/scripts/check_narrow_lane_store.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Compile + numeric check for narrow_lane_store fixtures.
+# Each VMI fixture runs in its own Python process so a 507035 fault cannot
+# poison the padded workaround launch.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPRO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -47,15 +49,21 @@ try:
     print("NUMERIC", r)
     raise SystemExit(0 if r.get("ok") else 1)
 except RuntimeError as exc:
+    msg = str(exc)
     print(f"LAUNCH_ERR {type(exc).__name__}: {exc}")
+    if "requires 'addr' operand" in msg or "pto-level=level3" in msg:
+        print("NATIVE_BUILD_ERR")
+    elif "507035" in msg or "vector core" in msg.lower():
+        print("VECTOR_CORE_FAULT")
     raise SystemExit(0)
 except Exception as exc:
     msg = str(exc)
     print(f"LAUNCH_ERR {type(exc).__name__}: {exc}")
-    if "507035" in msg or "vector core" in msg.lower():
+    if "requires 'addr' operand" in msg or "pto-level=level3" in msg:
+        print("NATIVE_BUILD_ERR")
+    elif "507035" in msg or "vector core" in msg.lower():
         print("VECTOR_CORE_FAULT")
-        raise SystemExit(0)
-    raise SystemExit(2)
+    raise SystemExit(0)
 PY
   rc=$?
   set -e
@@ -67,7 +75,9 @@ PY
     echo | tee -a "${LOG}"
     return
   fi
-  if grep -qE "LAUNCH_ERR.*NPU not available" "${OUT}/${name}.log"; then
+  if grep -q "NATIVE_BUILD_ERR" "${OUT}/${name}.log"; then
+    fail "${name} native build (level3/addr)"
+  elif grep -qE "LAUNCH_ERR.*NPU not available" "${OUT}/${name}.log"; then
     skip "${name} numeric (no device)"
   elif grep -qE "VECTOR_CORE_FAULT|507035" "${OUT}/${name}.log"; then
     if [ "${expect}" = "fault" ]; then
@@ -83,8 +93,9 @@ PY
   echo | tee -a "${LOG}"
 }
 
-run_fixture "faulting_vmi" "fault"
+# Padded first so a clean process records the workaround before the fault case.
 run_fixture "padded_workaround_vmi" "pass"
+run_fixture "faulting_vmi" "fault"
 
 echo "=== reference_asc_cce.asc (bisheng) ===" | tee -a "${LOG}"
 if [ -z "${BISHENG}" ] || [ ! -x "${BISHENG}" ]; then

--- a/docs/repro/narrow_lane_store/scripts/check_narrow_lane_store.sh
+++ b/docs/repro/narrow_lane_store/scripts/check_narrow_lane_store.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Compile + numeric check for narrow_lane_store fixtures.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPRO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIXTURES="${REPRO_ROOT}/fixtures"
+OUT="${REPRO_ROOT}/outputs/check_narrow_lane_store"
+LOG="${OUT}/results.txt"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/env.sh"
+
+mkdir -p "${OUT}"
+: > "${LOG}"
+
+BISHENG="${BISHENG:-${ASCEND_HOME_PATH}/tools/bisheng_compiler/bin/bisheng}"
+if [ ! -x "${BISHENG}" ]; then
+  BISHENG="$(command -v bisheng || true)"
+fi
+ASCEND="${ASCEND_HOME_PATH}"
+NPU_ARCH="${ASCEND_NPU_ARCH:-dav-3510}"
+PY="$(command -v python || command -v python3)"
+
+pass() { echo "PASS: $*" | tee -a "${LOG}"; }
+fail() { echo "FAIL: $*" | tee -a "${LOG}"; }
+skip() { echo "SKIP: $*" | tee -a "${LOG}"; }
+
+echo "narrow_lane_store check — $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee -a "${LOG}"
+echo "PTOAS_ROOT=${PTOAS_ROOT}" | tee -a "${LOG}"
+echo "python=${PY}" | tee -a "${LOG}"
+echo "bisheng=${BISHENG:-MISSING}" | tee -a "${LOG}"
+echo | tee -a "${LOG}"
+
+run_fixture() {
+  local name="$1"
+  local expect="$2"  # fault | pass
+  echo "=== ${name} ===" | tee -a "${LOG}"
+  set +e
+  PYTHONPATH="${FIXTURES}:${PYTHONPATH:-}" "${PY}" - <<PY > "${OUT}/${name}.log" 2>&1
+import importlib
+m = importlib.import_module("${name}")
+kern = next(getattr(m, n) for n in dir(m) if n.startswith("narrow_lane_store_"))
+compiled = kern.compile()
+print("COMPILE_OK", len(compiled.mlir_text()))
+try:
+    r = m.run_numeric()
+    print("NUMERIC", r)
+    raise SystemExit(0 if r.get("ok") else 1)
+except RuntimeError as exc:
+    print(f"LAUNCH_ERR {type(exc).__name__}: {exc}")
+    raise SystemExit(0)
+except Exception as exc:
+    msg = str(exc)
+    print(f"LAUNCH_ERR {type(exc).__name__}: {exc}")
+    if "507035" in msg or "vector core" in msg.lower():
+        print("VECTOR_CORE_FAULT")
+        raise SystemExit(0)
+    raise SystemExit(2)
+PY
+  rc=$?
+  set -e
+  tee -a "${LOG}" < "${OUT}/${name}.log"
+  if grep -q "COMPILE_OK" "${OUT}/${name}.log"; then
+    pass "${name} compiles"
+  else
+    fail "${name} compile"
+    echo | tee -a "${LOG}"
+    return
+  fi
+  if grep -qE "LAUNCH_ERR.*NPU not available" "${OUT}/${name}.log"; then
+    skip "${name} numeric (no device)"
+  elif grep -qE "VECTOR_CORE_FAULT|507035" "${OUT}/${name}.log"; then
+    if [ "${expect}" = "fault" ]; then
+      fail "${name} launch — vector core fault (bug reproduced)"
+    else
+      fail "${name} launch — unexpected vector core fault"
+    fi
+  elif grep -q "'ok': True" "${OUT}/${name}.log"; then
+    pass "${name} numeric"
+  else
+    fail "${name} numeric mismatch/error (rc=${rc})"
+  fi
+  echo | tee -a "${LOG}"
+}
+
+run_fixture "faulting_vmi" "fault"
+run_fixture "padded_workaround_vmi" "pass"
+
+echo "=== reference_asc_cce.asc (bisheng) ===" | tee -a "${LOG}"
+if [ -z "${BISHENG}" ] || [ ! -x "${BISHENG}" ]; then
+  skip "bisheng not found"
+else
+  REF_OBJ="${OUT}/reference_asc_cce.o"
+  set +e
+  "${BISHENG}" -O2 -fPIC -std=c++17 --npu-arch="${NPU_ARCH}" --cce-aicore-only -c \
+    "${FIXTURES}/reference_asc_cce.asc" -o "${REF_OBJ}" \
+    -I"${ASCEND}/include" \
+    -I"${ASCEND}/compiler/tikcpp/tikcfw" \
+    -I"${ASCEND}/compiler/tikcpp/tikcfw/impl" \
+    -I"${ASCEND}/compiler/tikcpp/tikcfw/interface" \
+    > "${OUT}/reference_asc_cce.log" 2>&1
+  ref_rc=$?
+  set -e
+  if [ "${ref_rc}" -eq 0 ] && [ -s "${REF_OBJ}" ]; then
+    pass "reference_asc_cce.asc → .o"
+  else
+    fail "reference_asc_cce.asc compile exit ${ref_rc}"
+    tail -30 "${OUT}/reference_asc_cce.log" | tee -a "${LOG}"
+  fi
+fi
+echo | tee -a "${LOG}"
+echo "Full log: ${LOG}" | tee -a "${LOG}"

--- a/docs/repro/narrow_lane_store/scripts/env.sh
+++ b/docs/repro/narrow_lane_store/scripts/env.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# CANN + PTOAS/ptodsl env for narrow_lane_store numeric checks.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPRO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ASCEND_HOME_PATH="${ASCEND_HOME_PATH:-${ASCEND_TOOLKIT_HOME:-/home/jzhuang/cann_installed/9.1.0-beta.3/cann-9.1.0-beta.3}}"
+
+PTOAS_ROOT="${PTOAS_ROOT:-$(cd "${REPRO_ROOT}/../../.." && pwd)}"
+
+# shellcheck disable=SC1091
+if [ -f "${ASCEND_HOME_PATH}/bin/setenv.bash" ]; then
+  source "${ASCEND_HOME_PATH}/bin/setenv.bash"
+elif [ -f "${ASCEND_HOME_PATH}/../set_env.sh" ]; then
+  # shellcheck disable=SC1091
+  source "${ASCEND_HOME_PATH}/../set_env.sh"
+elif [ -f "/home/jzhuang/cann_installed/9.1.0-beta.3/cann/set_env.sh" ]; then
+  # shellcheck disable=SC1091
+  source "/home/jzhuang/cann_installed/9.1.0-beta.3/cann/set_env.sh"
+fi
+
+if [ -n "${PTOAS_ROOT}" ] && [ -f "${PTOAS_ROOT}/scripts/ptoas_env.sh" ]; then
+  export PTOAS_ENV_SKIP_SMOKE_TEST="${PTOAS_ENV_SKIP_SMOKE_TEST:-1}"
+  # shellcheck disable=SC1091
+  source "${PTOAS_ROOT}/scripts/ptoas_env.sh"
+fi
+
+export PYTHONPATH="${PTOAS_ROOT}/ptodsl${PYTHONPATH:+:${PYTHONPATH}}"
+export NPU_TEST_DEVICE="${NPU_TEST_DEVICE:-npu:1}"
+export ASCEND_NPU_ARCH="${ASCEND_NPU_ARCH:-dav-3510}"
+unset CCC_OVERRIDE_OPTIONS || true
+
+echo "REPRO_ROOT=${REPRO_ROOT}"
+echo "ASCEND_HOME_PATH=${ASCEND_HOME_PATH}"
+echo "PTOAS_ROOT=${PTOAS_ROOT}"
+echo "NPU_TEST_DEVICE=${NPU_TEST_DEVICE}"
+echo "python=$(command -v python || command -v python3 || echo MISSING)"


### PR DESCRIPTION
See `docs/repro/narrow_lane_store/BUG_REPORT.md` for reproduce.

This is on-device runtime bug, not compile-only error. Tested with CANN 9.1.0.beta3.