### PR TITLE
feat(ptodsl): add scalar GM L1 bypass access

### DIFF
--- a/docs/isa/micro-isa/18-special-scalar.md
+++ b/docs/isa/micro-isa/18-special-scalar.md
@@ -237,11 +237,9 @@ Example:
 
 ## Scalar-Pipeline Memory Operations
 
-`pto.load_scalar` and `pto.store_scalar` access one element through the scalar
-pipeline. The pointer element type and memory space determine the accessed
-value type and storage domain. In PTODSL, pass `bypass_l1=True` to select the
-AICore GM device-memory form (`pto.ld_dev` / `pto.st_dev`) while keeping the
-same scalar-pipeline API.
+`pto.load_scalar` and `pto.store_scalar` access one element through the general
+scalar-memory interface. The pointer element type and memory space determine
+the accessed value type and storage domain.
 
 ### `pto.load_scalar`
 
@@ -257,9 +255,6 @@ same scalar-pipeline API.
   offset of type `index`.
 - **Result:** One scalar value of type `T`.
 - **Attributes:** None.
-- **PTODSL:** `pto.load_scalar(ptr, offset=0, bypass_l1=False)`. With
-  `bypass_l1=True`, the operation requires a GM pointer with an i8, i16, i32,
-  or i64 element type and emits `pto.ld_dev`.
 - **Semantics:** Read the element at `ptr + offset` through the scalar pipeline.
 
 ```text
@@ -284,9 +279,6 @@ value = memory[ptr.address + offset * sizeof(T)] as T
   `%offset` is an element offset of type `index`.
 - **Results:** None.
 - **Attributes:** None.
-- **PTODSL:** `pto.store_scalar(ptr, offset, value, bypass_l1=False)`. With
-  `bypass_l1=True`, the operation requires a GM pointer with an i8, i16, i32,
-  or i64 element type and emits `pto.st_dev`.
 - **Semantics:** Write `%value` to the element at `ptr + offset` through the
   scalar pipeline.
 
@@ -396,6 +388,6 @@ not establish ordering with other memory operations.
 
 | Requirement | Operation family |
 |-------------|------------------|
-| General typed scalar access through the scalar pipeline | `pto.load_scalar`, `pto.store_scalar` with `bypass_l1=False` |
-| Ordinary AICore integer GM access that bypasses local L1 | `pto.load_scalar`, `pto.store_scalar` with `bypass_l1=True` (emits `pto.ld_dev`, `pto.st_dev`) |
+| General typed scalar access through the scalar-memory interface | `pto.load_scalar`, `pto.store_scalar` |
+| Ordinary AICore integer GM access that bypasses local L1 | `pto.ld_dev`, `pto.st_dev` |
 | SIMT workitem scalar memory access | See [SIMT Ops](17-simt.md) |

--- a/docs/isa/micro-isa/18-special-scalar.md
+++ b/docs/isa/micro-isa/18-special-scalar.md
@@ -237,9 +237,11 @@ Example:
 
 ## Scalar-Pipeline Memory Operations
 
-`pto.load_scalar` and `pto.store_scalar` access one element through the general
-scalar-memory interface. The pointer element type and memory space determine
-the accessed value type and storage domain.
+`pto.load_scalar` and `pto.store_scalar` access one element through the scalar
+pipeline. The pointer element type and memory space determine the accessed
+value type and storage domain. In PTODSL, pass `bypass_l1=True` to select the
+AICore GM device-memory form (`pto.ld_dev` / `pto.st_dev`) while keeping the
+same scalar-pipeline API.
 
 ### `pto.load_scalar`
 
@@ -255,6 +257,9 @@ the accessed value type and storage domain.
   offset of type `index`.
 - **Result:** One scalar value of type `T`.
 - **Attributes:** None.
+- **PTODSL:** `pto.load_scalar(ptr, offset=0, bypass_l1=False)`. With
+  `bypass_l1=True`, the operation requires a GM pointer with an i8, i16, i32,
+  or i64 element type and emits `pto.ld_dev`.
 - **Semantics:** Read the element at `ptr + offset` through the scalar pipeline.
 
 ```text
