### PR TITLE
fix(vmi): lower supported vselr shapes to VPTO

### DIFF
--- a/docs/isa/vmi-isa/03-eltwise-compute.md
+++ b/docs/isa/vmi-isa/03-eltwise-compute.md
@@ -548,9 +548,10 @@ scalar type must match the vector element type.
   elements; `index_T` must be an integer type with the same storage width as
   `T`.
 - **constraints:** Source, index, and result have the same lane count. The
-  supported shapes are exactly `256×T` for 8-bit elements, `128×T` for 16-bit
-  elements, and `64×T` for 32-bit elements. Every `index[i]` must identify a
-  valid source lane; behavior is unspecified for an out-of-range index.
+  supported lane counts are `N ∈ {64, 128, 256}` for 8-bit elements,
+  `N ∈ {64, 128}` for 16-bit elements, and `N = 64` for 32-bit elements.
+  Every `index[i]` must identify a valid logical source lane; behavior is
+  unspecified for an out-of-range index.
 
 - **notes:**
   - This is the permute/gather class — it is the register-resident realization

--- a/docs/isa/vmi-isa/03-eltwise-compute.md
+++ b/docs/isa/vmi-isa/03-eltwise-compute.md
@@ -1,6 +1,8 @@
 # 3. Eltwise Compute
 
