### PR TITLE
test(vpto): guard vscatter memory effects against EarlyCSE

### DIFF
--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -291,7 +291,7 @@ getVPTOStructFieldAddress(ConversionPatternRewriter &rewriter, Location loc,
 struct PlannedDecl {
   std::string name;
   FunctionType type;
-  bool writeOnlyDestination = false;
+  bool needsVscatterMemoryEffectsWorkaround = false;
 };
 
 struct LoweringState {
@@ -4442,17 +4442,33 @@ materializeDecls(ModuleOp module, ArrayRef<PlannedDecl> plannedDecls,
   OpBuilder builder(module.getBodyRegion());
   builder.setInsertionPointToStart(&module.getBodyRegion().front());
   for (const PlannedDecl &decl : plannedDecls) {
-    if (func::FuncOp existing = module.lookupSymbol<func::FuncOp>(decl.name)) {
-      if (existing.getFunctionType() != decl.type) {
+    func::FuncOp func = module.lookupSymbol<func::FuncOp>(decl.name);
+    if (func) {
+      if (func.getFunctionType() != decl.type) {
         diagOS << "VPTO LLVM emission failed: conflicting declaration for "
                << decl.name << "\n";
         return failure();
       }
-      continue;
+    } else {
+      func = builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
+      func.setPrivate();
     }
-    auto func =
-        builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
-    func.setPrivate();
+
+    if (!decl.needsVscatterMemoryEffectsWorkaround)
+      continue;
+
+    // Work around a bug in older Bisheng releases: vscatter was not modeled
+    // as writing through its destination pointer, so EarlyCSE could eliminate
+    // a load after vscatter as redundant. Carry the intrinsic's real memory
+    // effects on its declaration through func-to-llvm. The dispatcher later
+    // rewrites LLVM 21's memory(...) spelling for Bisheng's LLVM 15 parser.
+    func->setAttr(
+        "memory_effects",
+        LLVM::MemoryEffectsAttr::get(
+            module.getContext(),
+            {LLVM::ModRefInfo::NoModRef, LLVM::ModRefInfo::Mod,
+             LLVM::ModRefInfo::NoModRef}));
+    func->setAttr("no_unwind", builder.getUnitAttr());
   }
   return success();
 }
@@ -11551,16 +11567,6 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   }
 
   applyArtifactVisibilityLinkage(deviceModule, *llvmModule);
-  for (llvm::Function &func : *llvmModule) {
-    if (!func.getName().starts_with("llvm.hivm.vscatter."))
-      continue;
-    // Bisheng LLVM 15 verifies these intrinsic memory effects. Record them
-    // through the LLVM 21 API here; the dispatcher rewrites the new textual
-    // memory(...) spelling before handing the IR to Bisheng.
-    func.setOnlyAccessesArgMemory();
-    func.addFnAttr(llvm::Attribute::NoUnwind);
-    func.addFnAttr(llvm::Attribute::WriteOnly);
-  }
   applySimtEntryCallingConvention(*llvmModule, simtEntryNames);
   if (failed(attachAIVectorScopeMetadata(*llvmModule, diagOS)))
     return failure();

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -291,7 +291,6 @@ getVPTOStructFieldAddress(ConversionPatternRewriter &rewriter, Location loc,
 struct PlannedDecl {
   std::string name;
   FunctionType type;
-  bool needsVscatterMemoryEffectsWorkaround = false;
 };
 
 struct LoweringState {
@@ -4442,33 +4441,17 @@ materializeDecls(ModuleOp module, ArrayRef<PlannedDecl> plannedDecls,
   OpBuilder builder(module.getBodyRegion());
   builder.setInsertionPointToStart(&module.getBodyRegion().front());
   for (const PlannedDecl &decl : plannedDecls) {
-    func::FuncOp func = module.lookupSymbol<func::FuncOp>(decl.name);
-    if (func) {
-      if (func.getFunctionType() != decl.type) {
+    if (func::FuncOp existing = module.lookupSymbol<func::FuncOp>(decl.name)) {
+      if (existing.getFunctionType() != decl.type) {
         diagOS << "VPTO LLVM emission failed: conflicting declaration for "
                << decl.name << "\n";
         return failure();
       }
-    } else {
-      func = builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
-      func.setPrivate();
-    }
-
-    if (!decl.needsVscatterMemoryEffectsWorkaround)
       continue;
-
-    // Work around a bug in older Bisheng releases: vscatter was not modeled
-    // as writing through its destination pointer, so EarlyCSE could eliminate
-    // a load after vscatter as redundant. Carry the intrinsic's real memory
-    // effects on its declaration through func-to-llvm. The dispatcher later
-    // rewrites LLVM 21's memory(...) spelling for Bisheng's LLVM 15 parser.
-    func->setAttr(
-        "memory_effects",
-        LLVM::MemoryEffectsAttr::get(
-            module.getContext(),
-            {LLVM::ModRefInfo::NoModRef, LLVM::ModRefInfo::Mod,
-             LLVM::ModRefInfo::NoModRef}));
-    func->setAttr("no_unwind", builder.getUnitAttr());
+    }
+    auto func =
+        builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
+    func.setPrivate();
   }
   return success();
 }
@@ -7857,8 +7840,7 @@ public:
         op.getLoc(), *calleeName, TypeRange{},
         ValueRange{adaptor.getValue(), adaptor.getDestination(),
                    adaptor.getOffsets(), adaptor.getMask()});
-    state.plannedDecls.push_back(
-        PlannedDecl{calleeName->str(), funcType, true});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     rewriter.eraseOp(op);
     return success();
   }
@@ -11567,6 +11549,16 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   }
 
   applyArtifactVisibilityLinkage(deviceModule, *llvmModule);
+  for (llvm::Function &func : *llvmModule) {
+    if (!func.getName().starts_with("llvm.hivm.vscatter."))
+      continue;
+    // Work around a bug in older Bisheng releases: vscatter was not modeled
+    // as writing through its destination pointer, so EarlyCSE could eliminate
+    // a load after vscatter as redundant.
+    func.setOnlyAccessesArgMemory();
+    func.addFnAttr(llvm::Attribute::NoUnwind);
+    func.addFnAttr(llvm::Attribute::WriteOnly);
+  }
   applySimtEntryCallingConvention(*llvmModule, simtEntryNames);
   if (failed(attachAIVectorScopeMetadata(*llvmModule, diagOS)))
     return failure();

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -293,7 +293,7 @@ getVPTOStructFieldAddress(ConversionPatternRewriter &rewriter, Location loc,
 struct PlannedDecl {
   std::string name;
   FunctionType type;
-  bool writeOnlyDestination = false;
+  bool needsVscatterMemoryEffectsWorkaround = false;
 };
 
 struct LoweringState {
@@ -4487,17 +4487,33 @@ materializeDecls(ModuleOp module, ArrayRef<PlannedDecl> plannedDecls,
   OpBuilder builder(module.getBodyRegion());
   builder.setInsertionPointToStart(&module.getBodyRegion().front());
   for (const PlannedDecl &decl : plannedDecls) {
-    if (func::FuncOp existing = module.lookupSymbol<func::FuncOp>(decl.name)) {
-      if (existing.getFunctionType() != decl.type) {
+    func::FuncOp func = module.lookupSymbol<func::FuncOp>(decl.name);
+    if (func) {
+      if (func.getFunctionType() != decl.type) {
         diagOS << "VPTO LLVM emission failed: conflicting declaration for "
                << decl.name << "\n";
         return failure();
       }
-      continue;
+    } else {
+      func = builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
+      func.setPrivate();
     }
-    auto func =
-        builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
-    func.setPrivate();
+
+    if (!decl.needsVscatterMemoryEffectsWorkaround)
+      continue;
+
+    // Work around a bug in older Bisheng releases: vscatter was not modeled
+    // as writing through its destination pointer, so EarlyCSE could eliminate
+    // a load after vscatter as redundant. Carry the intrinsic's real memory
+    // effects on its declaration through func-to-llvm. The dispatcher later
+    // rewrites LLVM 21's memory(...) spelling for Bisheng's LLVM 15 parser.
+    func->setAttr(
+        "memory_effects",
+        LLVM::MemoryEffectsAttr::get(
+            module.getContext(),
+            {LLVM::ModRefInfo::NoModRef, LLVM::ModRefInfo::Mod,
+             LLVM::ModRefInfo::NoModRef}));
+    func->setAttr("no_unwind", builder.getUnitAttr());
   }
   return success();
 }
@@ -12249,16 +12265,6 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   }
 
   applyArtifactVisibilityLinkage(deviceModule, *llvmModule);
-  for (llvm::Function &func : *llvmModule) {
-    if (!func.getName().starts_with("llvm.hivm.vscatter."))
-      continue;
-    // Bisheng LLVM 15 verifies these intrinsic memory effects. Record them
-    // through the LLVM 21 API here; the dispatcher rewrites the new textual
-    // memory(...) spelling before handing the IR to Bisheng.
-    func.setOnlyAccessesArgMemory();
-    func.addFnAttr(llvm::Attribute::NoUnwind);
-    func.addFnAttr(llvm::Attribute::WriteOnly);
-  }
   applySimtEntryCallingConvention(*llvmModule, simtEntryNames);
   if (failed(attachAIVectorScopeMetadata(*llvmModule, diagOS)))
     return failure();

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -293,7 +293,6 @@ getVPTOStructFieldAddress(ConversionPatternRewriter &rewriter, Location loc,
 struct PlannedDecl {
   std::string name;
   FunctionType type;
-  bool needsVscatterMemoryEffectsWorkaround = false;
 };
 
 struct LoweringState {
@@ -4487,33 +4486,17 @@ materializeDecls(ModuleOp module, ArrayRef<PlannedDecl> plannedDecls,
   OpBuilder builder(module.getBodyRegion());
   builder.setInsertionPointToStart(&module.getBodyRegion().front());
   for (const PlannedDecl &decl : plannedDecls) {
-    func::FuncOp func = module.lookupSymbol<func::FuncOp>(decl.name);
-    if (func) {
-      if (func.getFunctionType() != decl.type) {
+    if (func::FuncOp existing = module.lookupSymbol<func::FuncOp>(decl.name)) {
+      if (existing.getFunctionType() != decl.type) {
         diagOS << "VPTO LLVM emission failed: conflicting declaration for "
                << decl.name << "\n";
         return failure();
       }
-    } else {
-      func = builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
-      func.setPrivate();
-    }
-
-    if (!decl.needsVscatterMemoryEffectsWorkaround)
       continue;
-
-    // Work around a bug in older Bisheng releases: vscatter was not modeled
-    // as writing through its destination pointer, so EarlyCSE could eliminate
-    // a load after vscatter as redundant. Carry the intrinsic's real memory
-    // effects on its declaration through func-to-llvm. The dispatcher later
-    // rewrites LLVM 21's memory(...) spelling for Bisheng's LLVM 15 parser.
-    func->setAttr(
-        "memory_effects",
-        LLVM::MemoryEffectsAttr::get(
-            module.getContext(),
-            {LLVM::ModRefInfo::NoModRef, LLVM::ModRefInfo::Mod,
-             LLVM::ModRefInfo::NoModRef}));
-    func->setAttr("no_unwind", builder.getUnitAttr());
+    }
+    auto func =
+        builder.create<func::FuncOp>(module.getLoc(), decl.name, decl.type);
+    func.setPrivate();
   }
   return success();
 }
@@ -8456,8 +8439,7 @@ public:
         op.getLoc(), *calleeName, TypeRange{},
         ValueRange{adaptor.getValue(), adaptor.getDestination(),
                    adaptor.getOffsets(), adaptor.getMask()});
-    state.plannedDecls.push_back(
-        PlannedDecl{calleeName->str(), funcType, true});
+    state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     rewriter.eraseOp(op);
     return success();
   }
@@ -12265,6 +12247,16 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   }
 
   applyArtifactVisibilityLinkage(deviceModule, *llvmModule);
+  for (llvm::Function &func : *llvmModule) {
+    if (!func.getName().starts_with("llvm.hivm.vscatter."))
+      continue;
+    // Work around a bug in older Bisheng releases: vscatter was not modeled
+    // as writing through its destination pointer, so EarlyCSE could eliminate
+    // a load after vscatter as redundant.
+    func.setOnlyAccessesArgMemory();
+    func.addFnAttr(llvm::Attribute::NoUnwind);
+    func.addFnAttr(llvm::Attribute::WriteOnly);
+  }
   applySimtEntryCallingConvention(*llvmModule, simtEntryNames);
   if (failed(attachAIVectorScopeMetadata(*llvmModule, diagOS)))
     return failure();

--- a/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
@@ -85,18 +85,9 @@ LogicalResult lowerVPTOModuleToLLVMIRText(
   }
   os.flush();
   // LLVM 21 prints arg-memory effects with memory(...), while the Bisheng
-  // LLVM 15 parser accepts only the equivalent legacy spellings.
-  constexpr StringLiteral modernWriteOnlyArgMem = "memory(argmem: write)";
-  size_t offset = 0;
-  while ((offset = output.find(modernWriteOnlyArgMem.str(), offset)) !=
-         std::string::npos) {
-    output.replace(offset, modernWriteOnlyArgMem.size(),
-                   "writeonly argmemonly");
-    offset += StringRef("writeonly argmemonly").size();
-  }
-
+  // LLVM 15 parser accepts only the equivalent legacy argmemonly spelling.
   constexpr StringLiteral modernArgMemOnly = "memory(argmem: readwrite)";
-  offset = 0;
+  size_t offset = 0;
   while ((offset = output.find(modernArgMemOnly.str(), offset)) !=
          std::string::npos) {
     output.replace(offset, modernArgMemOnly.size(), "argmemonly");

--- a/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
@@ -85,9 +85,18 @@ LogicalResult lowerVPTOModuleToLLVMIRText(
   }
   os.flush();
   // LLVM 21 prints arg-memory effects with memory(...), while the Bisheng
-  // LLVM 15 parser accepts only the equivalent legacy argmemonly spelling.
-  constexpr StringLiteral modernArgMemOnly = "memory(argmem: readwrite)";
+  // LLVM 15 parser accepts only the equivalent legacy spellings.
+  constexpr StringLiteral modernWriteOnlyArgMem = "memory(argmem: write)";
   size_t offset = 0;
+  while ((offset = output.find(modernWriteOnlyArgMem.str(), offset)) !=
+         std::string::npos) {
+    output.replace(offset, modernWriteOnlyArgMem.size(),
+                   "writeonly argmemonly");
+    offset += StringRef("writeonly argmemonly").size();
+  }
+
+  constexpr StringLiteral modernArgMemOnly = "memory(argmem: readwrite)";
+  offset = 0;
   while ((offset = output.find(modernArgMemOnly.str(), offset)) !=
          std::string::npos) {
     output.replace(offset, modernArgMemOnly.size(), "argmemonly");

--- a/test/lit/vpto/vscatter_cse_memory_effects_vpto_llvm.pto
+++ b/test/lit/vpto/vscatter_cse_memory_effects_vpto_llvm.pto
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Guards the vscatter memory effects required to prevent Bisheng EarlyCSE from
+// reusing a vlds result across an in-place scatter.
+// RUN: ptoas --cann-output-version=9.0.0 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+// RUN: ptoas --cann-output-version=9.0.0-beta.1 --pto-arch=a5 --pto-backend=vpto --emit-vpto-llvm-ir %s -o - 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
+  func.func @vscatter_cse_memory_effects(%data: !pto.ptr<f32, ub>,
+                                         %out: !pto.ptr<f32, ub>,
+                                         %value: !pto.vreg<64xf32>,
+                                         %offsets: !pto.vreg<64xi32>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : index
+    %c64 = arith.constant 64 : index
+    pto.vecscope {
+      %mask = pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
+      %before = pto.vlds %data[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+      pto.vscatter %value, %data, %offsets, %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.vreg<64xi32>, !pto.mask<b32>
+      pto.mem_bar "VST_VLD"
+      %after = pto.vlds %data[%c0] : !pto.ptr<f32, ub> -> !pto.vreg<64xf32>
+      pto.vsts %before, %out[%c0], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+      pto.vsts %after, %out[%c64], %mask : !pto.vreg<64xf32>, !pto.ptr<f32, ub>, !pto.mask<b32>
+    }
+    return
+  }
+}
+
+// CHECK: declare <64 x float> @llvm.hivm.vldsx1.v64f32
+// CHECK: declare void @llvm.hivm.vscatter.v64f32.v300({{.*}}) #[[VSCATTER_ATTR:[0-9]+]]
+// CHECK: declare void @llvm.hivm.mem.bar.vst.vld()
+// CHECK: declare void @llvm.hivm.vstsx1.v64f32
+// CHECK-LABEL: define void @vscatter_cse_memory_effects_mix_aiv
+// CHECK: call <64 x float> @llvm.hivm.vldsx1.v64f32
+// CHECK: call void @llvm.hivm.vscatter.v64f32.v300
+// CHECK-NEXT: call void @llvm.hivm.mem.bar.vst.vld()
+// CHECK-NEXT: {{.*}}call <64 x float> @llvm.hivm.vldsx1.v64f32
+// CHECK: call void @llvm.hivm.vstsx1.v64f32
+// CHECK: call void @llvm.hivm.vstsx1.v64f32
+// CHECK: attributes #[[VSCATTER_ATTR]] = { nounwind writeonly argmemonly


### PR DESCRIPTION
## 背景

旧版 Bisheng 没有正确把 `vscatter` 建模为通过 destination pointer 写内存，可能导致 EarlyCSE 将 scatter 之后的同址 load 错误消除。PTOAS 已在 LLVM module 生成后为对应 intrinsic 补充 memory attributes，但现有测试没有覆盖实际 CSE 序列。

## 修改

- 保留翻译后针对 `llvm.hivm.vscatter.*` 的兼容补丁，并在两条 VPTO LLVM emitter 路径中明确注释旧 Bisheng 的错误内存建模及其 EarlyCSE 后果。
- 删除没有被声明物化逻辑消费的 `PlannedDecl::writeOnlyDestination` 字段。
- 新增最小 lit 回归，覆盖同址 `vlds -> vscatter -> mem_bar(VST_VLD) -> vlds`，并检查最终 declaration 的 `nounwind writeonly argmemonly`。

## 验证

- 两个修改的 emitter 与 dispatcher 对象编译通过；完整 `PTOASPythonCore` 重编随后被外部 LLVM/MLIR 源码和生成头版本不一致阻断，与本次改动无关。
- 使用仓库现有构建产物执行新增回归的 CANN 9.0.0 与 9.0.0-beta.1 两条 `RUN:` 命令：PASS。
- Bisheng 15.0.5：`bisheng -target hiipu64-hisilicon-cce -O2 -S -emit-llvm ...`，优化后仍保留 2 次同址 `vldsx1`，`vscatter` 为 `argmemonly nounwind writeonly`。

Refs mouliangyu/PTOAS#564
