### PR TITLE
feat(pto): support global HF32 mode configuration

### DIFF
--- a/include/PTO/IR/PTOAttrs.td
+++ b/include/PTO/IR/PTOAttrs.td
@@ -668,6 +668,19 @@ def PTO_RoundModeAttr : EnumAttr<PTO_Dialect, PTO_RoundModeEnum, "round_mode"> {
   let summary = "rounding mode attribute";
 }
 
+// HF32 transform mode. Ascend exposes nearest-zero and nearest-even
+// conversion modes independently of the enable bit.
+def PTO_HF32TransModeEnum : PTO_I32Enum<
+  "HF32TransMode", "HF32 transform rounding mode", [
+    I32EnumAttrCase<"NEAREST_EVEN", 0>,
+    I32EnumAttrCase<"NEAREST_ZERO", 1>
+  ]>;
+
+def PTO_HF32TransModeAttr : EnumAttr<PTO_Dialect, PTO_HF32TransModeEnum,
+                                     "hf32_trans_mode"> {
+  let summary = "HF32 transform rounding mode";
+}
+
 //===----------------------------------------------------------------------===//
 // MAD semantic controls
 //===----------------------------------------------------------------------===//

--- a/include/PTO/IR/PTOOps.td
+++ b/include/PTO/IR/PTOOps.td
@@ -3023,6 +3023,30 @@ def SetFFTsOp : PTO_Op<"set_ffts", [MemoryEffects<[MemRead, MemWrite]>]> {
   let hasVerifier = 1;
 }
 
