### PR TITLE
fix(ptodsl): validate physical section boundaries

### DIFF
--- a/include/PTO/Transforms/Passes.h
+++ b/include/PTO/Transforms/Passes.h
@@ -40,6 +40,7 @@ std::unique_ptr<Pass> createPTOInferValidatePipeInitPass();
 std::unique_ptr<Pass> createPTOResolveReservedBuffersPass();
 std::unique_ptr<Pass> createPTOWrapFunctionsInSectionsPass();
 std::unique_ptr<Pass> createPTONormalizeUncoveredTileSectionsPass();
+std::unique_ptr<Pass> createPTOValidatePhysicalSectionBoundariesPass();
 std::unique_ptr<Pass> createPTOMaterializeTileOpSectionsPass();
 std::unique_ptr<Pass> createVPTOSplitCVModulePass();
 std::unique_ptr<Pass> createVPTONormalizeContainerPass();

--- a/include/PTO/Transforms/Passes.td
+++ b/include/PTO/Transforms/Passes.td
@@ -356,6 +356,28 @@ def PTONormalizeUncoveredTileSections
   ];
 }
 
+def PTOValidatePhysicalSectionBoundaries
+    : Pass<"pto-validate-physical-section-boundaries", "ModuleOp"> {
+  let summary = "Verify SSA isolation at physical section boundaries";
+  let description = [{
+    Verifies that values defined inside a `pto.section.cube` or
+    `pto.section.vector` remain inside that lexical physical section. Values
+    defined outside a section may be captured by it, but values cannot be
+    passed implicitly between sibling sections or from a section to its
+    enclosing function. This validation is run after inferred sections are
+    materialized, so explicit and automatically inferred sections obey the
+    same boundary rules.
+  }];
+
+  let constructor =
+      "mlir::pto::createPTOValidatePhysicalSectionBoundariesPass()";
+
+  let dependentDialects = [
+    "mlir::pto::PTODialect",
+    "mlir::func::FuncDialect"
+  ];
+}
+
 def PTOMaterializeTileOpSections
     : Pass<"pto-materialize-tileop-sections", "ModuleOp"> {
   let summary = "Verify PTODSL tileop helpers and materialize their single compute section";

--- a/lib/PTO/Transforms/CMakeLists.txt
+++ b/lib/PTO/Transforms/CMakeLists.txt
@@ -104,6 +104,7 @@ add_mlir_dialect_library(PTOTransforms
   SlotAffineAnalysis.cpp
   PTOWrapFunctionsInSectionsPass.cpp
   PTONormalizeUncoveredTileSections.cpp
+  PTOValidatePhysicalSectionBoundaries.cpp
   PTOMaterializeTileOpSections.cpp
   VPTONormalizeContainer.cpp
   VPTOSplitCVModule.cpp

--- a/lib/PTO/Transforms/PTOValidatePhysicalSectionBoundaries.cpp
+++ b/lib/PTO/Transforms/PTOValidatePhysicalSectionBoundaries.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+//===- PTOValidatePhysicalSectionBoundaries.cpp ---------------------------===//
+//
+// Verify the lexical SSA boundary of physical Cube/Vector sections.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PTO/IR/PTO.h"
+#include "PTO/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+namespace pto {
+
+#define GEN_PASS_DEF_PTOVALIDATEPHYSICALSECTIONBOUNDARIES
+#include "PTO/Transforms/Passes.h.inc"
+
+namespace {
+
+static Operation *getNearestPhysicalSection(Operation *op) {
+  for (Operation *current = op; current;
+       current = current->getParentOp()) {
+    if (isa<SectionCubeOp, SectionVectorOp>(current))
+      return current;
+  }
+  return nullptr;
+}
+
+static Operation *getNearestPhysicalSection(BlockArgument argument) {
+  if (!argument)
+    return nullptr;
+  return getNearestPhysicalSection(argument.getOwner()->getParentOp());
+}
+
+static Operation *getDefiningPhysicalSection(Value value) {
+  if (auto blockArgument = dyn_cast<BlockArgument>(value))
+    return getNearestPhysicalSection(blockArgument);
+  if (Operation *definingOp = value.getDefiningOp())
+    return getNearestPhysicalSection(definingOp);
+  return nullptr;
+}
+
+static StringRef getPhysicalSectionKind(Operation *section) {
+  if (!section)
+    return "outside a physical section";
+  return isa<SectionCubeOp>(section) ? "pto.section.cube"
+                                     : "pto.section.vector";
+}
+
+static LogicalResult verifyOperandBoundary(Operation *user, OpOperand &operand) {
+  Operation *definingSection = getDefiningPhysicalSection(operand.get());
+  if (!definingSection)
+    return success();
+
+  Operation *usingSection = getNearestPhysicalSection(user);
+  if (definingSection == usingSection)
+    return success();
+
+  return user->emitOpError()
+         << "value defined in " << getPhysicalSectionKind(definingSection)
+         << " cannot be used " << (usingSection ? "inside " : "outside ")
+         << (usingSection ? getPhysicalSectionKind(usingSection)
+                          : "the defining physical section")
+         << "; physical sections have lexical SSA scope. Pass shared data "
+            "through a caller-owned GM/UB buffer with explicit "
+            "synchronization, or recompute it in the consumer section";
+}
+
+static LogicalResult verifyFunction(func::FuncOp function) {
+  LogicalResult result = success();
+  function.walk([&](Operation *op) {
+    if (failed(result))
+      return WalkResult::interrupt();
+    for (OpOperand &operand : op->getOpOperands()) {
+      if (failed(verifyOperandBoundary(op, operand))) {
+        result = failure();
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  return result;
+}
+
+struct PTOValidatePhysicalSectionBoundariesPass
+    : public impl::PTOValidatePhysicalSectionBoundariesBase<
+          PTOValidatePhysicalSectionBoundariesPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    LogicalResult result = success();
+    module.walk([&](func::FuncOp function) {
+      if (failed(result))
+        return WalkResult::interrupt();
+      result = verifyFunction(function);
+      return failed(result) ? WalkResult::interrupt() : WalkResult::advance();
+    });
+    if (failed(result))
+      signalPassFailure();
+  }
+};
+
+} // namespace
+} // namespace pto
+} // namespace mlir
+
+std::unique_ptr<mlir::Pass>
+mlir::pto::createPTOValidatePhysicalSectionBoundariesPass() {
+  return std::make_unique<mlir::pto::PTOValidatePhysicalSectionBoundariesPass>();
+}

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -53,9 +53,13 @@ def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True)
     _inject_closure_defaults(function_def, closure_vars.nonlocals)
     _sanitize_signature_for_exec(function_def)
     function_def = _ConditionalExpressionNormalizer().visit(function_def)
-    function_def = _SectionLexicalRewriter().visit(function_def)
+    section_rewriter = _SectionLexicalRewriter()
+    function_def = section_rewriter.visit(function_def)
     if rewrite_control_flow:
-        rewriter = _ControlFlowRewriter(static_env)
+        rewriter = _ControlFlowRewriter(
+            static_env,
+            section_entry_bindings=section_rewriter.section_entry_bindings,
+        )
         function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
     tree = ast.Module(body=[function_def], type_ignores=[])
     ast.fix_missing_locations(tree)
@@ -94,6 +98,9 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
         self._counter = 0
         self._env = {}
         self._local_names = set()
+        self._known_bindings = set()
+        self._section_outer_bindings = None
+        self.section_entry_bindings = {}
 
     @staticmethod
     def _is_section_with(node):
@@ -111,7 +118,9 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
 
     def _activate_targets(self, targets):
         for name in targets & self._local_names:
-            self._env.setdefault(name, self._fresh_alias(name))
+            alias = self._env.setdefault(name, self._fresh_alias(name))
+            if self._section_outer_bindings is not None and name in self._section_outer_bindings:
+                self.section_entry_bindings.setdefault(alias, name)
 
     def _visit_block(self, stmts, env=None):
         old_env = self._env
@@ -126,13 +135,16 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
     def _visit_section_body(self, stmts):
         old_env = self._env
         old_names = self._local_names
+        old_outer_bindings = self._section_outer_bindings
         self._env = {}
         self._local_names = _name_info(stmts).stores
+        self._section_outer_bindings = set(self._known_bindings)
         try:
             return [self.visit(stmt) for stmt in stmts]
         finally:
             self._env = old_env
             self._local_names = old_names
+            self._section_outer_bindings = old_outer_bindings
 
     def visit_With(self, node):
         if not self._is_section_with(node):
@@ -148,6 +160,8 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
             targets |= self._target_names(target)
         self._activate_targets(targets)
         node.targets = [self.visit(target) for target in node.targets]
+        if self._section_outer_bindings is None:
+            self._known_bindings.update(targets)
         return node
 
     def visit_AnnAssign(self, node):
@@ -155,6 +169,8 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
             node.value = self.visit(node.value)
         self._activate_targets(self._target_names(node.target))
         node.target = self.visit(node.target)
+        if self._section_outer_bindings is None:
+            self._known_bindings.update(self._target_names(node.target))
         return node
 
     def visit_AugAssign(self, node):
@@ -165,6 +181,8 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
             node.value = self.visit(node.value)
             self._activate_targets({name})
             node.target.id = self._env[name]
+            if self._section_outer_bindings is None:
+                self._known_bindings.add(name)
             return node
         return self.generic_visit(node)
 
@@ -172,6 +190,8 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
         node.iter = self.visit(node.iter)
         self._activate_targets(self._target_names(node.target))
         node.target = self.visit(node.target)
+        if self._section_outer_bindings is None:
+            self._known_bindings.update(self._target_names(node.target))
         node.body, body_env = self._visit_block(node.body, self._env)
         self._env.update(body_env)
         node.orelse, else_env = self._visit_block(node.orelse, self._env)
@@ -906,8 +926,9 @@ class _SlotCarryRewriter(ast.NodeTransformer):
 
 
 class _ControlFlowRewriter:
-    def __init__(self, static_env=None):
+    def __init__(self, static_env=None, *, section_entry_bindings=None):
         self._static_env = dict(static_env or {})
+        self._section_entry_bindings = dict(section_entry_bindings or {})
         self._counter = 0
 
     def _fresh(self, prefix: str) -> str:
@@ -1307,7 +1328,10 @@ class _ControlFlowRewriter:
                     ),
                     args=[],
                     keywords=[
-                        ast.keyword(arg=name, value=_name(name))
+                        ast.keyword(
+                            arg=name,
+                            value=_name(self._section_entry_bindings.get(name, name)),
+                        )
                         for name in loop_carried
                     ] + [
                         ast.keyword(arg=slot_carry_names[slot], value=_name(slot_carry_names[slot]))

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -20,8 +20,15 @@ class PTODSLAstRewriteError(SyntaxError):
     """Raised when AST rewrite sees unsupported Python control flow."""
 
 
-def rewrite_jit_function(fn, *, static_bindings=None):
-    """Return a function whose Python if/for control flow lowers to PTODSL APIs."""
+def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True):
+    """Return a function with PTODSL lexical sections lowered safely.
+
+    ``pto.section`` is a physical SSA region, not a Python ``with`` hint.  The
+    section body therefore gets a small source-level lexical rewrite even when
+    the optional control-flow rewrite is disabled.  This keeps Python's
+    function-local assignment rules from leaking a section-local SSA value into
+    a sibling physical section.
+    """
     try:
         source = inspect.getsource(fn)
     except (OSError, TypeError) as exc:
