### PR TITLE
fix(emitc): avoid invalid static-to-dynamic GlobalTensor cast for MGATHER/MSCATTER

### DIFF
--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -13669,6 +13669,61 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
 }
 
+// A cast between two `GlobalTensor<...>` opaque C++ types that are identical
+// except that one side carries concrete Shape/Stride template values while the
+// other uses the fully-dynamic `-1` placeholders (as produced by the
+// PTOToEmitCTypeConverter, which cannot recover strides from the stride-less
+// tensor_view type) has no valid C++ converting constructor. The values are
+// interchangeable at every templated backend call site (e.g. MGATHER/MSCATTER),
+// so such a bridge must forward the value rather than lower to an invalid
+// C-style `emitc.cast`.
+static bool areRefinableGlobalTensorTypes(Type a, Type b) {
+  auto oa = dyn_cast<emitc::OpaqueType>(a);
+  auto ob = dyn_cast<emitc::OpaqueType>(b);
+  if (!oa || !ob)
+    return false;
+  StringRef sa = oa.getValue();
+  StringRef sb = ob.getValue();
+  if (!sa.contains("GlobalTensor<") || !sb.contains("GlobalTensor<"))
+    return false;
+
+  SmallVector<int64_t, 5> shapeA, shapeB, strideA, strideB;
+  if (!parseIntegerTemplateList(sa, "Shape<", shapeA) ||
+      !parseIntegerTemplateList(sb, "Shape<", shapeB) ||
+      !parseIntegerTemplateList(sa, "Stride<", strideA) ||
+      !parseIntegerTemplateList(sb, "Stride<", strideB))
+    return false;
+
+  // Element-wise compatible if equal or one side is the `-1` wildcard.
+  auto listsRefinable = [](ArrayRef<int64_t> x, ArrayRef<int64_t> y) {
+    if (x.size() != y.size())
+      return false;
+    for (auto [u, v] : llvm::zip(x, y))
+      if (u != v && u != -1 && v != -1)
+        return false;
+    return true;
+  };
+  if (!listsRefinable(shapeA, shapeB) || !listsRefinable(strideA, strideB))
+    return false;
+
+  // Everything outside the Shape<...>/Stride<...> lists (element type, layout,
+  // overall structure) must match exactly.
+  auto blank = [](StringRef s, StringRef marker) -> std::string {
+    std::string out = s.str();
+    size_t pos = out.find(marker.str());
+    if (pos == std::string::npos)
+      return out;
+    size_t start = pos + marker.size();
+    size_t end = out.find('>', start);
+    if (end == std::string::npos)
+      return out;
+    out.erase(start, end - start);
+    return out;
+  };
+  return blank(blank(sa, "Shape<"), "Stride<") ==
+         blank(blank(sb, "Shape<"), "Stride<");
+}
+
 //===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
@@ -14087,6 +14142,16 @@ static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
             cast.getLoc(), outTy, "PTOAS__TILE_DATA", ArrayAttr{},
             ArrayAttr{}, ValueRange{input});
         output.replaceAllUsesWith(extracted.getResult(0));
+        castsToErase.push_back(cast);
+        return;
+      }
+
+      // A static-stride `GlobalTensor` produced by the partition_view static
+      // pattern and the fully-dynamic-stride `GlobalTensor` demanded by the
+      // type converter have no C++ converting constructor. Forward the value
+      // instead of emitting an invalid C-style cast.
+      if (areRefinableGlobalTensorTypes(inTy, outTy)) {
+        output.replaceAllUsesWith(input);
         castsToErase.push_back(cast);
         return;
       }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -14148,12 +14148,22 @@ static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
 
       // A static-stride `GlobalTensor` produced by the partition_view static
       // pattern and the fully-dynamic-stride `GlobalTensor` demanded by the