+//===----------------------------------------------------------------------===//
+// HF32 Configuration Operation
+//===----------------------------------------------------------------------===//
+
+def SetHF32ModeOp : PTO_Op<"sethf32mode", [MemoryEffects<[MemRead, MemWrite]>]> {
+  let summary = "Configure the global Cube HF32 transform mode";
+  let description = [{
+    Updates the HF32 mode used by subsequent Cube matrix operations. When
+    disabled, the transform mode is off; when enabled, `mode` selects
+    nearest-even or nearest-zero FP32-to-HF32 conversion.
+  }];
+
+  let arguments = (ins
+    BoolAttr:$enable,
+    PTO_HF32TransModeAttr:$mode
+  );
+  let results = (outs);
+  let hasVerifier = 1;
+
+  let assemblyFormat = [{
+    `{` `enable` `=` $enable `,` `mode` `=` $mode `}` attr-dict
+  }];
+}
+
 
 def PrintOp : PTO_Op<"print", [MemoryEffects<[MemRead, MemWrite]>]> {
   let summary = "Print debug: format string (attribute) and scalar value.";

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -3500,6 +3500,11 @@ LogicalResult mlir::pto::SetFFTsOp::verify() {
   return mlir::success();
 }
 
+LogicalResult mlir::pto::SetHF32ModeOp::verify() {
+  // The generated enum attribute constrains the transform mode value.
+  return mlir::success();
+}
+
 ParseResult mlir::pto::SyncSetOp::parse(OpAsmParser &parser,
                                         OperationState &result) {
   return parseSyncEventOpCommon(parser, result,

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -5980,6 +5980,37 @@ struct PTOSetFFTsToEmitC : public OpConversionPattern<mlir::pto::SetFFTsOp> {
   }
 };
 
+struct PTOSetHF32ModeToEmitC
+    : public OpConversionPattern<mlir::pto::SetHF32ModeOp> {
+  using OpConversionPattern<mlir::pto::SetHF32ModeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::pto::SetHF32ModeOp op, OpAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MLIRContext *ctx = rewriter.getContext();
+    StringRef enableToken = op.getEnable() ? "AscendC::HF32Mode::ENABLE"
+                                           : "AscendC::HF32Mode::DISABLE";
+    rewriter.create<emitc::CallOpaqueOp>(
+        op.getLoc(), TypeRange{}, "AscendC::SetHF32Mode",
+        rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, enableToken)}),
+        ArrayAttr{}, ValueRange{});
+
+    if (op.getEnable()) {
+      StringRef modeToken =
+          op.getMode() == pto::HF32TransMode::NEAREST_ZERO
+              ? "AscendC::HF32TransMode::NEAREST_ZERO"
+              : "AscendC::HF32TransMode::NEAREST_EVEN";
+      rewriter.create<emitc::CallOpaqueOp>(
+          op.getLoc(), TypeRange{}, "AscendC::SetHF32TransMode",
+          rewriter.getArrayAttr({emitc::OpaqueAttr::get(ctx, modeToken)}),
+          ArrayAttr{}, ValueRange{});
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct PTOSyncSetToEmitC : public OpConversionPattern<mlir::pto::SyncSetOp> {
   PTOSyncSetToEmitC(TypeConverter &typeConverter, MLIRContext *ctx,
                     PTOArch targetArch)
@@ -13626,6 +13657,7 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   patterns.add<PTOStructSetToEmitC>(typeConverter, ctx);
   patterns.add<PTOTReshapeToEmitC>(typeConverter, ctx);
   patterns.add<PTOBitcastToEmitC>(typeConverter, ctx);
+  patterns.add<PTOSetHF32ModeToEmitC>(typeConverter, ctx);
   patterns.add<PTOSetQuantScalarToEmitC, PTOSetQuantVectorToEmitC>(
       typeConverter, ctx, targetArch);
   patterns.add<PTOTAllocToEmitC>(typeConverter, ctx, targetArch);

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -548,6 +548,26 @@ static Value setCtrlBit(Location loc, Value ctrl, unsigned bitIndex, bool value,
   return rewriter.create<pto::Sbitset0Op>(loc, ctrl, bit).getResult();
 }
 
+struct ExpandHF32ModePattern : public OpRewritePattern<pto::SetHF32ModeOp> {
+  using OpRewritePattern<pto::SetHF32ModeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(pto::SetHF32ModeOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value ctrl = rewriter.create<pto::GetCtrlOp>(loc);
+    ctrl = setCtrlBit(loc, ctrl, 46, op.getEnable(), rewriter);
+    // Disabling HF32 must preserve the previously selected transform mode;
+    // AscendC::SetHF32Mode(DISABLE) does not write the trans-mode bit.
+    if (op.getEnable())
+      ctrl = setCtrlBit(loc, ctrl, 47,
+                        op.getMode() == pto::HF32TransMode::NEAREST_ZERO,
+                        rewriter);
+    rewriter.create<pto::SetCtrlOp>(loc, ctrl);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 static Value buildMadSemanticCtrl(Location loc, Value ctrl,
                                   bool isHif8,
                                   std::optional<pto::Tf32Mode> tf32Mode,
@@ -555,13 +575,12 @@ static Value buildMadSemanticCtrl(Location loc, Value ctrl,
                                   bool hasNDir,
                                   PatternRewriter &rewriter) {
   ctrl = setCtrlBit(loc, ctrl, 45, isHif8, rewriter);
+  // An absent tf32_mode means no per-MAD override. Preserve the global
+  // HF32/TF32 state already present in CTRL for this semantic MAD.
   if (tf32Mode) {
     ctrl = setCtrlBit(loc, ctrl, 46, true, rewriter);
     ctrl = setCtrlBit(loc, ctrl, 47,
                       *tf32Mode == pto::Tf32Mode::RoundAway, rewriter);
-  } else {
-    ctrl = setCtrlBit(loc, ctrl, 46, false, rewriter);
-    ctrl = setCtrlBit(loc, ctrl, 47, false, rewriter);
   }
   if (satMode)
     ctrl = setCtrlBit(loc, ctrl, 48, *satMode == pto::MadSatMode::NoSat,
@@ -2048,6 +2067,7 @@ struct VPTOExpandWrapperOpsPass
                  ExpandAtomicConfigPattern<pto::SetAtomicS32Op>,
                  ExpandAtomicConfigPattern<pto::SetAtomicS16Op>,
                  ExpandAtomicConfigPattern<pto::SetAtomicS8Op>,
+                 ExpandHF32ModePattern,
                  ExpandMadSemanticPattern<pto::MadOp>,
                  ExpandMadSemanticPattern<pto::MadAccOp>,
                  ExpandMadSemanticPattern<pto::MadBiasOp>,

--- a/test/lit/pto/sethf32mode.pto
+++ b/test/lit/pto/sethf32mode.pto
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// the CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See the LICENSE file in the root of the software repository for the full text of the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o - | FileCheck %s --check-prefix=VPTO
+// RUN: ptoas --pto-arch=a3 --pto-backend=emitc %s -o - | FileCheck %s --check-prefix=EMITC
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @sethf32mode() attributes {pto.kernel_kind = #pto.kernel_kind<cube>} {
+    pto.sethf32mode {enable = true, mode = #pto<hf32_trans_mode NEAREST_ZERO>}
+    pto.sethf32mode {enable = true, mode = #pto<hf32_trans_mode NEAREST_EVEN>}
+    pto.sethf32mode {enable = false, mode = #pto<hf32_trans_mode NEAREST_EVEN>}
+    return
+  }
+}
+
+// VPTO-LABEL: func.func @sethf32mode
+// VPTO: pto.get_ctrl
+// VPTO: pto.sbitset1
+// VPTO: pto.sbitset1
+// VPTO: pto.set_ctrl
+// VPTO: pto.sbitset1
+// VPTO: pto.sbitset0
+// VPTO: pto.set_ctrl
+// VPTO: pto.sbitset0
+// VPTO: pto.set_ctrl
+
+// EMITC-LABEL: sethf32mode
+// EMITC: AscendC::SetHF32Mode(AscendC::HF32Mode::ENABLE)
+// EMITC: AscendC::SetHF32TransMode(AscendC::HF32TransMode::NEAREST_ZERO)
+// EMITC: AscendC::SetHF32Mode(AscendC::HF32Mode::ENABLE)
+// EMITC: AscendC::SetHF32TransMode(AscendC::HF32TransMode::NEAREST_EVEN)
+// EMITC: AscendC::SetHF32Mode(AscendC::HF32Mode::DISABLE)

--- a/test/lit/vpto/cube/mad_global_hf32_preserve.pto
+++ b/test/lit/vpto/cube/mad_global_hf32_preserve.pto
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// the CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and limitations under the License.
+
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto %s -o /dev/null 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @mad_global_hf32_preserve(
+      %lhs: !pto.ptr<f32, l0a>,
+      %rhs: !pto.ptr<f32, l0b>,
+      %dst: !pto.ptr<f32, l0c>) attributes {pto.kernel} {
+    %c16 = arith.constant 16 : i64
+    pto.sethf32mode {enable = true, mode = #pto<hf32_trans_mode NEAREST_ZERO>}
+    pto.mad %lhs, %rhs, %dst, %c16, %c16, %c16
+      : !pto.ptr<f32, l0a>, !pto.ptr<f32, l0b>, !pto.ptr<f32, l0c>, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @mad_global_hf32_preserve
+// CHECK: pto.sbitset1 {{.*}}, {{.*}} : i64
+// CHECK: pto.sbitset1 {{.*}}, {{.*}} : i64
+// CHECK: pto.set_ctrl
+// CHECK: %[[MAD_CTRL:.*]] = pto.get_ctrl : i64
+// CHECK-NOT: pto.sbitset{{[01]}} {{.*}}, {{.*}} : i64
+// CHECK: pto.sbitset0 {{.*}}, {{.*}} : i64
+// CHECK: pto.sbitset0 {{.*}}, {{.*}} : i64
+// CHECK: pto.mad_raw
+// CHECK: pto.set_ctrl %[[MAD_CTRL]] : i64


### PR DESCRIPTION
## Summary

- Add the `pto.sethf32mode` PTO operation with explicit enable and HF32 transform-mode attributes.
- Lower HF32 configuration through CTRL bits 46/47 in the VPTO wrapper pass.
- Emit equivalent `AscendC::SetHF32Mode` and `AscendC::SetHF32TransMode` calls in the EmitC backend.
- Preserve global HF32/TF32 CTRL state when a semantic Cube MAD has no explicit `tf32_mode`; explicit `tf32_mode` remains a per-MAD override.
- Add regression coverage for global-mode configuration and its interaction with semantic MAD lowering.

## Validation

- `cmake --build .work/builds/issue-990-hf32-mode-clang --target PTOASCompiler -j4`
- VPTO and EmitC FileCheck coverage for `test/lit/pto/sethf32mode.pto` passed.
- VPTO FileCheck coverage for `test/lit/vpto/cube/mad_semantic_to_raw.pto` passed.
- VPTO regression for global HF32 preservation in `test/lit/vpto/cube/mad_global_hf32_preserve.pto` passed.

Closes #990