@@ -46,8 +53,10 @@ def rewrite_jit_function(fn, *, static_bindings=None):
     _inject_closure_defaults(function_def, closure_vars.nonlocals)
     _sanitize_signature_for_exec(function_def)
     function_def = _ConditionalExpressionNormalizer().visit(function_def)
-    rewriter = _ControlFlowRewriter(static_env)
-    function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
+    function_def = _SectionLexicalRewriter().visit(function_def)
+    if rewrite_control_flow:
+        rewriter = _ControlFlowRewriter(static_env)
+        function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
     tree = ast.Module(body=[function_def], type_ignores=[])
     ast.fix_missing_locations(tree)
 
@@ -75,6 +84,114 @@ def rewrite_jit_function(fn, *, static_bindings=None):
     rewritten.__module__ = fn.__module__
     rewritten.__qualname__ = fn.__qualname__
     return rewritten
+
+
+class _SectionLexicalRewriter(ast.NodeTransformer):
+    """Give ``with pto.section(...)`` a lexical, closure-like name scope."""
+
+    def __init__(self):
+        super().__init__()
+        self._counter = 0
+        self._env = {}
+        self._local_names = set()
+
+    @staticmethod
+    def _is_section_with(node):
+        return isinstance(node, ast.With) and any(
+            _is_pto_attr_call(item.context_expr, "section") for item in node.items
+        )
+
+    def _fresh_alias(self, name):
+        alias = f"__pto_section_{self._counter}_{name}"
+        self._counter += 1
+        return alias
+
+    def _target_names(self, target):
+        return _target_stores(target)
+
+    def _activate_targets(self, targets):
+        for name in targets & self._local_names:
+            self._env.setdefault(name, self._fresh_alias(name))
+
+    def _visit_block(self, stmts, env=None):
+        old_env = self._env
+        if env is not None:
+            self._env = dict(env)
+        try:
+            result = [self.visit(stmt) for stmt in stmts]
+            return result, dict(self._env)
+        finally:
+            self._env = old_env
+
+    def _visit_section_body(self, stmts):
+        old_env = self._env
+        old_names = self._local_names
+        self._env = {}
+        self._local_names = _name_info(stmts).stores
+        try:
+            return [self.visit(stmt) for stmt in stmts]
+        finally:
+            self._env = old_env
+            self._local_names = old_names
+
+    def visit_With(self, node):
+        if not self._is_section_with(node):
+            return self.generic_visit(node)
+        node.items = [self.visit(item) for item in node.items]
+        node.body = self._visit_section_body(node.body)
+        return node
+
+    def visit_Assign(self, node):
+        node.value = self.visit(node.value)
+        targets = set()
+        for target in node.targets:
+            targets |= self._target_names(target)
+        self._activate_targets(targets)
+        node.targets = [self.visit(target) for target in node.targets]
+        return node
+
+    def visit_AnnAssign(self, node):
+        if node.value is not None:
+            node.value = self.visit(node.value)
+        self._activate_targets(self._target_names(node.target))
+        node.target = self.visit(node.target)
+        return node
+
+    def visit_AugAssign(self, node):
+        if isinstance(node.target, ast.Name) and node.target.id in self._local_names:
+            name = node.target.id
+            if name in self._env:
+                node.target.id = self._env[name]
+            node.value = self.visit(node.value)
+            self._activate_targets({name})
+            node.target.id = self._env[name]
+            return node
+        return self.generic_visit(node)
+
+    def visit_For(self, node):
+        node.iter = self.visit(node.iter)
+        self._activate_targets(self._target_names(node.target))
+        node.target = self.visit(node.target)
+        node.body, body_env = self._visit_block(node.body, self._env)
+        self._env.update(body_env)
+        node.orelse, else_env = self._visit_block(node.orelse, self._env)
+        self._env.update(else_env)
+        return node
+
+    def visit_If(self, node):
+        node.test = self.visit(node.test)
+        entry_env = dict(self._env)
+        node.body, body_env = self._visit_block(node.body, entry_env)
+        node.orelse, else_env = self._visit_block(node.orelse, entry_env)
+        self._env.update(body_env)
+        self._env.update(else_env)
+        return node
+
+    def visit_Name(self, node):
+        alias = self._env.get(node.id)
+        if alias is not None:
+            node.id = alias
+        return node
 
 
 def _find_function_def(tree, name: str):
