### PR TITLE
fix(ptodsl): merge section-local conditional bindings (#1162)

### DIFF
--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -59,6 +59,7 @@ def rewrite_jit_function(fn, *, static_bindings=None, rewrite_control_flow=True)
         rewriter = _ControlFlowRewriter(
             static_env,
             section_entry_bindings=section_rewriter.section_entry_bindings,
+            section_uninitialized_aliases=section_rewriter.section_uninitialized_aliases,
         )
         function_def.body = rewriter.rewrite_block(function_def.body, live_after=set())
     tree = ast.Module(body=[function_def], type_ignores=[])
@@ -101,6 +102,7 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
         self._known_bindings = set()
         self._section_outer_bindings = None
         self.section_entry_bindings = {}
+        self.section_uninitialized_aliases = set()
 
     @staticmethod
     def _is_section_with(node):
@@ -118,7 +120,9 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
 
     def _activate_targets(self, targets):
         for name in targets & self._local_names:
-            alias = self._env.setdefault(name, self._fresh_alias(name))
+            if name not in self._env:
+                self._env[name] = self._fresh_alias(name)
+            alias = self._env[name]
             if self._section_outer_bindings is not None and name in self._section_outer_bindings:
                 self.section_entry_bindings.setdefault(alias, name)
 
@@ -201,13 +205,21 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
     def visit_If(self, node):
         node.test = self.visit(node.test)
         # Both branches of a runtime conditional share one authored binding.
-        # Reserve its section-local alias before visiting either branch so the
-        # branch merge does not treat the second branch as a new binding.
+        # Any future env-forking visitor must apply the same invariant: reserve
+        # common targets before visiting either branch. For section-local
+        # bindings this prevents the branch merge from creating two aliases.
         common_targets = _name_info(node.body).stores & _name_info(node.orelse).stores
         self._activate_targets(common_targets)
         entry_env = dict(self._env)
         node.body, body_env = self._visit_block(node.body, entry_env)
         node.orelse, else_env = self._visit_block(node.orelse, entry_env)
+        entry_aliases = set(entry_env.values())
+        branch_only_aliases = set(body_env.values()) ^ set(else_env.values())
+        self.section_uninitialized_aliases.update(
+            alias
+            for alias in branch_only_aliases - entry_aliases
+            if alias not in self.section_entry_bindings
+        )
         self._env.update(body_env)
         self._env.update(else_env)
         return node
@@ -947,15 +959,24 @@ class _SlotCarryRewriter(ast.NodeTransformer):
 
 
 class _ControlFlowRewriter:
-    def __init__(self, static_env=None, *, section_entry_bindings=None):
+    def __init__(self, static_env=None, *, section_entry_bindings=None, section_uninitialized_aliases=None):
         self._static_env = dict(static_env or {})
         self._section_entry_bindings = dict(section_entry_bindings or {})
+        self._section_uninitialized_aliases = set(section_uninitialized_aliases or ())
         self._counter = 0
 
     def _fresh(self, prefix: str) -> str:
         value = f"__pto_ast_{prefix}_{self._counter}"
         self._counter += 1
         return value
+
+    def _section_entry_value(self, name):
+        if name in self._section_uninitialized_aliases:
+            raise PTODSLAstRewriteError(
+                "ast_rewrite=True runtime if reads a section-local value before it is initialized; "
+                f"initialize {name!r} before the conditional"
+            )
+        return _name(self._section_entry_bindings.get(name, name))
 
     def rewrite_block(self, stmts, *, live_after, live_after_slots=None, allow_loop_control=False, static_iters=None):
         rewritten_reversed = []
@@ -1211,7 +1232,7 @@ class _ControlFlowRewriter:
         result.extend(
             ast.Assign(
                 targets=[_name(old_name, ast.Store())],
-                value=_name(self._section_entry_bindings.get(name, name)),
+                value=self._section_entry_value(name),
             )
             for name, old_name in old_value_names.items()
         )

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -200,6 +200,11 @@ class _SectionLexicalRewriter(ast.NodeTransformer):
 
     def visit_If(self, node):
         node.test = self.visit(node.test)
+        # Both branches of a runtime conditional share one authored binding.
+        # Reserve its section-local alias before visiting either branch so the
+        # branch merge does not treat the second branch as a new binding.
+        common_targets = _name_info(node.body).stores & _name_info(node.orelse).stores
+        self._activate_targets(common_targets)
         entry_env = dict(self._env)
         node.body, body_env = self._visit_block(node.body, entry_env)
         node.orelse, else_env = self._visit_block(node.orelse, entry_env)

--- a/ptodsl/ptodsl/_ast_rewrite.py
+++ b/ptodsl/ptodsl/_ast_rewrite.py
@@ -1211,7 +1211,7 @@ class _ControlFlowRewriter:
         result.extend(
             ast.Assign(
                 targets=[_name(old_name, ast.Store())],
-                value=_name(name),
+                value=_name(self._section_entry_bindings.get(name, name)),
             )
             for name, old_name in old_value_names.items()
         )

--- a/ptodsl/tests/test_section.py
+++ b/ptodsl/tests/test_section.py
@@ -159,6 +159,35 @@ def lexical_section_sibling_conditional_rebinding_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def lexical_section_sibling_single_sided_conditional_rebinding_probe():
+    one = pto.const(1, dtype=pto.i32)
+    m_tile = pto.const(0, dtype=pto.i32)
+    n_tile = pto.const(0, dtype=pto.i32)
+    with pto.section("cube"):
+        if pto.get_block_idx() < one:
+            m_tile = one
+            n_tile = one
+        m_tile_1 = pto.const(0, dtype=pto.i32)
+        n_tile_1 = pto.const(0, dtype=pto.i32)
+        if pto.get_block_idx() < one:
+            m_tile_1 = m_tile
+            n_tile_1 = n_tile
+        pto.wait_flag("S", "MTE2", event_id=m_tile_1)
+        pto.wait_flag("S", "MTE2", event_id=n_tile_1)
+    with pto.section("vector"):
+        if pto.get_block_idx() < one:
+            m_tile = one
+            n_tile = one
+        m_tile_2 = pto.const(0, dtype=pto.i32)
+        n_tile_2 = pto.const(0, dtype=pto.i32)
+        if pto.get_block_idx() < one:
+            m_tile_2 = m_tile
+            n_tile_2 = n_tile
+        pto.wait_flag("MTE2", "S", event_id=m_tile_2)
+        pto.wait_flag("MTE2", "S", event_id=n_tile_2)
+
+
+@pto.jit(target="a5", mode="explicit")
 def lexical_section_loop_carry_probe():
     one = pto.const(1, dtype=pto.i32)
     m_tile = pto.const(0, dtype=pto.i64)
@@ -261,6 +290,14 @@ def main() -> None:
     assert sibling_conditional_text.count("scf.if") == 2
     with make_context() as context:
         module = Module.parse(sibling_conditional_text, context)
+        module.operation.verify()
+
+    sibling_single_sided_text = lexical_section_sibling_single_sided_conditional_rebinding_probe.compile().mlir_text()
+    assert sibling_single_sided_text.count("pto.section.cube {") == 1
+    assert sibling_single_sided_text.count("pto.section.vector {") == 1
+    assert sibling_single_sided_text.count("scf.if") == 4
+    with make_context() as context:
+        module = Module.parse(sibling_single_sided_text, context)
         module.operation.verify()
 
     loop_carry_text = lexical_section_loop_carry_probe.compile().mlir_text()

--- a/ptodsl/tests/test_section.py
+++ b/ptodsl/tests/test_section.py
@@ -10,6 +10,7 @@
 """Focused tracing coverage for explicit physical section hints."""
 
 from ptodsl import pto
+from ptodsl._ast_rewrite import PTODSLAstRewriteError
 from ptodsl._context import make_context
 from ptodsl._tracing.active import current_session
 from ptoas.mlir.ir import Module
@@ -120,6 +121,17 @@ def lexical_section_rebinding_probe():
         pto.wait_flag("MTE2", "S", event_id=event_id)
 
 
+@pto.jit(target="a5")
+def lexical_non_section_conditional_rebinding_probe():
+    one = pto.const(1, dtype=pto.i32)
+    value = pto.const(0, dtype=pto.i32)
+    if pto.get_block_idx() < one:
+        value = one
+    else:
+        value = pto.const(2, dtype=pto.i32)
+    pto.wait_flag("S", "MTE2", event_id=value)
+
+
 @pto.jit(target="a5", mode="explicit")
 def lexical_section_conditional_rebinding_probe():
     one = pto.const(1, dtype=pto.i32)
@@ -185,6 +197,30 @@ def lexical_section_sibling_single_sided_conditional_rebinding_probe():
             n_tile_2 = n_tile
         pto.wait_flag("MTE2", "S", event_id=m_tile_2)
         pto.wait_flag("MTE2", "S", event_id=n_tile_2)
+
+
+@pto.jit(target="a5", mode="explicit")
+def lexical_section_uninitialized_conditional_probe():
+    one = pto.const(1, dtype=pto.i32)
+    with pto.section("cube"):
+        if pto.get_block_idx() < one:
+            value = one
+        pto.wait_flag("S", "MTE2", event_id=value)
+
+
+@pto.jit(target="a5", mode="explicit")
+def lexical_section_nested_conditional_rebinding_probe():
+    one = pto.const(1, dtype=pto.i32)
+    value = pto.const(0, dtype=pto.i32)
+    with pto.section("cube"):
+        if pto.get_block_idx() < one:
+            if pto.get_block_idx() < one:
+                value = one
+            else:
+                value = pto.const(2, dtype=pto.i32)
+        else:
+            value = pto.const(3, dtype=pto.i32)
+        pto.wait_flag("S", "MTE2", event_id=value)
 
 
 @pto.jit(target="a5", mode="explicit")
@@ -280,6 +316,12 @@ def main() -> None:
     assert lexical_text.count("pto.section.cube {") == 1
     assert lexical_text.count("pto.section.vector {") == 1
 
+    non_section_lexical_text = lexical_non_section_conditional_rebinding_probe.compile().mlir_text()
+    assert non_section_lexical_text.count("scf.if") == 1
+    with make_context() as context:
+        module = Module.parse(non_section_lexical_text, context)
+        module.operation.verify()
+
     conditional_lexical_text = lexical_section_conditional_rebinding_probe.compile().mlir_text()
     assert conditional_lexical_text.count("pto.section.cube {") == 1
     assert "scf.if" in conditional_lexical_text
@@ -299,6 +341,19 @@ def main() -> None:
     with make_context() as context:
         module = Module.parse(sibling_single_sided_text, context)
         module.operation.verify()
+
+    nested_conditional_text = lexical_section_nested_conditional_rebinding_probe.compile().mlir_text()
+    assert nested_conditional_text.count("pto.section.cube {") == 1
+    assert nested_conditional_text.count("scf.if") == 2
+    with make_context() as context:
+        module = Module.parse(nested_conditional_text, context)
+        module.operation.verify()
+
+    _expect_raises(
+        PTODSLAstRewriteError,
+        lambda: lexical_section_uninitialized_conditional_probe.compile(),
+        "reads a section-local value before it is initialized",
+    )
 
     loop_carry_text = lexical_section_loop_carry_probe.compile().mlir_text()
     assert loop_carry_text.count("pto.section.cube {") == 1

--- a/ptodsl/tests/test_section.py
+++ b/ptodsl/tests/test_section.py
@@ -133,6 +133,32 @@ def lexical_section_conditional_rebinding_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def lexical_section_sibling_conditional_rebinding_probe():
+    one = pto.const(1, dtype=pto.i32)
+    two = pto.const(2, dtype=pto.i32)
+    m_tile = pto.const(0, dtype=pto.i32)
+    n_tile = pto.const(0, dtype=pto.i32)
+    with pto.section("cube"):
+        if pto.get_block_idx() < one:
+            m_tile = one
+            n_tile = one
+        else:
+            m_tile = two
+            n_tile = two
+        pto.wait_flag("S", "MTE2", event_id=m_tile)
+        pto.wait_flag("S", "MTE2", event_id=n_tile)
+    with pto.section("vector"):
+        if pto.get_block_idx() < one:
+            m_tile = one
+            n_tile = one
+        else:
+            m_tile = two
+            n_tile = two
+        pto.wait_flag("MTE2", "S", event_id=m_tile)
+        pto.wait_flag("MTE2", "S", event_id=n_tile)
+
+
+@pto.jit(target="a5", mode="explicit")
 def lexical_section_loop_carry_probe():
     one = pto.const(1, dtype=pto.i32)
     m_tile = pto.const(0, dtype=pto.i64)
@@ -228,6 +254,14 @@ def main() -> None:
     conditional_lexical_text = lexical_section_conditional_rebinding_probe.compile().mlir_text()
     assert conditional_lexical_text.count("pto.section.cube {") == 1
     assert "scf.if" in conditional_lexical_text
+
+    sibling_conditional_text = lexical_section_sibling_conditional_rebinding_probe.compile().mlir_text()
+    assert sibling_conditional_text.count("pto.section.cube {") == 1
+    assert sibling_conditional_text.count("pto.section.vector {") == 1
+    assert sibling_conditional_text.count("scf.if") == 2
+    with make_context() as context:
+        module = Module.parse(sibling_conditional_text, context)
+        module.operation.verify()
 
     loop_carry_text = lexical_section_loop_carry_probe.compile().mlir_text()
     assert loop_carry_text.count("pto.section.cube {") == 1


### PR DESCRIPTION
## Problem

PTODSL AST rewriting can raise Python `UnboundLocalError` when a physical section rebinds local variables such as `m_tile` and `n_tile` inside runtime control flow.

The failure occurs in two related cases:

- Both branches of a runtime `if` assign the same section-local variable.
- A one-sided runtime `if` assigns the variable, followed by another runtime `if` that reads it.

The issue appears with sibling `cube` and `vector` sections and prevents PTODSL tracing from reaching MLIR generation.

## Root Cause

The section lexical rewriter could allocate different aliases for the same authored variable in different branches. During branch merging, the control-flow rewriter could also initialize an old value from an uninitialized section alias instead of the value available at section entry.

## Fix

- Allocate one shared section-local alias for variables assigned by both runtime-if branches.
- Initialize conditional merge values from the recorded section-entry binding when one exists.
- Keep physical-section boundaries and existing escape validation unchanged.

## Tests

- Added both sibling-section regression scenarios to the existing `ptodsl/tests/test_section.py`.
- `check-dsl`: 30/30 PTODSL tests passed.
- MLIR parsing and verification passed for the new scenarios.

Fixes #1162