### PR TITLE
fix(vpto): keep block queries outside inferred vector scopes

### DIFF
--- a/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
+++ b/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
@@ -89,7 +89,11 @@ static bool isExplicitVectorScopeCarrier(Operation *op) {
 }
 
 static bool isForbiddenInsideInferredVectorScope(Operation *op) {
-  return isa<pto::VbitsortOp, pto::Vmrgsort4Op>(op);
+  // Bisheng cannot expand block-query results produced inside an AIV vector
+  // scope. Keep these scalar queries outside the inferred scope and capture
+  // their results instead.
+  return isa<pto::VbitsortOp, pto::Vmrgsort4Op, pto::GetBlockIdxOp,
+             pto::GetBlockNumOp>(op);
 }
 
 static bool isVectorScopeBoundaryOperation(Operation *op) {

--- a/test/lit/vpto/auto_vecscope_infer_block_query_boundary.pto
+++ b/test/lit/vpto/auto_vecscope_infer_block_query_boundary.pto
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --pto-level=level3 --emit-vpto %s -o - | FileCheck %s
+
+module attributes {pto.target_arch = "a5"} {
+  module attributes {pto.backend = "vpto", pto.kernel_kind = #pto.kernel_kind<vector>} {
+    func.func @auto_vecscope_infer_block_query_boundary() {
+      %c0_i64 = arith.constant 0 : i64
+      %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<bf16, ub>
+      %c0 = arith.constant 0 : index
+      %c6 = arith.constant 6 : index
+      %c1 = arith.constant 1 : index
+      %c8_i64 = arith.constant 8 : i64
+      %c43 = arith.constant 43 : index
+
+      scf.for %iv = %c0 to %c6 step %c1 {
+        %block_idx = pto.get_block_idx
+        %quotient = arith.floordivsi %block_idx, %c8_i64 : i64
+        %index = arith.index_cast %quotient : i64 to index
+        %in_bounds = arith.cmpi slt, %index, %c43 : index
+        scf.if %in_bounds {
+          %value = pto.vlds %ub[%c0] : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+          %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+          pto.vsts %value, %ub[%c0], %mask : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
+        }
+      }
+      return
+    }
+
+    func.func @auto_vecscope_infer_block_num_boundary() {
+      %c0_i64 = arith.constant 0 : i64
+      %ub = pto.castptr %c0_i64 : i64 -> !pto.ptr<bf16, ub>
+      %c0 = arith.constant 0 : index
+      %c1_i64 = arith.constant 1 : i64
+      %block_num = pto.get_block_num
+      %has_blocks = arith.cmpi sge, %block_num, %c1_i64 : i64
+      scf.if %has_blocks {
+        %value = pto.vlds %ub[%c0] : !pto.ptr<bf16, ub> -> !pto.vreg<128xbf16>
+        %mask = pto.pset_b16 "PAT_ALL" : !pto.mask<b16>
+        pto.vsts %value, %ub[%c0], %mask : !pto.vreg<128xbf16>, !pto.ptr<bf16, ub>, !pto.mask<b16>
+      }
+      return
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @auto_vecscope_infer_block_query_boundary
+// CHECK: %[[BLOCK_IDX:.*]] = pto.get_block_idx
+// CHECK: scf.for
+// CHECK-NEXT: pto.vecscope {
+// CHECK-NOT: pto.get_block_idx
+// CHECK: arith.floordivsi %[[BLOCK_IDX]]
+// CHECK: scf.if
+// CHECK: pto.vlds
+// CHECK: pto.vsts
+// CHECK: }
+
+// CHECK-LABEL: func.func @auto_vecscope_infer_block_num_boundary
+// CHECK: %[[BLOCK_NUM:.*]] = pto.get_block_num
+// CHECK-NEXT: pto.vecscope {
+// CHECK-NOT: pto.get_block_num
+// CHECK: arith.cmpi sge, %[[BLOCK_NUM]]
+// CHECK: scf.if
+// CHECK: pto.vlds
+// CHECK: pto.vsts
+// CHECK: }


### PR DESCRIPTION
## Summary

- keep `pto.get_block_idx` and `pto.get_block_num` outside automatically inferred VPTO vector scopes
- capture block-query results into the inferred scope so scalar bounds can still control vector bodies
- add regression coverage for block-index and block-count guards around vector load/store operations

## Root cause

Automatic vecscope inference classified pure block queries as safe scalar producers and moved them into the vector cluster when all users were also moved. This emitted `llvm.hivm.GET.BLOCK.*` inside `llvm.loop.aivector_scope`, where Bisheng failed with:

```text
Do not know how to expand the result of this operator!
```

Treating block queries as inference boundaries leaves the query outside the scope while preserving its SSA uses inside the guarded vector region.

## Validation

- `cmake --build build --target check-pto -j16`
  - 1,684 passed
  - 1 unsupported
- reproduced Request 1 before the fix with both fixtures from PR #1147
- after the fix, both fixtures complete PTOAS device emission and produce fat objects:
  - `current_vmi_block_idx_vf.pto`
  - `current_vmi_multibuf_expand_full.pto`

Addresses Request 1 of #1148.
