### PR TITLE
[PTOAS/PTODSL] Support explicit FP4 L1-to-L0 S4 staging

### DIFF
--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -672,6 +672,81 @@ pto.mte_l1_l0b %l1_b, %l0b, %c32_i64, %c16_i64, %c0_i64, %c0_i64
 
 ---
 
+### Explicit Packed-FP4 L1 to L0 Loads
+
+`pto.load_cbuf_to_ca_s4` and `pto.load_cbuf_to_cb_s4` move an explicitly
+selected two-dimensional region of packed FP4 data from L1 into L0A or L0B.
+They preserve authored start, extent, and stride controls instead of deriving
+them from a logical matrix shape.
+
+- **syntax:**
+```mlir
+pto.load_cbuf_to_ca_s4 %src, %dst, %m_start, %k_start, %m_step,
+  %k_step, %src_stride, %dst_stride, %transpose
+  : !pto.ptr<T, l1>, !pto.ptr<T, l0a>, i64, i64, i64, i64, i64, i64, i64
+
+pto.load_cbuf_to_cb_s4 %src, %dst, %m_start, %k_start, %m_step,
+  %k_step, %src_stride, %dst_stride, %transpose
+  : !pto.ptr<T, l1>, !pto.ptr<T, l0b>, i64, i64, i64, i64, i64, i64, i64
+```
+
+**Parameter Table:**
+
+| Parameter | Width | Description |
+|-----------|-------|-------------|
+| `%src` | ptr | Packed-FP4 source in `l1` |
+| `%dst` | ptr | Destination in `l0a` for the CA form or `l0b` for the CB form |
+| `%m_start` | unsigned 16-bit | First source block on the M axis |
+| `%k_start` | unsigned 16-bit | First source block on the packed-S4 K axis |
+| `%m_step` | unsigned 8-bit | Number of source blocks transferred on the M axis; must be nonzero |
+| `%k_step` | unsigned 8-bit | Number of source blocks transferred on the packed-S4 K axis; must be nonzero |
+| `%src_stride` | unsigned 16-bit | Source outer stride in packed fractal-block units; must be nonzero |
+| `%dst_stride` | unsigned 16-bit | Destination outer stride in packed fractal-block units; must be nonzero |
+| `%transpose` | i64 flag | `0` disables transposition; `1` enables transposition |
+
+`%k_start` and `%k_step` use packed-S4 units: one unit contains two FP4
+values. Values supplied to these operands are consumed directly and are not
+divided by two. This differs from shape-derived operations, which may convert
+logical FP4 extents while deriving their controls.
+
+Conceptually, with transposition disabled, the operation selects the following
+block region:
+
+```text
+for m_block in 0 .. m_step:
+  for k_block in 0 .. k_step:
+    dst_block[m_block, k_block; dst_stride] =
+        src_block[m_start + m_block, k_start + k_block; src_stride]
+```
+
+When `%transpose` is `1`, the selected source region is placed using the
+transposed Cube operand layout.
+
+**Constraints:**
+
+- `%src` must be in `l1`; the CA destination must be in `l0a`, and the CB
+  destination must be in `l0b`.
+- `T` must be `!pto.f4E1M2x2` or `!pto.f4E2M1x2`, and source and destination
+  must use the same packed FP4 type.
+- Start and stride values must fit their 16-bit fields. Step values must be in
+  `1..255`. `%transpose` must be `0` or `1`.
+
+**Example:**
+
+```mlir
+pto.load_cbuf_to_ca_s4 %l1_a, %l0a, %c0_i64, %c4_i64, %c16_i64,
+  %c4_i64, %c16_i64, %c16_i64, %c0_i64
+  : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>,
+    i64, i64, i64, i64, i64, i64, i64
+
+pto.load_cbuf_to_cb_s4 %l1_b, %l0b, %c0_i64, %c4_i64, %c16_i64,
+  %c4_i64, %c16_i64, %c16_i64, %c1_i64
+  : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>,
+    i64, i64, i64, i64, i64, i64, i64
+```
+
+---
+
 ### MX Scale Load Model
 
 MX scale loads prepare the scale payloads consumed by `pto.mad_mx*`. Each scale

--- a/docs/isa/micro-isa/16-cube-matmul.md
+++ b/docs/isa/micro-isa/16-cube-matmul.md
@@ -672,45 +672,54 @@ pto.mte_l1_l0b %l1_b, %l0b, %c32_i64, %c16_i64, %c0_i64, %c0_i64
 
 ---
 
-### Explicit Packed-FP4 L1 to L0 Loads
+### Full-control L1 to L0 Loads
 
-`pto.load_cbuf_to_ca_s4` and `pto.load_cbuf_to_cb_s4` move an explicitly
-selected two-dimensional region of packed FP4 data from L1 into L0A or L0B.
-They preserve authored start, extent, and stride controls instead of deriving
-them from a logical matrix shape.
+`pto.mte_l1_l0a` and `pto.mte_l1_l0b` each accept either their shape-derived
+form above or a full-control form. The full-control form preserves authored
+start, extent, and stride controls instead of deriving them from a logical
+matrix shape.
 
 - **syntax:**
 ```mlir
-pto.load_cbuf_to_ca_s4 %src, %dst, %m_start, %k_start, %m_step,
-  %k_step, %src_stride, %dst_stride, %transpose
-  : !pto.ptr<T, l1>, !pto.ptr<T, l0a>, i64, i64, i64, i64, i64, i64, i64
+pto.mte_l1_l0a %src, %dst, %m_start, %k_start, %m_step,
+  %k_step, %src_stride, %dst_stride
+  : !pto.ptr<T, l1>, !pto.ptr<T, l0a>, i64, i64, i64, i64, i64, i64
 
-pto.load_cbuf_to_cb_s4 %src, %dst, %m_start, %k_start, %m_step,
-  %k_step, %src_stride, %dst_stride, %transpose
-  : !pto.ptr<T, l1>, !pto.ptr<T, l0b>, i64, i64, i64, i64, i64, i64, i64
+pto.mte_l1_l0b %src, %dst, %m_start, %k_start, %m_step,
+  %k_step, %src_stride, %dst_stride
+  : !pto.ptr<T, l1>, !pto.ptr<T, l0b>, i64, i64, i64, i64, i64, i64
 ```
+
+The shape-derived and full-control groups are mutually exclusive. A partial
+group is invalid. The named field spelling is available when an incomplete or
+mixed operation must be diagnosed; complete groups print in the compact
+positional spelling shown above.
 
 **Parameter Table:**
 
 | Parameter | Width | Description |
 |-----------|-------|-------------|
-| `%src` | ptr | Packed-FP4 source in `l1` |
-| `%dst` | ptr | Destination in `l0a` for the CA form or `l0b` for the CB form |
+| `%src` | ptr | L1 source in `l1` |
+| `%dst` | ptr | Destination in `l0a` for the left form or `l0b` for the right form |
 | `%m_start` | unsigned 16-bit | First source block on the M axis |
-| `%k_start` | unsigned 16-bit | First source block on the packed-S4 K axis |
+| `%k_start` | unsigned 16-bit | First source block on the K axis |
 | `%m_step` | unsigned 8-bit | Number of source blocks transferred on the M axis; must be nonzero |
-| `%k_step` | unsigned 8-bit | Number of source blocks transferred on the packed-S4 K axis; must be nonzero |
-| `%src_stride` | unsigned 16-bit | Source outer stride in packed fractal-block units; must be nonzero |
-| `%dst_stride` | unsigned 16-bit | Destination outer stride in packed fractal-block units; must be nonzero |
-| `%transpose` | i64 flag | `0` disables transposition; `1` enables transposition |
+| `%k_step` | unsigned 8-bit | Number of source blocks transferred on the K axis; must be nonzero |
+| `%src_stride` | unsigned 16-bit | Source outer stride in fractal-block units; must be nonzero |
+| `%dst_stride` | unsigned 16-bit | Destination outer stride in fractal-block units; must be nonzero |
+| `transpose` | attr | Optional boolean source-tile transpose before destination placement |
 
-`%k_start` and `%k_step` use packed-S4 units: one unit contains two FP4
-values. Values supplied to these operands are consumed directly and are not
-divided by two. This differs from shape-derived operations, which may convert
-logical FP4 extents while deriving their controls.
+For packed `!pto.f4E1M2x2` and `!pto.f4E2M1x2`, PTOAS expands the same
+`mte_l1_l0a/b` wrapper to its internal S4 load operation. The K controls use
+different units: `%k_start` is a packed `f4x2` source coordinate, so one unit
+is one byte containing two logical FP4 values; `%k_step` is a 32-byte S4
+K-block, so one unit covers 64 logical FP4 values. Full-control values are
+forwarded unchanged. Shape-derived forms convert the logical K coordinates by
+dividing `%start_col` by two for `%k_start` and rounding the K extent up to
+64-value blocks for `%k_step`.
 
-Conceptually, with transposition disabled, the operation selects the following
-block region:
+Conceptually, with transposition disabled, the full-control form selects the
+following block region:
 
 ```text
 for m_block in 0 .. m_step:
@@ -719,30 +728,30 @@ for m_block in 0 .. m_step:
         src_block[m_start + m_block, k_start + k_block; src_stride]
 ```
 
-When `%transpose` is `1`, the selected source region is placed using the
+When `transpose` is `true`, the selected source region is placed using the
 transposed Cube operand layout.
 
 **Constraints:**
 
-- `%src` must be in `l1`; the CA destination must be in `l0a`, and the CB
+- `%src` must be in `l1`; the left destination must be in `l0a`, and the right
   destination must be in `l0b`.
-- `T` must be `!pto.f4E1M2x2` or `!pto.f4E2M1x2`, and source and destination
-  must use the same packed FP4 type.
 - Start and stride values must fit their 16-bit fields. Step values must be in
