### PR TITLE
fix: make TileOps editable

### DIFF
--- a/ptodsl/tests/test_python_package_layout.py
+++ b/ptodsl/tests/test_python_package_layout.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+
+import tomllib
+import unittest
+from pathlib import Path
+
+
+class PythonPackageLayoutTest(unittest.TestCase):
+    def test_tileops_is_declared_as_an_editable_python_package(self):
+        project_root = Path(__file__).resolve().parents[2]
+        with (project_root / "pyproject.toml").open("rb") as stream:
+            pyproject = tomllib.load(stream)
+
+        packages = pyproject["tool"]["scikit-build"]["wheel"]["packages"]
+        self.assertEqual(packages["TileOps"], "lib/TileOps")
+        self.assertTrue((project_root / packages["TileOps"] / "__init__.py").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ptodsl/tests/test_python_package_layout.py
+++ b/ptodsl/tests/test_python_package_layout.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python3
 # Copyright (c) 2026 Huawei Technologies Co., Ltd.
-# This program is free software; you can redistribute it and/or modify it under the terms and conditions of
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
 # CANN Open Software License Agreement Version 2.0 (the "License").
 # Please refer to the License for details. You may not use this file except in compliance with the License.
 # THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
-import tomllib
 import unittest
 from pathlib import Path
 
@@ -15,12 +13,11 @@ from pathlib import Path
 class PythonPackageLayoutTest(unittest.TestCase):
     def test_tileops_is_declared_as_an_editable_python_package(self):
         project_root = Path(__file__).resolve().parents[2]
-        with (project_root / "pyproject.toml").open("rb") as stream:
-            pyproject = tomllib.load(stream)
+        pyproject = (project_root / "pyproject.toml").read_text(encoding="utf-8")
 
-        packages = pyproject["tool"]["scikit-build"]["wheel"]["packages"]
-        self.assertEqual(packages["TileOps"], "lib/TileOps")
-        self.assertTrue((project_root / packages["TileOps"] / "__init__.py").is_file())
+        self.assertIn("[tool.scikit-build.wheel.packages]", pyproject)
+        self.assertIn('TileOps = "lib/TileOps"', pyproject)
+        self.assertTrue((project_root / "lib/TileOps/__init__.py").is_file())
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ install.components = ["PTOAS_Python"]
 [tool.scikit-build.wheel.packages]
 ptodsl = "ptodsl/ptodsl"
 ptoas = "ptodsl/ptoas"
+TileOps = "lib/TileOps"
 
 [tool.scikit-build.cmake.define]
 PTOAS_RELEASE_VERSION_OVERRIDE = { env = "PTOAS_RELEASE_VERSION_OVERRIDE", default = "" }


### PR DESCRIPTION
## Summary

Make `lib/TileOps` a standard scikit-build-core Python package so editable installs resolve TileOps modules directly from the source tree.

This prevents stale copied TileOps files from affecting development after source changes.

## Validation

- Full PTODSL CTest suite: 34/34 passed
- Editable TileOps import resolves to `lib/TileOps`
- Wheel build and installed TileOps import passed

Fixes #1190