### PR TITLE
add FpToSi in vmi.vcvt

### DIFF
--- a/docs/isa/vmi-isa/06-convert.md
+++ b/docs/isa/vmi-isa/06-convert.md
@@ -14,21 +14,27 @@
 
 - **semantics:** Unified elementwise type conversion. The conversion direction
   is derived from the source and destination element types; the verifier
-  dispatches to one of six kinds:
+  dispatches to one of seven kinds:
 
   1. **FpWiden** — `fp → fp`, `|dst| > |src|` (e.g. `f16 → f32`,
      `bf16 → f32`, `fp8_e4m3 → f16`).
 
   2. **FpNarrow** — `fp → fp`, `|dst| < |src|` (e.g. `f32 → f16`,
-     `f32 → bf16`, `f32 → fp8_e4m3`).
+     `f32 → bf16`, `f32 → fp8_e4m3`). Same-width `fp → fp`
+     (`|dst| == |src|`, e.g. `bf16 → f16`).
 
-  3. **FpToSi** — `fp → int` (e.g. `f32 → i32`, `f16 → i8`).
+  3. **FpToSi** — `fp → signed int`. Supported pairs follow the contract
+     table `lookupVMIFpToSiContract`: `f32→s32`, `f16→s16`, `f32→s16`,
+     `f16→s8`, `f16→s32` (nosat), `bf16→s32`.
 
-  4. **SiToFp** — `int → fp` (e.g. `i32 → f32`, `i8 → f16`).
+  4. **FpToUi** — `fp → unsigned int`. Supported pairs follow the contract
+     table `lookupVMIFpToUIContract`: currently `f16→u8`.
 
-  5. **IntWiden** — `int → int`, `|dst| > |src|`.
+  5. **SiToFp** — `int → fp` (e.g. `i32 → f32`, `i8 → f16`).
 
-  6. **IntNarrow** — `int → int`, `|dst| < |src|`.
+  6. **IntWiden** — `int → int`, `|dst| > |src|`.
+
+  7. **IntNarrow** — `int → int`, `|dst| < |src|`.
 
 - **syntax:**
   ```mlir
@@ -51,7 +57,7 @@
   | Attribute | Values | Valid for | Description |
   |---|---|---|---|
   | `rounding` | `"R"` (nearest-even), `"A"` (away-from-zero), `"H"` (half-up), `"Z"` (toward-zero) | fp narrowing | Rounding mode |
-  | `saturate` | `"SAT"`, `"NOSAT"` | **required** for fp-narrow / int-narrow / fp→si | `SAT` clamps to ±max of the destination type; `NOSAT` performs a direct bit truncation of the result representation. |
+  | `saturate` | `"SAT"`, `"NOSAT"` | required for fp-narrow / int-narrow; for fp→si / fp→ui the requirement follows the vcvt contract's `requiresSat` (e.g. `f16→s8` required, `f16→s32` **forbidden** — no overflow possible; same-width `bf16→f16` required) | `SAT` clamps to ±max of the destination type; `NOSAT` performs a direct bit truncation of the result representation. |
 
 - **datatypes:** Source and destination from `{f32, f16, bf16, fp8_e4m3, fp8_e5m2, i32, i16, i8, ui32, ui16, ui8}`
 - **lowering to `pto.mi`:**
@@ -62,6 +68,8 @@
   | 8↔32 (radix-4) | widen: `UNPK_B8` + `vintlv` + `vcvt P0` + `punpack`; narrow: `PK4_B32` store (or `vselr` gather) + `ppack` | `2–3` | `2–3` |
   | f32→fp8 quant | `1 cast` + `PK4_B32` | `K` | `1` |
   | f32→int8 quant | 3-stage cast + `PK4_B32` | `~3K` | `3` |
+  | fp↔fp same-width (`bf16→f16`) | `K × vcvt` (1:1, no part) | `K` | `1` |
+  | fp→si / fp→ui | per contract pair: same-width 1:1, widen EVEN/ODD, narrow EVEN/ODD+Vor | `K`–`~3K` | `2`–`3` |
   | int↔int (same width) | `K × vtrc` or `K × vcvt` | `K` | `1` |
 
 - **example:**
@@ -91,6 +99,15 @@
   // f32 → i32 fp-to-si (saturate required)
   %r = pto.vmi.vcvt %x {saturate = "SAT"}
       : !pto.vmi.vreg<64×f32> -> !pto.vmi.vreg<64×i32>
+
+  // bf16 → f16 same-width fp-to-fp (VPTO contract pair, routed via FpNarrow;
+  // saturate required)
+  %h = pto.vmi.vcvt %g {saturate = "SAT"}
+      : !pto.vmi.vreg<128×bf16> -> !pto.vmi.vreg<128×f16>
+
+  // f16 → u8 fp-to-ui (unsigned; contract pair, saturate required)
+  %u = pto.vmi.vcvt %x {saturate = "SAT"}
+      : !pto.vmi.vreg<128×f16> -> !pto.vmi.vreg<128×ui8>
   ```
 
 - **notes:**

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -568,6 +568,15 @@ def VMIFPToSIOp : VMI_Op<"fptosi", [Pure]> {
   let assemblyFormat = "$source attr-dict `:` type($source) `->` type($result)";
 }
 
