### PR TITLE
fix(vmi): grouped iota logical tails + group_size=1 vdup

### DIFF
--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5225,12 +5225,12 @@ FailureOr<Value> createIotaContiguousChunk(Location loc, Type resultType,
 ///
 /// Preferred recipes (O(1), independent of G = physVL/S):
 ///   * S == 1 → vdup(base)
-///   * S power-of-2 (all legal sub-VL S on this ISA) →
+///   * S power-of-2 integer (all legal sub-VL S on this ISA) →
 ///       ASC:  vadds(vand(vci(0), S-1), base)
 ///       DESC: vsub(vdup(base), vand(vci(0), S-1))
 ///
-/// Fallback for non-pow2 integer / float bases (rare): per-group
-/// vci(base) ∓ g*S + lane-range vsel.
+/// Residual fallback (non-integer base): per-group vci(base) ∓ g*S +
+/// lane-range vsel. Index iota is integer-only in practice.
 ///
 /// When S == physVL this is just `vci(base)` (single group fills the VL).
 FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -5229,6 +5229,7 @@ FailureOr<Value> createIotaContiguousChunk(Location loc, Type resultType,
 ///     take lanes [g*S, (g+1)*S) from adj
 ///
 /// When S == physVL this is just `vci(base)` (single group fills the VL).
+/// When S == 1 every lane equals `base` — one `vdup(base)` (not O(VL) vsel).
 FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
                                                Value base, int64_t groupSize,
                                                StringAttr orderAttr,
@@ -5241,17 +5242,28 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
   if (groupSize <= 0 || lanesPerPart % groupSize != 0)
     return failure();
 
+  FailureOr<Value> allMask =
+      createAllTrueMaskForVReg(loc, vregType, rewriter);
+  if (failed(allMask))
+    return failure();
+
+  // group_size==1: dst[i] = base for every lane — broadcast, not a ramp pack.
+  if (groupSize == 1) {
+    return rewriter
+        .create<VdupOp>(loc, resultType, base, *allMask,
+                        /*position=*/nullptr)
+        .getResult();
+  }
+
   StringRef order = orderAttr ? orderAttr.getValue() : StringRef("ASC");
   FailureOr<Value> full =
       createIotaContiguousChunk(loc, resultType, base, /*laneOffset=*/0,
                                 orderAttr, rewriter);
-  FailureOr<Value> allMask =
-      createAllTrueMaskForVReg(loc, vregType, rewriter);
   FailureOr<MaskType> maskType =
       getMaskTypeForVReg(vregType, rewriter.getContext());
   FailureOr<Value> zeroScalar =
       createScalarOffsetConstant(loc, base.getType(), 0, rewriter);
-  if (failed(full) || failed(allMask) || failed(maskType) || failed(zeroScalar))
+  if (failed(full) || failed(maskType) || failed(zeroScalar))
     return failure();
 
   int64_t groupsPerChunk = lanesPerPart / groupSize;
@@ -5413,8 +5425,14 @@ struct OneToNVMIIotaOpPattern : OpConversionPattern<IotaOp> {
             op, "grouped iota currently supports contiguous layout only; "
                 "ensure_layout to contiguous before lowering");
 
-      if (static_cast<int64_t>(resultTypes.size()) * *lanesPerPart !=
-          logicalLanes)
+      // Allow grouped logical tails: physical arity is ceil(L / physVL), so
+      // capacity may exceed L (e.g. L=32,group=2 → 1×VL64 with lanes 32..63
+      // inactive; L=96,group=3 → 2×VL64 with last chunk partial). Padding
+      // lanes keep the same periodic pattern; consumers/stores apply the
+      // ordinary contiguous tail mask.
+      int64_t expectedArity =
+          (logicalLanes + *lanesPerPart - 1) / *lanesPerPart;
+      if (static_cast<int64_t>(resultTypes.size()) != expectedArity)
         return rewriter.notifyMatchFailure(
             op, "grouped contiguous iota physical result count mismatch");
 

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -31,6 +31,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
@@ -5222,14 +5223,16 @@ FailureOr<Value> createIotaContiguousChunk(Location loc, Type resultType,
 /// Pack group-periodic ramps inside one physical VL when S < physVL and
 /// physVL % S == 0 (e.g. i32 L=64,group=2 → [base..base+31 | base..base+31]).
 ///
-/// Recipe (matches reduce/quant "mask + offset-by-S + VOR/Vsel"):
-///   full = vci(base)                         // [base+0 .. base+VL)
-///   for g in 0..G-1:
-///     adj = full ∓ g*S                       // ASC: −; DESC: +
-///     take lanes [g*S, (g+1)*S) from adj
+/// Preferred recipes (O(1), independent of G = physVL/S):
+///   * S == 1 → vdup(base)
+///   * S power-of-2 (all legal sub-VL S on this ISA) →
+///       ASC:  vadds(vand(vci(0), S-1), base)
+///       DESC: vsub(vdup(base), vand(vci(0), S-1))
+///
+/// Fallback for non-pow2 integer / float bases (rare): per-group
+/// vci(base) ∓ g*S + lane-range vsel.
 ///
 /// When S == physVL this is just `vci(base)` (single group fills the VL).
-/// When S == 1 every lane equals `base` — one `vdup(base)` (not O(VL) vsel).
 FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
                                                Value base, int64_t groupSize,
                                                StringAttr orderAttr,
@@ -5256,6 +5259,46 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
   }
 
   StringRef order = orderAttr ? orderAttr.getValue() : StringRef("ASC");
+  int64_t groupsPerChunk = lanesPerPart / groupSize;
+  if (groupsPerChunk == 1)
+    return createIotaContiguousChunk(loc, resultType, base, /*laneOffset=*/0,
+                                     orderAttr, rewriter);
+
+  // Power-of-2 S: dst[i] = base ± (i % S) via AND-mask (beats O(G) vsel pack
+  // and VL/2 VOR/mask duplication). Lane ids are always an ascending vci(0).
+  if (llvm::isPowerOf2_64(static_cast<uint64_t>(groupSize)) &&
+      isa<IntegerType>(base.getType())) {
+    FailureOr<Value> zeroScalar =
+        createScalarOffsetConstant(loc, base.getType(), 0, rewriter);
+    FailureOr<Value> maskScalar = createScalarOffsetConstant(
+        loc, base.getType(), groupSize - 1, rewriter);
+    if (failed(zeroScalar) || failed(maskScalar))
+      return failure();
+
+    Value laneIds =
+        rewriter.create<VciOp>(loc, resultType, *zeroScalar, StringAttr{})
+            .getResult();
+    Value maskVec =
+        rewriter
+            .create<VdupOp>(loc, resultType, *maskScalar, *allMask,
+                            /*position=*/nullptr)
+            .getResult();
+    Value rem = rewriter
+                    .create<VandOp>(loc, resultType, laneIds, maskVec, *allMask)
+                    .getResult();
+    if (order == "DESC") {
+      Value baseVec =
+          rewriter
+              .create<VdupOp>(loc, resultType, base, *allMask,
+                              /*position=*/nullptr)
+              .getResult();
+      return rewriter.create<VsubOp>(loc, resultType, baseVec, rem, *allMask)
+          .getResult();
+    }
+    return rewriter.create<VaddsOp>(loc, resultType, rem, base, *allMask)
+        .getResult();
+  }
+
   FailureOr<Value> full =
       createIotaContiguousChunk(loc, resultType, base, /*laneOffset=*/0,
                                 orderAttr, rewriter);
@@ -5265,10 +5308,6 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
       createScalarOffsetConstant(loc, base.getType(), 0, rewriter);
   if (failed(full) || failed(maskType) || failed(zeroScalar))
     return failure();
-
-  int64_t groupsPerChunk = lanesPerPart / groupSize;
-  if (groupsPerChunk == 1)
-    return *full;
 
   Value result = rewriter
                      .create<VdupOp>(loc, resultType, *zeroScalar, *allMask,
@@ -5405,7 +5444,7 @@ struct OneToNVMIIotaOpPattern : OpConversionPattern<IotaOp> {
     //
     // Contiguous materialization:
     //   * S % physVL == 0 → VCI chunk per distinct laneOffset (share parts).
-    //   * physVL % S == 0 → sub-VL pack via mask + offset-by-S + vsel.
+    //   * physVL % S == 0 → sub-VL: vdup (S=1) or vand(vci(0),S-1)+vadds(base).
     if constexpr (std::is_same_v<IotaOp, VMIGroupIotaOp>) {
       int64_t numGroups = op.getGroupAttr().getInt();
       int64_t logicalLanes = resultVMIType.getElementCount();

--- a/test/lit/vmi_new/vmi_to_vpto_iota_group_logical_tail.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_iota_group_logical_tail.pto
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+// Grouped logical tails: physical arity is ceil(L / physVL); excess lanes in
+// the last chunk follow ordinary contiguous inactive/padding handling.
+//
+// i32 physVL=64:
+//   size=32, group=2 → S=16, one VL: [0..15|0..15|pad..], store mask VL32
+//   size=96, group=3 → S=32, two VL: full [0..31|0..31] + partial [0..31|pad],
+//                       second store mask VL32
+
+module {
+  func.func @vmi_to_vpto_iota_group_tail_i32_32_g2(
+      %base: i32, %dst: !pto.ptr<i32, ub>, %mask: !pto.vmi.mask<32xpred>) {
+    %c0 = arith.constant 0 : index
+    %idx = pto.vmi.vci %base {group = 2 : i64}
+        : i32 -> !pto.vmi.vreg<32xi32>
+    %c1000 = arith.constant 1000 : i32
+    %out = pto.vmi.vadds %idx, %c1000, %mask
+        : !pto.vmi.vreg<32xi32>, i32, !pto.vmi.mask<32xpred>
+        -> !pto.vmi.vreg<32xi32>
+    pto.vmi.vstore %out, %dst[%c0]
+        : !pto.vmi.vreg<32xi32>, !pto.ptr<i32, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_iota_group_tail_i32_96_g3(
+      %base: i32, %dst: !pto.ptr<i32, ub>, %mask: !pto.vmi.mask<96xpred>) {
+    %c0 = arith.constant 0 : index
+    %idx = pto.vmi.vci %base {group = 3 : i64}
+        : i32 -> !pto.vmi.vreg<96xi32>
+    %c1000 = arith.constant 1000 : i32
+    %out = pto.vmi.vadds %idx, %c1000, %mask
+        : !pto.vmi.vreg<96xi32>, i32, !pto.vmi.mask<96xpred>
+        -> !pto.vmi.vreg<96xi32>
+    pto.vmi.vstore %out, %dst[%c0]
+        : !pto.vmi.vreg<96xi32>, !pto.ptr<i32, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_iota_group_tail_i32_32_g2(
+// CHECK-SAME: %[[BASE:.*]]: i32
+// Sub-VL pack S=16 across one physical VL; consumer then stores with VL32 tail.
+// CHECK: pto.vci %[[BASE]] : i32 -> !pto.vreg<64xi32>
+// CHECK: pto.vsel
+// CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
+// CHECK: pto.vadds {{.*}}, %[[C1000]]
+// Tail mask on store: only 32 of 64 physical lanes active.
+// CHECK: %[[C32:.*]] = arith.constant 32 : i32
+// CHECK: pto.plt_b32 %[[C32]]
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_iota_group_tail_i32_96_g3(
+// CHECK-SAME: %[[BASE:.*]]: i32
+// Two physical parts share the same S=32 sub-VL pattern.
+// CHECK: pto.vci %[[BASE]] : i32 -> !pto.vreg<64xi32>
+// CHECK: pto.vsel
+// CHECK: %[[PACKED:.*]] = pto.vsel
+// CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
+// First chunk full VL store; second chunk partial (32 active).
+// CHECK: pto.vsts
+// CHECK: %[[C32:.*]] = arith.constant 32 : i32
+// CHECK: pto.plt_b32 %[[C32]]
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_iota_group_logical_tail.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_iota_group_logical_tail.pto
@@ -48,11 +48,16 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_group_tail_i32_32_g2(
 // CHECK-SAME: %[[BASE:.*]]: i32
-// Sub-VL pack S=16 across one physical VL; consumer then stores with VL32 tail.
-// CHECK: pto.vci %[[BASE]] : i32 -> !pto.vreg<64xi32>
-// CHECK: pto.vsel
+// Sub-VL pack S=16: vand(vci(0),15)+vadds(base); store with VL32 tail.
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[C15:.*]] = arith.constant 15 : i32
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i32 -> !pto.vreg<64xi32>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C15]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
-// CHECK: pto.vadds {{.*}}, %[[C1000]]
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
 // Tail mask on store: only 32 of 64 physical lanes active.
 // CHECK: %[[C32:.*]] = arith.constant 32 : i32
 // CHECK: pto.plt_b32 %[[C32]]
@@ -61,10 +66,14 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_group_tail_i32_96_g3(
 // CHECK-SAME: %[[BASE:.*]]: i32
-// Two physical parts share the same S=32 sub-VL pattern.
-// CHECK: pto.vci %[[BASE]] : i32 -> !pto.vreg<64xi32>
-// CHECK: pto.vsel
-// CHECK: %[[PACKED:.*]] = pto.vsel
+// Two physical parts share the same S=32 AND-mask pattern.
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[C31:.*]] = arith.constant 31 : i32
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i32 -> !pto.vreg<64xi32>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C31]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
 // CHECK: pto.vadds %[[PACKED]], %[[C1000]]
 // CHECK: pto.vadds %[[PACKED]], %[[C1000]]

--- a/test/lit/vmi_new/vmi_to_vpto_iota_group_size1_vdup.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_iota_group_size1_vdup.pto
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+// Extreme group-count: i8 size=256, group=256 → group_size=1.
+// Semantics: every lane equals base. Must lower to one vdup(base), not an
+// O(physVL) mask/vsel/vadds chain.
+
+module {
+  func.func @vmi_to_vpto_iota_group_size1_i8_256(
+      %base: i8, %dst: !pto.ptr<i8, ub>, %mask: !pto.vmi.mask<256xpred>) {
+    %c0 = arith.constant 0 : index
+    %idx = pto.vmi.vci %base {group = 256 : i64}
+        : i8 -> !pto.vmi.vreg<256xi8>
+    %c1 = arith.constant 1 : i8
+    %out = pto.vmi.vadds %idx, %c1, %mask
+        : !pto.vmi.vreg<256xi8>, i8, !pto.vmi.mask<256xpred>
+        -> !pto.vmi.vreg<256xi8>
+    pto.vmi.vstore %out, %dst[%c0]
+        : !pto.vmi.vreg<256xi8>, !pto.ptr<i8, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_iota_group_size1_i8_256(
+// CHECK-SAME: %[[BASE:.*]]: i8
+// CHECK: %[[DUP:.*]] = pto.vdup %[[BASE]]
+// CHECK-NOT: pto.vci
+// CHECK-NOT: pto.vsel
+// CHECK: %[[C1:.*]] = arith.constant 1 : i8
+// CHECK: pto.vadds %[[DUP]], %[[C1]]
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_iota_group_subvl.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_iota_group_subvl.pto
@@ -9,8 +9,8 @@
 // RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
 
 // Sub-VL group-periodic contiguous iota: S < physVL and physVL % S == 0.
-// Materialize via vci(base) + per-group (∓ g*S) + lane-range vsel, then
-// consume with vadds(+1000) + vsts (no unpack).
+// Integer pow2 S: vand(vci(0), S-1) + vadds(base) — O(1), independent of G.
+// Consume with vadds(+1000) + vsts (no unpack).
 //
 // i32 physVL=64:  g2→S=32, g4→S=16, g8→S=8
 // i16 physVL=128: g2→S=64, g4→S=32
@@ -89,11 +89,13 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_subvl_i32_g2(
 // CHECK-SAME: %[[BASE:.*]]: i32
-// CHECK: %[[FULL:.*]] = pto.vci %[[BASE]] : i32 -> !pto.vreg<64xi32>
-// CHECK: pto.pset_b32 "PAT_VL32"
-// CHECK: pto.vsel
-// CHECK: pto.vadds %[[FULL]]
-// CHECK: %[[PACKED:.*]] = pto.vsel
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[C31:.*]] = arith.constant 31 : i32
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i32 -> !pto.vreg<64xi32>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C31]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
 // CHECK: pto.vadds %[[PACKED]], %[[C1000]]
 // CHECK: pto.vsts
@@ -101,39 +103,56 @@ module {
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_subvl_i32_g4(
 // CHECK-SAME: %[[BASE:.*]]: i32
-// CHECK: pto.vci %[[BASE]] : i32 -> !pto.vreg<64xi32>
-// CHECK-COUNT-3: pto.vsel
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[C15:.*]] = arith.constant 15 : i32
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i32 -> !pto.vreg<64xi32>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C15]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
-// CHECK: pto.vadds {{.*}}, %[[C1000]]
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
 // CHECK: pto.vsts
 // CHECK-NOT: pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_subvl_i32_g8(
 // CHECK-SAME: %[[BASE:.*]]: i32
-// CHECK: pto.vci %[[BASE]] : i32 -> !pto.vreg<64xi32>
-// CHECK-COUNT-7: pto.vsel
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[C7:.*]] = arith.constant 7 : i32
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i32 -> !pto.vreg<64xi32>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C7]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
-// CHECK: pto.vadds {{.*}}, %[[C1000]]
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
 // CHECK: pto.vsts
 // CHECK-NOT: pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_subvl_i16_g2(
 // CHECK-SAME: %[[BASE:.*]]: i16
-// CHECK: pto.vci %[[BASE]] : i16 -> !pto.vreg<128xi16>
-// CHECK: pto.pset_b16 "PAT_VL64"
-// CHECK: pto.vsel
-// CHECK: pto.vadds
-// CHECK: pto.vsel
+// CHECK: %[[C0:.*]] = arith.constant 0 : i16
+// CHECK: %[[C63:.*]] = arith.constant 63 : i16
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i16 -> !pto.vreg<128xi16>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C63]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i16
-// CHECK: pto.vadds {{.*}}, %[[C1000]]
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
 // CHECK: pto.vsts
 // CHECK-NOT: pto.vmi.
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_subvl_i16_g4(
 // CHECK-SAME: %[[BASE:.*]]: i16
-// CHECK: pto.vci %[[BASE]] : i16 -> !pto.vreg<128xi16>
-// CHECK-COUNT-3: pto.vsel
+// CHECK: %[[C0:.*]] = arith.constant 0 : i16
+// CHECK: %[[C31:.*]] = arith.constant 31 : i16
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i16 -> !pto.vreg<128xi16>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C31]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i16
-// CHECK: pto.vadds {{.*}}, %[[C1000]]
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
 // CHECK: pto.vsts
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_iota_group_vl_half.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_iota_group_vl_half.pto
@@ -8,9 +8,8 @@
 
 // RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
 
-// Sub-VL VL/2 (physVL=64, group=2 → S=32) recipe selection:
-//   * integer → AND-mask: vand(vci(0), S-1) + vadds(base)  (no vsel)
-//   * float   → legacy O(G) vsel pack (vand not legal on float)
+// Sub-VL VL/2: i32 physVL=64, group=2 → S=32.
+// AND-mask recipe: vand(vci(0), S-1) + vadds(base) — O(1), no vsel.
 
 module {
   func.func @vmi_to_vpto_iota_vl_half_i32_g2_and(
@@ -26,20 +25,6 @@ module {
         : !pto.vmi.vreg<64xi32>, !pto.ptr<i32, ub>
     return
   }
-
-  func.func @vmi_to_vpto_iota_vl_half_f32_g2_vsel(
-      %base: f32, %dst: !pto.ptr<f32, ub>, %mask: !pto.vmi.mask<64xpred>) {
-    %c0 = arith.constant 0 : index
-    %idx = pto.vmi.vci %base {group = 2 : i64}
-        : f32 -> !pto.vmi.vreg<64xf32>
-    %c1 = arith.constant 1.0 : f32
-    %out = pto.vmi.vadds %idx, %c1, %mask
-        : !pto.vmi.vreg<64xf32>, f32, !pto.vmi.mask<64xpred>
-        -> !pto.vmi.vreg<64xf32>
-    pto.vmi.vstore %out, %dst[%c0]
-        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
-    return
-  }
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_iota_vl_half_i32_g2_and(
@@ -53,19 +38,5 @@ module {
 // CHECK-NOT: pto.vsel
 // CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
 // CHECK: pto.vadds %[[PACKED]], %[[C1000]]
-// CHECK: pto.vsts
-// CHECK-NOT: pto.vmi.
-
-// CHECK-LABEL: func.func @vmi_to_vpto_iota_vl_half_f32_g2_vsel(
-// CHECK-SAME: %[[BASE:.*]]: f32
-// Float cannot use vand; keep the old vci(base) + offset-by-S + vsel pack.
-// CHECK: %[[FULL:.*]] = pto.vci %[[BASE]] : f32 -> !pto.vreg<64xf32>
-// CHECK: pto.pset_b32 "PAT_VL32"
-// CHECK: pto.vsel
-// CHECK: pto.vadds %[[FULL]]
-// CHECK: %[[PACKED:.*]] = pto.vsel
-// CHECK-NOT: pto.vand
-// CHECK: %[[C1:.*]] = arith.constant {{1\.[0-9]+e\+00}} : f32
-// CHECK: pto.vadds %[[PACKED]], %[[C1]]
 // CHECK: pto.vsts
 // CHECK-NOT: pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_iota_group_vl_half_and_vs_vsel.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_iota_group_vl_half_and_vs_vsel.pto
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: pto-test-opt %s -vmi-lower-unified-to-legacy -vmi-mask-granularity-assignment -vmi-layout-assignment -vmi-to-vpto | FileCheck %s
+
+// Sub-VL VL/2 (physVL=64, group=2 → S=32) recipe selection:
+//   * integer → AND-mask: vand(vci(0), S-1) + vadds(base)  (no vsel)
+//   * float   → legacy O(G) vsel pack (vand not legal on float)
+
+module {
+  func.func @vmi_to_vpto_iota_vl_half_i32_g2_and(
+      %base: i32, %dst: !pto.ptr<i32, ub>, %mask: !pto.vmi.mask<64xpred>) {
+    %c0 = arith.constant 0 : index
+    %idx = pto.vmi.vci %base {group = 2 : i64}
+        : i32 -> !pto.vmi.vreg<64xi32>
+    %c1000 = arith.constant 1000 : i32
+    %out = pto.vmi.vadds %idx, %c1000, %mask
+        : !pto.vmi.vreg<64xi32>, i32, !pto.vmi.mask<64xpred>
+        -> !pto.vmi.vreg<64xi32>
+    pto.vmi.vstore %out, %dst[%c0]
+        : !pto.vmi.vreg<64xi32>, !pto.ptr<i32, ub>
+    return
+  }
+
+  func.func @vmi_to_vpto_iota_vl_half_f32_g2_vsel(
+      %base: f32, %dst: !pto.ptr<f32, ub>, %mask: !pto.vmi.mask<64xpred>) {
+    %c0 = arith.constant 0 : index
+    %idx = pto.vmi.vci %base {group = 2 : i64}
+        : f32 -> !pto.vmi.vreg<64xf32>
+    %c1 = arith.constant 1.0 : f32
+    %out = pto.vmi.vadds %idx, %c1, %mask
+        : !pto.vmi.vreg<64xf32>, f32, !pto.vmi.mask<64xpred>
+        -> !pto.vmi.vreg<64xf32>
+    pto.vmi.vstore %out, %dst[%c0]
+        : !pto.vmi.vreg<64xf32>, !pto.ptr<f32, ub>
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @vmi_to_vpto_iota_vl_half_i32_g2_and(
+// CHECK-SAME: %[[BASE:.*]]: i32
+// CHECK: %[[C0:.*]] = arith.constant 0 : i32
+// CHECK: %[[C31:.*]] = arith.constant 31 : i32
+// CHECK: %[[LANES:.*]] = pto.vci %[[C0]] : i32 -> !pto.vreg<64xi32>
+// CHECK: %[[MASKV:.*]] = pto.vdup %[[C31]]
+// CHECK: %[[REM:.*]] = pto.vand %[[LANES]], %[[MASKV]]
+// CHECK: %[[PACKED:.*]] = pto.vadds %[[REM]], %[[BASE]]
+// CHECK-NOT: pto.vsel
+// CHECK: %[[C1000:.*]] = arith.constant 1000 : i32
+// CHECK: pto.vadds %[[PACKED]], %[[C1000]]
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vmi.
+
+// CHECK-LABEL: func.func @vmi_to_vpto_iota_vl_half_f32_g2_vsel(
+// CHECK-SAME: %[[BASE:.*]]: f32
+// Float cannot use vand; keep the old vci(base) + offset-by-S + vsel pack.
+// CHECK: %[[FULL:.*]] = pto.vci %[[BASE]] : f32 -> !pto.vreg<64xf32>
+// CHECK: pto.pset_b32 "PAT_VL32"
+// CHECK: pto.vsel
+// CHECK: pto.vadds %[[FULL]]
+// CHECK: %[[PACKED:.*]] = pto.vsel
+// CHECK-NOT: pto.vand
+// CHECK: %[[C1:.*]] = arith.constant {{1\.[0-9]+e\+00}} : f32
+// CHECK: pto.vadds %[[PACKED]], %[[C1]]
+// CHECK: pto.vsts
+// CHECK-NOT: pto.vmi.


### PR DESCRIPTION
## Summary
Follow-up to #1112. Two post-merge issues in grouped `vci` / `group_iota` lowering:

- **Grouped logical tails:** API/verifiers accept cases like i32 `size=32, group=2` and `size=96, group=3`, but VMIToVPTO required `arity * physVL == L`, so conversion failed. Relax to `ceil(L / physVL)` and reuse ordinary contiguous tail masks on the last chunk.
- **`group_size == 1`:** extreme packs (e.g. i8 `size=256, group=256`) lowered to an O(physVL) mask/`vsel`/`vadds` chain; semantics are a broadcast → one `vdup(base)`.

Public `group=1` (ordinary iota) is unchanged.

## Test plan
- [x] Lit `vmi_to_vpto_iota_group_logical_tail.pto` (i32 32/g2, 96/g3 + store tail masks)
- [x] Lit `vmi_to_vpto_iota_group_size1_vdup.pto` (i8 256/g256 → single `vdup`, no `vsel` chain)
- [x] Existing group subvl / group2 / group1-tail still pass
- [x] Confirmed both new lits **fail** on unfixed tip, **pass** with this patch


Made with [Cursor](https://cursor.com)