@@ -1030,7 +1147,15 @@ class _ControlFlowRewriter:
         dynamic_body.extend(
             ast.Assign(
                 targets=[_name(name, ast.Store())],
-                value=ast.Attribute(value=_name(branch_name), attr=name, ctx=ast.Load()),
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=_name(branch_name),
+                        attr="get",
+                        ctx=ast.Load(),
+                    ),
+                    args=[ast.Constant(value=name)],
+                    keywords=[],
+                ),
             )
             for name in merge_names
         )

--- a/ptodsl/ptodsl/_control_flow.py
+++ b/ptodsl/ptodsl/_control_flow.py
@@ -384,6 +384,17 @@ class BranchHandle:
     def assign(self, **kwargs):
         self._owner._assign_branch_values(kwargs)
 
+    def get(self, name: str):
+        """Return a merged value by name, including generated names.
+
+        The AST rewriter uses generated names such as ``__pto_section_0_x``
+        for lexical section bindings.  Keep those names out of the attribute
+        namespace, but provide an explicit lookup path for the rewriter.
+        """
+        if not isinstance(name, str):
+            raise TypeError("br.get(...) expects a string name")
+        return self._owner._get_merged_value(name)
+
     def __getattr__(self, name):
         if name.startswith("_"):
             raise AttributeError(name)

