### PR TITLE
feat(vpto): extend scalar f16 SIMT math support

### DIFF
--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -791,10 +791,11 @@ else:
 - **syntax:** `%r = pto.absf %x : T -> T`
 - **semantics:** Return `abs(x)`. For `vector<2xT>`, absolute value is applied
   independently to each element.
-- **inputs:** `%x` is an `f32` scalar, `vector<2xf16>`, or `vector<2xbf16>`.
+- **inputs:** `%x` is an `f16` or `f32` scalar, `vector<2xf16>`, or
+  `vector<2xbf16>`.
 - **outputs:** One value with the same type as `%x`.
-- **constraints and limitations:** Scalar `f16` and scalar `bf16` are not
-  accepted by this op; use the packed form only for `vector<2xT>`.
+- **constraints and limitations:** Scalar `bf16` is not accepted by this op;
+  use the packed form for `vector<2xbf16>`.
 
 ### `pto.sqrt`
 

--- a/docs/isa/micro-isa/17-simt.md
+++ b/docs/isa/micro-isa/17-simt.md
@@ -880,9 +880,10 @@ else:
 - **semantics:** Return the floating minimum of `%a` and `%b`.
 - **inputs:** `%a` and `%b` have the same type.
 - **outputs:** One value with the same type as the inputs.
-- **constraints and limitations:** `T` is `f32`, `bf16`, `vector<2xf16>`, or
-  `vector<2xbf16>`. For vector types, the minimum is computed element-wise. NaN
-  handling follows the target floating-point minimum rule.
+- **constraints and limitations:** `T` is `f16`, `f32`, `bf16`,
+  `vector<2xf16>`, or `vector<2xbf16>`. For vector types, the minimum is
+  computed element-wise. NaN handling follows the target floating-point
+  minimum rule.
 
 ### `pto.fmax`
 
@@ -890,9 +891,10 @@ else:
 - **semantics:** Return the floating maximum of `%a` and `%b`.
 - **inputs:** `%a` and `%b` have the same type.
 - **outputs:** One value with the same type as the inputs.
