### PR TITLE
fix(vmi): avoid VSLDB for single group slot load

### DIFF
--- a/docs/designs/vmi-layout-lowering-cases.md
+++ b/docs/designs/vmi-layout-lowering-cases.md
@@ -2383,6 +2383,14 @@ for g = 0..7:
   out[group_off + g] = rhs_base[rhs_off + g]
 ```
 
+The single-group unit-stride case is special. A `group_slot_load` with
+`num_groups = 1` has only one semantic scalar slot, so it lowers through
+`pto.vlds {dist = "BRC_B*"}` rather than `pto.vsldb`. `vsldb` requires its
+source base operand to be 32B aligned, while the scalar effective address only
+needs the natural alignment of its element type. The broadcast load preserves
+the physical vreg shape; only lane 0 is semantically live for the one-slot
+layout.
+
 If `source_group_stride != 1`, this packed `slots = 8` layout requires a
 strided/gather group-slot load materializer. Until that support exists,
 `group_slot_load` with `slots = 8` and non-unit stride must diagnose instead of

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -3338,6 +3338,13 @@ std::optional<std::string> getPointStoreDistToken(Type elementType) {
   return (Twine("1PT_B") + Twine(elementBits)).str();
 }
 
+std::optional<std::string> getScalarBroadcastLoadDistToken(Type elementType) {
+  unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+    return std::nullopt;
+  return (Twine("BRC_B") + Twine(elementBits)).str();
+}
+
 struct VPTOCmpMode {
   StringRef mode;
   std::optional<IntegerType::SignednessSemantics> signedness;
@@ -6492,6 +6499,35 @@ static LogicalResult lowerGroupSlotLoadParts(
     if (!stride || *stride != 1)
       return rewriter.notifyMatchFailure(
           op, "slots=8 group_slot_load requires constant unit stride");
+
+    // A single logical group only needs one scalar source element.  VSLDB is
+    // a 32B block load and requires its base operand to be 32B aligned, which
+    // is too strong for a valid element-aligned pointer such as base + k.
+    // VLD BRC loads that scalar from the effective element address and
+    // broadcasts it; only lane 0 is semantically live in this layout.
+    if (numGroups == 1) {
+      std::optional<std::string> dist =
+          getScalarBroadcastLoadDistToken(resultVMIType.getElementType());
+      if (!dist)
+        return rewriter.notifyMatchFailure(
+            op, "single-slot group_slot_load requires supported BRC load "
+                "element width");
+      if (resultTypes.size() != 1)
+        return rewriter.notifyMatchFailure(
+            op, "single-slot group_slot_load arity mismatch");
+      auto vregType = dyn_cast<VRegType>(resultTypes.front());
+      if (!vregType)
+        return rewriter.notifyMatchFailure(
+            op, "single-slot group_slot_load result must be vreg");
+      results.push_back(rewriter
+                            .create<VldsOp>(op->getLoc(), vregType,
+                                            /*updated_base=*/Type{}, source,
+                                            offset,
+                                            rewriter.getStringAttr(*dist))
+                            .getResult());
+      return success();
+    }
+
     for (auto [chunk, resultType] : llvm::enumerate(resultTypes)) {
       auto vregType = dyn_cast<VRegType>(resultType);
       if (!vregType)

--- a/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
+++ b/test/lit/vmi_new/vmi_compact_load_store_group_alias.pto
@@ -19,6 +19,17 @@ module {
     return
   }
 
+  func.func @compact_1_after_addptr(%src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>,
+                                    %element: index) {
+    %zero = arith.constant 0 : index
+    %src_element = pto.addptr %src, %element : !pto.ptr<f32, ub> -> !pto.ptr<f32, ub>
+    %value = pto.vmi.vload %src_element[%zero]
+        : !pto.ptr<f32, ub> -> !pto.vmi.vreg<1xf32>
+    pto.vmi.vstore %value, %dst[%element]
+        : !pto.vmi.vreg<1xf32>, !pto.ptr<f32, ub>
+    return
+  }
+
   func.func @compact_2(%src: !pto.ptr<f32, ub>, %dst: !pto.ptr<f32, ub>,
                        %off: index) {
     %value = pto.vmi.vload %src[%off]
@@ -96,8 +107,14 @@ module {
 // LEGACY-SAME: {num_groups = 1 : i64}
 
 // LOWER-LABEL: func.func @compact_1(
-// LOWER: pto.pset_b32 "PAT_VL1"
-// LOWER: pto.vsldb
+// LOWER: pto.vlds {{.*}} {dist = "BRC_B32"}
+// LOWER: pto.vsts
+// LOWER-NOT: pto.vmi.
+
+// LOWER-LABEL: func.func @compact_1_after_addptr(
+// LOWER: %[[SRC_ELEMENT:.*]] = pto.addptr %arg0, %arg2
+// LOWER: pto.vlds %[[SRC_ELEMENT]][%{{.*}}] {dist = "BRC_B32"}
+// LOWER-NOT: pto.vsldb
 // LOWER: pto.vsts
 // LOWER-NOT: pto.vmi.
 


### PR DESCRIPTION
Fixes #1109

## Summary

- Lower `group_slot_load(num_groups=1, slots=8)` through `vlds` with `dist = BRC_B32`.
- Keep multi-group `slots=8` loads on the existing `VSLDB` path.
- Add regression coverage for direct and `addptr`-derived single-element loads.
- Document the alignment-sensitive lowering rule.

## Validation

- Focused VMI lit tests: 3/3 passed.
- `check-dsl`: 30/30 passed.
- `check-pto`: 1,647/1,687 passed; 39 existing unrelated tests failed.
- PR386 license-header check: passed.

Relates to PR #1109.