### PR TITLE
fix(samples): mark p2p communication kernels as vector

### DIFF
--- a/test/samples/CommSync/comm_p2p.py
+++ b/test/samples/CommSync/comm_p2p.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from ptoas.mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
+from ptoas.mlir.ir import Attribute, Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from ptoas.mlir.dialects import arith, func, pto
 
 
@@ -41,6 +41,7 @@ def build():
             with InsertionPoint(module.body):
                 fn = func.FuncOp("comm_p2p_kernel", fn_ty)
                 fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
+                fn.operation.attributes["pto.kernel_kind"] = Attribute.parse("#pto.kernel_kind<vector>")
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):

--- a/test/samples/CommSync/comm_p2p_binding_variants.py
+++ b/test/samples/CommSync/comm_p2p_binding_variants.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-from ptoas.mlir.ir import Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
+from ptoas.mlir.ir import Attribute, Context, F32Type, IndexType, InsertionPoint, IntegerType, Location, Module, UnitAttr
 from ptoas.mlir.dialects import arith, func, pto
 
 
@@ -40,6 +40,7 @@ def build():
             with InsertionPoint(module.body):
                 fn = func.FuncOp("comm_p2p_binding_variants_kernel", fn_ty)
                 fn.operation.attributes["pto.entry"] = UnitAttr.get(ctx)
+                fn.operation.attributes["pto.kernel_kind"] = Attribute.parse("#pto.kernel_kind<vector>")
                 entry = fn.add_entry_block()
 
             with InsertionPoint(entry):


### PR DESCRIPTION
## Summary

- mark `comm_p2p` and `comm_p2p_binding_variants` entry functions as vector kernels
- keep PTOAS fence lowering consistent with the `dav-c220-vec` architecture selected by A3 board validation
- prevent these samples from emitting `pipe_barrier(PIPE_FIX)` in vector kernels

## Root cause

PR #1033 made vector GM fences lower to `pipe_barrier(PIPE_ALL); dsb(DSB_DDR);`, but the two Python sample builders only set `pto.entry`. Without `pto.kernel_kind = #pto.kernel_kind<vector>`, EmitC lowering treated them as non-vector and emitted the conservative MTE2/MTE3/FIX sequence. The board generator independently selected `dav-c220-vec`, so the generated `PIPE_FIX` barrier caused an AIV illegal-instruction failure.

## Validation

- both Python sample builders compile and verify
- generated PTO IR contains `pto.kernel_kind = #pto.kernel_kind<vector>`
- generated C++ contains `pipe_barrier(PIPE_ALL); dsb(DSB_DDR);`
- generated C++ contains no `pipe_barrier(PIPE_FIX)`
- `git diff --check` passes
- A3 runtime retest is pending because the available board account currently lacks access to `/dev/davinci*`

## Related

- #953
- #1026
- #1033