+def VMIFPToUIOp : VMI_Op<"fptoui", [Pure]> {
+  let summary = "VMI floating-point to unsigned integer elementwise conversion";
+  let arguments = (ins VMI_VRegTypeConstraint:$source,
+                   OptionalAttr<StrAttr>:$saturate);
+  let results = (outs VMI_VRegTypeConstraint:$result);
+  let hasVerifier = 1;
+  let assemblyFormat = "$source attr-dict `:` type($source) `->` type($result)";
+}
+
 def VMISIToFPOp : VMI_Op<"sitofp", [Pure]> {
   let summary = "VMI signed integer to floating-point elementwise conversion";
   let arguments = (ins VMI_VRegTypeConstraint:$source);

--- a/include/PTO/IR/VMIUtils.h
+++ b/include/PTO/IR/VMIUtils.h
@@ -53,6 +53,54 @@ FailureOr<int64_t> mapPhysicalLaneToLogical(Type type, int64_t part,
 FailureOr<bool> isPaddingLane(Type type, int64_t part, int64_t chunk,
                               int64_t lane);
 
+// ---------------------------------------------------------------------------
+// VMI FpToSi hardware contract (mirrored from VPTO lookupVcvtContract).
+// Used by VMI verifiers and VMIToVPTO lowering to agree on requiresSat /
+// requiresPart without duplicating the logic.
+// ---------------------------------------------------------------------------
+
+struct VMIFpToSiContract {
+  bool requiresSat;
+  bool requiresPart;
+};
+
+/// Returns the FpToSi contract for the given src→dst element type pair,
+/// or nullopt if this float→signed-int path is not supported by the hardware.
+std::optional<VMIFpToSiContract>
+lookupVMIFpToSiContract(Type srcElem, Type dstElem);
+
+// ---------------------------------------------------------------------------
+// VMI FpToUi hardware contract (mirrors VPTO lookupVcvtContract).
+// Symmetric to FpToSi but for float→unsigned-int paths.
+// ---------------------------------------------------------------------------
+
+struct VMIFpToUiContract {
+  bool requiresSat;
+  bool requiresPart;
+};
+
+/// Returns the FpToUi contract for the given src→dst element type pair,
+/// or nullopt if this float→unsigned-int path is not supported by the hardware.
+std::optional<VMIFpToUiContract>
+lookupVMIFpToUIContract(Type srcElem, Type dstElem);
+
+// ---------------------------------------------------------------------------
+// VMI FpToFp hardware contract (VMI-owned; may diverge from VPTO).
+// Only same-width fp->fp needs a pair whitelist here; widen/narrow fp->fp
+// reuse the extf/truncf layout framework and do not consult this table.
+// ---------------------------------------------------------------------------
+
+struct VMIFpToFpContract {
+  bool requiresRnd;
+  bool requiresSat;
+  bool requiresPart;
+};
+
+/// Returns the FpToFp contract for the given src->dst element type pair,
+/// or nullopt if this fp-to-fp path is not supported by the VMI contract.
+std::optional<VMIFpToFpContract>
+lookupVMIFpToFpContract(Type srcElem, Type dstElem);
+
 } // namespace mlir::pto
 
 #endif // PTO_IR_VMIUTILS_H

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -595,6 +595,93 @@ static int64_t getDenseLogicalLanesInPart(int64_t elementCount, int64_t factor,
 
 } // namespace
 
+// ---------------------------------------------------------------------------
+// FpToSi hardware contract (mirrors VPTO lookupVcvtContract fp→int rows)
+// ---------------------------------------------------------------------------
+
+namespace mlir::pto {
+
+std::optional<VMIFpToSiContract>
+lookupVMIFpToSiContract(Type srcElem, Type dstElem) {
+  // Must be float → signed/signless integer.
+  if (!isVMIFloatLikeType(srcElem))
+    return std::nullopt;
+  auto dstInt = dyn_cast<IntegerType>(dstElem);
+  if (!dstInt || dstInt.isUnsigned())
+    return std::nullopt;
+
+  bool srcF32 = srcElem.isF32();
+  bool srcF16 = srcElem.isF16();
+  bool srcBF16 = srcElem.isBF16();
+  unsigned dstBits = dstInt.getWidth();
+
+  // f32 → s32: same width, rnd, sat, no part
+  if (srcF32 && dstBits == 32)
+    return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/false};
+  // f32 → s16: narrow 2×, rnd, sat, part (EvenOdd)
+  if (srcF32 && dstBits == 16)
+    return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+  // f16 → s32: widen 2×, rnd, NO sat, part (EvenOdd)
+  if (srcF16 && dstBits == 32)
+    return VMIFpToSiContract{/*requiresSat=*/false, /*requiresPart=*/true};
+  // f16 → s16: same width, rnd, sat, no part
+  if (srcF16 && dstBits == 16)
+    return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/false};
+  // f16 → s8: narrow 2×, rnd, sat, part (EvenOdd)
+  if (srcF16 && dstBits == 8)
+    return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+  // bf16 → s32: widen 2×, rnd, sat, part (EvenOdd)
+  if (srcBF16 && dstBits == 32)
+    return VMIFpToSiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+
+  return std::nullopt;
+}
+
+// ---------------------------------------------------------------------------
+// FpToUi hardware contract (mirrors VPTO lookupVcvtContract fp→uint rows)
+// ---------------------------------------------------------------------------
+
+std::optional<VMIFpToUiContract>
+lookupVMIFpToUIContract(Type srcElem, Type dstElem) {
+  // Must be float → unsigned integer.
+  if (!isVMIFloatLikeType(srcElem))
+    return std::nullopt;
+  auto dstInt = dyn_cast<IntegerType>(dstElem);
+  if (!dstInt || !dstInt.isUnsigned())
+    return std::nullopt;
+
+  bool srcF16 = srcElem.isF16();
+  unsigned dstBits = dstInt.getWidth();
+
+  // f16 → u8: narrow 2×, rnd, sat, part (EvenOdd)
+  if (srcF16 && dstBits == 8)
+    return VMIFpToUiContract{/*requiresSat=*/true, /*requiresPart=*/true};
+
+  return std::nullopt;
+}
+
+// ---------------------------------------------------------------------------
+// FpToFp hardware contract (VMI-owned; may diverge from VPTO).
+// Only same-width fp->fp is enumerated here.
+// ---------------------------------------------------------------------------
+
+std::optional<VMIFpToFpContract>
+lookupVMIFpToFpContract(Type srcElem, Type dstElem) {
+  if (!isVMIFloatLikeType(srcElem) || !isVMIFloatLikeType(dstElem))
+    return std::nullopt;
+  unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
+  unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
+  if (srcBits != dstBits)
+    return std::nullopt;
+  // bf16 -> f16: same-width, rnd, sat, no part.
+  if (srcElem.isBF16() && dstElem.isF16())
+    return VMIFpToFpContract{/*requiresRnd=*/true, /*requiresSat=*/true,
+                            /*requiresPart=*/false};
+  return std::nullopt;
+}
+
+} // namespace mlir::pto
+
 VMILayoutAttr VMILayoutAttr::getContiguous(MLIRContext *context,
                                            int64_t laneStride) {
   return VMILayoutAttr::get(context, "contiguous", 1, 1, 0, laneStride);
@@ -1709,10 +1796,20 @@ LogicalResult VMITruncFOp::verify() {
       !isVMIFloatLikeType(resultType.getElementType()))
     return emitOpError(
         "requires floating-point-like source and result element types");
-  if (getVMIElementBitWidth(sourceType.getElementType()) <=
-      getVMIElementBitWidth(resultType.getElementType()))
+  unsigned srcBits = getVMIElementBitWidth(sourceType.getElementType());
+  unsigned dstBits = getVMIElementBitWidth(resultType.getElementType());
+  if (srcBits < dstBits)
     return emitOpError(
-        "requires result element type to be narrower than source element type");
+        "requires result element type to be narrower than or same-width "
+        "as source element type");
+  if (srcBits == dstBits) {
+    // Same-width fp→fp (e.g. bf16→f16): only allowed for supported VMI
+    // fp-to-fp contract pairs.
+    if (!lookupVMIFpToFpContract(sourceType.getElementType(),
+                                 resultType.getElementType()))
+      return emitOpError("same-width fp-to-fp conversion is not supported "
+                         "for this type pair; see lookupVMIFpToFpContract");
+  }
   if (auto roundingAttr = (*this)->getAttrOfType<StringAttr>("rounding")) {
     StringRef rounding = roundingAttr.getValue();
     if (rounding != "R" && rounding != "A" && rounding != "H" &&
@@ -1739,14 +1836,55 @@ LogicalResult VMIFPToSIOp::verify() {
   if (!isVMISignedOrSignlessIntegerType(resultType.getElementType()))
     return emitOpError("requires signed or signless integer result element "
                        "type");
-  if (getVMIElementBitWidth(resultType.getElementType()) != 32)
-    return emitOpError("requires 32-bit integer result element type");
-  auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
-  if (!satAttr)
-    return emitOpError("'saturate' attribute is required (SAT or NOSAT)");
-  StringRef satVal = satAttr.getValue();
-  if (satVal != "SAT" && satVal != "NOSAT")
-    return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
+  auto contract =
+      lookupVMIFpToSiContract(sourceType.getElementType(),
+                              resultType.getElementType());
+  if (!contract)
+    return emitOpError("unsupported fp-to-si conversion element type pair");
+  if (contract->requiresSat) {
+    auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
+    if (!satAttr)
+      return emitOpError("'saturate' attribute is required for this fp-to-si "
+                         "conversion (SAT or NOSAT)");
+    StringRef satVal = satAttr.getValue();
+    if (satVal != "SAT" && satVal != "NOSAT")
+      return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
+  } else {
+    if ((*this)->getAttrOfType<StringAttr>("saturate"))
+      return emitOpError("'saturate' attribute is not valid for this fp-to-si "
+                         "conversion (no overflow possible)");
+  }
+  return success();
+}
+
+LogicalResult VMIFPToUIOp::verify() {
+  auto sourceType = cast<VMIVRegType>(getSource().getType());
+  auto resultType = cast<VMIVRegType>(getResult().getType());
+  if (sourceType.getElementCount() != resultType.getElementCount())
+    return emitOpError(
+        "requires source and result logical lane counts to match");
+  if (!isVMIFloatLikeType(sourceType.getElementType()))
+    return emitOpError("requires floating-point-like source element type");
+  if (!isVMIUnsignedIntegerType(resultType.getElementType()))
+    return emitOpError("requires unsigned integer result element type");
+  auto contract =
+      lookupVMIFpToUIContract(sourceType.getElementType(),
+                              resultType.getElementType());
+  if (!contract)
+    return emitOpError("unsupported fp-to-ui conversion element type pair");
+  if (contract->requiresSat) {
+    auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
+    if (!satAttr)
+      return emitOpError("'saturate' attribute is required for this fp-to-ui "
+                         "conversion (SAT or NOSAT)");
+    StringRef satVal = satAttr.getValue();
+    if (satVal != "SAT" && satVal != "NOSAT")
+      return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
+  } else {
+    if ((*this)->getAttrOfType<StringAttr>("saturate"))
+      return emitOpError("'saturate' attribute is not valid for this fp-to-ui "
+                         "conversion (no overflow possible)");
+  }
   return success();
 }
 
@@ -2374,7 +2512,7 @@ LogicalResult VMIPackOp::verify() {
 }
 
 
-enum class CvtDirection { FpWiden, FpNarrow, FpToSi, SiToFp, IntWiden, IntNarrow };
+enum class CvtDirection { FpWiden, FpNarrow, FpToSi, FpToUi, SiToFp, IntWiden, IntNarrow };
 
 // Shared helper: validates mask-data alignment and pmode value.
 // Applicable to all VMI elementwise ops that carry mask + pmode.
@@ -3435,15 +3573,20 @@ LogicalResult VMICvtOp::verify() {
       dir = CvtDirection::FpWiden;
     else if (dstBits < srcBits)
       dir = CvtDirection::FpNarrow;
-    else
-      return emitOpError(
-          "fp-to-fp conversion must change element bit-width");
+    else {
+      // Same-width fp→fp (e.g. bf16 → f16): only allowed for VMI fp-to-fp
+      // contract pairs, routed through FpNarrow (1:1 TruncF).
+      if (!lookupVMIFpToFpContract(srcElem, dstElem))
+        return emitOpError(
+            "same-width fp-to-fp conversion is not supported for this type "
+            "pair; see lookupVMIFpToFpContract");
+      dir = CvtDirection::FpNarrow;
+    }
   } else if (srcFp && dstInt) {
-    if (!isVMISignedOrSignlessIntegerType(dstElem))
-      return emitOpError(
-          "fp-to-int conversion requires signed or signless integer result "
-          "element type");
-    dir = CvtDirection::FpToSi;
+    if (isVMIUnsignedIntegerType(dstElem))
+      dir = CvtDirection::FpToUi;
+    else
+      dir = CvtDirection::FpToSi;
   } else if (srcInt && dstFp) {
     if (!isVMISignedOrSignlessIntegerType(srcElem))
       return emitOpError(
@@ -3479,33 +3622,66 @@ LogicalResult VMICvtOp::verify() {
 
   // --- saturate ---
   auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
-  bool needSat = (dir == CvtDirection::FpNarrow ||
-                  dir == CvtDirection::IntNarrow ||
-                  dir == CvtDirection::FpToSi);
-  if (needSat) {
-    if (!satAttr)
-      return emitOpError("'saturate' attribute is required for fp-narrow / "
-                         "int-narrow / fp-to-si conversions; write 'SAT' or "
-                         "'NOSAT'");
-    StringRef satVal = satAttr.getValue();
-    if (satVal != "SAT" && satVal != "NOSAT")
-      return emitOpError("saturate must be 'SAT' or 'NOSAT'");
-    // si32 -> si8 IntNarrow has no native hardware form.  Lowering aliases
-    // it through ui32 -> ui8 (bit-pattern equal ONLY under NOSAT).  Reject
-    // SAT here because ui32 -> ui8 SAT clamps to [0, 255], which does NOT
-    // match the expected si32 -> si8 SAT clamp to [-128, 127].
-    if (dir == CvtDirection::IntNarrow && satVal == "SAT" &&
-        srcBits == 32 && dstBits == 8 &&
-        isa<IntegerType>(srcElem) &&
-        cast<IntegerType>(srcElem).isSigned() &&
-        isa<IntegerType>(dstElem) &&
-        cast<IntegerType>(dstElem).isSigned())
-      return emitOpError("si32 -> si8 int-narrow does not support "
-                         "saturate=\"SAT\" (no native hardware form; "
-                         "only saturate=\"NOSAT\" is allowed)");
-  } else if (satAttr) {
-    return emitOpError("'saturate' attribute is only valid for fp-narrow / "
-                       "int-narrow / fp-to-si conversions");
+  if (dir == CvtDirection::FpToSi) {
+    auto contract = lookupVMIFpToSiContract(srcElem, dstElem);
+    if (!contract)
+      return emitOpError("unsupported fp-to-si conversion element type pair");
+    if (contract->requiresSat) {
+      if (!satAttr)
+        return emitOpError("'saturate' attribute is required for this "
+                           "fp-to-si conversion; write 'SAT' or 'NOSAT'");
+      StringRef satVal = satAttr.getValue();
+      if (satVal != "SAT" && satVal != "NOSAT")
+        return emitOpError("saturate must be 'SAT' or 'NOSAT'");
+    } else {
+      if (satAttr)
+        return emitOpError("'saturate' attribute is not valid for this "
+                           "fp-to-si conversion (no overflow possible)");
+    }
+  } else if (dir == CvtDirection::FpToUi) {
+    auto contract = lookupVMIFpToUIContract(srcElem, dstElem);
+    if (!contract)
+      return emitOpError("unsupported fp-to-ui conversion element type pair");
+    if (contract->requiresSat) {
+      if (!satAttr)
+        return emitOpError("'saturate' attribute is required for this "
+                           "fp-to-ui conversion; write 'SAT' or 'NOSAT'");
+      StringRef satVal = satAttr.getValue();
+      if (satVal != "SAT" && satVal != "NOSAT")
+        return emitOpError("saturate must be 'SAT' or 'NOSAT'");
+    } else {
+      if (satAttr)
+        return emitOpError("'saturate' attribute is not valid for this "
+                           "fp-to-ui conversion (no overflow possible)");
+    }
+  } else {
+    bool needSat = (dir == CvtDirection::FpNarrow ||
+                    dir == CvtDirection::IntNarrow);
+    if (needSat) {
+      if (!satAttr)
+        return emitOpError("'saturate' attribute is required for fp-narrow / "
+                           "int-narrow conversions; write 'SAT' or "
+                           "'NOSAT'");
+      StringRef satVal = satAttr.getValue();
+      if (satVal != "SAT" && satVal != "NOSAT")
+        return emitOpError("saturate must be 'SAT' or 'NOSAT'");
+      // si32 -> si8 IntNarrow has no native hardware form.  Lowering aliases
+      // it through ui32 -> ui8 (bit-pattern equal ONLY under NOSAT).  Reject
+      // SAT here because ui32 -> ui8 SAT clamps to [0, 255], which does NOT
+      // match the expected si32 -> si8 SAT clamp to [-128, 127].
+      if (dir == CvtDirection::IntNarrow && satVal == "SAT" &&
+          srcBits == 32 && dstBits == 8 &&
+          isa<IntegerType>(srcElem) &&
+          cast<IntegerType>(srcElem).isSigned() &&
+          isa<IntegerType>(dstElem) &&
+          cast<IntegerType>(dstElem).isSigned())
+        return emitOpError("si32 -> si8 int-narrow does not support "
+                           "saturate=\"SAT\" (no native hardware form; "
+                           "only saturate=\"NOSAT\" is allowed)");
+    } else if (satAttr) {
+      return emitOpError("'saturate' attribute is only valid for fp-narrow / "
+                         "int-narrow conversions");
+    }
   }
 
   // --- sign ---

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -727,12 +727,44 @@ struct LayoutSolver {
         return WalkResult::advance();
       }
       if (auto fptosi = dyn_cast<VMIFPToSIOp>(op)) {
-        if (failed(unite(fptosi.getSource(), fptosi.getResult(), op)))
+        auto sourceType = cast<VMIVRegType>(fptosi.getSource().getType());
+        auto resultType = cast<VMIVRegType>(fptosi.getResult().getType());
+        VMILayoutSupport supports;
+        FailureOr<VMICastLayoutFact> fact =
+            supports.getPreferredCastLayoutFact(sourceType, resultType);
+        VMILayoutAttr resultLayout = getContiguousLayout();
+        if (succeeded(fact))
+          resultLayout = fact->resultLayout;
+        if (failed(setPreferredLayout(fptosi.getResult(), resultLayout,
+                                      op, DataLayoutSeedPhase::Cast)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
+      if (auto fptoui = dyn_cast<VMIFPToUIOp>(op)) {
+        auto sourceType = cast<VMIVRegType>(fptoui.getSource().getType());
+        auto resultType = cast<VMIVRegType>(fptoui.getResult().getType());
+        VMILayoutSupport supports;
+        FailureOr<VMICastLayoutFact> fact =
+            supports.getPreferredCastLayoutFact(sourceType, resultType);
+        VMILayoutAttr resultLayout = getContiguousLayout();
+        if (succeeded(fact))
+          resultLayout = fact->resultLayout;
+        if (failed(setPreferredLayout(fptoui.getResult(), resultLayout,
+                                      op, DataLayoutSeedPhase::Cast)))
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
       if (auto sitofp = dyn_cast<VMISIToFPOp>(op)) {
-        if (failed(unite(sitofp.getSource(), sitofp.getResult(), op)))
+        auto sourceType = cast<VMIVRegType>(sitofp.getSource().getType());
+        auto resultType = cast<VMIVRegType>(sitofp.getResult().getType());
+        VMILayoutSupport supports;
+        FailureOr<VMICastLayoutFact> fact =
+            supports.getPreferredCastLayoutFact(sourceType, resultType);
+        VMILayoutAttr resultLayout = getContiguousLayout();
+        if (succeeded(fact))
+          resultLayout = fact->resultLayout;
+        if (failed(setPreferredLayout(sitofp.getResult(), resultLayout,
+                                      op, DataLayoutSeedPhase::Cast)))
           return WalkResult::interrupt();
         return WalkResult::advance();
       }

--- a/lib/PTO/Transforms/VMILayoutPropagation.cpp
+++ b/lib/PTO/Transforms/VMILayoutPropagation.cpp
@@ -181,7 +181,8 @@ static bool isSameLayoutOp(Operation *op) {
 }
 
 static bool isCastOp(Operation *op) {
-  return isa<VMIExtFOp, VMIExtSIOp, VMIExtUIOp, VMITruncFOp, VMITruncIOp>(op);
+  return isa<VMIExtFOp, VMIExtSIOp, VMIExtUIOp, VMITruncFOp, VMITruncIOp,
+               VMIFPToSIOp, VMIFPToUIOp, VMISIToFPOp>(op);
 }
 
 class VMISameLayoutTransfer final : public VMILayoutTransfer {
@@ -848,6 +849,28 @@ const VMILayoutTransfer *getTransfer(Operation *op) {
     return &gatherTransfer;
   if (isa<VMIBitcastOp>(op))
     return &bitcastTransfer;
+  if (isa<VMIFPToSIOp, VMIFPToUIOp, VMISIToFPOp>(op)) {
+    // Same-width fp<->int: same-layout.  Widen/narrow: cast.
+    auto srcType = dyn_cast<VMIVRegType>(op->getOperand(0).getType());
+    auto dstType = dyn_cast<VMIVRegType>(op->getResult(0).getType());
+    if (srcType && dstType) {
+      auto srcElem = srcType.getElementType();
+      auto dstElem = dstType.getElementType();
+      unsigned srcBits = 0;
+      unsigned dstBits = 0;
+      if (auto ft = dyn_cast<FloatType>(srcElem))
+        srcBits = ft.getWidth();
+      else if (auto it = dyn_cast<IntegerType>(srcElem))
+        srcBits = it.getWidth();
+      if (auto ft = dyn_cast<FloatType>(dstElem))
+        dstBits = ft.getWidth();
+      else if (auto it = dyn_cast<IntegerType>(dstElem))
+        dstBits = it.getWidth();
+      if (srcBits > 0 && srcBits == dstBits)
+        return &sameLayoutTransfer;
+    }
+    return &castTransfer;
+  }
   if (isSameLayoutOp(op))
     return &sameLayoutTransfer;
   if (isa<VMIEnsureMaskGranularityOp>(op))

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -490,6 +490,9 @@ static constexpr HighPriorityCastLayoutPattern
 };
 
 static constexpr LegalCastLayoutPattern kLegalCastLayoutPatterns[] = {
+    // Same-width fp-to-fp (bf16 -> f16): dense contiguous 1:1.
+    {bits<16>(), bits<16>(), c(), c()},
+
     // 2x widening.
     {bits<8>(), bits<16>(), c(), d(2)},
     {bits<8>(), bits<16>(), ls(2), c()},
@@ -533,6 +536,9 @@ static constexpr LegalCastLayoutPattern kLegalCastLayoutPatterns[] = {
 
 static constexpr LegalMaskGranularityCastLayoutPattern
     kLegalMaskGranularityCastLayoutPatterns[] = {
+        // Same-width fp-to-fp (bf16 -> f16): dense contiguous 1:1.
+        {mb16(), mb16(), c(), c()},
+
         // 2x widening.
         {mb8(), mb16(), c(), d(2)},
         {mb8(), mb16(), ls(2), c()},

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -230,8 +230,8 @@ static unsigned getVMIElementBitWidth(Type type) {
 
 /// Inspect the source and result element types of a vcvt and classify the
 /// conversion direction.  Returns one of:
-///   "widen_fp", "narrow_fp", "fptosi", "sitofp",
-///   "widen_int", "narrow_int"
+///   "widen_fp", "narrow_fp", "fptosi", "fptoui",
+///   "sitofp", "widen_int", "narrow_int"
 static StringRef classifyCvtDirection(Type srcElem, Type dstElem) {
   bool srcFp = isFloatType(srcElem);
   bool dstFp = isFloatType(dstElem);
@@ -240,8 +240,11 @@ static StringRef classifyCvtDirection(Type srcElem, Type dstElem) {
 
   if (srcFp && dstFp)
     return dstBits > srcBits ? "widen_fp" : "narrow_fp";
-  if (srcFp && !dstFp)
+  if (srcFp && !dstFp) {
+    if (auto intTy = dyn_cast<IntegerType>(dstElem))
+      return intTy.isUnsigned() ? "fptoui" : "fptosi";
     return "fptosi";
+  }
   if (!srcFp && dstFp)
     return "sitofp";
   // int → int
@@ -436,6 +439,10 @@ static LogicalResult lowerVCvt(VMICvtOp op, OpBuilder &builder) {
   } else if (direction == "fptosi") {
     result =
         builder.create<VMIFPToSIOp>(loc, resultType, source, saturateAttr)
+            .getResult();
+  } else if (direction == "fptoui") {
+    result =
+        builder.create<VMIFPToUIOp>(loc, resultType, source, saturateAttr)
             .getResult();
   } else if (direction == "sitofp") {
     result =

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -10262,6 +10262,33 @@ struct OneToNVMITruncFOpPattern : OpConversionPattern<VMITruncFOp> {
 
     unsigned resultBits = pto::getPTOStorageElemBitWidth(
         resultVRegTypes.front().getElementType());
+    // Same-width fp->fp (bf16 -> f16): dense contiguous 1:1, no part, rnd+sat.
+    if (sourceBits == resultBits && sourceLayout && resultLayout &&
+        sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 1 &&
+        resultLayout.isContiguous() && resultLayout.getLaneStride() == 1 &&
+        sourceParts.size() == resultTypes.size()) {
+      FailureOr<Value> sourceMask =
+          createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
+      if (failed(sourceMask))
+        return rewriter.notifyMatchFailure(op, "failed to build truncf masks");
+      StringAttr rnd = rewriter.getStringAttr(
+          getTruncFRoundMode(op, resultVRegTypes.front().getElementType()));
+      StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
+      SmallVector<Value> results;
+      results.reserve(resultTypes.size());
+      for (auto [sourcePart, resultType] :
+           llvm::zip_equal(sourceParts, resultVRegTypes)) {
+        results.push_back(rewriter
+                              .create<VcvtOp>(op.getLoc(), resultType,
+                                              sourcePart, *sourceMask, rnd, sat,
+                                              /*part=*/nullptr)
+                              .getResult());
+      }
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
+    }
+
     if (sourceLayout && resultLayout && sourceLayout.isContiguous() &&
         sourceLayout.getLaneStride() == 1 && resultLayout.isContiguous() &&
         resultLayout.getLaneStride() != 1 &&
@@ -10914,45 +10941,394 @@ struct OneToNVMIFPToSIOpPattern : OpConversionPattern<VMIFPToSIOp> {
   LogicalResult
   matchAndRewrite(VMIFPToSIOp op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    auto sourceVMIType = cast<VMIVRegType>(op.getSource().getType());
+    auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     if (failed(maybe_resultTypes))
       return failure();
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.size() != resultTypes.size())
+
+    Type srcElem = sourceVMIType.getElementType();
+    Type dstElem = resultVMIType.getElementType();
+    auto contract = lookupVMIFpToSiContract(srcElem, dstElem);
+    if (!contract)
       return rewriter.notifyMatchFailure(
-          op, "fptosi physical source/result arity mismatch");
+          op, "unsupported fp-to-si conversion element type pair");
 
-    SmallVector<Value> results;
-    results.reserve(resultTypes.size());
-    StringAttr rnd = rewriter.getStringAttr("R");
-    StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
-    for (auto [sourcePart, resultType] :
-         llvm::zip_equal(sourceParts, resultTypes)) {
-      auto sourceType = dyn_cast<VRegType>(sourcePart.getType());
-      auto resultVRegType = dyn_cast<VRegType>(resultType);
-      if (!sourceType || !sourceType.getElementType().isF32() ||
-          !resultVRegType ||
-          !isa<IntegerType>(resultVRegType.getElementType()) ||
-          pto::getPTOStorageElemBitWidth(resultVRegType.getElementType()) != 32)
+    // Validate source physical part types.
+    if (sourceParts.empty())
+      return rewriter.notifyMatchFailure(
+          op, "fptosi requires at least one physical source chunk");
+    auto sourceType0 = dyn_cast<VRegType>(sourceParts.front().getType());
+    if (!sourceType0)
+      return rewriter.notifyMatchFailure(
+          op, "expected physical fptosi source type");
+    for (Value sourcePart : sourceParts) {
+      auto currentSourceType = dyn_cast<VRegType>(sourcePart.getType());
+      if (!currentSourceType || currentSourceType != sourceType0)
         return rewriter.notifyMatchFailure(
-            op, "fptosi requires physical f32 source and 32-bit integer "
-                "result chunks");
-
-      FailureOr<Value> mask =
-          createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-      if (failed(mask))
-        return rewriter.notifyMatchFailure(op, "failed to build fptosi mask");
-      results.push_back(rewriter
-                            .create<VcvtOp>(op.getLoc(), resultVRegType,
-                                            sourcePart, *mask, rnd, sat,
-                                            /*part=*/nullptr)
-                            .getResult());
+            op, "fptosi source physical parts must have matching type");
     }
 
-    replaceOpWithFlatConvertedValues(rewriter, op, results, *this->getTypeConverter());
+    // Validate result physical part types.
+    if (resultTypes.empty())
+      return rewriter.notifyMatchFailure(
+          op, "fptosi requires at least one physical result chunk");
+    SmallVector<VRegType> resultVRegTypes;
+    resultVRegTypes.reserve(resultTypes.size());
+    for (Type physicalResultType : resultTypes) {
+      auto resultType = dyn_cast<VRegType>(physicalResultType);
+      if (!resultType)
+        return rewriter.notifyMatchFailure(
+            op, "unsupported physical fptosi result type");
+      resultVRegTypes.push_back(resultType);
+    }
+
+    StringAttr rnd = rewriter.getStringAttr("R");
+    StringAttr sat =
+        contract->requiresSat
+            ? op->getAttrOfType<StringAttr>("saturate")
+            : nullptr;
+
+    if (!contract->requiresPart) {
+      // Same-width (f32→s32, f16→s16): 1:1 mapping, no part.
+      if (sourceParts.size() != resultTypes.size())
+        return rewriter.notifyMatchFailure(
+            op, "same-width fptosi requires matching physical arity");
+
+      SmallVector<Value> results;
+      results.reserve(resultTypes.size());
+      for (auto [sourcePart, resultType] :
+           llvm::zip_equal(sourceParts, resultVRegTypes)) {
+        FailureOr<Value> mask =
+            createAllTrueMaskForVReg(op.getLoc(),
+                                     cast<VRegType>(sourcePart.getType()),
+                                     rewriter);
+        if (failed(mask))
+          return rewriter.notifyMatchFailure(
+              op, "failed to build fptosi mask");
+        results.push_back(
+            rewriter
+                .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
+                                rnd, sat, /*part=*/nullptr)
+                .getResult());
+      }
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
+    }
+
+    // requiresPart: widen (f16→s32, bf16→s32) or narrow (f32→s16, f16→s8).
+    unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
+    unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
+
+    if (dstBits > srcBits) {
+      // Widen: dense 1:1 (single part) or 2× EvenOdd.
+      VMILayoutAttr srcLayout = sourceVMIType.getLayoutAttr();
+      VMILayoutAttr dstLayout = resultVMIType.getLayoutAttr();
+      if (srcLayout && dstLayout && srcLayout.isContiguous() &&
+          dstLayout.isContiguous() && dstLayout.getLaneStride() == 1 &&
+          ((srcBits == 16 && srcLayout.getLaneStride() == 2) ||
+           (srcBits == 8 && srcLayout.getLaneStride() == 4)) &&
+          resultTypes.size() == sourceParts.size()) {
+        // Dense 1:1: each source chunk → 1 result chunk (single part).
+        StringRef part = srcBits == 16 ? StringRef("EVEN") : StringRef("P0");
+        FailureOr<Value> mask =
+            createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
+        if (failed(mask))
+          return rewriter.notifyMatchFailure(
+              op, "failed to build fptosi widen 1:1 mask");
+        SmallVector<Value> results;
+        results.reserve(resultTypes.size());
+        for (auto [sourcePart, resultType] :
+             llvm::zip_equal(sourceParts, resultVRegTypes)) {
+          results.push_back(
+              rewriter
+                  .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
+                                  rnd, sat,
+                                  rewriter.getStringAttr(part))
+                  .getResult());
+        }
+        replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                         *this->getTypeConverter());
+        return success();
+      }
+
+      // Standard 2× EvenOdd: 1 source chunk → 2 result chunks.
+      if (resultTypes.size() != 2 * sourceParts.size())
+        return rewriter.notifyMatchFailure(
+            op, "widen fptosi requires result arity = 2 × source arity");
+
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      SmallVector<Value> results;
+      results.reserve(resultTypes.size());
+      for (int64_t partIndex = 0; partIndex < 2; ++partIndex) {
+        for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
+          VRegType resultType =
+              resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
+          FailureOr<Value> mask =
+              createAllTrueMaskForVReg(op.getLoc(),
+                                       cast<VRegType>(sourcePart.getType()),
+                                       rewriter);
+          if (failed(mask))
+            return rewriter.notifyMatchFailure(
+                op, "failed to build fptosi mask");
+          results.push_back(
+              rewriter
+                  .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
+                                  rnd, sat,
+                                  rewriter.getStringAttr(
+                                      kEvenOddParts[partIndex]))
+                  .getResult());
+        }
+      }
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
+    }
+
+    // Narrow: sourceFactor source chunks merge into 1 result chunk.
+    int64_t factor = srcBits / dstBits; // 2 for 32→16 or 16→8
+    VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+    int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
+                                   ? resultLayout.getLaneStride()
+                                   : 1;
+    if (resultLaneStride <= 0 || factor % resultLaneStride != 0)
+      return rewriter.notifyMatchFailure(
+          op, "narrow fptosi: unsupported result lane stride");
+    int64_t sourceFactor = factor / resultLaneStride;
+    if (sourceParts.size() != sourceFactor * resultTypes.size())
+      return rewriter.notifyMatchFailure(
+          op, "narrow fptosi: source arity != sourceFactor × result arity");
+
+    FailureOr<Value> sourceMask =
+        createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
+    if (failed(sourceMask))
+      return rewriter.notifyMatchFailure(
+          op, "failed to build truncf source mask");
+
+    static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+    SmallVector<Value> results;
+    results.reserve(resultTypes.size());
+    for (auto [chunkIndex, resultType] : llvm::enumerate(resultVRegTypes)) {
+      FailureOr<Value> resultMask =
+          createAllTrueMaskForVReg(op.getLoc(), resultType, rewriter);
+      if (failed(resultMask))
+        return rewriter.notifyMatchFailure(
+            op, "failed to build narrow fptosi result mask");
+
+      SmallVector<Value> partials;
+      partials.reserve(sourceFactor);
+      for (int64_t partIndex = 0; partIndex < sourceFactor; ++partIndex) {
+        Value sourcePart =
+            sourceParts[partIndex * resultTypes.size() + chunkIndex];
+        partials.push_back(
+            rewriter
+                .create<VcvtOp>(
+                    op.getLoc(), resultType, sourcePart, *sourceMask, rnd, sat,
+                    rewriter.getStringAttr(kEvenOddParts[partIndex]))
+                .getResult());
+      }
+
+      Value merged = partials.front();
+      for (Value partial : llvm::drop_begin(partials))
+        merged = rewriter
+                     .create<VorOp>(op.getLoc(), resultType, merged, partial,
+                                    *resultMask)
+                     .getResult();
+      results.push_back(merged);
+    }
+
+    replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                     *this->getTypeConverter());
     return success();
+  }
+};
+
+struct OneToNVMIFPToUIOpPattern : OpConversionPattern<VMIFPToUIOp> {
+  using OpConversionPattern<VMIFPToUIOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(VMIFPToUIOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto sourceVMIType = cast<VMIVRegType>(op.getSource().getType());
+    auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
+    ValueRange sourceParts = adaptor.getSource();
+    FailureOr<SmallVector<Type>> maybe_resultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    if (failed(maybe_resultTypes))
+      return failure();
+    SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
+
+    Type srcElem = sourceVMIType.getElementType();
+    Type dstElem = resultVMIType.getElementType();
+    auto contract = lookupVMIFpToUIContract(srcElem, dstElem);
+    if (!contract)
+      return rewriter.notifyMatchFailure(
+          op, "unsupported fp-to-ui conversion element type pair");
+
+    // Validate source physical part types.
+    if (sourceParts.empty())
+      return rewriter.notifyMatchFailure(
+          op, "fptoui requires at least one physical source chunk");
+    auto sourceType0 = dyn_cast<VRegType>(sourceParts.front().getType());
+    if (!sourceType0)
+      return rewriter.notifyMatchFailure(
+          op, "expected physical fptoui source type");
+    for (Value sourcePart : sourceParts) {
+      auto currentSourceType = dyn_cast<VRegType>(sourcePart.getType());
+      if (!currentSourceType || currentSourceType != sourceType0)
+        return rewriter.notifyMatchFailure(
+            op, "fptoui source physical parts must have matching type");
+    }
+
+    // Validate result physical part types.
+    if (resultTypes.empty())
+      return rewriter.notifyMatchFailure(
+          op, "fptoui requires at least one physical result chunk");
+    SmallVector<VRegType> resultVRegTypes;
+    resultVRegTypes.reserve(resultTypes.size());
+    for (Type physicalResultType : resultTypes) {
+      auto resultType = dyn_cast<VRegType>(physicalResultType);
+      if (!resultType)
+        return rewriter.notifyMatchFailure(
+            op, "unsupported physical fptoui result type");
+      resultVRegTypes.push_back(resultType);
+    }
+
+    StringAttr rnd = rewriter.getStringAttr("R");
+    StringAttr sat = contract->requiresSat
+                         ? op->getAttrOfType<StringAttr>("saturate")
+                         : nullptr;
+
+    if (!contract->requiresPart) {
+      // Same-width: 1:1 mapping, no part.
+      if (sourceParts.size() != resultTypes.size())
+        return rewriter.notifyMatchFailure(
+            op, "same-width fptoui requires matching physical arity");
+
+      SmallVector<Value> results;
+      results.reserve(resultTypes.size());
+      for (auto [sourcePart, resultType] :
+           llvm::zip_equal(sourceParts, resultVRegTypes)) {
+        FailureOr<Value> mask =
+            createAllTrueMaskForVReg(op.getLoc(),
+                                     cast<VRegType>(sourcePart.getType()),
+                                     rewriter);
+        if (failed(mask))
+          return rewriter.notifyMatchFailure(
+              op, "failed to build fptoui mask");
+        results.push_back(
+            rewriter
+                .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
+                                rnd, sat, /*part=*/nullptr)
+                .getResult());
+      }
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
+    }
+
+    // requiresPart: narrow (f16→u8).
+    unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
+    unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
+
+    if (dstBits > srcBits) {
+      // Widen: 2× EvenOdd (currently no fp→ui widen paths, but handle
+      // generically).
+      if (resultTypes.size() != 2 * sourceParts.size())
+        return rewriter.notifyMatchFailure(
+            op, "widen fptoui requires result arity = 2 × source arity");
+
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      SmallVector<Value> results;
+      results.reserve(resultTypes.size());
+      for (int64_t partIndex = 0; partIndex < 2; ++partIndex) {
+        for (auto [chunkIndex, sourcePart] : llvm::enumerate(sourceParts)) {
+          VRegType resultType =
+              resultVRegTypes[partIndex * sourceParts.size() + chunkIndex];
+          FailureOr<Value> mask =
+              createAllTrueMaskForVReg(op.getLoc(),
+                                       cast<VRegType>(sourcePart.getType()),
+                                       rewriter);
+          if (failed(mask))
+            return rewriter.notifyMatchFailure(
+                op, "failed to build fptoui widen mask");
+          results.push_back(
+              rewriter
+                  .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *mask,
+                                  rnd, sat,
+                                  rewriter.getStringAttr(kEvenOddParts[partIndex]))
+                  .getResult());
+        }
+      }
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
+    }
+
+    // Narrow (f16→u8): EvenOdd — source parts are grouped by EvenOdd factor,
+    // each result chunk merges 2 source parts via vcvt EVEN/ODD + vor.
+    if (dstBits < srcBits) {
+      int64_t factor = srcBits / dstBits; // 2 for 16→8
+      VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
+      int64_t resultLaneStride = resultLayout && resultLayout.isContiguous()
+                                     ? resultLayout.getLaneStride()
+                                     : 1;
+      if (resultLaneStride <= 0 || factor % resultLaneStride != 0)
+        return rewriter.notifyMatchFailure(
+            op, "narrow fptoui: unsupported result lane stride");
+      int64_t sourceFactor = factor / resultLaneStride;
+      if (sourceParts.size() != sourceFactor * resultTypes.size())
+        return rewriter.notifyMatchFailure(
+            op, "narrow fptoui: source arity != sourceFactor × result arity");
+
+      FailureOr<Value> sourceMask =
+          createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
+      if (failed(sourceMask))
+        return rewriter.notifyMatchFailure(
+            op, "failed to build fptoui source mask");
+
+      static constexpr StringRef kEvenOddParts[] = {"EVEN", "ODD"};
+      SmallVector<Value> results;
+      results.reserve(resultTypes.size());
+      for (auto [chunkIndex, resultType] : llvm::enumerate(resultVRegTypes)) {
+        FailureOr<Value> resultMask =
+            createAllTrueMaskForVReg(op.getLoc(), resultType, rewriter);
+        if (failed(resultMask))
+          return rewriter.notifyMatchFailure(
+              op, "failed to build narrow fptoui result mask");
+
+        SmallVector<Value> partials;
+        partials.reserve(sourceFactor);
+        for (int64_t partIndex = 0; partIndex < sourceFactor; ++partIndex) {
+          Value sourcePart =
+              sourceParts[partIndex * resultTypes.size() + chunkIndex];
+          partials.push_back(
+              rewriter
+                  .create<VcvtOp>(op.getLoc(), resultType, sourcePart, *sourceMask,
+                                  rnd, sat,
+                                  rewriter.getStringAttr(kEvenOddParts[partIndex]))
+                  .getResult());
+        }
+
+        Value merged = partials.front();
+        for (Value partial : llvm::drop_begin(partials))
+          merged = rewriter
+                       .create<VorOp>(op.getLoc(), resultType, merged, partial,
+                                      *resultMask)
+                       .getResult();
+        results.push_back(merged);
+      }
+
+      replaceOpWithFlatConvertedValues(rewriter, op, results,
+                                       *this->getTypeConverter());
+      return success();
+    }
+
+    return failure();
   }
 };
 
@@ -11526,6 +11902,7 @@ void populateVMIConversionPatterns(
       OneToNVMIExtFOpPattern, OneToNVMITruncFOpPattern,
       OneToNVMIExtIOpPattern<VMIExtSIOp>, OneToNVMIExtIOpPattern<VMIExtUIOp>,
       OneToNVMITruncIOpPattern, OneToNVMIFPToSIOpPattern,
+      OneToNVMIFPToUIOpPattern,
       OneToNVMISIToFPOpPattern, OneToNVMIBitcastOpPattern,
       OneToNVMIInterleaveOpPattern<VMIVintlvOp, VintlvOp>,
       OneToNVMIInterleaveOpPattern<VMIVdintlvOp, VdintlvOp>,
@@ -11636,18 +12013,81 @@ LogicalResult checkSupportedFPToSIShape(VMIFPToSIOp op,
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   if (!sourceLayout || !resultLayout)
     return fail("requires assigned source/result layouts");
-  if (sourceLayout != resultLayout)
-    return fail("requires source/result layouts to match");
-  if (!sourceType.getElementType().isF32())
-    return fail("requires f32 source element type");
-  if (!isa<IntegerType>(resultType.getElementType()) ||
-      pto::getPTOStorageElemBitWidth(resultType.getElementType()) != 32)
-    return fail("requires 32-bit integer result element type");
-  FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
-  FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(sourceArity) || failed(resultArity) ||
-      *sourceArity != *resultArity)
-    return fail("requires matching computable physical arity");
+
+  Type srcElem = sourceType.getElementType();
+  Type dstElem = resultType.getElementType();
+  auto contract = lookupVMIFpToSiContract(srcElem, dstElem);
+  if (!contract)
+    return fail("unsupported fp-to-si conversion element type pair");
+
+  unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
+  unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
+
+  if (srcBits == dstBits) {
+    // Same-width (f32→s32, f16→s16): layout equality + arity equality.
+    if (sourceLayout != resultLayout)
+      return fail("same-width fp-to-si requires matching layouts");
+    FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
+    FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+    if (failed(sourceArity) || failed(resultArity) ||
+        *sourceArity != *resultArity)
+      return fail("same-width fp-to-si requires matching physical arity");
+  } else {
+    // Widen or narrow: use the cast-layout framework (same as extf/truncf).
+    VMILayoutSupport layoutSupport;
+    FailureOr<VMICastLayoutFact> fact =
+        layoutSupport.getCastLayoutFactForLayouts(
+            sourceType, resultType, sourceLayout, resultLayout, reason);
+    if (failed(fact))
+      return failure();
+  }
+
+  return success();
+}
+
+LogicalResult checkSupportedFPToUIShape(VMIFPToUIOp op,
+                                        std::string *reason = nullptr) {
+  auto fail = [&](const Twine &message) {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
+  VMILayoutAttr resultLayout = resultType.getLayoutAttr();
+  if (!sourceLayout || !resultLayout)
+    return fail("requires assigned source/result layouts");
+
+  Type srcElem = sourceType.getElementType();
+  Type dstElem = resultType.getElementType();
+  auto contract = lookupVMIFpToUIContract(srcElem, dstElem);
+  if (!contract)
+    return fail("unsupported fp-to-ui conversion element type pair");
+
+  unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
+  unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
+
+  if (srcBits == dstBits) {
+    // Same-width: layout equality + arity equality.
+    if (sourceLayout != resultLayout)
+      return fail("same-width fp-to-ui requires matching layouts");
+    FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
+    FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
+    if (failed(sourceArity) || failed(resultArity) ||
+        *sourceArity != *resultArity)
+      return fail("same-width fp-to-ui requires matching physical arity");
+  } else {
+    // Widen or narrow: use the cast-layout framework.
+    VMILayoutSupport layoutSupport;
+    FailureOr<VMICastLayoutFact> fact =
+        layoutSupport.getCastLayoutFactForLayouts(
+            sourceType, resultType, sourceLayout, resultLayout, reason);
+    if (failed(fact))
+      return failure();
+  }
+
   return success();
 }
 
@@ -12940,8 +13380,22 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
       fptosi.emitError()
           << kVMIDiagUnsupportedPrefix
-          << "pto.vmi.fptosi supports f32 source chunks to matching 32-bit "
-             "integer result chunks with identical assigned layouts ("
+          << "pto.vmi.fptosi supports fp-to-signed-int conversion pairs "
+             "listed in the VPTO vcvt contract; check lookupVMIFpToSiContract ("
+          << reason << ")";
+      return WalkResult::interrupt();
+    }
+
+    if (auto fptoui = dyn_cast<VMIFPToUIOp>(op)) {
+      std::string reason;
+      if (succeeded(checkSupportedFPToUIShape(fptoui, &reason)))
+        return WalkResult::advance();
+
+      fptoui.emitError()
+          << kVMIDiagUnsupportedPrefix
+          << "pto.vmi.fptoui supports fp-to-unsigned-int conversion pairs "
+             "listed in the VPTO vcvt contract (e.g. f16 → u8); "
+             "check lookupVMIFpToUIContract ("
           << reason << ")";
       return WalkResult::interrupt();
     }

--- a/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
+++ b/test/lit/vmi_new/vmi_conversion_contract_matrix.pto
@@ -33,7 +33,7 @@ module {
 
 module {
   func.func @missing_saturate(%x: !pto.vmi.vreg<64xf32>) {
-    // expected-error@+1 {{'saturate' attribute is required for fp-narrow / int-narrow / fp-to-si conversions}}
+    // expected-error@+1 {{'saturate' attribute is required for fp-narrow / int-narrow conversions}}
     %r = pto.vmi.vcvt %x : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf16>
     return
   }
@@ -43,7 +43,7 @@ module {
 
 module {
   func.func @saturate_wrong_direction(%x: !pto.vmi.vreg<64xsi16>) {
-    // expected-error@+1 {{'saturate' attribute is only valid for fp-narrow / int-narrow / fp-to-si conversions}}
+    // expected-error@+1 {{'saturate' attribute is only valid for fp-narrow / int-narrow conversions}}
     %r = pto.vmi.vcvt %x {saturate = "SAT"} : !pto.vmi.vreg<64xsi16> -> !pto.vmi.vreg<64xf32>
     return
   }

--- a/test/lit/vmi_new/vmi_fptoui_verifier.pto
+++ b/test/lit/vmi_new/vmi_fptoui_verifier.pto
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -split-input-file -verify-diagnostics | FileCheck %s
+
+// Legacy VMIFPToUIOp verifier tests — direct op construction (no vcvt).
+
+// Positive: f16->u8 with SAT.
+func.func @f16_to_u8_sat(%source: !pto.vmi.vreg<128xf16>)
+    -> !pto.vmi.vreg<128xui8> {
+  // expected-no-error
+  %result = pto.vmi.fptoui %source {saturate = "SAT"}
+      : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+  return %result : !pto.vmi.vreg<128xui8>
+}
+
+// CHECK-LABEL: func.func @f16_to_u8_sat
+// CHECK: pto.vmi.fptoui
+
+// -----
+
+// Negative: f16->u8 without saturate (required by contract).
+func.func @f16_to_u8_no_sat(%source: !pto.vmi.vreg<128xf16>)
+    -> !pto.vmi.vreg<128xui8> {
+  // expected-error@+1 {{'saturate' attribute is required for this fp-to-ui conversion}}
+  %result = pto.vmi.fptoui %source
+      : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+  return %result : !pto.vmi.vreg<128xui8>
+}
+
+// -----
+
+// Negative: f16->u8 with invalid saturate value.
+func.func @f16_to_u8_bad_sat(%source: !pto.vmi.vreg<128xf16>)
+    -> !pto.vmi.vreg<128xui8> {
+  // expected-error@+1 {{saturate attr must be 'SAT' or 'NOSAT'}}
+  %result = pto.vmi.fptoui %source {saturate = "FOO"}
+      : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+  return %result : !pto.vmi.vreg<128xui8>
+}
+
+// -----
+
+// Negative: f16->s8 via fptoui (requires unsigned result).
+func.func @f16_to_s8_via_fptoui(%source: !pto.vmi.vreg<128xf16>)
+    -> !pto.vmi.vreg<128xsi8> {
+  // expected-error@+1 {{requires unsigned integer result element type}}
+  %result = pto.vmi.fptoui %source {saturate = "SAT"}
+      : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xsi8>
+  return %result : !pto.vmi.vreg<128xsi8>
+}

--- a/test/lit/vmi_new/vmi_to_vpto_fptosi_fptoui_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptosi_fptoui_multichunk.pto
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Multichunk coverage for the pairs that previously had none (review 5.5):
+//   * f32->s16 narrow FpToSi multichunk (256-element source, 2 chunk pairs)
+//   * f16->s8  narrow FpToSi multichunk (256-element source)
+//   * f16->u8  narrow FpToUi multichunk (256-element source)
+// Each narrow chunk pair lowers to EvenOdd pto.vcvt merged with pto.vor.
+
+module {
+  // f32->s16 narrow multichunk: 256xf32 (deinterleaved=2 -> 4 parts) -> 2x 128xsi16
+  func.func @f32_to_s16_multichunk(
+      %input: !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>)
+      -> (!pto.vreg<128xsi16>, !pto.vreg<128xsi16>) {
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<256xf32, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<256xsi16, #pto.vmi.layout<contiguous>>
+    %p0, %p1 = "pto.vmi.unpack"(%narrow)
+        : (!pto.vmi.vreg<256xsi16, #pto.vmi.layout<contiguous>>)
+        -> (!pto.vreg<128xsi16>, !pto.vreg<128xsi16>)
+    return %p0, %p1 : !pto.vreg<128xsi16>, !pto.vreg<128xsi16>
+  }
+
+  // f16->s8 narrow multichunk: 256xf16 (deinterleaved=2 -> 2 parts) -> 1x 256xsi8
+  func.func @f16_to_s8_multichunk(
+      %input: !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 2>>)
+      -> !pto.vreg<256xsi8> {
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<256xsi8, #pto.vmi.layout<contiguous>>
+    %p = "pto.vmi.unpack"(%narrow)
+        : (!pto.vmi.vreg<256xsi8, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<256xsi8>
+    return %p : !pto.vreg<256xsi8>
+  }
+
+  // f16->u8 narrow FpToUi multichunk: 256xf16 (deinterleaved=2) -> 1x 256xui8
+  func.func @f16_to_u8_multichunk(
+      %input: !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 2>>)
+      -> !pto.vreg<256xui8> {
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<256xf16, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<256xui8, #pto.vmi.layout<contiguous>>
+    %p = "pto.vmi.unpack"(%narrow)
+        : (!pto.vmi.vreg<256xui8, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<256xui8>
+    return %p : !pto.vreg<256xui8>
+  }
+}
+
+// CHECK-LABEL: func.func @f32_to_s16_multichunk(
+// CHECK-DAG: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xsi16>
+// CHECK-DAG: pto.vcvt {{.*}} {part = "ODD", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xsi16>
+// CHECK: pto.vor
+
+// CHECK-LABEL: func.func @f16_to_s8_multichunk(
+// CHECK-DAG: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xsi8>
+// CHECK-DAG: pto.vcvt {{.*}} {part = "ODD", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xsi8>
+// CHECK: pto.vor
+
+// CHECK-LABEL: func.func @f16_to_u8_multichunk(
+// CHECK-DAG: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xui8>
+// CHECK-DAG: pto.vcvt {{.*}} {part = "ODD", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xui8>
+// CHECK: pto.vor

--- a/test/lit/vmi_new/vmi_to_vpto_fptosi_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptosi_multichunk.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Multichunk FpToSi widen: 256-element f16 source -> 2 chunks, 4 results.
+
+module {
+  // f16->s32 widen multichunk: 2 source chunks -> 4 result chunks (EVEN/ODD × 2)
+  func.func @f16_to_s32_multichunk(
+      %input: !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xsi32>, !pto.vreg<64xsi32>,
+          !pto.vreg<64xsi32>, !pto.vreg<64xsi32>) {
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<256xf16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<256xsi32, #pto.vmi.layout<deinterleaved = 2>>
+    %p0, %p1, %p2, %p3 = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<256xsi32, #pto.vmi.layout<deinterleaved = 2>>)
+        -> (!pto.vreg<64xsi32>, !pto.vreg<64xsi32>,
+            !pto.vreg<64xsi32>, !pto.vreg<64xsi32>)
+    return %p0, %p1, %p2, %p3
+        : !pto.vreg<64xsi32>, !pto.vreg<64xsi32>,
+          !pto.vreg<64xsi32>, !pto.vreg<64xsi32>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_s32_multichunk(
+// CHECK-DAG: pto.vcvt {{.*}} {part = "EVEN", rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
+// CHECK-DAG: pto.vcvt {{.*}} {part = "ODD", rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
+// CHECK-NOT: sat

--- a/test/lit/vmi_new/vmi_to_vpto_fptosi_narrow.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptosi_narrow.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Narrow FpToSi paths: f32->s16, f16->s8 (both EvenOdd, sat).
+
+module {
+  // f32->s16 narrow: EvenOdd parts, rnd="R", sat="SAT"
+  func.func @f32_to_s16(
+      %input: !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>)
+      -> !pto.vreg<128xsi16> {
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf32, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<128xsi16, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%narrow)
+        : (!pto.vmi.vreg<128xsi16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xsi16>
+    return %r : !pto.vreg<128xsi16>
+  }
+
+  // f16->s8 narrow: EvenOdd parts, rnd="R", sat="SAT"
+  func.func @f16_to_s8(
+      %input: !pto.vmi.vreg<128xf16, #pto.vmi.layout<deinterleaved = 2>>)
+      -> !pto.vreg<256xsi8> {
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf16, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<128xsi8, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%narrow)
+        : (!pto.vmi.vreg<128xsi8, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<256xsi8>
+    return %r : !pto.vreg<256xsi8>
+  }
+}
+
+// CHECK-LABEL: func.func @f32_to_s16(
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xsi16>
+// CHECK: pto.vcvt {{.*}} {part = "ODD", rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<128xsi16>
+
+// CHECK-LABEL: func.func @f16_to_s8(
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xsi8>
+// CHECK: pto.vcvt {{.*}} {part = "ODD", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xsi8>

--- a/test/lit/vmi_new/vmi_to_vpto_fptosi_same_width.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptosi_same_width.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Same-width FpToSi paths: f16->s16, plus existing f32->s32 regression.
+
+module {
+  // f16->s16 same-width: 1:1, no part, rnd="R", sat="SAT"
+  func.func @f16_to_s16(
+      %input: !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xsi16> {
+    %cvt = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xsi16, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%cvt)
+        : (!pto.vmi.vreg<128xsi16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xsi16>
+    return %r : !pto.vreg<128xsi16>
+  }
+
+  // f32->s32 same-width regression: 1:1, no part, rnd="R", sat="SAT"
+  func.func @f32_to_s32(
+      %input: !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<64xsi32> {
+    %cvt = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf32, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<64xsi32, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%cvt)
+        : (!pto.vmi.vreg<64xsi32, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<64xsi32>
+    return %r : !pto.vreg<64xsi32>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_s16(
+// CHECK: pto.vcvt {{.*}} {rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xsi16>
+// CHECK-NOT: part
+
+// CHECK-LABEL: func.func @f32_to_s32(
+// CHECK: pto.vcvt {{.*}} {rnd = "R", sat = "SAT"} : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xsi32>
+// CHECK-NOT: part

--- a/test/lit/vmi_new/vmi_to_vpto_fptosi_widen.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptosi_widen.pto
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Widen FpToSi paths: f16->s32 (NO sat), bf16->s32 (sat).
+
+module {
+  // f16->s32 widen: EvenOdd parts, rnd="R", NO sat
+  func.func @f16_to_s32(
+      %input: !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xsi32>, !pto.vreg<64xsi32>) {
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xsi32, #pto.vmi.layout<deinterleaved = 2>>
+    %p0, %p1 = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<128xsi32, #pto.vmi.layout<deinterleaved = 2>>)
+        -> (!pto.vreg<64xsi32>, !pto.vreg<64xsi32>)
+    return %p0, %p1 : !pto.vreg<64xsi32>, !pto.vreg<64xsi32>
+  }
+
+  // bf16->s32 widen: EvenOdd parts, rnd="R", sat="SAT"
+  func.func @bf16_to_s32(
+      %input: !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>)
+      -> (!pto.vreg<64xsi32>, !pto.vreg<64xsi32>) {
+    %wide = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xsi32, #pto.vmi.layout<deinterleaved = 2>>
+    %p0, %p1 = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<128xsi32, #pto.vmi.layout<deinterleaved = 2>>)
+        -> (!pto.vreg<64xsi32>, !pto.vreg<64xsi32>)
+    return %p0, %p1 : !pto.vreg<64xsi32>, !pto.vreg<64xsi32>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_s32(
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
+// CHECK: pto.vcvt {{.*}} {part = "ODD", rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
+// CHECK-NOT: sat
+
+// CHECK-LABEL: func.func @bf16_to_s32(
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
+// CHECK: pto.vcvt {{.*}} {part = "ODD", rnd = "R", sat = "SAT"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<64xsi32>

--- a/test/lit/vmi_new/vmi_to_vpto_fptosi_widen_dense_1to1.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptosi_widen_dense_1to1.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// FpToSi widen dense-1:1 branch (VMIToVPTO.cpp OneToNVMIFPToSIOpPattern):
+// src contiguous lane_stride=2, dst contiguous lane_stride=1, and
+// resultTypes.size()==sourceParts.size() -> each source chunk maps 1:1 to a
+// single EVEN part (no ODD). The existing widen lit tests all use
+// deinterleaved=2 result layouts and therefore take the 2x EvenOdd branch;
+// this case covers the previously-untested dense 1:1 path.
+
+module {
+  func.func @f16_to_s32_dense_1to1(
+      %input: !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>)
+      -> !pto.vreg<64xsi32> {
+    %wide = pto.vmi.vcvt %input
+        : !pto.vmi.vreg<64xf16, #pto.vmi.layout<contiguous, lane_stride = 2>>
+        -> !pto.vmi.vreg<64xsi32, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%wide)
+        : (!pto.vmi.vreg<64xsi32, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<64xsi32>
+    return %r : !pto.vreg<64xsi32>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_s32_dense_1to1(
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<64xsi32>
+// CHECK-NOT: part = "ODD"
+// CHECK-NOT: sat

--- a/test/lit/vmi_new/vmi_to_vpto_fptoui_f16_to_u8.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_fptoui_f16_to_u8.pto
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// FpToUi narrow lowering: f16->u8, EvenOdd parts, rnd="R", sat="SAT".
+// Mirrors the f16->s8 narrow pattern but with ui8 result type.
+
+module {
+  func.func @f16_to_u8(
+      %input: !pto.vmi.vreg<128xf16, #pto.vmi.layout<deinterleaved = 2>>)
+      -> !pto.vreg<256xui8> {
+    %narrow = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf16, #pto.vmi.layout<deinterleaved = 2>>
+        -> !pto.vmi.vreg<128xui8, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%narrow)
+        : (!pto.vmi.vreg<128xui8, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<256xui8>
+    return %r : !pto.vreg<256xui8>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_u8(
+// CHECK: pto.vcvt {{.*}} {part = "EVEN", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xui8>
+// CHECK: pto.vcvt {{.*}} {part = "ODD", rnd = "R", sat = "SAT"} : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<256xui8>

--- a/test/lit/vmi_new/vmi_to_vpto_vcvt_bf16_to_f16_same_width.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vcvt_bf16_to_f16_same_width.pto
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-to-vpto | FileCheck %s
+
+// Same-width fp->fp conversion (bf16 -> f16) opened up by commit 22121924
+// ("add fp16 -> u8"): VMITruncFOp::verify was relaxed from src > dst to
+// src >= dst, gated by lookupVMIFpToFpContract. BF16->F16 is a live VMI
+// fp-to-fp contract pair (lookupVMIFpToFpContract: requiresRnd=true,
+// requiresSat=true, requiresPart=false) and is documented in
+// docs/isa/micro-isa/09-conversion-ops.md. This regression test covers the
+// VMI-level same-width path: the lowered pto.vcvt must carry rnd="R" +
+// sat="SAT" and NO part.
+
+module {
+  func.func @bf16_to_f16_same_width(
+      %input: !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>)
+      -> !pto.vreg<128xf16> {
+    %cvt = pto.vmi.vcvt %input {saturate = "SAT"}
+        : !pto.vmi.vreg<128xbf16, #pto.vmi.layout<contiguous>>
+        -> !pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>
+    %r = "pto.vmi.unpack"(%cvt)
+        : (!pto.vmi.vreg<128xf16, #pto.vmi.layout<contiguous>>)
+        -> !pto.vreg<128xf16>
+    return %r : !pto.vreg<128xf16>
+  }
+}
+
+// CHECK-LABEL: func.func @bf16_to_f16_same_width(
+// CHECK: pto.vcvt {{.*}} {rnd = "R", sat = "SAT"} : !pto.vreg<128xbf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
+// CHECK-NOT: part

--- a/test/lit/vmi_new/vmi_vcvt_fptosi_lower_to_legacy_new.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptosi_lower_to_legacy_new.pto
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy | FileCheck %s
+
+// Verify vcvt -> legacy fptosi passthrough for new paths.
+// Key: f16->s32 must produce fptosi WITHOUT saturate attr.
+
+module {
+  // f16->s32: no sat on vcvt -> no sat on fptosi
+  func.func @f16_to_s32(%s: !pto.vmi.vreg<64xf16>) -> !pto.vmi.vreg<64xsi32> {
+    %r = pto.vmi.vcvt %s : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi32>
+    return %r : !pto.vmi.vreg<64xsi32>
+  }
+  // f32->s16: SAT on vcvt -> SAT on fptosi
+  func.func @f32_to_s16(%s: !pto.vmi.vreg<64xf32>) -> !pto.vmi.vreg<64xsi16> {
+    %r = pto.vmi.vcvt %s {saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi16>
+    return %r : !pto.vmi.vreg<64xsi16>
+  }
+  // f16->s8: NOSAT on vcvt -> NOSAT on fptosi
+  func.func @f16_to_s8(%s: !pto.vmi.vreg<64xf16>) -> !pto.vmi.vreg<64xsi8> {
+    %r = pto.vmi.vcvt %s {saturate = "NOSAT"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi8>
+    return %r : !pto.vmi.vreg<64xsi8>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_s32
+// CHECK: pto.vmi.fptosi %{{.*}} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi32>
+// CHECK-NOT: saturate
+
+// CHECK-LABEL: func.func @f32_to_s16
+// CHECK: pto.vmi.fptosi %{{.*}} {saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi16>
+
+// CHECK-LABEL: func.func @f16_to_s8
+// CHECK: pto.vmi.fptosi %{{.*}} {saturate = "NOSAT"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi8>

--- a/test/lit/vmi_new/vmi_vcvt_fptosi_new_paths_invalid.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptosi_new_paths_invalid.pto
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --emit-pto-ir %s 2>&1 | FileCheck %s
+
+// Negative tests for FpToSi paths: sat exception, unsupported type pairs.
+// Each function is independently invalid; the first verifier error wins.
+
+module {
+  // f16->s32 with sat: must be rejected (no overflow possible, requiresSat=false)
+  func.func @f16_to_s32_with_sat(%source: !pto.vmi.vreg<64xf16>) {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi32>
+    return
+  }
+  // f32->s16 without sat: must be rejected (requiresSat=true)
+  func.func @f32_to_s16_no_sat(%source: !pto.vmi.vreg<64xf32>) {
+    %result = pto.vmi.vcvt %source
+        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi16>
+    return
+  }
+  // f16->u8: unsigned dst rejected by vcvt verifier
+  func.func @f16_to_u8(%source: !pto.vmi.vreg<64xf16>) {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xui8>
+    return
+  }
+}
+
+// CHECK: error:

--- a/test/lit/vmi_new/vmi_vcvt_fptosi_new_paths_valid.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptosi_new_paths_valid.pto
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s | FileCheck %s
+
+// Verify that 5 new FpToSi paths construct without verifier errors.
+
+module {
+  // f16->s32: requiresSat=false, no sat attr needed
+  func.func @f16_to_s32(%s: !pto.vmi.vreg<64xf16>) -> !pto.vmi.vreg<64xsi32> {
+    %r = pto.vmi.vcvt %s : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi32>
+    return %r : !pto.vmi.vreg<64xsi32>
+  }
+  // f32->s16: requiresSat=true, SAT
+  func.func @f32_to_s16_sat(%s: !pto.vmi.vreg<64xf32>) -> !pto.vmi.vreg<64xsi16> {
+    %r = pto.vmi.vcvt %s {saturate = "SAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi16>
+    return %r : !pto.vmi.vreg<64xsi16>
+  }
+  // f32->s16: requiresSat=true, NOSAT
+  func.func @f32_to_s16_nosat(%s: !pto.vmi.vreg<64xf32>) -> !pto.vmi.vreg<64xsi16> {
+    %r = pto.vmi.vcvt %s {saturate = "NOSAT"} : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xsi16>
+    return %r : !pto.vmi.vreg<64xsi16>
+  }
+  // f16->s16: requiresSat=true, SAT
+  func.func @f16_to_s16_sat(%s: !pto.vmi.vreg<64xf16>) -> !pto.vmi.vreg<64xsi16> {
+    %r = pto.vmi.vcvt %s {saturate = "SAT"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi16>
+    return %r : !pto.vmi.vreg<64xsi16>
+  }
+  // f16->s8: requiresSat=true, SAT
+  func.func @f16_to_s8_sat(%s: !pto.vmi.vreg<64xf16>) -> !pto.vmi.vreg<64xsi8> {
+    %r = pto.vmi.vcvt %s {saturate = "SAT"} : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xsi8>
+    return %r : !pto.vmi.vreg<64xsi8>
+  }
+  // bf16->s32: requiresSat=true, SAT
+  func.func @bf16_to_s32_sat(%s: !pto.vmi.vreg<64xbf16>) -> !pto.vmi.vreg<64xsi32> {
+    %r = pto.vmi.vcvt %s {saturate = "SAT"} : !pto.vmi.vreg<64xbf16> -> !pto.vmi.vreg<64xsi32>
+    return %r : !pto.vmi.vreg<64xsi32>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_s32
+// CHECK: pto.vmi.vcvt
+// CHECK-NOT: saturate
+// CHECK-LABEL: func.func @f32_to_s16_sat
+// CHECK: pto.vmi.vcvt {{.*}}{saturate = "SAT"}
+// CHECK-LABEL: func.func @f32_to_s16_nosat
+// CHECK: pto.vmi.vcvt {{.*}}{saturate = "NOSAT"}
+// CHECK-LABEL: func.func @f16_to_s16_sat
+// CHECK: pto.vmi.vcvt {{.*}}{saturate = "SAT"}
+// CHECK-LABEL: func.func @f16_to_s8_sat
+// CHECK: pto.vmi.vcvt {{.*}}{saturate = "SAT"}
+// CHECK-LABEL: func.func @bf16_to_s32_sat
+// CHECK: pto.vmi.vcvt {{.*}}{saturate = "SAT"}

--- a/test/lit/vmi_new/vmi_vcvt_fptoui_f16_to_u8_valid.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptoui_f16_to_u8_valid.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s | FileCheck %s
+
+// FpToUi verifier positive cases: f16->u8 with SAT and NOSAT.
+
+module {
+  func.func @f16_to_u8_sat(%source: !pto.vmi.vreg<128xf16>)
+      -> !pto.vmi.vreg<128xui8> {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+    return %result : !pto.vmi.vreg<128xui8>
+  }
+
+  func.func @f16_to_u8_nosat(%source: !pto.vmi.vreg<128xf16>)
+      -> !pto.vmi.vreg<128xui8> {
+    %result = pto.vmi.vcvt %source {saturate = "NOSAT"}
+        : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+    return %result : !pto.vmi.vreg<128xui8>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_u8_sat(
+// CHECK: pto.vmi.vcvt
+// CHECK-SAME: saturate = "SAT"
+// CHECK-SAME: !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+
+// CHECK-LABEL: func.func @f16_to_u8_nosat(
+// CHECK: pto.vmi.vcvt
+// CHECK-SAME: saturate = "NOSAT"
+// CHECK-SAME: !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>

--- a/test/lit/vmi_new/vmi_vcvt_fptoui_invalid.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptoui_invalid.pto
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --emit-pto-ir %s 2>&1 | FileCheck %s
+
+// FpToUi verifier negative cases:
+//   - unsupported fp->ui pairs (f32->u8, bf16->u8)
+//   - saturate attr missing when required (f16->u8 no sat)
+
+module {
+  // f32->u8: not in VPTO contract — must be rejected.
+  func.func @f32_to_u8(%source: !pto.vmi.vreg<64xf32>) {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xui8>
+    return
+  }
+
+  // bf16->u8: not in VPTO contract — must be rejected.
+  func.func @bf16_to_u8(%source: !pto.vmi.vreg<128xbf16>) {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<128xbf16> -> !pto.vmi.vreg<128xui8>
+    return
+  }
+
+  // f16->u8 without saturate — required by contract, must be rejected.
+  func.func @f16_to_u8_no_sat(%source: !pto.vmi.vreg<128xf16>) {
+    %result = pto.vmi.vcvt %source
+        : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+    return
+  }
+}
+
+// CHECK: 'saturate' attribute is required for this fp-to-ui conversion

--- a/test/lit/vmi_new/vmi_vcvt_fptoui_lower_to_legacy.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptoui_lower_to_legacy.pto
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy | FileCheck %s
+
+// lowerVCvt must dispatch fptoui direction to VMIFPToUIOp (not VMIFPToSIOp),
+// and forward the saturate attribute correctly.
+
+module {
+  func.func @f16_to_u8_sat(%source: !pto.vmi.vreg<128xf16>)
+      -> !pto.vmi.vreg<128xui8> {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+    return %result : !pto.vmi.vreg<128xui8>
+  }
+
+  func.func @f16_to_u8_nosat(%source: !pto.vmi.vreg<128xf16>)
+      -> !pto.vmi.vreg<128xui8> {
+    %result = pto.vmi.vcvt %source {saturate = "NOSAT"}
+        : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xui8>
+    return %result : !pto.vmi.vreg<128xui8>
+  }
+}
+
+// CHECK-LABEL: func.func @f16_to_u8_sat(
+// CHECK: pto.vmi.fptoui
+// CHECK-SAME: saturate = "SAT"
+
+// CHECK-LABEL: func.func @f16_to_u8_nosat(
+// CHECK: pto.vmi.fptoui
+// CHECK-SAME: saturate = "NOSAT"

--- a/test/lit/vmi_new/vmi_vcvt_fptoui_signless.pto
+++ b/test/lit/vmi_new/vmi_vcvt_fptoui_signless.pto
@@ -6,18 +6,21 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 
-// RUN: not ptoas --emit-pto-ir %s 2>&1 | FileCheck %s
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy | FileCheck %s
 
-// saturate attribute is only valid for narrowing / fp-to-int conversions.
-// Using it on an FpWiden op (f16 -> f32) must be rejected.
+// Signless integers default to signed semantics: f16->i8 (signless, not ui8)
+// must route to FpToSi (fptosi), not FpToUi (fptoui).
 
 module {
-  func.func @vmi_vcvt_saturate_bad_direction_invalid(
-      %source: !pto.vmi.vreg<64xf16>) {
-    %result = pto.vmi.vcvt %source {saturate = "NOSAT"}
-        : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xf32>
-    return
+  func.func @f16_to_signless_i8(%source: !pto.vmi.vreg<128xf16>)
+      -> !pto.vmi.vreg<128xi8> {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<128xf16> -> !pto.vmi.vreg<128xi8>
+    return %result : !pto.vmi.vreg<128xi8>
   }
 }
 
-// CHECK: 'saturate' attribute is only valid for fp-narrow / int-narrow conversions
+// CHECK-LABEL: func.func @f16_to_signless_i8(
+// CHECK: pto.vmi.fptosi
+// CHECK-NOT: pto.vmi.fptoui
+// CHECK-SAME: saturate = "SAT"

--- a/test/lit/vmi_new/vmi_vcvt_same_width_fp_invalid.pto
+++ b/test/lit/vmi_new/vmi_vcvt_same_width_fp_invalid.pto
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not ptoas --emit-pto-ir %s 2>&1 | FileCheck %s
+
+// Negative tests for same-width fp->fp vcvt: only bf16->f16 is in the VMI
+// fp-to-fp contract (lookupVMIFpToFpContract); every other same-width fp
+// pair must be rejected. Each function is independently invalid; the first
+// verifier error wins.
+
+module {
+  // f16->bf16 same-width: not in lookupVMIFpToFpContract -> rejected
+  func.func @f16_to_bf16_same_width(%source: !pto.vmi.vreg<64xf16>) {
+    %result = pto.vmi.vcvt %source {saturate = "SAT"}
+        : !pto.vmi.vreg<64xf16> -> !pto.vmi.vreg<64xbf16>
+    return
+  }
+  // f32->f32 same-width: not in lookupVMIFpToFpContract -> rejected
+  func.func @f32_to_f32_same_width(%source: !pto.vmi.vreg<64xf32>) {
+    %result = pto.vmi.vcvt %source
+        : !pto.vmi.vreg<64xf32> -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// CHECK: same-width fp-to-fp conversion is not supported

--- a/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/compare.py
+++ b/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/compare.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden = np.fromfile("golden_v2.bin", dtype=np.int32)
+    output = np.fromfile("v2.bin", dtype=np.int32)
+    if golden.shape != output.shape or not np.array_equal(golden, output):
+        diff = np.nonzero(golden != output)[0]
+        idx = int(diff[0]) if diff.size else -1
+        print(f"[ERROR] compare failed idx={idx} golden={int(golden[idx]) if idx >= 0 else 'n/a'} output={int(output[idx]) if idx >= 0 else 'n/a'}")
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/golden.py
+++ b/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/golden.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# bf16 -> si32 (FpToSi) with saturate = "SAT" golden.
+#
+# V300 SAT policy for FpToSi (rounding = "R", i.e. RN):
+#   * finite in-range values          -> round-to-nearest-even to int32
+#   * finite out-of-range (positive)  -> INT32_MAX (0x7FFFFFFF)
+#   * finite out-of-range (negative)  -> INT32_MIN (0x80000000)
+#   * +inf                            -> INT32_MAX
+#   * -inf                            -> INT32_MIN
+#   * NaN                             -> 0
+#
+# bfloat16 has the same exponent range as f32 but only 7 mantissa bits, so the
+# golden is computed on the EXACT bf16 value (after round-to-nearest-even
+# f32->bf16) -- the same bits the kernel consumes -- not on the original probe.
+
+import argparse
+import struct
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 256
+INT32_MAX = np.int32(0x7FFFFFFF)
+INT32_MIN = np.int32(-0x80000000)
+
+
+def f32(x):
+    return np.float32(x)
+
+
+def to_bf16_bits(x):
+    """f32 -> bfloat16 bit pattern (uint16), round-to-nearest-even."""
+    x = np.asarray(x, dtype=np.float32)
+    u = x.view(np.uint32)
+    lsb = (u >> np.uint32(16)) & np.uint32(1)
+    rounding_bias = np.uint32(0x7FFF) + lsb
+    r = ((u + rounding_bias) >> np.uint32(16)).astype(np.uint16)
+    # Force any NaN to a canonical bf16 NaN (rounding must not turn it into inf).
+    r = np.where(np.isnan(x), np.uint16(0x7FC0), r)
+    return r
+
+
+def bf16_bits_to_f32(bits):
+    u = bits.astype(np.uint32) << np.uint32(16)
+    return u.view(np.float32)
+
+
+# A 32-value probe. ELEMS = 256 = 8 * 32, giving a clean 8x-repeat schedule.
+PROBE = [
+    # --- in-range: RN round-half-to-even edges + typical values ---
+    f32(0.0),          # 0
+    f32(0.5),          # RN -> 0
+    f32(1.5),          # RN -> 2
+    f32(2.5),          # RN -> 2
+    f32(-0.5),         # RN -> 0
+    f32(-1.5),         # RN -> -2
+    f32(-2.5),         # RN -> -2
+    f32(1.0),          # 1
+    f32(-1.0),         # -1
+    f32(127.0),        # 127
+    f32(-128.0),       # -128
+    f32(32767.0),      # 32767
+    f32(-32768.0),     # -32768
+    f32(1e6),          # bf16-representable ~1e6
+    f32(-1e6),
+    f32(999999.0),
+    f32(1234567.5),    # rounds to nearest bf16, golden uses that exact value
+    f32(-1234567.5),
+
+    # --- out-of-range positive: clamp to INT32_MAX ---
+    f32(2.147484e9),   # slightly above INT32_MAX
+    f32(3.0e9),
+    f32(1.0e10),
+    f32(3.4e38),       # near f32/bf16 max
+    f32(float("inf")), # +inf
+
+    # --- out-of-range negative: clamp to INT32_MIN ---
+    f32(-2.147484e9),
+    f32(-3.0e9),
+    f32(-1.0e10),
+    f32(-3.4e38),
+    f32(float("-inf")),
+
+    # --- NaN saturates to 0 under V300 SAT ---
+    f32(float("nan")),
+
+    # --- extra RN edges ---
+    f32(0.25),         # RN -> 0
+    f32(0.75),         # RN -> 1
+    f32(-0.25),        # RN -> 0
+]
+
+assert len(PROBE) == 32, f"PROBE length must be 32, got {len(PROBE)}"
+
+
+def rn_to_int(x):
+    # np.rint uses banker's rounding, matching RN on integer boundaries.
+    return int(np.rint(x))
+
+
+def saturating_fptosi(v):
+    if np.isnan(v):
+        return 0
+    if np.isposinf(v):
+        return int(INT32_MAX)
+    if np.isneginf(v):
+        return int(INT32_MIN)
+    r = rn_to_int(v)
+    if r >= int(INT32_MAX):
+        return int(INT32_MAX)
+    if r <= int(INT32_MIN):
+        return int(INT32_MIN)
+    return r
+
+
+def generate(output_dir: Path) -> None:
+    probe = np.array(PROBE, dtype=np.float32)
+    probe_bf16 = to_bf16_bits(probe)  # uint16 bf16 patterns
+
+    src = np.tile(probe_bf16, ELEMS // len(PROBE))[:ELEMS].astype(np.uint16)
+    src_f32 = bf16_bits_to_f32(src)
+    golden = np.array([saturating_fptosi(v) for v in src_f32], dtype=np.int32)
+
+    # Sentinel so a completely-missed store shows up as garbage, not coincidence.
+    dst = np.full(ELEMS, -559038737, dtype=np.int32)  # 0xDEADBEEF
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src.tofile(output_dir / "v1.bin")
+    dst.tofile(output_dir / "v2.bin")
+    golden.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/kernel.pto
+++ b/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/kernel.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// bf16 -> si32 widen with saturate = "SAT". 256 bf16 (512B) -> 256 si32 (1024B).
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_fptosi_bf16_to_s32_sat_kernel(
+      %src_gm: !pto.ptr<bf16, gm>,
+      %dst_gm: !pto.ptr<si32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<bf16, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<si32, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<bf16, gm>, !pto.ptr<bf16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+      %cvt = pto.vmi.vcvt %wide {saturate = "SAT"}
+          : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xsi32>
+      pto.vmi.vstore %cvt, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xsi32>, !pto.ptr<si32, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<si32, ub>, !pto.ptr<si32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/launch.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/launch.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+// bf16 is carried as raw int16_t bit patterns (bfloat16) to the kernel.
+extern "C" __global__ [aicore] void
+vmi_fptosi_bf16_to_s32_sat_kernel(__gm__ int16_t *src,
+                                  __gm__ int32_t *dst);
+
+void LaunchVmi_fptosi_bf16_to_s32_sat_kernel(int16_t *src, int32_t *dst,
+                                             void *stream) {
+  vmi_fptosi_bf16_to_s32_sat_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int16_t *)src, (__gm__ int32_t *)dst);
+}

--- a/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/main.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/main.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVmi_fptosi_bf16_to_s32_sat_kernel(int16_t *src, int32_t *dst,
+                                             void *stream);
+
+int main() {
+  constexpr size_t kElems = 256;
+  size_t srcBytes = kElems * sizeof(int16_t);  // bf16 bit patterns
+  size_t dstBytes = kElems * sizeof(int32_t);
+  int16_t *srcHost = nullptr;
+  int16_t *srcDevice = nullptr;
+  int32_t *dstHost = nullptr;
+  int32_t *dstDevice = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&srcHost), srcBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&dstHost), dstBytes));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, srcBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&dstDevice, dstBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", srcBytes, srcHost, srcBytes);
+  ReadFile("./v2.bin", dstBytes, dstHost, dstBytes);
+  ACL_CHECK(aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(dstDevice, dstBytes, dstHost, dstBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmi_fptosi_bf16_to_s32_sat_kernel(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", dstHost, dstBytes);
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(dstDevice);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(dstHost);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/ptoas.flags
+++ b/test/vpto/cases/vmi_new/fptosi-bf16-to-s32-sat/ptoas.flags
@@ -1,0 +1,1 @@
+--pto-arch a5 --pto-backend=vpto

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/compare.py
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/compare.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden = np.fromfile("golden_v2.bin", dtype=np.int16)
+    output = np.fromfile("v2.bin", dtype=np.int16)
+    if golden.shape != output.shape or not np.array_equal(golden, output):
+        diff = np.nonzero(golden != output)[0]
+        idx = int(diff[0]) if diff.size else -1
+        print(f"[ERROR] compare failed idx={idx} golden={int(golden[idx]) if idx >= 0 else 'n/a'} output={int(output[idx]) if idx >= 0 else 'n/a'}")
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/golden.py
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/golden.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# f16 -> si16 (FpToSi) with saturate = "SAT" golden.
+#
+# V300 SAT policy for FpToSi (rounding = "R", i.e. RN):
+#   * finite in-range values        -> round-to-nearest-even to int16
+#   * finite out-of-range positive  -> INT16_MAX (32767)
+#   * finite out-of-range negative  -> INT16_MIN (-32768)
+#   * +inf / -inf                   -> INT16_MAX / INT16_MIN
+#   * NaN                           -> 0
+#
+# f16 range is [-65504, 65504], so values above 32767 (and below -32768) are
+# genuinely out-of-range for si16 and must clamp. Golden is computed on the
+# EXACT f16 value (np.float16 rounds the probe on construction), the same bits
+# the kernel consumes.
+
+import argparse
+import struct
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 256
+INT16_MAX = 32767
+INT16_MIN = -32768
+
+
+def f16(x):
+    return np.float16(x)
+
+
+# A 32-value probe. ELEMS = 256 = 8 * 32, giving a clean 8x-repeat schedule.
+PROBE = [
+    # --- in-range RN edges + typical values ---
+    f16(0.0),          # 0
+    f16(0.5),          # RN -> 0
+    f16(1.5),          # RN -> 2
+    f16(2.5),          # RN -> 2
+    f16(-0.5),         # RN -> 0
+    f16(-1.5),         # RN -> -2
+    f16(-2.5),         # RN -> -2
+    f16(1.0),          # 1
+    f16(-1.0),         # -1
+    f16(127.0),        # 127
+    f16(-128.0),       # -128
+    f16(255.0),        # 255
+    f16(-256.0),       # -256
+    f16(16384.0),      # 16384
+    f16(-16384.0),     # -16384
+
+    # --- boundary: f16 rounds 32767 up to 32768, which must clamp to 32767 ---
+    f16(32767.0),      # f16 stores 32768 -> clamp 32767
+    f16(32768.0),      # clamp 32767
+    f16(-32768.0),     # exactly INT16_MIN, in range
+    f16(-32769.0),     # f16 rounds to -32768 (spacing 32) -> in range -32768
+
+    # --- out-of-range -> clamp ---
+    f16(40000.0),      # clamp 32767
+    f16(60000.0),      # clamp 32767
+    f16(65504.0),      # f16 max -> clamp 32767
+    f16(-40000.0),     # clamp -32768
+    f16(-60000.0),     # clamp -32768
+    f16(-65504.0),     # clamp -32768
+    f16(float("inf")), # clamp 32767
+    f16(float("-inf")),# clamp -32768
+
+    # --- NaN saturates to 0 under V300 SAT ---
+    f16(float("nan")),
+
+    # --- extra RN edges ---
+    f16(0.25),         # RN -> 0
+    f16(0.75),         # RN -> 1
+    f16(-0.25),        # RN -> 0
+    f16(3.5),          # RN -> 4
+]
+
+assert len(PROBE) == 32, f"PROBE length must be 32, got {len(PROBE)}"
+
+
+def rn_to_int(x):
+    return int(np.rint(x))
+
+
+def saturating_fptosi(v):
+    if np.isnan(v):
+        return 0
+    if np.isposinf(v):
+        return INT16_MAX
+    if np.isneginf(v):
+        return INT16_MIN
+    return max(INT16_MIN, min(INT16_MAX, rn_to_int(v)))
+
+
+def generate(output_dir: Path) -> None:
+    probe = np.array(PROBE, dtype=np.float16)
+    src = np.tile(probe.view(np.uint16), ELEMS // len(PROBE))[:ELEMS].astype(np.uint16)
+    src_f = src.view(np.float16).astype(np.float32)
+    golden = np.array([saturating_fptosi(v) for v in src_f], dtype=np.int16)
+
+    dst = np.full(ELEMS, -21846, dtype=np.int16)  # 0xAAAA sentinel
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src.tofile(output_dir / "v1.bin")
+    dst.tofile(output_dir / "v2.bin")
+    golden.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/kernel.pto
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/kernel.pto
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// f16 -> si16 same-width with saturate = "SAT". 256 f16 (512B) -> 256 si16 (512B).
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_fptosi_f16_to_s16_sat_kernel(
+      %src_gm: !pto.ptr<f16, gm>,
+      %dst_gm: !pto.ptr<si16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<si16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
+      %cvt = pto.vmi.vcvt %wide {saturate = "SAT"}
+          : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xsi16>
+      pto.vmi.vstore %cvt, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xsi16>, !pto.ptr<si16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<si16, ub>, !pto.ptr<si16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/launch.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vmi_fptosi_f16_to_s16_sat_kernel(__gm__ int16_t *src,
+                                 __gm__ int16_t *dst);
+
+void LaunchVmi_fptosi_f16_to_s16_sat_kernel(int16_t *src, int16_t *dst,
+                                            void *stream) {
+  vmi_fptosi_f16_to_s16_sat_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int16_t *)src, (__gm__ int16_t *)dst);
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/main.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/main.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVmi_fptosi_f16_to_s16_sat_kernel(int16_t *src, int16_t *dst,
+                                            void *stream);
+
+int main() {
+  constexpr size_t kElems = 256;
+  size_t srcBytes = kElems * sizeof(int16_t);  // f16 bit patterns
+  size_t dstBytes = kElems * sizeof(int16_t);
+  int16_t *srcHost = nullptr;
+  int16_t *srcDevice = nullptr;
+  int16_t *dstHost = nullptr;
+  int16_t *dstDevice = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&srcHost), srcBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&dstHost), dstBytes));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, srcBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&dstDevice, dstBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", srcBytes, srcHost, srcBytes);
+  ReadFile("./v2.bin", dstBytes, dstHost, dstBytes);
+  ACL_CHECK(aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(dstDevice, dstBytes, dstHost, dstBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmi_fptosi_f16_to_s16_sat_kernel(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", dstHost, dstBytes);
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(dstDevice);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(dstHost);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/ptoas.flags
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s16-sat/ptoas.flags
@@ -1,0 +1,1 @@
+--pto-arch a5 --pto-backend=vpto

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/compare.py
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/compare.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden = np.fromfile("golden_v2.bin", dtype=np.int32)
+    output = np.fromfile("v2.bin", dtype=np.int32)
+    if golden.shape != output.shape or not np.array_equal(golden, output):
+        diff = np.nonzero(golden != output)[0]
+        idx = int(diff[0]) if diff.size else -1
+        print(f"[ERROR] compare failed idx={idx} golden={int(golden[idx]) if idx >= 0 else 'n/a'} output={int(output[idx]) if idx >= 0 else 'n/a'}")
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/golden.py
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/golden.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# f16 -> si32 (FpToSi) WITHOUT saturate golden.
+#
+# requiresSat=false for f16->s32: f16 max (65504) fits comfortably in si32
+# (+-2.1e9), so no overflow is possible and the kernel omits the saturate attr.
+# The golden therefore is plain round-to-nearest-even -- NO clamping.
+#
+# IMPORTANT: without SAT, out-of-range/NaN inputs are architecturally
+# undefined, so the probe deliberately contains ONLY finite f16-representable
+# values. Golden is computed on the exact f16 value the kernel consumes.
+
+import argparse
+import struct
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 256
+
+
+def f16(x):
+    return np.float16(x)
+
+
+# A 32-value probe of finite f16 values only (no inf/nan -- undefined without
+# saturate). ELEMS = 256 = 8 * 32, giving a clean 8x-repeat schedule.
+PROBE = [
+    f16(0.0),          # 0
+    f16(0.5),          # RN -> 0
+    f16(1.5),          # RN -> 2
+    f16(2.5),          # RN -> 2
+    f16(-0.5),         # RN -> 0
+    f16(-1.5),         # RN -> -2
+    f16(-2.5),         # RN -> -2
+    f16(1.0),          # 1
+    f16(-1.0),         # -1
+    f16(127.0),        # 127
+    f16(-128.0),       # -128
+    f16(32767.0),      # f16 stores 32768 (rounds up), in range
+    f16(-32768.0),     # -32768
+    f16(65504.0),      # f16 max, fits si32
+    f16(-65504.0),     # -65504
+    f16(60000.0),      # 60000
+    f16(-60000.0),     # -60000
+    f16(0.25),         # RN -> 0
+    f16(0.75),         # RN -> 1
+    f16(-0.25),        # RN -> 0
+    f16(-0.75),        # RN -> -1
+    f16(1234.5),       # RN -> 1234 (banker's: 1234.5 -> 1234)
+    f16(-1234.5),      # RN -> -1234
+    f16(2.0),          # 2
+    f16(-2.0),         # -2
+    f16(100.5),        # RN -> 100 (banker's)
+    f16(-100.5),       # RN -> -100
+    f16(16384.0),      # 16384
+    f16(-16384.0),     # -16384
+    f16(3.0),          # 3
+    f16(-3.0),         # -3
+    f16(5.5),          # RN -> 6
+]
+
+assert len(PROBE) == 32, f"PROBE length must be 32, got {len(PROBE)}"
+
+
+def rn_to_int(x):
+    # np.rint uses banker's rounding, matching RN on integer boundaries.
+    return int(np.rint(x))
+
+
+def generate(output_dir: Path) -> None:
+    probe = np.array(PROBE, dtype=np.float16)
+    src = np.tile(probe.view(np.uint16), ELEMS // len(PROBE))[:ELEMS].astype(np.uint16)
+    src_f = src.view(np.float16).astype(np.float32)
+    # No clamp: f16 range always fits si32.
+    golden = np.array([rn_to_int(v) for v in src_f], dtype=np.int32)
+
+    dst = np.full(ELEMS, -559038737, dtype=np.int32)  # 0xDEADBEEF sentinel
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src.tofile(output_dir / "v1.bin")
+    dst.tofile(output_dir / "v2.bin")
+    golden.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/kernel.pto
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/kernel.pto
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// f16 -> si32 (widen, saturate NOT required — no overflow possible).
+// f16 max(65504) fits in si32(±2.1e9), so hardware sat is architecturally
+// unnecessary. This case validates the requiresSat=false path: the saturate
+// attribute must be absent from both the VMI vcvt and the lowered pto.vcvt.
+//
+// 256 f16 lanes (512 bytes) -> 256 si32 lanes (1024 bytes).
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_fptosi_f16_to_s32_nosat_kernel(
+      %src_gm: !pto.ptr<f16, gm>,
+      %dst_gm: !pto.ptr<si32, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<si32, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
+      // No saturate attr: requiresSat=false for f16->s32.
+      %cvt = pto.vmi.vcvt %wide
+          : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xsi32>
+      pto.vmi.vstore %cvt, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xsi32>, !pto.ptr<si32, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<si32, ub>, !pto.ptr<si32, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/launch.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vmi_fptosi_f16_to_s32_nosat_kernel(__gm__ int16_t *src,
+                                   __gm__ int32_t *dst);
+
+void LaunchVmi_fptosi_f16_to_s32_nosat_kernel(int16_t *src, int32_t *dst,
+                                              void *stream) {
+  vmi_fptosi_f16_to_s32_nosat_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int16_t *)src, (__gm__ int32_t *)dst);
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/main.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/main.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVmi_fptosi_f16_to_s32_nosat_kernel(int16_t *src, int32_t *dst,
+                                              void *stream);
+
+int main() {
+  constexpr size_t kElems = 256;
+  size_t srcBytes = kElems * sizeof(int16_t);  // f16 bit patterns
+  size_t dstBytes = kElems * sizeof(int32_t);
+  int16_t *srcHost = nullptr;
+  int16_t *srcDevice = nullptr;
+  int32_t *dstHost = nullptr;
+  int32_t *dstDevice = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&srcHost), srcBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&dstHost), dstBytes));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, srcBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&dstDevice, dstBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", srcBytes, srcHost, srcBytes);
+  ReadFile("./v2.bin", dstBytes, dstHost, dstBytes);
+  ACL_CHECK(aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(dstDevice, dstBytes, dstHost, dstBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmi_fptosi_f16_to_s32_nosat_kernel(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", dstHost, dstBytes);
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(dstDevice);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(dstHost);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/ptoas.flags
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s32-nosat/ptoas.flags
@@ -1,0 +1,1 @@
+--pto-arch a5 --pto-backend=vpto

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/compare.py
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/compare.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden = np.fromfile("golden_v2.bin", dtype=np.int8)
+    output = np.fromfile("v2.bin", dtype=np.int8)
+    if golden.shape != output.shape or not np.array_equal(golden, output):
+        diff = np.nonzero(golden != output)[0]
+        idx = int(diff[0]) if diff.size else -1
+        print(f"[ERROR] compare failed idx={idx} golden={int(golden[idx]) if idx >= 0 else 'n/a'} output={int(output[idx]) if idx >= 0 else 'n/a'}")
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/golden.py
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/golden.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# f16 -> si8 (FpToSi) with saturate = "SAT" golden.
+#
+# V300 SAT policy for FpToSi (rounding = "R", i.e. RN):
+#   * finite in-range values        -> round-to-nearest-even to int8
+#   * finite out-of-range positive  -> INT8_MAX (127)
+#   * finite out-of-range negative  -> INT8_MIN (-128)
+#   * +inf / -inf                   -> INT8_MAX / INT8_MIN
+#   * NaN                           -> 0
+#
+# f16 range is [-65504, 65504], so almost everything above 127 clamps. Golden
+# is computed on the exact f16 value the kernel consumes.
+
+import argparse
+import struct
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 256
+INT8_MAX = 127
+INT8_MIN = -128
+
+
+def f16(x):
+    return np.float16(x)
+
+
+# A 32-value probe. ELEMS = 256 = 8 * 32, giving a clean 8x-repeat schedule.
+PROBE = [
+    # --- in-range RN edges + typical values ---
+    f16(0.0),          # 0
+    f16(0.5),          # RN -> 0
+    f16(1.5),          # RN -> 2
+    f16(2.5),          # RN -> 2
+    f16(-0.5),         # RN -> 0
+    f16(-1.5),         # RN -> -2
+    f16(-2.5),         # RN -> -2
+    f16(1.0),          # 1
+    f16(-1.0),         # -1
+    f16(100.0),        # 100
+    f16(-100.0),       # -100
+
+    # --- boundary clamping ---
+    f16(127.0),        # exactly INT8_MAX
+    f16(128.0),        # clamp 127
+    f16(130.0),        # clamp 127
+    f16(-128.0),       # exactly INT8_MIN
+    f16(-129.0),       # clamp -128
+    f16(-130.0),       # clamp -128
+
+    # --- well out of range -> clamp ---
+    f16(200.0),        # clamp 127
+    f16(-200.0),       # clamp -128
+    f16(1000.0),       # clamp 127
+    f16(-1000.0),      # clamp -128
+    f16(60000.0),      # clamp 127
+    f16(-60000.0),     # clamp -128
+    f16(65504.0),      # f16 max -> clamp 127
+    f16(-65504.0),     # clamp -128
+    f16(float("inf")), # clamp 127
+    f16(float("-inf")),# clamp -128
+
+    # --- NaN saturates to 0 under V300 SAT ---
+    f16(float("nan")),
+
+    # --- extra RN edges ---
+    f16(0.25),         # RN -> 0
+    f16(0.75),         # RN -> 1
+    f16(-0.25),        # RN -> 0
+    f16(3.5),          # RN -> 4
+]
+
+assert len(PROBE) == 32, f"PROBE length must be 32, got {len(PROBE)}"
+
+
+def rn_to_int(x):
+    return int(np.rint(x))
+
+
+def saturating_fptosi(v):
+    if np.isnan(v):
+        return 0
+    if np.isposinf(v):
+        return INT8_MAX
+    if np.isneginf(v):
+        return INT8_MIN
+    return max(INT8_MIN, min(INT8_MAX, rn_to_int(v)))
+
+
+def generate(output_dir: Path) -> None:
+    probe = np.array(PROBE, dtype=np.float16)
+    src = np.tile(probe.view(np.uint16), ELEMS // len(PROBE))[:ELEMS].astype(np.uint16)
+    src_f = src.view(np.float16).astype(np.float32)
+    golden = np.array([saturating_fptosi(v) for v in src_f], dtype=np.int8)
+
+    dst = np.full(ELEMS, -86, dtype=np.int8)  # 0xAA sentinel
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src.tofile(output_dir / "v1.bin")
+    dst.tofile(output_dir / "v2.bin")
+    golden.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/kernel.pto
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/kernel.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// f16 -> si8 narrow with saturate = "SAT". 256 f16 (512B) -> 256 si8 (256B).
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_fptosi_f16_to_s8_sat_kernel(
+      %src_gm: !pto.ptr<f16, gm>,
+      %dst_gm: !pto.ptr<si8, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<si8, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
+      %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
+          : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xsi8>
+      pto.vmi.vstore %narrow, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xsi8>, !pto.ptr<si8, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c256_i64
+      nburst(%c1_i64, %c256_i64, %c256_i64)
+      : !pto.ptr<si8, ub>, !pto.ptr<si8, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/launch.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vmi_fptosi_f16_to_s8_sat_kernel(__gm__ int16_t *src,
+                                __gm__ int8_t *dst);
+
+void LaunchVmi_fptosi_f16_to_s8_sat_kernel(int16_t *src, int8_t *dst,
+                                           void *stream) {
+  vmi_fptosi_f16_to_s8_sat_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int16_t *)src, (__gm__ int8_t *)dst);
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/main.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/main.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVmi_fptosi_f16_to_s8_sat_kernel(int16_t *src, int8_t *dst,
+                                           void *stream);
+
+int main() {
+  constexpr size_t kElems = 256;
+  size_t srcBytes = kElems * sizeof(int16_t);  // f16 bit patterns
+  size_t dstBytes = kElems * sizeof(int8_t);
+  int16_t *srcHost = nullptr;
+  int16_t *srcDevice = nullptr;
+  int8_t *dstHost = nullptr;
+  int8_t *dstDevice = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&srcHost), srcBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&dstHost), dstBytes));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, srcBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&dstDevice, dstBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", srcBytes, srcHost, srcBytes);
+  ReadFile("./v2.bin", dstBytes, dstHost, dstBytes);
+  ACL_CHECK(aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(dstDevice, dstBytes, dstHost, dstBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmi_fptosi_f16_to_s8_sat_kernel(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", dstHost, dstBytes);
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(dstDevice);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(dstHost);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/ptoas.flags
+++ b/test/vpto/cases/vmi_new/fptosi-f16-to-s8-sat/ptoas.flags
@@ -1,0 +1,1 @@
+--pto-arch a5 --pto-backend=vpto

--- a/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/compare.py
+++ b/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/compare.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden = np.fromfile("golden_v2.bin", dtype=np.int16)
+    output = np.fromfile("v2.bin", dtype=np.int16)
+    if golden.shape != output.shape or not np.array_equal(golden, output):
+        diff = np.nonzero(golden != output)[0]
+        idx = int(diff[0]) if diff.size else -1
+        print(f"[ERROR] compare failed idx={idx} golden={int(golden[idx]) if idx >= 0 else 'n/a'} output={int(output[idx]) if idx >= 0 else 'n/a'}")
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/golden.py
+++ b/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/golden.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# f32 -> si16 (FpToSi) with saturate = "SAT" golden.
+#
+# V300 SAT policy for FpToSi (rounding = "R", i.e. RN):
+#   * finite in-range values        -> round-to-nearest-even to int16
+#   * finite out-of-range positive  -> INT16_MAX (32767)
+#   * finite out-of-range negative  -> INT16_MIN (-32768)
+#   * +inf / -inf                   -> INT16_MAX / INT16_MIN
+#   * NaN                           -> 0
+#
+# f32 spans far beyond si16, so out-of-range clamping is the dominant path.
+
+import argparse
+import struct
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 256
+INT16_MAX = 32767
+INT16_MIN = -32768
+
+
+def f32(x):
+    return np.float32(x)
+
+
+# A 32-value probe. ELEMS = 256 = 8 * 32, giving a clean 8x-repeat schedule.
+PROBE = [
+    # --- in-range RN edges + typical values ---
+    f32(0.0),          # 0
+    f32(0.5),          # RN -> 0
+    f32(1.5),          # RN -> 2
+    f32(2.5),          # RN -> 2
+    f32(-0.5),         # RN -> 0
+    f32(-1.5),         # RN -> -2
+    f32(-2.5),         # RN -> -2
+    f32(1.0),          # 1
+    f32(-1.0),         # -1
+    f32(127.0),        # 127
+    f32(-128.0),       # -128
+
+    # --- boundary clamping ---
+    f32(32767.0),      # exactly INT16_MAX
+    f32(32767.5),      # RN -> 32768 -> clamp 32767
+    f32(32768.0),      # clamp 32767
+    f32(32769.0),      # clamp 32767
+    f32(-32768.0),     # exactly INT16_MIN
+    f32(-32768.5),     # RN -> -32769 -> clamp -32768
+    f32(-32769.0),     # clamp -32768
+
+    # --- well out of range -> clamp ---
+    f32(40000.0),      # clamp 32767
+    f32(-40000.0),     # clamp -32768
+    f32(100000.0),     # clamp 32767
+    f32(-100000.0),    # clamp -32768
+    f32(1e6),          # clamp 32767
+    f32(-1e6),         # clamp -32768
+    f32(3.4e38),       # near f32 max -> clamp 32767
+    f32(-3.4e38),      # clamp -32768
+    f32(float("inf")), # clamp 32767
+    f32(float("-inf")),# clamp -32768
+
+    # --- NaN saturates to 0 under V300 SAT ---
+    f32(float("nan")),
+
+    # --- extra RN edges ---
+    f32(0.25),         # RN -> 0
+    f32(0.75),         # RN -> 1
+    f32(-0.25),        # RN -> 0
+]
+
+assert len(PROBE) == 32, f"PROBE length must be 32, got {len(PROBE)}"
+
+
+def rn_to_int(x):
+    return int(np.rint(x))
+
+
+def saturating_fptosi(v):
+    if np.isnan(v):
+        return 0
+    if np.isposinf(v):
+        return INT16_MAX
+    if np.isneginf(v):
+        return INT16_MIN
+    return max(INT16_MIN, min(INT16_MAX, rn_to_int(v)))
+
+
+def generate(output_dir: Path) -> None:
+    probe = np.array(PROBE, dtype=np.float32)
+    src = np.tile(probe, ELEMS // len(PROBE))[:ELEMS].astype(np.float32)
+    golden = np.array([saturating_fptosi(v) for v in src], dtype=np.int16)
+
+    dst = np.full(ELEMS, -21846, dtype=np.int16)  # 0xAAAA sentinel
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src.tofile(output_dir / "v1.bin")
+    dst.tofile(output_dir / "v2.bin")
+    golden.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/kernel.pto
+++ b/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/kernel.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// f32 -> si16 narrow with saturate = "SAT". 256 f32 (1024B) -> 256 si16 (512B).
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_fptosi_f32_to_s16_sat_kernel(
+      %src_gm: !pto.ptr<f32, gm>,
+      %dst_gm: !pto.ptr<si16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f32, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<si16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c1024_i64
+      nburst(%c1_i64, %c1024_i64, %c1024_i64)
+      : !pto.ptr<f32, gm>, !pto.ptr<f32, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<f32, ub> -> !pto.vmi.vreg<256xf32>
+      %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
+          : !pto.vmi.vreg<256xf32> -> !pto.vmi.vreg<256xsi16>
+      pto.vmi.vstore %narrow, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xsi16>, !pto.ptr<si16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<si16, ub>, !pto.ptr<si16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/launch.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vmi_fptosi_f32_to_s16_sat_kernel(__gm__ float *src,
+                                 __gm__ int16_t *dst);
+
+void LaunchVmi_fptosi_f32_to_s16_sat_kernel(float *src, int16_t *dst,
+                                            void *stream) {
+  vmi_fptosi_f32_to_s16_sat_kernel<<<1, nullptr, stream>>>(
+      (__gm__ float *)src, (__gm__ int16_t *)dst);
+}

--- a/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/main.cpp
+++ b/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/main.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVmi_fptosi_f32_to_s16_sat_kernel(float *src, int16_t *dst,
+                                            void *stream);
+
+int main() {
+  constexpr size_t kElems = 256;
+  size_t srcBytes = kElems * sizeof(float);
+  size_t dstBytes = kElems * sizeof(int16_t);
+  float *srcHost = nullptr;
+  float *srcDevice = nullptr;
+  int16_t *dstHost = nullptr;
+  int16_t *dstDevice = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&srcHost), srcBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&dstHost), dstBytes));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, srcBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&dstDevice, dstBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", srcBytes, srcHost, srcBytes);
+  ReadFile("./v2.bin", dstBytes, dstHost, dstBytes);
+  ACL_CHECK(aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(dstDevice, dstBytes, dstHost, dstBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmi_fptosi_f32_to_s16_sat_kernel(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", dstHost, dstBytes);
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(dstDevice);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(dstHost);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/ptoas.flags
+++ b/test/vpto/cases/vmi_new/fptosi-f32-to-s16-sat/ptoas.flags
@@ -1,0 +1,1 @@
+--pto-arch a5 --pto-backend=vpto

--- a/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/compare.py
+++ b/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/compare.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden = np.fromfile("golden_v2.bin", dtype=np.uint8)
+    output = np.fromfile("v2.bin", dtype=np.uint8)
+    if golden.shape != output.shape or not np.array_equal(golden, output):
+        diff = np.nonzero(golden != output)[0]
+        idx = int(diff[0]) if diff.size else -1
+        if idx >= 0:
+            print(
+                f"[ERROR] compare failed idx={idx} "
+                f"golden=0x{int(golden[idx]):02x} output=0x{int(output[idx]):02x} "
+                f"(total_mismatches={diff.size})"
+            )
+        else:
+            print(f"[ERROR] compare failed shape mismatch: golden={golden.shape} output={output.shape}")
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/golden.py
+++ b/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/golden.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# f16 -> u8 (FpToUi) with saturate = "SAT" golden.
+#
+# V300 SAT policy: negatives → 0, overflow → 255, NaN → 0,
+# +inf → 255, -inf → 0.  RN (round-half-to-even) before clamp.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 256
+U8_MAX = 255
+U8_MIN = 0
+
+
+def f16(x):
+    return np.float16(x)
+
+
+# 32-entry probe, tiled 8× → 256 lanes.
+PROBE = [
+    # --- zeros / smallest RN ties ---
+    f16(0.0),
+    f16(0.25),         # RN → 0
+    f16(0.5),          # RN → 0 (banker's)
+    f16(0.75),         # RN → 1
+    f16(1.0),
+    f16(1.5),          # RN → 2
+    f16(2.5),          # RN → 2
+
+    # --- typical in-range ---
+    f16(3.0),
+    f16(42.0),
+    f16(127.0),
+    f16(200.0),
+
+    # --- upper boundary + RN ties near 255 ---
+    f16(254.0),
+    f16(254.5),        # RN → 254 (banker's)
+    f16(255.0),
+    f16(255.5),        # RN → 256 → SAT → 255
+
+    # --- overflow high, must clamp to 255 ---
+    f16(256.0),
+    f16(1000.0),
+    f16(65504.0),      # f16 max finite
+
+    # --- negatives (all → 0 under V300 SAT) ---
+    f16(-0.25),
+    f16(-1.0),
+    f16(-42.0),
+    f16(-128.0),
+    f16(-255.0),
+    f16(-1000.0),
+    f16(-65504.0),     # f16 min finite
+
+    # --- IEEE specials ---
+    f16(float("inf")),   # → 255
+    f16(float("-inf")),  # → 0
+    f16(float("nan")),   # → 0
+
+    # --- pad to 32 ---
+    f16(64.0),
+    f16(128.0),
+    f16(192.0),
+    f16(32.0),
+]
+assert len(PROBE) == 32, f"PROBE length must be 32, got {len(PROBE)}"
+
+
+def sat_f16_to_u8(v: np.float16) -> int:
+    """V300 SAT policy for f16 → u8 (RN, clamp to [0, 255])."""
+    if np.isnan(v):
+        return 0
+    if np.isposinf(v):
+        return U8_MAX
+    if np.isneginf(v):
+        return U8_MIN
+    # Round-half-to-even, then clamp.
+    r = int(np.rint(np.float32(v)))
+    return max(U8_MIN, min(U8_MAX, r))
+
+
+def nosat_f16_to_u8(v: np.float16) -> int:
+    """NOSAT reference: low-8 unsigned truncation of RN-rounded int."""
+    if np.isnan(v):
+        return 0
+    if np.isinf(v):
+        # NOSAT on infinities: low-8 truncation of the saturated int value.
+        # +inf → INT32_MAX → 0x7FFFFFFF → low-8 = 0xFF = 255
+        # -inf → INT32_MIN → 0x80000000 → low-8 = 0x00 = 0
+        return 255 if v > 0 else 0
+    r = int(np.rint(np.float32(v)))
+    return r & 0xFF
+
+
+def generate(output_dir: Path) -> None:
+    probe = np.array(PROBE, dtype=np.float16)
+    src = np.tile(probe, ELEMS // len(probe))[:ELEMS].astype(np.float16)
+
+    golden_sat = np.array([sat_f16_to_u8(v) for v in src], dtype=np.uint8)
+    nosat_ref = np.array([nosat_f16_to_u8(v) for v in src], dtype=np.uint8)
+
+    # Guardrail: SAT golden MUST differ from NOSAT reference (otherwise the
+    # lowering could silently produce NOSAT behavior).
+    if np.array_equal(golden_sat, nosat_ref):
+        raise SystemExit(
+            "[FATAL] SAT golden equals NOSAT reference — guardrail failed. "
+            "The probe set does not exercise SAT clamping. "
+            "Add negative or overflow values to the probe."
+        )
+
+    # Sentinel-fill pre-kernel destination so a missed store shows up as
+    # garbage instead of coincidentally-matching zeros.
+    pre_dst = np.full(ELEMS, 0xCD, dtype=np.uint8)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src.tofile(output_dir / "v1.bin")
+    pre_dst.tofile(output_dir / "v2.bin")
+    golden_sat.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/kernel.pto
+++ b/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/kernel.pto
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// case: vmi_new/fptoui-f16-to-u8-sat
+// family: conversion
+// target_ops: pto.vmi.fptoui
+// scenarios: f16-to-u8, sat, narrow-2x-evenodd
+//
+// Purpose: end-to-end validation of the fptoui path (f16 → u8 with SAT).
+// This is the only fp→unsigned-int path supported by the VPTO vcvt contract.
+// SAT semantics (V300 policy): negatives clamp to 0, overflow clamps to 255,
+// NaN → 0.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_fptoui_f16_to_u8_sat_kernel(
+      %src_gm: !pto.ptr<f16, gm>,
+      %dst_gm: !pto.ptr<ui8, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c256_i64 = arith.constant 256 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c1024_i64 = arith.constant 1024 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<f16, ub>
+    %ub_dst = pto.castptr %c1024_i64 : i64 -> !pto.ptr<ui8, ub>
+
+    // GM -> UB: 256 f16 lanes = 512 bytes.
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<f16, gm>, !pto.ptr<f16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<f16, ub> -> !pto.vmi.vreg<256xf16>
+      // FpToUi: f16 -> u8 with SAT.  V300 SAT policy:
+      //   negatives → 0,  >255 → 255,  NaN → 0,  +inf → 255,  -inf → 0.
+      %narrow = pto.vmi.vcvt %wide {saturate = "SAT"}
+          : !pto.vmi.vreg<256xf16> -> !pto.vmi.vreg<256xui8>
+      pto.vmi.vstore %narrow, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xui8>, !pto.ptr<ui8, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+
+    // UB -> GM: 256 u8 lanes = 256 bytes.
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c256_i64
+      nburst(%c1_i64, %c256_i64, %c256_i64)
+      : !pto.ptr<ui8, ub>, !pto.ptr<ui8, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/launch.cpp
+++ b/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/launch.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+extern "C" __global__ [aicore] void
+vmi_fptoui_f16_to_u8_sat_kernel(__gm__ int16_t *src,
+                                __gm__ uint8_t *dst);
+
+void LaunchVmi_fptoui_f16_to_u8_sat_kernel(int16_t *src, uint8_t *dst,
+                                           void *stream) {
+  vmi_fptoui_f16_to_u8_sat_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int16_t *)src, (__gm__ uint8_t *)dst);
+}

--- a/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/main.cpp
+++ b/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/main.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVmi_fptoui_f16_to_u8_sat_kernel(int16_t *src, uint8_t *dst,
+                                           void *stream);
+
+int main() {
+  constexpr size_t kElems = 256;
+  size_t srcBytes = kElems * sizeof(int16_t);
+  size_t dstBytes = kElems * sizeof(uint8_t);
+  int16_t *srcHost = nullptr;
+  int16_t *srcDevice = nullptr;
+  uint8_t *dstHost = nullptr;
+  uint8_t *dstDevice = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&srcHost), srcBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&dstHost), dstBytes));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, srcBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&dstDevice, dstBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", srcBytes, srcHost, srcBytes);
+  ReadFile("./v2.bin", dstBytes, dstHost, dstBytes);
+  ACL_CHECK(aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(dstDevice, dstBytes, dstHost, dstBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmi_fptoui_f16_to_u8_sat_kernel(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", dstHost, dstBytes);
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(dstDevice);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(dstHost);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/ptoas.flags
+++ b/test/vpto/cases/vmi_new/fptoui-f16-to-u8-sat/ptoas.flags
@@ -1,0 +1,1 @@
+--pto-arch a5 --pto-backend=vpto

--- a/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/compare.py
+++ b/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/compare.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import sys
+
+import numpy as np
+
+
+def main() -> None:
+    golden = np.fromfile("golden_v2.bin", dtype=np.uint16)
+    output = np.fromfile("v2.bin", dtype=np.uint16)
+    if golden.shape != output.shape or not np.array_equal(golden, output):
+        diff = np.nonzero(golden != output)[0]
+        idx = int(diff[0]) if diff.size else -1
+        print(f"[ERROR] compare failed idx={idx} golden={int(golden[idx]) if idx >= 0 else 'n/a'} output={int(output[idx]) if idx >= 0 else 'n/a'}")
+        sys.exit(2)
+    print("[INFO] compare passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/golden.py
+++ b/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/golden.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+# bf16 -> f16 (F2F) with saturate = "SAT" golden.
+#
+# bf16 and f16 share the same exponent bias; f16 has MORE mantissa bits
+# (10 vs 7), so every bf16 value whose magnitude is <= 65504 (f16 max) is
+# exactly representable in f16 and the conversion is lossless -- no rounding,
+# no saturation. The probe deliberately uses only such values, so the golden
+# is the exact f16 bit pattern of each bf16 value.
+
+import argparse
+import struct
+from pathlib import Path
+
+import numpy as np
+
+ELEMS = 256
+
+
+def f32(x):
+    return np.float32(x)
+
+
+def to_bf16_bits(x):
+    """f32 -> bfloat16 bit pattern (uint16), round-to-nearest-even."""
+    x = np.asarray(x, dtype=np.float32)
+    u = x.view(np.uint32)
+    lsb = (u >> np.uint32(16)) & np.uint32(1)
+    rounding_bias = np.uint32(0x7FFF) + lsb
+    r = ((u + rounding_bias) >> np.uint32(16)).astype(np.uint16)
+    r = np.where(np.isnan(x), np.uint16(0x7FC0), r)
+    return r
+
+
+def bf16_bits_to_f32(bits):
+    u = bits.astype(np.uint32) << np.uint32(16)
+    return u.view(np.float32)
+
+
+# 32-value probe, all |v| <= 65504 (exactly representable in f16).
+PROBE = [
+    f32(0.0),          # 0
+    f32(0.5),          # 0.5
+    f32(1.5),          # 1.5
+    f32(2.5),          # 2.5
+    f32(-0.5),         # -0.5
+    f32(-1.5),         # -1.5
+    f32(-2.5),         # -2.5
+    f32(1.0),          # 1
+    f32(-1.0),         # -1
+    f32(127.0),        # 127
+    f32(-128.0),       # -128
+    f32(32767.0),      # 32767
+    f32(-32768.0),     # -32768
+    f32(60000.0),      # 60000
+    f32(-60000.0),     # -60000
+    f32(65504.0),      # f16 max
+    f32(-65504.0),     # f16 min
+    f32(0.25),         # 0.25
+    f32(0.75),         # 0.75
+    f32(-0.25),        # -0.25
+    f32(-0.75),        # -0.75
+    f32(1234.5),       # 1234.5
+    f32(-1234.5),      # -1234.5
+    f32(2.0),          # 2
+    f32(-2.0),         # -2
+    f32(100.5),        # 100.5
+    f32(-100.5),       # -100.5
+    f32(16384.0),      # 16384
+    f32(-16384.0),     # -16384
+    f32(3.0),          # 3
+    f32(-3.0),         # -3
+    f32(5.5),          # 5.5
+]
+
+assert len(PROBE) == 32, f"PROBE length must be 32, got {len(PROBE)}"
+
+
+def generate(output_dir: Path) -> None:
+    probe = np.array(PROBE, dtype=np.float32)
+    probe_bf16 = to_bf16_bits(probe)
+
+    src = np.tile(probe_bf16, ELEMS // len(PROBE))[:ELEMS].astype(np.uint16)
+    src_f32 = bf16_bits_to_f32(src)
+    # bf16 RNE can round a probe value just above f16 max (65504 -> 65536).
+    # Hardware SAT clamps such finite out-of-range values to f16 max/min
+    # (65504 / -65504); np.float16 alone would overflow to +-inf, so clamp first.
+    F16_MAX = 65504.0
+    src_f32_clamped = np.clip(src_f32, -F16_MAX, F16_MAX)
+    golden_f16 = src_f32_clamped.astype(np.float16)
+    golden = golden_f16.view(np.uint16).astype(np.uint16)
+
+    # Sentinel so a completely-missed store shows up as garbage, not coincidence.
+    dst = np.full(ELEMS, 0xAAAA, dtype=np.uint16)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src.tofile(output_dir / "v1.bin")
+    dst.tofile(output_dir / "v2.bin")
+    golden.tofile(output_dir / "golden_v2.bin")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=Path, default=Path("."))
+    args = parser.parse_args()
+    generate(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/kernel.pto
+++ b/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/kernel.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// bf16 -> f16 same-width fp-to-fp with saturate = "SAT".
+// 256 bf16 (512 bytes) -> 256 f16 (512 bytes). The golden uses only bf16
+// values that are exactly representable in f16 (|v| <= 65504), so the
+// conversion is lossless and the SAT attribute is never exercised numerically.
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vmi_vcvt_bf16_to_f16_sat_kernel(
+      %src_gm: !pto.ptr<bf16, gm>,
+      %dst_gm: !pto.ptr<f16, gm>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+
+    %ub_src = pto.castptr %c0_i64 : i64 -> !pto.ptr<bf16, ub>
+    %ub_dst = pto.castptr %c4096_i64 : i64 -> !pto.ptr<f16, ub>
+
+    pto.mte_gm_ub %src_gm, %ub_src, %c0_i64, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<bf16, gm>, !pto.ptr<bf16, ub>, i64, i64, i64, i64, i64
+
+    pto.set_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+    pto.wait_flag["PIPE_MTE2", "PIPE_V", "EVENT_ID0"]
+
+    pto.vecscope {
+      %wide = pto.vmi.vload %ub_src[%c0] : !pto.ptr<bf16, ub> -> !pto.vmi.vreg<256xbf16>
+      %cvt = pto.vmi.vcvt %wide {saturate = "SAT"}
+          : !pto.vmi.vreg<256xbf16> -> !pto.vmi.vreg<256xf16>
+      pto.vmi.vstore %cvt, %ub_dst[%c0]
+          : !pto.vmi.vreg<256xf16>, !pto.ptr<f16, ub>
+    }
+
+    pto.set_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.wait_flag["PIPE_V", "PIPE_MTE3", "EVENT_ID0"]
+    pto.mte_ub_gm %ub_dst, %dst_gm, %c512_i64
+      nburst(%c1_i64, %c512_i64, %c512_i64)
+      : !pto.ptr<f16, ub>, !pto.ptr<f16, gm>, i64, i64, i64, i64
+    pto.barrier #pto.pipe<PIPE_ALL>
+    return
+  }
+}

--- a/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/launch.cpp
+++ b/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/launch.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#ifndef __VEC_SCOPE__
+#define __VEC_SCOPE__
+#endif
+#if defined(__CCE_AICORE__) && defined(__NPU_ARCH__) && (__NPU_ARCH__ == 2201)
+typedef struct { unsigned char v; } hifloat8_t;
+typedef struct { unsigned char v; } float8_e4m3_t;
+typedef struct { unsigned char v; } float8_e5m2_t;
+typedef struct { unsigned char v; } float8_e8m0_t;
+typedef struct { unsigned char v; } float4_e1m2x2_t;
+typedef struct { unsigned char v; } float4_e2m1x2_t;
+#endif
+#include <cstdint>
+#if !defined(__CCE_AICORE__) && !defined(TMRGSORT_HPP)
+struct MrgSortExecutedNumList {
+  uint16_t mrgSortList0;
+  uint16_t mrgSortList1;
+  uint16_t mrgSortList2;
+  uint16_t mrgSortList3;
+};
+#endif
+#ifndef __CPU_SIM
+#include "acl/acl.h"
+#endif
+
+// bf16 and f16 are both carried as raw int16_t bit patterns.
+extern "C" __global__ [aicore] void
+vmi_vcvt_bf16_to_f16_sat_kernel(__gm__ int16_t *src,
+                                __gm__ int16_t *dst);
+
+void LaunchVmi_vcvt_bf16_to_f16_sat_kernel(int16_t *src, int16_t *dst,
+                                           void *stream) {
+  vmi_vcvt_bf16_to_f16_sat_kernel<<<1, nullptr, stream>>>(
+      (__gm__ int16_t *)src, (__gm__ int16_t *)dst);
+}

--- a/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/main.cpp
+++ b/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/main.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+#include "acl/acl.h"
+#include "test_common.h"
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace PtoTestCommon;
+
+#define ACL_CHECK(expr)                                                          \
+  do {                                                                           \
+    const aclError _ret = (expr);                                                \
+    if (_ret != ACL_SUCCESS) {                                                   \
+      std::fprintf(stderr, "[ERROR] %s failed: %d (%s:%d)\n", #expr,             \
+                   (int)_ret, __FILE__, __LINE__);                               \
+      rc = 1;                                                                    \
+      goto cleanup;                                                              \
+    }                                                                            \
+  } while (0)
+
+void LaunchVmi_vcvt_bf16_to_f16_sat_kernel(int16_t *src, int16_t *dst,
+                                           void *stream);
+
+int main() {
+  constexpr size_t kElems = 256;
+  size_t srcBytes = kElems * sizeof(int16_t);  // bf16 bit patterns
+  size_t dstBytes = kElems * sizeof(int16_t);  // f16 bit patterns
+  int16_t *srcHost = nullptr;
+  int16_t *srcDevice = nullptr;
+  int16_t *dstHost = nullptr;
+  int16_t *dstDevice = nullptr;
+  int rc = 0;
+  bool aclInited = false;
+  bool deviceSet = false;
+  int deviceId = 0;
+  aclrtStream stream = nullptr;
+
+  ACL_CHECK(aclInit(nullptr));
+  aclInited = true;
+  if (const char *envDevice = std::getenv("ACL_DEVICE_ID"))
+    deviceId = std::atoi(envDevice);
+  ACL_CHECK(aclrtSetDevice(deviceId));
+  deviceSet = true;
+  ACL_CHECK(aclrtCreateStream(&stream));
+  ACL_CHECK(aclrtMallocHost((void **)(&srcHost), srcBytes));
+  ACL_CHECK(aclrtMallocHost((void **)(&dstHost), dstBytes));
+  ACL_CHECK(aclrtMalloc((void **)&srcDevice, srcBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+  ACL_CHECK(aclrtMalloc((void **)&dstDevice, dstBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+
+  ReadFile("./v1.bin", srcBytes, srcHost, srcBytes);
+  ReadFile("./v2.bin", dstBytes, dstHost, dstBytes);
+  ACL_CHECK(aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  ACL_CHECK(aclrtMemcpy(dstDevice, dstBytes, dstHost, dstBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+  LaunchVmi_vcvt_bf16_to_f16_sat_kernel(srcDevice, dstDevice, stream);
+  ACL_CHECK(aclrtSynchronizeStream(stream));
+  ACL_CHECK(aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST));
+  WriteFile("./v2.bin", dstHost, dstBytes);
+
+cleanup:
+  aclrtFree(srcDevice);
+  aclrtFree(dstDevice);
+  aclrtFreeHost(srcHost);
+  aclrtFreeHost(dstHost);
+  if (stream)
+    aclrtDestroyStream(stream);
+  if (deviceSet)
+    aclrtResetDevice(deviceId);
+  if (aclInited)
+    aclFinalize();
+  return rc;
+}

--- a/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/ptoas.flags
+++ b/test/vpto/cases/vmi_new/vcvt-bf16-to-f16-sat/ptoas.flags
@@ -1,0 +1,1 @@
+--pto-arch a5 --pto-backend=vpto


### PR DESCRIPTION
  扩展 vmi.vcvt 的 FpToSi/FpToUi 转换，为整条链路补上 golden + lit 测试。

  - 新增 `lookupVMIFpToSiContract`（6 对：f32->s32、f16->s16、f32->s16、
    f16->s8、f16->s32、bf16->s32）与 `lookupVMIFpToUIContract`（f16->u8），
  - 将 `VMITruncFOp::verify` 从 `src > dst` 放宽为 `src >= dst`，同宽 fp->fp。
  - 实现 `OneToNVMIFPToSIOpPattern`（同宽 1:1、widen dense-1:1/EvenOdd、
    narrow EvenOdd+Vor）与 `OneToNVMIFPToUIOpPattern`；`VMILowerUnifiedToLegacy`
    增加 `fptoui` 分发，`VMILayoutAssignment`/`VMILayoutPropagation` 增加
    FpToUi 的 layout 处理。