### PR TITLE
[PTOAS/PTODSL] Make MX staging controls optional

### DIFF
--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -682,6 +682,39 @@ entry applies to one 32-element K group.
 - L1 source data is organized as 32B scale fragments in the same logical order
   as the associated data tile.
 
+### MX Scale Load Operands
+
+`pto.mte_l1_l0a_mx` and `pto.mte_l1_l0b_mx` store the following operands as
+independently optional fields, but a valid operation supplies exactly one
+complete operand group:
+
+- **Shape-derived group:** `m`, `k`, `start_row`, `start_col` for L0A, or
+  `k`, `n`, `start_row`, `start_col` for L0B. PTOAS derives the MX traversal
+  from the matrix shape and element type.
+- **Full MX group:** `x_start`, `y_start`, `x_step`, `y_step`, `src_stride`,
+  `dst_stride`. Use this group when the scale source has an explicit physical
+  layout that cannot be derived from the logical matrix shape.
+
+The two groups are mutually exclusive. A partial group is invalid. `x_start`
+and `y_start` are MX scale-fragment grid coordinates; `x_step` and `y_step`
+are grid traversal extents; `src_stride` and `dst_stride` are grid-row strides.
+The full MX values are not logical element counts or byte offsets.
+
+The named field spelling is available when an incomplete or mixed operation
+must be diagnosed. Complete groups print in the compact positional spelling
+used by the examples below.
+
+```mlir
+pto.mte_l1_l0a_mx %src, %dst,
+  x_start(%x_start), y_start(%y_start), x_step(%x_step), y_step(%y_step),
+  src_stride(%src_stride), dst_stride(%dst_stride)
+  : !pto.ptr<T, l1>, !pto.ptr<T, l0a>, i64, i64, i64, i64, i64, i64
+```
+
+`%src` must be in `l1` and address a 32-byte-aligned MX scale fragment.
+`%dst` must be in the matching `l0a` or `l0b` space. It is always the real
+staged L0 byte pointer and must be 16-byte aligned.
+
 ### `pto.mte_l1_l0a_mx`
 
 - **syntax:**
@@ -706,7 +739,10 @@ pto.mte_l1_l0a_mx %src, %dst, %m, %k, %start_row, %start_col
 **Constraints:**
 
 - `%src` must be in `l1`, `%dst` must be in `l0a`.
