### PR TITLE
test(ptobc): fix TCI tmp roundtrip fixture

### DIFF
--- a/tools/ptobc/testdata/tci_trowexpandadd_tmp_v0_roundtrip.pto
+++ b/tools/ptobc/testdata/tci_trowexpandadd_tmp_v0_roundtrip.pto
@@ -10,9 +10,9 @@ module {
   func.func @tci_trowexpandadd_tmp_v0() {
     %c0_i16 = arith.constant 0 : i16
 
-    %tci_tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>
+    %tci_tmp = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=448, v_row=1, v_col=448, blayout=row_major, slayout=none_box, fractal=512, pad=0>
     %tci_dst = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>
-    pto.tci ins(%c0_i16, %tci_tmp : i16, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=128, v_row=1, v_col=128, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
+    pto.tci ins(%c0_i16, %tci_tmp : i16, !pto.tile_buf<loc=vec, dtype=f32, rows=1, cols=448, v_row=1, v_col=448, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
             outs(%tci_dst : !pto.tile_buf<loc=vec, dtype=i16, rows=1, cols=16, v_row=1, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>)
 
     %src0 = pto.alloc_tile : !pto.tile_buf<loc=vec, dtype=f32, rows=8, cols=16, v_row=8, v_col=16, blayout=row_major, slayout=none_box, fractal=512, pad=0>


### PR DESCRIPTION
## Summary

- resize the explicit i16 TCI tmp fixture from `1x128xf32` (512 bytes) to `1x448xf32` (1792 bytes)
- align the PTO-BC roundtrip corpus with the A2/A3 TCI verifier and implicit-tmp materializer introduced by #1131
- fix both `ptobc_tci_trowexpandadd_tmp_v0_encode` and `ptobc_stage9_e2e`, which surfaced in #1197 even though that PR only changes documentation

## Root cause

#1131 added a 1792-byte minimum tmp capacity for 16-bit TCI destinations and materializes exactly `1x448xf32`, but the pre-existing PTO-BC fixture remained `1x128xf32` (512 bytes). The dedicated encoder test and the stage9 corpus scan therefore both failed while parsing the same fixture.

## Validation

- `tools/ptobc/tests/tci_trowexpandadd_tmp_v0_encode.sh`
- `tools/ptobc/tests/stage9_e2e.sh` over `tools/ptobc/testdata`
- `git diff --check`