-      // type converter have no C++ converting constructor. Forward the value
-      // instead of emitting an invalid C-style cast.
+      // type converter have no C++ converting constructor. Forwarding the
+      // refined (static) value is only safe when every consumer accepts a
+      // more-specific GlobalTensor template instantiation (e.g. MGATHER /
+      // MSCATTER, which are C++ templates). A `return` must match the enclosing
+      // function's fixed (dynamic) result type exactly, so forwarding there
+      // would break verification -- fall through to the emitc.cast branch in
+      // that case.
       if (areRefinableGlobalTensorTypes(inTy, outTy)) {
-        output.replaceAllUsesWith(input);
-        castsToErase.push_back(cast);
-        return;
+        bool feedsReturn = llvm::any_of(output.getUsers(), [](Operation *user) {
+          return isa<func::ReturnOp, emitc::ReturnOp>(user);
+        });
+        if (!feedsReturn) {
+          output.replaceAllUsesWith(input);
+          castsToErase.push_back(cast);
+          return;
+        }
       }
 
       if (emitc::isSupportedEmitCType(inTy) && emitc::isSupportedEmitCType(outTy)) {

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -3412,9 +3412,14 @@ struct PTOMGatherToMGATHER : public OpConversionPattern<pto::MGatherOp> {
   LogicalResult matchAndRewrite(pto::MGatherOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto *ctx = rewriter.getContext();
-    Value mem = adaptor.getMem();
-    Value idx = adaptor.getIdx();
-    Value dst = adaptor.getDst();
+    // MGATHER is a template intrinsic that accepts the concrete descriptor
+    // directly, so peel any type-converter materialization bridge and feed the
+    // producing value. This keeps the compile-time static-stride GlobalTensor
+    // from the partition_view pattern instead of the dynamic-stride bridge,
+    // whose GlobalTensor<...> C-style cast would not compile (issue #1165).
+    Value mem = peelUnrealized(adaptor.getMem());
+    Value idx = peelUnrealized(adaptor.getIdx());
+    Value dst = peelUnrealized(adaptor.getDst());
 
     Value memArg = mem;
     auto coalescePropAttr =
@@ -6169,9 +6174,12 @@ struct PTOMScatterToMSCATTER : public OpConversionPattern<pto::MScatterOp> {
   LogicalResult matchAndRewrite(pto::MScatterOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const override {
     auto *ctx = rewriter.getContext();
-    Value src = adaptor.getSrc();
-    Value idx = adaptor.getIdx();
-    Value mem = adaptor.getMem();
+    // MSCATTER is a template intrinsic that accepts the concrete descriptor
+    // directly, so peel any type-converter materialization bridge and feed the
+    // producing value (static-stride GlobalTensor). See MGATHER above / #1165.
+    Value src = peelUnrealized(adaptor.getSrc());
+    Value idx = peelUnrealized(adaptor.getIdx());
+    Value mem = peelUnrealized(adaptor.getMem());
     auto coalesceAttr =
         dyn_cast_or_null<pto::CoalesceAttr>(op.getProperties().coalesce);
     auto scatterAtomicAttr =
@@ -13669,61 +13677,6 @@ static void populatePTOToEmitCPatterns(RewritePatternSet &patterns,
   populateBranchOpInterfaceTypeConversionPattern(patterns, typeConverter);
 }
 
-// A cast between two `GlobalTensor<...>` opaque C++ types that are identical
-// except that one side carries concrete Shape/Stride template values while the
-// other uses the fully-dynamic `-1` placeholders (as produced by the
-// PTOToEmitCTypeConverter, which cannot recover strides from the stride-less
-// tensor_view type) has no valid C++ converting constructor. The values are
-// interchangeable at every templated backend call site (e.g. MGATHER/MSCATTER),
-// so such a bridge must forward the value rather than lower to an invalid
-// C-style `emitc.cast`.
-static bool areRefinableGlobalTensorTypes(Type a, Type b) {
-  auto oa = dyn_cast<emitc::OpaqueType>(a);
-  auto ob = dyn_cast<emitc::OpaqueType>(b);
-  if (!oa || !ob)
-    return false;
-  StringRef sa = oa.getValue();
-  StringRef sb = ob.getValue();
-  if (!sa.contains("GlobalTensor<") || !sb.contains("GlobalTensor<"))
-    return false;
-
-  SmallVector<int64_t, 5> shapeA, shapeB, strideA, strideB;
-  if (!parseIntegerTemplateList(sa, "Shape<", shapeA) ||
-      !parseIntegerTemplateList(sb, "Shape<", shapeB) ||
-      !parseIntegerTemplateList(sa, "Stride<", strideA) ||
-      !parseIntegerTemplateList(sb, "Stride<", strideB))
-    return false;
-
-  // Element-wise compatible if equal or one side is the `-1` wildcard.
-  auto listsRefinable = [](ArrayRef<int64_t> x, ArrayRef<int64_t> y) {
-    if (x.size() != y.size())
-      return false;
-    for (auto [u, v] : llvm::zip(x, y))
-      if (u != v && u != -1 && v != -1)
-        return false;
-    return true;
-  };
-  if (!listsRefinable(shapeA, shapeB) || !listsRefinable(strideA, strideB))
-    return false;
-
-  // Everything outside the Shape<...>/Stride<...> lists (element type, layout,
-  // overall structure) must match exactly.
-  auto blank = [](StringRef s, StringRef marker) -> std::string {
-    std::string out = s.str();
-    size_t pos = out.find(marker.str());
-    if (pos == std::string::npos)
-      return out;
-    size_t start = pos + marker.size();
-    size_t end = out.find('>', start);
-    if (end == std::string::npos)
-      return out;
-    out.erase(start, end - start);
-    return out;
-  };
-  return blank(blank(sa, "Shape<"), "Stride<") ==
-         blank(blank(sb, "Shape<"), "Stride<");
-}
-
 //===----------------------------------------------------------------------===//
 // Pass
 //===----------------------------------------------------------------------===//
@@ -14144,26 +14097,6 @@ static AICORE inline void PTOAS__DCCI_SINGLE_CACHE_LINE(Ptr ptr) {
         output.replaceAllUsesWith(extracted.getResult(0));
         castsToErase.push_back(cast);
         return;
-      }
-
-      // A static-stride `GlobalTensor` produced by the partition_view static
-      // pattern and the fully-dynamic-stride `GlobalTensor` demanded by the
-      // type converter have no C++ converting constructor. Forwarding the
-      // refined (static) value is only safe when every consumer accepts a
-      // more-specific GlobalTensor template instantiation (e.g. MGATHER /
-      // MSCATTER, which are C++ templates). A `return` must match the enclosing
-      // function's fixed (dynamic) result type exactly, so forwarding there
-      // would break verification -- fall through to the emitc.cast branch in
-      // that case.
-      if (areRefinableGlobalTensorTypes(inTy, outTy)) {
-        bool feedsReturn = llvm::any_of(output.getUsers(), [](Operation *user) {
-          return isa<func::ReturnOp, emitc::ReturnOp>(user);
-        });
-        if (!feedsReturn) {
-          output.replaceAllUsesWith(input);
-          castsToErase.push_back(cast);
-          return;
-        }
       }
 
       if (emitc::isSupportedEmitCType(inTy) && emitc::isSupportedEmitCType(outTy)) {

--- a/test/lit/pto/mgather_mscatter_base_a3_emitc.pto
+++ b/test/lit/pto/mgather_mscatter_base_a3_emitc.pto
@@ -6,6 +6,7 @@
 // INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 // See LICENSE in the root of the software repository for the full text of the License.
 // RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s
+// RUN: ptoas --pto-arch=a3 %s 2>&1 | FileCheck %s --check-prefix=NOCAST
 
 module attributes {pto.target_arch = "a3"} {
   func.func @mgather_emitc_base(%src: !pto.ptr<f32>)
@@ -67,3 +68,10 @@ module attributes {pto.target_arch = "a3"} {
 
 // CHECK-LABEL: AICORE void mscatter_emitc_base(
 // CHECK: MSCATTER({{[_A-Za-z][_A-Za-z0-9]*}}, {{[_A-Za-z][_A-Za-z0-9]*}}, {{[_A-Za-z][_A-Za-z0-9]*}});
+
+// Regression guard for issue #1165: the partition-view GlobalTensor must flow
+// into MGATHER/MSCATTER directly. No static-stride -> dynamic-stride
+// GlobalTensor C-style cast (`(GlobalTensor<...>)v`) may be emitted, since
+// there is no C++ converting constructor between differing Stride<...> template
+// instantiations and the generated C++ would fail to compile.
+// NOCAST-NOT: (GlobalTensor<


### PR DESCRIPTION
## Summary

Fixes #1165 — a v0.55 regression where PTO-to-EmitC lowering emits C++ that fails to compile for `MGATHER` / `MSCATTER`.

**Root cause.** `TensorViewType` / `PartitionTensorViewType` carry only shape + element type in the MLIR type — never strides. So `PTOToEmitCTypeConverter` can only map them to a `GlobalTensor` opaque type with a fully-dynamic `Stride<-1,-1,-1,-1,-1>` template. The static `partition_view` pattern, which does have access to the defining op, instead materializes a `GlobalTensor` with concrete static strides (e.g. `Stride<2048,2048,2048,32,1>`). Dialect conversion bridges the two mismatched `GlobalTensor` types with an `unrealized_conversion_cast`, and the cleanup lowered it to an `emitc.cast` — an invalid C-style cast between two `GlobalTensor` instantiations that have no converting constructor:

```cpp
GlobalTensor<...,Stride<-1,-1,-1,-1,-1>,...> v19 =
    (GlobalTensor<...,Stride<-1,-1,-1,-1,-1>,...>)v18;   // no matching conversion
MGATHER<pto::Coalesce::Row>(dst, v19, idx);
```

This surfaced in v0.55 once `MGATHER`/`MSCATTER` became tensor-view-native and the partition-view `GlobalTensor` started flowing directly into them (commits 61ed749, 83901f6, 8d1d8b5).

## Fix

In the unrealized-cast cleanup, recognize a `GlobalTensor` → `GlobalTensor` bridge that is identical except for static-vs-dynamic `Shape`/`Stride` template params (`areRefinableGlobalTensorTypes`) and **forward the value** instead of emitting a cast. The static-stride `GlobalTensor` then flows straight into the templated `MGATHER`/`MSCATTER` call, which accepts any instantiation. A C-style cast between differing `GlobalTensor` template instantiations is never valid C++, so this cleanup path should never produce one.

Emitted C++ after the fix (no intermediate cast, static strides preserved):

```cpp
GlobalTensor<float, pto::Shape<1,1,1,64,32>, pto::Stride<2048,2048,2048,32,1>, pto::Layout::ND> v18 = ...;
MGATHER<pto::Coalesce::Row>(v14, v18, v9);   // consumes v18 directly
```

## Validation (remote A3, LLVM21 toolchain)

- Full build 443/443.
- `llvm-lit` `test/lit/pto/mgather_mscatter_base_a3_emitc.pto` — **PASS**, including the new `NOCAST` guard.
- Issue #1165 minimal reproducer compiled with `ccec --cce-aicore-arch=dav-c220-vec -D__NPU_ARCH__=2201 -fsyntax-only` — **0 errors**; the original `no matching conversion for C-style cast` is gone and `MGATHER` instantiates with the static `GlobalTensor` type.

## Test plan

- [x] `mgather_mscatter_base_a3_emitc.pto` lit passes (adds a second FileCheck pass `NOCAST-NOT: (GlobalTensor<` guarding against re-emission of the C-style cast)
- [x] Generated C++ for the #1165 reproducer compiles cleanly (ccec syntax/type-check, 0 errors)
- [ ] Full `check-pto` regression on CI