@@ -279,6 +284,9 @@ value = memory[ptr.address + offset * sizeof(T)] as T
   `%offset` is an element offset of type `index`.
 - **Results:** None.
 - **Attributes:** None.
+- **PTODSL:** `pto.store_scalar(ptr, offset, value, bypass_l1=False)`. With
+  `bypass_l1=True`, the operation requires a GM pointer with an i8, i16, i32,
+  or i64 element type and emits `pto.st_dev`.
 - **Semantics:** Write `%value` to the element at `ptr + offset` through the
   scalar pipeline.
 
@@ -388,6 +396,6 @@ not establish ordering with other memory operations.
 
 | Requirement | Operation family |
 |-------------|------------------|
-| General typed scalar access through the scalar-memory interface | `pto.load_scalar`, `pto.store_scalar` |
-| Ordinary AICore integer GM access that bypasses local L1 | `pto.ld_dev`, `pto.st_dev` |
+| General typed scalar access through the scalar pipeline | `pto.load_scalar`, `pto.store_scalar` with `bypass_l1=False` |
+| Ordinary AICore integer GM access that bypasses local L1 | `pto.load_scalar`, `pto.store_scalar` with `bypass_l1=True` (emits `pto.ld_dev`, `pto.st_dev`) |
 | SIMT workitem scalar memory access | See [SIMT Ops](17-simt.md) |

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -261,6 +261,7 @@ def PTOStgOp : PTO_SimtOp<"stg", [
 }
 
 def PTOLdDevOp : PTO_MicroOp<"ld_dev", [
+    OpPipeInterface,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let summary = "Load one scalar GM element while bypassing the local L1 data cache.";
@@ -283,9 +284,14 @@ def PTOLdDevOp : PTO_MicroOp<"ld_dev", [
   let assemblyFormat = [{
     $ptr `[` $offset `]` attr-dict `:` type($ptr) `->` type($value)
   }];
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_S; }
+  }];
 }
 
 def PTOStDevOp : PTO_MicroOp<"st_dev", [
+    OpPipeInterface,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let summary = "Store one scalar GM element while bypassing the local L1 data cache.";
@@ -308,6 +314,10 @@ def PTOStDevOp : PTO_MicroOp<"st_dev", [
 
   let assemblyFormat = [{
     $value `,` $ptr `[` $offset `]` attr-dict `:` type($ptr) `,` type($value)
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::pto::PIPE getPipe() { return ::mlir::pto::PIPE::PIPE_S; }
   }];
 }
 

--- a/ptodsl/README.md
+++ b/ptodsl/README.md
@@ -361,6 +361,7 @@ Start here for the full reference:
 - `ptodsl/docs/user_guide/09-predicate-and-mask-ops.md`
 - `ptodsl/docs/user_guide/10-sync-ops.md`
 - `ptodsl/docs/user_guide/13-simt-micro-ops.md`
+- `ptodsl/docs/user_guide/15-special-scalar.md`
 
 ## How the IR check works
 

--- a/ptodsl/docs/user_guide/01-introduction.md
+++ b/ptodsl/docs/user_guide/01-introduction.md
@@ -324,7 +324,7 @@ Chapter 11 walks through this example in full detail.
 |---------------|---------------|
 | New to PTODSL | Chapter 2 (Quick Start), then Chapter 3 (Kernel Entries & Modules) |
 | Writing your first kernel | Chapter 2 → Chapter 4 (Type System) → Chapter 5 (Control Flow) |
-| Looking up a specific operation | Chapters 6–10, Chapter 13, and Chapter 14 (organized by topic) |
+| Looking up a specific operation | Chapters 6–10, Chapters 13–15 (organized by topic) |
 | Understanding the flash attention reference | Chapter 11 |
 
 **Chapter overview:**
@@ -345,3 +345,4 @@ Chapter 11 walks through this example in full detail.
 | 12 | Additional examples |
 | 13 | SIMT micro-ops |
 | 14 | The Virtual Micro-instruction Set (VMI): logical vector instructions, masks, and type-directed authoring |
+| 15 | Special scalar memory access: scalar-pipeline loads/stores, L1-bypassing GM access, and SIMT scalar access |

--- a/ptodsl/docs/user_guide/15-special-scalar.md
+++ b/ptodsl/docs/user_guide/15-special-scalar.md
@@ -1,0 +1,103 @@
+# 15. Special Scalar Memory Access
+
+This chapter covers scalar memory operations that are useful when a kernel
+needs one element at a time outside a tile transfer. It explains the two
+forms of `pto.load_scalar` / `pto.store_scalar` and how they differ from the
+SIMT-only `scalar.load` / `scalar.store` and `pto.ldg` / `pto.stg` operations.
+
+## 15.1 Choosing a scalar access form
+
+Use the operation that matches both the execution context and the memory
+behavior you need:
+
+| Operation | Execution context | Memory/type contract | Use it for |
+|-----------|-------------------|----------------------|------------|
+| `pto.load_scalar` / `pto.store_scalar` | Ordinary `@pto.jit` entry | One element through a typed pointer; the element type is inferred from the pointer | Scalar-pipeline access with the normal scalar-memory behavior |
+| `pto.load_scalar(..., bypass_l1=True)` / `pto.store_scalar(..., bypass_l1=True)` | Ordinary `@pto.jit` entry | GM pointer with an `i8`, `i16`, `i32`, or `i64` element type | Integer GM metadata or control values that must bypass the local L1 data cache |
+| `scalar.load` / `scalar.store` | `@pto.simt` helper or SIMT scope | One scalar per work-item; supports typed pointer and tile-element forms | Per-work-item scalar computation |
+| `pto.ldg` / `pto.stg` | `@pto.simt` helper or SIMT scope | GM pointer, optional cache controls, and scalar or supported packed element types | SIMT GM access when cache policy or packed values matter |
+
+`offset` is an element offset in all four surfaces. It is not a byte offset.
+For example, offset `3` on an `i32` pointer addresses the fourth `i32`
+element, not byte address `base + 3`.
+
+## 15.2 Scalar-pipeline access
+
+### `pto.load_scalar(ptr, offset=0, *, bypass_l1=False) -> ScalarType`
+
+Loads one element from `ptr` and returns a runtime PTO scalar. The result type
+is always the element type of `ptr`; no separate result-type argument is
+needed.
+
+With the default `bypass_l1=False`, `ptr` may refer to the memory space
+appropriate for the normal scalar-pipeline access. With
+`bypass_l1=True`, `ptr` must be a GM pointer whose element type is one of
+`pto.i8`, `pto.i16`, `pto.i32`, or `pto.i64`.
+
+### `pto.store_scalar(ptr, offset, value, *, bypass_l1=False) -> None`
+
+Stores one scalar `value` to `ptr[offset]`. The value must be compatible with
+the pointer element type. The `bypass_l1=True` form has the same GM and
+integer-type restrictions as the corresponding load.
+
+Both operations are ordinary AICore scalar-pipeline operations. They must not
+be placed inside a `@pto.simt` helper or SIMT execution scope. The bypass form
+only changes the local L1 data-cache behavior; it does not provide atomicity,
+memory ordering, synchronization, or an L2 cache policy.
+
+### Example: normal and L1-bypassing scalar access
+
+<!-- ptodsl-doc-test: {"mode":"compile","symbol":"special_scalar_access_probe","compile":{}} -->
+```python
+from ptodsl import pto
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def special_scalar_access_probe(
+    src: pto.ptr(pto.i32, "gm"),
+    dst: pto.ptr(pto.i32, "gm"),
+):
+    # Normal scalar-pipeline access.
+    value = pto.load_scalar(src, 1)
+    pto.store_scalar(dst, 1, value)
+
+    # Integer GM access that bypasses the local L1 data cache.
+    metadata = pto.load_scalar(src, 3, bypass_l1=True)
+    pto.store_scalar(dst, 3, metadata, bypass_l1=True)
+```
+
+The two calls in the second pair still use the PTODSL
+`load_scalar`/`store_scalar` names. The `bypass_l1` flag selects their
+L1-bypassing memory behavior while preserving the scalar-pipeline API.
+
+## 15.3 Constraints and diagnostics
+
+The following combinations are rejected during compilation:
+
+- `bypass_l1` is not a Python `bool`.
+- `bypass_l1=True` is used with a non-GM pointer.
+- `bypass_l1=True` is used with a floating-point or unsupported pointer
+  element type.
+- Either bypass operation is placed in a SIMT execution scope.
+- A store value does not match the destination pointer's element type.
+
+Use `pto.castptr` only when you genuinely have an integer address and know its
+memory space and element type. For ordinary GM tensors, pass the typed pointer
+from the kernel entry directly.
+
+## 15.4 SIMT scalar and GM access
+
+`scalar.load` and `scalar.store` are intended for SIMT code. They execute one
+logical access per work-item and can use a tile element such as
+`scalar.load(tile[row, col])` or an explicit typed pointer and element offset.
+They are the right choice when the surrounding computation is already inside
+`@pto.simt`.
+
+`pto.ldg` and `pto.stg` are the SIMT GM-specific forms. They provide explicit
+L1/L2 cache-policy arguments and support the broader scalar and packed value
+types accepted by the SIMT GM interface. They must remain inside a SIMT
+execution scope and should be chosen when those cache controls or packed
+values are part of the kernel contract.
+
+For a plain integer GM metadata access in an ordinary AICore entry, prefer
+`pto.load_scalar` / `pto.store_scalar` with `bypass_l1=True`.

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -2328,10 +2328,54 @@ def vmrgsort4(destination, source0, source1, source2, source3, count, config):
     )
 
 