-  `1..255`. `%transpose` must be `0` or `1`.
+  `1..255`.
+- Packed FP4 source and destination types must match when PTOAS selects the S4
+  expansion.
 
 **Example:**
 
 ```mlir
-pto.load_cbuf_to_ca_s4 %l1_a, %l0a, %c0_i64, %c4_i64, %c16_i64,
-  %c4_i64, %c16_i64, %c16_i64, %c0_i64
+pto.mte_l1_l0a %l1_a, %l0a, %c0_i64, %c4_i64, %c16_i64,
+  %c4_i64, %c16_i64, %c16_i64 {transpose = false}
   : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>,
-    i64, i64, i64, i64, i64, i64, i64
+    i64, i64, i64, i64, i64, i64
 
-pto.load_cbuf_to_cb_s4 %l1_b, %l0b, %c0_i64, %c4_i64, %c16_i64,
-  %c4_i64, %c16_i64, %c16_i64, %c1_i64
+pto.mte_l1_l0b %l1_b, %l0b, %c0_i64, %c4_i64, %c16_i64,
+  %c4_i64, %c16_i64, %c16_i64 {transpose = true}
   : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>,
-    i64, i64, i64, i64, i64, i64, i64
+    i64, i64, i64, i64, i64, i64
 ```
 
 ---

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -3056,51 +3056,55 @@ def PTO_MteGmL1FracOp : PTO_MteOp<"mte_gm_l1_frac", [
 }
 
 def PTO_MteL1L0aOp : PTO_MteOp<"mte_l1_l0a", [
+    AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let arguments = (ins
     PTO_BufferLikeType:$source,
     PTO_BufferLikeType:$destination,
-    I64:$m,
-    I64:$k,
-    I64:$start_row,
-    I64:$start_col,
+    Optional<I64>:$m,
+    Optional<I64>:$k,
+    Optional<I64>:$start_row,
+    Optional<I64>:$start_col,
+    Optional<I64>:$m_start,
+    Optional<I64>:$k_start,
+    Optional<I64>:$m_step,
+    Optional<I64>:$k_step,
+    Optional<I64>:$src_stride,
+    Optional<I64>:$dst_stride,
     DefaultValuedAttr<BoolAttr, "false">:$transpose
   );
 
   let results = (outs);
 
   let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $source `,` $destination `,` $m `,` $k `,` $start_row `,` $start_col
-    attr-dict `:` type($source) `,` type($destination) `,` type($m) `,`
-    type($k) `,` type($start_row) `,` type($start_col)
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def PTO_MteL1L0bOp : PTO_MteOp<"mte_l1_l0b", [
+    AttrSizedOperandSegments,
     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
   ]> {
   let arguments = (ins
     PTO_BufferLikeType:$source,
     PTO_BufferLikeType:$destination,
-    I64:$k,
-    I64:$n,
-    I64:$start_row,
-    I64:$start_col,
+    Optional<I64>:$k,
+    Optional<I64>:$n,
+    Optional<I64>:$start_row,
+    Optional<I64>:$start_col,
+    Optional<I64>:$m_start,
+    Optional<I64>:$k_start,
+    Optional<I64>:$m_step,
+    Optional<I64>:$k_step,
+    Optional<I64>:$src_stride,
+    Optional<I64>:$dst_stride,
     DefaultValuedAttr<BoolAttr, "false">:$transpose
   );
 
   let results = (outs);
 
   let hasVerifier = 1;
-
-  let assemblyFormat = [{
-    $source `,` $destination `,` $k `,` $n `,` $start_row `,` $start_col
-    attr-dict `:` type($source) `,` type($destination) `,` type($k) `,`
-    type($n) `,` type($start_row) `,` type($start_col)
-  }];
+  let hasCustomAssemblyFormat = 1;
 }
 
 def PTO_MteL1L0aMxOp : PTO_MteOp<"mte_l1_l0a_mx", [

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -1387,6 +1387,7 @@ def PTO_LoadCbufToCaS4Op : PTO_MteOp<"load_cbuf_to_ca_s4"> {
   );
 
   let results = (outs);
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $source `,` $destination `,` $m_start `,` $k_start `,` $m_step `,`
@@ -1436,6 +1437,7 @@ def PTO_LoadCbufToCbS4Op : PTO_MteOp<"load_cbuf_to_cb_s4"> {
   );
 
   let results = (outs);
+  let hasVerifier = 1;
 
   let assemblyFormat = [{
     $source `,` $destination `,` $m_start `,` $k_start `,` $m_step `,`

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -8714,37 +8714,82 @@ static LogicalResult verifyMxLoadAlignment(Operation *op, Value source,
                                   kMxDestinationAddressUnitBytes);
 }
 
+static LogicalResult verifyStaticControlRange(Operation *op, Value value,
+                                              StringRef name, int64_t min,
+                                              int64_t max) {
+  APInt intValue;
+  if (!matchPattern(value, m_ConstantInt(&intValue)))
+    return success();
+  int64_t signedValue = intValue.getSExtValue();
+  if (signedValue < min)
+    return op->emitOpError() << name
+                             << (min == 0 ? " must be non-negative"
+                                          : " must be greater than zero");
+  if (signedValue > max)
+    return op->emitOpError() << name << " must be <= " << max
+                             << " to fit the hardware control field";
+  return success();
+}
+
 template <typename OpTy>
 static LogicalResult verifyExplicitCubeBridgeLoadControls(OpTy op) {
-  auto checkConstRange = [&](Value value, StringRef name, int64_t min,
-                             int64_t max) -> LogicalResult {
-    APInt intValue;
-    if (!matchPattern(value, m_ConstantInt(&intValue))) {
-      return success();
-    }
-    int64_t signedValue = intValue.getSExtValue();
-    if (signedValue < min)
-      return op.emitOpError()
-             << name
-             << (min == 0 ? " must be non-negative"
-                          : " must be greater than zero");
-    if (signedValue > max)
-      return op.emitOpError()
-             << name << " must be <= " << max
-             << " to fit the hardware control field";
-    return success();
-  };
-
   constexpr int64_t kU16Max = 65535;
   constexpr int64_t kU8Max = 255;
-  if (failed(checkConstRange(op.getMStart(), "m_start", 0, kU16Max)) ||
-      failed(checkConstRange(op.getKStart(), "k_start", 0, kU16Max)) ||
-      failed(checkConstRange(op.getMStep(), "m_step", 1, kU8Max)) ||
-      failed(checkConstRange(op.getKStep(), "k_step", 1, kU8Max)) ||
-      failed(checkConstRange(op.getSrcStride(), "src_stride", 1, kU16Max)) ||
-      failed(checkConstRange(op.getDstStride(), "dst_stride", 1, kU16Max)))
+  Operation *operation = op.getOperation();
+  if (failed(verifyStaticControlRange(operation, op.getMStart(), "m_start", 0,
+                                      kU16Max)) ||
+      failed(verifyStaticControlRange(operation, op.getKStart(), "k_start", 0,
+                                      kU16Max)) ||
+      failed(verifyStaticControlRange(operation, op.getMStep(), "m_step", 1,
+                                      kU8Max)) ||
+      failed(verifyStaticControlRange(operation, op.getKStep(), "k_step", 1,
+                                      kU8Max)) ||
+      failed(verifyStaticControlRange(operation, op.getSrcStride(),
+                                      "src_stride", 1, kU16Max)) ||
+      failed(verifyStaticControlRange(operation, op.getDstStride(),
+                                      "dst_stride", 1, kU16Max)))
     return failure();
   return success();
+}
+
+template <typename OpTy>
+static LogicalResult verifyS4CubeBridgeLoad(OpTy op,
+                                            AddressSpace expectedDstSpace,
+                                            StringRef dstName) {
+  if (failed(verifyCubeBridgeLoadLikeOp(op, expectedDstSpace, dstName)))
+    return failure();
+
+  Type sourceElem = getBufferElementType(op.getSource().getType());
+  Type destinationElem = getBufferElementType(op.getDestination().getType());
+  if (!pto::isPTOFloat4PackedType(sourceElem))
+    return op.emitOpError(
+        "requires packed FP4 source element type f4e1m2x2 or f4e2m1x2");
+  if (!pto::isPTOFloat4PackedType(destinationElem))
+    return op.emitOpError(
+        "requires packed FP4 destination element type f4e1m2x2 or f4e2m1x2");
+  if (sourceElem != destinationElem)
+    return op.emitOpError(
+        "requires source and destination packed FP4 element types to match");
+  if (failed(verifyExplicitCubeBridgeLoadControls(op)))
+    return failure();
+  return verifyStaticControlRange(op.getOperation(), op.getTranspose(),
+                                  "transpose", 0, 1);
+}
+
+template <typename OpTy>
+static LogicalResult verifyRegularCubeBridgeLoad(OpTy op,
+                                                 AddressSpace expectedDstSpace,
+                                                 StringRef dstName) {
+  if (failed(verifyCubeBridgeLoadLikeOp(op, expectedDstSpace, dstName)))
+    return failure();
+  Type sourceElem = getBufferElementType(op.getSource().getType());
+  Type destinationElem = getBufferElementType(op.getDestination().getType());
+  if (pto::isPTOFloat4PackedType(sourceElem))
+    return op.emitOpError("packed FP4 source requires the S4 load operation");
+  if (pto::isPTOFloat4PackedType(destinationElem))
+    return op.emitOpError(
+        "packed FP4 destination requires the S4 load operation");
+  return verifyExplicitCubeBridgeLoadControls(op);
 }
 
 LogicalResult MteL0cL1Op::verify() {
@@ -8855,17 +8900,19 @@ LogicalResult LoadCbufToCbMxOp::verify() {
 }
 
 LogicalResult LoadCbufToCaOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT"))) {
-    return failure();
-  }
-  return verifyExplicitCubeBridgeLoadControls(*this);
+  return verifyRegularCubeBridgeLoad(*this, AddressSpace::LEFT, "LEFT");
 }
 
 LogicalResult LoadCbufToCbOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT"))) {
-    return failure();
-  }
-  return verifyExplicitCubeBridgeLoadControls(*this);
+  return verifyRegularCubeBridgeLoad(*this, AddressSpace::RIGHT, "RIGHT");
+}
+
+LogicalResult LoadCbufToCaS4Op::verify() {
+  return verifyS4CubeBridgeLoad(*this, AddressSpace::LEFT, "LEFT");
+}
+
+LogicalResult LoadCbufToCbS4Op::verify() {
+  return verifyS4CubeBridgeLoad(*this, AddressSpace::RIGHT, "RIGHT");
 }
 
 void MteL1L0aOp::getEffects(

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -8419,39 +8419,37 @@ static LogicalResult verifyCubeBridgeLoadStart(OpTy op) {
 }
 
 template <typename OpTy>
-static void setMxLoadOperandSegmentSizes(OperationState &result,
-                                         ArrayRef<int32_t> segmentSizes) {
+static void setCubeBridgeLoadOperandSegmentSizes(
+    OperationState &result, ArrayRef<int32_t> segmentSizes) {
   auto &segments = result.getOrAddProperties<typename OpTy::Properties>()
                        .operandSegmentSizes;
   llvm::copy(segmentSizes, segments.begin());
 }
 
-struct MxLoadAsmOperand {
+struct CubeBridgeLoadAsmOperand {
   OpAsmParser::UnresolvedOperand operand;
   Type type;
   bool present = false;
 };
 
-static std::optional<unsigned>
-getMxLoadOperandIndex(StringRef keyword, ArrayRef<StringRef> shapeNames) {
+static std::optional<unsigned> getCubeBridgeLoadOperandIndex(
+    StringRef keyword, ArrayRef<StringRef> shapeNames,
+    ArrayRef<StringRef> fullNames) {
   for (auto [index, name] : llvm::enumerate(shapeNames))
     if (keyword == name) {
       return index;
     }
 
-  static constexpr StringRef kFullNames[] = {
-      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
-  for (auto [index, name] : llvm::enumerate(kFullNames))
-    if (keyword == name) {
+  for (auto [index, name] : llvm::enumerate(fullNames))
+    if (keyword == name)
       return shapeNames.size() + index;
-    }
   return std::nullopt;
 }
 
 template <typename OpTy>
-static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
-                                    OperationState &result,
-                                    ArrayRef<StringRef> shapeNames) {
+static ParseResult parseMteL1L0OptionalOperandsOp(
+    OpAsmParser &parser, OperationState &result, ArrayRef<StringRef> shapeNames,
+    ArrayRef<StringRef> fullNames, StringRef operandDescription = "operands") {
   OpAsmParser::UnresolvedOperand source;
   OpAsmParser::UnresolvedOperand destination;
   if (parser.parseOperand(source) || parser.parseComma() ||
@@ -8459,19 +8457,20 @@ static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
     return failure();
 
   SmallVector<OpAsmParser::UnresolvedOperand, 6> legacyOperands;
-  SmallVector<MxLoadAsmOperand, 10> namedOperands(10);
+  SmallVector<CubeBridgeLoadAsmOperand, 10> namedOperands(10);
   SmallVector<unsigned, 10> namedOperandOrder;
   bool usesNamedOperands = false;
 
   auto parseNamedOperand = [&](StringRef keyword) -> ParseResult {
-    std::optional<unsigned> index = getMxLoadOperandIndex(keyword, shapeNames);
+    std::optional<unsigned> index =
+        getCubeBridgeLoadOperandIndex(keyword, shapeNames, fullNames);
     if (!index)
       return parser.emitError(parser.getCurrentLocation(),
-                              "unknown MX load operand '")
+                              "unknown cube bridge load operand '")
              << keyword << "'";
     if (namedOperands[*index].present)
       return parser.emitError(parser.getCurrentLocation(),
-                              "duplicate MX load operand '")
+                              "duplicate cube bridge load operand '")
              << keyword << "'";
     if (parser.parseLParen() || parser.parseOperand(namedOperands[*index].operand) ||
         parser.parseRParen())
@@ -8510,9 +8509,10 @@ static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
 
   if (!usesNamedOperands && legacyOperands.size() != 4 &&
       legacyOperands.size() != 6)
-    return parser.emitError(parser.getCurrentLocation(),
-                            "expects either four shape-derived or six full "
-                            "positional MX operands");
+    return parser.emitError(
+               parser.getCurrentLocation(),
+               "expects either four shape-derived or six full positional ")
+           << operandDescription;
 
   if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
@@ -8571,17 +8571,14 @@ static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
         return failure();
     }
   }
-  setMxLoadOperandSegmentSizes<OpTy>(result, segmentSizes);
+  setCubeBridgeLoadOperandSegmentSizes<OpTy>(result, segmentSizes);
   return success();
 }
 
-static void printMteL1L0MxOp(OpAsmPrinter &printer, Operation *operation,
-                             Value source, Value destination,
-                             ArrayRef<Value> shapeOperands,
-                             ArrayRef<StringRef> shapeNames,
-                             ArrayRef<Value> fullOperands) {
-  SmallVector<StringRef, 6> fullNames = {
-      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+static void printMteL1L0OptionalOperandsOp(
+    OpAsmPrinter &printer, Operation *operation, Value source, Value destination,
+    ArrayRef<Value> shapeOperands, ArrayRef<StringRef> shapeNames,
+    ArrayRef<Value> fullOperands, ArrayRef<StringRef> fullNames) {
 
   const bool hasShape = llvm::any_of(shapeOperands, [](Value value) {
     return static_cast<bool>(value);
@@ -8792,6 +8789,55 @@ static LogicalResult verifyRegularCubeBridgeLoad(OpTy op,
   return verifyExplicitCubeBridgeLoadControls(op);
 }
 
+static LogicalResult verifyMteL1L0LoadOperands(
+    Operation *op, ArrayRef<Value> shapeOperands,
+    ArrayRef<StringRef> shapeNames, ArrayRef<Value> fullOperands) {
+  const bool hasShape = llvm::any_of(shapeOperands, [](Value value) {
+    return static_cast<bool>(value);
+  });
+  const bool hasFull = llvm::any_of(fullOperands, [](Value value) {
+    return static_cast<bool>(value);
+  });
+  if (hasShape && hasFull)
+    return op->emitOpError(
+        "cannot mix shape-derived operands with full control operands");
+  if (!hasShape && !hasFull)
+    return op->emitOpError(
+        "requires either all shape-derived operands or all full control operands");
+
+  if (hasShape) {
+    for (auto [value, name] : llvm::zip(shapeOperands, shapeNames))
+      if (!value)
+        return op->emitOpError()
+               << "shape-derived form requires " << name;
+    return verifyCubeBridgeLoadStart(op, shapeOperands[2], shapeNames[2],
+                                     shapeOperands[3], shapeNames[3]);
+  }
+
+  static constexpr StringRef kFullNames[] = {
+      "m_start", "k_start", "m_step", "k_step", "src_stride", "dst_stride"};
+  for (auto [value, name] : llvm::zip(fullOperands, kFullNames))
+    if (!value)
+      return op->emitOpError() << "full control form requires " << name;
+
+  constexpr int64_t kU16Max = 65535;
+  constexpr int64_t kU8Max = 255;
+  if (failed(verifyStaticControlRange(op, fullOperands[0], "m_start", 0,
+                                      kU16Max)) ||
+      failed(verifyStaticControlRange(op, fullOperands[1], "k_start", 0,
+                                      kU16Max)) ||
+      failed(verifyStaticControlRange(op, fullOperands[2], "m_step", 1,
+                                      kU8Max)) ||
+      failed(verifyStaticControlRange(op, fullOperands[3], "k_step", 1,
+                                      kU8Max)) ||
+      failed(verifyStaticControlRange(op, fullOperands[4], "src_stride", 1,
+                                      kU16Max)) ||
+      failed(verifyStaticControlRange(op, fullOperands[5], "dst_stride", 1,
+                                      kU16Max)))
+    return failure();
+  return success();
+}
+
 LogicalResult MteL0cL1Op::verify() {
   if (!isBufferLike(getSource().getType()) ||
       !isBufferLike(getDestination().getType()))
@@ -8815,29 +8861,88 @@ LogicalResult MteL1L0aOp::verify() {
   if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT"))) {
     return failure();
   }
-  return verifyCubeBridgeLoadStart(*this);
+  return verifyMteL1L0LoadOperands(
+      getOperation(), {getM(), getK(), getStartRow(), getStartCol()},
+      {"m", "k", "start_row", "start_col"},
+      {getMStart(), getKStart(), getMStep(), getKStep(), getSrcStride(),
+       getDstStride()});
 }
 
 LogicalResult MteL1L0bOp::verify() {
   if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT"))) {
     return failure();
   }
-  return verifyCubeBridgeLoadStart(*this);
+  return verifyMteL1L0LoadOperands(
+      getOperation(), {getK(), getN(), getStartRow(), getStartCol()},
+      {"k", "n", "start_row", "start_col"},
+      {getMStart(), getKStart(), getMStep(), getKStep(), getSrcStride(),
+       getDstStride()});
+}
+
+ParseResult MteL1L0aOp::parse(OpAsmParser &parser, OperationState &result) {
+  static constexpr StringRef kShapeNames[] = {
+      "m", "k", "start_row", "start_col"};
+  static constexpr StringRef kFullNames[] = {
+      "m_start", "k_start", "m_step", "k_step", "src_stride", "dst_stride"};
+  return parseMteL1L0OptionalOperandsOp<MteL1L0aOp>(
+      parser, result, kShapeNames, kFullNames);
+}
+
+void MteL1L0aOp::print(OpAsmPrinter &printer) {
+  static constexpr StringRef kShapeNames[] = {
+      "m", "k", "start_row", "start_col"};
+  static constexpr StringRef kFullNames[] = {
+      "m_start", "k_start", "m_step", "k_step", "src_stride", "dst_stride"};
+  printMteL1L0OptionalOperandsOp(
+      printer, getOperation(), getSource(), getDestination(),
+      {getM(), getK(), getStartRow(), getStartCol()}, kShapeNames,
+      {getMStart(), getKStart(), getMStep(), getKStep(), getSrcStride(),
+       getDstStride()},
+      kFullNames);
+}
+
+ParseResult MteL1L0bOp::parse(OpAsmParser &parser, OperationState &result) {
+  static constexpr StringRef kShapeNames[] = {
+      "k", "n", "start_row", "start_col"};
+  static constexpr StringRef kFullNames[] = {
+      "m_start", "k_start", "m_step", "k_step", "src_stride", "dst_stride"};
+  return parseMteL1L0OptionalOperandsOp<MteL1L0bOp>(
+      parser, result, kShapeNames, kFullNames);
+}
+
+void MteL1L0bOp::print(OpAsmPrinter &printer) {
+  static constexpr StringRef kShapeNames[] = {
+      "k", "n", "start_row", "start_col"};
+  static constexpr StringRef kFullNames[] = {
+      "m_start", "k_start", "m_step", "k_step", "src_stride", "dst_stride"};
+  printMteL1L0OptionalOperandsOp(
+      printer, getOperation(), getSource(), getDestination(),
+      {getK(), getN(), getStartRow(), getStartCol()}, kShapeNames,
+      {getMStart(), getKStart(), getMStep(), getKStep(), getSrcStride(),
+       getDstStride()},
+      kFullNames);
 }
 
 ParseResult MteL1L0aMxOp::parse(OpAsmParser &parser, OperationState &result) {
   static constexpr StringRef kShapeNames[] = {
       "m", "k", "start_row", "start_col"};
-  return parseMteL1L0MxOp<MteL1L0aMxOp>(parser, result, kShapeNames);
+  static constexpr StringRef kFullNames[] = {
+      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+  return parseMteL1L0OptionalOperandsOp<MteL1L0aMxOp>(
+      parser, result, kShapeNames, kFullNames, "MX operands");
 }
 
 void MteL1L0aMxOp::print(OpAsmPrinter &printer) {
   static constexpr StringRef kShapeNames[] = {
       "m", "k", "start_row", "start_col"};
-  printMteL1L0MxOp(printer, getOperation(), getSource(), getDestination(),
-                    {getM(), getK(), getStartRow(), getStartCol()}, kShapeNames,
-                    {getXStart(), getYStart(), getXStep(), getYStep(),
-                     getSrcStride(), getDstStride()});
+  static constexpr StringRef kFullNames[] = {
+      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+  printMteL1L0OptionalOperandsOp(
+      printer, getOperation(), getSource(), getDestination(),
+      {getM(), getK(), getStartRow(), getStartCol()}, kShapeNames,
+      {getXStart(), getYStart(), getXStep(), getYStep(), getSrcStride(),
+       getDstStride()},
+      kFullNames);
 }
 
 LogicalResult MteL1L0aMxOp::verify() {
@@ -8856,16 +8961,23 @@ LogicalResult MteL1L0aMxOp::verify() {
 ParseResult MteL1L0bMxOp::parse(OpAsmParser &parser, OperationState &result) {
   static constexpr StringRef kShapeNames[] = {
       "k", "n", "start_row", "start_col"};
-  return parseMteL1L0MxOp<MteL1L0bMxOp>(parser, result, kShapeNames);
+  static constexpr StringRef kFullNames[] = {
+      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+  return parseMteL1L0OptionalOperandsOp<MteL1L0bMxOp>(
+      parser, result, kShapeNames, kFullNames, "MX operands");
 }
 
 void MteL1L0bMxOp::print(OpAsmPrinter &printer) {
   static constexpr StringRef kShapeNames[] = {
       "k", "n", "start_row", "start_col"};
-  printMteL1L0MxOp(printer, getOperation(), getSource(), getDestination(),
-                    {getK(), getN(), getStartRow(), getStartCol()}, kShapeNames,
-                    {getXStart(), getYStart(), getXStep(), getYStep(),
-                     getSrcStride(), getDstStride()});
+  static constexpr StringRef kFullNames[] = {
+      "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
+  printMteL1L0OptionalOperandsOp(
+      printer, getOperation(), getSource(), getDestination(),
+      {getK(), getN(), getStartRow(), getStartCol()}, kShapeNames,
+      {getXStart(), getYStart(), getXStep(), getYStep(), getSrcStride(),
+       getDstStride()},
+      kFullNames);
 }
 
 LogicalResult MteL1L0bMxOp::verify() {

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -880,11 +880,18 @@ deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
     // to the raw *_s4 bridge op. This matches the pto-isa TExtract helpers.
     return rewriter.create<arith::DivUIOp>(loc, value, constant(2));
   };
+  auto deriveKStep = [&](Value byteExtent) -> Value {
+    // A packed FP4 element contains two logical values.  The S4 bridge
+    // consumes one 32-byte block, so a partial 64-value FP4 block still
+    // requires one hardware step.  Round before converting to the packed
+    // control unit instead of truncating ceilDiv(..., 32) / 2.
+    return ceilDivConst(byteExtent, isFp4Packed ? 64 : 32);
+  };
 
   if (!transpose) {
     Value mStep = ceilDivConst(n, 16);
     Value kBytes = rewriter.create<arith::MulIOp>(loc, k, constant(elemBytes));
-    Value kStep = maybeScaleS4KCoord(ceilDivConst(kBytes, 32));
+    Value kStep = deriveKStep(kBytes);
     Value stride = ceilDivConst(n, 16);
     return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,
                                stride, stride};
@@ -898,7 +905,7 @@ deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
   nAlign = rewriter.create<arith::MulIOp>(loc, nAlign, constant(c0Size));
   Value mStep = ceilDivConst(kAlign, 16);
   Value nBytes = rewriter.create<arith::MulIOp>(loc, nAlign, constant(elemBytes));
-  Value kStep = maybeScaleS4KCoord(ceilDivConst(nBytes, 32));
+  Value kStep = deriveKStep(nBytes);
   Value srcStride = ceilDivConst(kAlign, 16);
   Value dstStride = ceilDivConst(nAlign, 16);
   return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,
@@ -934,11 +941,18 @@ deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
     // to the raw *_s4 bridge op. This matches the pto-isa TExtract helpers.
     return rewriter.create<arith::DivUIOp>(loc, value, constant(2));
   };
+  auto deriveKStep = [&](Value byteExtent) -> Value {
+    // A packed FP4 element contains two logical values.  The S4 bridge
+    // consumes one 32-byte block, so a partial 64-value FP4 block still
+    // requires one hardware step.  Round before converting to the packed
+    // control unit instead of truncating ceilDiv(..., 32) / 2.
+    return ceilDivConst(byteExtent, isFp4Packed ? 64 : 32);
+  };
 
   if (!transpose) {
     Value mStep = ceilDivConst(m, 16);
     Value kBytes = rewriter.create<arith::MulIOp>(loc, k, constant(elemBytes));
-    Value kStep = maybeScaleS4KCoord(ceilDivConst(kBytes, 32));
+    Value kStep = deriveKStep(kBytes);
     Value stride = ceilDivConst(m, 16);
     return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,
                                stride, stride};
@@ -952,7 +966,7 @@ deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
   kAlign = rewriter.create<arith::MulIOp>(loc, kAlign, constant(c0Size));
   Value mStep = ceilDivConst(kAlign, 16);
   Value mBytes = rewriter.create<arith::MulIOp>(loc, mAlign, constant(elemBytes));
-  Value kStep = maybeScaleS4KCoord(ceilDivConst(mBytes, 32));
+  Value kStep = deriveKStep(mBytes);
   Value srcStride = ceilDivConst(kAlign, 16);
   Value dstStride = ceilDivConst(mAlign, 16);
   return LoadCbufToCbControl{mStart, maybeScaleS4KCoord(kStart), mStep, kStep,

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -1574,9 +1574,15 @@ struct ExpandLeftLoadPattern : public OpRewritePattern<pto::MteL1L0aOp> {
     if (!destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
     }
-    FailureOr<LoadCbufToCbControl> control = deriveLoadCbufToCaControl(
-        loc, op.getM(), op.getK(), elementType,
-        op.getStartRow(), op.getStartCol(), op.getTranspose(), rewriter);
+    FailureOr<LoadCbufToCbControl> control = [&]() -> FailureOr<LoadCbufToCbControl> {
+      if (op.getMStart())
+        return LoadCbufToCbControl{op.getMStart(), op.getKStart(),
+                                   op.getMStep(), op.getKStep(),
+                                   op.getSrcStride(), op.getDstStride()};
+      return deriveLoadCbufToCaControl(
+          loc, op.getM(), op.getK(), elementType, op.getStartRow(),
+          op.getStartCol(), op.getTranspose(), rewriter);
+    }();
     if (failed(control))
       return rewriter.notifyMatchFailure(op,
                                          "failed to derive load_cbuf_to_ca control");
@@ -1615,9 +1621,15 @@ struct ExpandRightLoadPattern : public OpRewritePattern<pto::MteL1L0bOp> {
     if (!destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
     }
-    FailureOr<LoadCbufToCbControl> control = deriveLoadCbufToCbControl(
-        loc, op.getK(), op.getN(), elementType,
-        op.getStartRow(), op.getStartCol(), op.getTranspose(), rewriter);
+    FailureOr<LoadCbufToCbControl> control = [&]() -> FailureOr<LoadCbufToCbControl> {
+      if (op.getMStart())
+        return LoadCbufToCbControl{op.getMStart(), op.getKStart(),
+                                   op.getMStep(), op.getKStep(),
+                                   op.getSrcStride(), op.getDstStride()};
+      return deriveLoadCbufToCbControl(
+          loc, op.getK(), op.getN(), elementType, op.getStartRow(),
+          op.getStartCol(), op.getTranspose(), rewriter);
+    }();
     if (failed(control))
       return rewriter.notifyMatchFailure(op,
                                          "failed to derive load_cbuf_to_cb control");

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -944,17 +944,15 @@ Cube compute step; it does not issue those transfers itself.
 
 **Description**: Explicit-control L1-to-L0A/L0B loads. This overload preserves
 the authored fractal-block control fields and does not infer strides from a
-logical tile shape. It currently rejects FP4 packed source pointers because
-the compatibility wrapper cannot yet guarantee selection of the FP4-specific
-L1-to-L0 intrinsic on this path. For FP4 packed operands, use the structured
-shape-derived `mte_l1_l0a(..., m, k, ...)` or `mte_l1_l0b(..., k, n, ...)`
-form below.
+logical tile shape. The source pointer element type selects the data-movement
+semantics: `f4e1m2x2` and `f4e2m1x2` use packed-S4 staging, while other
+supported element types use the regular L1-to-L0 load.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `src` | `PtrType` (L1/MAT) | L1 source pointer; parent-allocation matrix offsets are represented by the control fields below. FP4 packed source pointers are not supported by this explicit-control overload. |
+| `src` | `PtrType` (L1/MAT) | L1 source pointer; parent-allocation matrix offsets are represented by the control fields below. Packed `f4e1m2x2` and `f4e2m1x2` sources select packed-S4 staging. |
 | `dst` | `PtrType` (L0A/L0B) | L0 destination pointer; stage/version offsets belong in this pointer. |
 | `m_start`, `k_start` | `int` in `0..65535` | Source fractal-block coordinates at which the load begins. |
 | `m_step`, `k_step` | `int` in `1..255` | Number of fractal blocks transferred along the two source axes. |
@@ -965,7 +963,10 @@ form below.
 
 Use this overload when a source/destination subregion has layout control that
 cannot be reconstructed from a canonical `m`/`k`/`n` tile shape. The pointer
-order is always `src, dst`.
+order is always `src, dst`. For packed FP4 sources, `k_start` and `k_step` are
+already expressed in packed-S4 units, where one unit contains two FP4 values.
+PTODSL preserves all six controls exactly; callers must not pre-scale the K
+controls to compensate for the structured form's shape conversion.
 
 ---
 

--- a/ptodsl/docs/user_guide/07-data-movement-ops.md
+++ b/ptodsl/docs/user_guide/07-data-movement-ops.md
@@ -944,15 +944,16 @@ Cube compute step; it does not issue those transfers itself.
 
 **Description**: Explicit-control L1-to-L0A/L0B loads. This overload preserves
 the authored fractal-block control fields and does not infer strides from a
-logical tile shape. The source pointer element type selects the data-movement
-semantics: `f4e1m2x2` and `f4e2m1x2` use packed-S4 staging, while other
-supported element types use the regular L1-to-L0 load.
+logical tile shape. PTODSL emits the same `mte_l1_l0a` / `mte_l1_l0b` wrapper
+IR as the structured overload; PTOAS selects packed-S4 staging for
+`f4e1m2x2` and `f4e2m1x2`, and the regular L1-to-L0 load for other supported
+element types.
 
 **Parameters**:
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `src` | `PtrType` (L1/MAT) | L1 source pointer; parent-allocation matrix offsets are represented by the control fields below. Packed `f4e1m2x2` and `f4e2m1x2` sources select packed-S4 staging. |
+| `src` | `PtrType` (L1/MAT) | L1 source pointer; parent-allocation matrix offsets are represented by the control fields below. |
 | `dst` | `PtrType` (L0A/L0B) | L0 destination pointer; stage/version offsets belong in this pointer. |
 | `m_start`, `k_start` | `int` in `0..65535` | Source fractal-block coordinates at which the load begins. |
 | `m_step`, `k_step` | `int` in `1..255` | Number of fractal blocks transferred along the two source axes. |
@@ -963,10 +964,11 @@ supported element types use the regular L1-to-L0 load.
 
 Use this overload when a source/destination subregion has layout control that
 cannot be reconstructed from a canonical `m`/`k`/`n` tile shape. The pointer
-order is always `src, dst`. For packed FP4 sources, `k_start` and `k_step` are
-already expressed in packed-S4 units, where one unit contains two FP4 values.
-PTODSL preserves all six controls exactly; callers must not pre-scale the K
-controls to compensate for the structured form's shape conversion.
+order is always `src, dst`. For packed FP4 sources, `k_start` is a packed
+`f4x2` source coordinate (one byte, or two logical FP4 values), while `k_step`
+is a 32-byte S4 K-block (64 logical FP4 values). PTODSL preserves all six
+controls in the wrapper IR exactly; callers must not pre-scale the K controls
+to compensate for the structured form's shape conversion.
 
 ---
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5361,14 +5361,6 @@ def mem_bar(barrier_type):
     _pto.MemBarOp(kind=_membar_attr(barrier_name))
 
 
-def _is_fp4_packed_pointer_value(value, *, context: str) -> bool:
-    elem_type = _pointer_element_type(value, context=context)
-    return any(
-        _isinstance_pto_type(elem_type, type_name)
-        for type_name in ("F4E1M2x2Type", "F4E2M1x2Type")
-    )
-
-
 def _normalize_cube_transpose(value, *, context: str) -> bool:
     """Normalize the legacy BoolAttr-compatible 0/1 spelling."""
     if isinstance(value, bool):
@@ -5376,69 +5368,6 @@ def _normalize_cube_transpose(value, *, context: str) -> bool:
     if isinstance(value, int) and value in (0, 1):
         return bool(value)
     raise TypeError(f"{context} transpose expects bool or integer 0/1")
-
-
-def _emit_explicit_l1_l0_load(
-    source,
-    destination,
-    controls,
-    transpose,
-    *,
-    op_name: str,
-    regular_op,
-    s4_op,
-):
-    source_value = unwrap_surface_value(source)
-    destination_value = unwrap_surface_value(destination)
-    control_names = (
-        "m_start",
-        "k_start",
-        "m_step",
-        "k_step",
-        "src_stride",
-        "dst_stride",
-    )
-    source_is_fp4 = _is_fp4_packed_pointer_value(
-        source_value, context=f"{op_name} source"
-    )
-    destination_is_fp4 = _is_fp4_packed_pointer_value(
-        destination_value, context=f"{op_name} destination"
-    )
-    if source_is_fp4 != destination_is_fp4:
-        raise TypeError(
-            f"{op_name} source and destination must both use packed FP4 "
-            "or both use regular element types"
-        )
-    if source_is_fp4:
-        source_elem_type = _pointer_element_type(
-            source_value, context=f"{op_name} source"
-        )
-        destination_elem_type = _pointer_element_type(
-            destination_value, context=f"{op_name} destination"
-        )
-        if source_elem_type != destination_elem_type:
-            raise TypeError(
-                f"{op_name} source and destination packed FP4 element types "
-                "must match"
-            )
-    normalized_controls = tuple(
-        _coerce_i64(value, context=f"{op_name} {name}")
-        for name, value in zip(control_names, controls)
-    )
-    if source_is_fp4:
-        s4_op(
-            source_value,
-            destination_value,
-            *normalized_controls,
-            _coerce_i64(int(transpose), context=f"{op_name} transpose"),
-        )
-        return
-    regular_op(
-        source_value,
-        destination_value,
-        *normalized_controls,
-        transpose=transpose,
-    )
 
 
 @_explicit_mode_only("pto.mte_l1_l0a(...)")
@@ -5461,7 +5390,8 @@ def mte_l1_l0a(
     """``pto.mte_l1_l0a`` – structured or explicit-control L1-to-L0A load.
 
     Use either the existing shape-derived ``m``/``k`` form or provide all six
-    explicit L1-to-L0A controls. Packed FP4 sources select the S4 load path.
+    explicit L1-to-L0A controls. PTOAS selects the regular or packed-S4 raw
+    load during wrapper expansion.
     """
     transpose = _normalize_cube_transpose(transpose, context="mte_l1_l0a")
     controls = (m_start, k_start, m_step, k_step, src_stride, dst_stride)
@@ -5480,14 +5410,16 @@ def mte_l1_l0a(
                 "mte_l1_l0a explicit controls require m_start, k_start, "
                 "m_step, k_step, src_stride, and dst_stride"
             )
-        _emit_explicit_l1_l0_load(
-            source,
-            destination,
-            controls,
-            transpose,
-            op_name="mte_l1_l0a",
-            regular_op=_pto.LoadCbufToCaOp,
-            s4_op=_pto.LoadCbufToCaS4Op,
+        _pto.MteL1L0aOp(
+            unwrap_surface_value(source),
+            unwrap_surface_value(destination),
+            m_start=_coerce_i64(m_start, context="mte_l1_l0a m_start"),
+            k_start=_coerce_i64(k_start, context="mte_l1_l0a k_start"),
+            m_step=_coerce_i64(m_step, context="mte_l1_l0a m_step"),
+            k_step=_coerce_i64(k_step, context="mte_l1_l0a k_step"),
+            src_stride=_coerce_i64(src_stride, context="mte_l1_l0a src_stride"),
+            dst_stride=_coerce_i64(dst_stride, context="mte_l1_l0a dst_stride"),
+            transpose=transpose,
         )
         return
     if m is None or k is None:
@@ -5495,10 +5427,10 @@ def mte_l1_l0a(
     _pto.MteL1L0aOp(
         unwrap_surface_value(source),
         unwrap_surface_value(destination),
-        _coerce_i64(m, context="mte_l1_l0a m"),
-        _coerce_i64(k, context="mte_l1_l0a k"),
-        _coerce_i64(start_row, context="mte_l1_l0a start_row"),
-        _coerce_i64(start_col, context="mte_l1_l0a start_col"),
+        m=_coerce_i64(m, context="mte_l1_l0a m"),
+        k=_coerce_i64(k, context="mte_l1_l0a k"),
+        start_row=_coerce_i64(start_row, context="mte_l1_l0a start_row"),
+        start_col=_coerce_i64(start_col, context="mte_l1_l0a start_col"),
         transpose=transpose,
     )
 
@@ -5523,7 +5455,8 @@ def mte_l1_l0b(
     """``pto.mte_l1_l0b`` – structured or explicit-control L1-to-L0B load.
 
     Use either the existing shape-derived ``k``/``n`` form or provide all six
-    explicit L1-to-L0B controls. Packed FP4 sources select the S4 load path.
+    explicit L1-to-L0B controls. PTOAS selects the regular or packed-S4 raw
+    load during wrapper expansion.
     """
     transpose = _normalize_cube_transpose(transpose, context="mte_l1_l0b")
     controls = (m_start, k_start, m_step, k_step, src_stride, dst_stride)
@@ -5542,14 +5475,16 @@ def mte_l1_l0b(
                 "mte_l1_l0b explicit controls require m_start, k_start, "
                 "m_step, k_step, src_stride, and dst_stride"
             )
-        _emit_explicit_l1_l0_load(
-            source,
-            destination,
-            controls,
-            transpose,
-            op_name="mte_l1_l0b",
-            regular_op=_pto.LoadCbufToCbOp,
-            s4_op=_pto.LoadCbufToCbS4Op,
+        _pto.MteL1L0bOp(
+            unwrap_surface_value(source),
+            unwrap_surface_value(destination),
+            m_start=_coerce_i64(m_start, context="mte_l1_l0b m_start"),
+            k_start=_coerce_i64(k_start, context="mte_l1_l0b k_start"),
+            m_step=_coerce_i64(m_step, context="mte_l1_l0b m_step"),
+            k_step=_coerce_i64(k_step, context="mte_l1_l0b k_step"),
+            src_stride=_coerce_i64(src_stride, context="mte_l1_l0b src_stride"),
+            dst_stride=_coerce_i64(dst_stride, context="mte_l1_l0b dst_stride"),
+            transpose=transpose,
         )
         return
     if k is None or n is None:
@@ -5557,10 +5492,10 @@ def mte_l1_l0b(
     _pto.MteL1L0bOp(
         unwrap_surface_value(source),
         unwrap_surface_value(destination),
-        _coerce_i64(k, context="mte_l1_l0b k"),
-        _coerce_i64(n, context="mte_l1_l0b n"),
-        _coerce_i64(start_row, context="mte_l1_l0b start_row"),
-        _coerce_i64(start_col, context="mte_l1_l0b start_col"),
+        k=_coerce_i64(k, context="mte_l1_l0b k"),
+        n=_coerce_i64(n, context="mte_l1_l0b n"),
+        start_row=_coerce_i64(start_row, context="mte_l1_l0b start_row"),
+        start_col=_coerce_i64(start_col, context="mte_l1_l0b start_col"),
         transpose=transpose,
     )
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -5361,20 +5361,84 @@ def mem_bar(barrier_type):
     _pto.MemBarOp(kind=_membar_attr(barrier_name))
 
 
-def _is_fp4_packed_pointer_value(value) -> bool:
-    type_text = str(getattr(value, "type", ""))
-    return type_text.startswith("!pto.ptr<!pto.f4") and "x2, " in type_text
+def _is_fp4_packed_pointer_value(value, *, context: str) -> bool:
+    elem_type = _pointer_element_type(value, context=context)
+    return any(
+        _isinstance_pto_type(elem_type, type_name)
+        for type_name in ("F4E1M2x2Type", "F4E2M1x2Type")
+    )
 
 
-def _reject_explicit_fp4_load(source_value, *, op_name: str, source_role: str):
-    if _is_fp4_packed_pointer_value(source_value):
+def _normalize_cube_transpose(value, *, context: str) -> bool:
+    """Normalize the legacy BoolAttr-compatible 0/1 spelling."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    raise TypeError(f"{context} transpose expects bool or integer 0/1")
+
+
+def _emit_explicit_l1_l0_load(
+    source,
+    destination,
+    controls,
+    transpose,
+    *,
+    op_name: str,
+    regular_op,
+    s4_op,
+):
+    source_value = unwrap_surface_value(source)
+    destination_value = unwrap_surface_value(destination)
+    control_names = (
+        "m_start",
+        "k_start",
+        "m_step",
+        "k_step",
+        "src_stride",
+        "dst_stride",
+    )
+    source_is_fp4 = _is_fp4_packed_pointer_value(
+        source_value, context=f"{op_name} source"
+    )
+    destination_is_fp4 = _is_fp4_packed_pointer_value(
+        destination_value, context=f"{op_name} destination"
+    )
+    if source_is_fp4 != destination_is_fp4:
         raise TypeError(
-            f"{op_name} explicit-control FP4 loads are not supported yet because "
-            "the compatibility wrapper would currently emit the regular load path; "
-            f"using FP4 in {source_role} may silently select an incorrect intrinsic. "
-            "Use the "
-            "shape-derived m/k or k/n form for FP4 L1-to-L0 loads."
+            f"{op_name} source and destination must both use packed FP4 "
+            "or both use regular element types"
         )
+    if source_is_fp4:
+        source_elem_type = _pointer_element_type(
+            source_value, context=f"{op_name} source"
+        )
+        destination_elem_type = _pointer_element_type(
+            destination_value, context=f"{op_name} destination"
+        )
+        if source_elem_type != destination_elem_type:
+            raise TypeError(
+                f"{op_name} source and destination packed FP4 element types "
+                "must match"
+            )
+    normalized_controls = tuple(
+        _coerce_i64(value, context=f"{op_name} {name}")
+        for name, value in zip(control_names, controls)
+    )
+    if source_is_fp4:
+        s4_op(
+            source_value,
+            destination_value,
+            *normalized_controls,
+            _coerce_i64(int(transpose), context=f"{op_name} transpose"),
+        )
+        return
+    regular_op(
+        source_value,
+        destination_value,
+        *normalized_controls,
+        transpose=transpose,
+    )
 
 
 @_explicit_mode_only("pto.mte_l1_l0a(...)")
@@ -5397,9 +5461,9 @@ def mte_l1_l0a(
     """``pto.mte_l1_l0a`` – structured or explicit-control L1-to-L0A load.
 
     Use either the existing shape-derived ``m``/``k`` form or provide all six
-    explicit L1-to-L0A controls. The explicit-control overload currently rejects
-    FP4 packed pointers; use the shape-derived form for FP4 staging.
+    explicit L1-to-L0A controls. Packed FP4 sources select the S4 load path.
     """
+    transpose = _normalize_cube_transpose(transpose, context="mte_l1_l0a")
     controls = (m_start, k_start, m_step, k_step, src_stride, dst_stride)
     has_explicit_controls = any(control is not None for control in controls)
     if has_explicit_controls:
@@ -5416,19 +5480,14 @@ def mte_l1_l0a(
                 "mte_l1_l0a explicit controls require m_start, k_start, "
                 "m_step, k_step, src_stride, and dst_stride"
             )
-        source_value = unwrap_surface_value(source)
-        destination_value = unwrap_surface_value(destination)
-        _reject_explicit_fp4_load(source_value, op_name="mte_l1_l0a", source_role="source")
-        _pto.LoadCbufToCaOp(
-            source_value,
-            destination_value,
-            _coerce_i64(m_start, context="mte_l1_l0a m_start"),
-            _coerce_i64(k_start, context="mte_l1_l0a k_start"),
-            _coerce_i64(m_step, context="mte_l1_l0a m_step"),
-            _coerce_i64(k_step, context="mte_l1_l0a k_step"),
-            _coerce_i64(src_stride, context="mte_l1_l0a src_stride"),
-            _coerce_i64(dst_stride, context="mte_l1_l0a dst_stride"),
-            transpose=transpose,
+        _emit_explicit_l1_l0_load(
+            source,
+            destination,
+            controls,
+            transpose,
+            op_name="mte_l1_l0a",
+            regular_op=_pto.LoadCbufToCaOp,
+            s4_op=_pto.LoadCbufToCaS4Op,
         )
         return
     if m is None or k is None:
@@ -5464,9 +5523,9 @@ def mte_l1_l0b(
     """``pto.mte_l1_l0b`` – structured or explicit-control L1-to-L0B load.
 
     Use either the existing shape-derived ``k``/``n`` form or provide all six
-    explicit L1-to-L0B controls. The explicit-control overload currently rejects
-    FP4 packed pointers; use the shape-derived form for FP4 staging.
+    explicit L1-to-L0B controls. Packed FP4 sources select the S4 load path.
     """
+    transpose = _normalize_cube_transpose(transpose, context="mte_l1_l0b")
     controls = (m_start, k_start, m_step, k_step, src_stride, dst_stride)
     has_explicit_controls = any(control is not None for control in controls)
     if has_explicit_controls:
@@ -5483,19 +5542,14 @@ def mte_l1_l0b(
                 "mte_l1_l0b explicit controls require m_start, k_start, "
                 "m_step, k_step, src_stride, and dst_stride"
             )
-        source_value = unwrap_surface_value(source)
-        destination_value = unwrap_surface_value(destination)
-        _reject_explicit_fp4_load(source_value, op_name="mte_l1_l0b", source_role="source")
-        _pto.LoadCbufToCbOp(
-            source_value,
-            destination_value,
-            _coerce_i64(m_start, context="mte_l1_l0b m_start"),
-            _coerce_i64(k_start, context="mte_l1_l0b k_start"),
-            _coerce_i64(m_step, context="mte_l1_l0b m_step"),
-            _coerce_i64(k_step, context="mte_l1_l0b k_step"),
-            _coerce_i64(src_stride, context="mte_l1_l0b src_stride"),
-            _coerce_i64(dst_stride, context="mte_l1_l0b dst_stride"),
-            transpose=transpose,
+        _emit_explicit_l1_l0_load(
+            source,
+            destination,
+            controls,
+            transpose,
+            op_name="mte_l1_l0b",
+            regular_op=_pto.LoadCbufToCbOp,
+            s4_op=_pto.LoadCbufToCbS4Op,
         )
         return
     if k is None or n is None:

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -6944,34 +6944,35 @@ def main() -> None:
     expect("pto.vsstb" in vsstb_post_update_surface_text, "vsstb(..., post_update=ON) should still lower through pto.vsstb on the current VPTO IR")
     expect("-> !pto.ptr<f32, ub>" in vsstb_post_update_surface_text, "vsstb(..., post_update=ON) should request the updated destination pointer result")
     expect("pto.mte_l1_l0b" in public_surface_text, "mte_l1_l0b(...) should lower to pto.mte_l1_l0b")
-    expect(public_surface_text.count("pto.load_cbuf_to_ca") == 1, "explicit mte_l1_l0a(...) should lower directly to pto.load_cbuf_to_ca")
-    expect(public_surface_text.count("pto.load_cbuf_to_cb") == 1, "explicit mte_l1_l0b(...) should lower directly to pto.load_cbuf_to_cb")
     expect(
-        explicit_fp4_s4_staging_text.count("pto.load_cbuf_to_ca_s4") == 1,
-        "FP4 explicit mte_l1_l0a(...) should select pto.load_cbuf_to_ca_s4",
+        public_surface_text.count("pto.mte_l1_l0a") >= 2,
+        "explicit mte_l1_l0a(...) should remain on the public wrapper op",
     )
     expect(
-        explicit_fp4_s4_staging_text.count("pto.load_cbuf_to_cb_s4") == 1,
-        "FP4 explicit mte_l1_l0b(...) should select pto.load_cbuf_to_cb_s4",
+        public_surface_text.count("pto.mte_l1_l0b") >= 2,
+        "explicit mte_l1_l0b(...) should remain on the public wrapper op",
     )
-    for op_name in ("load_cbuf_to_ca_s4", "load_cbuf_to_cb_s4"):
-        expect(
-            re.search(
-                rf"pto\.{op_name} .*%c0_i64(?:_\d+)?, %c4_i64(?:_\d+)?, "
-                rf"%c16_i64(?:_\d+)?, %c4_i64(?:_\d+)?, "
-                rf"%c16_i64(?:_\d+)?, %c16_i64(?:_\d+)?",
-                explicit_fp4_s4_staging_text,
-            ) is not None,
-            f"{op_name} should preserve raw packed-S4 k_start/k_step and strides",
-        )
+    expect(
+        explicit_fp4_s4_staging_text.count("pto.mte_l1_l0a") == 1,
+        "FP4 explicit mte_l1_l0a(...) should trace through pto.mte_l1_l0a",
+    )
+    expect(
+        explicit_fp4_s4_staging_text.count("pto.mte_l1_l0b") == 1,
+        "FP4 explicit mte_l1_l0b(...) should trace through pto.mte_l1_l0b",
+    )
+    expect(
+        "pto.load_cbuf_to_ca_s4" not in explicit_fp4_s4_staging_text and
+        "pto.load_cbuf_to_cb_s4" not in explicit_fp4_s4_staging_text,
+        "PTODSL must not expose internal raw S4 load operations",
+    )
     explicit_ca_controls = (
-        r"pto\.load_cbuf_to_ca .*%c4_i64(?:_\d+)?, %c0_i64(?:_\d+)?, "
+        r"pto\.mte_l1_l0a .*%c4_i64(?:_\d+)?, %c0_i64(?:_\d+)?, "
         r"%c4_i64(?:_\d+)?, %c16_i64(?:_\d+)?, "
         r"%c16_i64(?:_\d+)?, %c4_i64(?:_\d+)? \{transpose = true\}"
     )
     expect(
         re.search(explicit_ca_controls, public_surface_text) is not None,
-        "explicit mte_l1_l0a controls should preserve independent source and destination strides",
+        "explicit mte_l1_l0a controls should remain on the public wrapper",
     )
     expect("pto.mte_l1_l0a_mx" in public_surface_text, "mte_l1_l0a_mx(...) should lower to pto.mte_l1_l0a_mx")
     expect("pto.mte_l1_l0b_mx" in public_surface_text, "mte_l1_l0b_mx(...) should lower to pto.mte_l1_l0b_mx")

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -3307,6 +3307,26 @@ def explicit_mx_scale_staging_surface_probe():
 
 
 @pto.jit(target="a5", mode="explicit")
+def explicit_fp4_s4_staging_surface_probe():
+    zero_u64 = pto.const(0, dtype=pto.ui64)
+    a_l1 = pto.castptr(zero_u64, pto.ptr(pto.f4e1m2x2, "mat"))
+    a_l0 = pto.castptr(zero_u64, pto.ptr(pto.f4e1m2x2, "left"))
+    b_l1 = pto.castptr(zero_u64, pto.ptr(pto.f4e2m1x2, "mat"))
+    b_l0 = pto.castptr(zero_u64, pto.ptr(pto.f4e2m1x2, "right"))
+
+    pto.mte_l1_l0a(
+        a_l1, a_l0,
+        m_start=0, k_start=4, m_step=16, k_step=4,
+        src_stride=16, dst_stride=16,
+    )
+    pto.mte_l1_l0b(
+        b_l1, b_l0,
+        m_start=0, k_start=4, m_step=16, k_step=4,
+        src_stride=16, dst_stride=16, transpose=True,
+    )
+
+
+@pto.jit(target="a5", mode="explicit")
 def fixed_width_integer_specialization_probe():
     zero_u64 = pto.const(0, dtype=pto.ui64)
     gm_src = pto.castptr(zero_u64, pto.ptr(pto.f16, "gm"))
@@ -6425,6 +6445,11 @@ def main() -> None:
         explicit_mx_scale_staging_text,
         "explicit MX scale staging specialization",
     )
+    explicit_fp4_s4_staging_text = explicit_fp4_s4_staging_surface_probe.compile().mlir_text()
+    expect_parse_roundtrip_and_verify(
+        explicit_fp4_s4_staging_text,
+        "explicit FP4 S4 staging specialization",
+    )
     acc_store_pre_quant_text = acc_store_pre_quant_surface_probe.compile().mlir_text()
     expect_parse_roundtrip_and_verify(acc_store_pre_quant_text, "acc-store pre_quant public mode specialization")
     expect(
@@ -6921,6 +6946,24 @@ def main() -> None:
     expect("pto.mte_l1_l0b" in public_surface_text, "mte_l1_l0b(...) should lower to pto.mte_l1_l0b")
     expect(public_surface_text.count("pto.load_cbuf_to_ca") == 1, "explicit mte_l1_l0a(...) should lower directly to pto.load_cbuf_to_ca")
     expect(public_surface_text.count("pto.load_cbuf_to_cb") == 1, "explicit mte_l1_l0b(...) should lower directly to pto.load_cbuf_to_cb")
+    expect(
+        explicit_fp4_s4_staging_text.count("pto.load_cbuf_to_ca_s4") == 1,
+        "FP4 explicit mte_l1_l0a(...) should select pto.load_cbuf_to_ca_s4",
+    )
+    expect(
+        explicit_fp4_s4_staging_text.count("pto.load_cbuf_to_cb_s4") == 1,
+        "FP4 explicit mte_l1_l0b(...) should select pto.load_cbuf_to_cb_s4",
+    )
+    for op_name in ("load_cbuf_to_ca_s4", "load_cbuf_to_cb_s4"):
+        expect(
+            re.search(
+                rf"pto\.{op_name} .*%c0_i64(?:_\d+)?, %c4_i64(?:_\d+)?, "
+                rf"%c16_i64(?:_\d+)?, %c4_i64(?:_\d+)?, "
+                rf"%c16_i64(?:_\d+)?, %c16_i64(?:_\d+)?",
+                explicit_fp4_s4_staging_text,
+            ) is not None,
+            f"{op_name} should preserve raw packed-S4 k_start/k_step and strides",
+        )
     explicit_ca_controls = (
         r"pto\.load_cbuf_to_ca .*%c4_i64(?:_\d+)?, %c0_i64(?:_\d+)?, "
         r"%c4_i64(?:_\d+)?, %c16_i64(?:_\d+)?, "

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -594,7 +594,7 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                         getattr(_ops, func_name)(*args)
                     self.assertEqual(op_ctor.call_args.args, expected_call)
 
-    def test_mte_l1_l0_explicit_controls_dispatch_to_load_cbuf_ops(self):
+    def test_mte_l1_l0_explicit_controls_emit_wrapper_ops(self):
         source = object()
         destination = object()
         controls = {
@@ -607,45 +607,54 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         }
 
         with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
-             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"), \
-             patch.object(_ops, "_is_fp4_packed_pointer_value", return_value=False):
+             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"):
             ca_op = MagicMock()
-            with patch.object(_ops._pto, "LoadCbufToCaOp", ca_op):
+            with patch.object(_ops._pto, "MteL1L0aOp", ca_op):
                 _ops.mte_l1_l0a(source, destination, **controls, transpose=True)
             self.assertEqual(
                 ca_op.call_args.args,
                 (
                     source,
                     destination,
-                    "mte_l1_l0a m_start:3",
-                    "mte_l1_l0a k_start:5",
-                    "mte_l1_l0a m_step:16",
-                    "mte_l1_l0a k_step:2",
-                    "mte_l1_l0a src_stride:8",
-                    "mte_l1_l0a dst_stride:2",
                 ),
             )
-            self.assertEqual(ca_op.call_args.kwargs, {"transpose": True})
+            self.assertEqual(
+                ca_op.call_args.kwargs,
+                {
+                    "m_start": "mte_l1_l0a m_start:3",
+                    "k_start": "mte_l1_l0a k_start:5",
+                    "m_step": "mte_l1_l0a m_step:16",
+                    "k_step": "mte_l1_l0a k_step:2",
+                    "src_stride": "mte_l1_l0a src_stride:8",
+                    "dst_stride": "mte_l1_l0a dst_stride:2",
+                    "transpose": True,
+                },
+            )
 
             cb_op = MagicMock()
-            with patch.object(_ops._pto, "LoadCbufToCbOp", cb_op):
+            with patch.object(_ops._pto, "MteL1L0bOp", cb_op):
                 _ops.mte_l1_l0b(source, destination, **controls, transpose=True)
             self.assertEqual(
                 cb_op.call_args.args,
                 (
                     source,
                     destination,
-                    "mte_l1_l0b m_start:3",
-                    "mte_l1_l0b k_start:5",
-                    "mte_l1_l0b m_step:16",
-                    "mte_l1_l0b k_step:2",
-                    "mte_l1_l0b src_stride:8",
-                    "mte_l1_l0b dst_stride:2",
                 ),
             )
-            self.assertEqual(cb_op.call_args.kwargs, {"transpose": True})
+            self.assertEqual(
+                cb_op.call_args.kwargs,
+                {
+                    "m_start": "mte_l1_l0b m_start:3",
+                    "k_start": "mte_l1_l0b k_start:5",
+                    "m_step": "mte_l1_l0b m_step:16",
+                    "k_step": "mte_l1_l0b k_step:2",
+                    "src_stride": "mte_l1_l0b src_stride:8",
+                    "dst_stride": "mte_l1_l0b dst_stride:2",
+                    "transpose": True,
+                },
+            )
 
-    def test_mte_l1_l0_explicit_controls_dispatch_fp4_to_s4_ops(self):
+    def test_mte_l1_l0_explicit_fp4_controls_stay_on_wrapper_ops(self):
         controls = {
             "m_start": 0,
             "k_start": 4,
@@ -669,8 +678,8 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                 with self.subTest(dtype=dtype), \
                      patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
                      patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"), \
-                     patch.object(_ops._pto, "LoadCbufToCaS4Op") as ca_s4, \
-                     patch.object(_ops._pto, "LoadCbufToCbS4Op") as cb_s4:
+                     patch.object(_ops._pto, "MteL1L0aOp") as ca_op, \
+                     patch.object(_ops._pto, "MteL1L0bOp") as cb_op:
                     _ops.mte_l1_l0a(
                         source, destination_a, **controls, transpose=0
                     )
@@ -678,27 +687,27 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                         source, destination_b, **controls, transpose=1
                     )
 
-                ca_s4.assert_called_once_with(
+                ca_op.assert_called_once_with(
                     source,
                     destination_a,
-                    "mte_l1_l0a m_start:0",
-                    "mte_l1_l0a k_start:4",
-                    "mte_l1_l0a m_step:16",
-                    "mte_l1_l0a k_step:4",
-                    "mte_l1_l0a src_stride:16",
-                    "mte_l1_l0a dst_stride:16",
-                    "mte_l1_l0a transpose:0",
+                    m_start="mte_l1_l0a m_start:0",
+                    k_start="mte_l1_l0a k_start:4",
+                    m_step="mte_l1_l0a m_step:16",
+                    k_step="mte_l1_l0a k_step:4",
+                    src_stride="mte_l1_l0a src_stride:16",
+                    dst_stride="mte_l1_l0a dst_stride:16",
+                    transpose=False,
                 )
-                cb_s4.assert_called_once_with(
+                cb_op.assert_called_once_with(
                     source,
                     destination_b,
-                    "mte_l1_l0b m_start:0",
-                    "mte_l1_l0b k_start:4",
-                    "mte_l1_l0b m_step:16",
-                    "mte_l1_l0b k_step:4",
-                    "mte_l1_l0b src_stride:16",
-                    "mte_l1_l0b dst_stride:16",
-                    "mte_l1_l0b transpose:1",
+                    m_start="mte_l1_l0b m_start:0",
+                    k_start="mte_l1_l0b k_start:4",
+                    m_step="mte_l1_l0b m_step:16",
+                    k_step="mte_l1_l0b k_step:4",
+                    src_stride="mte_l1_l0b src_stride:16",
+                    dst_stride="mte_l1_l0b dst_stride:16",
+                    transpose=True,
                 )
 
     def test_mte_l1_l0_explicit_controls_normalize_legacy_transpose(self):
@@ -715,10 +724,12 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         destination = object()
         with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: value), \
-             patch.object(_ops, "_is_fp4_packed_pointer_value", return_value=False), \
-             patch.object(_ops._pto, "LoadCbufToCaOp") as ca_op:
+             patch.object(_ops._pto, "MteL1L0aOp") as ca_op:
             _ops.mte_l1_l0a(source, destination, **controls, transpose=1)
-        self.assertEqual(ca_op.call_args.kwargs, {"transpose": True})
+        self.assertEqual(
+            ca_op.call_args.kwargs,
+            {**controls, "transpose": True},
+        )
 
         with self.assertRaisesRegex(
             TypeError, "mte_l1_l0a transpose expects bool or integer 0/1"
@@ -736,15 +747,21 @@ class VectorCubeSurfaceTest(unittest.TestCase):
              patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: value), \
              patch.object(_ops._pto, "MteL1L0aOp") as ca_op:
             _ops.mte_l1_l0a(source, destination, 16, 32, transpose=0)
-        self.assertEqual(ca_op.call_args.kwargs, {"transpose": False})
+        self.assertEqual(
+            ca_op.call_args.kwargs,
+            {"m": 16, "k": 32, "start_row": 0, "start_col": 0, "transpose": False},
+        )
 
         with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
              patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: value), \
              patch.object(_ops._pto, "MteL1L0bOp") as cb_op:
             _ops.mte_l1_l0b(source, destination, 32, 16, transpose=1)
-        self.assertEqual(cb_op.call_args.kwargs, {"transpose": True})
+        self.assertEqual(
+            cb_op.call_args.kwargs,
+            {"k": 32, "n": 16, "start_row": 0, "start_col": 0, "transpose": True},
+        )
 
-    def test_mte_l1_l0_explicit_controls_reject_mixed_fp4_types(self):
+    def test_mte_l1_l0_explicit_controls_defer_fp4_type_validation_to_vpto(self):
         controls = {
             "m_start": 0,
             "k_start": 0,
@@ -754,33 +771,25 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             "dst_stride": 1,
         }
         with make_context():
-            cases = [
-                (
-                    "regular source with FP4 destination",
-                    "!pto.ptr<i8, l1>",
-                    "!pto.ptr<!pto.f4E2M1x2, l0a>",
-                ),
-                (
-                    "FP4 source with regular destination",
-                    "!pto.ptr<!pto.f4E2M1x2, l1>",
-                    "!pto.ptr<i8, l0a>",
-                ),
-                (
-                    "mismatched FP4 element types",
-                    "!pto.ptr<!pto.f4E1M2x2, l1>",
-                    "!pto.ptr<!pto.f4E2M1x2, l0a>",
-                ),
-            ]
-            for name, source_type, destination_type in cases:
-                with self.subTest(case=name):
-                    source = SimpleNamespace(type=Type.parse(source_type))
-                    destination = SimpleNamespace(
-                        type=Type.parse(destination_type)
-                    )
-                    with self.assertRaisesRegex(TypeError, "packed FP4"):
-                        _ops.mte_l1_l0a(
-                            source, destination, **controls, transpose=False
-                        )
+            source = SimpleNamespace(type=Type.parse("!pto.ptr<i8, l1>"))
+            destination = SimpleNamespace(
+                type=Type.parse("!pto.ptr<!pto.f4E2M1x2, l0a>")
+            )
+            with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+                 patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: value), \
+                 patch.object(_ops._pto, "MteL1L0aOp") as ca_op:
+                _ops.mte_l1_l0a(source, destination, **controls, transpose=False)
+            ca_op.assert_called_once_with(
+                source,
+                destination,
+                m_start=0,
+                k_start=0,
+                m_step=1,
+                k_step=1,
+                src_stride=1,
+                dst_stride=1,
+                transpose=False,
+            )
 
     def test_mte_l1_l0_legacy_forms_preserve_keyword_compatibility(self):
         source = object()
@@ -804,13 +813,18 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                 (
                     source,
                     destination,
-                    "mte_l1_l0a m:128",
-                    "mte_l1_l0a k:64",
-                    "mte_l1_l0a start_row:2",
-                    "mte_l1_l0a start_col:4",
                 ),
             )
-            self.assertEqual(ca_op.call_args.kwargs, {"transpose": True})
+            self.assertEqual(
+                ca_op.call_args.kwargs,
+                {
+                    "m": "mte_l1_l0a m:128",
+                    "k": "mte_l1_l0a k:64",
+                    "start_row": "mte_l1_l0a start_row:2",
+                    "start_col": "mte_l1_l0a start_col:4",
+                    "transpose": True,
+                },
+            )
 
             cb_op = MagicMock()
             with patch.object(_ops._pto, "MteL1L0bOp", cb_op):
@@ -828,13 +842,18 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                 (
                     source,
                     destination,
-                    "mte_l1_l0b k:64",
-                    "mte_l1_l0b n:128",
-                    "mte_l1_l0b start_row:4",
-                    "mte_l1_l0b start_col:2",
                 ),
             )
-            self.assertEqual(cb_op.call_args.kwargs, {"transpose": True})
+            self.assertEqual(
+                cb_op.call_args.kwargs,
+                {
+                    "k": "mte_l1_l0b k:64",
+                    "n": "mte_l1_l0b n:128",
+                    "start_row": "mte_l1_l0b start_row:4",
+                    "start_col": "mte_l1_l0b start_col:2",
+                    "transpose": True,
+                },
+            )
 
     def test_mte_l1_l0_explicit_controls_reject_ambiguous_forms(self):
         source = object()

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -15,7 +15,7 @@ import ptodsl._ops as _ops
 import ptodsl._pipe_namespace as _pipe_namespace
 from ptodsl._context import make_context
 from ptodsl import pto
-from ptoas.mlir.ir import F32Type
+from ptoas.mlir.ir import F32Type, Type
 def _identity(value):
     return value
 
@@ -607,7 +607,8 @@ class VectorCubeSurfaceTest(unittest.TestCase):
         }
 
         with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
-             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"):
+             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"), \
+             patch.object(_ops, "_is_fp4_packed_pointer_value", return_value=False):
             ca_op = MagicMock()
             with patch.object(_ops._pto, "LoadCbufToCaOp", ca_op):
                 _ops.mte_l1_l0a(source, destination, **controls, transpose=True)
@@ -644,24 +645,142 @@ class VectorCubeSurfaceTest(unittest.TestCase):
             )
             self.assertEqual(cb_op.call_args.kwargs, {"transpose": True})
 
-    def test_mte_l1_l0_explicit_controls_reject_fp4(self):
-        source = SimpleNamespace(type="!pto.ptr<!pto.f4E2M1x2, l1>")
-        destination = object()
+    def test_mte_l1_l0_explicit_controls_dispatch_fp4_to_s4_ops(self):
         controls = {
-            "m_start": 3,
-            "k_start": 5,
+            "m_start": 0,
+            "k_start": 4,
             "m_step": 16,
-            "k_step": 2,
-            "src_stride": 8,
-            "dst_stride": 2,
+            "k_step": 4,
+            "src_stride": 16,
+            "dst_stride": 16,
         }
 
+        with make_context():
+            for dtype in ("f4E1M2x2", "f4E2M1x2"):
+                source = SimpleNamespace(
+                    type=Type.parse(f"!pto.ptr<!pto.{dtype}, l1>")
+                )
+                destination_a = SimpleNamespace(
+                    type=Type.parse(f"!pto.ptr<!pto.{dtype}, l0a>")
+                )
+                destination_b = SimpleNamespace(
+                    type=Type.parse(f"!pto.ptr<!pto.{dtype}, l0b>")
+                )
+                with self.subTest(dtype=dtype), \
+                     patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+                     patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"), \
+                     patch.object(_ops._pto, "LoadCbufToCaS4Op") as ca_s4, \
+                     patch.object(_ops._pto, "LoadCbufToCbS4Op") as cb_s4:
+                    _ops.mte_l1_l0a(
+                        source, destination_a, **controls, transpose=0
+                    )
+                    _ops.mte_l1_l0b(
+                        source, destination_b, **controls, transpose=1
+                    )
+
+                ca_s4.assert_called_once_with(
+                    source,
+                    destination_a,
+                    "mte_l1_l0a m_start:0",
+                    "mte_l1_l0a k_start:4",
+                    "mte_l1_l0a m_step:16",
+                    "mte_l1_l0a k_step:4",
+                    "mte_l1_l0a src_stride:16",
+                    "mte_l1_l0a dst_stride:16",
+                    "mte_l1_l0a transpose:0",
+                )
+                cb_s4.assert_called_once_with(
+                    source,
+                    destination_b,
+                    "mte_l1_l0b m_start:0",
+                    "mte_l1_l0b k_start:4",
+                    "mte_l1_l0b m_step:16",
+                    "mte_l1_l0b k_step:4",
+                    "mte_l1_l0b src_stride:16",
+                    "mte_l1_l0b dst_stride:16",
+                    "mte_l1_l0b transpose:1",
+                )
+
+    def test_mte_l1_l0_explicit_controls_normalize_legacy_transpose(self):
+        controls = {
+            "m_start": 0,
+            "k_start": 4,
+            "m_step": 16,
+            "k_step": 4,
+            "src_stride": 8,
+            "dst_stride": 16,
+        }
+
+        source = object()
+        destination = object()
         with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
-             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: f"{context}:{value}"):
-            with self.assertRaisesRegex(TypeError, "explicit-control FP4 loads are not supported yet"):
-                _ops.mte_l1_l0a(source, destination, **controls, transpose=True)
-            with self.assertRaisesRegex(TypeError, "using FP4 in source may silently select an incorrect intrinsic"):
-                _ops.mte_l1_l0b(source, destination, **controls, transpose=True)
+             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: value), \
+             patch.object(_ops, "_is_fp4_packed_pointer_value", return_value=False), \
+             patch.object(_ops._pto, "LoadCbufToCaOp") as ca_op:
+            _ops.mte_l1_l0a(source, destination, **controls, transpose=1)
+        self.assertEqual(ca_op.call_args.kwargs, {"transpose": True})
+
+        with self.assertRaisesRegex(
+            TypeError, "mte_l1_l0a transpose expects bool or integer 0/1"
+        ):
+            _ops.mte_l1_l0a(source, destination, **controls, transpose=2)
+        with self.assertRaisesRegex(
+            TypeError, "mte_l1_l0b transpose expects bool or integer 0/1"
+        ):
+            _ops.mte_l1_l0b(object(), object(), **controls, transpose="true")
+
+    def test_mte_l1_l0_shape_transpose_accepts_legacy_zero_one(self):
+        source = object()
+        destination = object()
+        with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: value), \
+             patch.object(_ops._pto, "MteL1L0aOp") as ca_op:
+            _ops.mte_l1_l0a(source, destination, 16, 32, transpose=0)
+        self.assertEqual(ca_op.call_args.kwargs, {"transpose": False})
+
+        with patch.object(_ops, "unwrap_surface_value", side_effect=_identity), \
+             patch.object(_ops, "_coerce_i64", side_effect=lambda value, *, context: value), \
+             patch.object(_ops._pto, "MteL1L0bOp") as cb_op:
+            _ops.mte_l1_l0b(source, destination, 32, 16, transpose=1)
+        self.assertEqual(cb_op.call_args.kwargs, {"transpose": True})
+
+    def test_mte_l1_l0_explicit_controls_reject_mixed_fp4_types(self):
+        controls = {
+            "m_start": 0,
+            "k_start": 0,
+            "m_step": 1,
+            "k_step": 1,
+            "src_stride": 1,
+            "dst_stride": 1,
+        }
+        with make_context():
+            cases = [
+                (
+                    "regular source with FP4 destination",
+                    "!pto.ptr<i8, l1>",
+                    "!pto.ptr<!pto.f4E2M1x2, l0a>",
+                ),
+                (
+                    "FP4 source with regular destination",
+                    "!pto.ptr<!pto.f4E2M1x2, l1>",
+                    "!pto.ptr<i8, l0a>",
+                ),
+                (
+                    "mismatched FP4 element types",
+                    "!pto.ptr<!pto.f4E1M2x2, l1>",
+                    "!pto.ptr<!pto.f4E2M1x2, l0a>",
+                ),
+            ]
+            for name, source_type, destination_type in cases:
+                with self.subTest(case=name):
+                    source = SimpleNamespace(type=Type.parse(source_type))
+                    destination = SimpleNamespace(
+                        type=Type.parse(destination_type)
+                    )
+                    with self.assertRaisesRegex(TypeError, "packed FP4"):
+                        _ops.mte_l1_l0a(
+                            source, destination, **controls, transpose=False
+                        )
 
     def test_mte_l1_l0_legacy_forms_preserve_keyword_compatibility(self):
         source = object()

--- a/test/lit/vpto/cube/mte_l1_l0_fp4_s4_step_rounding.pto
+++ b/test/lit/vpto/cube/mte_l1_l0_fp4_s4_step_rounding.pto
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// Shape-derived packed FP4 loads must round partial 64-value S4 blocks up
+// before creating the verifier-protected raw S4 bridge operation.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @fp4_s4_step_rounding(
+      %src: !pto.ptr<!pto.f4E2M1x2, l1>,
+      %dst_a: !pto.ptr<!pto.f4E2M1x2, l0a>,
+      %dst_b: !pto.ptr<!pto.f4E2M1x2, l0b>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c16 = arith.constant 16 : i64
+    %c32 = arith.constant 32 : i64
+    %c96 = arith.constant 96 : i64
+
+    pto.mte_l1_l0a %src, %dst_a, %c16, %c32, %c0, %c0
+      : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64
+    pto.mte_l1_l0b %src, %dst_b, %c96, %c16, %c0, %c0
+      : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>, i64, i64, i64, i64
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @fp4_s4_step_rounding(
+// CHECK-DAG: %[[C2:.*]] = arith.constant 2 : i64
+// CHECK-DAG: %[[C0:.*]] = arith.constant 0 : i64
+// CHECK-DAG: %[[C1:.*]] = arith.constant 1 : i64
+// CHECK: pto.load_cbuf_to_ca_s4 %{{.*}}, %{{.*}}, %[[C0]], %[[C0]], %[[C1]], %[[C1]], %[[C1]], %[[C1]], %[[C0]]
+// CHECK: pto.load_cbuf_to_cb_s4 %{{.*}}, %{{.*}}, %[[C0]], %[[C0]], %[[C1]], %[[C2]], %[[C1]], %[[C1]], %[[C0]]

--- a/test/lit/vpto/cube/mte_l1_l0_full_controls.pto
+++ b/test/lit/vpto/cube/mte_l1_l0_full_controls.pto
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// The public wrapper accepts both the legacy shape form and the full-control
+// form. Wrapper expansion selects the private S4 operation only for packed FP4.
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-before=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=WRAPPER
+// RUN: ptoas --pto-arch=a5 --pto-backend=vpto --emit-vpto --mlir-print-ir-after=vpto-expand-wrapper-ops %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=EXPAND
+
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @full_controls(
+      %fp4_src: !pto.ptr<!pto.f4E2M1x2, l1>,
+      %fp4_a: !pto.ptr<!pto.f4E2M1x2, l0a>,
+      %fp4_b: !pto.ptr<!pto.f4E2M1x2, l0b>,
+      %f16_src: !pto.ptr<f16, l1>,
+      %f16_a: !pto.ptr<f16, l0a>,
+      %f16_b: !pto.ptr<f16, l0b>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c3 = arith.constant 3 : i64
+    %c5 = arith.constant 5 : i64
+    %c7 = arith.constant 7 : i64
+    %c9 = arith.constant 9 : i64
+    %c11 = arith.constant 11 : i64
+    %c13 = arith.constant 13 : i64
+    %c17 = arith.constant 17 : i64
+    %c19 = arith.constant 19 : i64
+    %c23 = arith.constant 23 : i64
+    %c29 = arith.constant 29 : i64
+    %c31 = arith.constant 31 : i64
+    %c37 = arith.constant 37 : i64
+    %c41 = arith.constant 41 : i64
+
+    pto.mte_l1_l0a %fp4_src, %fp4_a, %c3, %c5, %c7, %c9, %c11, %c13
+      : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64
+    pto.mte_l1_l0b %fp4_src, %fp4_b, dst_stride(%c41), k_step(%c37), m_step(%c31), k_start(%c29), src_stride(%c23), m_start(%c19) {transpose = true}
+      : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>, i64, i64, i64, i64, i64, i64
+    pto.mte_l1_l0a %f16_src, %f16_a, %c0, %c3, %c5, %c7, %c9, %c11
+      : !pto.ptr<f16, l1>, !pto.ptr<f16, l0a>, i64, i64, i64, i64, i64, i64
+    pto.mte_l1_l0b %f16_src, %f16_b, %c13, %c17, %c19, %c23, %c29, %c31 {transpose = true}
+      : !pto.ptr<f16, l1>, !pto.ptr<f16, l0b>, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// WRAPPER-LABEL: func.func @full_controls(
+// WRAPPER: pto.mte_l1_l0a %{{.*}}, %{{.*}}, %[[C3:.*]], %[[C5:.*]], %[[C7:.*]], %[[C9:.*]], %[[C11:.*]], %[[C13:[A-Za-z0-9_]+]]
+// WRAPPER: pto.mte_l1_l0b %{{.*}}, %{{.*}}, %[[C19:.*]], %[[C29:.*]], %[[C31:.*]], %[[C37:.*]], %[[C23:.*]], %[[C41:.*]] {transpose = true}
+// WRAPPER: pto.mte_l1_l0a %{{.*}}, %{{.*}}, %[[C0:.*]], %[[C3]], %[[C5]], %[[C7]], %[[C9]], %[[C11]]
+// WRAPPER: pto.mte_l1_l0b %{{.*}}, %{{.*}}, %[[C13]], %[[C17:.*]], %[[C19]], %[[C23]], %[[C29]], %[[C31]] {transpose = true}
+
+// EXPAND-LABEL: func.func @full_controls(
+// EXPAND: pto.load_cbuf_to_ca_s4 %{{.*}}, %{{.*}}, %[[C3:.*]], %[[C5:.*]], %[[C7:.*]], %[[C9:.*]], %[[C11:.*]], %[[C13:.*]], %{{.*}}
+// EXPAND: pto.load_cbuf_to_cb_s4 %{{.*}}, %{{.*}}, %[[C19:.*]], %[[C29:.*]], %[[C31:.*]], %[[C37:.*]], %[[C23:.*]], %[[C41:.*]], %{{.*}}
+// EXPAND: pto.load_cbuf_to_ca %{{.*}}, %{{.*}}, %[[C0:.*]], %[[C3]], %[[C5]], %[[C7]], %[[C9]], %[[C11:[A-Za-z0-9_]+]]
+// EXPAND: pto.load_cbuf_to_cb %{{.*}}, %{{.*}}, %[[C13]], %[[C17:.*]], %[[C19]], %[[C23]], %[[C29]], %[[C31]] {transpose = true}

--- a/test/lit/vpto/cube/mte_l1_l0_full_controls_verify_invalid.pto
+++ b/test/lit/vpto/cube/mte_l1_l0_full_controls_verify_invalid.pto
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: split-file %s %t
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/partial.pto -o - 2>&1 | FileCheck %s --check-prefix=PARTIAL
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/mixed.pto -o - 2>&1 | FileCheck %s --check-prefix=MIXED
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/five-positional.pto -o - 2>&1 | FileCheck %s --check-prefix=FIVE-POSITIONAL
+
+//--- partial.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @partial(%src: !pto.ptr<f16, l1>, %dst: !pto.ptr<f16, l0a>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    pto.mte_l1_l0a %src, %dst, m_start(%c0)
+      : !pto.ptr<f16, l1>, !pto.ptr<f16, l0a>, i64
+    return
+  }
+}
+
+//--- mixed.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @mixed(%src: !pto.ptr<f16, l1>, %dst: !pto.ptr<f16, l0a>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c16 = arith.constant 16 : i64
+    pto.mte_l1_l0a %src, %dst, m(%c16), k(%c16), start_row(%c0), start_col(%c0), m_start(%c0)
+      : !pto.ptr<f16, l1>, !pto.ptr<f16, l0a>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- five-positional.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @five_positional(%src: !pto.ptr<f16, l1>, %dst: !pto.ptr<f16, l0a>) attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    pto.mte_l1_l0a %src, %dst, %c0, %c0, %c0, %c0, %c0
+      : !pto.ptr<f16, l1>, !pto.ptr<f16, l0a>, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// PARTIAL: 'pto.mte_l1_l0a' op full control form requires k_start
+// MIXED: 'pto.mte_l1_l0a' op cannot mix shape-derived operands with full control operands
+// FIVE-POSITIONAL: expects either four shape-derived or six full positional operands

--- a/test/lit/vpto/load_cbuf_to_s4_verify_invalid.pto
+++ b/test/lit/vpto/load_cbuf_to_s4_verify_invalid.pto
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Huawei Technologies Co., Ltd.
+// This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+// CANN Open Software License Agreement Version 2.0 (the "License").
+// Please refer to the License for details. You may not use this file except in compliance with the License.
+// THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+// See LICENSE in the root of the software repository for the full text of the License.
+
+// RUN: split-file %s %t
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_source_space.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-SOURCE-SPACE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/cb_destination_space.pto -o - 2>&1 | FileCheck %s --check-prefix=CB-DESTINATION-SPACE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_source_type.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-SOURCE-TYPE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/cb_destination_type.pto -o - 2>&1 | FileCheck %s --check-prefix=CB-DESTINATION-TYPE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_type_mismatch.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-TYPE-MISMATCH
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_negative_start.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-NEGATIVE-START
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_start_overflow.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-START-OVERFLOW
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/cb_zero_step.pto -o - 2>&1 | FileCheck %s --check-prefix=CB-ZERO-STEP
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/cb_step_overflow.pto -o - 2>&1 | FileCheck %s --check-prefix=CB-STEP-OVERFLOW
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_zero_stride.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-ZERO-STRIDE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/ca_stride_overflow.pto -o - 2>&1 | FileCheck %s --check-prefix=CA-STRIDE-OVERFLOW
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/cb_transpose.pto -o - 2>&1 | FileCheck %s --check-prefix=CB-TRANSPOSE
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/regular_fp4.pto -o - 2>&1 | FileCheck %s --check-prefix=REGULAR-FP4
+// RUN: not ptoas --pto-arch=a5 --pto-backend=vpto %t/regular_fp4_destination.pto -o - 2>&1 | FileCheck %s --check-prefix=REGULAR-FP4-DESTINATION
+
+//--- ca_source_space.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, gm>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_ca_s4 %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, gm>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- cb_destination_space.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_cb_s4 %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_source_type.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<i8, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<i8, l0a>
+    pto.load_cbuf_to_ca_s4 %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1, %c0 : !pto.ptr<i8, l1>, !pto.ptr<i8, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- cb_destination_type.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<i8, l0b>
+    pto.load_cbuf_to_cb_s4 %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<i8, l0b>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_type_mismatch.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E1M2x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_ca_s4 %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1, %c0 : !pto.ptr<!pto.f4E1M2x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_start_overflow.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c65536 = arith.constant 65536 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_ca_s4 %src, %dst, %c0, %c65536, %c1, %c1, %c1, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_negative_start.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %cneg1 = arith.constant -1 : i64
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_ca_s4 %src, %dst, %cneg1, %c0, %c1, %c1, %c1, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- cb_zero_step.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0b>
+    pto.load_cbuf_to_cb_s4 %src, %dst, %c0, %c0, %c1, %c0, %c1, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- cb_step_overflow.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c256 = arith.constant 256 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0b>
+    pto.load_cbuf_to_cb_s4 %src, %dst, %c0, %c0, %c256, %c1, %c1, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_zero_stride.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_ca_s4 %src, %dst, %c0, %c0, %c1, %c1, %c0, %c1, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- ca_stride_overflow.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c65536 = arith.constant 65536 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_ca_s4 %src, %dst, %c0, %c0, %c1, %c1, %c1, %c65536, %c0 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- cb_transpose.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %c2 = arith.constant 2 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0b>
+    pto.load_cbuf_to_cb_s4 %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1, %c2 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>, i64, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- regular_fp4.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
+    pto.load_cbuf_to_ca %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1 : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+//--- regular_fp4_destination.pto
+module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cube>} {
+  func.func @test() attributes {pto.kernel} {
+    %c0 = arith.constant 0 : i64
+    %c1 = arith.constant 1 : i64
+    %src = pto.castptr %c0 : i64 -> !pto.ptr<i8, l1>
+    %dst = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0b>
+    pto.load_cbuf_to_cb %src, %dst, %c0, %c0, %c1, %c1, %c1, %c1 : !pto.ptr<i8, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>, i64, i64, i64, i64, i64, i64
+    return
+  }
+}
+
+// CA-SOURCE-SPACE: 'pto.load_cbuf_to_ca_s4' op requires MAT source
+// CB-DESTINATION-SPACE: 'pto.load_cbuf_to_cb_s4' op requires RIGHT destination
+// CA-SOURCE-TYPE: 'pto.load_cbuf_to_ca_s4' op requires packed FP4 source element type f4e1m2x2 or f4e2m1x2
+// CB-DESTINATION-TYPE: 'pto.load_cbuf_to_cb_s4' op requires packed FP4 destination element type f4e1m2x2 or f4e2m1x2
+// CA-TYPE-MISMATCH: 'pto.load_cbuf_to_ca_s4' op requires source and destination packed FP4 element types to match
+// CA-NEGATIVE-START: 'pto.load_cbuf_to_ca_s4' op m_start must be non-negative
+// CA-START-OVERFLOW: 'pto.load_cbuf_to_ca_s4' op k_start must be <= 65535 to fit the hardware control field
+// CB-ZERO-STEP: 'pto.load_cbuf_to_cb_s4' op k_step must be greater than zero
+// CB-STEP-OVERFLOW: 'pto.load_cbuf_to_cb_s4' op m_step must be <= 255 to fit the hardware control field
+// CA-ZERO-STRIDE: 'pto.load_cbuf_to_ca_s4' op src_stride must be greater than zero
+// CA-STRIDE-OVERFLOW: 'pto.load_cbuf_to_ca_s4' op dst_stride must be <= 65535 to fit the hardware control field
+// CB-TRANSPOSE: 'pto.load_cbuf_to_cb_s4' op transpose must be <= 1 to fit the hardware control field
+// REGULAR-FP4: 'pto.load_cbuf_to_ca' op packed FP4 source requires the S4 load operation
+// REGULAR-FP4-DESTINATION: 'pto.load_cbuf_to_cb' op packed FP4 destination requires the S4 load operation

--- a/test/lit/vpto/load_cbuf_to_s4_vpto_llvm.pto
+++ b/test/lit/vpto/load_cbuf_to_s4_vpto_llvm.pto
@@ -14,18 +14,39 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<cu
     %c1 = arith.constant 1 : i64
     %c4 = arith.constant 4 : i64
     %c8 = arith.constant 8 : i64
+    %c16 = arith.constant 16 : i64
     %src = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l1>
     %dsta = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0a>
     %dstb = pto.castptr %c0 : i64 -> !pto.ptr<!pto.f4E2M1x2, l0b>
 
-    pto.load_cbuf_to_ca_s4 %src, %dsta, %c0, %c0, %c8, %c1, %c8, %c8, %c0
+    pto.load_cbuf_to_ca_s4 %src, %dsta, %c0, %c4, %c16, %c4, %c8, %c16, %c0
       : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0a>, i64, i64, i64, i64, i64, i64, i64
-    pto.load_cbuf_to_cb_s4 %src, %dstb, %c0, %c0, %c4, %c1, %c4, %c4, %c1
+    pto.load_cbuf_to_cb_s4 %src, %dstb, %c0, %c4, %c16, %c4, %c8, %c16, %c1
       : !pto.ptr<!pto.f4E2M1x2, l1>, !pto.ptr<!pto.f4E2M1x2, l0b>, i64, i64, i64, i64, i64, i64, i64
     return
   }
 }
 
 // CHECK-LABEL: llvm.func @load_cbuf_to_s4_2dv2_control
-// CHECK: llvm.call @llvm.hivm.LOAD.L1.TO.L0A.2Dv2.s4
-// CHECK: llvm.call @llvm.hivm.LOAD.L1.TO.L0B.2Dv2.s4
+// CHECK-DAG: %[[SRC_STRIDE:.*]] = llvm.mlir.constant(8 : i64)
+// CHECK-DAG: %[[TRUE:.*]] = llvm.mlir.constant(1 : i64)
+// CHECK-DAG: %[[FALSE:.*]] = llvm.mlir.constant(0 : i64)
+// CHECK-DAG: %[[SRC:.*]] = llvm.inttoptr %[[FALSE]] : i64 to !llvm.ptr<2>
+// CHECK-DAG: %[[DSTA:.*]] = llvm.inttoptr %[[FALSE]] : i64 to !llvm.ptr<3>
+// CHECK-DAG: %[[DSTB:.*]] = llvm.inttoptr %[[FALSE]] : i64 to !llvm.ptr<4>
+// CHECK: %[[A_K_START:.*]] = llvm.mlir.constant(262144 : i64)
+// CHECK: %[[A_M_STEP:.*]] = llvm.mlir.constant(68719476736 : i64)
+// CHECK: %[[A_LOW:.*]] = llvm.or %[[A_K_START]], %[[A_M_STEP]] : i64
+// CHECK: %[[A_K_STEP:.*]] = llvm.mlir.constant(4398046511104 : i64)
+// CHECK: %[[A_CONFIG0:.*]] = llvm.or %[[A_LOW]], %[[A_K_STEP]] : i64
+// CHECK: %[[A_DST_STRIDE_SHIFTED:.*]] = llvm.mlir.constant(1048576 : i64)
+// CHECK: %[[A_CONFIG1:.*]] = llvm.or %[[A_DST_STRIDE_SHIFTED]], %[[SRC_STRIDE]] : i64
+// CHECK: llvm.call @llvm.hivm.LOAD.L1.TO.L0A.2Dv2.s4(%[[DSTA]], %[[SRC]], %[[A_CONFIG0]], %[[A_CONFIG1]], %[[FALSE]])
+// CHECK: %[[B_K_START:.*]] = llvm.mlir.constant(262144 : i64)
+// CHECK: %[[B_M_STEP:.*]] = llvm.mlir.constant(68719476736 : i64)
+// CHECK: %[[B_LOW:.*]] = llvm.or %[[B_K_START]], %[[B_M_STEP]] : i64
+// CHECK: %[[B_K_STEP:.*]] = llvm.mlir.constant(4398046511104 : i64)
+// CHECK: %[[B_CONFIG0:.*]] = llvm.or %[[B_LOW]], %[[B_K_STEP]] : i64
+// CHECK: %[[B_DST_STRIDE_SHIFTED:.*]] = llvm.mlir.constant(1048576 : i64)
+// CHECK: %[[B_CONFIG1:.*]] = llvm.or %[[B_DST_STRIDE_SHIFTED]], %[[SRC_STRIDE]] : i64
+// CHECK: llvm.call @llvm.hivm.LOAD.L1.TO.L0B.2Dv2.s4(%[[DSTB]], %[[SRC]], %[[B_CONFIG0]], %[[B_CONFIG1]], %[[TRUE]])


### PR DESCRIPTION
Closes #1200

## Summary

- Extend the existing `pto.mte_l1_l0a/b` explicit-control form to accept packed `f4e1m2x2` and `f4e2m1x2` source pointers.
- Dispatch packed FP4 sources to the existing `pto.load_cbuf_to_ca_s4/cb_s4` operations while keeping non-FP4 sources on the regular load path.
- Preserve all six explicit controls exactly. In particular, FP4 `k_start` and `k_step` are already packed-S4 units and receive no additional `/2` conversion.
- Add S4 raw-op verification for address spaces, compatible packed FP4 types, control-field ranges, and `transpose`.
- Reject packed FP4 on the regular raw load path so frontend dispatch mistakes fail during verification.
- Document the public PTODSL behavior and the S4 micro-ISA contract.

## Scope

This reuses the existing public PTODSL API and existing A5 S4 emitters. It does not add a new public S4 API, change the shape-derived FP4 expansion, or modify `lib/PTO/Transforms/*`.

## Validation

Validated on the 144 remote LLVM 21 environment:

- Built `PTOIR`, `PTOTransforms`, PTOAS tooling, generated Python op bindings, and `_core.so`.
- 5 focused VPTO lit tests passed, including exact S4 packed controls and adjacent shape-derived/regular-load regressions.
- `ptodsl/tests/test_vector_cube_ops.py`: 49 passed.
- `ptodsl/tests/test_jit_compile.py`: passed.
- `ptodsl/tests/test_docs_as_test.py`: 15 markdown files / 307 fenced blocks passed.

A5 was unreachable during validation, so hardware numerical validation remains pending.