### PR TITLE
fix(vpto): add SIMT fastmath control

### DIFF
--- a/test/lit/vpto/bisheng_simt_fastmath_cli.pto
+++ b/test/lit/vpto/bisheng_simt_fastmath_cli.pto
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --help | FileCheck %s
+// RUN: ptoas --simt-fastmath --help > /dev/null
+// RUN: ptoas --simt-fastmath=false --help > /dev/null
+
+// CHECK: --simt-fastmath
+// CHECK-SAME: Enable Bisheng SIMT floating-point contraction and fast math combining for VPTO device compilation

--- a/tools/ptoas/ObjectEmission.cpp
+++ b/tools/ptoas/ObjectEmission.cpp
@@ -50,6 +50,12 @@ static llvm::cl::opt<bool> enableBishengVecMISched(
                    "the scheduler"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> enableSimtFastMath(
+    "simt-fastmath",
+    llvm::cl::desc("Enable Bisheng SIMT floating-point contraction and fast "
+                   "math combining for VPTO device compilation"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<BishengVFAutoSyncMode> bishengVFAutoSyncMode(
     "bisheng-vf-auto-sync",
     llvm::cl::desc("Explicit Bisheng VF auto-sync mode for VPTO device "
@@ -520,6 +526,9 @@ static bool compileDeviceLLVMToObject(llvm::StringRef llPath,
     args.push_back("-mllvm");
     args.push_back("--cce-aicore-vec-misched=0");
   }
+  args.push_back("-mllvm");
+  args.push_back(std::string("--cce-simt-fpmath-combine=") +
+                 (enableSimtFastMath ? "true" : "false"));
   args.push_back("-c");
   args.push_back("-x");
   args.push_back("ir");


### PR DESCRIPTION
## Summary

- Add `--simt-fastmath`, disabled by default.
- Pass `--cce-simt-fpmath-combine=false` to Bisheng by default and enable it only when explicitly requested.
- Add CLI regression coverage for the new option.

## Validation

- PTOAS compiler shared library builds successfully.
- `ptoas --simt-fastmath --help` and `ptoas --simt-fastmath=false --help` succeed.
- The issue-1117 mul/add repro emits different objects for default and `--simt-fastmath` modes.
- Default LLVM IR remains separate `fmul` and `fadd` operations.

## Scope

This PR addresses the implicit SIMT `mulf + addf` contraction described in issue #1117. The scalar high-precision `fdiv` question remains open: CANN 9.0.0 exposes high-precision division only through vector `bisheng::cce::simd::hp::vdiv` / PTO `Div754`-style helpers; the candidate scalar LLVM intrinsics are not selectable on the current A5 Bisheng target.

Refs #1117