-def load_scalar(ptr_value, offset=0, result_type=None):
-    """``pto.load_scalar`` – load one scalar from a pointer-like value."""
-    if result_type is None:
-        result_type = _pointer_element_type(ptr_value, context="load_scalar(ptr)")
+def _resolve_l1_bypass_scalar_pointer(ptr_value, *, context: str):
+    """Validate the GM integer pointer contract used by ``ld_dev``."""
+    raw_ptr = unwrap_surface_value(ptr_value)
+    try:
+        ptr_type = _pto.PtrType(raw_ptr.type)
+    except Exception as exc:
+        raise TypeError(f"{context} requires a typed PTO pointer") from exc
+
+    gm_space = _pto.AddressSpaceAttr.get(_pto.AddressSpace.GM)
+    if ptr_type.memory_space != gm_space:
+        raise TypeError(f"{context} requires a GM pointer, got {raw_ptr.type}")
+
+    elem_type = ptr_type.element_type
+    if not IntegerType.isinstance(elem_type) or IntegerType(elem_type).width not in (8, 16, 32, 64):
+        raise TypeError(
+            f"{context} supports only i8, i16, i32 or i64 pointer elements, "
+            f"got {elem_type}"
+        )
+    return raw_ptr, elem_type
+
+
+def _validate_scalar_l1_bypass(value, *, context: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{context} expects bypass_l1 to be a bool")
+    return value
+
+
+def load_scalar(ptr_value, offset=0, *, bypass_l1=False):
+    """Load one scalar through the scalar pipeline.
+
+    ``bypass_l1=True`` selects the AICore GM device-memory form and emits
+    ``pto.ld_dev``.  The bypass form requires a GM pointer with an i8, i16,
+    i32, or i64 element type and is valid only in an ordinary AICore entry.
+    """
+    bypass_l1 = _validate_scalar_l1_bypass(bypass_l1, context="load_scalar(...)")
+    if bypass_l1:
+        raw_ptr, elem_type = _resolve_l1_bypass_scalar_pointer(
+            ptr_value, context="load_scalar(..., bypass_l1=True)"
+        )
+        return wrap_surface_value(
+            _pto.PTOLdDevOp(
+                elem_type,
+                raw_ptr,
+                _coerce_index(offset, context="load_scalar(offset)"),
+            ).value
+        )
+
+    result_type = _pointer_element_type(ptr_value, context="load_scalar(ptr)")
     return wrap_surface_value(
         _pto.LoadScalarOp(
             _resolve(result_type),
@@ -2341,8 +2385,30 @@ def load_scalar(ptr_value, offset=0, result_type=None):
     )
 
 
-def store_scalar(ptr_value, offset, value):
-    """``pto.store_scalar`` – store one scalar to a pointer-like value."""
+def store_scalar(ptr_value, offset, value, *, bypass_l1=False):
+    """Store one scalar through the scalar pipeline.
+
+    ``bypass_l1=True`` selects the AICore GM device-memory form and emits
+    ``pto.st_dev``.  The bypass form requires a GM pointer with an i8, i16,
+    i32, or i64 element type and is valid only in an ordinary AICore entry.
+    """
+    bypass_l1 = _validate_scalar_l1_bypass(bypass_l1, context="store_scalar(...)")
+    if bypass_l1:
+        raw_ptr, elem_type = _resolve_l1_bypass_scalar_pointer(
+            ptr_value, context="store_scalar(..., bypass_l1=True)"
+        )
+        raw_value = coerce_scalar_to_type(
+            value,
+            elem_type,
+            context="store_scalar(..., bypass_l1=True)",
+        )
+        _pto.PTOStDevOp(
+            raw_value,
+            raw_ptr,
+            _coerce_index(offset, context="store_scalar(offset)"),
+        )
+        return
+
     _pto.StoreScalarOp(
         unwrap_surface_value(ptr_value),
         _coerce_index(offset, context="store_scalar(offset)"),

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -133,6 +133,30 @@ def host_vec_copy(
     pto.tile.store(o_tile, out)
 
 
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def scalar_pipeline_access_modes_probe(
+    src: pto.ptr(pto.i32, "gm"),
+    dst: pto.ptr(pto.i32, "gm"),
+):
+    normal = pto.load_scalar(src, 1)
+    pto.store_scalar(dst, 2, normal)
+    bypass = pto.load_scalar(src, 3, bypass_l1=True)
+    pto.store_scalar(dst, 4, bypass, bypass_l1=True)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def scalar_pipeline_bypass_ub_invalid_probe():
+    src = pto.castptr(pto.const(0, dtype=pto.i64), pto.ptr(pto.i32, "ub"))
+    pto.load_scalar(src, 0, bypass_l1=True)
+
+
+@pto.jit(target="a5", backend="vpto", mode="explicit")
+def scalar_pipeline_bypass_float_invalid_probe(
+    src: pto.ptr(pto.f32, "gm"),
+):
+    pto.load_scalar(src, 0, bypass_l1=True)
+
+
 @pto.jit(target="a5", mode="explicit")
 def host_vec_copy_explicit(
     A_ptr: pto.ptr(pto.f32, "gm"),
@@ -4072,6 +4096,32 @@ def main() -> None:
     default_compiled = host_vec_copy.compile()
     explicit_default = host_vec_copy.compile(BLOCK=128)
     block64 = host_vec_copy.compile(BLOCK=64)
+
+    scalar_pipeline_text = scalar_pipeline_access_modes_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        scalar_pipeline_text,
+        "scalar pipeline access mode specialization",
+    )
+    expect(
+        scalar_pipeline_text.count("pto.load_scalar") == 1
+        and scalar_pipeline_text.count("pto.store_scalar") == 1,
+        "default scalar pipeline accesses should remain load_scalar/store_scalar",
+    )
+    expect(
+        scalar_pipeline_text.count("pto.ld_dev") == 1
+        and scalar_pipeline_text.count("pto.st_dev") == 1,
+        "bypass_l1 scalar pipeline accesses should lower to ld_dev/st_dev",
+    )
+    expect_raises(
+        TypeError,
+        lambda: scalar_pipeline_bypass_ub_invalid_probe.compile().mlir_text(),
+        "requires a GM pointer",
+    )
+    expect_raises(
+        TypeError,
+        lambda: scalar_pipeline_bypass_float_invalid_probe.compile().mlir_text(),
+        "supports only i8, i16, i32 or i64",
+    )
 
     expect(default_compiled is explicit_default, "default constexpr compile should hit specialization cache")
     expect(default_compiled is not block64, "different constexpr values should materialize different specializations")


### PR DESCRIPTION
## Summary
- add `bypass_l1` to PTODSL `load_scalar`/`store_scalar`
- lower bypass accesses to `pto.ld_dev`/`pto.st_dev`
- infer `load_scalar` result type from the pointer element type
- document special-scalar memory access and add regression coverage

## Validation
- `check-dsl`: PASS (27/27)
- `check-pto`: 1529/1618 passed; 88 TileLib daemon timeout failures under parallel execution

Closes #1032