--- a/ptodsl/ptodsl/_diagnostics.py
+++ b/ptodsl/ptodsl/_diagnostics.py
@@ -364,6 +364,16 @@ def inline_subkernel_value_escape_error(role: str, type_text: str) -> RuntimeErr
     )
 
 
+def physical_section_value_escape_error(source_kind: str, type_text: str) -> RuntimeError:
+    """Return a diagnostic for a value escaping a physical section."""
+    return RuntimeError(
+        f"cannot use a value defined in pto.section.{source_kind} outside that physical section "
+        f"(got {type_text}). Physical sections have lexical SSA scope; pass shared data "
+        "through a GM/UB buffer with explicit synchronization, or recompute the value "
+        "from section-entry inputs."
+    )
+
+
 def simd_value_escape_error(type_text: str) -> RuntimeError:
     """Return one diagnostic for transient SIMD values escaping a simd subkernel boundary."""
     return RuntimeError(
@@ -532,6 +542,7 @@ __all__ = [
     "jit_missing_annotation_error",
     "jit_non_gm_ptr_entry_error",
     "inline_subkernel_value_escape_error",
+    "physical_section_value_escape_error",
     "make_tensor_view_missing_metadata_error",
     "illegal_inline_subkernel_placement_error",
     "illegal_subkernel_placement_error",

--- a/ptodsl/ptodsl/_kernel_compilation.py
+++ b/ptodsl/ptodsl/_kernel_compilation.py
@@ -87,15 +87,18 @@ class KernelCompiler:
         self._compiled_cache = {}
 
     def tracing_callback(self, constexpr_bindings=None):
-        if not self._ast_rewrite:
-            return self._callback
         cache_key = tuple(
             (name, constexpr_bindings[name])
             for name in sorted(constexpr_bindings or {})
         )
+        cache_key = (self._ast_rewrite, cache_key)
         cached = self._trace_callback_cache.get(cache_key)
         if cached is None:
-            cached = rewrite_jit_function(self._callback, static_bindings=constexpr_bindings)
+            cached = rewrite_jit_function(
+                self._callback,
+                static_bindings=constexpr_bindings,
+                rewrite_control_flow=self._ast_rewrite,
+            )
             self._trace_callback_cache[cache_key] = cached
         return cached
 

--- a/ptodsl/ptodsl/_tracing/session.py
+++ b/ptodsl/ptodsl/_tracing/session.py
@@ -16,6 +16,7 @@ import hashlib
 from .._diagnostics import (
     inline_subkernel_value_escape_error,
     inline_tileop_capture_type_error,
+    physical_section_value_escape_error,
     subkernel_kernel_kind_mismatch_error,
 )
 from .._kernel_signature import RuntimeScalarParameterSpec
@@ -168,6 +169,8 @@ class TraceSession:
         self._authored_physical_sections: dict[object, set[str]] = {}
         self._inline_subkernel_counter = 0
         self._escaped_inline_values: dict[object, tuple[str, str]] = {}
+        self._physical_section_stack: list[tuple[str, object]] = []
+        self._physical_section_values: dict[object, tuple[str, str]] = {}
 
     @property
     def current_function(self):
@@ -284,7 +287,12 @@ class TraceSession:
         self._active_physical_sections.add(function_key)
         try:
             with InsertionPoint(section_block):
-                yield section_op
+                self._physical_section_stack.append((kind, section_op))
+                try:
+                    yield section_op
+                finally:
+                    self._physical_section_stack.pop()
+                self._record_physical_section_values(section_op, kind)
         except BaseException:
             if section_op.operation.parent is not None:
                 section_op.operation.erase()
@@ -295,8 +303,23 @@ class TraceSession:
         finally:
             self._active_physical_sections.remove(function_key)
 
+    def _record_physical_section_values(self, section_op, kind: str) -> None:
+        """Record values defined by *section_op* for source-level escape checks."""
+        for op_view in self._walk_op_tree([section_op]):
+            for result in op_view.operation.results:
+                self._physical_section_values[result] = (kind, str(result.type))
+            for region in op_view.operation.regions:
+                for block in region.blocks:
+                    for argument in block.arguments:
+                        self._physical_section_values[argument] = (kind, str(argument.type))
+
     def validate_surface_value_access(self, value) -> None:
         """Reject inline-subkernel SSA values that escaped their outlined helper body."""
+        raw_value = getattr(value, "_value", value)
+        section_record = self._physical_section_values.get(raw_value)
+        if section_record is not None and not self._is_value_inside_active_section(raw_value):
+            kind, type_text = section_record
+            raise physical_section_value_escape_error(kind, type_text)
         try:
             record = self._escaped_inline_values.get(value)
         except TypeError:
@@ -308,6 +331,20 @@ class TraceSession:
             return
         role, type_text = record
         raise inline_subkernel_value_escape_error(role, type_text)
+
+    def _is_value_inside_active_section(self, value) -> bool:
+        """Return whether *value* belongs to the currently traced section."""
+        owner = getattr(value, "owner", None)
+        if owner is None:
+            return False
+        for _, section_op in reversed(self._physical_section_stack):
+            section_operation = getattr(section_op, "operation", section_op)
+            current = getattr(owner, "operation", owner)
+            while current is not None:
+                if current is section_operation:
+                    return True
+                current = getattr(current, "parent", None)
+        return False
 
     @contextmanager
     def enter_function(self, ir_fn, *, owner_symbol_name: str | None = None):

--- a/ptodsl/tests/test_section.py
+++ b/ptodsl/tests/test_section.py
@@ -132,6 +132,21 @@ def lexical_section_conditional_rebinding_probe():
         pto.wait_flag("S", "MTE2", event_id=value)
 
 
+@pto.jit(target="a5", mode="explicit")
+def lexical_section_loop_carry_probe():
+    one = pto.const(1, dtype=pto.i32)
+    m_tile = pto.const(0, dtype=pto.i64)
+    n_tile = pto.const(0, dtype=pto.i64)
+    with pto.section("cube"):
+        for w in range(0, 4):
+            if w < 2:
+                m_tile = pto.get_block_idx()
+            if 1 < (w & 3):
+                n_tile = pto.get_block_idx()
+            pto.wait_flag("S", "MTE2", event_id=m_tile)
+            pto.wait_flag("S", "MTE2", event_id=n_tile)
+
+
 @pto.jit(target="a5", mode="explicit", ast_rewrite=False)
 def lexical_section_rebinding_no_rewrite_probe():
     event_id = pto.const(1, dtype=pto.i32)
@@ -213,6 +228,10 @@ def main() -> None:
     conditional_lexical_text = lexical_section_conditional_rebinding_probe.compile().mlir_text()
     assert conditional_lexical_text.count("pto.section.cube {") == 1
     assert "scf.if" in conditional_lexical_text
+
+    loop_carry_text = lexical_section_loop_carry_probe.compile().mlir_text()
+    assert loop_carry_text.count("pto.section.cube {") == 1
+    assert "scf.for" in loop_carry_text
 
     no_rewrite_text = lexical_section_rebinding_no_rewrite_probe.compile().mlir_text()
     vector_start = no_rewrite_text.index("pto.section.vector {")

--- a/ptodsl/tests/test_section.py
+++ b/ptodsl/tests/test_section.py
@@ -109,6 +109,49 @@ def section_inside_subkernel_probe():
             pass
 
 
+@pto.jit(target="a5", mode="explicit")
+def lexical_section_rebinding_probe():
+    event_id = pto.const(1, dtype=pto.i32)
+    one = pto.const(1, dtype=pto.i32)
+    with pto.section("cube"):
+        event_id = event_id + one
+        pto.wait_flag("S", "MTE2", event_id=event_id)
+    with pto.section("vector"):
+        pto.wait_flag("MTE2", "S", event_id=event_id)
+
+
+@pto.jit(target="a5", mode="explicit")
+def lexical_section_conditional_rebinding_probe():
+    one = pto.const(1, dtype=pto.i32)
+    with pto.section("cube"):
+        value = pto.const(0, dtype=pto.i32)
+        if pto.get_block_idx() < one:
+            value = one
+        else:
+            value = pto.const(2, dtype=pto.i32)
+        pto.wait_flag("S", "MTE2", event_id=value)
+
+
+@pto.jit(target="a5", mode="explicit", ast_rewrite=False)
+def lexical_section_rebinding_no_rewrite_probe():
+    event_id = pto.const(1, dtype=pto.i32)
+    one = pto.const(1, dtype=pto.i32)
+    with pto.section("cube"):
+        event_id = event_id + one
+        pto.wait_flag("S", "MTE2", event_id=event_id)
+    with pto.section("vector"):
+        pto.wait_flag("MTE2", "S", event_id=event_id)
+
+
+@pto.jit(target="a5", mode="explicit", ast_rewrite=False)
+def lexical_section_escape_probe():
+    escaped = []
+    with pto.section("cube"):
+        escaped.append(pto.const(2, dtype=pto.i32))
+    with pto.section("vector"):
+        pto.wait_flag("MTE2", "S", event_id=escaped[0])
+
+
 def _expect_raises(exc_type, callback, message):
     try:
         callback()
@@ -161,6 +204,26 @@ def main() -> None:
         RuntimeError,
         lambda: section_inside_subkernel_probe.compile(),
         "pto.section() is not allowed inside a cube or simd subkernel body",
+    )
+
+    lexical_text = lexical_section_rebinding_probe.compile().mlir_text()
+    assert lexical_text.count("pto.section.cube {") == 1
+    assert lexical_text.count("pto.section.vector {") == 1
+
+    conditional_lexical_text = lexical_section_conditional_rebinding_probe.compile().mlir_text()
+    assert conditional_lexical_text.count("pto.section.cube {") == 1
+    assert "scf.if" in conditional_lexical_text
+
+    no_rewrite_text = lexical_section_rebinding_no_rewrite_probe.compile().mlir_text()
+    vector_start = no_rewrite_text.index("pto.section.vector {")
+    vector_text = no_rewrite_text[vector_start:]
+    assert "arith.addi" not in vector_text
+    assert "pto.wait_flag_dyn" in vector_text
+
+    _expect_raises(
+        RuntimeError,
+        lambda: lexical_section_escape_probe.compile(),
+        "cannot use a value defined in pto.section.cube outside that physical section",
     )
     _expect_raises(
         RuntimeError,

--- a/test/lit/vpto/physical_section_boundaries.pto
+++ b/test/lit/vpto/physical_section_boundaries.pto
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it
+// under the terms of the CANN Open Software License Agreement Version 2.0.
+
+// Explicit sections and inferred sections use the same physical SSA rule.
+// RUN: pto-test-opt --pto-normalize-uncovered-tile-sections --pto-validate-physical-section-boundaries %s | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  func.func @legal_capture(%seed: i32) {
+    pto.section.cube {
+      %cube = arith.addi %seed, %seed : i32
+    }
+    return
+  }
+
+  func.func @inferred_sections(%src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>) {
+    %c0 = arith.constant 0 : index
+    %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+    %vec0 = pto.vlds %src[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %vec1 = pto.vlds %dst[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+    %sum = pto.vadd %vec0, %vec1, %mask : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+    pto.vsts %sum, %dst[%c0], %mask {dist = "NORM_B32"} : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    return
+  }
+}
+
+// CHECK: func.func @legal_capture
+// CHECK: pto.section.cube {
+// CHECK: func.func @inferred_sections
+// CHECK: pto.vlds

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -3362,6 +3362,8 @@ int mlir::pto::compilePTOASModule(
     preBackendPM.enableVerifier();
     preBackendPM.addPass(pto::createPTOMaterializeTileOpSectionsPass());
     preBackendPM.addPass(pto::createPTONormalizeUncoveredTileSectionsPass());
+    preBackendPM.addPass(
+        pto::createPTOValidatePhysicalSectionBoundariesPass());
     if (failed(preBackendPM.run(module.get()))) {
       llvm::errs() << "Error: failed to normalize uncovered PTO tile sections.\n";
       return 1;


### PR DESCRIPTION
## Summary

- Give `pto.section` lexical SSA-like variable isolation in PTODSL, so rebinding in a Cube section does not affect sibling Vector sections.
- Diagnose physical section values that escape through Python containers or other surface-value accesses.
- Add a PTOAS physical-section boundary verifier and run it after explicit/inferred section normalization.
- Add focused PTODSL and lit coverage for lexical rebinding, escape diagnostics, and inferred sections.

## Validation

- `ctest --test-dir build -L PTODSL --output-on-failure`: 24/24 passed in the source worktree.
- New lit test passed with `pto-test-opt --pto-normalize-uncovered-tile-sections --pto-validate-physical-section-boundaries`.
- `git diff --check` passed.
- In this PR worktree, `pto-test-opt` built successfully. The full PTOAS Python extension link was blocked by the local CMake/Python static-library configuration; no device or PTOAS/Bisheng end-to-end run was performed.

- Fixes #1095