-> **Category:** A (layout-passthrough). **Mask:** `Pg` (optional governing predicate, except `vselr` which has none).
+> **Category:** A (layout-passthrough) for ordinary per-lane operations;
+> `vselr` is classified separately as Category C below. **Mask:** `Pg`
+> (optional governing predicate, except `vselr` which has none).
 >
 > Pure per-lane ops. Layout passes through unchanged. An operand whose
 > cardinality along an axis is 1 becomes a broadcast (replicate-read, never
@@ -16,7 +18,7 @@
 - **semantics:** Unified fp/int elementwise add / subtract / multiply.
 
   ```c
-  for (int i = 0; i < L; i++)
+  for (int i = 0; i < N; i++)
       dst[i] = mask[i] ? lhs[i] + rhs[i] : (pmode_merge ? dst_old[i] : 0);
   ```
 
@@ -512,47 +514,54 @@ scalar type must match the vector element type.
 
 ### `pto.vmi.vselr`
 
+- **layout contract:** Category C (contiguous-required). Source, index, and
+  result use contiguous layout; an arbitrary input layout is not passed through
+  this operation. Compilation may materialize a contiguous representation at
+  this boundary. IR that reaches this operation with an assigned
+  non-contiguous layout is unsupported.
+
 - **semantics:** Dynamic lane permutation: `result[i] = source[index[i]]`.
 
   ```c
-  for (int i = 0; i < L; i++)
+  for (int i = 0; i < N; i++)
       dst[i] = src[index[i]];
   ```
 
 - **syntax:**
   ```mlir
-  %r = pto.vmi.vselr %source, %index : !pto.vmi.vreg<L×T>, !pto.vmi.vreg<L×index_T> -> !pto.vmi.vreg<L×T>
+  %r = pto.vmi.vselr %source, %index : !pto.vmi.vreg<N×T>, !pto.vmi.vreg<N×index_T> -> !pto.vmi.vreg<N×T>
   ```
 - **operands:**
 
   | Operand | Type | Description |
   |---|---|---|
-  | `source` | `!pto.vmi.vreg<L×T>` | Source vector to permute from |
-  | `index` | `!pto.vmi.vreg<L×index_T>` | Per-lane source lane index |
+  | `source` | `!pto.vmi.vreg<N×T>` | Source vector to select from |
+  | `index` | `!pto.vmi.vreg<N×index_T>` | Per-lane source lane index |
 
 - **results:**
 
   | Result | Type | Description |
   |---|---|---|
-  | `result` | `!pto.vmi.vreg<L×T>` | Permuted result |
+  | `result` | `!pto.vmi.vreg<N×T>` | Permuted result |
 
-- **datatypes:** `i8`–`i32`, `f16`, `bf16`, `f32`
-- **lowering to `pto.mi:**
-  ```
-  K × pto.vselr (+ index reg setup)
-  ```
-  `#mi = K`, `dep = 1` (+1 for index setup). +1 index vreg.
+- **datatypes:** 8-, 16-, and 32-bit integer or floating-point source/result
+  elements; `index_T` must be an integer type with the same storage width as
+  `T`.
+- **constraints:** Source, index, and result have the same lane count. The
+  supported shapes are exactly `256×T` for 8-bit elements, `128×T` for 16-bit
+  elements, and `64×T` for 32-bit elements. Every `index[i]` must identify a
+  valid source lane; behavior is unspecified for an out-of-range index.
 
 - **notes:**
   - This is the permute/gather class — it is the register-resident realization
     of a grouped broadcast.
   - `vselr` takes no mask; the index vector encodes the permutation directly.
-  - Not A5-native `vselrv2` (that form is not available on A5).
+  - `vselrv2` is not available on A5 and does not add other supported shapes.
 
 - **example:**
   ```mlir
   %r = pto.vmi.vselr %src, %idx
-      : !pto.vmi.vreg<64×f16>, !pto.vmi.vreg<4×i16> -> !pto.vmi.vreg<4×f16>
+      : !pto.vmi.vreg<128×f16>, !pto.vmi.vreg<128×i16> -> !pto.vmi.vreg<128×f16>
   ```
 
 ---

--- a/docs/isa/vmi-isa/10-appendices.md
+++ b/docs/isa/vmi-isa/10-appendices.md
@@ -37,7 +37,7 @@
 | 29 | `pto.vmi.vcmp` | 3: Eltwise | A | Elementwise compare → mask |
 | 30 | `pto.vmi.vcmps` | 3: Eltwise | A | Vector-scalar compare → mask |
 | 31 | `pto.vmi.vsel` | 3: Eltwise | A | Predicate select |
-| 32 | `pto.vmi.vselr` | 3: Eltwise | A | Dynamic lane permute |
+| 32 | `pto.vmi.vselr` | 3: Eltwise | C | Dynamic lane select; contiguous, exact-width shape |
 | 33 | `pto.vmi.vbrc` | 4: Broadcast | A/B | Broadcast scalar/group-slot |
 | 34 | `pto.vmi.vcadd` | 5: Reduce | B | Add-reduction |
 | 35 | `pto.vmi.vcmax` | 5: Reduce | B | Max-reduction |

--- a/docs/isa/vmi-isa/10-appendices.md
+++ b/docs/isa/vmi-isa/10-appendices.md
@@ -37,7 +37,7 @@
 | 29 | `pto.vmi.vcmp` | 3: Eltwise | A | Elementwise compare → mask |
 | 30 | `pto.vmi.vcmps` | 3: Eltwise | A | Vector-scalar compare → mask |
 | 31 | `pto.vmi.vsel` | 3: Eltwise | A | Predicate select |
-| 32 | `pto.vmi.vselr` | 3: Eltwise | C | Dynamic lane select; contiguous, exact-width shape |
+| 32 | `pto.vmi.vselr` | 3: Eltwise | C | Dynamic lane select; contiguous, supported logical shape |
 | 33 | `pto.vmi.vbrc` | 4: Broadcast | A/B | Broadcast scalar/group-slot |
 | 34 | `pto.vmi.vcadd` | 5: Reduce | B | Add-reduction |
 | 35 | `pto.vmi.vcmax` | 5: Reduce | B | Max-reduction |

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1424,11 +1424,11 @@ def VMIVselrOp : VMI_Op<"vselr", [Pure]> {
   let description = [{
     Dynamic lane permutation: for each lane i, result[i] = source[index[i]].
     Replaces the static-index `shuffle` op with a dynamic index vector operand.
-    Lowers 1:1 to `pto.vselr` for contiguous vectors with exactly 256 lanes for
-    8-bit elements, 128 lanes for 16-bit elements, or 64 lanes for 32-bit
-    elements.  Source, index, and result use the same lane count, and the index
-    element storage width must match the source element storage width.  Other
-    lane counts are not supported by this operation.
+    Lowers 1:1 to `pto.vselr` for contiguous vectors with 64, 128, or 256 lanes
+    for 8-bit elements; 64 or 128 lanes for 16-bit elements; or 64 lanes for
+    32-bit elements.  Source, index, and result use the same lane count, and
+    the index element storage width must match the source element storage
+    width.  Other lane counts are not supported by this operation.
 
     Example:
     ```

--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -1424,11 +1424,15 @@ def VMIVselrOp : VMI_Op<"vselr", [Pure]> {
   let description = [{
     Dynamic lane permutation: for each lane i, result[i] = source[index[i]].
     Replaces the static-index `shuffle` op with a dynamic index vector operand.
-    Lowers 1:1 to `pto.vselr` at the VPTO level.
+    Lowers 1:1 to `pto.vselr` for contiguous vectors with exactly 256 lanes for
+    8-bit elements, 128 lanes for 16-bit elements, or 64 lanes for 32-bit
+    elements.  Source, index, and result use the same lane count, and the index
+    element storage width must match the source element storage width.  Other
+    lane counts are not supported by this operation.
 
     Example:
     ```
-    %r = pto.vmi.vselr %src, %idx : !pto.vmi.vreg<64xf16>, !pto.vmi.vreg<4xi16> -> !pto.vmi.vreg<4xf16>
+    %r = pto.vmi.vselr %src, %idx : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xi16> -> !pto.vmi.vreg<128xf16>
     ```
   }];
   let arguments = (ins

--- a/include/PTO/Transforms/VMILayoutSupport.h
+++ b/include/PTO/Transforms/VMILayoutSupport.h
@@ -194,6 +194,12 @@ struct VMIHistogramLayoutFact {
   VMILayoutAttr resultLayout;
 };
 
+struct VMIVselrLayoutFact {
+  VMILayoutAttr sourceLayout;
+  VMILayoutAttr indexLayout;
+  VMILayoutAttr resultLayout;
+};
+
 class VMILayoutSupport {
 public:
   FailureOr<VMILoadLayoutFact>
@@ -392,6 +398,17 @@ public:
 
   FailureOr<VMIHistogramLayoutFact>
   getVchistLayoutFact(VMIVchistOp op, std::string *reason = nullptr) const;
+
+  FailureOr<VMIVselrLayoutFact>
+  getPreferredVselrLayoutFact(VMIVselrOp op,
+                              std::string *reason = nullptr) const;
+
+  FailureOr<VMIVselrLayoutFact>
+  getVselrLayoutFact(VMIVselrOp op,
+                     std::string *reason = nullptr) const;
+
+  LogicalResult getVselrSupport(VMIVselrOp op,
+                                std::string *reason = nullptr) const;
 
   LogicalResult getGroupReduceAddFSupport(VMIGroupReduceAddFOp op,
                                           std::string *reason = nullptr) const;

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -3829,6 +3829,17 @@ LogicalResult VMIVselrOp::verify() {
   if (!isa<IntegerType>(indexType.getElementType()))
     return emitOpError("requires index element type to be integer");
 
+  unsigned sourceBits =
+      pto::getPTOStorageElemBitWidth(sourceType.getElementType());
+  unsigned indexBits =
+      pto::getPTOStorageElemBitWidth(indexType.getElementType());
+  if (sourceBits != 8 && sourceBits != 16 && sourceBits != 32)
+    return emitOpError(
+        "requires source/result element storage width to be 8, 16, or 32 bits");
+  if (indexBits != sourceBits)
+    return emitOpError(
+        "requires index element storage width to match source element storage width");
+
   bool sourceHasLayout = isLayoutAssigned(sourceType);
   bool indexHasLayout = isLayoutAssigned(indexType);
   bool resultHasLayout = isLayoutAssigned(resultType);

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -798,6 +798,18 @@ struct LayoutSolver {
           return WalkResult::interrupt();
         return WalkResult::advance();
       }
+      if (auto vselr = dyn_cast<VMIVselrOp>(op)) {
+        VMILayoutSupport supports;
+        FailureOr<VMIVselrLayoutFact> fact =
+            supports.getPreferredVselrLayoutFact(vselr);
+        if (failed(fact))
+          return WalkResult::advance();
+        requestDataUse(vselr.getSourceMutable(), fact->sourceLayout);
+        requestDataUse(vselr.getIndexMutable(), fact->indexLayout);
+        if (failed(setNaturalLayout(vselr.getResult(), fact->resultLayout, op)))
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      }
       if (auto activePrefix = dyn_cast<VMIActivePrefixIndexOp>(op)) {
         if (failed(setNaturalLayout(activePrefix.getResult(),
                                     getContiguousLayout(), op)))

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -786,6 +786,28 @@ static constexpr GroupBroadcastLayoutPattern kGroupBroadcastLayoutPatterns[] = {
     {gbFull(4), gs(1), d(4)},
 };
 
+struct VselrLayoutPattern {
+  ElementBitsPattern elementBits;
+  ElementCountPattern sourceElements;
+  ElementCountPattern indexElements;
+  ElementCountPattern resultElements;
+  PhysicalChunkCountPattern sourceChunks;
+  PhysicalChunkCountPattern indexChunks;
+  PhysicalChunkCountPattern resultChunks;
+  LayoutPattern sourceLayout;
+  LayoutPattern indexLayout;
+  LayoutPattern resultLayout;
+};
+
+static constexpr VselrLayoutPattern kVselrLayoutPatterns[] = {
+    {bits<8>(), N<256>(), N<256>(), N<256>(), chunk<1>(), chunk<1>(),
+     chunk<1>(), c(), c(), c()},
+    {bits<16>(), N<128>(), N<128>(), N<128>(), chunk<1>(), chunk<1>(),
+     chunk<1>(), c(), c(), c()},
+    {bits<32>(), N<64>(), N<64>(), N<64>(), chunk<1>(), chunk<1>(),
+     chunk<1>(), c(), c(), c()},
+};
+
 struct HistogramLayoutPattern {
   LayoutPattern accLayout;
   LayoutPattern sourceLayout;
@@ -1086,11 +1108,121 @@ static VMIInterleaveLayoutFact materializeInterleaveLayoutFact(
   return fact;
 }
 
+static VMIVselrLayoutFact
+materializeVselrLayoutFact(MLIRContext *ctx,
+                           const VselrLayoutPattern &pattern) {
+  return VMIVselrLayoutFact{
+      materializeLayoutPattern(ctx, pattern.sourceLayout),
+      materializeLayoutPattern(ctx, pattern.indexLayout),
+      materializeLayoutPattern(ctx, pattern.resultLayout)};
+}
+
+static FailureOr<int64_t> getPhysicalArityForLayout(VMIVRegType type,
+                                                     VMILayoutAttr layout) {
+  auto assignedType = VMIVRegType::get(
+      type.getContext(), type.getElementCount(), type.getElementType(), layout);
+  return getVMIPhysicalArity(assignedType);
+}
+
+static bool matchesVselrLayoutPattern(const VselrLayoutPattern &pattern,
+                                      VMIVselrOp op,
+                                      const VMIVselrLayoutFact &fact) {
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  auto indexType = cast<VMIVRegType>(op.getIndex().getType());
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  unsigned sourceBits =
+      pto::getPTOStorageElemBitWidth(sourceType.getElementType());
+  unsigned indexBits =
+      pto::getPTOStorageElemBitWidth(indexType.getElementType());
+  if (sourceType.getElementType() != resultType.getElementType() ||
+      indexType.getElementCount() != resultType.getElementCount() ||
+      sourceBits != indexBits ||
+      !matchesElementBitsPattern(pattern.elementBits, sourceBits) ||
+      !matchesElementCountPattern(pattern.sourceElements,
+                                  sourceType.getElementCount()) ||
+      !matchesElementCountPattern(pattern.indexElements,
+                                  indexType.getElementCount()) ||
+      !matchesElementCountPattern(pattern.resultElements,
+                                  resultType.getElementCount()))
+    return false;
+
+  FailureOr<int64_t> sourceArity =
+      getPhysicalArityForLayout(sourceType, fact.sourceLayout);
+  FailureOr<int64_t> indexArity =
+      getPhysicalArityForLayout(indexType, fact.indexLayout);
+  FailureOr<int64_t> resultArity =
+      getPhysicalArityForLayout(resultType, fact.resultLayout);
+  return succeeded(sourceArity) && succeeded(indexArity) &&
+         succeeded(resultArity) &&
+         matchesPhysicalChunkCountPattern(pattern.sourceChunks,
+                                          *sourceArity) &&
+         matchesPhysicalChunkCountPattern(pattern.indexChunks, *indexArity) &&
+         matchesPhysicalChunkCountPattern(pattern.resultChunks, *resultArity);
+}
+
 } // namespace
 
 //===----------------------------------------------------------------------===//
 // Query implementations
 //===----------------------------------------------------------------------===//
+
+FailureOr<VMIVselrLayoutFact>
+VMILayoutSupport::getPreferredVselrLayoutFact(
+    VMIVselrOp op, std::string *reason) const {
+  auto fail = [&](const Twine &message) -> FailureOr<VMIVselrLayoutFact> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  for (const VselrLayoutPattern &pattern : kVselrLayoutPatterns) {
+    VMIVselrLayoutFact fact =
+        materializeVselrLayoutFact(op.getContext(), pattern);
+    if (matchesVselrLayoutPattern(pattern, op, fact))
+      return fact;
+  }
+  return fail("vselr requires contiguous layouts and exactly N=256 for 8-bit, "
+              "N=128 for 16-bit, or N=64 for 32-bit elements");
+}
+
+FailureOr<VMIVselrLayoutFact>
+VMILayoutSupport::getVselrLayoutFact(VMIVselrOp op,
+                                     std::string *reason) const {
+  auto fail = [&](const Twine &message) -> FailureOr<VMIVselrLayoutFact> {
+    if (reason)
+      *reason = message.str();
+    return failure();
+  };
+
+  auto sourceType = cast<VMIVRegType>(op.getSource().getType());
+  auto indexType = cast<VMIVRegType>(op.getIndex().getType());
+  auto resultType = cast<VMIVRegType>(op.getResult().getType());
+  VMIVselrLayoutFact assignedFact{sourceType.getLayoutAttr(),
+                                  indexType.getLayoutAttr(),
+                                  resultType.getLayoutAttr()};
+  if (!assignedFact.sourceLayout || !assignedFact.indexLayout ||
+      !assignedFact.resultLayout)
+    return fail("vselr requires assigned source/index/result layouts");
+
+  for (const VselrLayoutPattern &pattern : kVselrLayoutPatterns) {
+    VMIVselrLayoutFact tableFact =
+        materializeVselrLayoutFact(op.getContext(), pattern);
+    if (assignedFact.sourceLayout != tableFact.sourceLayout ||
+        assignedFact.indexLayout != tableFact.indexLayout ||
+        assignedFact.resultLayout != tableFact.resultLayout ||
+        !matchesVselrLayoutPattern(pattern, op, assignedFact))
+      continue;
+    return assignedFact;
+  }
+  return fail("vselr requires contiguous layouts and exactly N=256 for 8-bit, "
+              "N=128 for 16-bit, or N=64 for 32-bit elements");
+}
+
+LogicalResult
+VMILayoutSupport::getVselrSupport(VMIVselrOp op,
+                                  std::string *reason) const {
+  return getVselrLayoutFact(op, reason);
+}
 
 FailureOr<VMIGroupReduceLayoutFact>
 VMILayoutSupport::getPreferredGroupReduceLayoutFact(VMIVRegType sourceType,

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -800,7 +800,13 @@ struct VselrLayoutPattern {
 };
 
 static constexpr VselrLayoutPattern kVselrLayoutPatterns[] = {
+    {bits<8>(), N<64>(), N<64>(), N<64>(), chunk<1>(), chunk<1>(),
+     chunk<1>(), c(), c(), c()},
+    {bits<8>(), N<128>(), N<128>(), N<128>(), chunk<1>(), chunk<1>(),
+     chunk<1>(), c(), c(), c()},
     {bits<8>(), N<256>(), N<256>(), N<256>(), chunk<1>(), chunk<1>(),
+     chunk<1>(), c(), c(), c()},
+    {bits<16>(), N<64>(), N<64>(), N<64>(), chunk<1>(), chunk<1>(),
      chunk<1>(), c(), c(), c()},
     {bits<16>(), N<128>(), N<128>(), N<128>(), chunk<1>(), chunk<1>(),
      chunk<1>(), c(), c(), c()},
@@ -1181,8 +1187,9 @@ VMILayoutSupport::getPreferredVselrLayoutFact(
     if (matchesVselrLayoutPattern(pattern, op, fact))
       return fact;
   }
-  return fail("vselr requires contiguous layouts and exactly N=256 for 8-bit, "
-              "N=128 for 16-bit, or N=64 for 32-bit elements");
+  return fail("vselr requires contiguous layouts and supports N=64, 128, or "
+              "256 for 8-bit, N=64 or 128 for 16-bit, and N=64 for 32-bit "
+              "elements");
 }
 
 FailureOr<VMIVselrLayoutFact>
@@ -1214,8 +1221,9 @@ VMILayoutSupport::getVselrLayoutFact(VMIVselrOp op,
       continue;
     return assignedFact;
   }
-  return fail("vselr requires contiguous layouts and exactly N=256 for 8-bit, "
-              "N=128 for 16-bit, or N=64 for 32-bit elements");
+  return fail("vselr requires contiguous layouts and supports N=64, 128, or "
+              "256 for 8-bit, N=64 or 128 for 16-bit, and N=64 for 32-bit "
+              "elements");
 }
 
 LogicalResult

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -12714,8 +12714,8 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
       vselr.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.vselr supports only contiguous lane_stride=1 layouts "
-             "with N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit "
-             "elements ("
+             "with N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, "
+             "or N=64 for 32-bit elements ("
           << reason << ")";
       return WalkResult::interrupt();
     }

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -8954,6 +8954,47 @@ struct OneToNVMISelectOpPattern : OpConversionPattern<VMISelectOp> {
   }
 };
 
+struct OneToNVMIVselrOpPattern : OpConversionPattern<VMIVselrOp> {
+  using OpConversionPattern<VMIVselrOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(VMIVselrOp op, OneToNOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ValueRange sourceParts = adaptor.getSource();
+    ValueRange indexParts = adaptor.getIndex();
+    FailureOr<SmallVector<Type>> maybeResultTypes =
+        getConvertedResultTypes(op, 0, *this->getTypeConverter());
+    if (failed(maybeResultTypes))
+      return failure();
+    SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
+
+    if (sourceParts.size() != 1 || indexParts.size() != 1 ||
+        resultTypes.size() != 1)
+      return rewriter.notifyMatchFailure(
+          op, "vselr supports only one physical source/index/result part");
+
+    Value source = sourceParts.front();
+    Value index = indexParts.front();
+    auto sourceType = dyn_cast<VRegType>(source.getType());
+    auto indexType = dyn_cast<VRegType>(index.getType());
+    auto resultType = dyn_cast<VRegType>(resultTypes.front());
+    if (!sourceType || !indexType || !resultType ||
+        sourceType != resultType ||
+        sourceType.getElementCount() != indexType.getElementCount() ||
+        pto::getPTOStorageElemBitWidth(sourceType.getElementType()) !=
+            pto::getPTOStorageElemBitWidth(indexType.getElementType()))
+      return rewriter.notifyMatchFailure(
+          op, "vselr physical source/index/result type mismatch");
+
+    Value result =
+        rewriter.create<VselrOp>(op.getLoc(), resultType, source, index)
+            .getResult();
+    replaceOpWithFlatConvertedValues(rewriter, op, result,
+                                     *this->getTypeConverter());
+    return success();
+  }
+};
+
 struct OneToNVMIActivePrefixIndexOpPattern
     : OpConversionPattern<VMIActivePrefixIndexOp> {
   using OpConversionPattern<
@@ -11514,7 +11555,8 @@ void populateVMIConversionPatterns(
       OneToNVMIBinaryOpPattern<VMIShRSIOp, VshrOp>,
       OneToNVMIUnaryOpPattern<VMINotOp, VnotOp>,
       OneToNVMICmpOpPattern<VMICmpFOp>, OneToNVMICmpOpPattern<VMICmpIOp>,
-      OneToNVMISelectOpPattern, OneToNVMIActivePrefixIndexOpPattern,
+      OneToNVMISelectOpPattern, OneToNVMIVselrOpPattern,
+      OneToNVMIActivePrefixIndexOpPattern,
       OneToNVMICompressOpPattern, OneToNVMICompressStoreOpPattern,
       OneToNVMIReduceAddIOpPattern, OneToNVMIReduceAddFOpPattern,
       OneToNVMIGroupBroadcastOpPattern, OneToNVMIVdhistOpPattern,
@@ -12169,6 +12211,12 @@ checkSupportedReluShape(VMIReluOp op, std::string *reason = nullptr) {
   return success();
 }
 
+LogicalResult
+checkSupportedVselrShape(VMIVselrOp op, std::string *reason = nullptr) {
+  VMILayoutSupport supports;
+  return supports.getVselrSupport(op, reason);
+}
+
 void emitEnsureLayoutMaterializationError(VMIEnsureLayoutOp ensure,
                                           VMIVRegType sourceType,
                                           VMIVRegType resultType,
@@ -12659,6 +12707,18 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
       return emitMaskableUnsupported(
           op, "pto.vmi.select",
           cast<VMIVRegType>(select.getResult().getType()));
+    if (auto vselr = dyn_cast<VMIVselrOp>(op)) {
+      std::string reason;
+      if (succeeded(checkSupportedVselrShape(vselr, &reason)))
+        return WalkResult::advance();
+      vselr.emitError()
+          << kVMIDiagUnsupportedPrefix
+          << "pto.vmi.vselr supports only contiguous lane_stride=1 layouts "
+             "with N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit "
+             "elements ("
+          << reason << ")";
+      return WalkResult::interrupt();
+    }
 
     if (auto cmpf = dyn_cast<VMICmpFOp>(op)) {
       WalkResult physical = emitMaskableUnsupported(

--- a/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
+++ b/ptodsl/docs/user_guide/14-vmi-virtual-instruction-set.md
@@ -747,6 +747,12 @@ out = pto.vmi.vselr(src, idx)
 **Constraints**:
 - The result type is inferred directly from `source`.
 - `index` must be an integer-typed VMI vector.
+- Source and index element storage widths must match and be 8, 16, or 32 bits.
+- Source, index, and result must use contiguous layout. The supported shapes
+  are exactly 256 lanes for 8-bit elements, 128 lanes for 16-bit elements, or
+  64 lanes for 32-bit elements.
+- Every index value must identify a valid lane in `source`; out-of-range index
+  behavior is unspecified.
 
 ---
 

--- a/test/lit/vmi_new/vmi_to_vpto_vselr.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vselr.pto
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment | FileCheck %s --check-prefix=ASSIGN
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s --check-prefix=LOWER --implicit-check-not=pto.vmi.
+
+module {
+  func.func @vselr_ui32(%source: !pto.vmi.vreg<64xui32>,
+                        %index: !pto.vmi.vreg<64xui32>)
+      -> !pto.vmi.vreg<64xui32> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<64xui32>, !pto.vmi.vreg<64xui32>
+        -> !pto.vmi.vreg<64xui32>
+    return %result : !pto.vmi.vreg<64xui32>
+  }
+
+  func.func @vselr_f32(%source: !pto.vmi.vreg<64xf32>,
+                       %index: !pto.vmi.vreg<64xi32>)
+      -> !pto.vmi.vreg<64xf32> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xi32>
+        -> !pto.vmi.vreg<64xf32>
+    return %result : !pto.vmi.vreg<64xf32>
+  }
+
+  func.func @vselr_f16(%source: !pto.vmi.vreg<128xf16>,
+                       %index: !pto.vmi.vreg<128xi16>)
+      -> !pto.vmi.vreg<128xf16> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<128xf16>, !pto.vmi.vreg<128xi16>
+        -> !pto.vmi.vreg<128xf16>
+    return %result : !pto.vmi.vreg<128xf16>
+  }
+
+  func.func @vselr_ui8_full(%source: !pto.vmi.vreg<256xui8>,
+                            %index: !pto.vmi.vreg<256xui8>)
+      -> !pto.vmi.vreg<256xui8> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<256xui8>, !pto.vmi.vreg<256xui8>
+        -> !pto.vmi.vreg<256xui8>
+    return %result : !pto.vmi.vreg<256xui8>
+  }
+
+}
+
+// ASSIGN-COUNT-12: #pto.vmi.layout<contiguous>
+
+// LOWER-LABEL: func.func @vselr_ui32(
+// LOWER: %[[UI32:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<64xui32>, !pto.vreg<64xui32> -> !pto.vreg<64xui32>
+// LOWER: return %[[UI32]] : !pto.vreg<64xui32>
+
+// LOWER-LABEL: func.func @vselr_f32(
+// LOWER: %[[F32:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<64xf32>, !pto.vreg<64xi32> -> !pto.vreg<64xf32>
+// LOWER: return %[[F32]] : !pto.vreg<64xf32>
+
+// LOWER-LABEL: func.func @vselr_f16(
+// LOWER: %[[F16:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<128xf16>, !pto.vreg<128xi16> -> !pto.vreg<128xf16>
+// LOWER: return %[[F16]] : !pto.vreg<128xf16>
+
+// LOWER-LABEL: func.func @vselr_ui8_full(
+// LOWER: %[[UI8:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<256xui8>, !pto.vreg<256xui8> -> !pto.vreg<256xui8>
+// LOWER: return %[[UI8]] : !pto.vreg<256xui8>

--- a/test/lit/vmi_new/vmi_to_vpto_vselr.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vselr.pto
@@ -46,9 +46,36 @@ module {
     return %result : !pto.vmi.vreg<256xui8>
   }
 
+  func.func @vselr_ui8_128(%source: !pto.vmi.vreg<128xui8>,
+                           %index: !pto.vmi.vreg<128xui8>)
+      -> !pto.vmi.vreg<128xui8> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<128xui8>, !pto.vmi.vreg<128xui8>
+        -> !pto.vmi.vreg<128xui8>
+    return %result : !pto.vmi.vreg<128xui8>
+  }
+
+  func.func @vselr_ui8_64(%source: !pto.vmi.vreg<64xui8>,
+                          %index: !pto.vmi.vreg<64xui8>)
+      -> !pto.vmi.vreg<64xui8> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<64xui8>, !pto.vmi.vreg<64xui8>
+        -> !pto.vmi.vreg<64xui8>
+    return %result : !pto.vmi.vreg<64xui8>
+  }
+
+  func.func @vselr_ui16_64(%source: !pto.vmi.vreg<64xui16>,
+                           %index: !pto.vmi.vreg<64xui16>)
+      -> !pto.vmi.vreg<64xui16> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<64xui16>, !pto.vmi.vreg<64xui16>
+        -> !pto.vmi.vreg<64xui16>
+    return %result : !pto.vmi.vreg<64xui16>
+  }
+
 }
 
-// ASSIGN-COUNT-12: #pto.vmi.layout<contiguous>
+// ASSIGN-COUNT-21: #pto.vmi.layout<contiguous>
 
 // LOWER-LABEL: func.func @vselr_ui32(
 // LOWER: %[[UI32:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<64xui32>, !pto.vreg<64xui32> -> !pto.vreg<64xui32>
@@ -65,3 +92,15 @@ module {
 // LOWER-LABEL: func.func @vselr_ui8_full(
 // LOWER: %[[UI8:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<256xui8>, !pto.vreg<256xui8> -> !pto.vreg<256xui8>
 // LOWER: return %[[UI8]] : !pto.vreg<256xui8>
+
+// LOWER-LABEL: func.func @vselr_ui8_128(
+// LOWER: %[[UI8_128:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<256xui8>, !pto.vreg<256xui8> -> !pto.vreg<256xui8>
+// LOWER: return %[[UI8_128]] : !pto.vreg<256xui8>
+
+// LOWER-LABEL: func.func @vselr_ui8_64(
+// LOWER: %[[UI8_64:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<256xui8>, !pto.vreg<256xui8> -> !pto.vreg<256xui8>
+// LOWER: return %[[UI8_64]] : !pto.vreg<256xui8>
+
+// LOWER-LABEL: func.func @vselr_ui16_64(
+// LOWER: %[[UI16_64:.*]] = pto.vselr %{{.*}}, %{{.*}} : !pto.vreg<128xui16>, !pto.vreg<128xui16> -> !pto.vreg<128xui16>
+// LOWER: return %[[UI16_64]] : !pto.vreg<128xui16>

--- a/test/lit/vmi_new/vmi_to_vpto_vselr_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vselr_invalid.pto
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -split-input-file -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto 2>&1 | FileCheck %s
+
+module {
+  func.func @vselr_width_mismatch(
+      %source: !pto.vmi.vreg<64xf32>, %index: !pto.vmi.vreg<64xi16>) {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<64xf32>, !pto.vmi.vreg<64xi16>
+        -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// CHECK: 'pto.vmi.vselr' op requires index element storage width to match source element storage width
+
+// -----
+
+module {
+  func.func @vselr_short_f16(
+      %source: !pto.vmi.vreg<4xf16>, %index: !pto.vmi.vreg<4xi16>) {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<4xf16>, !pto.vmi.vreg<4xi16>
+        -> !pto.vmi.vreg<4xf16>
+    return
+  }
+}
+
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
+// CHECK-SAME: N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit
+// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements
+
+// -----
+
+module {
+  func.func @vselr_multichunk_source(
+      %source: !pto.vmi.vreg<128xf32>, %index: !pto.vmi.vreg<64xi32>) {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<64xi32>
+        -> !pto.vmi.vreg<64xf32>
+    return
+  }
+}
+
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
+// CHECK-SAME: N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit
+// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements
+
+// -----
+
+module {
+  func.func @vselr_all_multichunk(
+      %source: !pto.vmi.vreg<128xf32>, %index: !pto.vmi.vreg<128xi32>) {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<128xf32>, !pto.vmi.vreg<128xi32>
+        -> !pto.vmi.vreg<128xf32>
+    return
+  }
+}
+
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
+// CHECK-SAME: N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit
+// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements

--- a/test/lit/vmi_new/vmi_to_vpto_vselr_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vselr_invalid.pto
@@ -33,8 +33,8 @@ module {
 }
 
 // CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
-// CHECK-SAME: N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit
-// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements
+// CHECK-SAME: N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, or N=64 for 32-bit
+// CHECK-SAME: vselr requires contiguous layouts and supports N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, and N=64 for 32-bit elements
 
 // -----
 
@@ -49,8 +49,8 @@ module {
 }
 
 // CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
-// CHECK-SAME: N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit
-// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements
+// CHECK-SAME: N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, or N=64 for 32-bit
+// CHECK-SAME: vselr requires contiguous layouts and supports N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, and N=64 for 32-bit elements
 
 // -----
 
@@ -65,5 +65,5 @@ module {
 }
 
 // CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
-// CHECK-SAME: N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit
-// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements
+// CHECK-SAME: N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, or N=64 for 32-bit
+// CHECK-SAME: vselr requires contiguous layouts and supports N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, and N=64 for 32-bit elements

--- a/test/lit/vmi_new/vmi_to_vpto_vselr_layout_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vselr_layout_invalid.pto
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: not pto-test-opt %s -vmi-to-vpto 2>&1 | FileCheck %s
+
+module {
+  func.func @vselr_non_contiguous_layout(
+      %source: !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous, lane_stride = 2>>,
+      %index: !pto.vmi.vreg<32xi32, #pto.vmi.layout<contiguous, lane_stride = 2>>)
+      -> !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous, lane_stride = 2>> {
+    %result = pto.vmi.vselr %source, %index
+        : !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous, lane_stride = 2>>,
+          !pto.vmi.vreg<32xi32, #pto.vmi.layout<contiguous, lane_stride = 2>>
+        -> !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous, lane_stride = 2>>
+    return %result
+        : !pto.vmi.vreg<32xf32, #pto.vmi.layout<contiguous, lane_stride = 2>>
+  }
+}
+
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
+// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements

--- a/test/lit/vmi_new/vmi_to_vpto_vselr_layout_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_vselr_layout_invalid.pto
@@ -23,4 +23,4 @@ module {
 }
 
 // CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.vselr supports only contiguous lane_stride=1 layouts
-// CHECK-SAME: vselr requires contiguous layouts and exactly N=256 for 8-bit, N=128 for 16-bit, or N=64 for 32-bit elements
+// CHECK-SAME: vselr requires contiguous layouts and supports N=64, 128, or 256 for 8-bit, N=64 or 128 for 16-bit, and N=64 for 32-bit elements


### PR DESCRIPTION
## 背景

`pto.vmi.vselr` 已有 PTODSL/ODS surface 和目标 `pto.vselr` 后端支持，但缺少 VMI 到 VPTO 的 conversion pattern，导致合法的 VMI IR 在 conversion 阶段残留并报 `failed to legalize operation 'pto.vmi.vselr'`。

关联 issue：https://github.com/mouliangyu/PTOAS/issues/522

## 改动

- 为 `pto.vmi.vselr` 增加 VMI -> VPTO lowering，在合法形态下生成一条 `pto.vselr`。
- 在 `VMILayoutSupport` 的表中集中声明受支持的逻辑 shape，要求 source/index/result 均为 contiguous 且只占一个物理 part。
- layout assignment 只消费 support 返回的 preferred layout fact；布局冲突仍交给 propagator materialize `ensure_layout`。
- 在 VMI verifier 中检查 index 为整数，且 index/source storage width 一致。
- 对其他 lane count、非 contiguous 和物理 arity/type 不匹配形态给出明确 `VMI-UNSUPPORTED` 诊断，避免 silent wrong-code。
- 将 `vselr` 明确归为 Category C（contiguous-required），并更新 VMI/PTODSL 文档和 Appendix，说明 `result[i] = source[index[i]]` 语义及逻辑 shape 支持矩阵。
- 添加满宽和短向量 positive、width mismatch、其他 `N`、非 contiguous、multi-part 和边界回归测试。

旧 issue 附件中的 `result_type=` 已不属于当前 PTODSL API。本 PR 不恢复该参数；附件迁移为当前的 `pto.vmi.vselr(source, index)` 后用于验证核心 lowering。

## 支持范围

- contiguous layout
- 8-bit：`N ∈ {64, 128, 256}`
- 16-bit：`N ∈ {64, 128}`
- 32-bit：`N = 64`

短逻辑向量仍 lowering 为一条满宽物理 `pto.vselr`，例如 `128xui8`
lower 为一个 `256xui8` 物理寄存器；只观察前 128 个逻辑 lane，合法索引范围为
`[0, 128)`。需要两个或更多物理 part 的形态继续明确拒绝，避免错误地把跨 part
索引解释成独立 chunk 内索引。

## 验证

- `cmake --build build-llvm21 -j16 --target pto-test-opt`
- `llvm-lit -v build-llvm21/test/lit --filter 'vmi_to_vpto_vselr'`：3/3 passed
- `llvm-lit -v build-llvm21/test/lit --filter 'vmi_new/'`：461/461 passed
- 完整 lit：初次 1618 passed、1 unsupported、5 failed；其中 `vfsimt_size_patcher` 是直接运行 lit 前未构建测试工具，补建后单测通过。剩余 4 个均为既有 `tadd_*` Tile-to-UB FileCheck 失败，不涉及 VMI/vselr。
- 当前 API 的 issue 附件成功生成一条 `pto.vselr`，无残留 `pto.vmi`。
- LLVM emission 成功生成 `llvm.hivm.vselr.v64u32`。
- `git diff --check` clean。

未进行 NPU/CA simulator 运行时验证；目标 `pto.vselr` 的现有 runtime/backend 路径未在本 PR 中修改。