-- `%src` and `%dst` must satisfy 32B MX scale-fragment alignment.
+- `%src` must be 32-byte aligned to an MX scale fragment; `%dst` must be
+  16-byte aligned for the MX destination address unit.
+- Use either the complete shape-derived group or the complete full MX group
+  from [MX Scale Load Operands](#mx-scale-load-operands).
 
 **Example:**
 
@@ -741,7 +777,10 @@ pto.mte_l1_l0b_mx %src, %dst, %k, %n, %start_row, %start_col
 **Constraints:**
 
 - `%src` must be in `l1`, `%dst` must be in `l0b`.
-- `%src` and `%dst` must satisfy 32B MX scale-fragment alignment.
+- `%src` must be 32-byte aligned to an MX scale fragment; `%dst` must be
+  16-byte aligned for the MX destination address unit.
+- Use either the complete shape-derived group or the complete full MX group
+  from [MX Scale Load Operands](#mx-scale-load-operands).
 
 **Example:**
 

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -3074,41 +3074,53 @@ def PTO_MteL1L0bOp : PTO_MteOp<"mte_l1_l0b", [
 }
 
 def PTO_MteL1L0aMxOp : PTO_MteOp<"mte_l1_l0a_mx", [
+    AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let arguments = (ins
     PTO_BufferLikeType:$source,
     PTO_BufferLikeType:$destination,
-    Variadic<I64>:$controls
+    Optional<I64>:$m,
+    Optional<I64>:$k,
+    Optional<I64>:$start_row,
+    Optional<I64>:$start_col,
+    Optional<I64>:$x_start,
+    Optional<I64>:$y_start,
+    Optional<I64>:$x_step,
+    Optional<I64>:$y_step,
+    Optional<I64>:$src_stride,
+    Optional<I64>:$dst_stride
   );
 
   let results = (outs);
 
   let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $source `,` $destination `,` $controls attr-dict `:` type($source) `,`
-    type($destination) `,` type($controls)
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def PTO_MteL1L0bMxOp : PTO_MteOp<"mte_l1_l0b_mx", [
+    AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let arguments = (ins
     PTO_BufferLikeType:$source,
     PTO_BufferLikeType:$destination,
-    Variadic<I64>:$controls
+    Optional<I64>:$k,
+    Optional<I64>:$n,
+    Optional<I64>:$start_row,
+    Optional<I64>:$start_col,
+    Optional<I64>:$x_start,
+    Optional<I64>:$y_start,
+    Optional<I64>:$x_step,
+    Optional<I64>:$y_step,
+    Optional<I64>:$src_stride,
+    Optional<I64>:$dst_stride
   );
 
   let results = (outs);
 
   let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $source `,` $destination `,` $controls attr-dict `:` type($source) `,`
-    type($destination) `,` type($controls)
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def PTO_MteL0cL1Op : PTO_MteOp<"mte_l0c_l1", [

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -7758,8 +7758,210 @@ static LogicalResult verifyCubeBridgeLoadStart(OpTy op) {
                                    "start_row", op.getStartCol(), "start_col");
 }
 
-static LogicalResult verifyMxLoadControls(Operation *op,
-                                          OperandRange controls) {
+template <typename OpTy>
+static void setMxLoadOperandSegmentSizes(OperationState &result,
+                                         ArrayRef<int32_t> segmentSizes) {
+  auto &segments = result.getOrAddProperties<typename OpTy::Properties>()
+                       .operandSegmentSizes;
+  llvm::copy(segmentSizes, segments.begin());
+}
+
+struct MxLoadAsmOperand {
+  OpAsmParser::UnresolvedOperand operand;
+  Type type;
+  bool present = false;
+};
+
+static std::optional<unsigned>
+getMxLoadOperandIndex(StringRef keyword, ArrayRef<StringRef> shapeNames) {
+  for (auto [index, name] : llvm::enumerate(shapeNames))
+    if (keyword == name)
+      return index;
+
+  static constexpr StringRef kFullNames[] = {
+      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+  for (auto [index, name] : llvm::enumerate(kFullNames))
+    if (keyword == name)
+      return shapeNames.size() + index;
+  return std::nullopt;
+}
+
+template <typename OpTy>
+static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
+                                    OperationState &result,
+                                    ArrayRef<StringRef> shapeNames) {
+  OpAsmParser::UnresolvedOperand source;
+  OpAsmParser::UnresolvedOperand destination;
+  if (parser.parseOperand(source) || parser.parseComma() ||
+      parser.parseOperand(destination))
+    return failure();
+
+  SmallVector<OpAsmParser::UnresolvedOperand, 6> legacyOperands;
+  SmallVector<MxLoadAsmOperand, 10> namedOperands(10);
+  SmallVector<unsigned, 10> namedOperandOrder;
+  bool usesNamedOperands = false;
+
+  auto parseNamedOperand = [&](StringRef keyword) -> ParseResult {
+    std::optional<unsigned> index = getMxLoadOperandIndex(keyword, shapeNames);
+    if (!index)
+      return parser.emitError(parser.getCurrentLocation(),
+                              "unknown MX load operand '")
+             << keyword << "'";
+    if (namedOperands[*index].present)
+      return parser.emitError(parser.getCurrentLocation(),
+                              "duplicate MX load operand '")
+             << keyword << "'";
+    if (parser.parseLParen() || parser.parseOperand(namedOperands[*index].operand) ||
+        parser.parseRParen())
+      return failure();
+    namedOperands[*index].present = true;
+    namedOperandOrder.push_back(*index);
+    return success();
+  };
+
+  if (succeeded(parser.parseOptionalComma())) {
+    StringRef keyword;
+    if (succeeded(parser.parseOptionalKeyword(&keyword))) {
+      usesNamedOperands = true;
+      if (parseNamedOperand(keyword))
+        return failure();
+      while (succeeded(parser.parseOptionalComma())) {
+        if (parser.parseKeyword(&keyword) || parseNamedOperand(keyword))
+          return failure();
+      }
+    } else {
+      OpAsmParser::UnresolvedOperand operand;
+      if (parser.parseOperand(operand))
+        return failure();
+      legacyOperands.push_back(operand);
+      while (succeeded(parser.parseOptionalComma())) {
+        if (parser.parseOperand(operand))
+          return failure();
+        legacyOperands.push_back(operand);
+      }
+    }
+  }
+
+  if (!usesNamedOperands && legacyOperands.size() != 4 &&
+      legacyOperands.size() != 6)
+    return parser.emitError(parser.getCurrentLocation(),
+                            "expects either four shape-derived or six full "
+                            "positional MX operands");
+
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+    return failure();
+
+  Type sourceType;
+  Type destinationType;
+  if (parser.parseType(sourceType) || parser.parseComma() ||
+      parser.parseType(destinationType))
+    return failure();
+
+  SmallVector<Type, 6> legacyTypes;
+  if (usesNamedOperands) {
+    for (unsigned index : namedOperandOrder) {
+      Type type;
+      if (parser.parseComma() || parser.parseType(type))
+        return failure();
+      namedOperands[index].type = type;
+    }
+  } else {
+    for (size_t index = 0; index < legacyOperands.size(); ++index) {
+      Type type;
+      if (parser.parseComma() || parser.parseType(type))
+        return failure();
+      legacyTypes.push_back(type);
+    }
+  }
+
+  SmallVector<int32_t, 12> segmentSizes(12, 0);
+  segmentSizes[0] = 1;
+  segmentSizes[1] = 1;
+
+  if (parser.resolveOperand(source, sourceType, result.operands) ||
+      parser.resolveOperand(destination, destinationType, result.operands))
+    return failure();
+
+  if (usesNamedOperands) {
+    for (unsigned index = 0; index < namedOperands.size(); ++index) {
+      if (!namedOperands[index].present)
+        continue;
+      segmentSizes[2 + index] = 1;
+      if (parser.resolveOperand(namedOperands[index].operand,
+                                namedOperands[index].type,
+                                result.operands))
+        return failure();
+    }
+  } else {
+    const unsigned base = legacyOperands.size() <= 4 ? 0 : 4;
+    for (unsigned index = 0; index < legacyOperands.size(); ++index) {
+      segmentSizes[2 + base + index] = 1;
+      if (parser.resolveOperand(legacyOperands[index], legacyTypes[index],
+                                result.operands))
+        return failure();
+    }
+  }
+  setMxLoadOperandSegmentSizes<OpTy>(result, segmentSizes);
+  return success();
+}
+
+static void printMteL1L0MxOp(OpAsmPrinter &printer, Operation *operation,
+                             Value source, Value destination,
+                             ArrayRef<Value> shapeOperands,
+                             ArrayRef<StringRef> shapeNames,
+                             ArrayRef<Value> fullOperands) {
+  SmallVector<StringRef, 6> fullNames = {
+      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+
+  const bool hasShape = llvm::any_of(shapeOperands, [](Value value) {
+    return static_cast<bool>(value);
+  });
+  const bool hasFull = llvm::any_of(fullOperands, [](Value value) {
+    return static_cast<bool>(value);
+  });
+  const bool isShapeForm = hasShape && !hasFull &&
+      llvm::all_of(shapeOperands, [](Value value) { return static_cast<bool>(value); });
+  const bool isFullForm = hasFull && !hasShape &&
+      llvm::all_of(fullOperands, [](Value value) { return static_cast<bool>(value); });
+
+  printer << " " << source << ", " << destination;
+  SmallVector<Value, 10> printedOperands;
+  if (isShapeForm) {
+    for (Value value : shapeOperands) {
+      printer << ", " << value;
+      printedOperands.push_back(value);
+    }
+  } else if (isFullForm) {
+    for (Value value : fullOperands) {
+      printer << ", " << value;
+      printedOperands.push_back(value);
+    }
+  } else {
+    for (auto [index, value] : llvm::enumerate(shapeOperands)) {
+      if (!value)
+        continue;
+      printer << ", " << shapeNames[index] << "(" << value << ")";
+      printedOperands.push_back(value);
+    }
+    for (auto [index, value] : llvm::enumerate(fullOperands)) {
+      if (!value)
+        continue;
+      printer << ", " << fullNames[index] << "(" << value << ")";
+      printedOperands.push_back(value);
+    }
+  }
+
+  printer.printOptionalAttrDict(operation->getAttrs(),
+                                /*elidedAttrs=*/{"operandSegmentSizes"});
+  printer << " : " << source.getType() << ", " << destination.getType();
+  for (Value value : printedOperands)
+    printer << ", " << value.getType();
+}
+
+static LogicalResult verifyMxLoadOperands(Operation *op,
+                                          ArrayRef<Value> shapeOperands,
+                                          ArrayRef<StringRef> shapeNames,
+                                          ArrayRef<Value> fullOperands) {
   auto checkNonNegativeConst = [&](Value value,
                                    StringRef name) -> LogicalResult {
     APInt intValue;
@@ -7768,40 +7970,71 @@ static LogicalResult verifyMxLoadControls(Operation *op,
     return success();
   };
 
-  if (controls.size() == 4)
-    return verifyCubeBridgeLoadStart(op, controls[2], "start_row",
-                                     controls[3], "start_col");
-  if (controls.size() == 6) {
-    if (failed(verifyCubeBridgeLoadStart(op, controls[0], "x_start",
-                                         controls[1], "y_start")))
-      return failure();
-    if (failed(checkNonNegativeConst(controls[2], "x_step")) ||
-        failed(checkNonNegativeConst(controls[3], "y_step")) ||
-        failed(checkNonNegativeConst(controls[4], "src_stride")) ||
-        failed(checkNonNegativeConst(controls[5], "dst_stride")))
-      return failure();
-    return success();
+  const bool hasShape = llvm::any_of(shapeOperands, [](Value value) {
+    return static_cast<bool>(value);
+  });
+  const bool hasFull = llvm::any_of(fullOperands, [](Value value) {
+    return static_cast<bool>(value);
+  });
+  if (hasShape && hasFull)
+    return op->emitOpError()
+           << "cannot mix shape-derived MX operands with full MX operands";
+  if (!hasShape && !hasFull)
+    return op->emitOpError()
+           << "requires either all shape-derived MX operands or all full MX operands";
+
+  if (hasShape) {
+    for (auto [value, name] : llvm::zip(shapeOperands, shapeNames))
+      if (!value)
+        return op->emitOpError()
+               << "shape-derived MX form requires " << name;
+    return verifyCubeBridgeLoadStart(op, shapeOperands[2], shapeNames[2],
+                                     shapeOperands[3], shapeNames[3]);
   }
-  return op->emitOpError()
-         << "requires either four shape-derived controls or six explicit "
-            "MX controls";
+
+  static constexpr StringRef kFullNames[] = {
+      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+  for (auto [value, name] : llvm::zip(fullOperands, kFullNames))
+    if (!value)
+      return op->emitOpError() << "full MX form requires " << name;
+  if (failed(verifyCubeBridgeLoadStart(op, fullOperands[0], "x_start",
+                                       fullOperands[1], "y_start")))
+    return failure();
+  if (failed(checkNonNegativeConst(fullOperands[2], "x_step")) ||
+      failed(checkNonNegativeConst(fullOperands[3], "y_step")) ||
+      failed(checkNonNegativeConst(fullOperands[4], "src_stride")) ||
+      failed(checkNonNegativeConst(fullOperands[5], "dst_stride")))
+    return failure();
+  return success();
 }
 
-static LogicalResult verifyMxDestinationAlignment(Operation *op,
-                                                  Value destination) {
-  constexpr int64_t kMxDestinationAddressUnitBytes = 16;
-  auto pointerCast = destination.getDefiningOp<CastPtrOp>();
+static LogicalResult verifyMxPointerAlignment(Operation *op, Value pointer,
+                                              StringRef pointerName,
+                                              int64_t alignmentBytes) {
+  auto pointerCast = pointer.getDefiningOp<CastPtrOp>();
   if (!pointerCast || !isa<IntegerType>(pointerCast.getInput().getType()))
     return success();
 
   std::optional<int64_t> address =
       mlir::getConstantIntValue(pointerCast.getInput());
-  if (!address || (*address % kMxDestinationAddressUnitBytes) == 0)
+  if (!address || (*address % alignmentBytes) == 0)
     return success();
 
   return op->emitOpError()
-         << "statically known LOAD.MX destination address must be aligned to "
-         << kMxDestinationAddressUnitBytes << " bytes, got " << *address;
+         << "statically known LOAD.MX " << pointerName
+         << " address must be aligned to " << alignmentBytes << " bytes, got "
+         << *address;
+}
+
+static LogicalResult verifyMxLoadAlignment(Operation *op, Value source,
+                                           Value destination) {
+  constexpr int64_t kMxSourceAlignmentBytes = 32;
+  constexpr int64_t kMxDestinationAddressUnitBytes = 16;
+  if (failed(verifyMxPointerAlignment(op, source, "source",
+                                      kMxSourceAlignmentBytes)))
+    return failure();
+  return verifyMxPointerAlignment(op, destination, "destination",
+                                  kMxDestinationAddressUnitBytes);
 }
 
 LogicalResult MteL0cL1Op::verify() {
@@ -7835,20 +8068,58 @@ LogicalResult MteL1L0bOp::verify() {
   return verifyCubeBridgeLoadStart(*this);
 }
 
+ParseResult MteL1L0aMxOp::parse(OpAsmParser &parser, OperationState &result) {
+  static constexpr StringRef kShapeNames[] = {
+      "m", "k", "start_row", "start_col"};
+  return parseMteL1L0MxOp<MteL1L0aMxOp>(parser, result, kShapeNames);
+}
+
+void MteL1L0aMxOp::print(OpAsmPrinter &printer) {
+  static constexpr StringRef kShapeNames[] = {
+      "m", "k", "start_row", "start_col"};
+  printMteL1L0MxOp(printer, getOperation(), getSource(), getDestination(),
+                    {getM(), getK(), getStartRow(), getStartCol()}, kShapeNames,
+                    {getXStart(), getYStart(), getXStep(), getYStep(),
+                     getSrcStride(), getDstStride()});
+}
+
 LogicalResult MteL1L0aMxOp::verify() {
   if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT")))
     return failure();
-  if (failed(verifyMxLoadControls(getOperation(), getControls())))
+  if (failed(verifyMxLoadOperands(
+          getOperation(), {getM(), getK(), getStartRow(), getStartCol()},
+          {"m", "k", "start_row", "start_col"},
+          {getXStart(), getYStart(), getXStep(), getYStep(), getSrcStride(),
+           getDstStride()})))
     return failure();
-  return verifyMxDestinationAlignment(getOperation(), getDestination());
+  return verifyMxLoadAlignment(getOperation(), getSource(), getDestination());
+}
+
+ParseResult MteL1L0bMxOp::parse(OpAsmParser &parser, OperationState &result) {
+  static constexpr StringRef kShapeNames[] = {
+      "k", "n", "start_row", "start_col"};
+  return parseMteL1L0MxOp<MteL1L0bMxOp>(parser, result, kShapeNames);
+}
+
+void MteL1L0bMxOp::print(OpAsmPrinter &printer) {
+  static constexpr StringRef kShapeNames[] = {
+      "k", "n", "start_row", "start_col"};
+  printMteL1L0MxOp(printer, getOperation(), getSource(), getDestination(),
+                    {getK(), getN(), getStartRow(), getStartCol()}, kShapeNames,
+                    {getXStart(), getYStart(), getXStep(), getYStep(),
+                     getSrcStride(), getDstStride()});
 }
 
 LogicalResult MteL1L0bMxOp::verify() {
   if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT")))
     return failure();
-  if (failed(verifyMxLoadControls(getOperation(), getControls())))
+  if (failed(verifyMxLoadOperands(
+          getOperation(), {getK(), getN(), getStartRow(), getStartCol()},
+          {"k", "n", "start_row", "start_col"},
+          {getXStart(), getYStart(), getXStep(), getYStep(), getSrcStride(),
+           getDstStride()})))
     return failure();
-  return verifyMxDestinationAlignment(getOperation(), getDestination());
+  return verifyMxLoadAlignment(getOperation(), getSource(), getDestination());
 }
 
 LogicalResult LoadCbufToCaMxOp::verify() {

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -1570,18 +1570,21 @@ struct ExpandLeftLoadMxPattern : public OpRewritePattern<pto::MteL1L0aMxOp> {
       return rewriter.notifyMatchFailure(
           op, "failed to derive MX scale destination pointer");
 
-    OperandRange controls = op.getControls();
-    if (controls.size() != 4 && controls.size() != 6)
-      return rewriter.notifyMatchFailure(
-          op, "expected four shape-derived controls or six explicit MX controls");
     LoadCbufToMxControl control;
-    if (controls.size() == 6) {
-      control = {controls[0], controls[1], controls[2], controls[3],
-                 controls[4], controls[5]};
+    if (op.getXStart()) {
+      if (!op.getYStart() || !op.getXStep() || !op.getYStep() ||
+          !op.getSrcStride() || !op.getDstStride())
+        return rewriter.notifyMatchFailure(op,
+                                           "expected complete full MX operands");
+      control = {op.getXStart(), op.getYStart(), op.getXStep(), op.getYStep(),
+                 op.getSrcStride(), op.getDstStride()};
     } else {
+      if (!op.getM() || !op.getK() || !op.getStartRow() || !op.getStartCol())
+        return rewriter.notifyMatchFailure(
+            op, "expected complete shape-derived MX operands");
       FailureOr<LoadCbufToMxControl> derived = deriveLoadCbufToCaMxControl(
-          loc, controls[0], controls[1], sourceType.getElementType(),
-          controls[2], controls[3], rewriter);
+          loc, op.getM(), op.getK(), sourceType.getElementType(),
+          op.getStartRow(), op.getStartCol(), rewriter);
       if (failed(derived))
         return rewriter.notifyMatchFailure(
             op, "failed to derive load_cbuf_to_ca_mx control");
@@ -1616,18 +1619,21 @@ struct ExpandRightLoadMxPattern : public OpRewritePattern<pto::MteL1L0bMxOp> {
       return rewriter.notifyMatchFailure(
           op, "failed to derive MX scale destination pointer");
 
-    OperandRange controls = op.getControls();
-    if (controls.size() != 4 && controls.size() != 6)
-      return rewriter.notifyMatchFailure(
-          op, "expected four shape-derived controls or six explicit MX controls");
     LoadCbufToMxControl control;
-    if (controls.size() == 6) {
-      control = {controls[0], controls[1], controls[2], controls[3],
-                 controls[4], controls[5]};
+    if (op.getXStart()) {
+      if (!op.getYStart() || !op.getXStep() || !op.getYStep() ||
+          !op.getSrcStride() || !op.getDstStride())
+        return rewriter.notifyMatchFailure(op,
+                                           "expected complete full MX operands");
+      control = {op.getXStart(), op.getYStart(), op.getXStep(), op.getYStep(),
+                 op.getSrcStride(), op.getDstStride()};
     } else {
+      if (!op.getK() || !op.getN() || !op.getStartRow() || !op.getStartCol())
+        return rewriter.notifyMatchFailure(
+            op, "expected complete shape-derived MX operands");
       FailureOr<LoadCbufToMxControl> derived = deriveLoadCbufToCbMxControl(
-          loc, controls[0], controls[1], sourceType.getElementType(),
-          controls[2], controls[3], rewriter);
+          loc, op.getK(), op.getN(), sourceType.getElementType(),
+          op.getStartRow(), op.getStartCol(), rewriter);
       if (failed(derived))
         return rewriter.notifyMatchFailure(
             op, "failed to derive load_cbuf_to_cb_mx control");

--- a/ptodsl/docs/user_guide/04-type-system-and-buffer.md
+++ b/ptodsl/docs/user_guide/04-type-system-and-buffer.md
@@ -63,7 +63,7 @@ lp_vreg_ty = pto.vreg_type(256, pto.f8e4m3)
 
 Constructing scalar eager values or host tensor ABI contracts with a low-precision type is **not supported** — `pto.f8e4m3(1.0)` and `pto.tensor_spec(rank=2, dtype=pto.f8e4m3)` will raise an error.
 
-`pto.f8e8m0` is storage-only. Use it for MX scale storage, including an L1 source pointer passed to the explicit-control overload of `pto.mte_l1_l0a_mx` or `pto.mte_l1_l0b_mx`; it is not a scalar arithmetic type.
+`pto.f8e8m0` is storage-only. Use it for MX scale storage, including an L1 source pointer passed with the full MX field group to `pto.mte_l1_l0a_mx` or `pto.mte_l1_l0b_mx`; it is not a scalar arithmetic type.
 
 ### Integer literal guidance
 

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -979,25 +979,27 @@ Cube compute step; it does not issue those transfers itself.
 
 ---
 
-#### `pto.mte_l1_l0a_mx(src: PtrType, dst: PtrType, m: int, k: int, *, start_row: int = 0, start_col: int = 0) -> None`
-#### `pto.mte_l1_l0b_mx(src: PtrType, dst: PtrType, k: int, n: int, *, start_row: int = 0, start_col: int = 0) -> None`
-#### `pto.mte_l1_l0a_mx(src: PtrType, dst: PtrType, *, x_start: int, y_start: int, x_step: int, y_step: int, src_stride: int, dst_stride: int) -> None`
-#### `pto.mte_l1_l0b_mx(src: PtrType, dst: PtrType, *, x_start: int, y_start: int, x_step: int, y_step: int, src_stride: int, dst_stride: int) -> None`
+#### `pto.mte_l1_l0a_mx(src: PtrType, dst: PtrType, m: int | None = None, k: int | None = None, *, start_row: int | None = None, start_col: int | None = None, x_start: int | None = None, y_start: int | None = None, x_step: int | None = None, y_step: int | None = None, src_stride: int | None = None, dst_stride: int | None = None) -> None`
+#### `pto.mte_l1_l0b_mx(src: PtrType, dst: PtrType, k: int | None = None, n: int | None = None, *, start_row: int | None = None, start_col: int | None = None, x_start: int | None = None, y_start: int | None = None, x_step: int | None = None, y_step: int | None = None, src_stride: int | None = None, dst_stride: int | None = None) -> None`
 
-**Description**: MX-mode variants of `mte_l1_l0a` and `mte_l1_l0b`. The shape-derived overloads preserve the existing behavior. The explicit-control overloads are for scale staging where traversal must not be inferred from matrix shape; they preserve every supplied control value through the existing PTO wrapper before it expands to the internal raw MX load.
+**Description**: MX-mode variants of `mte_l1_l0a` and `mte_l1_l0b`. Every control field is independently optional, but a PTODSL call must provide exactly one complete group: either the shape-derived fields or the full MX fields. The shape-derived group preserves existing behavior. Use the full group when scale traversal cannot be inferred from matrix shape; every supplied value is preserved.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `src` | `PtrType` (L1) | MX scale source pointer. `pto.f8e8m0` is supported as a storage element type. |
-| `dst` | `PtrType` (L0A or L0B) | Real staged L0 destination pointer. Pass the actual L0 address; do not divide or otherwise encode it in PTODSL. |
-| `m`, `k` or `k`, `n` | `int` | Shape-derived overload dimensions. Do not combine them with explicit controls. |
-| `start_row`, `start_col` | `int` | Shape-derived overload source offsets. Do not combine them with explicit controls. |
-| `x_start` | `int` | MX load x start position. |
-| `y_start` | `int` | MX load y start position. |
-| `x_step` | `int` | MX load x traversal step. |
-| `y_step` | `int` | MX load y traversal step. |
-| `src_stride` | `int` | MX load source stride. |
-| `dst_stride` | `int` | MX load destination stride. |
+| `src` | `PtrType` (L1) | 32-byte-aligned MX scale source pointer. `pto.f8e8m0` is supported as a storage element type. |
+| `dst` | `PtrType` (L0A or L0B) | 16-byte-aligned real staged L0 destination pointer. Pass the actual L0 address; do not divide or otherwise encode it in PTODSL. |
+| `m`, `k` or `k`, `n` | `int | None` | Shape-derived dimensions. Supply both dimensions and do not combine them with full MX fields. |
+| `start_row`, `start_col` | `int | None` | Shape-derived source offsets. They default to `0` when the shape-derived group is used. With full MX fields they must be omitted, except explicit literal `0` remains accepted for compatibility. |
+| `x_start`, `y_start` | `int | None` | Start coordinates in the MX scale-fragment grid. |
+| `x_step`, `y_step` | `int | None` | Traversal extents in MX scale-fragment grid units. |
+| `src_stride` | `int | None` | Distance between source traversal rows in MX scale-fragment grid units. |
+| `dst_stride` | `int | None` | Distance between destination traversal rows in MX scale-fragment grid units. |
+
+The full group is `x_start`, `y_start`, `x_step`, `y_step`, `src_stride`, and
+`dst_stride`; all six values are required together. Its values are MX
+scale-fragment grid coordinates or strides, not logical element counts or byte
+offsets. A partial group or a mixture of shape-derived and full fields raises
+`TypeError`.
 
 **Returns**: None (side-effect operation).
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5329,8 +5329,8 @@ def mte_l1_l0a_mx(
     m=None,
     k=None,
     *,
-    start_row=0,
-    start_col=0,
+    start_row=None,
+    start_col=None,
     x_start=None,
     y_start=None,
     x_step=None,
@@ -5341,48 +5341,51 @@ def mte_l1_l0a_mx(
     """``pto.mte_l1_l0a_mx`` – MX cube-side LEFT staging.
 
     Use either the existing shape-derived ``m``/``k`` form or provide all six
-    explicit MX controls. Both forms trace through the L1-to-L0A MX wrapper.
+    full MX operands. Both forms trace through the L1-to-L0A MX wrapper.
     """
-    controls = (x_start, y_start, x_step, y_step, src_stride, dst_stride)
-    has_explicit_controls = any(control is not None for control in controls)
-    if has_explicit_controls:
+    full_operands = (x_start, y_start, x_step, y_step, src_stride, dst_stride)
+    has_full_operands = any(operand is not None for operand in full_operands)
+    if has_full_operands:
         if m is not None or k is not None:
             raise TypeError(
-                "mte_l1_l0a_mx accepts either m/k or explicit MX controls, not both"
+                "mte_l1_l0a_mx accepts either m/k or full MX operands, not both"
             )
-        if start_row != 0 or start_col != 0:
+        # The legacy API defaulted these shape-only fields to zero. Continue
+        # accepting explicit zero so existing full-MX callers remain valid.
+        if ((start_row is not None and start_row != 0) or
+                (start_col is not None and start_col != 0)):
             raise TypeError(
-                "mte_l1_l0a_mx start_row/start_col are unavailable with explicit MX controls"
+                "mte_l1_l0a_mx start_row/start_col are unavailable with full MX operands"
             )
-        if any(control is None for control in controls):
+        if any(operand is None for operand in full_operands):
             raise TypeError(
-                "mte_l1_l0a_mx explicit MX controls require x_start, y_start, "
+                "mte_l1_l0a_mx full MX operands require x_start, y_start, "
                 "x_step, y_step, src_stride, and dst_stride"
             )
         _pto.MteL1L0aMxOp(
             unwrap_surface_value(source),
             unwrap_surface_value(destination),
-            [
-                _coerce_i64(x_start, context="mte_l1_l0a_mx x_start"),
-                _coerce_i64(y_start, context="mte_l1_l0a_mx y_start"),
-                _coerce_i64(x_step, context="mte_l1_l0a_mx x_step"),
-                _coerce_i64(y_step, context="mte_l1_l0a_mx y_step"),
-                _coerce_i64(src_stride, context="mte_l1_l0a_mx src_stride"),
-                _coerce_i64(dst_stride, context="mte_l1_l0a_mx dst_stride"),
-            ],
+            x_start=_coerce_i64(x_start, context="mte_l1_l0a_mx x_start"),
+            y_start=_coerce_i64(y_start, context="mte_l1_l0a_mx y_start"),
+            x_step=_coerce_i64(x_step, context="mte_l1_l0a_mx x_step"),
+            y_step=_coerce_i64(y_step, context="mte_l1_l0a_mx y_step"),
+            src_stride=_coerce_i64(src_stride, context="mte_l1_l0a_mx src_stride"),
+            dst_stride=_coerce_i64(dst_stride, context="mte_l1_l0a_mx dst_stride"),
         )
         return
     if m is None or k is None:
-        raise TypeError("mte_l1_l0a_mx requires m and k without explicit MX controls")
+        raise TypeError("mte_l1_l0a_mx requires m and k without full MX operands")
+    if start_row is None:
+        start_row = 0
+    if start_col is None:
+        start_col = 0
     _pto.MteL1L0aMxOp(
         unwrap_surface_value(source),
         unwrap_surface_value(destination),
-        [
-            _coerce_i64(m, context="mte_l1_l0a_mx m"),
-            _coerce_i64(k, context="mte_l1_l0a_mx k"),
-            _coerce_i64(start_row, context="mte_l1_l0a_mx start_row"),
-            _coerce_i64(start_col, context="mte_l1_l0a_mx start_col"),
-        ],
+        m=_coerce_i64(m, context="mte_l1_l0a_mx m"),
+        k=_coerce_i64(k, context="mte_l1_l0a_mx k"),
+        start_row=_coerce_i64(start_row, context="mte_l1_l0a_mx start_row"),
+        start_col=_coerce_i64(start_col, context="mte_l1_l0a_mx start_col"),
     )
 
 
@@ -5393,8 +5396,8 @@ def mte_l1_l0b_mx(
     k=None,
     n=None,
     *,
-    start_row=0,
-    start_col=0,
+    start_row=None,
+    start_col=None,
     x_start=None,
     y_start=None,
     x_step=None,
@@ -5405,48 +5408,51 @@ def mte_l1_l0b_mx(
     """``pto.mte_l1_l0b_mx`` – MX cube-side RIGHT staging.
 
     Use either the existing shape-derived ``k``/``n`` form or provide all six
-    explicit MX controls. Both forms trace through the L1-to-L0B MX wrapper.
+    full MX operands. Both forms trace through the L1-to-L0B MX wrapper.
     """
-    controls = (x_start, y_start, x_step, y_step, src_stride, dst_stride)
-    has_explicit_controls = any(control is not None for control in controls)
-    if has_explicit_controls:
+    full_operands = (x_start, y_start, x_step, y_step, src_stride, dst_stride)
+    has_full_operands = any(operand is not None for operand in full_operands)
+    if has_full_operands:
         if k is not None or n is not None:
             raise TypeError(
-                "mte_l1_l0b_mx accepts either k/n or explicit MX controls, not both"
+                "mte_l1_l0b_mx accepts either k/n or full MX operands, not both"
             )
-        if start_row != 0 or start_col != 0:
+        # The legacy API defaulted these shape-only fields to zero. Continue
+        # accepting explicit zero so existing full-MX callers remain valid.
+        if ((start_row is not None and start_row != 0) or
+                (start_col is not None and start_col != 0)):
             raise TypeError(
-                "mte_l1_l0b_mx start_row/start_col are unavailable with explicit MX controls"
+                "mte_l1_l0b_mx start_row/start_col are unavailable with full MX operands"
             )
-        if any(control is None for control in controls):
+        if any(operand is None for operand in full_operands):
             raise TypeError(
-                "mte_l1_l0b_mx explicit MX controls require x_start, y_start, "
+                "mte_l1_l0b_mx full MX operands require x_start, y_start, "
                 "x_step, y_step, src_stride, and dst_stride"
             )
         _pto.MteL1L0bMxOp(
             unwrap_surface_value(source),
             unwrap_surface_value(destination),
-            [
-                _coerce_i64(x_start, context="mte_l1_l0b_mx x_start"),
-                _coerce_i64(y_start, context="mte_l1_l0b_mx y_start"),
-                _coerce_i64(x_step, context="mte_l1_l0b_mx x_step"),
-                _coerce_i64(y_step, context="mte_l1_l0b_mx y_step"),
-                _coerce_i64(src_stride, context="mte_l1_l0b_mx src_stride"),
-                _coerce_i64(dst_stride, context="mte_l1_l0b_mx dst_stride"),
-            ],
+            x_start=_coerce_i64(x_start, context="mte_l1_l0b_mx x_start"),
+            y_start=_coerce_i64(y_start, context="mte_l1_l0b_mx y_start"),
+            x_step=_coerce_i64(x_step, context="mte_l1_l0b_mx x_step"),
+            y_step=_coerce_i64(y_step, context="mte_l1_l0b_mx y_step"),
+            src_stride=_coerce_i64(src_stride, context="mte_l1_l0b_mx src_stride"),
+            dst_stride=_coerce_i64(dst_stride, context="mte_l1_l0b_mx dst_stride"),
         )
         return
     if k is None or n is None:
-        raise TypeError("mte_l1_l0b_mx requires k and n without explicit MX controls")
+        raise TypeError("mte_l1_l0b_mx requires k and n without full MX operands")
+    if start_row is None:
+        start_row = 0
+    if start_col is None:
+        start_col = 0
     _pto.MteL1L0bMxOp(
         unwrap_surface_value(source),
         unwrap_surface_value(destination),
-        [
-            _coerce_i64(k, context="mte_l1_l0b_mx k"),
-            _coerce_i64(n, context="mte_l1_l0b_mx n"),
-            _coerce_i64(start_row, context="mte_l1_l0b_mx start_row"),
-            _coerce_i64(start_col, context="mte_l1_l0b_mx start_col"),
-        ],
+        k=_coerce_i64(k, context="mte_l1_l0b_mx k"),
+        n=_coerce_i64(n, context="mte_l1_l0b_mx n"),
+        start_row=_coerce_i64(start_row, context="mte_l1_l0b_mx start_row"),
+        start_col=_coerce_i64(start_col, context="mte_l1_l0b_mx start_col"),
     )
 
 

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -21,7 +21,7 @@ def _identity(value):
 
 
 class VectorCubeSurfaceTest(unittest.TestCase):
-    def test_mte_mx_explicit_controls_preserve_all_values(self):
+    def test_mte_mx_full_operands_preserve_all_values(self):
         source = object()
         destination = object()
         controls = {
@@ -36,41 +36,99 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         def coerce(value, *, context):
             return f"{context}:{value}"
 
-        expected = (
-            source,
-            destination,
-            "mte_l1_l0a_mx x_start:3",
-            "mte_l1_l0a_mx y_start:5",
-            "mte_l1_l0a_mx x_step:16",
-            "mte_l1_l0a_mx y_step:2",
-            "mte_l1_l0a_mx src_stride:8",
-            "mte_l1_l0a_mx dst_stride:2",
-        )
         with patch.object(_ops, "_require_explicit_mode"), \
              patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_ops, "_coerce_i64", side_effect=coerce), \
              patch.object(_ops._pto, "MteL1L0aMxOp") as load_ca:
             pto.mte_l1_l0a_mx(source, destination, **controls)
-        load_ca.assert_called_once_with(source, destination, list(expected[2:]))
-
-        expected = (
+        load_ca.assert_called_once_with(
             source,
             destination,
-            "mte_l1_l0b_mx x_start:3",
-            "mte_l1_l0b_mx y_start:5",
-            "mte_l1_l0b_mx x_step:16",
-            "mte_l1_l0b_mx y_step:2",
-            "mte_l1_l0b_mx src_stride:8",
-            "mte_l1_l0b_mx dst_stride:2",
+            x_start="mte_l1_l0a_mx x_start:3",
+            y_start="mte_l1_l0a_mx y_start:5",
+            x_step="mte_l1_l0a_mx x_step:16",
+            y_step="mte_l1_l0a_mx y_step:2",
+            src_stride="mte_l1_l0a_mx src_stride:8",
+            dst_stride="mte_l1_l0a_mx dst_stride:2",
         )
+
         with patch.object(_ops, "_require_explicit_mode"), \
              patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_ops, "_coerce_i64", side_effect=coerce), \
              patch.object(_ops._pto, "MteL1L0bMxOp") as load_cb:
             pto.mte_l1_l0b_mx(source, destination, **controls)
-        load_cb.assert_called_once_with(source, destination, list(expected[2:]))
+        load_cb.assert_called_once_with(
+            source,
+            destination,
+            x_start="mte_l1_l0b_mx x_start:3",
+            y_start="mte_l1_l0b_mx y_start:5",
+            x_step="mte_l1_l0b_mx x_step:16",
+            y_step="mte_l1_l0b_mx y_step:2",
+            src_stride="mte_l1_l0b_mx src_stride:8",
+            dst_stride="mte_l1_l0b_mx dst_stride:2",
+        )
 
-    def test_mte_mx_explicit_controls_require_a_complete_mode(self):
+    def test_mte_mx_shape_operands_are_named(self):
+        source = object()
+        destination = object()
+
+        def coerce(value, *, context):
+            return f"{context}:{value}"
+
+        with patch.object(_ops, "_require_explicit_mode"), \
+             patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_coerce_i64", side_effect=coerce), \
+             patch.object(_ops._pto, "MteL1L0aMxOp") as load_ca:
+            pto.mte_l1_l0a_mx(
+                source, destination, 128, 256, start_row=3, start_col=5
+            )
+        load_ca.assert_called_once_with(
+            source,
+            destination,
+            m="mte_l1_l0a_mx m:128",
+            k="mte_l1_l0a_mx k:256",
+            start_row="mte_l1_l0a_mx start_row:3",
+            start_col="mte_l1_l0a_mx start_col:5",
+        )
+
+        with patch.object(_ops, "_require_explicit_mode"), \
+             patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_coerce_i64", side_effect=coerce), \
+             patch.object(_ops._pto, "MteL1L0bMxOp") as load_cb:
+            pto.mte_l1_l0b_mx(
+                source, destination, 256, 128, start_row=5, start_col=3
+            )
+        load_cb.assert_called_once_with(
+            source,
+            destination,
+            k="mte_l1_l0b_mx k:256",
+            n="mte_l1_l0b_mx n:128",
+            start_row="mte_l1_l0b_mx start_row:5",
+            start_col="mte_l1_l0b_mx start_col:3",
+        )
+
+    def test_mte_mx_shape_operands_default_starts_to_zero(self):
+        source = object()
+        destination = object()
+
+        def coerce(value, *, context):
+            return f"{context}:{value}"
+
+        with patch.object(_ops, "_require_explicit_mode"), \
+             patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_coerce_i64", side_effect=coerce), \
+             patch.object(_ops._pto, "MteL1L0aMxOp") as load_ca:
+            pto.mte_l1_l0a_mx(source, destination, 128, 256)
+        load_ca.assert_called_once_with(
+            source,
+            destination,
+            m="mte_l1_l0a_mx m:128",
+            k="mte_l1_l0a_mx k:256",
+            start_row="mte_l1_l0a_mx start_row:0",
+            start_col="mte_l1_l0a_mx start_col:0",
+        )
+
+    def test_mte_mx_full_operands_require_a_complete_mode(self):
         source = object()
         destination = object()
         complete_controls = {
@@ -85,8 +143,25 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         with patch.object(_ops, "_require_explicit_mode"):
             with self.assertRaisesRegex(TypeError, "require x_start"):
                 pto.mte_l1_l0a_mx(source, destination, x_start=3)
-            with self.assertRaisesRegex(TypeError, "either k/n or explicit"):
+            with self.assertRaisesRegex(TypeError, "either k/n or full"):
                 pto.mte_l1_l0b_mx(source, destination, 128, 256, **complete_controls)
+        with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"), \
+             patch.object(_ops._pto, "MteL1L0aMxOp") as load_ca:
+            pto.mte_l1_l0a_mx(
+                source, destination, start_row=0, start_col=0,
+                **complete_controls
+            )
+        load_ca.assert_called_once_with(
+            source,
+            destination,
+            x_start="mte_l1_l0a_mx x_start:3",
+            y_start="mte_l1_l0a_mx y_start:5",
+            x_step="mte_l1_l0a_mx x_step:16",
+            y_step="mte_l1_l0a_mx y_step:2",
+            src_stride="mte_l1_l0a_mx src_stride:8",
+            dst_stride="mte_l1_l0a_mx dst_stride:2",
+        )
 
         self.assertFalse(hasattr(pto, "load_cbuf_to_ca_mx"))
         self.assertFalse(hasattr(pto, "load_cbuf_to_cb_mx"))

--- a/test/lit/vpto/cube/load_cbuf_to_mx_verify_invalid.pto
+++ b/test/lit/vpto/cube/load_cbuf_to_mx_verify_invalid.pto
@@ -9,11 +9,15 @@
 // RUN: split-file %s %t
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_source.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-SOURCE
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/cb_destination.pto -o - 2>&1 | FileCheck %s --check-prefix=CB-DESTINATION
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_source_alignment.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-SOURCE-ALIGNMENT
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_alignment.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-ALIGNMENT
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_negative_x_step.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-NEGATIVE-X-STEP
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_negative_y_step.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-NEGATIVE-Y-STEP
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_negative_src_stride.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-NEGATIVE-SRC-STRIDE
 // RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_negative_dst_stride.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-NEGATIVE-DST-STRIDE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_partial_shape_fields.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-PARTIAL-SHAPE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/cb_mixed_fields.pto -o - 2>&1 | FileCheck %s --check-prefix=CB-MIXED-FIELDS
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_five_positional_fields.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-FIVE-POSITIONAL
 
 //--- ca_source.pto
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
@@ -46,6 +50,19 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1 = arith.constant 1 : i64
     %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f8E8M0, l1>
     %dst = pto.castptr %c1 : i64 -> !pto.ptr<f8E4M3FN, l0a>
+    pto.mte_l1_l0a_mx %src, %dst, %c0, %c0, %c0, %c0
+      : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0a>, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_source_alignment.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @ca_source_alignment() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c1 : i64 -> !pto.ptr<!pto.f8E8M0, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<f8E4M3FN, l0a>
     pto.mte_l1_l0a_mx %src, %dst, %c0, %c0, %c0, %c0
       : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0a>, i64, i64, i64, i64
     return
@@ -112,10 +129,54 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
   }
 }
 
+//--- ca_partial_shape_fields.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @ca_partial_shape_fields() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c16 = arith.constant 16 : i64
+    %c64 = arith.constant 64 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f8E8M0, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<f8E4M3FN, l0a>
+    pto.mte_l1_l0a_mx %src, %dst, m(%c16), k(%c64), start_row(%c0)
+      : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0a>, i64, i64, i64
+    return
+  }
+}
+
+//--- cb_mixed_fields.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @cb_mixed_fields() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c16 = arith.constant 16 : i64
+    %c64 = arith.constant 64 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f8E8M0, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<f8E4M3FN, l0b>
+    pto.mte_l1_l0b_mx %src, %dst, k(%c64), n(%c16), start_row(%c0), start_col(%c0), x_start(%c0)
+      : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0b>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_five_positional_fields.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @ca_five_positional_fields() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f8E8M0, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<f8E4M3FN, l0a>
+    pto.mte_l1_l0a_mx %src, %dst, %c0, %c0, %c0, %c0, %c0
+      : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0a>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
 // CA-SOURCE: 'pto.load_cbuf_to_ca_mx' op requires MAT source
 // CB-DESTINATION: 'pto.load_cbuf_to_cb_mx' op requires RIGHT destination
+// CA-SOURCE-ALIGNMENT: 'pto.mte_l1_l0a_mx' op statically known LOAD.MX source address must be aligned to 32 bytes, got 1
 // CA-ALIGNMENT: 'pto.mte_l1_l0a_mx' op statically known LOAD.MX destination address must be aligned to 16 bytes, got 1
 // CA-NEGATIVE-X-STEP: 'pto.mte_l1_l0a_mx' op x_step must be non-negative
 // CA-NEGATIVE-Y-STEP: 'pto.mte_l1_l0a_mx' op y_step must be non-negative
 // CA-NEGATIVE-SRC-STRIDE: 'pto.mte_l1_l0a_mx' op src_stride must be non-negative
 // CA-NEGATIVE-DST-STRIDE: 'pto.mte_l1_l0a_mx' op dst_stride must be non-negative
+// CA-PARTIAL-SHAPE: 'pto.mte_l1_l0a_mx' op shape-derived MX form requires start_col
+// CB-MIXED-FIELDS: 'pto.mte_l1_l0b_mx' op cannot mix shape-derived MX operands with full MX operands
+// CA-FIVE-POSITIONAL: expects either four shape-derived or six full positional MX operands

--- a/test/lit/vpto/cube/mte_l1_l0_mx_optional_operands.pto
+++ b/test/lit/vpto/cube/mte_l1_l0_mx_optional_operands.pto
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @mx_load_optional_operands(
+      %a_src: !pto.ptr<!pto.f8E8M0, l1>, %a_dst: !pto.ptr<f8E4M3FN, l0a>,
+      %b_src: !pto.ptr<!pto.f8E8M0, l1>, %b_dst: !pto.ptr<f8E4M3FN, l0b>)
+      attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c2 = arith.constant 2 : i64
+    %c3 = arith.constant 3 : i64
+    %c5 = arith.constant 5 : i64
+    %c8 = arith.constant 8 : i64
+    %c11 = arith.constant 11 : i64
+    %c13 = arith.constant 13 : i64
+    %c16 = arith.constant 16 : i64
+    %c17 = arith.constant 17 : i64
+    %c128 = arith.constant 128 : i64
+
+    pto.mte_l1_l0a_mx %a_src, %a_dst, m(%c16), k(%c128), start_row(%c0), start_col(%c2)
+      : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0a>, i64, i64, i64, i64
+    pto.mte_l1_l0b_mx %b_src, %b_dst, dst_stride(%c13), x_step(%c17), y_start(%c5), src_stride(%c11), y_step(%c8), x_start(%c3)
+      : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0b>, i64, i64, i64, i64, i64, i64
+    pto.mte_l1_l0a_mx %a_src, %a_dst, %c3, %c5, %c17, %c8, %c11, %c13
+      : !pto.ptr<!pto.f8E8M0, l1>, !pto.ptr<f8E4M3FN, l0a>, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @mx_load_optional_operands(
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : i64
+// CHECK-DAG: %[[C2:.*]] = arith.constant 2 : i64
+// CHECK-DAG: %[[C3:.*]] = arith.constant 3 : i64
+// CHECK-DAG: %[[C5:.*]] = arith.constant 5 : i64
+// CHECK-DAG: %[[C8:.*]] = arith.constant 8 : i64
+// CHECK-DAG: %[[C11:.*]] = arith.constant 11 : i64
+// CHECK-DAG: %[[C13:.*]] = arith.constant 13 : i64
+// CHECK-DAG: %[[C16:.*]] = arith.constant 16 : i64
+// CHECK-DAG: %[[C17:.*]] = arith.constant 17 : i64
+// CHECK-DAG: %[[C128:.*]] = arith.constant 128 : i64
+// CHECK: pto.mte_l1_l0a_mx %{{.*}}, %{{.*}}, %[[C16]], %[[C128]], %[[C0]], %[[C2]]
+// CHECK: pto.mte_l1_l0b_mx %{{.*}}, %{{.*}}, %[[C3]], %[[C5]], %[[C17]], %[[C8]], %[[C11]], %[[C13]]
+// CHECK: pto.mte_l1_l0a_mx %{{.*}}, %{{.*}}, %[[C3]], %[[C5]], %[[C17]], %[[C8]], %[[C11]], %[[C13]]


### PR DESCRIPTION
## Summary
- Expose one optional-field API for `mte_l1_l0a_mx` and `mte_l1_l0b_mx`.
- Preserve legacy positional 4-operand shape-derived and 6-operand full-control forms.
- Forward explicit MX staging fields without lossy control packing; keep real staged L0 destination pointer semantics.
- Add VPTO parsing, printing, verification, expansion, documentation, and regression coverage.

## Validation
Validated on remote 144 with LLVM 21.1.8:
- Focused VPTO lit tests: 3/3 passed.
- `ptodsl/tests/test_vector_cube_ops.py -v`: 45/45 passed.
- `ptodsl/tests/test_jit_compile.py`: passed.
- `ptodsl/tests/test_docs_as_test.py`: 14 markdown files, 305 fenced blocks passed.
- `ninja -C build PTOASPythonPackage PTODSLPackage`: passed.

## Compatibility
The verifier rejects partial or mixed control groups while existing positional callers remain supported. Full MX mode requires all six explicit fields: `x_start`, `y_start`, `x_step`, `y_step`, `src_stride`, and `dst_stride`.