-- **constraints and limitations:** `T` is `f32`, `bf16`, `vector<2xf16>`, or
-  `vector<2xbf16>`. For vector types, the maximum is computed element-wise. NaN
-  handling follows the target floating-point maximum rule.
+- **constraints and limitations:** `T` is `f16`, `f32`, `bf16`,
+  `vector<2xf16>`, or `vector<2xbf16>`. For vector types, the maximum is
+  computed element-wise. NaN handling follows the target floating-point
+  maximum rule.
 
 ### `pto.fma`
 

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -898,10 +898,10 @@ class PTO_BinaryFloatScalarOp<string mnemonic>
 
 def PTO_AbsFOp
     : PTO_SimtOp<"absf", [Pure, AllTypesMatch<["value", "result"]>]> {
-  let arguments = (ins AnyTypeOf<[F32, PTO_V2F16Type, PTO_V2BF16Type],
-                                 "f32, vector<2xf16> or vector<2xbf16>">:$value);
-  let results = (outs AnyTypeOf<[F32, PTO_V2F16Type, PTO_V2BF16Type],
-                                "f32, vector<2xf16> or vector<2xbf16>">:$result);
+  let arguments = (ins AnyTypeOf<[F16, F32, PTO_V2F16Type, PTO_V2BF16Type],
+                                 "f16, f32, vector<2xf16> or vector<2xbf16>">:$value);
+  let results = (outs AnyTypeOf<[F16, F32, PTO_V2F16Type, PTO_V2BF16Type],
+                                "f16, f32, vector<2xf16> or vector<2xbf16>">:$result);
 
   let assemblyFormat = [{
     $value attr-dict `:` type($value) `->` type($result)

--- a/include/PTO/IR/VPTOOps.td
+++ b/include/PTO/IR/VPTOOps.td
@@ -124,8 +124,9 @@ def PTO_SimtUnaryFloatValueType : AnyTypeOf<[F16, F32, BF16, PTO_V2F16Type, PTO_
                                            "f16, f32, bf16, vector<2xf16> or vector<2xbf16>">;
 def PTO_SimtUnaryF16F32ValueType : AnyTypeOf<[F16, F32, PTO_V2F16Type],
                                             "f16, f32 or vector<2xf16>">;
-def PTO_SimtBinaryF32BF16ValueType : AnyTypeOf<[F32, BF16, PTO_V2F16Type, PTO_V2BF16Type],
-                                              "f32, bf16, vector<2xf16> or vector<2xbf16>">;
+def PTO_SimtBinaryFloatValueType : AnyTypeOf<
+  [F16, F32, BF16, PTO_V2F16Type, PTO_V2BF16Type],
+  "f16, f32, bf16, vector<2xf16> or vector<2xbf16>">;
 def PTO_SimtBinaryF16F32ValueType : AnyTypeOf<[F16, F32, PTO_V2F16Type],
                                              "f16, f32 or vector<2xf16>">;
 def PTO_SimtConvertValueType : AnyTypeOf<[I32, I64, F16, BF16, F32,
@@ -924,13 +925,13 @@ def PTO_FloorOp : PTO_UnaryFloatScalarOp<"floor">;
 def PTO_RintOp : PTO_UnaryFloatScalarOp<"rint">;
 def PTO_RoundOp : PTO_UnaryFloatScalarOp<"round">;
 
-class PTO_BinaryF32BF16ScalarOp<string mnemonic>
+class PTO_BinaryFloatValueOp<string mnemonic>
     : PTO_SimtOp<mnemonic, [Pure, AllTypesMatch<["lhs", "rhs", "result"]>]> {
   let arguments = (ins
-    PTO_SimtBinaryF32BF16ValueType:$lhs,
-    PTO_SimtBinaryF32BF16ValueType:$rhs
+    PTO_SimtBinaryFloatValueType:$lhs,
+    PTO_SimtBinaryFloatValueType:$rhs
   );
-  let results = (outs PTO_SimtBinaryF32BF16ValueType:$result);
+  let results = (outs PTO_SimtBinaryFloatValueType:$result);
 
   let assemblyFormat = [{
     $lhs `,` $rhs attr-dict `:` type($lhs) `,` type($rhs) `->` type($result)
@@ -950,8 +951,8 @@ class PTO_BinaryF16F32ScalarOp<string mnemonic>
   }];
 }
 
-def PTO_FMinOp : PTO_BinaryF32BF16ScalarOp<"fmin">;
-def PTO_FMaxOp : PTO_BinaryF32BF16ScalarOp<"fmax">;
+def PTO_FMinOp : PTO_BinaryFloatValueOp<"fmin">;
+def PTO_FMaxOp : PTO_BinaryFloatValueOp<"fmax">;
 def PTO_PowOp : PTO_BinaryF16F32ScalarOp<"pow">;
 
 def PTO_FmaOp

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -3051,8 +3051,8 @@ template <>
 FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMinOp>(MLIRContext *context,
                                                               Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
-  if (elem != "f32" && elem != "bf16" && elem != "v2f16" &&
-      elem != "v2bf16")
+  if (elem != "f16" && elem != "f32" && elem != "bf16" &&
+      elem != "v2f16" && elem != "v2bf16")
     return failure();
   return StringAttr::get(context, "llvm.minnum." + elem).getValue();
 }
@@ -3061,8 +3061,8 @@ template <>
 FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMaxOp>(MLIRContext *context,
                                                               Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
-  if (elem != "f32" && elem != "bf16" && elem != "v2f16" &&
-      elem != "v2bf16")
+  if (elem != "f16" && elem != "f32" && elem != "bf16" &&
+      elem != "v2f16" && elem != "v2bf16")
     return failure();
   return StringAttr::get(context, "llvm.maxnum." + elem).getValue();
 }

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -2984,7 +2984,7 @@ template <>
 FailureOr<StringRef> buildUnaryScalarMathCallee<pto::AbsFOp>(MLIRContext *context,
                                                              Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
-  if (elem != "f32" && elem != "v2f16" && elem != "v2bf16")
+  if (elem != "f16" && elem != "f32" && elem != "v2f16" && elem != "v2bf16")
     return failure();
   return StringAttr::get(context, "llvm.fabs." + elem).getValue();
 }

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -3012,7 +3012,7 @@ template <>
 FailureOr<StringRef> buildUnaryScalarMathCallee<pto::AbsFOp>(MLIRContext *context,
                                                              Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
-  if (elem != "f32" && elem != "v2f16" && elem != "v2bf16")
+  if (elem != "f16" && elem != "f32" && elem != "v2f16" && elem != "v2bf16")
     return failure();
   return StringAttr::get(context, "llvm.fabs." + elem).getValue();
 }

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -3079,8 +3079,8 @@ template <>
 FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMinOp>(MLIRContext *context,
                                                               Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
-  if (elem != "f32" && elem != "bf16" && elem != "v2f16" &&
-      elem != "v2bf16")
+  if (elem != "f16" && elem != "f32" && elem != "bf16" &&
+      elem != "v2f16" && elem != "v2bf16")
     return failure();
   return StringAttr::get(context, "llvm.minnum." + elem).getValue();
 }
@@ -3089,8 +3089,8 @@ template <>
 FailureOr<StringRef> buildBinaryScalarMathCallee<pto::FMaxOp>(MLIRContext *context,
                                                               Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
-  if (elem != "f32" && elem != "bf16" && elem != "v2f16" &&
-      elem != "v2bf16")
+  if (elem != "f16" && elem != "f32" && elem != "bf16" &&
+      elem != "v2f16" && elem != "v2bf16")
     return failure();
   return StringAttr::get(context, "llvm.maxnum." + elem).getValue();
 }

--- a/ptodsl/docs/user_guide/13-simt-micro-ops.md
+++ b/ptodsl/docs/user_guide/13-simt-micro-ops.md
@@ -461,7 +461,11 @@ def simt_ops_integer_math_probe(dst: pto.ptr(pto.i32, "gm")):
 **Description**: Performs SIMT floating-point math. These functions are VPTO
 SIMT micro-ops and are distinct from the generic scalar helpers in Chapter 6.
 
-**Parameters**: PTO floating-point scalar operands.
+`pto.fmin` and `pto.fmax` accept `f16`, `f32`, `bf16`, `vector<2xf16>`, and
+`vector<2xbf16>` operands.
+
+**Parameters**: PTO floating-point scalar or packed operands supported by the
+selected operation.
 
 **Returns**: PTO scalar with the same type as the input value.
 

--- a/ptodsl/tests/test_jit_compile.py
+++ b/ptodsl/tests/test_jit_compile.py
@@ -891,6 +891,7 @@ def simt_collective_math_probe():
     pto.mul_i32toi64(lane, lane, signedness="unsigned")
 
     as_f32 = pto.convert(lane, pto.f32, rounding="r", saturation="nosat", signedness="signed")
+    as_f16 = pto.const(1.0, dtype=pto.f16)
     pto.convert(as_f32, pto.i32, rounding="z", saturation="sat", signedness="signed")
     pto.absf(as_f32)
     pto.sqrt(as_f32)
@@ -903,6 +904,8 @@ def simt_collective_math_probe():
     pto.round(as_f32)
     pto.fmin(as_f32, as_f32)
     pto.fmax(as_f32, as_f32)
+    pto.fmin(as_f16, as_f16)
+    pto.fmax(as_f16, as_f16)
     pto.fma(as_f32, as_f32, as_f32)
 
 
@@ -5635,6 +5638,14 @@ def main() -> None:
         "pto.resume",
     ):
         expect(op_name in simt_full_text, f"full SIMT surface should contain {op_name}")
+    expect(
+        re.search(r"pto\.fmin .* : f16, f16 -> f16", simt_full_text) is not None,
+        "full SIMT surface should accept scalar f16 pto.fmin",
+    )
+    expect(
+        re.search(r"pto\.fmax .* : f16, f16 -> f16", simt_full_text) is not None,
+        "full SIMT surface should accept scalar f16 pto.fmax",
+    )
     for fp8_vec in (
         "vector<4xf8E4M3FN>",
         "vector<8xf8E4M3FN>",

--- a/test/lit/vpto/simt_lowlevel_float_math_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_float_math_vpto_llvm.pto
@@ -7,6 +7,7 @@
 // See LICENSE in the root of the software repository for the full text of the License.
 
 // RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto %s -o %t --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
+// RUN: ( mkdir -p %T && ptoas --pto-arch=a5 --pto-backend=vpto --cann-output-version=9.0.0 %s -o %t.cann900 --mlir-print-ir-after=convert-func-to-llvm 2>&1 || true ) | FileCheck %s
 
 module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<vector>} {
   func.func @simt_float_math_kernel(%dst_f32: !pto.ptr<f32, ub>, %dst_f16: !pto.ptr<f16, ub>, %dst_bf16: !pto.ptr<bf16, ub>) attributes {pto.aicore} {
@@ -40,6 +41,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %abs = pto.absf %f32_a : f32 -> f32
     %fmin = pto.fmin %f32_a, %f32_b : f32, f32 -> f32
     %fmax = pto.fmax %bf16_a, %bf16_b : bf16, bf16 -> bf16
+    %fmin16 = pto.fmin %f16_a, %f16_b : f16, f16 -> f16
+    %fmax16 = pto.fmax %f16_a, %f16_b : f16, f16 -> f16
     %exp = pto.exp %f32_a : f32 -> f32
     %exp16 = pto.exp %f16_a : f16 -> f16
     %log = pto.log %f32_c : f32 -> f32
@@ -66,6 +69,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.store %pow16, %dst_f16[%c2] : !pto.ptr<f16, ub>, f16
     pto.store %rint, %dst_f16[%c3] : !pto.ptr<f16, ub>, f16
     pto.store %fma16, %dst_f16[%c4] : !pto.ptr<f16, ub>, f16
+    pto.store %fmin16, %dst_f16[%c5] : !pto.ptr<f16, ub>, f16
+    pto.store %fmax16, %dst_f16[%c6] : !pto.ptr<f16, ub>, f16
     pto.store %fmax, %dst_bf16[%c0] : !pto.ptr<bf16, ub>, bf16
     pto.store %ceil, %dst_bf16[%c1] : !pto.ptr<bf16, ub>, bf16
     pto.store %round, %dst_bf16[%c2] : !pto.ptr<bf16, ub>, bf16
@@ -80,6 +85,8 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 // CHECK-DAG: llvm.call @llvm.fabs.f32
 // CHECK-DAG: llvm.call @llvm.minnum.f32
 // CHECK-DAG: llvm.call @llvm.maxnum.bf16
+// CHECK-DAG: llvm.call @llvm.minnum.f16
+// CHECK-DAG: llvm.call @llvm.maxnum.f16
 // CHECK-DAG: llvm.call @llvm.exp.f32
 // CHECK-DAG: llvm.call @llvm.exp.f16
 // CHECK-DAG: llvm.call @llvm.log.f32

--- a/test/lit/vpto/simt_lowlevel_float_math_vpto_llvm.pto
+++ b/test/lit/vpto/simt_lowlevel_float_math_vpto_llvm.pto
@@ -34,11 +34,13 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %f16_a = arith.constant 1.500000e+00 : f16
     %f16_b = arith.constant 2.000000e+00 : f16
     %f16_c = arith.constant 4.000000e+00 : f16
+    %f16_neg = arith.constant -1.500000e+00 : f16
     %bf16_a = arith.constant 1.500000e+00 : bf16
     %bf16_b = arith.constant 2.000000e+00 : bf16
     %bf16_c = arith.constant 4.000000e+00 : bf16
 
     %abs = pto.absf %f32_a : f32 -> f32
+    %abs16 = pto.absf %f16_neg : f16 -> f16
     %fmin = pto.fmin %f32_a, %f32_b : f32, f32 -> f32
     %fmax = pto.fmax %bf16_a, %bf16_b : bf16, bf16 -> bf16
     %fmin16 = pto.fmin %f16_a, %f16_b : f16, f16 -> f16
@@ -64,6 +66,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     pto.store %pow, %dst_f32[%c4] : !pto.ptr<f32, ub>, f32
     pto.store %floor, %dst_f32[%c5] : !pto.ptr<f32, ub>, f32
     pto.store %fma, %dst_f32[%c6] : !pto.ptr<f32, ub>, f32
+    pto.store %abs16, %dst_f16[%c7] : !pto.ptr<f16, ub>, f16
     pto.store %exp16, %dst_f16[%c0] : !pto.ptr<f16, ub>, f16
     pto.store %log16, %dst_f16[%c1] : !pto.ptr<f16, ub>, f16
     pto.store %pow16, %dst_f16[%c2] : !pto.ptr<f16, ub>, f16
@@ -83,6 +86,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
 // CHECK-DAG: llvm.call @llvm.hivm.store.vfsimt.info
 // CHECK-LABEL: llvm.func @simt_float_math
 // CHECK-DAG: llvm.call @llvm.fabs.f32
+// CHECK-DAG: llvm.call @llvm.fabs.f16
 // CHECK-DAG: llvm.call @llvm.minnum.f32
 // CHECK-DAG: llvm.call @llvm.maxnum.bf16
 // CHECK-DAG: llvm.call @llvm.minnum.f16

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/compare.py
@@ -21,6 +21,7 @@ def main():
         (
             np.arange(0, 18, dtype=np.intp),
             np.arange(32, 96, dtype=np.intp),
+            np.arange(96, 128, dtype=np.intp),
         )
     )
     ok = golden.shape == out.shape and np.array_equal(golden[written], out[written])

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/compare.py
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/compare.py
@@ -17,9 +17,15 @@ def main():
     strict = os.getenv("COMPARE_STRICT", "1") != "0"
     golden = np.fromfile("golden_v1.bin", dtype=np.int32)
     out = np.fromfile("v1.bin", dtype=np.int32)
-    ok = golden.shape == out.shape and np.array_equal(golden, out)
+    written = np.concatenate(
+        (
+            np.arange(0, 18, dtype=np.intp),
+            np.arange(32, 96, dtype=np.intp),
+        )
+    )
+    ok = golden.shape == out.shape and np.array_equal(golden[written], out[written])
     if not ok:
-        idxs = np.nonzero(golden != out)[0]
+        idxs = written[golden[written] != out[written]]
         idx = int(idxs[0]) if idxs.size else 0
         print(
             f"[ERROR] mismatch at idx={idx}, golden={int(golden[idx])}, out={int(out[idx])}"

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/golden.py
@@ -23,6 +23,10 @@ def generate(output_dir: Path) -> None:
         [3, 2, 2, 1, 2, 2, 0, 16, 16, 1, 2, 2, 2, 6, 6, 6, -4, 4],
         dtype=np.int32,
     )
+    values = np.arange(-16, 16, dtype=np.float16)
+    three = np.float16(3)
+    golden_v1[32:64] = np.minimum(values, three).view(np.uint16).astype(np.int32)
+    golden_v1[64:96] = np.maximum(values, three).view(np.uint16).astype(np.int32)
     v1.tofile(output_dir / "v1.bin")
     golden_v1.tofile(output_dir / "golden_v1.bin")
 

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/golden.py
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/golden.py
@@ -27,6 +27,7 @@ def generate(output_dir: Path) -> None:
     three = np.float16(3)
     golden_v1[32:64] = np.minimum(values, three).view(np.uint16).astype(np.int32)
     golden_v1[64:96] = np.maximum(values, three).view(np.uint16).astype(np.int32)
+    golden_v1[96:128] = np.abs(np.arange(-16, 16, dtype=np.float16)).view(np.uint16)
     v1.tofile(output_dir / "v1.bin")
     golden_v1.tofile(output_dir / "golden_v1.bin")
 

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
@@ -39,6 +39,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %c16_i32 = arith.constant 16 : i32
     %c32_i32 = arith.constant 32 : i32
     %c64_i32 = arith.constant 64 : i32
+    %c96_i32 = arith.constant 96 : i32
 
     %f32_neg = arith.constant -3.000000e+00 : f32
     %f32_one = arith.constant 1.000000e+00 : f32
@@ -58,6 +59,7 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %tid_f16 = pto.convert %signed_tid round(r) nosat signed : i32 -> f16
 
     %abs = pto.absf %f32_neg : f32 -> f32
+    %abs_f16 = pto.absf %tid_f16 : f16 -> f16
     %sqrt_f32 = pto.sqrt %f32_four : f32 -> f32
     %sqrt_f16 = pto.sqrt %f16_four : f16 -> f16
     %fmin = pto.fmin %f32_one, %f32_two : f32, f32 -> f32
@@ -98,8 +100,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %fmax16 = pto.fmax %tid_f16, %f16_three : f16, f16 -> f16
     %fmin16_bits = llvm.bitcast %fmin16 : f16 to i16
     %fmax16_bits = llvm.bitcast %fmax16 : f16 to i16
+    %abs_f16_bits = llvm.bitcast %abs_f16 : f16 to i16
     %fmin16_out = arith.extui %fmin16_bits : i16 to i32
     %fmax16_out = arith.extui %fmax16_bits : i16 to i32
+    %abs_f16_out = arith.extui %abs_f16_bits : i16 to i32
 
     pto.store %abs_i, %dst[%c0] : !pto.ptr<i32, ub>, i32
     pto.store %sqrt_f32_i, %dst[%c1] : !pto.ptr<i32, ub>, i32
@@ -127,6 +131,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %fmax16_idx = arith.index_castui %fmax16_offset : i32 to index
     pto.store %fmin16_out, %dst[%fmin16_idx] : !pto.ptr<i32, ub>, i32
     pto.store %fmax16_out, %dst[%fmax16_idx] : !pto.ptr<i32, ub>, i32
+    %abs_f16_offset = arith.addi %tid, %c96_i32 : i32
+    %abs_f16_idx = arith.index_castui %abs_f16_offset : i32 to index
+    pto.store %abs_f16_out, %dst[%abs_f16_idx] : !pto.ptr<i32, ub>, i32
     return
   }
 }

--- a/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
+++ b/test/vpto/cases/micro-op/simt/simt-float-convert-core/kernel.pto
@@ -36,6 +36,9 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %c13 = arith.constant 13 : index
     %c14 = arith.constant 14 : index
     %c15 = arith.constant 15 : index
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c64_i32 = arith.constant 64 : i32
 
     %f32_neg = arith.constant -3.000000e+00 : f32
     %f32_one = arith.constant 1.000000e+00 : f32
@@ -49,6 +52,10 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %bf16_four = arith.constant 4.000000e+00 : bf16
     %i32_neg = arith.constant -4 : i32
     %u32_four = arith.constant 4 : i32
+    %f16_three = arith.constant 3.000000e+00 : f16
+    %tid = pto.get_tid_x : i32
+    %signed_tid = arith.subi %tid, %c16_i32 : i32
+    %tid_f16 = pto.convert %signed_tid round(r) nosat signed : i32 -> f16
 
     %abs = pto.absf %f32_neg : f32 -> f32
     %sqrt_f32 = pto.sqrt %f32_four : f32 -> f32
@@ -87,6 +94,12 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %fmabf16_i = pto.convert %fmabf16 round(z) sat signed : bf16 -> i32
     %s32_f32_i = pto.convert %s32_f32 round(z) sat signed : f32 -> i32
     %u32_f16_i = pto.convert %u32_f16 round(z) sat unsigned : f16 -> i32
+    %fmin16 = pto.fmin %tid_f16, %f16_three : f16, f16 -> f16
+    %fmax16 = pto.fmax %tid_f16, %f16_three : f16, f16 -> f16
+    %fmin16_bits = llvm.bitcast %fmin16 : f16 to i16
+    %fmax16_bits = llvm.bitcast %fmax16 : f16 to i16
+    %fmin16_out = arith.extui %fmin16_bits : i16 to i32
+    %fmax16_out = arith.extui %fmax16_bits : i16 to i32
 
     pto.store %abs_i, %dst[%c0] : !pto.ptr<i32, ub>, i32
     pto.store %sqrt_f32_i, %dst[%c1] : !pto.ptr<i32, ub>, i32
@@ -108,6 +121,12 @@ module attributes {pto.target_arch = "a5", pto.kernel_kind = #pto.kernel_kind<ve
     %c17 = arith.constant 17 : index
     pto.store %s32_f32_i, %dst[%c16] : !pto.ptr<i32, ub>, i32
     pto.store %u32_f16_i, %dst[%c17] : !pto.ptr<i32, ub>, i32
+    %fmin16_offset = arith.addi %tid, %c32_i32 : i32
+    %fmax16_offset = arith.addi %tid, %c64_i32 : i32
+    %fmin16_idx = arith.index_castui %fmin16_offset : i32 to index
+    %fmax16_idx = arith.index_castui %fmax16_offset : i32 to index
+    pto.store %fmin16_out, %dst[%fmin16_idx] : !pto.ptr<i32, ub>, i32
+    pto.store %fmax16_out, %dst[%fmax16_idx] : !pto.ptr<i32, ub>, i32
     return
   }
 }


### PR DESCRIPTION
- Extend the VPTO type constraints for `pto.fmin` and `pto.fmax` to accept scalar `f16`.
- Extend `pto.absf` to accept scalar `f16`.
- Update both LLVM emitters:
  - `pto.fmin` -> `llvm.minnum.f16`
  - `pto.fmax` -> `llvm.maxnum.f16`
  - `pto.absf` -> `llvm.fabs.f16`
- Update the SIMT ISA and PTODSL documentation.