### PR TITLE
fix: complete metrics rule cleanup

### DIFF
--- a/include/PTO/Transforms/GraphSyncSolver/EventIdSolver.h
+++ b/include/PTO/Transforms/GraphSyncSolver/EventIdSolver.h
@@ -35,7 +35,7 @@ class Action {
 public:
   const ACTION_TYPE actionType;
   Action() = delete;
-  Action(ACTION_TYPE actionType) : actionType(actionType) {};
+  explicit Action(ACTION_TYPE actionType) : actionType(actionType) {};
   virtual ~Action() = default;
   virtual std::string str() const = 0;
 };
@@ -52,7 +52,8 @@ public:
 class ActionAddNode : public Action {
 public:
   EventIdNode *const node;
-  ActionAddNode(EventIdNode *node) : Action(ACTION_TYPE::ADD_NODE), node(node) {
+  explicit ActionAddNode(EventIdNode *node)
+      : Action(ACTION_TYPE::ADD_NODE), node(node) {
     assert(node != nullptr);
   }
   static bool classof(const Action *e) {

--- a/lib/Bindings/Python/PTOModule.cpp
+++ b/lib/Bindings/Python/PTOModule.cpp
@@ -114,8 +114,7 @@ static MlirAttribute optionalAttributeFromPy(py::object attr) {
   return py::cast<MlirAttribute>(attr);
 }
 
-void populatePTODialectSubmodule(pybind11::module &m);
-void populatePTODialectSubmodule(pybind11::module &m) {
+static void populatePTODialectSubmodule(pybind11::module &m) {
   (void)m;
 }
 
@@ -1204,7 +1203,7 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
                 std::vector<int64_t> shp = toShapeVectorOrDynamicRank(shape_or_rank);
                 context = inferContextFromElementType(context, elementType);
                 MlirType t = mlirPTOTensorViewTypeGet(
-                    context, (intptr_t)shp.size(), shp.data(), elementType);
+                    context, static_cast<intptr_t>(shp.size()), shp.data(), elementType);
                 return cls.attr("__call__")(t);
             },
             py::arg("cls"), py::arg("shape_or_rank"), py::arg("element_type"),
@@ -1236,7 +1235,7 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
         std::vector<int64_t> shp = toShapeVectorOrDynamicRank(shape_or_rank);
         context = inferContextFromElementType(context, elementType);
         MlirType t = mlirPTOPartitionTensorViewTypeGet(context,
-                                            (intptr_t)shp.size(),
+                                            static_cast<intptr_t>(shp.size()),
                                             shp.data(),
                                             elementType);
         return cls.attr("__call__")(t);
@@ -1268,7 +1267,7 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
         [](py::object cls, py::sequence shape, MlirType elementType, MlirContext context) -> py::object {
         auto shp = toInt64Vector(shape);
         MlirType t = mlirPTOTileTypeGet(context,
-                                        (intptr_t)shp.size(),
+                                        static_cast<intptr_t>(shp.size()),
                                         shp.data(),
                                         elementType);
         return cls.attr("__call__")(t);
@@ -1359,7 +1358,7 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             if (!validShapeObj.is_none()) {
             // 支持 valid_shape 为 list[int] 或 list[Optional[int]]
             py::list lst = validShapeObj.cast<py::list>();
-            if ((size_t)lst.size() != shape.size()) {
+            if (static_cast<size_t>(lst.size()) != shape.size()) {
                 throw std::runtime_error("valid_shape rank must match shape rank");
             }
             validShape.resize(lst.size());
@@ -1379,16 +1378,16 @@ void mlir::pto::python::populatePTODialectBindings(pybind11::module_ &m) {
             MlirAttribute cfg = configObj.cast<MlirAttribute>();
             ty = mlirPTOTileBufTypeGetWithValidShapeAndConfig(
                 ctx,
-                (intptr_t)shape.size(), shape.data(),
+                static_cast<intptr_t>(shape.size()), shape.data(),
                 elementType, memorySpace,
-                (intptr_t)validShape.size(), validShape.data(),
+                static_cast<intptr_t>(validShape.size()), validShape.data(),
                 cfg);
             } else {
             ty = mlirPTOTileBufTypeGetWithValidShape(
                 ctx,
-                (intptr_t)shape.size(), shape.data(),
+                static_cast<intptr_t>(shape.size()), shape.data(),
                 elementType, memorySpace,
-                (intptr_t)validShape.size(), validShape.data());
+                static_cast<intptr_t>(validShape.size()), validShape.data());
             }
 
             if (mlirTypeIsNull(ty)) return py::none();

--- a/lib/CAPI/Dialect/PTO.cpp
+++ b/lib/CAPI/Dialect/PTO.cpp
@@ -53,8 +53,9 @@ static CanonicalValidShapeVector
 canonicalizeTileBufValidShape(ArrayRef<int64_t> validShape) {
   CanonicalValidShapeVector canonical;
   canonical.reserve(validShape.size());
-  for (int64_t dim : validShape)
+  for (int64_t dim : validShape) {
     canonical.push_back(dim < 0 ? ShapedType::kDynamic : dim);
+  }
   return canonical;
 }
 
@@ -298,7 +299,9 @@ MlirType mlirPTOTileBufTypeGetWithConfig(MlirContext ctx, intptr_t rank,
   MLIRContext *c = unwrap(ctx);
   auto shp = llvm::ArrayRef<int64_t>(shape, rank);
   auto cfg = mlir::dyn_cast_or_null<mlir::pto::TileBufConfigAttr>(unwrap(config));
-  if (!cfg) cfg = mlir::pto::TileBufConfigAttr::getDefault(c);
+  if (!cfg) {
+    cfg = mlir::pto::TileBufConfigAttr::getDefault(c);
+  }
   auto ty = mlir::pto::TileBufType::get(c, shp, unwrap(elementType), unwrap(memorySpace), cfg);
   return wrap(ty);
 }
@@ -615,16 +618,18 @@ MlirAttribute mlirPTOMaskPatternAttrGet(MlirContext ctx, int32_t value) {
   default:
     break;
   }
-  if (!v)
+  if (!v) {
     return MlirAttribute{nullptr};
+  }
   return wrap(mlir::pto::MaskPatternAttr::get(c, *v));
 }
 
 MlirAttribute mlirPTOMaskPatternAttrGetLegacyRaw(MlirContext ctx, int32_t value) {
   auto *c = unwrap(ctx);
   std::optional<mlir::pto::MaskPattern> v = maskPatternFromLegacyRaw(value);
-  if (!v)
+  if (!v) {
     return MlirAttribute{nullptr};
+  }
   return wrap(mlir::pto::MaskPatternAttr::get(c, *v));
 }
 
@@ -642,8 +647,9 @@ MlirAttribute mlirPTOMaskPatternAttrGetEnum(MlirContext ctx,
   auto *c = unwrap(ctx);
   std::optional<mlir::pto::MaskPattern> v =
       maskPatternFromIsaValue(static_cast<int32_t>(value));
-  if (!v)
+  if (!v) {
     return MlirAttribute{nullptr};
+  }
   return wrap(mlir::pto::MaskPatternAttr::get(c, *v));
 }
 
@@ -692,30 +698,41 @@ MlirAttribute mlirPTOTileBufConfigAttrGetDefault(MlirContext ctx) {
 }
 
 static mlir::pto::BLayoutAttr toBLayoutAttr(mlir::MLIRContext *c, mlir::Attribute a) {
-  if (auto bl = mlir::dyn_cast<mlir::pto::BLayoutAttr>(a)) return bl;
-  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a))
+  if (auto bl = mlir::dyn_cast<mlir::pto::BLayoutAttr>(a)) {
+    return bl;
+  }
+  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a)) {
     return mlir::pto::BLayoutAttr::get(c, static_cast<mlir::pto::BLayout>(ia.getInt()));
+  }
   return {};
 }
 static mlir::pto::SLayoutAttr toSLayoutAttr(mlir::MLIRContext *c, mlir::Attribute a) {
-  if (auto sl = mlir::dyn_cast<mlir::pto::SLayoutAttr>(a)) return sl;
-  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a))
+  if (auto sl = mlir::dyn_cast<mlir::pto::SLayoutAttr>(a)) {
+    return sl;
+  }
+  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a)) {
     return mlir::pto::SLayoutAttr::get(c, static_cast<mlir::pto::SLayout>(ia.getInt()));
+  }
   return {};
 }
 static mlir::pto::PadValueAttr toPadValueAttr(mlir::MLIRContext *c, mlir::Attribute a) {
-  if (auto pv = mlir::dyn_cast<mlir::pto::PadValueAttr>(a)) return pv;
-  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a))
+  if (auto pv = mlir::dyn_cast<mlir::pto::PadValueAttr>(a)) {
+    return pv;
+  }
+  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a)) {
     return mlir::pto::PadValueAttr::get(c, static_cast<mlir::pto::PadValue>(ia.getInt()));
+  }
   return {};
 }
 static mlir::pto::CompactModeAttr toCompactModeAttr(mlir::MLIRContext *c,
                                                     mlir::Attribute a) {
-  if (auto cm = mlir::dyn_cast<mlir::pto::CompactModeAttr>(a))
+  if (auto cm = mlir::dyn_cast<mlir::pto::CompactModeAttr>(a)) {
     return cm;
-  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a))
+  }
+  if (auto ia = mlir::dyn_cast<mlir::IntegerAttr>(a)) {
     return mlir::pto::CompactModeAttr::get(
         c, static_cast<mlir::pto::CompactMode>(ia.getInt()));
+  }
   return {};
 }
 
@@ -859,12 +876,14 @@ MlirAttribute mlirPTOTileBufConfigAttrGetWithCompactMode(
   auto slA = toSLayoutAttr(c, unwrap(sLayout));
   auto pvA = toPadValueAttr(c, unwrap(pad));
   auto cmA = toCompactModeAttr(c, unwrap(compactMode));
-  if (!blA || !slA || !pvA || !cmA)
+  if (!blA || !slA || !pvA || !cmA) {
     return MlirAttribute{nullptr};
+  }
 
   auto sz = mlir::dyn_cast<mlir::IntegerAttr>(unwrap(sFractalSize));
-  if (!sz || !sz.getType().isInteger(kI32BitWidth))
+  if (!sz || !sz.getType().isInteger(kI32BitWidth)) {
     return MlirAttribute{nullptr};
+  }
 
   return wrap(mlir::pto::TileBufConfigAttr::get(c, blA, slA, sz, pvA, cmA));
 }
@@ -877,8 +896,9 @@ MlirType mlirPTOGMTypeGet(MlirContext ctx, intptr_t rank, const int64_t *shape,
 
   llvm::SmallVector<int64_t, kGMTypeStrideInlineCapacity> strides(
       static_cast<size_t>(rank), ShapedType::kDynamic);
-  if (rank > 0)
-    strides[static_cast<size_t>(rank) - 1] = 1;
+  if (rank > 0) {
+      strides[static_cast<size_t>(rank) - 1] = 1;
+    }
   auto layout =
       StridedLayoutAttr::get(c, ShapedType::kDynamic, llvm::ArrayRef<int64_t>(strides));
   auto memSpace = mlir::pto::AddressSpaceAttr::get(c, mlir::pto::AddressSpace::GM);

--- a/lib/PTO/IR/PTO.cpp
+++ b/lib/PTO/IR/PTO.cpp
@@ -1212,7 +1212,6 @@ void mlir::pto::TScatterOp::print(OpAsmPrinter &p) {
 }
 
 namespace {
-
 struct CommRecvClause {
   OpAsmParser::UnresolvedOperand ping;
   std::optional<OpAsmParser::UnresolvedOperand> pong;
@@ -1941,7 +1940,7 @@ inferLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
 
   // ND: row-major contiguous
   bool isRowMajor = true;
-  for (int i = 0, e = (int)shape.size() - 1; i < e; ++i) {
+  for (int i = 0, e = static_cast<int>(shape.size()) - 1; i < e; ++i) {
     auto expectedStride = multiplyLayoutInts(strides[i + 1], shape[i + 1]);
     if (!expectedStride || strides[i] != *expectedStride) {
       isRowMajor = false;
@@ -1953,7 +1952,7 @@ inferLayout(ArrayRef<int64_t> shape, ArrayRef<int64_t> strides,
 
   // DN: col-major
   bool isColMajor = true;
-  for (int i = 0, e = (int)shape.size() - 1; i < e; ++i) {
+  for (int i = 0, e = static_cast<int>(shape.size()) - 1; i < e; ++i) {
     auto expectedStride = multiplyLayoutInts(strides[i], shape[i]);
     if (!expectedStride || strides[i + 1] != *expectedStride) {
       isColMajor = false;
@@ -3958,10 +3957,18 @@ static bool isTileLikeType(Type ty) {
 }
 
 static Type getElemTy(Type ty) {
-  if (auto tt = mlir::dyn_cast<RankedTensorType>(ty)) return tt.getElementType();
-  if (auto tv = mlir::dyn_cast<pto::TensorViewType>(ty)) return tv.getElementType();
-  if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty)) return tb.getElementType();
-  if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty)) return tv.getElementType();
+  if (auto tt = mlir::dyn_cast<RankedTensorType>(ty)) {
+    return tt.getElementType();
+  }
+  if (auto tv = mlir::dyn_cast<pto::TensorViewType>(ty)) {
+    return tv.getElementType();
+  }
+  if (auto tb = mlir::dyn_cast<pto::TileBufType>(ty)) {
+    return tb.getElementType();
+  }
+  if (auto tv = mlir::dyn_cast<pto::PartitionTensorViewType>(ty)) {
+    return tv.getElementType();
+  }
   return Type();
 }
 
@@ -4057,8 +4064,9 @@ static LogicalResult verifyAsyncFlatContiguous1DGMViewLike(Operation *op,
   }
 
   bool logical1D = true;
-  for (int i = 0, e = static_cast<int>(shape.size()) - 1; i < e; ++i)
+  for (int i = 0, e = static_cast<int>(shape.size()) - 1; i < e; ++i) {
     logical1D &= shape[i] == 1;
+  }
   if (!logical1D)
     return op->emitOpError()
            << "expects " << name
@@ -5965,7 +5973,6 @@ LogicalResult pto::TCIOp::verify() {
 }
 
 LogicalResult pto::TTriOp::verify() {
-
   Type dstTy = getDst().getType();
   if (failed(verifyVecTileCommon(*this, dstTy, "dst")))
     return failure();
@@ -6589,7 +6596,6 @@ llvm::LogicalResult mlir::pto::TRandomOp::verify() {
     return emitOpError("trandom is only supported for A5 targets");
   };
   auto verifyA5 = [&]() -> LogicalResult {
-
     Type dstTy = getDst().getType();
     if (failed(verifyTileBufCommon(*this, dstTy, "dst")))
       return failure();
@@ -7115,10 +7121,13 @@ mlir::LogicalResult mlir::pto::TInsertOp::verify() {
         return emitOpError("fp is only valid with src loc=acc");
       auto fpTy = getFp().getType();
       auto fpTb = dyn_cast<pto::TileBufType>(fpTy);
-      if (!fpTb) return emitOpError("expects fp to be !pto.tile_buf");
+      if (!fpTb) {
+        return emitOpError("expects fp to be !pto.tile_buf");
+      }
       if (failed(verifyTileBufCommon(*this, fpTy, "fp",
-                                     /*allowLowPrecision=*/isA5)))
+                                     /*allowLowPrecision=*/isA5))) {
         return failure();
+      }
       auto fpSpace = getSpace(fpTy);
       if (!fpSpace || *fpSpace != pto::AddressSpace::SCALING)
         return emitOpError("expects fp to be loc=scaling");
@@ -8006,9 +8015,15 @@ mlir::LogicalResult mlir::pto::TMovOp::verify() {
 
 // 辅助函数：获取 Rank，支持 ShapedType 和 PTO TileTypes
 static int64_t getRankHelper(Type t) {
-  if (auto s = dyn_cast<RankedTensorType>(t)) return s.getRank();
-  if (auto tile = dyn_cast<pto::TileBufType>(t)) return tile.getRank();
-  if (auto view = dyn_cast<pto::PartitionTensorViewType>(t)) return view.getRank();
+  if (auto s = dyn_cast<RankedTensorType>(t)) {
+    return s.getRank();
+  }
+  if (auto tile = dyn_cast<pto::TileBufType>(t)) {
+    return tile.getRank();
+  }
+  if (auto view = dyn_cast<pto::PartitionTensorViewType>(t)) {
+    return view.getRank();
+  }
   return -1;
 }
 
@@ -9136,7 +9151,6 @@ void mlir::pto::MScatterOp::print(OpAsmPrinter &p) {
 }
 
 LogicalResult MScatterOp::verify() {
-
   Type srcTy = getSrc().getType();
   Type idxTy = getIdx().getType();
   Type memTy = getMem().getType();
@@ -9363,7 +9377,6 @@ void mlir::pto::MGatherOp::print(OpAsmPrinter &p) {
 }
 
 LogicalResult MGatherOp::verify() {
-
   Type memTy = getMem().getType();
   Type idxTy = getIdx().getType();
   Type dstTy = getDst().getType();
@@ -10601,7 +10614,6 @@ mlir::LogicalResult mlir::pto::TQuantMxOp::verify() {
   };
 
   auto verifyA5 = [&]() -> LogicalResult {
-
     Type srcTy = getSrc().getType();
     Type dstTy = getDst().getType();
     Type expTy = getExp().getType();
@@ -10808,7 +10820,6 @@ mlir::LogicalResult mlir::pto::TReluOp::verify() {
 
 
 mlir::LogicalResult mlir::pto::TRemOp::verify() {
-
   Type src0Ty = getSrc0().getType();
   Type src1Ty = getSrc1().getType();
   Type dstTy = getDst().getType();
@@ -10963,7 +10974,6 @@ mlir::LogicalResult mlir::pto::TRemSOp::verify() {
 }
 
 mlir::LogicalResult mlir::pto::TFModSOp::verify() {
-
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   Type scalarTy = getScalar().getType();
@@ -11002,7 +11012,6 @@ static LogicalResult verifyTPowTmpShape(Operation *op, Type tmpTy, Type dstTy) {
 }
 
 mlir::LogicalResult mlir::pto::TPowOp::verify() {
-
   Type baseTy = getBase().getType();
   Type expTy = getExp().getType();
   Type dstTy = getDst().getType();
@@ -11069,7 +11078,6 @@ mlir::LogicalResult mlir::pto::TPowOp::verify() {
 }
 
 mlir::LogicalResult mlir::pto::TPowSOp::verify() {
-
   Type srcTy = getSrc().getType();
   Type dstTy = getDst().getType();
   Type scalarTy = getScalar().getType();
@@ -12641,7 +12649,9 @@ mlir::LogicalResult mlir::pto::TScatterOp::verify() {
   }
 
   auto isAllowedDataElem = [&](mlir::Type t) -> bool {
-    if (t.isF16() || t.isF32() || t.isBF16()) return true;
+    if (t.isF16() || t.isF32() || t.isBF16()) {
+      return true;
+    }
     if (auto it = mlir::dyn_cast<mlir::IntegerType>(t))
       return (it.getWidth() == 8 || it.getWidth() == 16 || it.getWidth() == 32);
     return false;
@@ -13690,7 +13700,6 @@ LogicalResult mlir::pto::TGemvAccOp::verify() {
 
 namespace mlir {
 namespace pto {
-
 static LogicalResult parseShapeAndElem(AsmParser &parser,
                                        SmallVectorImpl<int64_t> &shape,
                                        Type &elementType,
@@ -13890,7 +13899,9 @@ static void decomposeStridedLayout(AffineMap map, SmallVectorImpl<int64_t> &stri
   // 1. 初始化
   strides.assign(map.getNumDims(), 0);
   
-  if (map.getNumResults() != 1) return;
+  if (map.getNumResults() != 1) {
+    return;
+  }
   
   // 2. 摊平表达式
   SmallVector<AffineExpr, 4> terms;
@@ -13975,46 +13986,64 @@ static AffineMap buildStrictBitwiseAffineMap(MLIRContext *ctx,
 
 // Helper for parsing [64, 1]
 static ParseResult parseStrideList(AsmParser &parser, SmallVectorImpl<int64_t> &strides) {
-  if (parser.parseLSquare()) return failure();
+  if (parser.parseLSquare()) {
+    return failure();
+  }
   do {
     int64_t stride;
-    if (parser.parseInteger(stride)) return failure();
+    if (parser.parseInteger(stride)) {
+      return failure();
+    }
     strides.push_back(stride);
   } while (succeeded(parser.parseOptionalComma()));
-  if (parser.parseRSquare()) return failure();
+  if (parser.parseRSquare()) {
+    return failure();
+  }
   return success();
 }
 
 // The custom attribute parser for: strided<[64, 1], offset: [?, ?]>
 [[maybe_unused]] static ParseResult parseStridedLayout(AsmParser &parser, Attribute &layout) {
-  if (parser.parseLess()) return failure();
+  if (parser.parseLess()) {
+    return failure();
+  }
   
   // 1. Parse Strides
   SmallVector<int64_t> strides;
-  if (parseStrideList(parser, strides)) return failure();
+  if (parseStrideList(parser, strides)) {
+    return failure();
+  }
   
   bool isMultiDim = false;
   unsigned numSymbols = 0;
 
   // 2. Parse Offset
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseKeyword("offset") || parser.parseColon()) return failure();
+    if (parser.parseKeyword("offset") || parser.parseColon()) {
+      return failure();
+    }
     
     // Check for multi-dim syntax: [?, ?]
     if (succeeded(parser.parseOptionalLSquare())) {
       isMultiDim = true;
       do {
-        if (parser.parseQuestion()) return failure();
+        if (parser.parseQuestion()) {
+          return failure();
+        }
         numSymbols++;
       } while (succeeded(parser.parseOptionalComma()));
-      if (parser.parseRSquare()) return failure();
+      if (parser.parseRSquare()) {
+        return failure();
+      }
     } else {
       // Fallback for old scalar syntax '?'
       if (parser.parseOptionalQuestion()) { /* handle single scalar */ }
     }
   }
   
-  if (parser.parseGreater()) return failure();
+  if (parser.parseGreater()) {
+    return failure();
+  }
 
   // 3. Validation
   if (isMultiDim && numSymbols != strides.size()) {
@@ -14036,12 +14065,16 @@ static ParseResult parseStrideList(AsmParser &parser, SmallVectorImpl<int64_t> &
 // =============================================================================
 
 [[maybe_unused]] static void printLayout(AsmPrinter &printer, Attribute layoutAttr) {
-  if (!layoutAttr) return;
+  if (!layoutAttr) {
+    return;
+  }
   auto mapAttr = llvm::dyn_cast<AffineMapAttr>(layoutAttr);
   if (!mapAttr) { printer << ", " << layoutAttr; return; }
 
   AffineMap map = mapAttr.getValue();
-  if (map.isIdentity()) return; 
+  if (map.isIdentity()) {
+    return;
+  }
 
   // 1. [核心修改] 反解 Strides
   SmallVector<int64_t> strides;
@@ -14058,7 +14091,9 @@ static ParseResult parseStrideList(AsmParser &parser, SmallVectorImpl<int64_t> &
     printer << ", offset: [";
     for (unsigned i = 0; i < numSyms; ++i) {
       printer << "?";
-      if (i < numSyms - 1) printer << ", ";
+      if (i < numSyms - 1) {
+        printer << ", ";
+      }
     }
     printer << "]";
   }
@@ -14199,22 +14234,29 @@ LogicalResult SubViewOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
-
   // 1. 获取 Source Type
-  if (operands.empty()) return failure();
+  if (operands.empty()) {
+    return failure();
+  }
   auto sourceType = llvm::dyn_cast<TileBufType>(operands[0].getType());
-  if (!sourceType) return failure();
+  if (!sourceType) {
+    return failure();
+  }
 
   // 2. 获取 subview 逻辑窗口（sizes）
   ArrayAttr sizeAttr;
   if (properties) {
     const auto *prop = properties.as<SubViewOp::Properties *>();
-    if (prop) sizeAttr = prop->sizes;
+    if (prop) {
+      sizeAttr = prop->sizes;
+    }
   }
   if (!sizeAttr && attributes) {
     sizeAttr = attributes.getAs<ArrayAttr>("sizes");
   }
-  if (!sizeAttr) return failure();
+  if (!sizeAttr) {
+    return failure();
+  }
 
   SmallVector<int64_t> subviewShape;
   for (auto attr : sizeAttr) {
@@ -14279,7 +14321,9 @@ LogicalResult SubViewOp::inferReturnTypes(
 
   // 3. 继承 Config (若为空使用默认)
   auto cfg = sourceType.getConfigAttr();
-  if (!cfg) cfg = TileBufConfigAttr::getDefault(context);
+  if (!cfg) {
+    cfg = TileBufConfigAttr::getDefault(context);
+  }
 
   // 4. 构建 Result Type
   auto canonicalValidShape = canonicalizeTileBufValidShape(validShape);
@@ -14325,22 +14369,22 @@ static LogicalResult computeInnerShape(TileBufConfigAttr cfg, Type elemTy,
                                        bool &boxed, int32_t &bl, int32_t &sl) {
   auto readBLayoutI32 = [](Attribute attr, int32_t &out) -> bool {
     if (auto a = dyn_cast<BLayoutAttr>(attr)) {
-      out = (int32_t)a.getValue();
+      out = static_cast<int32_t>(a.getValue());
       return true;
     }
     if (auto a = dyn_cast<IntegerAttr>(attr)) {
-      out = (int32_t)a.getInt();
+      out = static_cast<int32_t>(a.getInt());
       return true;
     }
     return false;
   };
   auto readSLayoutI32 = [](Attribute attr, int32_t &out) -> bool {
     if (auto a = dyn_cast<SLayoutAttr>(attr)) {
-      out = (int32_t)a.getValue();
+      out = static_cast<int32_t>(a.getValue());
       return true;
     }
     if (auto a = dyn_cast<IntegerAttr>(attr)) {
-      out = (int32_t)a.getInt();
+      out = static_cast<int32_t>(a.getInt());
       return true;
     }
     return false;
@@ -14350,7 +14394,9 @@ static LogicalResult computeInnerShape(TileBufConfigAttr cfg, Type elemTy,
   int32_t fr = 512;
   (void)readBLayoutI32(cfg.getBLayout(), bl);
   (void)readSLayoutI32(cfg.getSLayout(), sl);
-  if (auto attr = dyn_cast<IntegerAttr>(cfg.getSFractalSize())) fr = (int32_t)attr.getInt();
+  if (auto attr = dyn_cast<IntegerAttr>(cfg.getSFractalSize())) {
+    fr = static_cast<int32_t>(attr.getInt());
+  }
 
   boxed = (sl != 0);
   if (!boxed) {
@@ -14360,7 +14406,9 @@ static LogicalResult computeInnerShape(TileBufConfigAttr cfg, Type elemTy,
   }
 
   int64_t elemBytes = static_cast<int64_t>(getElemByteSize(elemTy));
-  if (elemBytes <= 0) return failure();
+  if (elemBytes <= 0) {
+    return failure();
+  }
 
   if (fr == 1024) {
     innerRows = 16;
@@ -14449,9 +14497,13 @@ mlir::LogicalResult mlir::pto::SubViewOp::verify() {
   if (dstTy.getMemorySpace() != srcTy.getMemorySpace())
     return emitOpError("expects result address space to match source");
   auto srcCfg = srcTy.getConfigAttr();
-  if (!srcCfg) srcCfg = TileBufConfigAttr::getDefault(getContext());
+  if (!srcCfg) {
+    srcCfg = TileBufConfigAttr::getDefault(getContext());
+  }
   auto dstCfg = dstTy.getConfigAttr();
-  if (!dstCfg) dstCfg = TileBufConfigAttr::getDefault(getContext());
+  if (!dstCfg) {
+    dstCfg = TileBufConfigAttr::getDefault(getContext());
+  }
   if (dstCfg != srcCfg)
     return emitOpError("expects result tile config to match source");
 
@@ -14487,7 +14539,9 @@ mlir::LogicalResult mlir::pto::SubViewOp::verify() {
     return emitOpError("expects result valid_shape[1] to match inferred/explicit valid_col");
 
   auto cfg = srcTy.getConfigAttr();
-  if (!cfg) cfg = TileBufConfigAttr::getDefault(getContext());
+  if (!cfg) {
+    cfg = TileBufConfigAttr::getDefault(getContext());
+  }
 
   int64_t innerRows = 1, innerCols = 1;
   bool boxed = false;
@@ -18183,35 +18237,42 @@ static func::FuncOp getParentFunc(Operation *op) {
 static constexpr int64_t kSimtKeepResumeSlotLimit = 123;
 
 static Operation *getFirstNonConstantLikeOp(Block *block) {
-  if (!block)
+  if (!block) {
     return nullptr;
+  }
   for (Operation &op : *block) {
-    if (!op.hasTrait<OpTrait::ConstantLike>())
+    if (!op.hasTrait<OpTrait::ConstantLike>()) {
       return &op;
+    }
   }
   return nullptr;
 }
 
 static bool isOpInRange(Operation *op, Operation *first, Operation *last) {
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
-    if (cur == op)
+    if (cur == op) {
       return true;
-    if (cur == last)
+    }
+    if (cur == last) {
       return false;
+    }
   }
   return false;
 }
 
 static std::optional<unsigned> getSimtKeepResumeRegisterCount(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.getWidth() <= 32)
+    if (intType.getWidth() <= 32) {
       return 1;
-    if (intType.getWidth() == 64)
+    }
+    if (intType.getWidth() == 64) {
       return 2;
+    }
     return std::nullopt;
   }
-  if (type.isF16() || type.isBF16() || type.isF32())
+  if (type.isF16() || type.isBF16() || type.isF32()) {
     return 1;
+  }
   return std::nullopt;
 }
 
@@ -18232,22 +18293,26 @@ template <typename OpT>
 static LogicalResult verifySimtKeepResumeSlotRange(OpT op) {
   std::optional<unsigned> registerCount =
       getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
-  if (!registerCount)
+  if (!registerCount) {
     return success();
+  }
   int64_t slot = op.getSlot();
-  if (slot < 0 || slot >= kSimtKeepResumeSlotLimit)
+  if (slot < 0 || slot >= kSimtKeepResumeSlotLimit) {
     return op.emitOpError()
            << "requires slot in range [0, "
            << (kSimtKeepResumeSlotLimit - 1) << "]";
+  }
   if (*registerCount == 2) {
-    if ((slot % 2) != 0)
+    if ((slot % 2) != 0) {
       return op.emitOpError()
              << "requires an even slot for 64-bit keep/resume values";
-    if (slot + 1 >= kSimtKeepResumeSlotLimit)
+    }
+    if (slot + 1 >= kSimtKeepResumeSlotLimit) {
       return op.emitOpError()
              << "requires slot in range [0, "
              << (kSimtKeepResumeSlotLimit - 2)
              << "] for 64-bit keep/resume values";
+    }
   }
   return success();
 }
@@ -18257,15 +18322,18 @@ static bool overlapsEarlierSimtKeepResumeSlotUse(OpT op,
                                                  SmallVectorImpl<int64_t> &used) {
   std::optional<unsigned> registerCount =
       getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
-  if (!registerCount)
+  if (!registerCount) {
     return false;
+  }
   int64_t slot = op.getSlot();
   for (int64_t word = slot; word < slot + *registerCount; ++word) {
-    if (llvm::is_contained(used, word))
+    if (llvm::is_contained(used, word)) {
       return true;
+    }
   }
-  for (int64_t word = slot; word < slot + *registerCount; ++word)
+  for (int64_t word = slot; word < slot + *registerCount; ++word) {
     used.push_back(word);
+  }
   return false;
 }
 
@@ -18274,13 +18342,15 @@ static LogicalResult verifyUniqueResumeGroupSlots(ResumeOp current,
   SmallVector<int64_t, 4> slots;
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
     auto resume = dyn_cast<ResumeOp>(cur);
-    if (!resume)
+    if (!resume) {
       break;
+    }
     if (overlapsEarlierSimtKeepResumeSlotUse(resume, slots) &&
-        resume.getOperation() == current.getOperation())
+        resume.getOperation() == current.getOperation()) {
       return current.emitOpError()
              << "duplicates an earlier slot " << resume.getSlot()
              << " in the SIMT resume prologue group";
+    }
   }
   return success();
 }
@@ -18291,22 +18361,26 @@ static LogicalResult verifyUniqueKeepGroupSlots(KeepOp current,
   SmallVector<int64_t, 4> slots;
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
     auto keep = dyn_cast<KeepOp>(cur);
-    if (!keep)
+    if (!keep) {
       break;
+    }
     if (overlapsEarlierSimtKeepResumeSlotUse(keep, slots) &&
-        keep.getOperation() == current.getOperation())
+        keep.getOperation() == current.getOperation()) {
       return current.emitOpError()
              << "duplicates an earlier slot " << keep.getSlot()
              << " in the SIMT keep epilogue group";
-    if (cur == last)
+    }
+    if (cur == last) {
       break;
+    }
   }
   return success();
 }
 
 static bool isSupportedSimtKeepResumeType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth() <= 64;
+  }
   return type.isF16() || type.isBF16() || type.isF32();
 }
 

--- a/lib/PTO/IR/PTOAttrs.cpp
+++ b/lib/PTO/IR/PTOAttrs.cpp
@@ -55,11 +55,21 @@ bool TileBufConfigAttr::isDefault() const {
 }
 
 static int32_t getLayoutInt(Attribute a, int32_t def) {
-  if (auto bl = mlir::dyn_cast<BLayoutAttr>(a)) return static_cast<int32_t>(bl.getValue());
-  if (auto sl = mlir::dyn_cast<SLayoutAttr>(a)) return static_cast<int32_t>(sl.getValue());
-  if (auto pv = mlir::dyn_cast<PadValueAttr>(a)) return static_cast<int32_t>(pv.getValue());
-  if (auto cm = mlir::dyn_cast<CompactModeAttr>(a)) return static_cast<int32_t>(cm.getValue());
-  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) return static_cast<int32_t>(ia.getInt());
+  if (auto bl = mlir::dyn_cast<BLayoutAttr>(a)) {
+    return static_cast<int32_t>(bl.getValue());
+  }
+  if (auto sl = mlir::dyn_cast<SLayoutAttr>(a)) {
+    return static_cast<int32_t>(sl.getValue());
+  }
+  if (auto pv = mlir::dyn_cast<PadValueAttr>(a)) {
+    return static_cast<int32_t>(pv.getValue());
+  }
+  if (auto cm = mlir::dyn_cast<CompactModeAttr>(a)) {
+    return static_cast<int32_t>(cm.getValue());
+  }
+  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) {
+    return static_cast<int32_t>(ia.getInt());
+  }
   return def;
 }
 
@@ -83,7 +93,7 @@ LogicalResult TileBufConfigAttr::verify(function_ref<InFlightDiagnostic()> emitE
   if (!sFractalSize || !sFractalSize.getType().isInteger(kI32BitWidth))
     return emitError() << "s_fractal_size must be i32", failure();
 
-  int32_t s = (int32_t)sFractalSize.getInt();
+  int32_t s = static_cast<int32_t>(sFractalSize.getInt());
   if (s != kFractalMxSize && s != kFractalABSize && s != kFractalCSize)
     return emitError() << "unsupported s_fractal_size: " << s
                        << ", must be one of {"
@@ -112,24 +122,39 @@ LogicalResult TileBufConfigAttr::verify(function_ref<InFlightDiagnostic()> emitE
 
 // Helper: parse Attribute and convert to BLayoutAttr/SLayoutAttr/PadValueAttr
 static BLayoutAttr toBLayoutAttr(MLIRContext *ctx, Attribute a) {
-  if (auto bl = mlir::dyn_cast<BLayoutAttr>(a)) return bl;
-  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) return BLayoutAttr::get(ctx, static_cast<BLayout>(ia.getInt()));
+  if (auto bl = mlir::dyn_cast<BLayoutAttr>(a)) {
+    return bl;
+  }
+  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) {
+    return BLayoutAttr::get(ctx, static_cast<BLayout>(ia.getInt()));
+  }
   return {};
 }
 static SLayoutAttr toSLayoutAttr(MLIRContext *ctx, Attribute a) {
-  if (auto sl = mlir::dyn_cast<SLayoutAttr>(a)) return sl;
-  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) return SLayoutAttr::get(ctx, static_cast<SLayout>(ia.getInt()));
+  if (auto sl = mlir::dyn_cast<SLayoutAttr>(a)) {
+    return sl;
+  }
+  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) {
+    return SLayoutAttr::get(ctx, static_cast<SLayout>(ia.getInt()));
+  }
   return {};
 }
 static PadValueAttr toPadValueAttr(MLIRContext *ctx, Attribute a) {
-  if (auto pv = mlir::dyn_cast<PadValueAttr>(a)) return pv;
-  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) return PadValueAttr::get(ctx, static_cast<PadValue>(ia.getInt()));
+  if (auto pv = mlir::dyn_cast<PadValueAttr>(a)) {
+    return pv;
+  }
+  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) {
+    return PadValueAttr::get(ctx, static_cast<PadValue>(ia.getInt()));
+  }
   return {};
 }
 static CompactModeAttr toCompactModeAttr(MLIRContext *ctx, Attribute a) {
-  if (auto cm = mlir::dyn_cast<CompactModeAttr>(a)) return cm;
-  if (auto ia = mlir::dyn_cast<IntegerAttr>(a))
+  if (auto cm = mlir::dyn_cast<CompactModeAttr>(a)) {
+    return cm;
+  }
+  if (auto ia = mlir::dyn_cast<IntegerAttr>(a)) {
     return CompactModeAttr::get(ctx, static_cast<CompactMode>(ia.getInt()));
+  }
   return {};
 }
 
@@ -142,50 +167,78 @@ Attribute TileBufConfigAttr::parse(AsmParser &p, Type) {
   PadValueAttr pv = def.getPad();
   CompactModeAttr compact = def.getCompactMode();
 
-  if (p.parseLess()) return {};
+  if (p.parseLess()) {
+    return {};
+  }
 
-  if (succeeded(p.parseOptionalGreater()))
+  if (succeeded(p.parseOptionalGreater())) {
     return TileBufConfigAttr::get(ctx, bl, sl, sz, pv, compact);
+  }
 
   bool parsedGreater = false;
   while (!parsedGreater) {
     StringRef key;
-    if (p.parseKeyword(&key)) return {};
-    if (p.parseEqual()) return {};
+    if (p.parseKeyword(&key)) {
+      return {};
+    }
+    if (p.parseEqual()) {
+      return {};
+    }
 
     if (key == "blayout") {
       Attribute a;
-      if (p.parseAttribute(a)) return {};
+      if (p.parseAttribute(a)) {
+        return {};
+      }
       bl = toBLayoutAttr(ctx, a);
-      if (!bl) return {};
+      if (!bl) {
+        return {};
+      }
     } else if (key == "slayout") {
       Attribute a;
-      if (p.parseAttribute(a)) return {};
+      if (p.parseAttribute(a)) {
+        return {};
+      }
       sl = toSLayoutAttr(ctx, a);
-      if (!sl) return {};
+      if (!sl) {
+        return {};
+      }
     } else if (key == "s_fractal_size") {
       int32_t v = 0;
-      if (p.parseInteger(v)) return {};
+      if (p.parseInteger(v)) {
+        return {};
+      }
       sz = IntegerAttr::get(IntegerType::get(ctx, kI32BitWidth), v);
     } else if (key == "pad") {
       Attribute a;
-      if (p.parseAttribute(a)) return {};
+      if (p.parseAttribute(a)) {
+        return {};
+      }
       pv = toPadValueAttr(ctx, a);
-      if (!pv) return {};
+      if (!pv) {
+        return {};
+      }
     } else if (key == "compact") {
       Attribute a;
-      if (p.parseAttribute(a)) return {};
+      if (p.parseAttribute(a)) {
+        return {};
+      }
       compact = toCompactModeAttr(ctx, a);
-      if (!compact) return {};
+      if (!compact) {
+        return {};
+      }
     } else {
       p.emitError(p.getCurrentLocation(), "unknown key in tile_buf_config: ") << key;
       return {};
     }
 
     parsedGreater = succeeded(p.parseOptionalGreater());
-    if (parsedGreater)
+    if (parsedGreater) {
       break;
-    if (p.parseComma()) return {};
+    }
+    if (p.parseComma()) {
+      return {};
+    }
   }
 
   return TileBufConfigAttr::get(ctx, bl, sl, sz, pv, compact);
@@ -195,7 +248,7 @@ void TileBufConfigAttr::print(AsmPrinter &p) const {
   p << "<";
   p << "blayout=" << getBLayout();
   p << ", slayout=" << getSLayout();
-  p << ", s_fractal_size=" << (int32_t)getSFractalSize().getInt();
+  p << ", s_fractal_size=" << static_cast<int32_t>(getSFractalSize().getInt());
   p << ", pad=" << getPad();
   p << ", compact=" << getCompactMode();
   p << ">";

--- a/lib/PTO/IR/PTOTypeDefs.cpp
+++ b/lib/PTO/IR/PTOTypeDefs.cpp
@@ -33,8 +33,9 @@ using TileBufValidShapeVector =
 
 void mlir::pto::setPTOParserTargetArch(MLIRContext *context,
                                        PTOParserTargetArch arch) {
-  if (!context)
+  if (!context) {
     return;
+  }
 
   std::lock_guard<std::mutex> lock(parserTargetArchMutex);
   if (arch == PTOParserTargetArch::Unspecified) {
@@ -45,13 +46,15 @@ void mlir::pto::setPTOParserTargetArch(MLIRContext *context,
 }
 
 PTOParserTargetArch mlir::pto::getPTOParserTargetArch(MLIRContext *context) {
-  if (!context)
+  if (!context) {
     return PTOParserTargetArch::Unspecified;
+  }
 
   std::lock_guard<std::mutex> lock(parserTargetArchMutex);
   auto it = parserTargetArchByContext.find(context);
-  if (it == parserTargetArchByContext.end())
+  if (it == parserTargetArchByContext.end()) {
     return PTOParserTargetArch::Unspecified;
+  }
   return it->second;
 }
 
@@ -69,8 +72,9 @@ static TileBufValidShapeVector
 canonicalizeTileBufValidShape(ArrayRef<int64_t> validShape) {
   TileBufValidShapeVector canonical;
   canonical.reserve(validShape.size());
-  for (int64_t dim : validShape)
+  for (int64_t dim : validShape) {
     canonical.push_back(dim < 0 ? ShapedType::kDynamic : dim);
+  }
   return canonical;
 }
 
@@ -174,8 +178,9 @@ static std::optional<AddressSpace> resolveTileBufMemorySpace(StringRef locStr) {
 static BLayout resolveTileBufBLayout(MLIRContext *context,
                                      AddressSpace memorySpace,
                                      BLayout parsedLayout) {
-  if (memorySpace != AddressSpace::LEFT)
+  if (memorySpace != AddressSpace::LEFT) {
     return parsedLayout;
+  }
 
   switch (getPTOParserTargetArch(context)) {
   case PTOParserTargetArch::A3:
@@ -192,12 +197,16 @@ TileBufConfigAttr TileBufType::getConfigAttr() const {
   // 情况 A：getConfig() 已经是 TileBufConfigAttr
   if constexpr (std::is_same_v<decltype(getConfig()), TileBufConfigAttr>) {
     auto cfg = getConfig();
-    if (!cfg) cfg = TileBufConfigAttr::getDefault(getContext());
+    if (!cfg) {
+      cfg = TileBufConfigAttr::getDefault(getContext());
+    }
     return cfg;
   } else {
     // 情况 B：getConfig() 是 Attribute
     auto cfg = llvm::dyn_cast_or_null<TileBufConfigAttr>(getConfig());
-    if (!cfg) cfg = TileBufConfigAttr::getDefault(getContext());
+    if (!cfg) {
+      cfg = TileBufConfigAttr::getDefault(getContext());
+    }
     return cfg;
   }
 }
@@ -214,7 +223,7 @@ mlir::Attribute TileBufType::getCompactModeAttr() const {
 
 // ✅ numeric getters（可选）
 int32_t TileBufType::getSFractalSizeI32() const {
-  return (int32_t)getConfigAttr().getSFractalSize().getInt();
+  return static_cast<int32_t>(getConfigAttr().getSFractalSize().getInt());
 }
 
 int32_t TileBufType::getBLayoutValueI32() const {
@@ -637,8 +646,9 @@ void mlir::pto::TileBufType::print(mlir::AsmPrinter &printer) const {
   int64_t cols = shape.size() > 1 ? shape[1] : ShapedType::kDynamic;
 
   auto cfg = getConfigAttr();
-  if (!cfg)
+  if (!cfg) {
     cfg = mlir::pto::TileBufConfigAttr::getDefault(getContext());
+  }
   auto defaultCfg = TileBufConfigAttr::getDefault(getContext());
 
   llvm::StringRef locStr = stringifyLocFromMemorySpace(getMemorySpace());
@@ -701,18 +711,6 @@ void mlir::pto::TileBufType::print(mlir::AsmPrinter &printer) const {
 }
 
 // ---- MultiTileBufType custom asm ----
-//
-// Syntax:
-//
-//   Verbose form:
-//     !pto.multi_tile_buf<!pto.tile_buf<...>, count=N>
-//
-//   Compact (sugar) form:
-//     !pto.multi_tile_buf<vec, 16x16xf16, count=N>
-//
-// In the compact form the per-slot tile_buf is built from the same compact
-// syntax as `!pto.tile_buf<vec, ...>`, followed by a mandatory `count=N`.
-
 LogicalResult MultiTileBufType::verify(
     function_ref<InFlightDiagnostic()> emitError,
     mlir::pto::TileBufType slotType, uint32_t count) {

--- a/lib/PTO/IR/PTOTypeUtils.cpp
+++ b/lib/PTO/IR/PTOTypeUtils.cpp
@@ -42,8 +42,9 @@ bool mlir::pto::isPTOFloat4PackedType(Type t) {
 
 bool mlir::pto::isPTOPackedLdgStgVectorType(Type t) {
   // !pto.hif8x2 is a 2-byte packed hif8 value type (not a VectorType).
-  if (isPTOHiFloat8x2Type(t))
+  if (isPTOHiFloat8x2Type(t)) {
     return true;
+  }
   auto vecType = dyn_cast<VectorType>(t);
   if (!vecType || vecType.isScalable() || vecType.getRank() != 1)
     return false;
@@ -63,8 +64,9 @@ bool mlir::pto::isPTOPackedLdgStgVectorType(Type t) {
       validElem = lanes == 2 && (w == 8 || w == 16 || w == 32);
     }
   }
-  if (!validElem)
+  if (!validElem) {
     return false;
+  }
   unsigned totalBits =
       vecType.getDimSize(0) * getPTOStorageElemBitWidth(elemType);
   return totalBits == 16 || totalBits == 32 || totalBits == 64;
@@ -84,8 +86,9 @@ bool mlir::pto::isPTOLowPrecisionType(Type t) {
 }
 
 unsigned mlir::pto::getPTOStorageElemBitWidth(Type t) {
-  if (isPTOHiFloat8x2Type(t))
+  if (isPTOHiFloat8x2Type(t)) {
     return 16;
+  }
   if (isPTOLowPrecisionType(t))
     return kBitsPerByte;
   if (auto floatTy = dyn_cast<FloatType>(t))

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -26,14 +26,14 @@ using namespace mlir;
 using namespace mlir::pto;
 
 namespace {
-
 static std::string formatVMIVRegType(int64_t elementCount, Type elementType,
                                      Attribute layout) {
   std::string result;
   llvm::raw_string_ostream os(result);
   os << "!pto.vmi.vreg<" << elementCount << "x" << elementType;
-  if (layout)
+  if (layout) {
     os << ", " << layout;
+  }
   os << ">";
   return result;
 }
@@ -43,8 +43,9 @@ static std::string formatVMIMaskType(int64_t elementCount,
   std::string result;
   llvm::raw_string_ostream os(result);
   os << "!pto.vmi.mask<" << elementCount << "x" << granularity;
-  if (layout)
+  if (layout) {
     os << ", " << layout;
+  }
   os << ">";
   return result;
 }
@@ -77,16 +78,18 @@ static bool isVMIPredicateMaskableElementType(Type type) {
 
 static bool isVMIAnyI8I16I32Type(Type type) {
   auto integerType = dyn_cast<IntegerType>(type);
-  if (!integerType)
+  if (!integerType) {
     return false;
+  }
   return integerType.getWidth() == 8 || integerType.getWidth() == 16 ||
          integerType.getWidth() == 32;
 }
 
 static bool isVMISignedOrSignlessI8I16I32Type(Type type) {
   auto integerType = dyn_cast<IntegerType>(type);
-  if (!integerType || integerType.isUnsigned())
+  if (!integerType || integerType.isUnsigned()) {
     return false;
+  }
   return integerType.getWidth() == 8 || integerType.getWidth() == 16 ||
          integerType.getWidth() == 32;
 }
@@ -142,8 +145,9 @@ static bool isVMIIotaElementType(Type type) {
 
 static bool isCompatibleScalarForSemanticType(Type semanticType,
                                               Type scalarType) {
-  if (semanticType == scalarType)
+  if (semanticType == scalarType) {
     return true;
+  }
 
   auto semanticInt = dyn_cast<IntegerType>(semanticType);
   auto scalarInt = dyn_cast<IntegerType>(scalarType);
@@ -151,24 +155,29 @@ static bool isCompatibleScalarForSemanticType(Type semanticType,
       semanticInt.getWidth() != scalarInt.getWidth())
     return false;
 
-  if (semanticInt.isSigned())
+  if (semanticInt.isSigned()) {
     return scalarInt.isSigned() || scalarInt.isSignless();
-  if (semanticInt.isUnsigned())
+  }
+  if (semanticInt.isUnsigned()) {
     return scalarInt.isUnsigned() || scalarInt.isSignless();
+  }
   return scalarInt.isSignless();
 }
 
 static unsigned getVMIElementBitWidth(Type type) {
-  if (isa<IndexType>(type))
+  if (isa<IndexType>(type)) {
     return 64;
+  }
   return pto::getPTOStorageElemBitWidth(type);
 }
 
 static std::optional<unsigned> getVMIIntegerOrFloatBitWidth(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth();
-  if (auto floatType = dyn_cast<FloatType>(type))
+  }
+  if (auto floatType = dyn_cast<FloatType>(type)) {
     return floatType.getWidth();
+  }
   return std::nullopt;
 }
 
@@ -178,11 +187,13 @@ static int64_t divideCeilNonNegative(int64_t value, int64_t divisor) {
 
 static LogicalResult parseOptionalVMILayout(AsmParser &parser,
                                             Attribute &layout) {
-  if (failed(parser.parseOptionalComma()))
+  if (failed(parser.parseOptionalComma())) {
     return success();
+  }
 
-  if (failed(parser.parseAttribute(layout)))
+  if (failed(parser.parseAttribute(layout))) {
     return failure();
+  }
   if (!mlir::isa<VMILayoutAttr>(layout))
     return parser.emitError(parser.getCurrentLocation(),
                             "expected #pto.vmi.layout attribute");
@@ -190,32 +201,39 @@ static LogicalResult parseOptionalVMILayout(AsmParser &parser,
 }
 
 static FailureOr<int64_t> getVMIElementCount(Type type) {
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     return vregType.getElementCount();
-  if (auto maskType = dyn_cast<VMIMaskType>(type))
+  }
+  if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     return maskType.getElementCount();
+  }
   return failure();
 }
 
 static FailureOr<VMILayoutAttr> getAssignedVMILayout(Type type) {
   Attribute layout;
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     layout = vregType.getLayout();
-  else if (auto maskType = dyn_cast<VMIMaskType>(type))
+  }
+  else if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     layout = maskType.getLayout();
-  else
+  }
+  else {
     return failure();
+  }
 
   auto layoutAttr = dyn_cast_or_null<VMILayoutAttr>(layout);
-  if (!layoutAttr)
+  if (!layoutAttr) {
     return failure();
+  }
   return layoutAttr;
 }
 
 static FailureOr<int64_t> getLayoutFactor(Type type) {
   FailureOr<VMILayoutAttr> layout = getAssignedVMILayout(type);
-  if (failed(layout))
+  if (failed(layout)) {
     return failure();
+  }
   return (*layout).isDenseSplit() ? (*layout).getFactor() : 1;
 }
 
@@ -224,12 +242,15 @@ static FailureOr<int64_t> getLayoutBlockElems(Type type) {
 }
 
 static int64_t getMaskGranularityBitWidth(StringRef granularity) {
-  if (granularity == "b8")
+  if (granularity == "b8") {
     return 8;
-  if (granularity == "b16")
+  }
+  if (granularity == "b16") {
     return 16;
-  if (granularity == "b32")
+  }
+  if (granularity == "b32") {
     return 32;
+  }
   return 0;
 }
 
@@ -248,16 +269,18 @@ static StringRef getMaskGranularityForBitWidth(int64_t bits) {
 
 static FailureOr<StringRef> getVMIMaskPhysicalGranularity(VMIMaskType type) {
   int64_t bits = getMaskGranularityBitWidth(type.getGranularity());
-  if (bits == 0)
+  if (bits == 0) {
     return failure();
+  }
 
   VMILayoutAttr layout = type.getLayoutAttr();
   int64_t laneStride = layout && layout.hasLaneStride() ? layout.getLaneStride()
                                                         : 1;
   StringRef physicalGranularity =
       getMaskGranularityForBitWidth(bits * laneStride);
-  if (physicalGranularity.empty())
+  if (physicalGranularity.empty()) {
     return failure();
+  }
   return physicalGranularity;
 }
 
@@ -268,8 +291,9 @@ static FailureOr<int64_t> getPhysicalLanesPerPart(Type type) {
   if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     FailureOr<StringRef> physicalGranularity =
         getVMIMaskPhysicalGranularity(maskType);
-    if (failed(physicalGranularity))
+    if (failed(physicalGranularity)) {
       return failure();
+    }
     return getMaskLanesPerPart(*physicalGranularity);
   }
   return failure();
@@ -277,10 +301,12 @@ static FailureOr<int64_t> getPhysicalLanesPerPart(Type type) {
 
 static FailureOr<int64_t> getDenseLaneStride(Type type) {
   FailureOr<VMILayoutAttr> layout = getAssignedVMILayout(type);
-  if (failed(layout))
+  if (failed(layout)) {
     return failure();
-  if (isa<VMIMaskType>(type))
+  }
+  if (isa<VMIMaskType>(type)) {
     return 1;
+  }
   return (*layout).isDense() ? (*layout).getLaneStride() : 1;
 }
 
@@ -295,8 +321,9 @@ static bool isLayoutAssigned(VMIMaskType type) {
 static LogicalResult
 verifyAllSameVRegShapeAndLayout(Operation *op, ArrayRef<VMIVRegType> types,
                                 bool requireSameElement) {
-  if (types.empty())
+  if (types.empty()) {
     return success();
+  }
 
   VMIVRegType first = types.front();
   bool anyLayout = llvm::any_of(
@@ -321,8 +348,9 @@ verifyAllSameVRegShapeAndLayout(Operation *op, ArrayRef<VMIVRegType> types,
 
 static LogicalResult verifyAllSameVRegShapeAndLayoutPresence(
     Operation *op, ArrayRef<VMIVRegType> types, bool requireSameElement) {
-  if (types.empty())
+  if (types.empty()) {
     return success();
+  }
 
   VMIVRegType first = types.front();
   bool anyLayout = llvm::any_of(
@@ -351,8 +379,9 @@ static LogicalResult verifyElementwiseVRegOp(Operation *op, VMIVRegType lhs,
 
 static LogicalResult verifyFloatUnaryVRegOp(Operation *op, VMIVRegType source,
                                             VMIVRegType result) {
-  if (!isVMIFloatLikeType(source.getElementType()))
+  if (!isVMIFloatLikeType(source.getElementType())) {
     return op->emitOpError("requires floating-point-like VMI element type");
+  }
   return verifyAllSameVRegShapeAndLayout(op, {source, result},
                                          /*requireSameElement=*/true);
 }
@@ -360,8 +389,9 @@ static LogicalResult verifyFloatUnaryVRegOp(Operation *op, VMIVRegType source,
 static LogicalResult verifyFloatTernaryVRegOp(Operation *op, VMIVRegType lhs,
                                               VMIVRegType rhs, VMIVRegType acc,
                                               VMIVRegType result) {
-  if (!isVMIFloatLikeType(lhs.getElementType()))
+  if (!isVMIFloatLikeType(lhs.getElementType())) {
     return op->emitOpError("requires floating-point-like VMI element type");
+  }
   return verifyAllSameVRegShapeAndLayout(op, {lhs, rhs, acc, result},
                                          /*requireSameElement=*/true);
 }
@@ -369,8 +399,9 @@ static LogicalResult verifyFloatTernaryVRegOp(Operation *op, VMIVRegType lhs,
 static LogicalResult
 verifyAllSameMaskShapeLayoutAndGranularity(Operation *op,
                                            ArrayRef<VMIMaskType> types) {
-  if (types.empty())
+  if (types.empty()) {
     return success();
+  }
 
   VMIMaskType first = types.front();
   bool anyLayout = llvm::any_of(
@@ -404,12 +435,14 @@ static LogicalResult verifyMaskMatchesData(Operation *op, VMIMaskType maskType,
     if (!isLayoutAssigned(maskType) || !isLayoutAssigned(dataType))
       return op->emitOpError("requires either both mask and data to carry "
                              "layout or neither to carry layout");
-    if (maskType.getLayout() != dataType.getLayout())
+    if (maskType.getLayout() != dataType.getLayout()) {
       return op->emitOpError("requires mask layout to match data layout");
+    }
   }
 
-  if (maskType.isPred())
+  if (maskType.isPred()) {
     return success();
+  }
 
   unsigned elementBitWidth = getVMIElementBitWidth(dataType.getElementType());
   int64_t maskBitWidth = getMaskGranularityBitWidth(maskType.getGranularity());
@@ -423,33 +456,40 @@ static LogicalResult verifyMaskMatchesData(Operation *op, VMIMaskType maskType,
 
 
 static Type getMemoryElementType(Type type) {
-  if (auto ptrType = dyn_cast<PtrType>(type))
+  if (auto ptrType = dyn_cast<PtrType>(type)) {
     return ptrType.getElementType();
-  if (auto memrefType = dyn_cast<MemRefType>(type))
+  }
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
     return memrefType.getElementType();
+  }
   return {};
 }
 
 static bool isUBBackedMemoryType(Type type) {
-  if (auto ptrType = dyn_cast<PtrType>(type))
+  if (auto ptrType = dyn_cast<PtrType>(type)) {
     return ptrType.getMemorySpace().getAddressSpace() == AddressSpace::VEC;
+  }
 
   auto memrefType = dyn_cast<BaseMemRefType>(type);
-  if (!memrefType)
+  if (!memrefType) {
     return false;
+  }
 
   Attribute memorySpace = memrefType.getMemorySpace();
-  if (auto addressSpace = dyn_cast_or_null<AddressSpaceAttr>(memorySpace))
+  if (auto addressSpace = dyn_cast_or_null<AddressSpaceAttr>(memorySpace)) {
     return addressSpace.getAddressSpace() == AddressSpace::VEC;
-  if (auto integerSpace = dyn_cast_or_null<IntegerAttr>(memorySpace))
+  }
+  if (auto integerSpace = dyn_cast_or_null<IntegerAttr>(memorySpace)) {
     return integerSpace.getInt() == static_cast<int64_t>(AddressSpace::VEC);
+  }
   return false;
 }
 
 static LogicalResult verifyUBBackedMemory(Operation *op, Type memoryType,
                                           StringRef role) {
-  if (isUBBackedMemoryType(memoryType))
+  if (isUBBackedMemoryType(memoryType)) {
     return success();
+  }
   return op->emitOpError() << "requires memory " << role
                            << " to be UB-backed";
 }
@@ -458,8 +498,9 @@ static LogicalResult verifyMemoryElementMatches(Operation *op, Type memoryType,
                                                 VMIVRegType dataType,
                                                 StringRef role) {
   Type memoryElementType = getMemoryElementType(memoryType);
-  if (!memoryElementType)
+  if (!memoryElementType) {
     return success();
+  }
   if (memoryElementType != dataType.getElementType())
     return op->emitOpError() << "requires memory " << role
                              << " element type to match VMI data element type";
@@ -479,8 +520,9 @@ static LogicalResult verifyContiguousIfLayoutAssigned(Operation *op,
 
 static bool isPackedByteGroupStore(Type memoryType, VMIVRegType dataType) {
   Type memoryElementType = getMemoryElementType(memoryType);
-  if (!memoryElementType)
+  if (!memoryElementType) {
     return false;
+  }
   auto memoryIntegerType = dyn_cast<IntegerType>(memoryElementType);
   auto dataIntegerType = dyn_cast<IntegerType>(dataType.getElementType());
   return memoryIntegerType && dataIntegerType &&
@@ -489,8 +531,9 @@ static bool isPackedByteGroupStore(Type memoryType, VMIVRegType dataType) {
 
 static LogicalResult verifyNumGroups(Operation *op, VMIVRegType type,
                                      int64_t numGroups) {
-  if (numGroups <= 0)
+  if (numGroups <= 0) {
     return op->emitOpError("requires num_groups to be positive");
+  }
   if (type.getElementCount() % numGroups != 0)
     return op->emitOpError()
            << "requires num_groups to evenly divide VMI logical lane count "
@@ -517,8 +560,9 @@ static LogicalResult verifyPhysicalParts(Operation *op, Type vmiType,
           "requires data element type with known physical lane count");
     for (Type physicalType : physicalTypes) {
       auto partType = dyn_cast<VRegType>(physicalType);
-      if (!partType)
+      if (!partType) {
         return op->emitOpError("requires physical data parts to be !pto.vreg");
+      }
       if (partType.getElementCount() != *lanesPerPart ||
           partType.getElementType() != physicalElementType)
         return op->emitOpError(
@@ -528,8 +572,9 @@ static LogicalResult verifyPhysicalParts(Operation *op, Type vmiType,
   }
 
   auto maskType = dyn_cast<VMIMaskType>(vmiType);
-  if (!maskType)
+  if (!maskType) {
     return op->emitOpError("requires VMI data or mask type");
+  }
   if (maskType.isPred())
     return op->emitOpError(
         "requires layout-assigned mask with concrete granularity");
@@ -541,8 +586,9 @@ static LogicalResult verifyPhysicalParts(Operation *op, Type vmiType,
 
   for (Type physicalType : physicalTypes) {
     auto partType = dyn_cast<MaskType>(physicalType);
-    if (!partType)
+    if (!partType) {
       return op->emitOpError("requires physical mask parts to be !pto.mask");
+    }
     if (partType.getGranularity() != *physicalGranularity)
       return op->emitOpError(
           "requires physical mask part granularity to match VMI mask carrier");
@@ -575,8 +621,9 @@ mapDensePartIndexToLogicalLane(int64_t elementCount, int64_t factor,
   int64_t inBlockLane = indexInPart % blockElems;
   int64_t logicalBlock = partBlock * factor + part;
   int64_t logicalLane = logicalBlock * blockElems + inBlockLane;
-  if (logicalLane >= elementCount)
+  if (logicalLane >= elementCount) {
     return std::nullopt;
+  }
   return logicalLane;
 }
 
@@ -587,8 +634,9 @@ static int64_t getDenseLogicalLanesInPart(int64_t elementCount, int64_t factor,
     int64_t lanePart = 0;
     std::optional<int64_t> index = mapDenseLogicalLaneToPartIndex(
         elementCount, factor, blockElems, lane, lanePart);
-    if (index && lanePart == part)
+    if (index && lanePart == part) {
       maxIndex = std::max(maxIndex, *index);
+    }
   }
   return maxIndex + 1;
 }
@@ -600,15 +648,16 @@ static int64_t getDenseLogicalLanesInPart(int64_t elementCount, int64_t factor,
 // ---------------------------------------------------------------------------
 
 namespace mlir::pto {
-
 std::optional<VMIFpToSiContract>
 lookupVMIFpToSiContract(Type srcElem, Type dstElem) {
   // Must be float → signed/signless integer.
-  if (!isVMIFloatLikeType(srcElem))
+  if (!isVMIFloatLikeType(srcElem)) {
     return std::nullopt;
+  }
   auto dstInt = dyn_cast<IntegerType>(dstElem);
-  if (!dstInt || dstInt.isUnsigned())
+  if (!dstInt || dstInt.isUnsigned()) {
     return std::nullopt;
+  }
 
   bool srcF32 = srcElem.isF32();
   bool srcF16 = srcElem.isF16();
@@ -644,11 +693,13 @@ lookupVMIFpToSiContract(Type srcElem, Type dstElem) {
 std::optional<VMIFpToUiContract>
 lookupVMIFpToUIContract(Type srcElem, Type dstElem) {
   // Must be float → unsigned integer.
-  if (!isVMIFloatLikeType(srcElem))
+  if (!isVMIFloatLikeType(srcElem)) {
     return std::nullopt;
+  }
   auto dstInt = dyn_cast<IntegerType>(dstElem);
-  if (!dstInt || !dstInt.isUnsigned())
+  if (!dstInt || !dstInt.isUnsigned()) {
     return std::nullopt;
+  }
 
   bool srcF16 = srcElem.isF16();
   unsigned dstBits = dstInt.getWidth();
@@ -667,12 +718,14 @@ lookupVMIFpToUIContract(Type srcElem, Type dstElem) {
 
 std::optional<VMIFpToFpContract>
 lookupVMIFpToFpContract(Type srcElem, Type dstElem) {
-  if (!isVMIFloatLikeType(srcElem) || !isVMIFloatLikeType(dstElem))
+  if (!isVMIFloatLikeType(srcElem) || !isVMIFloatLikeType(dstElem)) {
     return std::nullopt;
+  }
   unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
   unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
-  if (srcBits != dstBits)
+  if (srcBits != dstBits) {
     return std::nullopt;
+  }
   // bf16 -> f16: same-width, rnd, sat, no part.
   if (srcElem.isBF16() && dstElem.isF16())
     return VMIFpToFpContract{/*requiresRnd=*/true, /*requiresSat=*/true,
@@ -714,8 +767,9 @@ Attribute VMILayoutAttr::parse(AsmParser &parser, Type) {
   int64_t slots = 0;
   int64_t laneStride = 1;
 
-  if (failed(parser.parseLess()) || failed(parser.parseKeyword(&kind)))
+  if (failed(parser.parseLess()) || failed(parser.parseKeyword(&kind))) {
     return {};
+  }
 
   if (kind == "contiguous") {
     factor = 1;
@@ -729,15 +783,18 @@ Attribute VMILayoutAttr::parse(AsmParser &parser, Type) {
       }
     }
   } else if (kind == "deinterleaved") {
-    if (failed(parser.parseEqual()) || failed(parser.parseInteger(factor)))
+    if (failed(parser.parseEqual()) || failed(parser.parseInteger(factor))) {
       return {};
+    }
     while (succeeded(parser.parseOptionalComma())) {
       StringRef field;
-      if (failed(parser.parseKeyword(&field)) || failed(parser.parseEqual()))
+      if (failed(parser.parseKeyword(&field)) || failed(parser.parseEqual())) {
         return {};
+      }
       if (field == "lane_stride") {
-        if (failed(parser.parseInteger(laneStride)))
+        if (failed(parser.parseInteger(laneStride))) {
           return {};
+        }
       } else {
         parser.emitError(parser.getCurrentLocation(),
                          "expected 'lane_stride = <integer>'");
@@ -745,21 +802,26 @@ Attribute VMILayoutAttr::parse(AsmParser &parser, Type) {
       }
     }
   } else if (kind == "block_deinterleaved") {
-    if (failed(parser.parseEqual()) || failed(parser.parseInteger(factor)))
+    if (failed(parser.parseEqual()) || failed(parser.parseInteger(factor))) {
       return {};
+    }
   } else if (kind == "num_groups") {
-    if (failed(parser.parseEqual()) || failed(parser.parseInteger(factor)))
+    if (failed(parser.parseEqual()) || failed(parser.parseInteger(factor))) {
       return {};
+    }
     while (succeeded(parser.parseOptionalComma())) {
       StringRef field;
-      if (failed(parser.parseKeyword(&field)) || failed(parser.parseEqual()))
+      if (failed(parser.parseKeyword(&field)) || failed(parser.parseEqual())) {
         return {};
+      }
       if (field == "slots") {
-        if (failed(parser.parseInteger(slots)))
+        if (failed(parser.parseInteger(slots))) {
           return {};
+        }
       } else if (field == "lane_stride") {
-        if (failed(parser.parseInteger(laneStride)))
+        if (failed(parser.parseInteger(laneStride))) {
           return {};
+        }
       } else {
         parser.emitError(parser.getCurrentLocation(),
                          "expected 'slots = <integer>' or "
@@ -775,8 +837,9 @@ Attribute VMILayoutAttr::parse(AsmParser &parser, Type) {
     return {};
   }
 
-  if (failed(parser.parseGreater()))
+  if (failed(parser.parseGreater())) {
     return {};
+  }
 
   return parser.getChecked<VMILayoutAttr>(loc, parser.getContext(), kind,
                                           factor, blockElems, slots,
@@ -786,20 +849,24 @@ Attribute VMILayoutAttr::parse(AsmParser &parser, Type) {
 void VMILayoutAttr::print(AsmPrinter &printer) const {
   printer << "<" << getKind();
   if (isContiguous()) {
-    if (getLaneStride() != 1)
+    if (getLaneStride() != 1) {
       printer << ", lane_stride = " << getLaneStride();
+    }
   } else if (isDeinterleaved()) {
     printer << " = " << getFactor();
-    if (getLaneStride() != 1)
+    if (getLaneStride() != 1) {
       printer << ", lane_stride = " << getLaneStride();
+    }
   } else if (isBlockDeinterleaved()) {
     printer << " = " << getFactor();
   } else if (isGroupSlots()) {
     printer << " = " << getFactor();
-    if (getSlots() != 0)
+    if (getSlots() != 0) {
       printer << ", slots = " << getSlots();
-    if (getLaneStride() != 1)
+    }
+    if (getLaneStride() != 1) {
       printer << ", lane_stride = " << getLaneStride();
+    }
   }
   printer << ">";
 }
@@ -885,8 +952,9 @@ Type VMIVRegType::parse(AsmParser &parser) {
 void VMIVRegType::print(AsmPrinter &printer) const {
   printer << "<" << getElementCount() << "x";
   printer.printType(getElementType());
-  if (getLayout())
+  if (getLayout()) {
     printer << ", " << getLayout();
+  }
   printer << ">";
 }
 
@@ -960,8 +1028,9 @@ Type VMIMaskType::parse(AsmParser &parser) {
 
 void VMIMaskType::print(AsmPrinter &printer) const {
   printer << "<" << getElementCount() << "x" << getGranularity();
-  if (getLayout())
+  if (getLayout()) {
     printer << ", " << getLayout();
+  }
   printer << ">";
 }
 
@@ -1001,8 +1070,9 @@ LogicalResult VMIMaskType::verify(function_ref<InFlightDiagnostic()> emitError,
 LogicalResult VMIConstantOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto denseAttr = dyn_cast<DenseElementsAttr>(getValue());
-  if (!denseAttr)
+  if (!denseAttr) {
     return emitOpError("requires dense elements constant attribute");
+  }
   if (denseAttr.getElementType() != resultType.getElementType())
     return emitOpError(
         "requires dense constant element type to match result element type");
@@ -1015,11 +1085,13 @@ LogicalResult VMIConstantOp::verify() {
 LogicalResult VMIBroadcastOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   Type valueType = getValue().getType();
-  if (valueType == resultType.getElementType())
+  if (valueType == resultType.getElementType()) {
     return success();
+  }
   if (auto vregType = dyn_cast<VMIVRegType>(valueType)) {
-    if (vregType.getElementCount() != 1)
+    if (vregType.getElementCount() != 1) {
       return emitOpError("requires VMI vector input to have one logical lane");
+    }
     if (vregType.getElementType() != resultType.getElementType())
       return emitOpError("requires VMI vector input element type to match "
                          "result element type");
@@ -1035,12 +1107,14 @@ LogicalResult VMIIotaOp::verify() {
   if (!isVMIIotaElementType(elementType))
     return emitOpError("requires result element type to be integer 8/16/32 "
                        "or f16/f32");
-  if (!isCompatibleScalarForSemanticType(elementType, getBase().getType()))
+  if (!isCompatibleScalarForSemanticType(elementType, getBase().getType())) {
     return emitOpError("requires base type to match result element type");
+  }
 
   if (std::optional<StringRef> order = getOrder()) {
-    if (*order != "ASC" && *order != "DESC")
+    if (*order != "ASC" && *order != "DESC") {
       return emitOpError("requires order to be ASC or DESC");
+    }
   }
   return success();
 }
@@ -1051,16 +1125,19 @@ LogicalResult VMIGroupIotaOp::verify() {
   if (!isVMIIotaElementType(elementType))
     return emitOpError("requires result element type to be integer 8/16/32 "
                        "or f16/f32");
-  if (!isCompatibleScalarForSemanticType(elementType, getBase().getType()))
+  if (!isCompatibleScalarForSemanticType(elementType, getBase().getType())) {
     return emitOpError("requires base type to match result element type");
+  }
   if (std::optional<StringRef> order = getOrder()) {
-    if (*order != "ASC" && *order != "DESC")
+    if (*order != "ASC" && *order != "DESC") {
       return emitOpError("requires order to be ASC or DESC");
+    }
   }
 
   int64_t numGroups = getGroupAttr().getInt();
-  if (numGroups <= 1)
+  if (numGroups <= 1) {
     return emitOpError("requires group greater than one");
+  }
   if (resultType.getElementCount() % numGroups != 0)
     return emitOpError("requires group to evenly divide result logical lane "
                        "count");
@@ -1085,10 +1162,12 @@ LogicalResult VMICreateGroupMaskOp::verify() {
   auto resultType = cast<VMIMaskType>(getResult().getType());
   int64_t numGroups = getNumGroupsAttr().getInt();
   int64_t groupSize = getGroupSizeAttr().getInt();
-  if (numGroups <= 0)
+  if (numGroups <= 0) {
     return emitOpError("requires positive num_groups");
-  if (groupSize <= 0)
+  }
+  if (groupSize <= 0) {
     return emitOpError("requires positive group_size");
+  }
   if (resultType.getElementCount() != numGroups * groupSize)
     return emitOpError("requires result lane count to equal num_groups * "
                        "group_size");
@@ -1098,10 +1177,12 @@ LogicalResult VMICreateGroupMaskOp::verify() {
 LogicalResult VMIConstantMaskOp::verify() {
   auto resultType = cast<VMIMaskType>(getResult().getType());
   auto denseAttr = dyn_cast<DenseElementsAttr>(getValue());
-  if (!denseAttr)
+  if (!denseAttr) {
     return emitOpError("requires dense elements mask constant attribute");
-  if (!denseAttr.getElementType().isInteger(1))
+  }
+  if (!denseAttr.getElementType().isInteger(1)) {
     return emitOpError("requires dense mask constant element type to be i1");
+  }
   if (denseAttr.getNumElements() != resultType.getElementCount())
     return emitOpError("requires dense mask constant element count to match "
                        "result logical lane count");
@@ -1143,10 +1224,12 @@ LogicalResult VMIAddFOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (!isVMIF16BF16OrF32Type(lhsType.getElementType()))
+  }
+  if (!isVMIF16BF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1154,10 +1237,12 @@ LogicalResult VMIAddIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1165,10 +1250,12 @@ LogicalResult VMISubFOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (!isVMIF16BF16OrF32Type(lhsType.getElementType()))
+  }
+  if (!isVMIF16BF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1176,10 +1263,12 @@ LogicalResult VMISubIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1187,10 +1276,12 @@ LogicalResult VMIMulFOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (!isVMIF16BF16OrF32Type(lhsType.getElementType()))
+  }
+  if (!isVMIF16BF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1198,10 +1289,12 @@ LogicalResult VMIMulIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1210,8 +1303,9 @@ LogicalResult VMIFmaOp::verify() {
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto accType = cast<VMIVRegType>(getAcc().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIF16BF16OrF32Type(lhsType.getElementType()))
+  if (!isVMIF16BF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
+  }
   return verifyFloatTernaryVRegOp(getOperation(), lhsType, rhsType, accType,
                                   resultType);
 }
@@ -1224,10 +1318,12 @@ LogicalResult VMIDivFOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (!isVMIF16OrF32Type(lhsType.getElementType()))
+  }
+  if (!isVMIF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16 or f32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1235,10 +1331,12 @@ LogicalResult VMIMinFOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (!isVMIF16BF16OrF32Type(lhsType.getElementType()))
+  }
+  if (!isVMIF16BF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1246,10 +1344,12 @@ LogicalResult VMIMaxFOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (!isVMIF16BF16OrF32Type(lhsType.getElementType()))
+  }
+  if (!isVMIF16BF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1276,24 +1376,27 @@ LogicalResult VMIMaxIOp::verify() {
 LogicalResult VMINegFOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return emitOpError("requires f16 or f32 VMI element type");
+  }
   return verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType);
 }
 
 LogicalResult VMIAbsFOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return emitOpError("requires f16 or f32 VMI element type");
+  }
   return verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType);
 }
 
 LogicalResult VMIAbsIOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(sourceType.getElementType()))
+  if (!isVMIIntegerLikeType(sourceType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
+  }
   if (!isVMISignedOrSignlessI8I16I32Type(sourceType.getElementType()))
     return emitOpError("requires signless or signed i8, i16, or i32 VMI "
                        "element type");
@@ -1305,32 +1408,36 @@ LogicalResult VMIAbsIOp::verify() {
 LogicalResult VMISqrtOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return emitOpError("requires f16 or f32 VMI element type");
+  }
   return verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType);
 }
 
 LogicalResult VMIExpOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return emitOpError("requires f16 or f32 VMI element type");
+  }
   return verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType);
 }
 
 LogicalResult VMILnOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return emitOpError("requires f16 or f32 VMI element type");
+  }
   return verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType);
 }
 
 LogicalResult VMIReluOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return emitOpError("requires f16 or f32 VMI element type");
+  }
   return verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType);
 }
 
@@ -1338,10 +1445,12 @@ LogicalResult VMIAndIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1349,10 +1458,12 @@ LogicalResult VMIOrIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1360,10 +1471,12 @@ LogicalResult VMIXOrIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1371,10 +1484,12 @@ LogicalResult VMIShLIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1386,8 +1501,9 @@ LogicalResult VMIShRUIOp::verify() {
   if (!integerType || integerType.isSigned())
     return emitOpError(
         "requires signless or unsigned integer VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType);
 }
 
@@ -1404,10 +1520,12 @@ LogicalResult VMIShRSIOp::verify() {
 LogicalResult VMINotOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(sourceType.getElementType()))
+  if (!isVMIIntegerLikeType(sourceType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(sourceType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(sourceType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   return verifyAllSameVRegShapeAndLayout(getOperation(),
                                          {sourceType, resultType},
                                          /*requireSameElement=*/true);
@@ -1419,10 +1537,12 @@ LogicalResult VMICmpFOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIMaskType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (!isVMIF16BF16OrF32Type(lhsType.getElementType()))
+  }
+  if (!isVMIF16BF16OrF32Type(lhsType.getElementType())) {
     return emitOpError("requires f16, bf16, or f32 VMI element type");
+  }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(), {lhsType, rhsType},
                                              /*requireSameElement=*/true)))
     return failure();
@@ -1433,10 +1553,12 @@ LogicalResult VMICmpIOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIMaskType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (!isVMIAnyI8I16I32Type(lhsType.getElementType()))
+  }
+  if (!isVMIAnyI8I16I32Type(lhsType.getElementType())) {
     return emitOpError("requires i8, i16, or i32 VMI element type");
+  }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(), {lhsType, rhsType},
                                              /*requireSameElement=*/true)))
     return failure();
@@ -1459,11 +1581,13 @@ LogicalResult VMIActivePrefixIndexOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto resultIntType = dyn_cast<IntegerType>(resultType.getElementType());
-  if (!resultIntType || !resultIntType.isSignless())
+  if (!resultIntType || !resultIntType.isSignless()) {
     return emitOpError("requires signless integer result element type");
+  }
   unsigned resultWidth = resultIntType.getWidth();
-  if (resultWidth != 8 && resultWidth != 16 && resultWidth != 32)
+  if (resultWidth != 8 && resultWidth != 16 && resultWidth != 32) {
     return emitOpError("requires i8, i16, or i32 result element type");
+  }
   return verifyMaskMatchesData(getOperation(), maskType, resultType);
 }
 
@@ -1501,15 +1625,19 @@ LogicalResult VMIReduceAddIOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(sourceType.getElementType()))
+  if (!isVMIIntegerLikeType(sourceType.getElementType())) {
     return emitOpError("requires integer-like VMI source element type");
+  }
   auto sourceIntegerType = dyn_cast<IntegerType>(sourceType.getElementType());
-  if (!sourceIntegerType || sourceIntegerType.getWidth() != 32)
+  if (!sourceIntegerType || sourceIntegerType.getWidth() != 32) {
     return emitOpError("requires 32-bit integer source element type");
-  if (sourceType.getElementType() != resultType.getElementType())
+  }
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("requires source and result element types to match");
-  if (resultType.getElementCount() != 1)
+  }
+  if (resultType.getElementCount() != 1) {
     return emitOpError("requires result to be a 1-lane VMI vector");
+  }
   return verifyMaskMatchesData(getOperation(), maskType, sourceType);
 }
 
@@ -1521,14 +1649,18 @@ LogicalResult VMIReduceAddFOp::verify() {
     return emitOpError(
         "requires reassoc attr because VPTO vcadd performs pair-wise "
         "floating-point reduction");
-  if (!isVMIFloatLikeType(sourceType.getElementType()))
+  if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return emitOpError("requires floating-point-like VMI source element type");
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  }
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return emitOpError("requires f16 or f32 source element type");
-  if (sourceType.getElementType() != resultType.getElementType())
+  }
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("requires source and result element types to match");
-  if (resultType.getElementCount() != 1)
+  }
+  if (resultType.getElementCount() != 1) {
     return emitOpError("requires result to be a 1-lane VMI vector");
+  }
   return verifyMaskMatchesData(getOperation(), maskType, sourceType);
 }
 
@@ -1539,12 +1671,15 @@ template <typename OpTy> LogicalResult verifyReduceMinMaxFOp(OpTy op) {
   if (!isVMIFloatLikeType(sourceType.getElementType()))
     return op.emitOpError(
         "requires floating-point-like VMI source element type");
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return op.emitOpError("requires f16 or f32 source element type");
-  if (sourceType.getElementType() != resultType.getElementType())
+  }
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return op.emitOpError("requires source and result element types to match");
-  if (resultType.getElementCount() != 1)
+  }
+  if (resultType.getElementCount() != 1) {
     return op.emitOpError("requires result to be a 1-lane VMI vector");
+  }
   return verifyMaskMatchesData(op.getOperation(), maskType, sourceType);
 }
 
@@ -1561,10 +1696,12 @@ template <typename OpTy> LogicalResult verifyReduceMinMaxIOp(OpTy op) {
       !isVMIAnyI8I16I32Type(sourceType.getElementType()))
     return op.emitOpError(
         "requires 8-bit, 16-bit, or 32-bit integer source element type");
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return op.emitOpError("requires source and result element types to match");
-  if (resultType.getElementCount() != 1)
+  }
+  if (resultType.getElementCount() != 1) {
     return op.emitOpError("requires result to be a 1-lane VMI vector");
+  }
   return verifyMaskMatchesData(op.getOperation(), maskType, sourceType);
 }
 
@@ -1584,13 +1721,15 @@ static LogicalResult verifyGroupReduceFloatOp(OpTy op, bool requiresReassoc) {
   if (!isVMIFloatLikeType(sourceType.getElementType()))
     return op.emitOpError(
         "requires floating-point-like VMI source element type");
-  if (!isVMIF16OrF32Type(sourceType.getElementType()))
+  if (!isVMIF16OrF32Type(sourceType.getElementType())) {
     return op.emitOpError("requires f16 or f32 source element type");
+  }
   if (resultType.getElementCount() != op.getNumGroupsAttr().getInt())
     return op.emitOpError(
         "requires result logical lane count to match num_groups");
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return op.emitOpError("requires source and result element types to match");
+  }
   if (auto sourceLayout = sourceType.getLayoutAttr()) {
     bool supportedSourceLayout =
         sourceLayout.isContiguous() ||
@@ -1608,8 +1747,9 @@ static LogicalResult verifyGroupReduceFloatOp(OpTy op, bool requiresReassoc) {
                                  "#pto.vmi.layout<num_groups = "
                               << op.getNumGroupsAttr().getInt() << ">";
   }
-  if (failed(verifyMaskMatchesData(op.getOperation(), maskType, sourceType)))
+  if (failed(verifyMaskMatchesData(op.getOperation(), maskType, sourceType))) {
     return failure();
+  }
   return verifyNumGroups(op.getOperation(), sourceType,
                          op.getNumGroupsAttr().getInt());
 }
@@ -1631,8 +1771,9 @@ static LogicalResult verifyGroupReduceIntegerOp(OpTy op) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  if (!isVMIIntegerLikeType(sourceType.getElementType()))
+  if (!isVMIIntegerLikeType(sourceType.getElementType())) {
     return op.emitOpError("requires integer-like VMI source element type");
+  }
   auto intType = dyn_cast<IntegerType>(sourceType.getElementType());
   if (!intType || !isVMIAnyI8I16I32Type(sourceType.getElementType()))
     return op.emitOpError(
@@ -1640,8 +1781,9 @@ static LogicalResult verifyGroupReduceIntegerOp(OpTy op) {
   if (resultType.getElementCount() != op.getNumGroupsAttr().getInt())
     return op.emitOpError(
         "requires result logical lane count to match num_groups");
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return op.emitOpError("requires source and result element types to match");
+  }
   if (auto sourceLayout = sourceType.getLayoutAttr()) {
     bool supportedSourceLayout =
         sourceLayout.isContiguous() ||
@@ -1659,8 +1801,9 @@ static LogicalResult verifyGroupReduceIntegerOp(OpTy op) {
                                  "#pto.vmi.layout<num_groups = "
                               << op.getNumGroupsAttr().getInt() << ">";
   }
-  if (failed(verifyMaskMatchesData(op.getOperation(), maskType, sourceType)))
+  if (failed(verifyMaskMatchesData(op.getOperation(), maskType, sourceType))) {
     return failure();
+  }
   return verifyNumGroups(op.getOperation(), sourceType,
                          op.getNumGroupsAttr().getInt());
 }
@@ -1691,8 +1834,9 @@ LogicalResult VMIGroupBroadcastOp::verify() {
   if (resultType.getElementCount() % numGroups != 0)
     return emitOpError(
         "requires num_groups to evenly divide result logical lane count");
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("requires source and result element types to match");
+  }
   if (auto sourceLayout = sourceType.getLayoutAttr()) {
     if (!sourceLayout.isGroupSlots() ||
         sourceLayout.getNumGroups() != numGroups)
@@ -1726,8 +1870,9 @@ template <typename OpTy> static LogicalResult verifyVMIHistogramOp(OpTy op) {
   if (resultType.getElementCount() != bins)
     return op.emitOpError("requires result element count to match acc "
                           "(bins must be identical)");
-  if (resultType.getLayoutAttr() != accType.getLayoutAttr())
+  if (resultType.getLayoutAttr() != accType.getLayoutAttr()) {
     return op.emitOpError("requires result layout attribute to match acc");
+  }
   auto resultElemType = dyn_cast<IntegerType>(resultType.getElementType());
   if (!resultElemType || resultElemType.getWidth() != 16 ||
       !matchesVMIIntSemantics(resultElemType, VMIIntSignSemantics::Unsigned))
@@ -1737,8 +1882,9 @@ template <typename OpTy> static LogicalResult verifyVMIHistogramOp(OpTy op) {
       !matchesVMIIntSemantics(sourceElemType, VMIIntSignSemantics::Unsigned))
     return op.emitOpError("requires source type to be "
                           "!pto.vmi.vreg<Nx{ui8|i8}> (interpreted as unsigned)");
-  if (maskType.getElementCount() != sourceType.getElementCount())
+  if (maskType.getElementCount() != sourceType.getElementCount()) {
     return op.emitOpError("requires mask logical lane count to match source");
+  }
 
   if (auto accLayout = accType.getLayoutAttr()) {
     if (!accLayout.isContiguous())
@@ -1759,8 +1905,9 @@ template <typename OpTy> static LogicalResult verifyVMIHistogramOp(OpTy op) {
     if (!maskLayout.isContiguous())
       return op.emitOpError("requires layout-assigned mask to use contiguous "
                             "layout");
-    if (maskType.getGranularity() != "b8")
+    if (maskType.getGranularity() != "b8") {
       return op.emitOpError("requires layout-assigned mask granularity b8");
+    }
   }
   return success();
 }
@@ -1821,11 +1968,13 @@ LogicalResult VMITruncFOp::verify() {
       return emitOpError("rounding attr must be R, A, H, or Z");
   }
   auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
-  if (!satAttr)
+  if (!satAttr) {
     return emitOpError("'saturate' attribute is required (SAT or NOSAT)");
+  }
   StringRef satVal = satAttr.getValue();
-  if (satVal != "SAT" && satVal != "NOSAT")
+  if (satVal != "SAT" && satVal != "NOSAT") {
     return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
+  }
   return success();
 }
 
@@ -1835,24 +1984,27 @@ LogicalResult VMIFPToSIOp::verify() {
   if (sourceType.getElementCount() != resultType.getElementCount())
     return emitOpError(
         "requires source and result logical lane counts to match");
-  if (!isVMIFloatLikeType(sourceType.getElementType()))
+  if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return emitOpError("requires floating-point-like source element type");
+  }
   if (!isVMISignedOrSignlessIntegerType(resultType.getElementType()))
     return emitOpError("requires signed or signless integer result element "
                        "type");
   auto contract =
       lookupVMIFpToSiContract(sourceType.getElementType(),
                               resultType.getElementType());
-  if (!contract)
+  if (!contract) {
     return emitOpError("unsupported fp-to-si conversion element type pair");
+  }
   if (contract->requiresSat) {
     auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
     if (!satAttr)
       return emitOpError("'saturate' attribute is required for this fp-to-si "
                          "conversion (SAT or NOSAT)");
     StringRef satVal = satAttr.getValue();
-    if (satVal != "SAT" && satVal != "NOSAT")
+    if (satVal != "SAT" && satVal != "NOSAT") {
       return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
+    }
   } else {
     if ((*this)->getAttrOfType<StringAttr>("saturate"))
       return emitOpError("'saturate' attribute is not valid for this fp-to-si "
@@ -1867,23 +2019,27 @@ LogicalResult VMIFPToUIOp::verify() {
   if (sourceType.getElementCount() != resultType.getElementCount())
     return emitOpError(
         "requires source and result logical lane counts to match");
-  if (!isVMIFloatLikeType(sourceType.getElementType()))
+  if (!isVMIFloatLikeType(sourceType.getElementType())) {
     return emitOpError("requires floating-point-like source element type");
-  if (!isVMIUnsignedIntegerType(resultType.getElementType()))
+  }
+  if (!isVMIUnsignedIntegerType(resultType.getElementType())) {
     return emitOpError("requires unsigned integer result element type");
+  }
   auto contract =
       lookupVMIFpToUIContract(sourceType.getElementType(),
                               resultType.getElementType());
-  if (!contract)
+  if (!contract) {
     return emitOpError("unsupported fp-to-ui conversion element type pair");
+  }
   if (contract->requiresSat) {
     auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
     if (!satAttr)
       return emitOpError("'saturate' attribute is required for this fp-to-ui "
                          "conversion (SAT or NOSAT)");
     StringRef satVal = satAttr.getValue();
-    if (satVal != "SAT" && satVal != "NOSAT")
+    if (satVal != "SAT" && satVal != "NOSAT") {
       return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
+    }
   } else {
     if ((*this)->getAttrOfType<StringAttr>("saturate"))
       return emitOpError("'saturate' attribute is not valid for this fp-to-ui "
@@ -1901,12 +2057,15 @@ LogicalResult VMISIToFPOp::verify() {
   if (!isVMISignedOrSignlessIntegerType(sourceType.getElementType()))
     return emitOpError(
         "requires signed or signless integer source element type");
-  if (!isVMIFloatLikeType(resultType.getElementType()))
+  if (!isVMIFloatLikeType(resultType.getElementType())) {
     return emitOpError("requires floating-point-like result element type");
-  if (getVMIElementBitWidth(sourceType.getElementType()) != 32)
+  }
+  if (getVMIElementBitWidth(sourceType.getElementType()) != 32) {
     return emitOpError("requires 32-bit integer source element type");
-  if (!resultType.getElementType().isF32())
+  }
+  if (!resultType.getElementType().isF32()) {
     return emitOpError("requires f32 result element type");
+  }
   return success();
 }
 
@@ -1958,11 +2117,13 @@ LogicalResult VMITruncIOp::verify() {
     return emitOpError(
         "requires result element type to be narrower than source element type");
   auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
-  if (!satAttr)
+  if (!satAttr) {
     return emitOpError("'saturate' attribute is required (SAT or NOSAT)");
+  }
   StringRef satVal = satAttr.getValue();
-  if (satVal != "SAT" && satVal != "NOSAT")
+  if (satVal != "SAT" && satVal != "NOSAT") {
     return emitOpError("saturate attr must be 'SAT' or 'NOSAT'");
+  }
   return success();
 }
 
@@ -1986,8 +2147,9 @@ LogicalResult VMIBitcastOp::verify() {
       return emitOpError(
           "requires either both source and result to carry layout or neither "
           "to carry layout");
-    if (sourceType.getLayout() != resultType.getLayout())
+    if (sourceType.getLayout() != resultType.getLayout()) {
       return emitOpError("requires source and result layouts to match");
+    }
   }
 
   return success();
@@ -2083,8 +2245,9 @@ void VMIGroupSlotLoadOp::getEffects(
 LogicalResult VMIGroupBroadcastLoadOp::verify() {
   auto resultType = cast<VMIVRegType>(getResult().getType());
   int64_t numGroups = getNumGroupsAttr().getInt();
-  if (numGroups <= 0)
+  if (numGroups <= 0) {
     return emitOpError("requires num_groups to be positive");
+  }
   if (resultType.getElementCount() % numGroups != 0)
     return emitOpError(
         "requires num_groups to evenly divide result logical lane count");
@@ -2374,8 +2537,9 @@ LogicalResult VMIShuffleOp::verify() {
 
 LogicalResult VMIChannelSplitOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
-  if (getResults().size() < 2)
+  if (getResults().size() < 2) {
     return emitOpError("requires at least two channel results");
+  }
   auto firstResultType = cast<VMIVRegType>(getResults().front().getType());
   if (sourceType.getElementCount() !=
       static_cast<int64_t>(getResults().size()) *
@@ -2390,8 +2554,9 @@ LogicalResult VMIChannelSplitOp::verify() {
                          "count and source element type");
   }
   bool anyLayout = isLayoutAssigned(sourceType);
-  for (Value result : getResults())
+  for (Value result : getResults()) {
     anyLayout |= isLayoutAssigned(cast<VMIVRegType>(result.getType()));
+  }
   if (anyLayout) {
     if (!isLayoutAssigned(sourceType))
       return emitOpError("requires layout-assigned channel_split source when "
@@ -2419,8 +2584,9 @@ LogicalResult VMIChannelSplitOp::verify() {
 }
 
 LogicalResult VMIChannelMergeOp::verify() {
-  if (getInputs().size() < 2)
+  if (getInputs().size() < 2) {
     return emitOpError("requires at least two channel inputs");
+  }
   auto firstInputType = cast<VMIVRegType>(getInputs().front().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   for (Value input : getInputs()) {
@@ -2436,8 +2602,9 @@ LogicalResult VMIChannelMergeOp::verify() {
     return emitOpError(
         "requires result lane count and element type to match merged channels");
   bool anyLayout = isLayoutAssigned(resultType);
-  for (Value input : getInputs())
+  for (Value input : getInputs()) {
     anyLayout |= isLayoutAssigned(cast<VMIVRegType>(input.getType()));
+  }
   if (anyLayout) {
     if (!isLayoutAssigned(resultType))
       return emitOpError("requires layout-assigned channel_merge result when "
@@ -2471,8 +2638,9 @@ LogicalResult VMIEnsureLayoutOp::verify() {
       sourceType.getElementType() != resultType.getElementType())
     return emitOpError("requires source and result to preserve VMI data shape "
                        "and element type");
-  if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType))
+  if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
     return emitOpError("requires source and result to be layout-assigned");
+  }
   return success();
 }
 
@@ -2483,8 +2651,9 @@ LogicalResult VMIEnsureMaskLayoutOp::verify() {
       sourceType.getGranularity() != resultType.getGranularity())
     return emitOpError("requires source and result to preserve VMI mask shape "
                        "and granularity");
-  if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType))
+  if (!isLayoutAssigned(sourceType) || !isLayoutAssigned(resultType)) {
     return emitOpError("requires source and result to be layout-assigned");
+  }
   return success();
 }
 
@@ -2523,8 +2692,9 @@ enum class CvtDirection { FpWiden, FpNarrow, FpToSi, FpToUi, SiToFp, IntWiden, I
 static LogicalResult verifyVMIPmodeMask(Operation *op, VMIMaskType maskType,
                                         VMIVRegType dataType,
                                         std::optional<StringRef> pmode) {
-  if (failed(verifyMaskMatchesData(op, maskType, dataType)))
+  if (failed(verifyMaskMatchesData(op, maskType, dataType))) {
     return failure();
+  }
   if (pmode.has_value()) {
     StringRef mode = pmode.value();
     if (mode != "merge" && mode != "zero")
@@ -2545,10 +2715,12 @@ static LogicalResult verifyVMIVariadicPmodeMask(Operation *op,
       return op->emitOpError("pmode must be \"merge\" or \"zero\", got \"")
              << mode << "\"";
   }
-  if (maskParts.empty())
+  if (maskParts.empty()) {
     return success();
-  if (maskParts.size() != 1)
+  }
+  if (maskParts.size() != 1) {
     return op->emitOpError("expects at most one mask operand");
+  }
   return verifyMaskMatchesData(op, cast<VMIMaskType>(maskParts.front().getType()),
                                dataType);
 }
@@ -2577,8 +2749,9 @@ verifyVMIVectorScalarOp(Operation *op, VMIVRegType srcType,
                                              /*requireSameElement=*/true)))
     return failure();
 
-  if (failed(verifyMaskMatchesData(op, maskType, resultType)))
+  if (failed(verifyMaskMatchesData(op, maskType, resultType))) {
     return failure();
+  }
 
   if (pmode.has_value()) {
     StringRef mode = pmode.value();
@@ -2600,13 +2773,15 @@ verifyVMIVectorScalarShiftOp(Operation *op, VMIVRegType srcType,
   if (!isVMIIntegerLikeType(eltTy))
     return op->emitOpError(
         "requires integer-like VMI element type for shift");
-  if (!scalarType.isSignlessInteger(16))
+  if (!scalarType.isSignlessInteger(16)) {
     return op->emitOpError("requires signless i16 shift amount");
+  }
   if (failed(verifyAllSameVRegShapeAndLayout(op, {srcType, resultType},
                                              /*requireSameElement=*/true)))
     return failure();
-  if (failed(verifyMaskMatchesData(op, maskType, resultType)))
+  if (failed(verifyMaskMatchesData(op, maskType, resultType))) {
     return failure();
+  }
   if (pmode.has_value()) {
     StringRef mode = pmode.value();
     if (mode != "merge" && mode != "zero")
@@ -2695,14 +2870,16 @@ LogicalResult VMIVbrcOp::verify() {
     // Group broadcast mode
     int64_t numGroupsVal = groupAttr.getInt();
     auto vregType = dyn_cast<VMIVRegType>(valueType);
-    if (!vregType)
+    if (!vregType) {
       return emitOpError("requires VMI vector input when num_groups is set");
+    }
     if (vregType.getElementCount() != numGroupsVal)
       return emitOpError()
              << "requires source logical lane count " << vregType.getElementCount()
              << " to match num_groups " << numGroupsVal;
-    if (vregType.getElementType() != resultType.getElementType())
+    if (vregType.getElementType() != resultType.getElementType()) {
       return emitOpError("requires source and result element types to match");
+    }
     if (auto sourceLayout = vregType.getLayoutAttr()) {
       if (!sourceLayout.isGroupSlots() ||
           sourceLayout.getNumGroups() != numGroupsVal)
@@ -2719,11 +2896,13 @@ LogicalResult VMIVbrcOp::verify() {
   }
 
   // Scalar/1-lane broadcast mode (no num_groups)
-  if (valueType == resultType.getElementType())
+  if (valueType == resultType.getElementType()) {
     return success();
+  }
   if (auto vregType = dyn_cast<VMIVRegType>(valueType)) {
-    if (vregType.getElementCount() != 1)
+    if (vregType.getElementCount() != 1) {
       return emitOpError("requires VMI vector input to have one logical lane");
+    }
     if (vregType.getElementType() != resultType.getElementType())
       return emitOpError("requires VMI vector input element type to match "
                          "result element type");
@@ -2739,17 +2918,20 @@ LogicalResult VMIVciOp::verify() {
   if (!isVMIIotaElementType(elementType))
     return emitOpError("requires result element type to be integer 8/16/32 "
                        "or f16/f32");
-  if (!isCompatibleScalarForSemanticType(elementType, getBase().getType()))
+  if (!isCompatibleScalarForSemanticType(elementType, getBase().getType())) {
     return emitOpError("requires base type to match result element type");
+  }
 
   if (std::optional<StringRef> order = getOrder()) {
-    if (*order != "ASC" && *order != "DESC")
+    if (*order != "ASC" && *order != "DESC") {
       return emitOpError("requires order to be ASC or DESC");
+    }
   }
   if (auto groupAttr = getGroupAttr()) {
     int64_t numGroups = groupAttr.getInt();
-    if (numGroups <= 0)
+    if (numGroups <= 0) {
       return emitOpError("requires group to be positive");
+    }
     if (resultType.getElementCount() % numGroups != 0)
       return emitOpError("requires group to evenly divide result logical lane "
                          "count");
@@ -2769,41 +2951,50 @@ LogicalResult VMIVciOp::verify() {
 LogicalResult VMIPsetOp::verify() {
   auto resultType = cast<VMIMaskType>(getResult().getType());
   StringRef pattern = getPattern();
-  if (pattern != "PAT_ALL")
+  if (pattern != "PAT_ALL") {
     return emitOpError("requires pattern to be \"PAT_ALL\"");
-  if (!resultType.isPred() && !isLayoutAssigned(resultType))
+  }
+  if (!resultType.isPred() && !isLayoutAssigned(resultType)) {
     return emitOpError("requires concrete mask result to carry layout");
+  }
   return success();
 }
 
 LogicalResult VMIPgeOp::verify() {
   auto resultType = cast<VMIMaskType>(getResult().getType());
   StringRef pattern = getPattern();
-  if (!pattern.starts_with("PAT_VL"))
+  if (!pattern.starts_with("PAT_VL")) {
     return emitOpError("requires pattern to start with \"PAT_VL\"");
+  }
   int64_t activeLanes;
-  if (pattern.drop_front(6).getAsInteger(10, activeLanes))
+  if (pattern.drop_front(6).getAsInteger(10, activeLanes)) {
     return emitOpError("requires pattern \"PAT_VL<n>\" with integer n");
-  if (activeLanes <= 0)
+  }
+  if (activeLanes <= 0) {
     return emitOpError("requires positive n in pattern \"PAT_VL<n>\"");
+  }
   if (activeLanes > resultType.getElementCount())
     return emitOpError("PAT_VL active lanes ") << activeLanes
         << " exceeds mask element count " << resultType.getElementCount();
-  if (!resultType.isPred() && !isLayoutAssigned(resultType))
+  if (!resultType.isPred() && !isLayoutAssigned(resultType)) {
     return emitOpError("requires concrete mask result to carry layout");
+  }
   return success();
 }
 
 LogicalResult VMIPltOp::verify() {
   auto resultType = cast<VMIMaskType>(getMask().getType());
   auto scalarType = dyn_cast<IntegerType>(getScalar().getType());
-  if (!scalarType || scalarType.getWidth() != 32)
+  if (!scalarType || scalarType.getWidth() != 32) {
     return emitOpError("requires i32 scalar input");
+  }
   auto scalarOutType = dyn_cast<IntegerType>(getScalarOut().getType());
-  if (!scalarOutType || scalarOutType.getWidth() != 32)
+  if (!scalarOutType || scalarOutType.getWidth() != 32) {
     return emitOpError("requires i32 scalar_out result");
-  if (!resultType.isPred() && !isLayoutAssigned(resultType))
+  }
+  if (!resultType.isPred() && !isLayoutAssigned(resultType)) {
     return emitOpError("requires concrete mask result to carry layout");
+  }
   return success();
 }
 
@@ -2811,8 +3002,9 @@ LogicalResult VMIVaddOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2823,8 +3015,9 @@ LogicalResult VMIVsubOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2835,8 +3028,9 @@ LogicalResult VMIVmulOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2847,10 +3041,12 @@ LogicalResult VMIVdivOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIFloatLikeType(lhsType.getElementType()))
+  if (!isVMIFloatLikeType(lhsType.getElementType())) {
     return emitOpError("requires floating-point-like VMI element type");
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  }
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2894,8 +3090,9 @@ LogicalResult VMIVmaxOp::verify() {
 LogicalResult VMIVnegOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType)))
+  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2925,8 +3122,9 @@ LogicalResult VMIVabsOp::verify() {
 LogicalResult VMIVsqrtOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType)))
+  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2936,8 +3134,9 @@ LogicalResult VMIVsqrtOp::verify() {
 LogicalResult VMIVexpOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType)))
+  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2947,8 +3146,9 @@ LogicalResult VMIVexpOp::verify() {
 LogicalResult VMIVlnOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType)))
+  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2958,8 +3158,9 @@ LogicalResult VMIVlnOp::verify() {
 LogicalResult VMIVreluOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType)))
+  if (failed(verifyFloatUnaryVRegOp(getOperation(), sourceType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2969,10 +3170,12 @@ LogicalResult VMIVreluOp::verify() {
 LogicalResult VMIVandOp::verify() {
   if (isa<VMIMaskType>(getLhs().getType())) {
     // Mask logic path: reject predication mask and pmode.
-    if (!getMask().empty())
+    if (!getMask().empty()) {
       return emitOpError("mask logic op does not support predication mask");
-    if (auto pmode = getPmode())
+    }
+    if (auto pmode = getPmode()) {
       return emitOpError("mask logic op does not support pmode");
+    }
     auto lhsType = cast<VMIMaskType>(getLhs().getType());
     auto rhsType = cast<VMIMaskType>(getRhs().getType());
     auto resultType = cast<VMIMaskType>(getResult().getType());
@@ -2983,10 +3186,12 @@ LogicalResult VMIVandOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  }
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -2996,10 +3201,12 @@ LogicalResult VMIVandOp::verify() {
 LogicalResult VMIVorOp::verify() {
   if (isa<VMIMaskType>(getLhs().getType())) {
     // Mask logic path: reject predication mask and pmode.
-    if (!getMask().empty())
+    if (!getMask().empty()) {
       return emitOpError("mask logic op does not support predication mask");
-    if (auto pmode = getPmode())
+    }
+    if (auto pmode = getPmode()) {
       return emitOpError("mask logic op does not support pmode");
+    }
     auto lhsType = cast<VMIMaskType>(getLhs().getType());
     auto rhsType = cast<VMIMaskType>(getRhs().getType());
     auto resultType = cast<VMIMaskType>(getResult().getType());
@@ -3010,10 +3217,12 @@ LogicalResult VMIVorOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  }
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -3023,10 +3232,12 @@ LogicalResult VMIVorOp::verify() {
 LogicalResult VMIVxorOp::verify() {
   if (isa<VMIMaskType>(getLhs().getType())) {
     // Mask logic path: reject predication mask and pmode.
-    if (!getMask().empty())
+    if (!getMask().empty()) {
       return emitOpError("mask logic op does not support predication mask");
-    if (auto pmode = getPmode())
+    }
+    if (auto pmode = getPmode()) {
       return emitOpError("mask logic op does not support pmode");
+    }
     auto lhsType = cast<VMIMaskType>(getLhs().getType());
     auto rhsType = cast<VMIMaskType>(getRhs().getType());
     auto resultType = cast<VMIMaskType>(getResult().getType());
@@ -3037,10 +3248,12 @@ LogicalResult VMIVxorOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  }
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -3051,10 +3264,12 @@ LogicalResult VMIVshlOp::verify() {
   auto lhsType = cast<VMIVRegType>(getLhs().getType());
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(lhsType.getElementType()))
+  if (!isVMIIntegerLikeType(lhsType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  }
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -3066,10 +3281,12 @@ LogicalResult VMIVshrOp::verify() {
   auto rhsType = cast<VMIVRegType>(getRhs().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   auto integerType = dyn_cast<IntegerType>(lhsType.getElementType());
-  if (!integerType)
+  if (!integerType) {
     return emitOpError("requires integer VMI element type");
-  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType)))
+  }
+  if (failed(verifyElementwiseVRegOp(getOperation(), lhsType, rhsType, resultType))) {
     return failure();
+  }
   if (failed(verifyVMIVariadicPmodeMask(getOperation(), getMask(),
                                       resultType, getPmode())))
     return failure();
@@ -3079,10 +3296,12 @@ LogicalResult VMIVshrOp::verify() {
 LogicalResult VMIVnotOp::verify() {
   if (isa<VMIMaskType>(getSource().getType())) {
     // Mask logic path: reject predication mask and pmode.
-    if (!getMask().empty())
+    if (!getMask().empty()) {
       return emitOpError("mask logic op does not support predication mask");
-    if (auto pmode = getPmode())
+    }
+    if (auto pmode = getPmode()) {
       return emitOpError("mask logic op does not support pmode");
+    }
     auto sourceType = cast<VMIMaskType>(getSource().getType());
     auto resultType = cast<VMIMaskType>(getResult().getType());
     return verifyAllSameMaskShapeLayoutAndGranularity(
@@ -3091,8 +3310,9 @@ LogicalResult VMIVnotOp::verify() {
   // VReg path.
   auto sourceType = cast<VMIVRegType>(getSource().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
-  if (!isVMIIntegerLikeType(sourceType.getElementType()))
+  if (!isVMIIntegerLikeType(sourceType.getElementType())) {
     return emitOpError("requires integer-like VMI element type");
+  }
   if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
                                              {sourceType, resultType},
                                              /*requireSameElement=*/true)))
@@ -3112,8 +3332,9 @@ LogicalResult VMIvSelOp::verify() {
                                              {trueType, falseType, resultType},
                                              /*requireSameElement=*/true)))
     return failure();
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
+  }
   if (auto pmode = getPmode(); pmode.has_value()) {
     StringRef mode = pmode.value();
     if (mode != "merge" && mode != "zero")
@@ -3137,11 +3358,13 @@ LogicalResult VMIvcaddOp::verify() {
                        "source element type");
 
   // Floating-point vcadd MUST carry reassoc
-  if (isFloat && !getReassoc())
+  if (isFloat && !getReassoc()) {
     return emitOpError("floating add-reduction requires reassoc attr");
+  }
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType))) {
     return failure();
+  }
 
   // Validate group vs result lane count
   if (auto groupAttr = getGroupAttr()) {
@@ -3167,14 +3390,16 @@ LogicalResult VMIvcaddOp::verify() {
   }
 
   // Element types must match
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("source and result element types must match");
+  }
 
   // pmode must be "zero" or "merge" if set
   if (auto pmode = getPmode()) {
     StringRef val = *pmode;
-    if (val != "zero" && val != "merge")
+    if (val != "zero" && val != "merge") {
       return emitOpError("pmode must be \"zero\" or \"merge\", got \"") << val << "\"";
+    }
   }
 
   return success();
@@ -3192,8 +3417,9 @@ LogicalResult VMIvcmaxOp::verify() {
     return emitOpError("requires integer-like or floating-point-like VMI "
                        "source element type");
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType))) {
     return failure();
+  }
 
   if (auto groupAttr = getGroupAttr()) {
     int64_t C = groupAttr.getInt();
@@ -3217,13 +3443,15 @@ LogicalResult VMIvcmaxOp::verify() {
              << resultType.getElementCount();
   }
 
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("source and result element types must match");
+  }
 
   if (auto pmode = getPmode()) {
     StringRef val = *pmode;
-    if (val != "zero" && val != "merge")
+    if (val != "zero" && val != "merge") {
       return emitOpError("pmode must be \"zero\" or \"merge\", got \"") << val << "\"";
+    }
   }
 
   return success();
@@ -3241,8 +3469,9 @@ LogicalResult VMIvcminOp::verify() {
     return emitOpError("requires integer-like or floating-point-like VMI "
                        "source element type");
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, sourceType))) {
     return failure();
+  }
 
   if (auto groupAttr = getGroupAttr()) {
     int64_t C = groupAttr.getInt();
@@ -3266,13 +3495,15 @@ LogicalResult VMIvcminOp::verify() {
              << resultType.getElementCount();
   }
 
-  if (sourceType.getElementType() != resultType.getElementType())
+  if (sourceType.getElementType() != resultType.getElementType()) {
     return emitOpError("source and result element types must match");
+  }
 
   if (auto pmode = getPmode()) {
     StringRef val = *pmode;
-    if (val != "zero" && val != "merge")
+    if (val != "zero" && val != "merge") {
       return emitOpError("pmode must be \"zero\" or \"merge\", got \"") << val << "\"";
+    }
   }
 
   return success();
@@ -3302,8 +3533,9 @@ LogicalResult VMIVgatherOp::verify() {
           getOperation(), {offsetsType, resultType},
           /*requireSameElement=*/false)))
     return failure();
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
+  }
 
   // 16-bit offsets only address the ui16 gather path (pto.vgather2 / b16 mask),
   // which requires a ui16 result element type. Reject other 16-bit-offset
@@ -3317,8 +3549,9 @@ LogicalResult VMIVgatherOp::verify() {
         "requires ui16 result element type when using ui16 offsets");
 
   if (auto pmode = getPmode()) {
-    if (pmode.value() != "merge" && pmode.value() != "zero")
+    if (pmode.value() != "merge" && pmode.value() != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
   return success();
 }
@@ -3349,12 +3582,14 @@ LogicalResult VMIVgatherbOp::verify() {
     return emitOpError(
         "requires signless or unsigned 16-bit or 32-bit integer offsets");
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
+  }
 
   if (auto pmode = getPmode()) {
-    if (pmode.value() != "merge" && pmode.value() != "zero")
+    if (pmode.value() != "merge" && pmode.value() != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
   return success();
 }
@@ -3391,12 +3626,14 @@ LogicalResult VMIVscatterOp::verify() {
                                              {valueType, offsetsType},
                                              /*requireSameElement=*/false)))
     return failure();
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, valueType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, valueType))) {
     return failure();
+  }
 
   if (auto pmode = getPmode()) {
-    if (pmode.value() != "merge" && pmode.value() != "zero")
+    if (pmode.value() != "merge" && pmode.value() != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
   return success();
 }
@@ -3413,28 +3650,33 @@ LogicalResult VMIVexpdifOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
-  if (!isVMIFloatLikeType(xType.getElementType()))
+  if (!isVMIFloatLikeType(xType.getElementType())) {
     return emitOpError("requires x element type to be f16 or f32");
+  }
 
   auto maxElemType = dyn_cast<FloatType>(maxType.getElementType());
-  if (!maxElemType || maxElemType.getWidth() != 32)
+  if (!maxElemType || maxElemType.getWidth() != 32) {
     return emitOpError("requires max element type to be f32");
+  }
 
   auto resultElemType = dyn_cast<FloatType>(resultType.getElementType());
-  if (!resultElemType || resultElemType.getWidth() != 32)
+  if (!resultElemType || resultElemType.getWidth() != 32) {
     return emitOpError("requires result element type to be f32");
+  }
 
   if (xType.getElementCount() != maxType.getElementCount() ||
       xType.getElementCount() != resultType.getElementCount())
     return emitOpError(
         "requires x, max, and result logical lane counts to match");
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
+  }
 
   if (auto pmode = getPmode()) {
-    if (pmode.value() != "merge" && pmode.value() != "zero")
+    if (pmode.value() != "merge" && pmode.value() != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
   return success();
 }
@@ -3445,23 +3687,27 @@ LogicalResult VMIVaxpyOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
-  if (!isVMIFloatLikeType(xType.getElementType()))
+  if (!isVMIFloatLikeType(xType.getElementType())) {
     return emitOpError("requires vector element type to be f16 or f32");
+  }
 
   if (xType != accType || accType != resultType)
     return emitOpError(
         "requires x, acc, and result to have identical VMI vreg types");
 
   auto alphaType = cast<FloatType>(getAlpha().getType());
-  if (alphaType != xType.getElementType())
+  if (alphaType != xType.getElementType()) {
     return emitOpError("requires alpha scalar type to match vector element type");
+  }
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
+  }
 
   if (auto pmode = getPmode()) {
-    if (pmode.value() != "merge" && pmode.value() != "zero")
+    if (pmode.value() != "merge" && pmode.value() != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
   return success();
 }
@@ -3471,23 +3717,27 @@ LogicalResult VMIVlreluOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
-  if (!isVMIFloatLikeType(xType.getElementType()))
+  if (!isVMIFloatLikeType(xType.getElementType())) {
     return emitOpError("requires vector element type to be f16 or f32");
+  }
 
-  if (xType != resultType)
+  if (xType != resultType) {
     return emitOpError("requires x and result to have identical VMI vreg types");
+  }
 
   auto slopeType = cast<FloatType>(getSlope().getType());
   if (slopeType != xType.getElementType())
     return emitOpError(
         "requires slope scalar type to match vector element type");
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
+  }
 
   if (auto pmode = getPmode()) {
-    if (pmode.value() != "merge" && pmode.value() != "zero")
+    if (pmode.value() != "merge" && pmode.value() != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
   return success();
 }
@@ -3498,19 +3748,22 @@ LogicalResult VMIVpreluOp::verify() {
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
 
-  if (!isVMIFloatLikeType(xType.getElementType()))
+  if (!isVMIFloatLikeType(xType.getElementType())) {
     return emitOpError("requires vector element type to be f16 or f32");
+  }
 
   if (xType != alphaType || alphaType != resultType)
     return emitOpError(
         "requires x, alpha, and result to have identical VMI vreg types");
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, resultType))) {
     return failure();
+  }
 
   if (auto pmode = getPmode()) {
-    if (pmode.value() != "merge" && pmode.value() != "zero")
+    if (pmode.value() != "merge" && pmode.value() != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
   return success();
 }
@@ -3578,14 +3831,17 @@ LogicalResult VMIVmullOp::verify() {
         "requires a, b, low, and high to have identical VMI vreg types");
 
   int64_t lanes = aType.getElementCount();
-  if (lanes != 64 && lanes != 128 && lanes != 256)
+  if (lanes != 64 && lanes != 128 && lanes != 256) {
     return emitOpError("requires logical lane count to be 64, 128, or 256");
+  }
 
-  if (failed(verifyMaskMatchesData(getOperation(), maskType, aType)))
+  if (failed(verifyMaskMatchesData(getOperation(), maskType, aType))) {
     return failure();
+  }
 
-  if (auto pmode = getPmode(); pmode && pmode.value() != "zero")
+  if (auto pmode = getPmode(); pmode && pmode.value() != "zero") {
     return emitOpError("pmode must be 'zero' when specified");
+  }
   return success();
 }
 
@@ -3635,10 +3891,12 @@ LogicalResult VMICvtOp::verify() {
   // 2. Classify the conversion direction.
   CvtDirection dir;
   if (srcFp && dstFp) {
-    if (dstBits > srcBits)
+    if (dstBits > srcBits) {
       dir = CvtDirection::FpWiden;
-    else if (dstBits < srcBits)
+    }
+    else if (dstBits < srcBits) {
       dir = CvtDirection::FpNarrow;
+    }
     else {
       // Same-width fp→fp (e.g. bf16 → f16): only allowed for VMI fp-to-fp
       // contract pairs, routed through FpNarrow (1:1 TruncF).
@@ -3649,10 +3907,12 @@ LogicalResult VMICvtOp::verify() {
       dir = CvtDirection::FpNarrow;
     }
   } else if (srcFp && dstInt) {
-    if (isVMIUnsignedIntegerType(dstElem))
+    if (isVMIUnsignedIntegerType(dstElem)) {
       dir = CvtDirection::FpToUi;
-    else
+    }
+    else {
       dir = CvtDirection::FpToSi;
+    }
   } else if (srcInt && dstFp) {
     if (!isVMISignedOrSignlessIntegerType(srcElem))
       return emitOpError(
@@ -3660,10 +3920,12 @@ LogicalResult VMICvtOp::verify() {
           "element type");
     dir = CvtDirection::SiToFp;
   } else if (srcInt && dstInt) {
-    if (dstBits > srcBits)
+    if (dstBits > srcBits) {
       dir = CvtDirection::IntWiden;
-    else if (dstBits < srcBits)
+    }
+    else if (dstBits < srcBits) {
       dir = CvtDirection::IntNarrow;
+    }
     else
       return emitOpError(
           "int-to-int conversion must change element bit-width");
@@ -3690,15 +3952,17 @@ LogicalResult VMICvtOp::verify() {
   auto satAttr = (*this)->getAttrOfType<StringAttr>("saturate");
   if (dir == CvtDirection::FpToSi) {
     auto contract = lookupVMIFpToSiContract(srcElem, dstElem);
-    if (!contract)
+    if (!contract) {
       return emitOpError("unsupported fp-to-si conversion element type pair");
+    }
     if (contract->requiresSat) {
       if (!satAttr)
         return emitOpError("'saturate' attribute is required for this "
                            "fp-to-si conversion; write 'SAT' or 'NOSAT'");
       StringRef satVal = satAttr.getValue();
-      if (satVal != "SAT" && satVal != "NOSAT")
+      if (satVal != "SAT" && satVal != "NOSAT") {
         return emitOpError("saturate must be 'SAT' or 'NOSAT'");
+      }
     } else {
       if (satAttr)
         return emitOpError("'saturate' attribute is not valid for this "
@@ -3706,15 +3970,17 @@ LogicalResult VMICvtOp::verify() {
     }
   } else if (dir == CvtDirection::FpToUi) {
     auto contract = lookupVMIFpToUIContract(srcElem, dstElem);
-    if (!contract)
+    if (!contract) {
       return emitOpError("unsupported fp-to-ui conversion element type pair");
+    }
     if (contract->requiresSat) {
       if (!satAttr)
         return emitOpError("'saturate' attribute is required for this "
                            "fp-to-ui conversion; write 'SAT' or 'NOSAT'");
       StringRef satVal = satAttr.getValue();
-      if (satVal != "SAT" && satVal != "NOSAT")
+      if (satVal != "SAT" && satVal != "NOSAT") {
         return emitOpError("saturate must be 'SAT' or 'NOSAT'");
+      }
     } else {
       if (satAttr)
         return emitOpError("'saturate' attribute is not valid for this "
@@ -3729,8 +3995,9 @@ LogicalResult VMICvtOp::verify() {
                            "int-narrow conversions; write 'SAT' or "
                            "'NOSAT'");
       StringRef satVal = satAttr.getValue();
-      if (satVal != "SAT" && satVal != "NOSAT")
+      if (satVal != "SAT" && satVal != "NOSAT") {
         return emitOpError("saturate must be 'SAT' or 'NOSAT'");
+      }
       // si32 -> si8 IntNarrow has no native hardware form.  Lowering aliases
       // it through ui32 -> ui8 (bit-pattern equal ONLY under NOSAT).  Reject
       // SAT here because ui32 -> ui8 SAT clamps to [0, 255], which does NOT
@@ -3763,8 +4030,9 @@ LogicalResult VMICvtOp::verify() {
   // --- pmode ---
   if (auto pmodeAttr = (*this)->getAttrOfType<StringAttr>("pmode")) {
     StringRef pmode = pmodeAttr.getValue();
-    if (pmode != "merge" && pmode != "zero")
+    if (pmode != "merge" && pmode != "zero") {
       return emitOpError("pmode must be 'merge' or 'zero'");
+    }
   }
 
   return success();
@@ -3790,8 +4058,9 @@ LogicalResult VMIVinterpretCastOp::verify() {
       return emitOpError(
           "requires either both source and result to carry layout or neither "
           "to carry layout");
-    if (sourceType.getLayout() != resultType.getLayout())
+    if (sourceType.getLayout() != resultType.getLayout()) {
       return emitOpError("requires source and result layouts to match");
+    }
   }
 
   return success();
@@ -3803,28 +4072,33 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
   OpAsmParser::UnresolvedOperand offsetOperand;
   SmallVector<OpAsmParser::UnresolvedOperand, 3> postBracketOps;
 
-  if (parser.parseOperand(operand))
+  if (parser.parseOperand(operand)) {
     return failure();
+  }
   preBracketOperands.push_back(operand);
 
   bool consumedLSquare = false;
   while (!consumedLSquare) {
     if (succeeded(parser.parseOptionalLSquare())) {
-      if (parser.parseOperand(offsetOperand) || parser.parseRSquare())
+      if (parser.parseOperand(offsetOperand) || parser.parseRSquare()) {
         return failure();
+      }
       consumedLSquare = true;
       break;
     }
-    if (parser.parseComma())
+    if (parser.parseComma()) {
       return failure();
+    }
     if (succeeded(parser.parseOptionalLSquare())) {
-      if (parser.parseOperand(offsetOperand) || parser.parseRSquare())
+      if (parser.parseOperand(offsetOperand) || parser.parseRSquare()) {
         return failure();
+      }
       consumedLSquare = true;
       break;
     }
-    if (parser.parseOperand(operand))
+    if (parser.parseOperand(operand)) {
       return failure();
+    }
     preBracketOperands.push_back(operand);
   }
 
@@ -3836,19 +4110,23 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
   // Up to 3, disambiguated after parsing attrs.
   while (succeeded(parser.parseOptionalComma())) {
     OpAsmParser::UnresolvedOperand postOp;
-    if (parser.parseOperand(postOp))
+    if (parser.parseOperand(postOp)) {
       return failure();
+    }
     postBracketOps.push_back(postOp);
-    if (postBracketOps.size() >= 3)
+    if (postBracketOps.size() >= 3) {
       break;
+    }
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   SmallVector<Type, 6> types;
-  if (parser.parseColon() || parser.parseTypeList(types))
+  if (parser.parseColon() || parser.parseTypeList(types)) {
     return failure();
+  }
 
   bool hasGroup = result.attributes.get("group") != nullptr;
   bool hasStride = false;
@@ -3897,8 +4175,9 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
            << "), got " << nTypes;
 
   for (size_t i = 0; i < nValues; ++i) {
-    if (parser.resolveOperand(preBracketOperands[i], types[i], result.operands))
+    if (parser.resolveOperand(preBracketOperands[i], types[i], result.operands)) {
       return failure();
+    }
   }
 
   Type destType = types[nValues];
@@ -3943,8 +4222,9 @@ ParseResult VMIvStoreOp::parse(OpAsmParser &parser, OperationState &result) {
 }
 
 void VMIvStoreOp::print(OpAsmPrinter &p) {
-  for (auto val : getValues())
+  for (auto val : getValues()) {
     p << ' ' << val << ", ";
+  }
   p << getDestination() << '[';
   p.printOperand(getOffset());
   p << ']';
@@ -3964,33 +4244,42 @@ void VMIvStoreOp::print(OpAsmPrinter &p) {
   }
   p.printOptionalAttrDict((*this)->getAttrs(), {"operandSegmentSizes"});
   p << " : ";
-  for (auto val : getValues())
+  for (auto val : getValues()) {
     p << val.getType() << ", ";
+  }
   p << getDestination().getType();
-  if (!getMask().empty())
+  if (!getMask().empty()) {
     p << ", " << getMask()[0].getType();
+  }
 }
 
 LogicalResult VMIvStoreOp::verify() {
   // group and dist_mode are mutually exclusive
-  if (getGroup() && getDistMode())
+  if (getGroup() && getDistMode()) {
     return emitOpError("group and dist_mode are mutually exclusive");
-  if (getGroup() && !getStride())
+  }
+  if (getGroup() && !getStride()) {
     return emitOpError("group requires a stride operand");
-  if (!getGroup() && getStride())
+  }
+  if (!getGroup() && getStride()) {
     return emitOpError("stride operand is only valid with group");
-  if (getGroup() && !getMask().empty())
+  }
+  if (getGroup() && !getMask().empty()) {
     return emitOpError("group mode does not support mask operand");
+  }
 
   if (getGroup()) {
     int64_t numGroups = getGroupAttr().getInt();
-    if (numGroups <= 0)
+    if (numGroups <= 0) {
       return emitOpError("group must be positive, got ") << numGroups;
-    if (getValues().size() != 1)
+    }
+    if (getValues().size() != 1) {
       return emitOpError("group mode requires exactly 1 value");
+    }
     auto valueType = cast<VMIVRegType>(getValues()[0].getType());
-    if (failed(verifyNumGroups(getOperation(), valueType, numGroups)))
+    if (failed(verifyNumGroups(getOperation(), valueType, numGroups))) {
       return failure();
+    }
   }
 
   // block_stride / repeat_stride: paired, mutually exclusive with
@@ -4004,34 +4293,40 @@ LogicalResult VMIvStoreOp::verify() {
     if (getDistMode())
       return emitOpError(
           "block_stride and dist_mode are mutually exclusive");
-    if (getValues().size() != 1)
+    if (getValues().size() != 1) {
       return emitOpError("block-stride mode requires exactly 1 value");
+    }
   }
 
   auto distMode = getDistMode();
   bool isDintlv = distMode && *distMode == "dintlv";
   size_t nValues = getValues().size();
-  if (nValues < 1)
+  if (nValues < 1) {
     return emitOpError("requires at least 1 value");
-  if (isDintlv && nValues != 2)
+  }
+  if (isDintlv && nValues != 2) {
     return emitOpError("dist-mode \"dintlv\" requires exactly 2 values");
+  }
   if (!isDintlv && nValues != 1)
     return emitOpError("requires exactly 1 value for dist-mode \"")
            << (distMode ? *distMode : "continuous") << "\"";
 
   bool hasMask = !getMask().empty();
-  if (getMask().size() > 1)
+  if (getMask().size() > 1) {
     return emitOpError("at most one mask allowed");
+  }
 
-  if (distMode && !validDistModes().count(*distMode))
+  if (distMode && !validDistModes().count(*distMode)) {
     return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
+  }
   if (distMode && (*distMode == "unpack" || *distMode == "brc"))
     return emitOpError("dist-mode \"")
            << *distMode << "\" is not valid for vstore";
 
   auto pmode = getPmode();
-  if (pmode && !validPModes().count(*pmode))
+  if (pmode && !validPModes().count(*pmode)) {
     return emitOpError("invalid pmode: \"") << *pmode << "\"";
+  }
   if (pmode && *pmode != "zero")
     return emitOpError("pmode \"merge\" is not supported for stores: the "
                        "legacy store lowering is mask-governed only and "
@@ -4064,8 +4359,9 @@ LogicalResult VMIvStoreOp::verify() {
 
   if (hasMask) {
     auto maskType = cast<VMIMaskType>(getMask()[0].getType());
-    if (failed(verifyMaskMatchesData(getOperation(), maskType, valueType)))
+    if (failed(verifyMaskMatchesData(getOperation(), maskType, valueType))) {
       return failure();
+    }
   }
 
   return success();
@@ -4086,8 +4382,9 @@ LogicalResult VMIVsstbOp::verify() {
       failed(verifyUBBackedMemory(getOperation(), getDestination().getType(),
                                   "destination")))
     return failure();
-  if (auto pmode = getPmode(); pmode && !validPModes().count(*pmode))
+  if (auto pmode = getPmode(); pmode && !validPModes().count(*pmode)) {
     return emitOpError("invalid pmode: \"") << *pmode << "\"";
+  }
   if (auto pmode = getPmode(); pmode && *pmode != "zero")
     return emitOpError("pmode \"merge\" is not supported for stores: the "
                        "legacy store lowering is mask-governed only and "
@@ -4115,8 +4412,9 @@ LogicalResult VMIVselrOp::verify() {
     return emitOpError(
         "requires index lane count to match result lane count");
 
-  if (!isa<IntegerType>(indexType.getElementType()))
+  if (!isa<IntegerType>(indexType.getElementType())) {
     return emitOpError("requires index element type to be integer");
+  }
 
   unsigned sourceBits =
       pto::getPTOStorageElemBitWidth(sourceType.getElementType());
@@ -4211,8 +4509,9 @@ LogicalResult VMIVcmpOp::verify() {
   }
 
   // Seed mask must match data shape.
-  if (failed(verifyMaskMatchesData(getOperation(), seedType, lhsType)))
+  if (failed(verifyMaskMatchesData(getOperation(), seedType, lhsType))) {
     return failure();
+  }
 
   // Result mask must match seed mask.
   if (seedType.getElementCount() != resultType.getElementCount())
@@ -4257,8 +4556,9 @@ LogicalResult VMIVcmpsOp::verify() {
   }
 
   // Seed mask must match data shape.
-  if (failed(verifyMaskMatchesData(getOperation(), seedType, srcType)))
+  if (failed(verifyMaskMatchesData(getOperation(), seedType, srcType))) {
     return failure();
+  }
 
   // Result mask must match seed mask.
   if (seedType.getElementCount() != resultType.getElementCount())
@@ -4290,29 +4590,35 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
   int numPostBracket = 0;
   OpAsmParser::UnresolvedOperand postOp1, postOp2;
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseOperand(postOp1))
+    if (parser.parseOperand(postOp1)) {
       return failure();
+    }
     numPostBracket = 1;
     if (succeeded(parser.parseOptionalComma())) {
-      if (parser.parseOperand(postOp2))
+      if (parser.parseOperand(postOp2)) {
         return failure();
+      }
       numPostBracket = 2;
     }
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes))
+  if (parser.parseOptionalAttrDict(result.attributes)) {
     return failure();
+  }
 
   Type sourceType;
-  if (parser.parseColonType(sourceType))
+  if (parser.parseColonType(sourceType)) {
     return failure();
+  }
 
-  if (parser.parseArrow())
+  if (parser.parseArrow()) {
     return failure();
+  }
 
   SmallVector<Type, 2> resultTypes;
-  if (parser.parseTypeList(resultTypes))
+  if (parser.parseTypeList(resultTypes)) {
     return failure();
+  }
 
   // Disambiguate post-bracket operands
   bool hasStride = false;
@@ -4333,8 +4639,9 @@ ParseResult VMIvLoadOp::parse(OpAsmParser &parser, OperationState &result) {
     strideOperand = postOp1;
   }
 
-  if (parser.resolveOperand(sourceOperand, sourceType, result.operands))
+  if (parser.resolveOperand(sourceOperand, sourceType, result.operands)) {
     return failure();
+  }
   if (parser.resolveOperand(offsetOperand, parser.getBuilder().getIndexType(),
                             result.operands))
     return failure();
@@ -4383,22 +4690,28 @@ void VMIvLoadOp::print(OpAsmPrinter &p) {
 LogicalResult VMIvLoadOp::verify() {
   // group and dist_mode are mutually exclusive, except brc which supports
   // group broadcast (one scalar per group → broadcast within each group).
-  if (getGroup() && getDistMode() && getDistMode() != "brc")
+  if (getGroup() && getDistMode() && getDistMode() != "brc") {
     return emitOpError("group and dist_mode are mutually exclusive");
-  if (getGroup() && !getStride())
+  }
+  if (getGroup() && !getStride()) {
     return emitOpError("group requires a stride operand");
-  if (!getGroup() && getStride())
+  }
+  if (!getGroup() && getStride()) {
     return emitOpError("stride operand is only valid with group");
+  }
 
   if (getGroup()) {
     int64_t numGroups = getGroupAttr().getInt();
-    if (numGroups <= 0)
+    if (numGroups <= 0) {
       return emitOpError("group must be positive, got ") << numGroups;
-    if (getResults().size() != 1)
+    }
+    if (getResults().size() != 1) {
       return emitOpError("group mode requires exactly 1 result");
+    }
     auto resultType = cast<VMIVRegType>(getResults()[0].getType());
-    if (failed(verifyNumGroups(getOperation(), resultType, numGroups)))
+    if (failed(verifyNumGroups(getOperation(), resultType, numGroups))) {
       return failure();
+    }
   }
 
   // block_stride and repeat_stride must be paired, mutually exclusive
@@ -4412,25 +4725,29 @@ LogicalResult VMIvLoadOp::verify() {
     if (getDistMode())
       return emitOpError(
           "block_stride and dist_mode are mutually exclusive");
-    if (getResults().size() != 1)
+    if (getResults().size() != 1) {
       return emitOpError("block-stride mode requires exactly 1 result");
+    }
   }
 
   // result count vs dist-mode
   auto distMode = getDistMode();
   bool isDintlv = distMode && *distMode == "dintlv";
   size_t nResults = getResults().size();
-  if (isDintlv && nResults != 2)
+  if (isDintlv && nResults != 2) {
     return emitOpError("dist-mode \"dintlv\" requires exactly 2 results");
+  }
   if (!isDintlv && nResults != 1)
     return emitOpError("requires exactly 1 result for dist-mode \"")
            << (distMode ? *distMode : "continuous") << "\"";
 
-  if (distMode && !validDistModes().count(*distMode))
+  if (distMode && !validDistModes().count(*distMode)) {
     return emitOpError("invalid dist-mode: \"") << *distMode << "\"";
+  }
   auto pmode = getPmode();
-  if (pmode && !validPModes().count(*pmode))
+  if (pmode && !validPModes().count(*pmode)) {
     return emitOpError("invalid pmode: \"") << *pmode << "\"";
+  }
 
   bool isUnpack = distMode && *distMode == "unpack";
   for (auto res : getResults()) {
@@ -4469,30 +4786,37 @@ Type mlir::pto::getVMIPhysicalDataElementType(VMIVRegType type) {
 
 FailureOr<int64_t> mlir::pto::getDataLanesPerPart(Type elementType) {
   unsigned elementBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elementBitWidth == 0)
+  if (elementBitWidth == 0) {
     return failure();
+  }
   constexpr int64_t kPhysicalVRegBits = 256 * 8;
-  if (kPhysicalVRegBits % elementBitWidth != 0)
+  if (kPhysicalVRegBits % elementBitWidth != 0) {
     return failure();
+  }
   return kPhysicalVRegBits / elementBitWidth;
 }
 
 FailureOr<int64_t> mlir::pto::getMaskLanesPerPart(StringRef granularity) {
-  if (granularity == "b8")
+  if (granularity == "b8") {
     return 256;
-  if (granularity == "b16")
+  }
+  if (granularity == "b16") {
     return 128;
-  if (granularity == "b32")
+  }
+  if (granularity == "b32") {
     return 64;
+  }
   return failure();
 }
 
 FailureOr<int64_t> mlir::pto::getVMILayoutBlockElems(Type type) {
   FailureOr<VMILayoutAttr> layout = getAssignedVMILayout(type);
-  if (failed(layout))
+  if (failed(layout)) {
     return failure();
-  if (!(*layout).isBlockDeinterleaved())
+  }
+  if (!(*layout).isBlockDeinterleaved()) {
     return 1;
+  }
 
   FailureOr<int64_t> lanesPerPart = getPhysicalLanesPerPart(type);
   constexpr int64_t kVCGBlocksPerPart = 8;
@@ -4506,8 +4830,9 @@ FailureOr<int64_t> mlir::pto::getVMIPhysicalArity(Type type) {
   FailureOr<int64_t> elementCount = getVMIElementCount(type);
   FailureOr<int64_t> lanesPerPart = getPhysicalLanesPerPart(type);
   FailureOr<VMILayoutAttr> layout = getAssignedVMILayout(type);
-  if (failed(elementCount) || failed(lanesPerPart) || failed(layout))
+  if (failed(elementCount) || failed(lanesPerPart) || failed(layout)) {
     return failure();
+  }
 
   if ((*layout).isGroupSlots() && (*layout).getSlots() > 0)
     return divideCeilNonNegative((*layout).getNumGroups(),
@@ -4515,8 +4840,9 @@ FailureOr<int64_t> mlir::pto::getVMIPhysicalArity(Type type) {
 
   int64_t factor = (*layout).isDenseSplit() ? (*layout).getFactor() : 1;
   FailureOr<int64_t> blockElems = getVMILayoutBlockElems(type);
-  if (failed(blockElems))
+  if (failed(blockElems)) {
     return failure();
+  }
   int64_t laneStride =
       isa<VMIMaskType>(type) ? 1
                              : ((*layout).isDense() ? (*layout).getLaneStride()
@@ -4542,24 +4868,27 @@ mlir::pto::mapLogicalLaneToPhysical(Type type, int64_t logicalLane) {
   if (failed(elementCount) || failed(factor) || failed(blockElems) ||
       failed(laneStride) || failed(lanesPerPart))
     return failure();
-  if (logicalLane < 0 || logicalLane >= *elementCount)
+  if (logicalLane < 0 || logicalLane >= *elementCount) {
     return failure();
+  }
 
   FailureOr<VMILayoutAttr> layout = getAssignedVMILayout(type);
   if (succeeded(layout) && (*layout).isGroupSlots() &&
       (*layout).getSlots() > 0) {
     int64_t slots = (*layout).getSlots();
     int64_t lane = logicalLane % slots;
-    if (lane >= *lanesPerPart)
+    if (lane >= *lanesPerPart) {
       return failure();
+    }
     return VMIPhysicalLane{/*part=*/0, logicalLane / slots, lane};
   }
 
   int64_t part = 0;
   std::optional<int64_t> indexInPart = mapDenseLogicalLaneToPartIndex(
       *elementCount, *factor, *blockElems, logicalLane, part);
-  if (!indexInPart)
+  if (!indexInPart) {
     return failure();
+  }
   int64_t physicalIndex = *indexInPart * *laneStride;
   return VMIPhysicalLane{part, physicalIndex / *lanesPerPart,
                          physicalIndex % *lanesPerPart};
@@ -4584,22 +4913,26 @@ FailureOr<int64_t> mlir::pto::mapPhysicalLaneToLogical(Type type, int64_t part,
   if (succeeded(layout) && (*layout).isGroupSlots() &&
       (*layout).getSlots() > 0) {
     int64_t slots = (*layout).getSlots();
-    if (part != 0 || lane >= slots)
+    if (part != 0 || lane >= slots) {
       return failure();
+    }
     int64_t logicalLane = chunk * slots + lane;
-    if (logicalLane >= *elementCount)
+    if (logicalLane >= *elementCount) {
       return failure();
+    }
     return logicalLane;
   }
 
   int64_t physicalIndexInPart = chunk * *lanesPerPart + lane;
-  if (physicalIndexInPart % *laneStride != 0)
+  if (physicalIndexInPart % *laneStride != 0) {
     return failure();
+  }
   int64_t indexInPart = physicalIndexInPart / *laneStride;
   std::optional<int64_t> logicalLane = mapDensePartIndexToLogicalLane(
       *elementCount, *factor, *blockElems, part, indexInPart);
-  if (!logicalLane)
+  if (!logicalLane) {
     return failure();
+  }
   return *logicalLane;
 }
 
@@ -4621,18 +4954,21 @@ FailureOr<bool> mlir::pto::isPaddingLane(Type type, int64_t part, int64_t chunk,
   if (succeeded(layout) && (*layout).isGroupSlots() &&
       (*layout).getSlots() > 0) {
     int64_t slots = (*layout).getSlots();
-    if (part != 0)
+    if (part != 0) {
       return true;
-    if (lane >= slots)
+    }
+    if (lane >= slots) {
       return true;
+    }
     return chunk * slots + lane >= *elementCount;
   }
 
   int64_t lanesInPart =
       getDenseLogicalLanesInPart(*elementCount, *factor, *blockElems, part);
   int64_t physicalIndexInPart = chunk * *lanesPerPart + lane;
-  if (physicalIndexInPart % *laneStride != 0)
+  if (physicalIndexInPart % *laneStride != 0) {
     return true;
+  }
   int64_t indexInPart = physicalIndexInPart / *laneStride;
   return indexInPart >= lanesInPart;
 }

--- a/lib/PTO/IR/VPTO.cpp
+++ b/lib/PTO/IR/VPTO.cpp
@@ -64,8 +64,9 @@ static std::string formatMaskType(StringRef granularity) {
 static LogicalResult verifyVRegTypeLike(Operation *op, Type type,
                                        StringRef roleDescription) {
   auto vecType = dyn_cast<VRegType>(type);
-  if (!vecType)
+  if (!vecType) {
     return op->emitOpError() << roleDescription << " must be !pto.vreg<...>";
+  }
 
   return VRegType::verify(
       [&]() { return op->emitOpError() << roleDescription << " "; },
@@ -74,16 +75,18 @@ static LogicalResult verifyVRegTypeLike(Operation *op, Type type,
 
 static LogicalResult verifyMaskTypeLike(Operation *op, Type type,
                                         StringRef roleDescription) {
-  if (!isa<MaskType>(type))
+  if (!isa<MaskType>(type)) {
     return op->emitOpError() << roleDescription << " must be !pto.mask<...>";
+  }
   return success();
 }
 
 static LogicalResult verifyNonLowPrecisionVRegElementTypeLike(
     Operation *op, Type type, StringRef roleDescription) {
   auto vecType = dyn_cast<VRegType>(type);
-  if (!vecType)
+  if (!vecType) {
     return success();
+  }
   if (pto::isPTOLowPrecisionType(vecType.getElementType()))
     return op->emitOpError()
            << roleDescription
@@ -97,8 +100,9 @@ static LogicalResult verifyMaskTypeWithGranularityLike(Operation *op, Type type,
                                                        StringRef roleDescription,
                                                        StringRef granularity) {
   auto maskType = dyn_cast<MaskType>(type);
-  if (!maskType)
+  if (!maskType) {
     return op->emitOpError() << roleDescription << " must be !pto.mask<...>";
+  }
   if (maskType.getGranularity() != granularity) {
     return op->emitOpError()
            << roleDescription << " must be " << formatMaskType(granularity);
@@ -139,8 +143,9 @@ static bool isMaskGranularityAdjacentNarrowing(StringRef inputGranularity,
 }
 
 static bool isSupportedShuffleValueType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth() == 32 || intType.getWidth() == 64;
+  }
   if (auto vecType = dyn_cast<VectorType>(type))
     return vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
            vecType.getElementType().isF16();
@@ -148,8 +153,9 @@ static bool isSupportedShuffleValueType(Type type) {
 }
 
 static bool isSupportedReduxValueType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth() == 32;
+  }
   return type.isF16() || type.isF32();
 }
 
@@ -176,11 +182,13 @@ LogicalResult SimtLaunchOp::verify() {
   }
 
   FunctionType calleeType = callee.getFunctionType();
-  if (!calleeType.getResults().empty())
+  if (!calleeType.getResults().empty()) {
     return emitOpError("requires a callee with no results");
+  }
 
-  if (calleeType.getNumInputs() != getArgs().size())
+  if (calleeType.getNumInputs() != getArgs().size()) {
     return emitOpError("incorrect number of operands for callee");
+  }
 
   for (auto [index, argType, operand] :
        llvm::enumerate(calleeType.getInputs(), getArgs())) {
@@ -205,8 +213,9 @@ static LogicalResult verifyShuffleSemanticControl(Operation *op,
                              << " operand to be i32";
 
   int64_t width = widthAttr.getInt();
-  if (width != 16 && width != 32)
+  if (width != 16 && width != 32) {
     return op->emitOpError() << "requires width to be 16 or 32";
+  }
   return success();
 }
 
@@ -229,8 +238,9 @@ static LogicalResult verifyReduxSemanticType(Operation *op, Type valueType,
     return op->emitOpError()
            << "requires explicit signedness for integer redux";
 
-  if (!signednessAttr)
+  if (!signednessAttr) {
     return success();
+  }
 
   auto signedness = cast<pto::SignednessAttr>(signednessAttr).getValue();
   (void)signedness;
@@ -238,8 +248,9 @@ static LogicalResult verifyReduxSemanticType(Operation *op, Type valueType,
 }
 
 static bool isStandardScalarConvertType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth() == 32 || intType.getWidth() == 64;
+  }
   return type.isF16() || type.isBF16() || type.isF32();
 }
 
@@ -254,8 +265,9 @@ static bool isVector2Of(Type type, llvm::function_ref<bool(Type)> elementPred) {
 }
 
 static bool isSupportedPackedConvertType(Type type) {
-  if (pto::isPTOHiFloat8x2Type(type))
+  if (pto::isPTOHiFloat8x2Type(type)) {
     return true;
+  }
   return isVector2Of(type, [](Type elem) {
     return elem.isF16() || elem.isBF16() || elem.isF32() ||
            pto::isPTOFloat8Type(elem) || pto::isPTOHiFloat8Type(elem);
@@ -464,8 +476,9 @@ static LogicalResult verifyConvertControls(Operation *op, Type srcType,
 }
 
 static bool isSupportedAtomicScalarType(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth() == 32 || intType.getWidth() == 64;
+  }
   return type.isF16() || type.isBF16() || type.isF32() ||
          isVector2F16OrBF16Type(type);
 }
@@ -482,24 +495,29 @@ static LogicalResult verifyAtomicCommon(Operation *op, Value ptr, Type valueType
            << "requires atomic result type to match value type";
 
   auto ptrTy = dyn_cast<PtrType>(ptr.getType());
-  if (!ptrTy)
+  if (!ptrTy) {
     return op->emitOpError() << "requires !pto.ptr pointer operand";
+  }
   if (ptrTy.getElementType() != valueType)
     return op->emitOpError()
            << "requires atomic value type to match pointer element type";
 
   AddressSpace addressSpace = ptrTy.getMemorySpace().getAddressSpace();
-  if (addressSpace != AddressSpace::GM && addressSpace != AddressSpace::VEC)
+  if (addressSpace != AddressSpace::GM && addressSpace != AddressSpace::VEC) {
     return op->emitOpError() << "requires GM or UB pointer";
-  if (addressSpace == AddressSpace::VEC && valueType.isInteger(64))
+  }
+  if (addressSpace == AddressSpace::VEC && valueType.isInteger(64)) {
     return op->emitOpError() << "does not support i64 UB-space atomics";
+  }
 
   auto intType = dyn_cast<IntegerType>(valueType);
   if (bitwise) {
-    if (!intType)
+    if (!intType) {
       return op->emitOpError() << "requires integer type for bitwise atomics";
-    if (addressSpace == AddressSpace::VEC && intType.getWidth() == 64)
+    }
+    if (addressSpace == AddressSpace::VEC && intType.getWidth() == 64) {
       return op->emitOpError() << "does not support i64 UB-space bitwise atomics";
+    }
   }
 
   if (signednessAttr && !intType)
@@ -521,23 +539,28 @@ static LogicalResult verifyAtomicCommon(Operation *op, Value ptr, Type valueType
 static LogicalResult verifyLdgStgAccess(Operation *op, Type ptrType,
                                         Type valueType) {
   auto ptrTy = dyn_cast<PtrType>(ptrType);
-  if (!ptrTy)
+  if (!ptrTy) {
     return op->emitOpError() << "requires !pto.ptr operand";
-  if (ptrTy.getMemorySpace().getAddressSpace() != AddressSpace::GM)
+  }
+  if (ptrTy.getMemorySpace().getAddressSpace() != AddressSpace::GM) {
     return op->emitOpError() << "requires GM pointer";
+  }
 
   if (auto intType = dyn_cast<IntegerType>(valueType)) {
     unsigned width = intType.getWidth();
-    if (width == 8 || width == 16 || width == 32 || width == 64)
+    if (width == 8 || width == 16 || width == 32 || width == 64) {
       return success();
+    }
   }
   if (valueType.isF16() || valueType.isBF16() || valueType.isF32() ||
       valueType.isF64())
     return success();
-  if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType))
+  if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType)) {
     return success();
-  if (pto::isPTOPackedLdgStgVectorType(valueType))
+  }
+  if (pto::isPTOPackedLdgStgVectorType(valueType)) {
     return success();
+  }
 
   return op->emitOpError()
          << "currently supports 8/16/32/64-bit integer, "
@@ -553,10 +576,12 @@ static LogicalResult verifyLdStDevAccess(Operation *op, Type ptrType,
            << "does not accept l1cache or l2cache policy attributes";
 
   auto ptrTy = dyn_cast<PtrType>(ptrType);
-  if (!ptrTy)
+  if (!ptrTy) {
     return op->emitOpError() << "requires !pto.ptr operand";
-  if (ptrTy.getMemorySpace().getAddressSpace() != AddressSpace::GM)
+  }
+  if (ptrTy.getMemorySpace().getAddressSpace() != AddressSpace::GM) {
     return op->emitOpError() << "requires GM pointer";
+  }
 
   auto intType = dyn_cast<IntegerType>(valueType);
   if (!intType || (intType.getWidth() != 8 && intType.getWidth() != 16 &&
@@ -674,8 +699,9 @@ LogicalResult MulhiOp::verify() {
 LogicalResult MulI32ToI64Op::verify() { return success(); }
 
 LogicalResult AtomicCasOp::verify() {
-  if (getCompare().getType() != getValue().getType())
+  if (getCompare().getType() != getValue().getType()) {
     return emitOpError() << "requires compare and value types to match";
+  }
   return verifyAtomicCommon(getOperation(), getPtr(), getValue().getType(),
                             getOld().getType(), /*bitwise=*/false,
                             getSignednessAttr());
@@ -839,8 +865,9 @@ static LogicalResult verifyNotNestedInVecScope(Operation *op,
 
 static LogicalResult verifyNestedInVecScope(Operation *op,
                                             StringRef opNameForDiag) {
-  if (op->getParentOfType<VecScopeOp>() || op->getParentOfType<StrictVecScopeOp>())
+  if (op->getParentOfType<VecScopeOp>() || op->getParentOfType<StrictVecScopeOp>()) {
     return success();
+  }
   return op->emitOpError()
          << "must be nested under pto.vecscope/pto.strict_vecscope; "
          << opNameForDiag << " is part of the vecscope control sequence";
@@ -848,8 +875,9 @@ static LogicalResult verifyNestedInVecScope(Operation *op,
 
 static LogicalResult verifyAlignTypeLike(Operation *op, Type type,
                                          StringRef roleDescription) {
-  if (!isa<AlignType>(type))
+  if (!isa<AlignType>(type)) {
     return op->emitOpError() << roleDescription << " must be !pto.align";
+  }
   return success();
 }
 
@@ -862,8 +890,9 @@ static bool isSupportedMovPadScalarType(Type type) {
     return intType.isSignless() &&
            (intType.getWidth() == 8 || intType.getWidth() == 16 ||
             intType.getWidth() == 32);
-  if (auto floatType = dyn_cast<FloatType>(type))
+  if (auto floatType = dyn_cast<FloatType>(type)) {
     return floatType.isF16() || floatType.isBF16() || floatType.isF32();
+  }
   return false;
 }
 
@@ -885,10 +914,12 @@ static std::optional<StringRef> getVdupMaskGranularity(Type elementType) {
       return std::nullopt;
     }
   }
-  if (elementType.isF16() || elementType.isBF16())
+  if (elementType.isF16() || elementType.isBF16()) {
     return StringRef("b16");
-  if (elementType.isF32())
+  }
+  if (elementType.isF32()) {
     return StringRef("b32");
+  }
   return std::nullopt;
 }
 
@@ -912,20 +943,24 @@ static bool isLoadAlignProducer(Operation *op) {
 static scf::IfOp getEnclosingBranchIf(Operation *op) {
   for (Operation *cursor = op; cursor; cursor = cursor->getParentOp()) {
     auto ifOp = dyn_cast<scf::IfOp>(cursor);
-    if (!ifOp)
+    if (!ifOp) {
       continue;
+    }
     Region *parentRegion = op->getParentRegion();
-    if (parentRegion == &ifOp.getThenRegion() || parentRegion == &ifOp.getElseRegion())
+    if (parentRegion == &ifOp.getThenRegion() || parentRegion == &ifOp.getElseRegion()) {
       return ifOp;
+    }
   }
   return nullptr;
 }
 
 static bool isValueOwnedByRegion(Value value, Region *region) {
-  if (auto blockArg = dyn_cast<BlockArgument>(value))
+  if (auto blockArg = dyn_cast<BlockArgument>(value)) {
     return blockArg.getParentRegion() == region;
-  if (Operation *def = value.getDefiningOp())
+  }
+  if (Operation *def = value.getDefiningOp()) {
     return def->getParentRegion() == region;
+  }
   return false;
 }
 
@@ -934,7 +969,6 @@ static FailureOr<Value> resolveLoadAlignRoot(Value value, Operation *user);
 
 static FailureOr<Value> resolveStoreAlignRootImpl(
     Value current, llvm::SmallPtrSet<void *, 8> visited) {
-
   while (true) {
     if (!visited.insert(current.getAsOpaquePointer()).second) {
       return failure();
@@ -943,22 +977,26 @@ static FailureOr<Value> resolveStoreAlignRootImpl(
     if (auto blockArg = dyn_cast<BlockArgument>(current)) {
       auto *owner = blockArg.getOwner();
       auto forOp = dyn_cast<scf::ForOp>(owner->getParentOp());
-      if (!forOp)
+      if (!forOp) {
         return failure();
+      }
       unsigned argNumber = blockArg.getArgNumber();
       unsigned ivCount = forOp.getNumInductionVars();
-      if (argNumber < ivCount)
+      if (argNumber < ivCount) {
         return failure();
+      }
       unsigned iterIdx = argNumber - ivCount;
-      if (iterIdx >= forOp.getInitArgs().size())
+      if (iterIdx >= forOp.getInitArgs().size()) {
         return failure();
+      }
       current = forOp.getInitArgs()[iterIdx];
       continue;
     }
 
     if (Operation *def = current.getDefiningOp()) {
-      if (isa<InitAlignOp>(def))
+      if (isa<InitAlignOp>(def)) {
         return current;
+      }
       if (auto stateOp = dyn_cast<PstuOp>(def)) {
         current = stateOp.getAlignIn();
         continue;
@@ -973,18 +1011,21 @@ static FailureOr<Value> resolveStoreAlignRootImpl(
       }
       if (auto forOp = dyn_cast<scf::ForOp>(def)) {
         auto result = dyn_cast<OpResult>(current);
-        if (!result)
+        if (!result) {
           return failure();
+        }
         unsigned resultIdx = result.getResultNumber();
-        if (resultIdx >= forOp.getYieldedValues().size())
+        if (resultIdx >= forOp.getYieldedValues().size()) {
           return failure();
+        }
         current = forOp.getYieldedValues()[resultIdx];
         continue;
       }
       if (auto ifOp = dyn_cast<scf::IfOp>(def)) {
         auto result = dyn_cast<OpResult>(current);
-        if (!result || !ifOp.elseBlock())
+        if (!result || !ifOp.elseBlock()) {
           return failure();
+        }
         unsigned resultIdx = result.getResultNumber();
         auto thenYield = dyn_cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
         auto elseYield = dyn_cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
@@ -996,8 +1037,9 @@ static FailureOr<Value> resolveStoreAlignRootImpl(
             resolveStoreAlignRootImpl(thenYield.getOperand(resultIdx), visited);
         FailureOr<Value> elseRoot =
             resolveStoreAlignRootImpl(elseYield.getOperand(resultIdx), visited);
-        if (failed(thenRoot) || failed(elseRoot) || *thenRoot != *elseRoot)
+        if (failed(thenRoot) || failed(elseRoot) || *thenRoot != *elseRoot) {
           return failure();
+        }
         return *thenRoot;
       }
     }
@@ -1016,8 +1058,9 @@ static LogicalResult verifyStoreAlignLoopThreading(Value align, Operation *user,
   Operation *cursor = user;
   while (auto forOp = cursor->getParentOfType<scf::ForOp>()) {
     Region *body = &forOp.getRegion();
-    if (isValueOwnedByRegion(align, body))
+    if (isValueOwnedByRegion(align, body)) {
       return success();
+    }
     if (!isValueOwnedByRegion(align, body)) {
       return user->emitOpError()
              << roleDescription
@@ -1032,11 +1075,13 @@ static LogicalResult verifyStoreAlignLoopThreading(Value align, Operation *user,
 static FailureOr<Value> resolveSingleAlignIfResult(scf::IfOp ifOp) {
   SmallVector<unsigned> alignResultIndices;
   for (auto [index, type] : llvm::enumerate(ifOp.getResultTypes())) {
-    if (isa<AlignType>(type))
+    if (isa<AlignType>(type)) {
       alignResultIndices.push_back(index);
+    }
   }
-  if (alignResultIndices.size() != 1)
+  if (alignResultIndices.size() != 1) {
     return failure();
+  }
   return ifOp.getResult(alignResultIndices.front());
 }
 
@@ -1107,8 +1152,9 @@ static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
           commonIf = nullptr;
           break;
         }
-        if (!commonIf)
+        if (!commonIf) {
           commonIf = enclosingIf;
+        }
         else if (commonIf != enclosingIf) {
           commonIf = nullptr;
           break;
@@ -1124,8 +1170,9 @@ static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
       return user->emitOpError()
              << "!pto.align value must form a single linear store-state chain";
     }
-    if (nextValues.empty())
+    if (nextValues.empty()) {
       return success();
+    }
     current = nextValues.front();
   }
 
@@ -1134,14 +1181,17 @@ static LogicalResult verifyStoreAlignLinearUses(Value value, Operation *user) {
 
 static LogicalResult verifyStoreAlignChain(Value align, Operation *user,
                                            StringRef roleDescription) {
-  if (disableVPTOAlignChainVerification)
+  if (disableVPTOAlignChainVerification) {
     return success();
+  }
 
-  if (failed(verifyAlignTypeLike(user, align.getType(), roleDescription)))
+  if (failed(verifyAlignTypeLike(user, align.getType(), roleDescription))) {
     return failure();
+  }
 
-  if (failed(verifyStoreAlignLoopThreading(align, user, roleDescription)))
+  if (failed(verifyStoreAlignLoopThreading(align, user, roleDescription))) {
     return failure();
+  }
 
   FailureOr<Value> root = resolveStoreAlignRoot(align, user);
   if (failed(root)) {
@@ -1171,48 +1221,55 @@ static LogicalResult verifyStoreAlignChain(Value align, Operation *user,
 
 static FailureOr<Value> resolveLoadAlignRootImpl(
     Value current, llvm::SmallPtrSet<void *, 8> visited) {
-
   while (true) {
-    if (!visited.insert(current.getAsOpaquePointer()).second)
+    if (!visited.insert(current.getAsOpaquePointer()).second) {
       return failure();
+    }
 
     if (auto blockArg = dyn_cast<BlockArgument>(current)) {
       auto *owner = blockArg.getOwner();
       auto forOp = dyn_cast<scf::ForOp>(owner->getParentOp());
-      if (!forOp)
+      if (!forOp) {
         return failure();
+      }
       unsigned argNumber = blockArg.getArgNumber();
       unsigned ivCount = forOp.getNumInductionVars();
-      if (argNumber < ivCount)
+      if (argNumber < ivCount) {
         return failure();
+      }
       unsigned iterIdx = argNumber - ivCount;
-      if (iterIdx >= forOp.getInitArgs().size())
+      if (iterIdx >= forOp.getInitArgs().size()) {
         return failure();
+      }
       current = forOp.getInitArgs()[iterIdx];
       continue;
     }
 
     if (Operation *def = current.getDefiningOp()) {
-      if (isa<VldasOp>(def))
+      if (isa<VldasOp>(def)) {
         return current;
+      }
       if (auto stateOp = dyn_cast<VldusOp>(def)) {
         current = stateOp.getAlign();
         continue;
       }
       if (auto forOp = dyn_cast<scf::ForOp>(def)) {
         auto result = dyn_cast<OpResult>(current);
-        if (!result)
+        if (!result) {
           return failure();
+        }
         unsigned resultIdx = result.getResultNumber();
-        if (resultIdx >= forOp.getYieldedValues().size())
+        if (resultIdx >= forOp.getYieldedValues().size()) {
           return failure();
+        }
         current = forOp.getYieldedValues()[resultIdx];
         continue;
       }
       if (auto ifOp = dyn_cast<scf::IfOp>(def)) {
         auto result = dyn_cast<OpResult>(current);
-        if (!result || !ifOp.elseBlock())
+        if (!result || !ifOp.elseBlock()) {
           return failure();
+        }
         unsigned resultIdx = result.getResultNumber();
         auto thenYield = dyn_cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
         auto elseYield = dyn_cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
@@ -1224,8 +1281,9 @@ static FailureOr<Value> resolveLoadAlignRootImpl(
             resolveLoadAlignRootImpl(thenYield.getOperand(resultIdx), visited);
         FailureOr<Value> elseRoot =
             resolveLoadAlignRootImpl(elseYield.getOperand(resultIdx), visited);
-        if (failed(thenRoot) || failed(elseRoot) || *thenRoot != *elseRoot)
+        if (failed(thenRoot) || failed(elseRoot) || *thenRoot != *elseRoot) {
           return failure();
+        }
         return *thenRoot;
       }
     }
@@ -1244,8 +1302,9 @@ static LogicalResult verifyLoadAlignLoopThreading(Value align, Operation *user,
   Operation *cursor = user;
   while (auto forOp = cursor->getParentOfType<scf::ForOp>()) {
     Region *body = &forOp.getRegion();
-    if (isValueOwnedByRegion(align, body))
+    if (isValueOwnedByRegion(align, body)) {
       return success();
+    }
     if (!isValueOwnedByRegion(align, body)) {
       return user->emitOpError()
              << roleDescription
@@ -1312,8 +1371,9 @@ static LogicalResult verifyLoadAlignLinearUses(Value value, Operation *user) {
           commonIf = nullptr;
           break;
         }
-        if (!commonIf)
+        if (!commonIf) {
           commonIf = enclosingIf;
+        }
         else if (commonIf != enclosingIf) {
           commonIf = nullptr;
           break;
@@ -1329,8 +1389,9 @@ static LogicalResult verifyLoadAlignLinearUses(Value value, Operation *user) {
       return user->emitOpError()
              << "!pto.align value must form a single linear load-state chain";
     }
-    if (nextValues.empty())
+    if (nextValues.empty()) {
       return success();
+    }
     current = nextValues.front();
   }
 
@@ -1339,14 +1400,17 @@ static LogicalResult verifyLoadAlignLinearUses(Value value, Operation *user) {
 
 static LogicalResult verifyLoadAlignChain(Value align, Operation *user,
                                           StringRef roleDescription) {
-  if (disableVPTOAlignChainVerification)
+  if (disableVPTOAlignChainVerification) {
     return success();
+  }
 
-  if (failed(verifyAlignTypeLike(user, align.getType(), roleDescription)))
+  if (failed(verifyAlignTypeLike(user, align.getType(), roleDescription))) {
     return failure();
+  }
 
-  if (failed(verifyLoadAlignLoopThreading(align, user, roleDescription)))
+  if (failed(verifyLoadAlignLoopThreading(align, user, roleDescription))) {
     return failure();
+  }
 
   FailureOr<Value> root = resolveLoadAlignRoot(align, user);
   if (failed(root)) {
@@ -1398,54 +1462,70 @@ static bool isSupportedPartToken(StringRef part) {
 static bool isSupportedSprToken(StringRef spr) { return spr == "AR"; }
 
 static std::optional<StringRef> normalizeRoundModeToken(StringRef token) {
-  if (token == "R" || token == "ROUND_R")
+  if (token == "R" || token == "ROUND_R") {
     return StringRef("R");
-  if (token == "A" || token == "ROUND_A")
+  }
+  if (token == "A" || token == "ROUND_A") {
     return StringRef("A");
-  if (token == "F" || token == "ROUND_F")
+  }
+  if (token == "F" || token == "ROUND_F") {
     return StringRef("F");
-  if (token == "C" || token == "ROUND_C")
+  }
+  if (token == "C" || token == "ROUND_C") {
     return StringRef("C");
-  if (token == "Z" || token == "ROUND_Z")
+  }
+  if (token == "Z" || token == "ROUND_Z") {
     return StringRef("Z");
-  if (token == "O" || token == "ROUND_O")
+  }
+  if (token == "O" || token == "ROUND_O") {
     return StringRef("O");
-  if (token == "H" || token == "ROUND_H")
+  }
+  if (token == "H" || token == "ROUND_H") {
     return StringRef("H");
+  }
   return std::nullopt;
 }
 
 static std::optional<StringRef> normalizeSaturationToken(StringRef token) {
-  if (token == "SAT" || token == "RS_ENABLE")
+  if (token == "SAT" || token == "RS_ENABLE") {
     return StringRef("SAT");
-  if (token == "NOSAT" || token == "RS_DISABLE")
+  }
+  if (token == "NOSAT" || token == "RS_DISABLE") {
     return StringRef("NOSAT");
+  }
   return std::nullopt;
 }
 
 static std::optional<StringRef> normalizeEvenOddPartToken(StringRef token) {
-  if (token == "EVEN" || token == "PART_EVEN")
+  if (token == "EVEN" || token == "PART_EVEN") {
     return StringRef("EVEN");
-  if (token == "ODD" || token == "PART_ODD")
+  }
+  if (token == "ODD" || token == "PART_ODD") {
     return StringRef("ODD");
+  }
   return std::nullopt;
 }
 
 static std::optional<StringRef> normalizePacked4PartToken(StringRef token) {
-  if (token == "P0" || token == "PART_P0")
+  if (token == "P0" || token == "PART_P0") {
     return StringRef("P0");
-  if (token == "P1" || token == "PART_P1")
+  }
+  if (token == "P1" || token == "PART_P1") {
     return StringRef("P1");
-  if (token == "P2" || token == "PART_P2")
+  }
+  if (token == "P2" || token == "PART_P2") {
     return StringRef("P2");
-  if (token == "P3" || token == "PART_P3")
+  }
+  if (token == "P3" || token == "PART_P3") {
     return StringRef("P3");
+  }
   return std::nullopt;
 }
 
 static std::optional<StringRef> normalizeVcvtPartToken(StringRef token) {
-  if (auto normalized = normalizeEvenOddPartToken(token))
+  if (auto normalized = normalizeEvenOddPartToken(token)) {
     return normalized;
+  }
   return normalizePacked4PartToken(token);
 }
 
@@ -1484,22 +1564,30 @@ struct VcvtContract {
 };
 
 static VcvtElemKind classifyVcvtElemType(Type type) {
-  if (type.isF16())
+  if (type.isF16()) {
     return VcvtElemKind::F16;
-  if (type.isBF16())
+  }
+  if (type.isBF16()) {
     return VcvtElemKind::BF16;
-  if (type.isF32())
+  }
+  if (type.isF32()) {
     return VcvtElemKind::F32;
-  if (pto::isPTOFloat8E4M3LikeType(type))
+  }
+  if (pto::isPTOFloat8E4M3LikeType(type)) {
     return VcvtElemKind::F8E4M3;
-  if (pto::isPTOFloat8E5M2LikeType(type))
+  }
+  if (pto::isPTOFloat8E5M2LikeType(type)) {
     return VcvtElemKind::F8E5M2;
-  if (pto::isPTOHiFloat8Type(type))
+  }
+  if (pto::isPTOHiFloat8Type(type)) {
     return VcvtElemKind::HiF8;
-  if (isa<pto::F4E1M2x2Type>(type))
+  }
+  if (isa<pto::F4E1M2x2Type>(type)) {
     return VcvtElemKind::F4E1M2x2;
-  if (isa<pto::F4E2M1x2Type>(type))
+  }
+  if (isa<pto::F4E2M1x2Type>(type)) {
     return VcvtElemKind::F4E2M1x2;
+  }
   if (auto intType = dyn_cast<IntegerType>(type)) {
     switch (intType.getWidth()) {
     case 8:
@@ -1548,10 +1636,12 @@ static std::optional<VcvtPartFamily> classifyVcvtPartFamily(unsigned srcBits,
                                                             unsigned dstBits) {
   unsigned largerBits = std::max(srcBits, dstBits);
   unsigned smallerBits = std::min(srcBits, dstBits);
-  if (largerBits == smallerBits * 2)
+  if (largerBits == smallerBits * 2) {
     return VcvtPartFamily::EvenOdd;
-  if (largerBits == smallerBits * 4)
+  }
+  if (largerBits == smallerBits * 4) {
     return VcvtPartFamily::Packed4;
+  }
   return std::nullopt;
 }
 
@@ -1567,8 +1657,9 @@ static bool isValidVcvtPartForFamily(StringRef part, VcvtPartFamily family) {
 
 static bool isValidVcvtRoundModeForContract(StringRef roundMode,
                                             const VcvtContract &contract) {
-  if (!contract.allowedRndModes)
+  if (!contract.allowedRndModes) {
     return true;
+  }
   return StringRef(contract.allowedRndModes).contains(roundMode);
 }
 
@@ -1758,14 +1849,18 @@ static std::optional<VcvtContract> lookupVcvtContract(VcvtElemKind src,
 } // namespace
 
 static std::optional<unsigned> getDistElementWidth(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth();
-  if (type.isF16() || type.isBF16())
+  }
+  if (type.isF16() || type.isBF16()) {
     return 16;
-  if (type.isF32())
+  }
+  if (type.isF32()) {
     return 32;
-  if (type.isF64())
+  }
+  if (type.isF64()) {
     return 64;
+  }
   return std::nullopt;
 }
 
@@ -1798,23 +1893,31 @@ static bool isSupportedVstsx2DistToken(StringRef dist) {
 static std::optional<StringRef>
 getVstsMaskGranularityOverride(StringRef dist, Type elementType) {
   auto width = getDistElementWidth(elementType);
-  if (!width)
+  if (!width) {
     return std::nullopt;
+  }
 
-  if (dist == "MRG4CHN_B8")
+  if (dist == "MRG4CHN_B8") {
     return StringRef("b32");
-  if (dist == "MRG2CHN_B8")
+  }
+  if (dist == "MRG2CHN_B8") {
     return StringRef("b16");
-  if (dist == "MRG2CHN_B16")
+  }
+  if (dist == "MRG2CHN_B16") {
     return StringRef("b32");
-  if (dist == "PK_B16")
+  }
+  if (dist == "PK_B16") {
     return StringRef("b16");
-  if (dist == "PK_B32" || dist == "PK_B64" || dist == "PK4_B32")
+  }
+  if (dist == "PK_B32" || dist == "PK_B64" || dist == "PK4_B32") {
     return StringRef("b32");
-  if (dist == "PK_B64")
+  }
+  if (dist == "PK_B64") {
     return StringRef("b32");
-  if (dist == "PK4_B32")
+  }
+  if (dist == "PK4_B32") {
     return StringRef("b32");
+  }
 
   return std::nullopt;
 }
@@ -1824,15 +1927,18 @@ static bool isSupportedPostMode(StringRef mode) {
 }
 
 static unsigned getIntOrFloatBitWidth(Type type) {
-  if (auto intType = dyn_cast<IntegerType>(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
     return intType.getWidth();
-  if (auto floatType = dyn_cast<FloatType>(type))
+  }
+  if (auto floatType = dyn_cast<FloatType>(type)) {
     return floatType.getWidth();
+  }
   if (pto::isPTOFloat8Type(type) || pto::isPTOHiFloat8Type(type) ||
       pto::isPTOFloat4PackedType(type))
     return 8;
-  if (pto::isPTOHiFloat8x2Type(type))
+  if (pto::isPTOHiFloat8x2Type(type)) {
     return 16;
+  }
   return 0;
 }
 
@@ -1842,18 +1948,21 @@ static bool isIntegerOrFloatLike(Type type) {
 
 static std::optional<int64_t> getVRegStorageBitWidth(Type type) {
   auto vecType = dyn_cast<VRegType>(type);
-  if (!vecType)
+  if (!vecType) {
     return std::nullopt;
+  }
   unsigned elemWidth = getIntOrFloatBitWidth(vecType.getElementType());
-  if (!elemWidth)
+  if (!elemWidth) {
     return std::nullopt;
+  }
   return vecType.getElementCount() * static_cast<int64_t>(elemWidth);
 }
 
 static LogicalResult verifyIntegerVRegTypeLike(Operation *op, Type type,
                                               StringRef roleDescription) {
-  if (failed(verifyVRegTypeLike(op, type, roleDescription)))
+  if (failed(verifyVRegTypeLike(op, type, roleDescription))) {
     return failure();
+  }
   auto vecType = cast<VRegType>(type);
   if (!isa<IntegerType>(vecType.getElementType()))
     return op->emitOpError()
@@ -1886,8 +1995,9 @@ static MemoryRole classifyMemoryRole(Type type) {
   }
 
   Attribute memorySpace = memrefType.getMemorySpace();
-  if (!memorySpace)
+  if (!memorySpace) {
     return MemoryRole::Unknown;
+  }
 
   if (auto addrSpace = dyn_cast<pto::AddressSpaceAttr>(memorySpace)) {
     switch (addrSpace.getAddressSpace()) {
@@ -1934,22 +2044,26 @@ static int64_t getBufferElementByteSize(Type type) {
 }
 
 static Type getBufferElementType(Type type) {
-  if (auto ptrType = dyn_cast<pto::PtrType>(type))
+  if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
     return ptrType.getElementType();
-  if (auto memrefType = dyn_cast<BaseMemRefType>(type))
+  }
+  if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
     return memrefType.getElementType();
+  }
   return {};
 }
 
 static std::optional<AddressSpace> getBufferAddressSpace(Type type) {
-  if (auto ptrType = dyn_cast<pto::PtrType>(type))
+  if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
     return ptrType.getMemorySpace().getAddressSpace();
+  }
   if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
     if (auto space =
             dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace()))
       return space.getAddressSpace();
-    if (auto intSpace = dyn_cast_or_null<IntegerAttr>(memrefType.getMemorySpace()))
+    if (auto intSpace = dyn_cast_or_null<IntegerAttr>(memrefType.getMemorySpace())) {
       return static_cast<AddressSpace>(intSpace.getInt());
+    }
   }
   return std::nullopt;
 }
@@ -1962,8 +2076,9 @@ static LogicalResult verifyCubeBridgeLoadLikeOp(BridgeLoadOp op,
       !isBufferLike(op.getDestination().getType()))
     return op.emitOpError("requires buffer-like source and destination");
 
-  if (getBufferAddressSpace(op.getSource().getType()) != AddressSpace::MAT)
+  if (getBufferAddressSpace(op.getSource().getType()) != AddressSpace::MAT) {
     return op.emitOpError("requires MAT source");
+  }
   if (getBufferAddressSpace(op.getDestination().getType()) != expectedDstSpace) {
     return op.emitOpError()
            << "requires " << dstName << " destination";
@@ -1986,8 +2101,9 @@ static LogicalResult verifyCubeBridgeLoadLikeOp(BridgeLoadOp op,
 
 static ParseResult parseRequiredOperandWithComma(
     OpAsmParser &parser, OpAsmParser::UnresolvedOperand &operand) {
-  if (parser.parseOperand(operand))
+  if (parser.parseOperand(operand)) {
     return failure();
+  }
   (void)parser.parseOptionalComma();
   return success();
 }
@@ -1995,15 +2111,18 @@ static ParseResult parseRequiredOperandWithComma(
 static ParseResult parseDmaTripleGroup(
     OpAsmParser &parser, StringRef keyword,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operands) {
-  if (parser.parseKeyword(keyword) || parser.parseLParen())
+  if (parser.parseKeyword(keyword) || parser.parseLParen()) {
     return failure();
+  }
   for (int i = 0; i < 3; ++i) {
     OpAsmParser::UnresolvedOperand operand;
-    if (parser.parseOperand(operand))
+    if (parser.parseOperand(operand)) {
       return failure();
+    }
     operands.push_back(operand);
-    if (i != 2 && parser.parseComma())
+    if (i != 2 && parser.parseComma()) {
       return failure();
+    }
   }
   return parser.parseRParen();
 }
@@ -2014,18 +2133,22 @@ static ParseResult parseOptionalDmaTripleGroupAlias(
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operands) {
   parsedKeyword = {};
   for (StringRef keyword : keywords) {
-    if (failed(parser.parseOptionalKeyword(keyword)))
+    if (failed(parser.parseOptionalKeyword(keyword))) {
       continue;
+    }
     parsedKeyword = keyword;
-    if (parser.parseLParen())
+    if (parser.parseLParen()) {
       return failure();
+    }
     for (int i = 0; i < 3; ++i) {
       OpAsmParser::UnresolvedOperand operand;
-      if (parser.parseOperand(operand))
+      if (parser.parseOperand(operand)) {
         return failure();
+      }
       operands.push_back(operand);
-      if (i != 2 && parser.parseComma())
+      if (i != 2 && parser.parseComma()) {
         return failure();
+      }
     }
     return parser.parseRParen();
   }
@@ -2033,12 +2156,15 @@ static ParseResult parseOptionalDmaTripleGroupAlias(
 }
 
 static bool isDmaLoopKeyword(StringRef keyword) {
-  if (keyword == "loop")
+  if (keyword == "loop") {
     return true;
-  if (!keyword.consume_front("loop"))
+  }
+  if (!keyword.consume_front("loop")) {
     return false;
-  if (keyword.empty())
+  }
+  if (keyword.empty()) {
     return false;
+  }
   return llvm::all_of(keyword, llvm::isDigit);
 }
 
@@ -2046,11 +2172,13 @@ static ParseResult parseDmaTripleTypes(OpAsmParser &parser,
                                        SmallVectorImpl<Type> &types) {
   for (int i = 0; i < 3; ++i) {
     Type type;
-    if (parser.parseType(type))
+    if (parser.parseType(type)) {
       return failure();
+    }
     types.push_back(type);
-    if (i != 2 && parser.parseComma())
+    if (i != 2 && parser.parseComma()) {
       return failure();
+    }
   }
   return success();
 }
@@ -2058,8 +2186,9 @@ static ParseResult parseDmaTripleTypes(OpAsmParser &parser,
 static ParseResult parseDmaPadTypes(OpAsmParser &parser,
                                     SmallVectorImpl<Type> &types) {
   Type valueType;
-  if (parser.parseType(valueType))
+  if (parser.parseType(valueType)) {
     return failure();
+  }
   types.push_back(valueType);
   if (succeeded(parser.parseOptionalComma())) {
     Type leftType;
@@ -2087,37 +2216,43 @@ static void printDmaTripleTypes(OpAsmPrinter &printer, StringRef keyword,
 static void printDmaPadGroup(OpAsmPrinter &printer, Value value, Value left,
                              Value right) {
   printer << " pad(" << value;
-  if (left || right)
+  if (left || right) {
     printer << ", " << left << ", " << right;
+  }
   printer << ")";
 }
 
 static void printDmaPadTypes(OpAsmPrinter &printer, Type valueType,
                              Type leftType, Type rightType) {
   printer << ", pad " << valueType;
-  if (leftType || rightType)
+  if (leftType || rightType) {
     printer << ", " << leftType << ", " << rightType;
+  }
 }
 
 static FailureOr<CubeLoadFracMode>
 parseCubeLoadFracModeKeyword(StringRef keyword) {
-  if (std::optional<CubeLoadFracMode> mode = symbolizeCubeLoadFracMode(keyword))
+  if (std::optional<CubeLoadFracMode> mode = symbolizeCubeLoadFracMode(keyword)) {
     return *mode;
+  }
   return failure();
 }
 
 static ParseResult parseFixedKeywordOperandGroup(
     OpAsmParser &parser, StringRef keyword, int operandCount,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operands) {
-  if (parser.parseKeyword(keyword) || parser.parseLParen())
+  if (parser.parseKeyword(keyword) || parser.parseLParen()) {
     return failure();
+  }
   for (int i = 0; i < operandCount; ++i) {
     OpAsmParser::UnresolvedOperand operand;
-    if (parser.parseOperand(operand))
+    if (parser.parseOperand(operand)) {
       return failure();
+    }
     operands.push_back(operand);
-    if (i + 1 != operandCount && parser.parseComma())
+    if (i + 1 != operandCount && parser.parseComma()) {
       return failure();
+    }
   }
   return parser.parseRParen();
 }
@@ -2125,15 +2260,18 @@ static ParseResult parseFixedKeywordOperandGroup(
 static ParseResult parseFixedKeywordTypes(OpAsmParser &parser, StringRef keyword,
                                           int typeCount,
                                           SmallVectorImpl<Type> &types) {
-  if (parser.parseKeyword(keyword))
+  if (parser.parseKeyword(keyword)) {
     return failure();
+  }
   for (int i = 0; i < typeCount; ++i) {
     Type type;
-    if (parser.parseType(type))
+    if (parser.parseType(type)) {
       return failure();
+    }
     types.push_back(type);
-    if (i + 1 != typeCount && parser.parseComma())
+    if (i + 1 != typeCount && parser.parseComma()) {
       return failure();
+    }
   }
   return success();
 }
@@ -2141,16 +2279,19 @@ static ParseResult parseFixedKeywordTypes(OpAsmParser &parser, StringRef keyword
 static ParseResult parseCubeLoadFracSrcLayoutGroup(
     OpAsmParser &parser,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &operands) {
-  if (parser.parseKeyword("src_layout") || parser.parseLParen())
+  if (parser.parseKeyword("src_layout") || parser.parseLParen()) {
     return failure();
+  }
   OpAsmParser::UnresolvedOperand innerStride;
-  if (parser.parseOperand(innerStride))
+  if (parser.parseOperand(innerStride)) {
     return failure();
+  }
   operands.push_back(innerStride);
   if (succeeded(parser.parseOptionalComma())) {
     OpAsmParser::UnresolvedOperand outerStride;
-    if (parser.parseOperand(outerStride))
+    if (parser.parseOperand(outerStride)) {
       return failure();
+    }
     operands.push_back(outerStride);
   }
   return parser.parseRParen();
@@ -2158,16 +2299,19 @@ static ParseResult parseCubeLoadFracSrcLayoutGroup(
 
 static ParseResult parseCubeLoadFracSrcLayoutTypes(OpAsmParser &parser,
                                                    SmallVectorImpl<Type> &types) {
-  if (parser.parseKeyword("src_layout") || parser.parseLParen())
+  if (parser.parseKeyword("src_layout") || parser.parseLParen()) {
     return failure();
+  }
   Type innerStrideType;
-  if (parser.parseType(innerStrideType))
+  if (parser.parseType(innerStrideType)) {
     return failure();
+  }
   types.push_back(innerStrideType);
   if (succeeded(parser.parseOptionalComma())) {
     Type outerStrideType;
-    if (parser.parseType(outerStrideType))
+    if (parser.parseType(outerStrideType)) {
       return failure();
+    }
     types.push_back(outerStrideType);
   }
   return parser.parseRParen();
@@ -2177,8 +2321,9 @@ static void printCubeLoadFracSrcLayoutGroup(OpAsmPrinter &printer,
                                             Value srcInnerStride,
                                             Value srcOuterStride) {
   printer << ", src_layout(" << srcInnerStride;
-  if (srcOuterStride)
+  if (srcOuterStride) {
     printer << ", " << srcOuterStride;
+  }
   printer << ")";
 }
 
@@ -2186,36 +2331,41 @@ static void printCubeLoadFracSrcLayoutTypes(OpAsmPrinter &printer,
                                             Type srcInnerStrideType,
                                             Type srcOuterStrideType) {
   printer << ", src_layout(" << srcInnerStrideType;
-  if (srcOuterStrideType)
+  if (srcOuterStrideType) {
     printer << ", " << srcOuterStrideType;
+  }
   printer << ")";
 }
 
 static FailureOr<AccStoreMode> parseAccStoreModeKeyword(StringRef keyword) {
-  if (std::optional<AccStoreMode> mode = symbolizeAccStoreMode(keyword))
+  if (std::optional<AccStoreMode> mode = symbolizeAccStoreMode(keyword)) {
     return *mode;
+  }
   return failure();
 }
 
 [[maybe_unused]] static ParseResult parseAccStoreModeGroup(
     OpAsmParser &parser, StringRef &modeKeyword,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &modeOperands) {
-  if (parser.parseKeyword(&modeKeyword))
+  if (parser.parseKeyword(&modeKeyword)) {
     return failure();
+  }
   if (failed(parseAccStoreModeKeyword(modeKeyword)))
     return parser.emitError(parser.getCurrentLocation(),
                             "expected one of 'nz2nd', 'nz2dn', or 'nz2nz'");
   auto parseModeOperandWithParens = [&]() -> ParseResult {
     OpAsmParser::UnresolvedOperand operand;
-    if (parser.parseLParen() || parser.parseOperand(operand) || parser.parseRParen())
+    if (parser.parseLParen() || parser.parseOperand(operand) || parser.parseRParen()) {
       return failure();
+    }
     modeOperands.push_back(operand);
     return success();
   };
   auto parseModeOperandAfterLParen = [&]() -> ParseResult {
     OpAsmParser::UnresolvedOperand operand;
-    if (parser.parseOperand(operand) || parser.parseRParen())
+    if (parser.parseOperand(operand) || parser.parseRParen()) {
       return failure();
+    }
     modeOperands.push_back(operand);
     return success();
   };
@@ -2225,17 +2375,21 @@ static FailureOr<AccStoreMode> parseAccStoreModeKeyword(StringRef keyword) {
     return success();
   case AccStoreMode::Nz2dn:
     (void)parser.parseOptionalComma();
-    if (succeeded(parser.parseOptionalKeyword("loop0_src_stride")))
+    if (succeeded(parser.parseOptionalKeyword("loop0_src_stride"))) {
       return parseModeOperandWithParens();
-    if (failed(parser.parseOptionalLParen()))
+    }
+    if (failed(parser.parseOptionalLParen())) {
       return success();
+    }
     return parseModeOperandAfterLParen();
   case AccStoreMode::Nz2nz:
     (void)parser.parseOptionalComma();
-    if (succeeded(parser.parseOptionalKeyword("split")))
+    if (succeeded(parser.parseOptionalKeyword("split"))) {
       return parseModeOperandWithParens();
-    if (failed(parser.parseOptionalLParen()))
+    }
+    if (failed(parser.parseOptionalLParen())) {
       return success();
+    }
     return parseModeOperandAfterLParen();
   }
   return success();
@@ -2244,19 +2398,22 @@ static FailureOr<AccStoreMode> parseAccStoreModeKeyword(StringRef keyword) {
 [[maybe_unused]] static ParseResult
 parseAccStoreModeTypes(OpAsmParser &parser, StringRef modeKeyword,
                        SmallVectorImpl<Type> &modeTypes) {
-  if (parser.parseKeyword(modeKeyword))
+  if (parser.parseKeyword(modeKeyword)) {
     return failure();
+  }
   auto parseModeTypeWithParens = [&]() -> ParseResult {
     Type modeType;
-    if (parser.parseLParen() || parser.parseType(modeType) || parser.parseRParen())
+    if (parser.parseLParen() || parser.parseType(modeType) || parser.parseRParen()) {
       return failure();
+    }
     modeTypes.push_back(modeType);
     return success();
   };
   auto parseModeTypeAfterLParen = [&]() -> ParseResult {
     Type modeType;
-    if (parser.parseType(modeType) || parser.parseRParen())
+    if (parser.parseType(modeType) || parser.parseRParen()) {
       return failure();
+    }
     modeTypes.push_back(modeType);
     return success();
   };
@@ -2266,17 +2423,21 @@ parseAccStoreModeTypes(OpAsmParser &parser, StringRef modeKeyword,
     return success();
   case AccStoreMode::Nz2dn:
     (void)parser.parseOptionalComma();
-    if (succeeded(parser.parseOptionalKeyword("loop0_src_stride")))
+    if (succeeded(parser.parseOptionalKeyword("loop0_src_stride"))) {
       return parseModeTypeWithParens();
-    if (failed(parser.parseOptionalLParen()))
+    }
+    if (failed(parser.parseOptionalLParen())) {
       return success();
+    }
     return parseModeTypeAfterLParen();
   case AccStoreMode::Nz2nz:
     (void)parser.parseOptionalComma();
-    if (succeeded(parser.parseOptionalKeyword("split")))
+    if (succeeded(parser.parseOptionalKeyword("split"))) {
       return parseModeTypeWithParens();
-    if (failed(parser.parseOptionalLParen()))
+    }
+    if (failed(parser.parseOptionalLParen())) {
       return success();
+    }
     return parseModeTypeAfterLParen();
   }
   return success();
@@ -2291,12 +2452,14 @@ parseAccStoreModeTypes(OpAsmParser &parser, StringRef modeKeyword,
   case AccStoreMode::Nz2nd:
     return;
   case AccStoreMode::Nz2dn:
-    if (loop0SrcStride)
+    if (loop0SrcStride) {
       printer << ", loop0_src_stride(" << loop0SrcStride << ")";
+    }
     return;
   case AccStoreMode::Nz2nz:
-    if (split)
+    if (split) {
       printer << ", split(" << split << ")";
+    }
     return;
   }
   llvm_unreachable("unexpected mte_l0c mode");
@@ -2311,12 +2474,14 @@ parseAccStoreModeTypes(OpAsmParser &parser, StringRef modeKeyword,
   case AccStoreMode::Nz2nd:
     return;
   case AccStoreMode::Nz2dn:
-    if (loop0SrcStrideType)
+    if (loop0SrcStrideType) {
       printer << ", loop0_src_stride(" << loop0SrcStrideType << ")";
+    }
     return;
   case AccStoreMode::Nz2nz:
-    if (splitType)
+    if (splitType) {
       printer << ", split(" << splitType << ")";
+    }
     return;
   }
   llvm_unreachable("unexpected mte_l0c mode");
@@ -2343,27 +2508,32 @@ parseAccStoreModeTypes(OpAsmParser &parser, StringRef modeKeyword,
 [[maybe_unused]] static ParseResult parseMteL0cL1OptionalFpc(
     OpAsmParser &parser,
     SmallVectorImpl<OpAsmParser::UnresolvedOperand> &fpcOperands) {
-  if (failed(parser.parseOptionalKeyword("fpc")))
+  if (failed(parser.parseOptionalKeyword("fpc"))) {
     return success();
-  if (parser.parseLParen())
+  }
+  if (parser.parseLParen()) {
     return failure();
+  }
   OpAsmParser::UnresolvedOperand operand;
-  if (parser.parseOperand(operand) || parser.parseRParen())
+  if (parser.parseOperand(operand) || parser.parseRParen()) {
     return failure();
+  }
   fpcOperands.push_back(operand);
   return success();
 }
 
 [[maybe_unused]] static void printMteL0cL1OptionalFpc(OpAsmPrinter &printer,
                                                       Value fpc) {
-  if (fpc)
+  if (fpc) {
     printer << ", fpc(" << fpc << ")";
+  }
 }
 
 [[maybe_unused]] static void
 printMteL0cL1OptionalFpcType(OpAsmPrinter &printer, Type fpcType) {
-  if (fpcType)
+  if (fpcType) {
     printer << ", fpc(" << fpcType << ")";
+  }
 }
 
 [[maybe_unused]] static ParseResult parseMteL0cL1OptionalLoop3Types(
@@ -2372,13 +2542,16 @@ printMteL0cL1OptionalFpcType(OpAsmPrinter &printer, Type fpcType) {
     SmallVectorImpl<Type> &loop3DstStrideTypes, StringRef opName) {
   if (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword))
+    if (parser.parseKeyword(&keyword)) {
       return failure();
-    if (keyword != "loop3")
+    }
+    if (keyword != "loop3") {
       return parser.emitError(parser.getCurrentLocation(), "expected 'loop3'");
+    }
     SmallVector<Type> loop3GroupTypes;
-    if (parseDmaTripleTypes(parser, loop3GroupTypes))
+    if (parseDmaTripleTypes(parser, loop3GroupTypes)) {
       return failure();
+    }
     loop3CountTypes.push_back(loop3GroupTypes[0]);
     loop3SrcStrideTypes.push_back(loop3GroupTypes[1]);
     loop3DstStrideTypes.push_back(loop3GroupTypes[2]);
@@ -2408,20 +2581,25 @@ printMteL0cL1OptionalFpcType(OpAsmPrinter &printer, Type fpcType) {
 
   switch (mode) {
   case AccStoreMode::Nz2nd:
-    if (split)
+    if (split) {
       return op->emitOpError(nz2ndSplitError);
-    if (loop0SrcStride)
+    }
+    if (loop0SrcStride) {
       return op->emitOpError(nz2ndLoop0Error);
+    }
     return success();
   case AccStoreMode::Nz2dn:
-    if (split)
+    if (split) {
       return op->emitOpError(nz2dnSplitError);
+    }
     return success();
   case AccStoreMode::Nz2nz:
-    if (loop0SrcStride)
+    if (loop0SrcStride) {
       return op->emitOpError(nz2nzLoop0Error);
-    if (loop3Count)
+    }
+    if (loop3Count) {
       return op->emitOpError(nz2nzLoop3Error);
+    }
     return success();
   }
   llvm_unreachable("unexpected mte_l0c mode");
@@ -2516,18 +2694,21 @@ static Type getStructuredAccStoreScalingElementType(Value value) {
 
 static bool isStructuredAccStoreClipPayloadForUInt8(Type type) {
   auto intType = dyn_cast<IntegerType>(type);
-  if (!intType || intType.getWidth() != 16)
+  if (!intType || intType.getWidth() != 16) {
     return false;
+  }
   return intType.isUnsigned() || intType.isSignless();
 }
 
 static bool isStructuredAccStoreClipPayloadForSignedInt(Type type) {
   auto intType = dyn_cast<IntegerType>(type);
-  if (!intType)
+  if (!intType) {
     return false;
+  }
   unsigned width = intType.getWidth();
-  if (width != 4 && width != 8 && width != 16)
+  if (width != 4 && width != 8 && width != 16) {
     return false;
+  }
   return intType.isSigned() || intType.isSignless();
 }
 
@@ -2544,13 +2725,16 @@ static bool isStructuredAccStoreFloatScalarPayload(Value value) {
 }
 
 static bool isStructuredAccStoreClipSupportedElementType(Type type) {
-  if (auto floatType = dyn_cast<FloatType>(type))
+  if (auto floatType = dyn_cast<FloatType>(type)) {
     return floatType.isF16();
+  }
   auto intType = dyn_cast<IntegerType>(type);
-  if (!intType)
+  if (!intType) {
     return false;
-  if (intType.isUnsignedInteger(8))
+  }
+  if (intType.isUnsignedInteger(8)) {
     return true;
+  }
   if (intType.isSignlessInteger(4) || intType.isSignlessInteger(8) ||
       intType.isSignlessInteger(16))
     return true;
@@ -2563,13 +2747,15 @@ static bool isStructuredAccStoreClipSupportedElementType(Type type) {
 static LogicalResult verifyStructuredAccStoreClipPayload(Operation *op,
                                                         Type destinationElementType,
                                                         Value clipValue) {
-  if (!clipValue)
+  if (!clipValue) {
     return success();
+  }
 
   Type clipType = clipValue.getType();
   if (destinationElementType.isF16()) {
-    if (!clipType.isF16())
+    if (!clipType.isF16()) {
       return op->emitOpError("clip for f16 destination requires f16 payload");
+    }
     return success();
   }
 
@@ -2580,16 +2766,18 @@ static LogicalResult verifyStructuredAccStoreClipPayload(Operation *op,
            << destinationElementType;
 
   if (intType.isUnsignedInteger(8)) {
-    if (!isStructuredAccStoreClipPayloadForUInt8(clipType))
+    if (!isStructuredAccStoreClipPayloadForUInt8(clipType)) {
       return op->emitOpError("clip for ui8 destination requires ui16/signless i16 payload");
+    }
     return success();
   }
 
   if (intType.isSignlessInteger(4) || intType.isSignlessInteger(8) ||
       intType.isSignlessInteger(16) || intType.isSignedInteger(4) ||
       intType.isSignedInteger(8) || intType.isSignedInteger(16)) {
-    if (!isStructuredAccStoreClipPayloadForSignedInt(clipType))
+    if (!isStructuredAccStoreClipPayloadForSignedInt(clipType)) {
       return op->emitOpError("clip for signed 4/8/16-bit destination requires signed/signless i4/i8/i16 payload");
+    }
     return success();
   }
 
@@ -2725,20 +2913,24 @@ static bool isStructuredAccStoreDestinationFamily(
   case StructuredAccStoreDestinationFamily::BF16:
     return type.isBF16();
   case StructuredAccStoreDestinationFamily::I32:
-    if (auto intType = dyn_cast<IntegerType>(type))
+    if (auto intType = dyn_cast<IntegerType>(type)) {
       return intType.getWidth() == 32;
+    }
     return false;
   case StructuredAccStoreDestinationFamily::I16:
-    if (auto intType = dyn_cast<IntegerType>(type))
+    if (auto intType = dyn_cast<IntegerType>(type)) {
       return intType.getWidth() == 16 && !intType.isUnsigned();
+    }
     return false;
   case StructuredAccStoreDestinationFamily::I8:
-    if (auto intType = dyn_cast<IntegerType>(type))
+    if (auto intType = dyn_cast<IntegerType>(type)) {
       return intType.getWidth() == 8;
+    }
     return false;
   case StructuredAccStoreDestinationFamily::I4:
-    if (auto intType = dyn_cast<IntegerType>(type))
+    if (auto intType = dyn_cast<IntegerType>(type)) {
       return intType.getWidth() == 4 && !intType.isUnsigned();
+    }
     return false;
   case StructuredAccStoreDestinationFamily::FP8:
     return pto::isPTOFloat8Type(type) || pto::isPTOHiFloat8Type(type) ||
@@ -2749,15 +2941,19 @@ static bool isStructuredAccStoreDestinationFamily(
 
 static ParseResult parseStructuredAccStoreUnitFlag(OpAsmParser &parser,
                                                    StructuredAccStoreAsmState &state) {
-  if (state.unitFlag)
+  if (state.unitFlag) {
     return parser.emitError(parser.getCurrentLocation(), "duplicate unit_flag clause");
+  }
   StringRef keyword;
-  if (parser.parseLParen() || parser.parseKeyword(&keyword) || parser.parseRParen())
+  if (parser.parseLParen() || parser.parseKeyword(&keyword) || parser.parseRParen()) {
     return failure();
-  if (keyword == "check_only")
+  }
+  if (keyword == "check_only") {
     state.unitFlag = AccStoreUnitFlagCtrl::CheckOnly;
-  else if (keyword == "check_and_clear")
+  }
+  else if (keyword == "check_and_clear") {
     state.unitFlag = AccStoreUnitFlagCtrl::CheckAndClear;
+  }
   else
     return parser.emitError(parser.getCurrentLocation(),
                             "expected 'check_only' or 'check_and_clear'");
@@ -2766,8 +2962,9 @@ static ParseResult parseStructuredAccStoreUnitFlag(OpAsmParser &parser,
 
 static ParseResult parseStructuredAccStorePreQuant(
     OpAsmParser &parser, StructuredAccStoreAsmState &state) {
-  if (state.preQuantMode)
+  if (state.preQuantMode) {
     return parser.emitError(parser.getCurrentLocation(), "duplicate pre_quant clause");
+  }
   OpAsmParser::UnresolvedOperand payload;
   StringRef modeKeyword;
   if (parser.parseLParen() || parser.parseOperand(payload) || parser.parseComma() ||
@@ -2775,8 +2972,9 @@ static ParseResult parseStructuredAccStorePreQuant(
       parser.parseKeyword(&modeKeyword) || parser.parseRParen())
     return failure();
   auto mode = symbolizeAccStoreQuantPreMode(modeKeyword);
-  if (!mode)
+  if (!mode) {
     return parser.emitError(parser.getCurrentLocation(), "invalid pre_quant mode");
+  }
   state.preQuantOperands.push_back(payload);
   state.preQuantMode = *mode;
   return success();
@@ -2784,40 +2982,48 @@ static ParseResult parseStructuredAccStorePreQuant(
 
 static ParseResult parseStructuredAccStorePreRelu(
     OpAsmParser &parser, StructuredAccStoreAsmState &state) {
-  if (state.preReluMode)
+  if (state.preReluMode) {
     return parser.emitError(parser.getCurrentLocation(), "duplicate pre_relu clause");
+  }
   StringRef modeKeyword;
   bool hasPayload = false;
   OpAsmParser::UnresolvedOperand payload;
-  if (parser.parseLParen())
+  if (parser.parseLParen()) {
     return failure();
+  }
   if (failed(parser.parseOptionalKeyword("mode"))) {
     hasPayload = true;
     if (parser.parseOperand(payload) || parser.parseComma() ||
         parser.parseKeyword("mode"))
       return failure();
   }
-  if (parser.parseEqual() || parser.parseKeyword(&modeKeyword))
+  if (parser.parseEqual() || parser.parseKeyword(&modeKeyword)) {
     return failure();
+  }
   auto mode = symbolizeReluPreMode(modeKeyword);
-  if (!mode)
+  if (!mode) {
     return parser.emitError(parser.getCurrentLocation(), "invalid pre_relu mode");
+  }
   if (succeeded(parser.parseOptionalComma())) {
-    if (parser.parseKeyword("clip") || parser.parseEqual())
+    if (parser.parseKeyword("clip") || parser.parseEqual()) {
       return failure();
+    }
     if (!state.clipValueOperands.empty())
       return parser.emitError(parser.getCurrentLocation(),
                               "duplicate clip payload in pre_relu clause");
     OpAsmParser::UnresolvedOperand clipValue;
-    if (parser.parseOperand(clipValue))
+    if (parser.parseOperand(clipValue)) {
       return failure();
+    }
     state.clipValueOperands.push_back(clipValue);
   }
-  if (parser.parseRParen())
+  if (parser.parseRParen()) {
     return failure();
+  }
 
-  if (hasPayload)
+  if (hasPayload) {
     state.preReluOperands.push_back(payload);
+  }
   state.preReluMode = *mode;
   return success();
 }
@@ -2828,21 +3034,24 @@ static ParseResult parseStructuredAccStoreLayout(
   if (failed(mode))
     return parser.emitError(parser.getCurrentLocation(),
                             "expected one of 'nz2nd', 'nz2dn', or 'nz2nz'");
-  if (state.mode)
+  if (state.mode) {
     return parser.emitError(parser.getCurrentLocation(), "duplicate layout clause");
+  }
   state.mode = *mode;
   if (*mode == AccStoreMode::Nz2dn) {
     if (succeeded(parser.parseOptionalLParen())) {
       OpAsmParser::UnresolvedOperand operand;
-      if (parser.parseOperand(operand) || parser.parseRParen())
+      if (parser.parseOperand(operand) || parser.parseRParen()) {
         return failure();
+      }
       state.loop0SrcStrideOperands.push_back(operand);
     }
   } else if (*mode == AccStoreMode::Nz2nz) {
     if (succeeded(parser.parseOptionalLParen())) {
       OpAsmParser::UnresolvedOperand operand;
-      if (parser.parseOperand(operand) || parser.parseRParen())
+      if (parser.parseOperand(operand) || parser.parseRParen()) {
         return failure();
+      }
       state.splitOperands.push_back(operand);
     }
   }
@@ -2851,8 +3060,9 @@ static ParseResult parseStructuredAccStoreLayout(
 
 static ParseResult parseStructuredAccStoreLoop3(
     OpAsmParser &parser, StructuredAccStoreAsmState &state) {
-  if (!state.loop3CountOperands.empty())
+  if (!state.loop3CountOperands.empty()) {
     return parser.emitError(parser.getCurrentLocation(), "duplicate loop3 clause");
+  }
   OpAsmParser::UnresolvedOperand count;
   OpAsmParser::UnresolvedOperand srcStride;
   OpAsmParser::UnresolvedOperand dstStride;
@@ -2868,8 +3078,9 @@ static ParseResult parseStructuredAccStoreLoop3(
 
 static ParseResult parseStructuredAccStoreAtomic(
     OpAsmParser &parser, StructuredAccStoreAsmState &state) {
-  if (state.atomicType || state.atomicOp)
+  if (state.atomicType || state.atomicOp) {
     return parser.emitError(parser.getCurrentLocation(), "duplicate atomic clause");
+  }
   StringRef typeKeyword;
   StringRef opKeyword;
   if (parser.parseLParen() || parser.parseKeyword("type") || parser.parseEqual() ||
@@ -2879,10 +3090,12 @@ static ParseResult parseStructuredAccStoreAtomic(
     return failure();
   auto type = symbolizeAccStoreAtomicType(typeKeyword);
   auto op = symbolizeAccStoreAtomicOp(opKeyword);
-  if (!type)
+  if (!type) {
     return parser.emitError(parser.getCurrentLocation(), "invalid atomic type");
-  if (!op)
+  }
+  if (!op) {
     return parser.emitError(parser.getCurrentLocation(), "invalid atomic op");
+  }
   state.atomicType = *type;
   state.atomicOp = *op;
   return success();
@@ -2894,33 +3107,42 @@ static ParseResult parseStructuredAccStoreClauses(
   bool seenClause = false;
   while (true) {
     if (seenClause) {
-      if (failed(parser.parseOptionalComma()))
+      if (failed(parser.parseOptionalComma())) {
         return success();
+      }
     }
     StringRef keyword;
     OptionalParseResult optParseResult = parser.parseOptionalKeyword(&keyword);
     if (!optParseResult.has_value() || failed(*optParseResult)) {
-      if (!seenClause)
+      if (!seenClause) {
         return success();
+      }
       return parser.emitError(parser.getCurrentLocation(), "expected valid keyword");
     }
     seenClause = true;
 
     StructuredAccStoreClauseKind kind;
-    if (keyword == "unit_flag")
+    if (keyword == "unit_flag") {
       kind = StructuredAccStoreClauseKind::UnitFlag;
-    else if (keyword == "pre_quant")
+    }
+    else if (keyword == "pre_quant") {
       kind = StructuredAccStoreClauseKind::PreQuant;
-    else if (keyword == "pre_relu")
+    }
+    else if (keyword == "pre_relu") {
       kind = StructuredAccStoreClauseKind::PreRelu;
-    else if (keyword == "nz2nd" || keyword == "nz2dn" || keyword == "nz2nz")
+    }
+    else if (keyword == "nz2nd" || keyword == "nz2dn" || keyword == "nz2nz") {
       kind = StructuredAccStoreClauseKind::Layout;
-    else if (keyword == "loop3")
+    }
+    else if (keyword == "loop3") {
       kind = StructuredAccStoreClauseKind::Loop3;
-    else if (keyword == "sat" || keyword == "nosat")
+    }
+    else if (keyword == "sat" || keyword == "nosat") {
       kind = StructuredAccStoreClauseKind::Sat;
-    else if (keyword == "atomic")
+    }
+    else if (keyword == "atomic") {
       kind = StructuredAccStoreClauseKind::Atomic;
+    }
     else
       return parser.emitError(parser.getCurrentLocation(), "unknown mte_l0c clause");
 
@@ -2948,8 +3170,9 @@ static ParseResult parseStructuredAccStoreClauses(
       parseResult = parseStructuredAccStoreLoop3(parser, state);
       break;
     case StructuredAccStoreClauseKind::Sat:
-      if (state.satMode)
+      if (state.satMode) {
         return parser.emitError(parser.getCurrentLocation(), "duplicate sat/nosat clause");
+      }
       if (keyword == "nosat") {
         state.satMode = AccStoreSatMode::NoSat;
         break;
@@ -2959,8 +3182,9 @@ static ParseResult parseStructuredAccStoreClauses(
         if (parser.parseKeyword(&satOption) || satOption != "preserve_nan")
           return parser.emitError(parser.getCurrentLocation(),
                                   "expected preserve_nan");
-        if (parser.parseRParen())
+        if (parser.parseRParen()) {
           return failure();
+        }
         state.satMode = AccStoreSatMode::SatPreserveNan;
       } else {
         state.satMode = AccStoreSatMode::Sat;
@@ -2970,16 +3194,18 @@ static ParseResult parseStructuredAccStoreClauses(
       parseResult = parseStructuredAccStoreAtomic(parser, state);
       break;
     }
-    if (failed(parseResult))
+    if (failed(parseResult)) {
       return failure();
+    }
   }
 }
 
 static ParseResult parseStructuredOptionalType(OpAsmParser &parser,
                                                SmallVectorImpl<Type> &types) {
   Type type;
-  if (parser.parseType(type))
+  if (parser.parseType(type)) {
     return failure();
+  }
   types.push_back(type);
   return success();
 }
@@ -2995,25 +3221,29 @@ static LogicalResult verifyStructuredAccStoreLike(
     std::optional<AccStoreAtomicType> atomicType,
     std::optional<AccStoreAtomicOp> atomicOp, bool allowAtomic) {
   auto getBufferElementType = [](Type type) -> Type {
-    if (auto ptrType = dyn_cast<pto::PtrType>(type))
+    if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
       return ptrType.getElementType();
-    if (auto memrefType = dyn_cast<BaseMemRefType>(type))
+    }
+    if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
       return memrefType.getElementType();
+    }
     return {};
   };
   Type sourceElementType = getBufferElementType(srcType);
   Type destinationElementType = getBufferElementType(dstType);
 
-  if (static_cast<bool>(preQuant) != static_cast<bool>(preQuantMode))
+  if (static_cast<bool>(preQuant) != static_cast<bool>(preQuantMode)) {
     return op->emitOpError("pre_quant requires payload and mode together");
+  }
   if (preQuantMode) {
     if (*preQuantMode == AccStoreQuantPreMode::NoConvert) {
       // The no_convert keyword carries no quantization parameters; the
       // syntactic payload operand is ignored for compatibility with the
       // structured pre_quant clause form.
     } else if (isStructuredAccStoreVectorQuantMode(*preQuantMode)) {
-      if (!isStructuredAccStoreScalingPayload(preQuant))
+      if (!isStructuredAccStoreScalingPayload(preQuant)) {
         return op->emitOpError("vector pre_quant mode requires scaling pointer payload");
+      }
       if (!isStructuredAccStoreFloatScalarPayloadType(
               getStructuredAccStoreScalingElementType(preQuant)))
         return op->emitOpError(
@@ -3032,11 +3262,13 @@ static LogicalResult verifyStructuredAccStoreLike(
 
     if (*preQuantMode != AccStoreQuantPreMode::NoConvert) {
       if (isa<Float32Type>(sourceElementType)) {
-        if (!isStructuredAccStoreFloatPreQuantMode(*preQuantMode))
+        if (!isStructuredAccStoreFloatPreQuantMode(*preQuantMode)) {
           return emitIncompatibleQuantModeError();
+        }
       } else if (sourceElementType.isSignlessInteger(32)) {
-        if (!isStructuredAccStoreInt32PreQuantMode(*preQuantMode))
+        if (!isStructuredAccStoreInt32PreQuantMode(*preQuantMode)) {
           return emitIncompatibleQuantModeError();
+        }
       } else {
         return op->emitOpError()
                << "pre_quant requires source element type to be f32 or i32, got "
@@ -3060,31 +3292,39 @@ static LogicalResult verifyStructuredAccStoreLike(
     return failure();
 
   if (!preReluMode) {
-    if (preRelu)
+    if (preRelu) {
       return op->emitOpError("pre_relu payload requires pre_relu mode");
-    if (clipValue)
+    }
+    if (clipValue) {
       return op->emitOpError("clip requires pre_relu clause");
+    }
   } else {
     switch (*preReluMode) {
     case ReluPreMode::NoRelu:
-      if (preRelu)
+      if (preRelu) {
         return op->emitOpError("mode does not accept pre_relu payload");
+      }
       break;
     case ReluPreMode::NormalRelu:
-      if (preRelu)
+      if (preRelu) {
         return op->emitOpError("mode does not accept pre_relu payload");
+      }
       break;
     case ReluPreMode::ScalarRelu:
-      if (!preRelu)
+      if (!preRelu) {
         return op->emitOpError("scalar_relu requires payload");
-      if (!isStructuredAccStoreFloatScalarPayload(preRelu))
+      }
+      if (!isStructuredAccStoreFloatScalarPayload(preRelu)) {
         return op->emitOpError("scalar_relu requires f16/bf16/f32 payload");
+      }
       break;
     case ReluPreMode::VectorRelu:
-      if (!preRelu)
+      if (!preRelu) {
         return op->emitOpError("vector_relu requires payload");
-      if (!isStructuredAccStoreScalingPayload(preRelu))
+      }
+      if (!isStructuredAccStoreScalingPayload(preRelu)) {
         return op->emitOpError("vector_relu requires scaling pointer payload");
+      }
       if (!isStructuredAccStoreFloatScalarPayloadType(
               getStructuredAccStoreScalingElementType(preRelu)))
         return op->emitOpError(
@@ -3097,29 +3337,37 @@ static LogicalResult verifyStructuredAccStoreLike(
 
   bool hasLoop3 = static_cast<bool>(loop3Count) || static_cast<bool>(loop3SrcStride) ||
                   static_cast<bool>(loop3DstStride);
-  if (hasLoop3 && !(loop3Count && loop3SrcStride && loop3DstStride))
+  if (hasLoop3 && !(loop3Count && loop3SrcStride && loop3DstStride)) {
     return op->emitOpError("loop3 requires count, src stride, and dst stride together");
+  }
 
   if (!mode) {
-    if (split)
+    if (split) {
       return op->emitOpError("split requires nz2nz");
-    if (loop0SrcStride)
+    }
+    if (loop0SrcStride) {
       return op->emitOpError("loop0_src_stride requires nz2dn");
-    if (loop3Count)
+    }
+    if (loop3Count) {
       return op->emitOpError("loop3 requires nz2nd or nz2dn");
+    }
   } else {
     switch (*mode) {
     case AccStoreMode::Nz2nd:
-      if (split)
+      if (split) {
         return op->emitOpError("nz2nd does not accept split");
-      if (loop0SrcStride)
+      }
+      if (loop0SrcStride) {
         return op->emitOpError("nz2nd does not accept loop0_src_stride");
+      }
       break;
     case AccStoreMode::Nz2dn: {
-      if (!loop0SrcStride)
+      if (!loop0SrcStride) {
         return op->emitOpError("nz2dn requires loop0_src_stride");
-      if (split)
+      }
+      if (split) {
         return op->emitOpError("nz2dn does not accept split");
+      }
       APInt loop0Value;
       if (unitFlag && *unitFlag != AccStoreUnitFlagCtrl::Off &&
           (!matchPattern(loop0SrcStride, m_ConstantInt(&loop0Value)) ||
@@ -3130,10 +3378,12 @@ static LogicalResult verifyStructuredAccStoreLike(
       break;
     }
     case AccStoreMode::Nz2nz:
-      if (loop0SrcStride)
+      if (loop0SrcStride) {
         return op->emitOpError("nz2nz does not accept loop0_src_stride");
-      if (loop3Count)
+      }
+      if (loop3Count) {
         return op->emitOpError("loop3 requires nz2nd or nz2dn");
+      }
       if (!isa<FloatType>(destinationElementType) ||
           !cast<FloatType>(destinationElementType).isF32())
         return op->emitOpError("nz2nz requires destination element type to be f32");
@@ -3141,10 +3391,12 @@ static LogicalResult verifyStructuredAccStoreLike(
     }
   }
 
-  if (static_cast<bool>(atomicType) != static_cast<bool>(atomicOp))
+  if (static_cast<bool>(atomicType) != static_cast<bool>(atomicOp)) {
     return op->emitOpError("atomic requires type and op together");
-  if ((atomicType || atomicOp) && !allowAtomic)
+  }
+  if ((atomicType || atomicOp) && !allowAtomic) {
     return op->emitOpError("atomic is only supported for mte_l0c_gm");
+  }
 
   return success();
 }
@@ -3171,11 +3423,13 @@ static void printStructuredAccStoreClauses(
   }
   if (preReluMode) {
     printer << ", pre_relu(";
-    if (preRelu)
+    if (preRelu) {
       printer << preRelu << ", ";
+    }
     printer << "mode = " << stringifyReluPreMode(*preReluMode);
-    if (clipValue)
+    if (clipValue) {
       printer << ", clip = " << clipValue;
+    }
     printer << ")";
   }
   if (mode) {
@@ -3185,13 +3439,15 @@ static void printStructuredAccStoreClauses(
       break;
     case AccStoreMode::Nz2dn:
       printer << ", nz2dn";
-      if (loop0SrcStride)
+      if (loop0SrcStride) {
         printer << "(" << loop0SrcStride << ")";
+      }
       break;
     case AccStoreMode::Nz2nz:
       printer << ", nz2nz";
-      if (split)
+      if (split) {
         printer << "(" << split << ")";
+      }
       break;
     }
   }
@@ -3222,16 +3478,21 @@ static void printStructuredAccStoreOptionalTypes(
     OpAsmPrinter &printer, Value preQuant, Value preRelu, Value clipValue,
     Value split, Value loop0SrcStride, Value loop3Count, Value loop3SrcStride,
     Value loop3DstStride) {
-  if (preQuant)
+  if (preQuant) {
     printer << ", " << preQuant.getType();
-  if (preRelu)
+  }
+  if (preRelu) {
     printer << ", " << preRelu.getType();
-  if (clipValue)
+  }
+  if (clipValue) {
     printer << ", " << clipValue.getType();
-  if (split)
+  }
+  if (split) {
     printer << ", " << split.getType();
-  if (loop0SrcStride)
+  }
+  if (loop0SrcStride) {
     printer << ", " << loop0SrcStride.getType();
+  }
   if (loop3Count)
     printer << ", " << loop3Count.getType() << ", " << loop3SrcStride.getType()
             << ", " << loop3DstStride.getType();
@@ -3389,10 +3650,12 @@ static LogicalResult verifyCopyGmToUbufOp(CopyOp op, bool expectSourceGM) {
   int64_t sourceElemBytes = getBufferElementByteSize(op.getSource().getType());
   int64_t destinationElemBytes =
       getBufferElementByteSize(op.getDestination().getType());
-  if (sourceElemBytes <= 0 || destinationElemBytes <= 0)
+  if (sourceElemBytes <= 0 || destinationElemBytes <= 0) {
     return op.emitOpError("requires copy source and destination element types with known byte width");
-  if (sourceElemBytes != destinationElemBytes)
+  }
+  if (sourceElemBytes != destinationElemBytes) {
     return op.emitOpError("requires source and destination element byte widths to match");
+  }
 
   return success();
 }
@@ -3451,10 +3714,12 @@ static LogicalResult verifyCopyUbufToGmOp(CopyOp op, bool expectSourceGM) {
   int64_t sourceElemBytes = getBufferElementByteSize(op.getSource().getType());
   int64_t destinationElemBytes =
       getBufferElementByteSize(op.getDestination().getType());
-  if (sourceElemBytes <= 0 || destinationElemBytes <= 0)
+  if (sourceElemBytes <= 0 || destinationElemBytes <= 0) {
     return op.emitOpError("requires copy source and destination element types with known byte width");
-  if (sourceElemBytes != destinationElemBytes)
+  }
+  if (sourceElemBytes != destinationElemBytes) {
     return op.emitOpError("requires source and destination element byte widths to match");
+  }
 
   return success();
 }
@@ -3473,10 +3738,12 @@ static LogicalResult verifyCopyCbufToUbufLikeOp(CopyOp op) {
   int64_t sourceElemBytes = getBufferElementByteSize(op.getSource().getType());
   int64_t destinationElemBytes =
       getBufferElementByteSize(op.getDestination().getType());
-  if (sourceElemBytes <= 0 || destinationElemBytes <= 0)
+  if (sourceElemBytes <= 0 || destinationElemBytes <= 0) {
     return op.emitOpError("requires copy source and destination element types with known byte width");
-  if (sourceElemBytes != destinationElemBytes)
+  }
+  if (sourceElemBytes != destinationElemBytes) {
     return op.emitOpError("requires source and destination element byte widths to match");
+  }
 
   return success();
 }
@@ -3532,8 +3799,9 @@ LogicalResult VRegType::verify(function_ref<InFlightDiagnostic()> emitError,
 
 LogicalResult VecScopeOp::verify() {
   Region &bodyRegion = getBody();
-  if (bodyRegion.empty())
+  if (bodyRegion.empty()) {
     return emitOpError("expects a non-empty body region");
+  }
 
   Block &body = bodyRegion.front();
   if (body.getNumArguments() != 0)
@@ -3545,8 +3813,9 @@ LogicalResult VecScopeOp::verify() {
 
 LogicalResult StrictVecScopeOp::verify() {
   Region &bodyRegion = getBody();
-  if (bodyRegion.empty())
+  if (bodyRegion.empty()) {
     return emitOpError("expects a non-empty body region");
+  }
 
   Block &body = bodyRegion.front();
   if (body.getNumArguments() != getCaptures().size())
@@ -3613,12 +3882,15 @@ void MteGmUbOp::build(OpBuilder &builder, OperationState &state, Value source,
                       std::optional<pto::DmaPadConfig> pad) {
   state.addOperands({source, destination, l2CacheCtl, lenBurst, nburst.count,
                      nburst.srcStride, nburst.dstStride});
-  for (const pto::DmaLoopConfig &loop : loops)
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.count);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.srcStride);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.dstStride);
+  }
   bool hasPadCounts = pad && pad->leftCount && pad->rightCount;
   assert((!pad || static_cast<bool>(pad->leftCount) ==
                        static_cast<bool>(pad->rightCount)) &&
@@ -3646,10 +3918,12 @@ void MteGmUbOp::build(OpBuilder &builder, OperationState &state, Value source,
                       std::optional<pto::DmaLoopConfig> loop2,
                       std::optional<pto::DmaPadConfig> pad) {
   SmallVector<pto::DmaLoopConfig> loops;
-  if (loop1)
+  if (loop1) {
     loops.push_back(*loop1);
-  if (loop2)
+  }
+  if (loop2) {
     loops.push_back(*loop2);
+  }
   build(builder, state, source, destination, l2CacheCtl, lenBurst, nburst,
         loops, pad);
 }
@@ -3669,11 +3943,13 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   while (true) {
     if (succeeded(parser.parseOptionalKeyword("pad"))) {
-      if (parser.parseLParen())
+      if (parser.parseLParen()) {
         return failure();
+      }
       OpAsmParser::UnresolvedOperand value;
-      if (parser.parseOperand(value))
+      if (parser.parseOperand(value)) {
         return failure();
+      }
       padOperands.push_back(value);
       if (succeeded(parser.parseOptionalComma())) {
         OpAsmParser::UnresolvedOperand left;
@@ -3684,8 +3960,9 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
         padOperands.push_back(left);
         padOperands.push_back(right);
       }
-      if (parser.parseRParen())
+      if (parser.parseRParen()) {
         return failure();
+      }
       break;
     }
 
@@ -3694,15 +3971,17 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
                                          parsedKeyword, loopGroupOperands))
       return failure();
-    if (parsedKeyword.empty())
+    if (parsedKeyword.empty()) {
       break;
+    }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
     loopDstStrideOperands.push_back(loopGroupOperands[2]);
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, l2CacheCtlType, lenBurstType;
   SmallVector<Type> nburstTypes, loopCountTypes, loopSrcStrideTypes,
@@ -3715,20 +3994,23 @@ ParseResult MteGmUbOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword))
+    if (parser.parseKeyword(&keyword)) {
       return failure();
+    }
     if (isDmaLoopKeyword(keyword)) {
       SmallVector<Type> loopGroupTypes;
-      if (parseDmaTripleTypes(parser, loopGroupTypes))
+      if (parseDmaTripleTypes(parser, loopGroupTypes)) {
         return failure();
+      }
       loopCountTypes.push_back(loopGroupTypes[0]);
       loopSrcStrideTypes.push_back(loopGroupTypes[1]);
       loopDstStrideTypes.push_back(loopGroupTypes[2]);
       continue;
     }
     if (keyword == "pad") {
-      if (!padTypes.empty() || parseDmaPadTypes(parser, padTypes))
+      if (!padTypes.empty() || parseDmaPadTypes(parser, padTypes)) {
         return failure();
+      }
       continue;
     }
     return parser.emitError(parser.getCurrentLocation(),
@@ -3809,14 +4091,16 @@ void MteGmUbOp::getEffects(
 }
 
 LogicalResult MteGmUbOp::verify() {
-  if (failed(verifyCopyGmToUbufOp(*this, true)))
+  if (failed(verifyCopyGmToUbufOp(*this, true))) {
     return failure();
+  }
   if (failed(verifyDmaLoadStoreLoopGroups(
           getOperation(), getLoopCounts(), getLoopSrcStrides(),
           getLoopDstStrides())))
     return failure();
-  if (!getPadValue() && (getLeftPaddingCount() || getRightPaddingCount()))
+  if (!getPadValue() && (getLeftPaddingCount() || getRightPaddingCount())) {
     return emitOpError() << "requires pad group to provide a pad value";
+  }
   if (getPadValue() && static_cast<bool>(getLeftPaddingCount()) !=
                          static_cast<bool>(getRightPaddingCount()))
     return emitOpError()
@@ -3833,8 +4117,9 @@ LogicalResult MteGmUbOp::verify() {
 
 LogicalResult SetMovPadValOp::verify() {
   Type valueType = getValue().getType();
-  if (isSupportedMovPadScalarType(valueType))
+  if (isSupportedMovPadScalarType(valueType)) {
     return success();
+  }
   return emitOpError()
          << "expects i8/i16/i32 or f16/bf16/f32 scalar operand, but got "
          << valueType;
@@ -3854,8 +4139,9 @@ static LogicalResult verifyMadPointerKinds(Operation *op, Type lhsTy, Type rhsTy
   auto lhsType = dyn_cast<pto::PtrType>(lhsTy);
   auto rhsType = dyn_cast<pto::PtrType>(rhsTy);
   auto dstType = dyn_cast<pto::PtrType>(dstTy);
-  if (!lhsType || !rhsType || !dstType)
+  if (!lhsType || !rhsType || !dstType) {
     return op->emitOpError("requires typed !pto.ptr lhs/rhs/dst operands");
+  }
 
   const auto lhsAS = lhsType.getMemorySpace().getAddressSpace();
   const auto rhsAS = rhsType.getMemorySpace().getAddressSpace();
@@ -3864,15 +4150,18 @@ static LogicalResult verifyMadPointerKinds(Operation *op, Type lhsTy, Type rhsTy
   const bool isStrongCube =
       lhsAS == pto::AddressSpace::LEFT && rhsAS == pto::AddressSpace::RIGHT &&
       dstAS == pto::AddressSpace::ACC;
-  if (!isStrongCube)
+  if (!isStrongCube) {
     return op->emitOpError("requires l0a/l0b/l0c-typed lhs/rhs/dst pointers");
+  }
 
-  if (!biasTy)
+  if (!biasTy) {
     return success();
+  }
 
   auto biasType = dyn_cast<pto::PtrType>(*biasTy);
-  if (!biasType)
+  if (!biasType) {
     return op->emitOpError("requires typed !pto.ptr bias operand");
+  }
   if (biasType.getMemorySpace().getAddressSpace() != pto::AddressSpace::BIAS) {
     return op->emitOpError("requires bias pointer in !pto.ptr<..., bt>");
   }
@@ -3905,8 +4194,9 @@ static LogicalResult verifyMadMxCommon(Operation *op, Type lhsTy, Type rhsTy,
                                        Type dstTy,
                                        std::optional<Type> biasTy =
                                            std::nullopt) {
-  if (failed(verifyMadPointerKinds(op, lhsTy, rhsTy, dstTy, biasTy)))
+  if (failed(verifyMadPointerKinds(op, lhsTy, rhsTy, dstTy, biasTy))) {
     return failure();
+  }
 
   auto lhsType = cast<pto::PtrType>(lhsTy);
   auto rhsType = cast<pto::PtrType>(rhsTy);
@@ -3917,8 +4207,9 @@ static LogicalResult verifyMadMxCommon(Operation *op, Type lhsTy, Type rhsTy,
   const bool isStrongCube =
       lhsAS == pto::AddressSpace::LEFT && rhsAS == pto::AddressSpace::RIGHT &&
       dstAS == pto::AddressSpace::ACC;
-  if (!isStrongCube)
+  if (!isStrongCube) {
     return op->emitOpError("requires l0a/l0b/l0c-typed lhs/rhs/dst pointers");
+  }
 
   if (!isMxElementType(lhsType.getElementType()) ||
       !isMxElementType(rhsType.getElementType())) {
@@ -3959,10 +4250,12 @@ void MadMxBiasOp::getEffects(
 
 static std::optional<pto::MadUnitFlagMode>
 parseMadUnitFlagModeToken(StringRef token) {
-  if (token == "check_only")
+  if (token == "check_only") {
     return pto::MadUnitFlagMode::CheckOnly;
-  if (token == "check_and_set")
+  }
+  if (token == "check_and_set") {
     return pto::MadUnitFlagMode::CheckAndSet;
+  }
   return std::nullopt;
 }
 
@@ -3977,10 +4270,12 @@ static StringRef stringifyMadUnitFlagModeToken(pto::MadUnitFlagMode mode) {
 }
 
 static std::optional<pto::Tf32Mode> parseTf32ModeToken(StringRef token) {
-  if (token == "round_even")
+  if (token == "round_even") {
     return pto::Tf32Mode::RoundEven;
-  if (token == "round_away")
+  }
+  if (token == "round_away") {
     return pto::Tf32Mode::RoundAway;
+  }
   return std::nullopt;
 }
 
@@ -4010,14 +4305,16 @@ static LogicalResult verifyMadSemanticClauses(Operation *op, Type lhsTy,
                                               std::optional<pto::Tf32Mode> tf32Mode,
                                               std::optional<pto::MadSatMode> satMode,
                                               bool hasNDir) {
-  if (failed(verifyMadPointerKinds(op, lhsTy, rhsTy, dstTy, biasTy)))
+  if (failed(verifyMadPointerKinds(op, lhsTy, rhsTy, dstTy, biasTy))) {
     return failure();
+  }
 
   auto lhsType = dyn_cast<pto::PtrType>(lhsTy);
   auto rhsType = dyn_cast<pto::PtrType>(rhsTy);
   auto dstType = dyn_cast<pto::PtrType>(dstTy);
-  if (!lhsType || !rhsType || !dstType)
+  if (!lhsType || !rhsType || !dstType) {
     return op->emitOpError("requires typed !pto.ptr lhs/rhs/dst operands");
+  }
 
   if (tf32Mode) {
     if (!(lhsType.getElementType().isF32() && rhsType.getElementType().isF32() &&
@@ -4033,8 +4330,9 @@ static LogicalResult verifyMadSemanticClauses(Operation *op, Type lhsTy,
   }
   if (satMode) {
     auto isFloatLike = [](Type type) {
-      if (isa<FloatType>(type))
+      if (isa<FloatType>(type)) {
         return true;
+      }
       return pto::isPTOLowPrecisionType(type);
     };
     if (!(isFloatLike(lhsType.getElementType()) &&
@@ -4069,8 +4367,9 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
     return failure();
 
   auto parseUnitFlagClause = [&]() -> ParseResult {
-    if (failed(parser.parseOptionalKeyword("unit_flag")))
+    if (failed(parser.parseOptionalKeyword("unit_flag"))) {
       return success();
+    }
     if (parser.parseLParen() || parser.parseKeyword(&unitFlagKeyword) ||
         parser.parseRParen())
       return failure();
@@ -4103,10 +4402,12 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
     return success();
   };
   auto parseTf32Clause = [&]() -> ParseResult {
-    if (!parseTf32ModeClause)
+    if (!parseTf32ModeClause) {
       return success();
-    if (failed(parser.parseOptionalKeyword("tf32_mode")))
+    }
+    if (failed(parser.parseOptionalKeyword("tf32_mode"))) {
       return success();
+    }
     if (parser.parseLParen() || parser.parseKeyword(&tf32Keyword) ||
         parser.parseRParen())
       return failure();
@@ -4129,8 +4430,9 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
       failed(parseNDirClause()))
     return failure();
 
-  if (parser.parseOptionalAttrDict(attrs) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(attrs) || parser.parseColon()) {
     return failure();
+  }
 
   Type lhsType, rhsType, dstType, mType, nType, kType, biasType;
   if (parser.parseType(lhsType) || parser.parseComma() ||
@@ -4138,8 +4440,9 @@ static ParseResult parseMadSemanticOpCommon(OpAsmParser &parser,
       parser.parseType(dstType) || parser.parseComma())
     return failure();
   if (hasBias) {
-    if (parser.parseType(biasType) || parser.parseComma())
+    if (parser.parseType(biasType) || parser.parseComma()) {
       return failure();
+    }
   }
   if (parser.parseType(mType) || parser.parseComma() || parser.parseType(nType) ||
       parser.parseComma() || parser.parseType(kType))
@@ -4174,18 +4477,21 @@ static void printMadSemanticClauses(OpAsmPrinter &printer, Operation *op,
     printer << " unit_flag("
             << stringifyMadUnitFlagModeToken(unitFlagMode.getValue()) << ")";
   }
-  if (op->hasAttr("disable_gemv"))
+  if (op->hasAttr("disable_gemv")) {
     printer << " disable_gemv";
-  if (auto satMode = op->getAttrOfType<pto::MadSatModeAttr>("sat_mode"))
+  }
+  if (auto satMode = op->getAttrOfType<pto::MadSatModeAttr>("sat_mode")) {
     printer << ' ' << stringifyMadSatModeToken(satMode.getValue());
+  }
   if (allowTf32Mode) {
     if (auto tf32Mode = op->getAttrOfType<pto::Tf32ModeAttr>("tf32_mode")) {
       printer << " tf32_mode(" << stringifyTf32ModeToken(tf32Mode.getValue())
               << ")";
     }
   }
-  if (op->hasAttr("n_dir"))
+  if (op->hasAttr("n_dir")) {
     printer << " n_dir";
+  }
 }
 
 static ArrayRef<StringRef> getMadSemanticElidedAttrs(bool allowTf32Mode) {
@@ -4454,32 +4760,39 @@ Value MadMxBiasRawOp::getBiasOrNull() { return getBias(); }
 
 static bool isCompatibleScalarForSemanticType(Type semanticType,
                                               Type scalarType) {
-  if (semanticType == scalarType)
+  if (semanticType == scalarType) {
     return true;
+  }
 
   auto semanticInt = dyn_cast<IntegerType>(semanticType);
   auto scalarInt = dyn_cast<IntegerType>(scalarType);
-  if (!semanticInt || !scalarInt || semanticInt.getWidth() != scalarInt.getWidth())
+  if (!semanticInt || !scalarInt || semanticInt.getWidth() != scalarInt.getWidth()) {
     return false;
+  }
 
-  if (semanticInt.isSigned())
+  if (semanticInt.isSigned()) {
     return scalarInt.isSigned() || scalarInt.isSignless();
-  if (semanticInt.isUnsigned())
+  }
+  if (semanticInt.isUnsigned()) {
     return scalarInt.isUnsigned() || scalarInt.isSignless();
+  }
   return scalarInt.isSignless();
 }
 
 LogicalResult VbrOp::verify() {
-  if (failed(verifyVRegTypeLike(*this, getResult().getType(), "result")))
+  if (failed(verifyVRegTypeLike(*this, getResult().getType(), "result"))) {
     return failure();
+  }
 
   auto resultVecType = cast<VRegType>(getResult().getType());
   Type elementType = getValue().getType();
-  if (isa<ShapedType, VectorType>(elementType))
+  if (isa<ShapedType, VectorType>(elementType)) {
     return emitOpError("value must be a scalar matching the result element type");
+  }
   Type resultElementType = resultVecType.getElementType();
-  if (!isCompatibleScalarForSemanticType(resultElementType, elementType))
+  if (!isCompatibleScalarForSemanticType(resultElementType, elementType)) {
     return emitOpError("value type must match result element type");
+  }
   return success();
 }
 
@@ -4492,8 +4805,9 @@ static LogicalResult verifyWideningReductionVecOp(ReductionOp op,
 
   auto inputType = dyn_cast<VRegType>(op.getInput().getType());
   auto resultType = dyn_cast<VRegType>(op.getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return failure();
+  }
 
   Type inputElemType = inputType.getElementType();
   Type expectedResultElemType = inputElemType;
@@ -4534,8 +4848,9 @@ LogicalResult VcmaxOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getInput().getType(), "input")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result")))
     return failure();
-  if (getInput().getType() != getResult().getType())
+  if (getInput().getType() != getResult().getType()) {
     return emitOpError("input and result must have the same vector type");
+  }
   return success();
 }
 
@@ -4543,25 +4858,29 @@ LogicalResult VcminOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getInput().getType(), "input")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result")))
     return failure();
-  if (getInput().getType() != getResult().getType())
+  if (getInput().getType() != getResult().getType()) {
     return emitOpError("input and result must have the same vector type");
+  }
   return success();
 }
 
 LogicalResult VciOp::verify() {
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!resultType)
+  if (!resultType) {
     return emitOpError("result must be !pto.vreg<...>");
+  }
   Type resultElemType = resultType.getElementType();
   bool supportedInteger = false;
   if (auto intType = dyn_cast<IntegerType>(resultElemType))
     supportedInteger = intType.getWidth() == 8 || intType.getWidth() == 16 ||
                        intType.getWidth() == 32;
   bool supportedFloat = resultElemType.isF16() || resultElemType.isF32();
-  if (!supportedInteger && !supportedFloat)
+  if (!supportedInteger && !supportedFloat) {
     return emitOpError("result element type must be integer or f16/f32");
-  if (!isCompatibleScalarForSemanticType(resultElemType, getIndex().getType()))
+  }
+  if (!isCompatibleScalarForSemanticType(resultElemType, getIndex().getType())) {
     return emitOpError("index type must match result element type");
+  }
   return success();
 }
 
@@ -4581,8 +4900,9 @@ static bool isSameVgather2IntegerSemantics(IntegerType sourceType,
   if (!sourceType || !resultType ||
       sourceType.getWidth() != resultType.getWidth())
     return false;
-  if (sourceType.isUnsigned())
+  if (sourceType.isUnsigned()) {
     return resultType.isUnsigned();
+  }
   return !resultType.isUnsigned();
 }
 
@@ -4591,28 +4911,34 @@ static bool isVgather2B8ResultType(IntegerType sourceType,
   if (!sourceType || !resultType || sourceType.getWidth() != 8 ||
       resultType.getWidth() != 16)
     return false;
-  if (sourceType.isUnsigned())
+  if (sourceType.isUnsigned()) {
     return resultType.isUnsigned();
+  }
   return !resultType.isUnsigned();
 }
 
 LogicalResult Vgather2Op::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
+  }
   MemoryRole sourceRole = classifyMemoryRole(getSource().getType());
-  if (sourceRole == MemoryRole::GM)
+  if (sourceRole == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
+  }
 
   auto offsetsType = dyn_cast<VRegType>(getOffsets().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!offsetsType || !resultType)
+  if (!offsetsType || !resultType) {
     return emitOpError("offsets and result must be !pto.vreg<...>");
+  }
 
   auto offsetsElemType = dyn_cast<IntegerType>(offsetsType.getElementType());
-  if (!offsetsElemType)
+  if (!offsetsElemType) {
     return emitOpError("offset vector must use integer element type");
-  if (offsetsType.getElementCount() != resultType.getElementCount())
+  }
+  if (offsetsType.getElementCount() != resultType.getElementCount()) {
     return emitOpError("offset and result vectors must have the same element count");
+  }
 
   Type sourceElemType = getBufferElementType(getSource().getType());
   Type resultElemType = resultType.getElementType();
@@ -4662,8 +4988,9 @@ LogicalResult Vgather2Op::verify() {
         "requires source element type i8/ui8/i16/ui16/i32/ui32/f16/bf16/f32");
   }
 
-  if (resultElemWidth != 16 && resultElemWidth != 32)
+  if (resultElemWidth != 16 && resultElemWidth != 32) {
     return emitOpError("result element type must be 16-bit or 32-bit");
+  }
   if (resultType.getElementCount() != expectedLanes)
     return emitOpError() << "expects result type "
                          << formatVRegType(expectedLanes, resultElemType);
@@ -4678,8 +5005,9 @@ LogicalResult Vgather2Op::verify() {
 }
 
 LogicalResult CopyUbufToUbufOp::verify() {
-  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType()))
+  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType())) {
     return emitOpError("requires pointer-like source and destination");
+  }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getDestination().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed source and destination");
@@ -4705,8 +5033,9 @@ void CopyUbufToCbufOp::getEffects(
 }
 
 LogicalResult CopyUbufToCbufOp::verify() {
-  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType()))
+  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType())) {
     return emitOpError("requires pointer-like source and destination");
+  }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getDestination().getType()) != MemoryRole::Other)
     return emitOpError("requires UB-backed source and CBUF-backed destination");
@@ -4721,8 +5050,9 @@ void MteUbUbOp::getEffects(
 }
 
 LogicalResult MteUbUbOp::verify() {
-  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType()))
+  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType())) {
     return emitOpError("requires pointer-like source and destination");
+  }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getDestination().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed source and destination");
@@ -4737,8 +5067,9 @@ void MteUbL1Op::getEffects(
 }
 
 LogicalResult MteUbL1Op::verify() {
-  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType()))
+  if (!isBufferLike(getSource().getType()) || !isBufferLike(getDestination().getType())) {
     return emitOpError("requires pointer-like source and destination");
+  }
   if (classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getDestination().getType()) != MemoryRole::Other)
     return emitOpError("requires UB-backed source and CBUF-backed destination");
@@ -4752,11 +5083,13 @@ void VgatherbOp::getEffects(
 }
 
 LogicalResult VgatherbOp::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
+  }
   MemoryRole sourceRole = classifyMemoryRole(getSource().getType());
-  if (sourceRole == MemoryRole::GM)
+  if (sourceRole == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
+  }
 
   if (failed(verifyMaskTypeWithGranularityLike(getOperation(), getMask().getType(),
                                                "mask type", "b32")))
@@ -4764,13 +5097,16 @@ LogicalResult VgatherbOp::verify() {
 
   auto offsetsType = dyn_cast<VRegType>(getOffsets().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!offsetsType || !resultType)
+  if (!offsetsType || !resultType) {
     return emitOpError("offsets and result must be !pto.vreg<...>");
+  }
   auto offsetsElemType = dyn_cast<IntegerType>(offsetsType.getElementType());
-  if (!offsetsElemType)
+  if (!offsetsElemType) {
     return emitOpError("offset vector must use integer element type");
-  if (offsetsElemType.getWidth() != 32)
+  }
+  if (offsetsElemType.getWidth() != 32) {
     return emitOpError("currently requires 32-bit offset vector elements");
+  }
   // vgatherb is a 32-byte block gather: each offset addresses one 32-byte block.
   // The offset vector holds VL/32 block addresses (always ui32), while the
   // result vector holds VL/sizeof(T) elements of the data type.  These counts
@@ -4788,24 +5124,31 @@ void Vgather2BcOp::getEffects(
 }
 
 LogicalResult Vgather2BcOp::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
-  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
-  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
+  }
 
   auto offsetsType = dyn_cast<VRegType>(getOffsets().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!offsetsType || !resultType)
+  if (!offsetsType || !resultType) {
     return emitOpError("offsets and result must be !pto.vreg<...>");
+  }
   auto offsetsElemType = dyn_cast<IntegerType>(offsetsType.getElementType());
-  if (!offsetsElemType)
+  if (!offsetsElemType) {
     return emitOpError("offset vector must use integer element type");
-  if (offsetsElemType.getWidth() != 32)
+  }
+  if (offsetsElemType.getWidth() != 32) {
     return emitOpError("currently requires 32-bit offset vector elements");
-  if (offsetsType.getElementCount() != resultType.getElementCount())
+  }
+  if (offsetsType.getElementCount() != resultType.getElementCount()) {
     return emitOpError("offset and result vectors must have the same element count");
+  }
   return success();
 }
 
@@ -4817,10 +5160,12 @@ LogicalResult VbitsortOp::verify() {
       classifyMemoryRole(getSource().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getIndices().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed destination/source/indices");
-  if (!getRepeatTimes().getType().isIndex())
+  if (!getRepeatTimes().getType().isIndex()) {
     return emitOpError("repeat_times must be index");
-  if (failed(verifyNotNestedInVecScope(*this, "pto.vbitsort")))
+  }
+  if (failed(verifyNotNestedInVecScope(*this, "pto.vbitsort"))) {
     return failure();
+  }
   return success();
 }
 
@@ -4859,10 +5204,12 @@ LogicalResult Vmrgsort4Op::verify() {
       src3PtrType.getElementType() != elemType)
     return emitOpError(
         "requires destination and all sources to have the same element type");
-  if (!elemType.isF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isF32()) {
     return emitOpError("requires f16 or f32 element type");
-  if (failed(verifyNotNestedInVecScope(*this, "pto.vmrgsort4")))
+  }
+  if (failed(verifyNotNestedInVecScope(*this, "pto.vmrgsort4"))) {
     return failure();
+  }
   return success();
 }
 
@@ -4896,15 +5243,18 @@ void VldsOp::getEffects(
 
 template <typename LoadOp>
 static LogicalResult verifyVldsCommon(LoadOp op) {
-  if (!isBufferLike(op.getSource().getType()))
+  if (!isBufferLike(op.getSource().getType())) {
     return op.emitOpError("requires a pointer-like source");
+  }
 
-  if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+  if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
 
   MemoryRole sourceRole = classifyMemoryRole(op.getSource().getType());
-  if (sourceRole == MemoryRole::GM)
+  if (sourceRole == MemoryRole::GM) {
     return op.emitOpError("requires a UB-backed source");
+  }
 
   if (op.getDistAttr()) {
     StringRef dist = *op.getDist();
@@ -4919,11 +5269,13 @@ static LogicalResult verifyVldsCommon(LoadOp op) {
 }
 
 LogicalResult VldsOp::verify() {
-  if (failed(verifyVldsCommon(*this)))
+  if (failed(verifyVldsCommon(*this))) {
     return failure();
+  }
   if (Value updatedBase = getUpdatedBase()) {
-    if (updatedBase.getType() != getSource().getType())
+    if (updatedBase.getType() != getSource().getType()) {
       return emitOpError("requires updated base result to match base type");
+    }
   }
   return success();
 }
@@ -4934,12 +5286,15 @@ void VldasOp::getEffects(
 }
 
 LogicalResult VldasOp::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
-  if (failed(verifyAlignTypeLike(*this, getResult().getType(), "result type")))
+  }
+  if (failed(verifyAlignTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
-  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
+  }
   return success();
 }
 
@@ -4948,10 +5303,12 @@ LogicalResult InitAlignOp::verify() {
 }
 
 LogicalResult SprclrOp::verify() {
-  if (!isSupportedSprToken(getSpr()))
+  if (!isSupportedSprToken(getSpr())) {
     return emitOpError("requires spr to be \"AR\"");
-  if (failed(verifyNestedInVecScope(*this, "pto.sprclr")))
+  }
+  if (failed(verifyNestedInVecScope(*this, "pto.sprclr"))) {
     return failure();
+  }
   return success();
 }
 
@@ -4959,27 +5316,35 @@ static LogicalResult verifySprStoreCommon(Operation *op, StringRef opName,
                                           StringRef spr, Value destination,
                                           Value offset,
                                           bool requireImmediateOffset) {
-  if (!isSupportedSprToken(spr))
+  if (!isSupportedSprToken(spr)) {
     return op->emitOpError("requires spr to be \"AR\"");
-  if (failed(verifyNestedInVecScope(op, opName)))
+  }
+  if (failed(verifyNestedInVecScope(op, opName))) {
     return failure();
+  }
   auto ptrType = dyn_cast<pto::PtrType>(destination.getType());
-  if (!ptrType)
+  if (!ptrType) {
     return op->emitOpError("requires a pointer-like UB destination");
-  if (classifyMemoryRole(destination.getType()) != MemoryRole::UB)
+  }
+  if (classifyMemoryRole(destination.getType()) != MemoryRole::UB) {
     return op->emitOpError("requires a UB-backed destination");
+  }
   auto intType = dyn_cast<IntegerType>(ptrType.getElementType());
-  if (!intType || intType.getWidth() != 32 || intType.isSigned())
+  if (!intType || intType.getWidth() != 32 || intType.isSigned()) {
     return op->emitOpError("requires ui32/i32 UB destination element type");
-  if (!offset.getType().isInteger(32))
+  }
+  if (!offset.getType().isInteger(32)) {
     return op->emitOpError("requires i32 offset");
+  }
   if (requireImmediateOffset) {
     APInt offsetValue;
-    if (!matchPattern(offset, m_ConstantInt(&offsetValue)))
+    if (!matchPattern(offset, m_ConstantInt(&offsetValue))) {
       return op->emitOpError("requires constant immediate offset");
+    }
     int64_t signedOffset = offsetValue.getSExtValue();
-    if (signedOffset < -128 || signedOffset > 127)
+    if (signedOffset < -128 || signedOffset > 127) {
       return op->emitOpError("requires signed 8-bit immediate offset");
+    }
   }
   return success();
 }
@@ -5030,15 +5395,18 @@ LogicalResult VldusOp::verify() {
       failed(verifyAlignTypeLike(*this, getUpdatedAlign().getType(),
                                  "updated align type")))
     return failure();
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
-  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
+  }
   if (static_cast<bool>(getIncrement()) != static_cast<bool>(getUpdatedBase()))
     return emitOpError(
         "requires increment and updated base result to appear together");
-  if (getUpdatedBase() && getUpdatedBase().getType() != getSource().getType())
+  if (getUpdatedBase() && getUpdatedBase().getType() != getSource().getType()) {
     return emitOpError("requires updated base result to match source type");
+  }
   return success();
 }
 
@@ -5049,16 +5417,20 @@ void UvldOp::getEffects(
 }
 
 LogicalResult UvldOp::verify() {
-  if (failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+  if (failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
-  if (!isBufferLike(getSource().getType()))
+  }
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a buffer-like source");
-  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
+  }
 
   auto sourceMemRef = dyn_cast<BaseMemRefType>(getSource().getType());
-  if (!sourceMemRef)
+  if (!sourceMemRef) {
     return success();
+  }
 
   Type sourceElementType = sourceMemRef.getElementType();
   Type vectorElementType = cast<VRegType>(getResult().getType()).getElementType();
@@ -5070,33 +5442,39 @@ LogicalResult UvldOp::verify() {
 
 LogicalResult VdupOp::verify() {
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!resultType)
+  if (!resultType) {
     return emitOpError("result must be !pto.vreg<...>");
+  }
 
   std::optional<StringRef> granularity =
       getVdupMaskGranularity(resultType.getElementType());
-  if (!granularity)
+  if (!granularity) {
     return emitOpError("result element type must use b8, b16, or b32 mask granularity");
+  }
   if (failed(verifyMaskTypeWithGranularityLike(
           getOperation(), getMask().getType(), "mask type", *granularity)))
     return failure();
 
-  if (!isSupportedVdupPosition(getPosition()))
+  if (!isSupportedVdupPosition(getPosition())) {
     return emitOpError("position must be LOWEST or HIGHEST");
+  }
 
   Type inputType = getInput().getType();
   if (auto inputVecType = dyn_cast<VRegType>(inputType)) {
-    if (inputVecType != resultType)
+    if (inputVecType != resultType) {
       return emitOpError("vector input must match result vector type");
+    }
     return success();
   }
 
-  if (getPosition())
+  if (getPosition()) {
     return emitOpError("position is only supported for vector input");
+  }
 
   Type resultElementType = resultType.getElementType();
-  if (!isCompatibleScalarForSemanticType(resultElementType, inputType))
+  if (!isCompatibleScalarForSemanticType(resultElementType, inputType)) {
     return emitOpError("scalar input must match result element type");
+  }
 
   return success();
 }
@@ -5120,8 +5498,9 @@ LogicalResult TensorViewAddrOp::verify() {
     expectedRank = memrefType.getRank();
     auto srcSpace =
         dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace());
-    if (srcSpace && srcSpace != gmSpace)
+    if (srcSpace && srcSpace != gmSpace) {
       return emitOpError("memref source must stay in gm memory space");
+    }
   } else {
     return emitOpError(
         "source must be a tensor_view, partition_tensor_view, or memref");
@@ -5131,23 +5510,27 @@ LogicalResult TensorViewAddrOp::verify() {
     if (dstMemRefType.getElementType() != elementType)
       return emitOpError(
           "memref result element type must match source element type");
-    if (dstMemRefType.getRank() != expectedRank)
+    if (dstMemRefType.getRank() != expectedRank) {
       return emitOpError("memref result rank must match source rank");
+    }
     auto dstSpace =
         dyn_cast_or_null<pto::AddressSpaceAttr>(dstMemRefType.getMemorySpace());
-    if (dstSpace && dstSpace != gmSpace)
+    if (dstSpace && dstSpace != gmSpace) {
       return emitOpError("memref result must stay in gm memory space");
+    }
     return success();
   }
 
   auto dstPtrType = dyn_cast<pto::PtrType>(dstType);
-  if (!dstPtrType)
+  if (!dstPtrType) {
     return emitOpError("result must be a memref or !pto.ptr<...>");
+  }
   if (dstPtrType.getElementType() != elementType)
     return emitOpError(
         "pointer result element type must match source element type");
-  if (dstPtrType.getMemorySpace() != gmSpace)
+  if (dstPtrType.getMemorySpace() != gmSpace) {
     return emitOpError("pointer result must stay in gm memory space");
+  }
   return success();
 }
 
@@ -5175,23 +5558,27 @@ LogicalResult TileBufAddrOp::verify() {
     if (dstMemRefType.getElementType() != elementType)
       return emitOpError(
           "memref result element type must match tile element type");
-    if (dstMemRefType.getRank() != srcRank)
+    if (dstMemRefType.getRank() != srcRank) {
       return emitOpError("memref result rank must match tile rank");
+    }
     auto dstSpace =
         dyn_cast_or_null<pto::AddressSpaceAttr>(dstMemRefType.getMemorySpace());
-    if (srcSpace && dstSpace && srcSpace != dstSpace)
+    if (srcSpace && dstSpace && srcSpace != dstSpace) {
       return emitOpError("memref result must stay within the tile memory space");
+    }
     return success();
   }
 
   auto dstPtrType = dyn_cast<pto::PtrType>(dstType);
-  if (!dstPtrType)
+  if (!dstPtrType) {
     return emitOpError("result must be a memref or !pto.ptr<...>");
+  }
   if (dstPtrType.getElementType() != elementType)
     return emitOpError(
         "pointer result element type must match tile element type");
-  if (srcSpace && dstPtrType.getMemorySpace() != srcSpace)
+  if (srcSpace && dstPtrType.getMemorySpace() != srcSpace) {
     return emitOpError("pointer result must stay within the tile memory space");
+  }
   return success();
 }
 
@@ -5200,8 +5587,9 @@ LogicalResult PsetB8Op::verify() {
                                                "result type", "b8")))
     return failure();
 
-  if (!isSupportedPredicatePattern(getPattern()))
+  if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
+  }
   return success();
 }
 
@@ -5210,8 +5598,9 @@ LogicalResult PsetB16Op::verify() {
                                                "result type", "b16")))
     return failure();
 
-  if (!isSupportedPredicatePattern(getPattern()))
+  if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
+  }
   return success();
 }
 
@@ -5219,8 +5608,9 @@ LogicalResult PsetB32Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
                                                "result type", "b32")))
     return failure();
-  if (!isSupportedPredicatePattern(getPattern()))
+  if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
+  }
   return success();
 }
 
@@ -5228,8 +5618,9 @@ LogicalResult PgeB8Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
                                                "result type", "b8")))
     return failure();
-  if (!isSupportedPredicatePattern(getPattern()))
+  if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
+  }
   return success();
 }
 
@@ -5237,8 +5628,9 @@ LogicalResult PgeB16Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
                                                "result type", "b16")))
     return failure();
-  if (!isSupportedPredicatePattern(getPattern()))
+  if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
+  }
   return success();
 }
 
@@ -5246,8 +5638,9 @@ LogicalResult PgeB32Op::verify() {
   if (failed(verifyMaskTypeWithGranularityLike(*this, getResult().getType(),
                                                "result type", "b32")))
     return failure();
-  if (!isSupportedPredicatePattern(getPattern()))
+  if (!isSupportedPredicatePattern(getPattern())) {
     return emitOpError("requires a supported PAT_* predicate pattern");
+  }
   return success();
 }
 
@@ -5259,10 +5652,12 @@ static LogicalResult verifyPredicateLaneCountOp(PltOp op,
     return failure();
   Type scalarType = op.getScalar().getType();
   auto scalarIntType = dyn_cast<IntegerType>(scalarType);
-  if (!scalarIntType || scalarIntType.getWidth() != 32)
+  if (!scalarIntType || scalarIntType.getWidth() != 32) {
     return op.emitOpError("requires scalar to be i32");
-  if (op.getScalarOut().getType() != scalarType)
+  }
+  if (op.getScalarOut().getType() != scalarType) {
     return op.emitOpError("requires scalar_out to match scalar type");
+  }
   return success();
 }
 
@@ -5280,10 +5675,12 @@ static LogicalResult verifyPredicateLoopBoundOp(PltmOp op,
   if (failed(verifyMaskTypeWithGranularityLike(op, op.getMask().getType(),
                                                "mask type", granularity)))
     return failure();
-  if (!op.getLoop().getType().isInteger(16))
+  if (!op.getLoop().getType().isInteger(16)) {
     return op.emitOpError("requires loop operand to be i16");
-  if (!op.getBound().getType().isInteger(32))
+  }
+  if (!op.getBound().getType().isInteger(32)) {
     return op.emitOpError("requires bound operand to be i32");
+  }
   return success();
 }
 
@@ -5301,8 +5698,9 @@ LogicalResult PpackOp::verify() {
   if (failed(verifyMaskTypeLike(*this, getInput().getType(), "input type")) ||
       failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
     return failure();
-  if (!isSupportedPartToken(getPart()))
+  if (!isSupportedPartToken(getPart())) {
     return emitOpError("requires part to be LOWER or HIGHER");
+  }
   auto inputMaskType = cast<MaskType>(getInput().getType());
   auto resultMaskType = cast<MaskType>(getResult().getType());
   StringRef inputGranularity = inputMaskType.getGranularity();
@@ -5319,8 +5717,9 @@ LogicalResult PunpackOp::verify() {
   if (failed(verifyMaskTypeLike(*this, getInput().getType(), "input type")) ||
       failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
     return failure();
-  if (!isSupportedPartToken(getPart()))
+  if (!isSupportedPartToken(getPart())) {
     return emitOpError("requires part to be LOWER or HIGHER");
+  }
   auto inputMaskType = cast<MaskType>(getInput().getType());
   auto resultMaskType = cast<MaskType>(getResult().getType());
   StringRef inputGranularity = inputMaskType.getGranularity();
@@ -5378,17 +5777,22 @@ void PldsOp::getEffects(
 }
 
 LogicalResult PldsOp::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
-  if (failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
+  }
   MemoryRole sourceRole = classifyMemoryRole(getSource().getType());
-  if (sourceRole == MemoryRole::GM)
+  if (sourceRole == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
-  if (!getOffset().getType().isIndex())
+  }
+  if (!getOffset().getType().isIndex()) {
     return emitOpError("requires index offset");
-  if (!isSupportedPredicateLoadDist(getDist()))
+  }
+  if (!isSupportedPredicateLoadDist(getDist())) {
     return emitOpError("requires predicate load dist to be NORM, US, or DS");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getSource().getType())
     return emitOpError("requires updated base result to match base type");
@@ -5402,16 +5806,21 @@ void PldiOp::getEffects(
 }
 
 LogicalResult PldiOp::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
-  if (failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
-  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
-  if (!matchPattern(getOffset(), m_Constant()))
+  }
+  if (!matchPattern(getOffset(), m_Constant())) {
     return emitOpError("requires offset to be a constant index immediate");
-  if (!isSupportedPredicateLoadDist(getDist()))
+  }
+  if (!isSupportedPredicateLoadDist(getDist())) {
     return emitOpError("requires predicate load dist to be NORM, US, or DS");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getSource().getType())
     return emitOpError("requires updated base result to match base type");
@@ -5422,28 +5831,34 @@ template <typename OpTy>
 static LogicalResult verifyElementwiseVecScalarOpLike(OpTy op) {
   auto inputType = dyn_cast<VRegType>(op.getInput().getType());
   auto resultType = dyn_cast<VRegType>(op.getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return op.emitOpError("input and result must be !pto.vreg<...>");
-  if (inputType != resultType)
+  }
+  if (inputType != resultType) {
     return op.emitOpError("input and result vector types must match");
+  }
 
   Type elemType = inputType.getElementType();
   Type scalarType = op.getScalar().getType();
-  if (scalarType == elemType)
+  if (scalarType == elemType) {
     return success();
+  }
 
   auto elemInt = dyn_cast<IntegerType>(elemType);
   auto scalarInt = dyn_cast<IntegerType>(scalarType);
-  if (!elemInt || !scalarInt || elemInt.getWidth() != scalarInt.getWidth())
+  if (!elemInt || !scalarInt || elemInt.getWidth() != scalarInt.getWidth()) {
     return op.emitOpError("scalar type must match vector element type");
+  }
 
-  if (elemInt.isSigned() && (scalarInt.isSigned() || scalarInt.isSignless()))
+  if (elemInt.isSigned() && (scalarInt.isSigned() || scalarInt.isSignless())) {
     return success();
+  }
   if (elemInt.isUnsigned() &&
       (scalarInt.isUnsigned() || scalarInt.isSignless()))
     return success();
-  if (elemInt.isSignless() && scalarInt.isSignless())
+  if (elemInt.isSignless() && scalarInt.isSignless()) {
     return success();
+  }
 
   return op.emitOpError(
       "integer scalar type must match vector element width and use matching signedness or signless i<width>");
@@ -5451,17 +5866,20 @@ static LogicalResult verifyElementwiseVecScalarOpLike(OpTy op) {
 
 template <typename OpTy>
 static LogicalResult verifyVecScalarOpLike(OpTy op) {
-  if (failed(verifyElementwiseVecScalarOpLike(op)))
+  if (failed(verifyElementwiseVecScalarOpLike(op))) {
     return failure();
+  }
   return success();
 }
 
 template <typename OpTy>
 static LogicalResult verifyVecScalarMaskedOpLike(OpTy op) {
-  if (failed(verifyElementwiseVecScalarOpLike(op)))
+  if (failed(verifyElementwiseVecScalarOpLike(op))) {
     return failure();
-  if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type"))) {
     return failure();
+  }
   if (failed(verifyNonLowPrecisionVRegElementTypeLike(
           op.getOperation(), op.getInput().getType(), "input type")))
     return failure();
@@ -5482,10 +5900,12 @@ static LogicalResult verifyCarryVecOp(CarryOp op) {
   auto rhsType = cast<VRegType>(op.getRhs().getType());
   auto resultType = cast<VRegType>(op.getResult().getType());
   auto lhsElemType = cast<IntegerType>(lhsType.getElementType());
-  if (lhsType != rhsType || lhsType != resultType)
+  if (lhsType != rhsType || lhsType != resultType) {
     return op.emitOpError("requires lhs, rhs, and result to have matching vector types");
-  if (lhsElemType.getWidth() != 32)
+  }
+  if (lhsElemType.getWidth() != 32) {
     return op.emitOpError("currently requires 32-bit integer vector elements");
+  }
   return success();
 }
 
@@ -5506,61 +5926,79 @@ LogicalResult VlreluOp::verify() { return verifyVecScalarMaskedOpLike(*this); }
 LogicalResult VshlsOp::verify() {
   auto inputType = dyn_cast<VRegType>(getInput().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return emitOpError("input and result must be !pto.vreg<...>");
-  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
-  if (inputType != resultType)
+  }
+  if (inputType != resultType) {
     return emitOpError("input and result vector types must match");
-  if (!isa<IntegerType>(inputType.getElementType()))
+  }
+  if (!isa<IntegerType>(inputType.getElementType())) {
     return emitOpError("requires integer vector and integer scalar");
+  }
   auto scalarType = dyn_cast<IntegerType>(getScalar().getType());
-  if (!scalarType || !scalarType.isSignlessInteger(16))
+  if (!scalarType || !scalarType.isSignlessInteger(16)) {
     return emitOpError("requires signless i16 scalar");
+  }
   return success();
 }
 LogicalResult VshrsOp::verify() {
   auto inputType = dyn_cast<VRegType>(getInput().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return emitOpError("input and result must be !pto.vreg<...>");
-  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
-  if (inputType != resultType)
+  }
+  if (inputType != resultType) {
     return emitOpError("input and result vector types must match");
-  if (!isa<IntegerType>(inputType.getElementType()))
+  }
+  if (!isa<IntegerType>(inputType.getElementType())) {
     return emitOpError("requires integer vector and integer scalar");
+  }
   auto scalarType = dyn_cast<IntegerType>(getScalar().getType());
-  if (!scalarType || !scalarType.isSignlessInteger(16))
+  if (!scalarType || !scalarType.isSignlessInteger(16)) {
     return emitOpError("requires signless i16 scalar");
+  }
   return success();
 }
 
 LogicalResult VabsOp::verify() {
-  if (failed(verifyVRegTypeLike(*this, getInput().getType(), "operand type")))
+  if (failed(verifyVRegTypeLike(*this, getInput().getType(), "operand type"))) {
     return failure();
-  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
-  if (failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
+  }
+  if (failed(verifyVRegTypeLike(*this, getResult().getType(), "result type"))) {
     return failure();
-  if (getInput().getType() != getResult().getType())
+  }
+  if (getInput().getType() != getResult().getType()) {
     return emitOpError("requires matching register vector shape");
+  }
   return success();
 }
 
 template <typename UnaryOp>
 static LogicalResult verifyUnaryVecOp(UnaryOp op) {
-  if (failed(verifyVRegTypeLike(op, op.getInput().getType(), "operand type")))
+  if (failed(verifyVRegTypeLike(op, op.getInput().getType(), "operand type"))) {
     return failure();
-  if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type"))) {
     return failure();
-  if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+  }
+  if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   if (failed(verifyNonLowPrecisionVRegElementTypeLike(
           op.getOperation(), op.getInput().getType(), "operand type")))
     return failure();
-  if (op.getInput().getType() != op.getResult().getType())
+  if (op.getInput().getType() != op.getResult().getType()) {
     return op.emitOpError("requires matching register vector shape");
+  }
   return success();
 }
 
@@ -5569,17 +6007,20 @@ LogicalResult VlnOp::verify() { return verifyUnaryVecOp(*this); }
 LogicalResult VsqrtOp::verify() { return verifyUnaryVecOp(*this); }
 LogicalResult VnegOp::verify() { return verifyUnaryVecOp(*this); }
 LogicalResult VreluOp::verify() {
-  if (failed(verifyUnaryVecOp(*this)))
+  if (failed(verifyUnaryVecOp(*this))) {
     return failure();
+  }
   auto inputType = cast<VRegType>(getInput().getType());
   Type elemType = inputType.getElementType();
   if (auto intType = dyn_cast<IntegerType>(elemType)) {
-    if (intType.getWidth() != 32 || intType.isUnsigned())
+    if (intType.getWidth() != 32 || intType.isUnsigned()) {
       return emitOpError("requires si32/i32/f16/f32 vector element type");
+    }
     return success();
   }
-  if (!elemType.isF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isF32()) {
     return emitOpError("requires si32/i32/f16/f32 vector element type");
+  }
   return success();
 }
 LogicalResult VnotOp::verify() { return verifyUnaryVecOp(*this); }
@@ -5587,14 +6028,18 @@ LogicalResult VnotOp::verify() { return verifyUnaryVecOp(*this); }
 template <typename BinaryOp>
 static LogicalResult verifyBinaryVecOp(BinaryOp op,
                                        bool allowLowPrecision = false) {
-  if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type")))
+  if (failed(verifyVRegTypeLike(op, op.getLhs().getType(), "lhs type"))) {
     return failure();
-  if (failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type")))
+  }
+  if (failed(verifyVRegTypeLike(op, op.getRhs().getType(), "rhs type"))) {
     return failure();
-  if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(op, op.getMask().getType(), "mask type"))) {
     return failure();
-  if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type")))
+  }
+  if (failed(verifyVRegTypeLike(op, op.getResult().getType(), "result type"))) {
     return failure();
+  }
   if (!allowLowPrecision &&
       failed(verifyNonLowPrecisionVRegElementTypeLike(
           op.getOperation(), op.getLhs().getType(), "lhs type")))
@@ -5637,27 +6082,33 @@ static LogicalResult verifyTernaryVecOp(TernaryOp op) {
 }
 
 LogicalResult VmaddOp::verify() {
-  if (failed(verifyTernaryVecOp(*this)))
+  if (failed(verifyTernaryVecOp(*this))) {
     return failure();
+  }
   Type elemType = cast<VRegType>(getAcc().getType()).getElementType();
-  if (!elemType.isF16() && !elemType.isBF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isBF16() && !elemType.isF32()) {
     return emitOpError("requires f16/bf16/f32 vector element type");
+  }
   return success();
 }
 LogicalResult VshlOp::verify() {
-  if (failed(verifyBinaryVecOp(*this)))
+  if (failed(verifyBinaryVecOp(*this))) {
     return failure();
+  }
   auto lhsType = cast<VRegType>(getLhs().getType());
-  if (!isa<IntegerType>(lhsType.getElementType()))
+  if (!isa<IntegerType>(lhsType.getElementType())) {
     return emitOpError("requires integer vector element type");
+  }
   return success();
 }
 LogicalResult VshrOp::verify() {
-  if (failed(verifyBinaryVecOp(*this)))
+  if (failed(verifyBinaryVecOp(*this))) {
     return failure();
+  }
   auto lhsType = cast<VRegType>(getLhs().getType());
-  if (!isa<IntegerType>(lhsType.getElementType()))
+  if (!isa<IntegerType>(lhsType.getElementType())) {
     return emitOpError("requires integer vector element type");
+  }
   return success();
 }
 LogicalResult VaddcOp::verify() { return verifyCarryVecOp(*this); }
@@ -5672,8 +6123,9 @@ static LogicalResult verifyReductionVecOp(ReductionOp op) {
 
 template <typename ReductionOp>
 static LogicalResult verifyGroupReductionVecOp(ReductionOp op) {
-  if (failed(verifyReductionVecOp(op)))
+  if (failed(verifyReductionVecOp(op))) {
     return failure();
+  }
   auto inputType = cast<VRegType>(op.getInput().getType());
   Type elemType = inputType.getElementType();
   if (auto intType = dyn_cast<IntegerType>(elemType)) {
@@ -5683,8 +6135,9 @@ static LogicalResult verifyGroupReductionVecOp(ReductionOp op) {
           "requires 8-bit, 16-bit, or 32-bit integer vector element type");
     return success();
   }
-  if (!elemType.isF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isF32()) {
     return op.emitOpError("requires i16/i32/f16/f32 vector element type");
+  }
   return success();
 }
 
@@ -5692,12 +6145,14 @@ LogicalResult VcgaddOp::verify() { return verifyGroupReductionVecOp(*this); }
 LogicalResult VcgmaxOp::verify() { return verifyGroupReductionVecOp(*this); }
 LogicalResult VcgminOp::verify() { return verifyGroupReductionVecOp(*this); }
 LogicalResult VcpaddOp::verify() {
-  if (failed(verifyReductionVecOp(*this)))
+  if (failed(verifyReductionVecOp(*this))) {
     return failure();
+  }
   auto inputType = cast<VRegType>(getInput().getType());
   Type elemType = inputType.getElementType();
-  if (!elemType.isF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isF32()) {
     return emitOpError("requires f16 or f32 vector element type");
+  }
   return success();
 }
 
@@ -5720,10 +6175,12 @@ static LogicalResult verifyHistogramOp(HistOp op) {
   if (!sourceElemType || sourceElemType.getWidth() != 8 ||
       sourceType.getElementCount() != 256)
     return op.emitOpError("requires source type to be !pto.vreg<256xi8>");
-  if (resultType != accType)
+  if (resultType != accType) {
     return op.emitOpError("requires result type to match acc type");
-  if (!op.getBin().getType().isInteger(32))
+  }
+  if (!op.getBin().getType().isInteger(32)) {
     return op.emitOpError("requires bin operand to be i32");
+  }
   return success();
 }
 
@@ -5746,8 +6203,9 @@ static LogicalResult verifyExtremaPredicateOp(ExtremaOp op) {
         "requires mask and predicate result to share one mask type");
 
   Type elemType = cast<VRegType>(op.getInput().getType()).getElementType();
-  if (elemType.isF16() || elemType.isF32())
+  if (elemType.isF16() || elemType.isF32()) {
     return success();
+  }
   auto intType = dyn_cast<IntegerType>(elemType);
   if (!intType || (intType.getWidth() != 8 && intType.getWidth() != 16 &&
                    intType.getWidth() != 32))
@@ -5768,15 +6226,19 @@ static LogicalResult verifyLaneSelectOp(SelectOp op) {
   auto src0Type = cast<VRegType>(op.getSrc0().getType());
   auto src1Type = cast<VRegType>(op.getSrc1().getType());
   auto resultType = cast<VRegType>(op.getResult().getType());
-  if (src0Type != resultType)
+  if (src0Type != resultType) {
     return op.emitOpError("requires src0 and result to have identical vector types");
-  if (src1Type.getElementCount() != src0Type.getElementCount())
+  }
+  if (src1Type.getElementCount() != src0Type.getElementCount()) {
     return op.emitOpError("requires src0/src1 to have identical element counts");
+  }
   auto src1ElemType = dyn_cast<IntegerType>(src1Type.getElementType());
-  if (!src1ElemType)
+  if (!src1ElemType) {
     return op.emitOpError("requires src1 to use integer vector elements");
-  if (src1ElemType.getWidth() != getIntOrFloatBitWidth(src0Type.getElementType()))
+  }
+  if (src1ElemType.getWidth() != getIntOrFloatBitWidth(src0Type.getElementType())) {
     return op.emitOpError("requires src1 integer element width to match src0 element width");
+  }
   return success();
 }
 
@@ -5803,8 +6265,9 @@ static LogicalResult verifyPartVecOp(PartOp op) {
   if (op.getLhs().getType() != op.getRhs().getType() ||
       op.getLhs().getType() != op.getResult().getType())
     return op.emitOpError("requires operands and result to share one vector type");
-  if (!isSupportedPartToken(op.getPart()))
+  if (!isSupportedPartToken(op.getPart())) {
     return op.emitOpError("requires part to be LOWER or HIGHER");
+  }
   return success();
 }
 
@@ -5833,17 +6296,21 @@ LogicalResult VusqzOp::verify() {
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
     return failure();
-  if (getSrc().getType() != getResult().getType())
+  if (getSrc().getType() != getResult().getType()) {
     return emitOpError("requires src and result to share one vector type");
+  }
   auto srcType = cast<VRegType>(getSrc().getType());
   auto elemType = dyn_cast<IntegerType>(srcType.getElementType());
-  if (!elemType)
+  if (!elemType) {
     return emitOpError("requires signed integer vector element type");
-  if (elemType.isUnsigned())
+  }
+  if (elemType.isUnsigned()) {
     return emitOpError("requires signed integer vector element type");
+  }
   unsigned width = elemType.getWidth();
-  if (width != 8 && width != 16 && width != 32)
+  if (width != 8 && width != 16 && width != 32) {
     return emitOpError("requires s8/s16/s32 vector element type");
+  }
   return success();
 }
 
@@ -5851,14 +6318,16 @@ LogicalResult VpackOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getSrc().getType(), "src type")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
     return failure();
-  if (!isSupportedPartToken(getPart()))
+  if (!isSupportedPartToken(getPart())) {
     return emitOpError("requires part to be LOWER or HIGHER");
+  }
   auto srcType = cast<VRegType>(getSrc().getType());
   auto resultType = cast<VRegType>(getResult().getType());
   Type srcElemType = srcType.getElementType();
   Type resultElemType = resultType.getElementType();
-  if (!isa<IntegerType>(srcElemType) || !isa<IntegerType>(resultElemType))
+  if (!isa<IntegerType>(srcElemType) || !isa<IntegerType>(resultElemType)) {
     return emitOpError("currently requires integer source and result element types");
+  }
   if (resultType.getElementCount() != srcType.getElementCount() * 2)
     return emitOpError(
         "requires result element count to be twice the source element count");
@@ -5869,8 +6338,9 @@ LogicalResult VpackOp::verify() {
         "requires result element width to be half the source element width");
   auto srcIntType = cast<IntegerType>(srcElemType);
   auto resultIntType = cast<IntegerType>(resultElemType);
-  if (!resultIntType.isUnsigned())
+  if (!resultIntType.isUnsigned()) {
     return emitOpError("requires unsigned result element type");
+  }
   if (!((srcIntType.getWidth() == 32 && resultIntType.getWidth() == 16) ||
         (srcIntType.getWidth() == 16 && resultIntType.getWidth() == 8)))
     return emitOpError(
@@ -5915,10 +6385,12 @@ LogicalResult VcmpOp::verify() {
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
       failed(verifyMaskTypeLike(*this, getResult().getType(), "result type")))
     return failure();
-  if (getSrc0().getType() != getSrc1().getType())
+  if (getSrc0().getType() != getSrc1().getType()) {
     return emitOpError("requires src0 and src1 to have identical vector types");
-  if (!isSupportedCmpMode(getCmpMode()))
+  }
+  if (!isSupportedCmpMode(getCmpMode())) {
     return emitOpError("requires cmp_mode to be one of eq/ne/lt/le/gt/ge");
+  }
   return success();
 }
 
@@ -5930,10 +6402,12 @@ LogicalResult VcmpsOp::verify() {
   auto srcType = cast<VRegType>(getSrc().getType());
   Type srcElementType = srcType.getElementType();
   Type scalarType = getScalar().getType();
-  if (!isCompatibleScalarForSemanticType(srcElementType, scalarType))
+  if (!isCompatibleScalarForSemanticType(srcElementType, scalarType)) {
     return emitOpError("requires scalar type to match source element type");
-  if (!isSupportedCmpMode(getCmpMode()))
+  }
+  if (!isSupportedCmpMode(getCmpMode())) {
     return emitOpError("requires cmp_mode to be one of eq/ne/lt/le/gt/ge");
+  }
   return success();
 }
 
@@ -5982,25 +6456,31 @@ void VtrcOp::print(OpAsmPrinter &printer) {
 LogicalResult VtrcOp::verify() {
   auto inputType = dyn_cast<VRegType>(getInput().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return emitOpError("input and result must be !pto.vreg<...>");
-  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
-  if (inputType != resultType)
+  }
+  if (inputType != resultType) {
     return emitOpError("requires input and result to have identical vreg type");
+  }
   auto elemType = inputType.getElementType();
-  if (!(elemType.isF16() || elemType.isF32() || elemType.isBF16()))
+  if (!(elemType.isF16() || elemType.isF32() || elemType.isBF16())) {
     return emitOpError("requires f16/f32/bf16 vector element type");
+  }
   auto expectedGranularity = getVdupMaskGranularity(elemType);
-  if (!expectedGranularity)
+  if (!expectedGranularity) {
     return emitOpError("requires element type with supported predicate granularity");
+  }
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
                                                "mask type",
                                                *expectedGranularity)))
     return failure();
   auto normalized = normalizeRoundModeToken(getRoundMode());
-  if (!normalized || !isSupportedVtrcRoundMode(*normalized))
+  if (!normalized || !isSupportedVtrcRoundMode(*normalized)) {
     return emitOpError("round mode must be one of R/A/F/C/Z");
+  }
   return success();
 }
 
@@ -6012,14 +6492,17 @@ LogicalResult VmulscvtOp::verify() {
 
   auto inputType = cast<VRegType>(getInput().getType());
   auto resultType = cast<VRegType>(getResult().getType());
-  if (!inputType.getElementType().isF32())
+  if (!inputType.getElementType().isF32()) {
     return emitOpError("requires f32 input vector element type");
-  if (!resultType.getElementType().isF16())
+  }
+  if (!resultType.getElementType().isF16()) {
     return emitOpError("requires f16 result vector element type");
+  }
 
   auto scalarType = getScalar().getType();
-  if (!scalarType.isF32())
+  if (!scalarType.isF32()) {
     return emitOpError("requires f32 scalar operand");
+  }
 
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
                                                "mask type", "b32")))
@@ -6032,14 +6515,17 @@ LogicalResult VmulscvtOp::verify() {
         "requires source and result to preserve total vector storage width");
 
   auto normalizedRnd = normalizeRoundModeToken(getRnd());
-  if (!normalizedRnd)
+  if (!normalizedRnd) {
     return emitOpError("rnd must be one of R/A/F/C/Z/O");
-  if (*normalizedRnd != "A")
+  }
+  if (*normalizedRnd != "A") {
     return emitOpError("currently only supports rnd A");
+  }
 
   auto normalizedPart = normalizeEvenOddPartToken(getPart());
-  if (!normalizedPart)
+  if (!normalizedPart) {
     return emitOpError("part must be EVEN or ODD");
+  }
   return success();
 }
 
@@ -6066,8 +6552,9 @@ ParseResult VcvtOp::parse(OpAsmParser &parser, OperationState &result) {
       [&](StringRef sourceName, StringRef canonicalName,
           auto normalizeFn) -> ParseResult {
     Attribute rawAttr = attrs.get(sourceName);
-    if (!rawAttr)
+    if (!rawAttr) {
       return success();
+    }
     auto strAttr = dyn_cast<StringAttr>(rawAttr);
     if (!strAttr)
       return parser.emitError(parser.getCurrentLocation())
@@ -6107,28 +6594,33 @@ void VcvtOp::print(OpAsmPrinter &printer) {
 LogicalResult VcvtOp::verify() {
   auto inputType = dyn_cast<VRegType>(getInput().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return emitOpError("input and result must be !pto.vreg<...>");
-  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
+  }
+  if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type"))) {
     return failure();
+  }
 
   VcvtElemKind inputElemKind = classifyVcvtElemType(inputType.getElementType());
   VcvtElemKind resultElemKind = classifyVcvtElemType(resultType.getElementType());
   auto contract = lookupVcvtContract(inputElemKind, resultElemKind);
-  if (!contract)
+  if (!contract) {
     return emitOpError("unsupported vcvt source/result element type pair");
+  }
 
   auto inputElemBits = getVcvtElemBitWidth(inputElemKind);
   auto resultElemBits = getVcvtElemBitWidth(resultElemKind);
-  if (!inputElemBits || !resultElemBits)
+  if (!inputElemBits || !resultElemBits) {
     return emitOpError("could not determine vcvt element bit width");
+  }
   unsigned maskBitWidth = std::min(*inputElemBits, 32u);
   StringRef expectedMaskGranularity = maskBitWidth == 8    ? "b8"
                                       : maskBitWidth == 16 ? "b16"
                                       : maskBitWidth == 32 ? "b32"
                                                            : "";
-  if (expectedMaskGranularity.empty())
+  if (expectedMaskGranularity.empty()) {
     return emitOpError("could not determine vcvt mask granularity");
+  }
   if (failed(verifyMaskTypeWithGranularityLike(
           *this, getMask().getType(), "mask type", expectedMaskGranularity)))
     return failure();
@@ -6141,10 +6633,12 @@ LogicalResult VcvtOp::verify() {
   if (getRndAttr()) {
     StringRef roundMode = *getRnd();
     auto normalizedRoundMode = normalizeRoundModeToken(roundMode);
-    if (!normalizedRoundMode)
+    if (!normalizedRoundMode) {
       return emitOpError("rnd must be one of R/A/F/C/Z/O/H");
-    if (!isValidVcvtRoundModeForContract(*normalizedRoundMode, *contract))
+    }
+    if (!isValidVcvtRoundModeForContract(*normalizedRoundMode, *contract)) {
       return emitOpError("rnd attr is not valid for this vcvt type pair");
+    }
   }
   if (static_cast<bool>(getRndAttr()) != contract->requiresRnd) {
     return contract->requiresRnd ? emitOpError("requires rnd attr for this vcvt type pair")
@@ -6153,8 +6647,9 @@ LogicalResult VcvtOp::verify() {
 
   if (getSatAttr()) {
     StringRef sat = *getSat();
-    if (!normalizeSaturationToken(sat))
+    if (!normalizeSaturationToken(sat)) {
       return emitOpError("sat must be SAT or NOSAT");
+    }
   }
   if (static_cast<bool>(getSatAttr()) != contract->requiresSat) {
     return contract->requiresSat ? emitOpError("requires sat attr for this vcvt type pair")
@@ -6164,13 +6659,16 @@ LogicalResult VcvtOp::verify() {
   if (getPartAttr()) {
     StringRef part = *getPart();
     auto normalizedPart = normalizeVcvtPartToken(part);
-    if (!normalizedPart)
+    if (!normalizedPart) {
       return emitOpError("part must be one of EVEN/ODD/P0/P1/P2/P3");
+    }
     std::optional<VcvtPartFamily> partFamily = contract->partFamily;
-    if (!partFamily)
+    if (!partFamily) {
       partFamily = classifyVcvtPartFamily(*inputElemBits, *resultElemBits);
-    if (!partFamily)
+    }
+    if (!partFamily) {
       return emitOpError("part attr is not supported for this vcvt width relation");
+    }
     if (!isValidVcvtPartForFamily(*normalizedPart, *partFamily)) {
       switch (*partFamily) {
       case VcvtPartFamily::EvenOdd:
@@ -6192,13 +6690,15 @@ LogicalResult VcvtOp::verify() {
 LogicalResult VbitcastOp::verify() {
   auto inputType = dyn_cast<VRegType>(getInput().getType());
   auto resultType = dyn_cast<VRegType>(getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return emitOpError("input and result must be !pto.vreg<...>");
+  }
 
   auto getStorageBits = [](VRegType type) -> std::optional<int64_t> {
     Type elementType = type.getElementType();
-    if (auto intType = dyn_cast<IntegerType>(elementType))
+    if (auto intType = dyn_cast<IntegerType>(elementType)) {
       return type.getElementCount() * static_cast<int64_t>(intType.getWidth());
+    }
     if (auto floatType = dyn_cast<FloatType>(elementType))
       return type.getElementCount() *
              static_cast<int64_t>(floatType.getWidth());
@@ -6207,8 +6707,9 @@ LogicalResult VbitcastOp::verify() {
 
   auto inputBits = getStorageBits(inputType);
   auto resultBits = getStorageBits(resultType);
-  if (!inputBits || !resultBits)
+  if (!inputBits || !resultBits) {
     return emitOpError("requires integer or floating-point vreg element type");
+  }
   if (*inputBits != *resultBits) {
     return emitOpError("requires source and result vectors to carry the same "
                        "total number of bits");
@@ -6306,10 +6807,12 @@ LogicalResult VmullOp::verify() {
     return failure();
   auto lhsType = cast<VRegType>(getLhs().getType());
   auto lhsElemType = dyn_cast<IntegerType>(lhsType.getElementType());
-  if (!lhsElemType)
+  if (!lhsElemType) {
     return emitOpError("requires integer vector element type");
-  if (lhsElemType.getWidth() != 32)
+  }
+  if (lhsElemType.getWidth() != 32) {
     return emitOpError("currently requires 32-bit integer vector elements");
+  }
   return success();
 }
 
@@ -6341,12 +6844,14 @@ static LogicalResult verifyBinaryVecNoMaskOp(BinaryVecNoMaskOp op) {
 
 template <typename BinaryVecNoMaskOp>
 static LogicalResult verifyFloatBinaryVecNoMaskOp(BinaryVecNoMaskOp op) {
-  if (failed(verifyBinaryVecNoMaskOp(op)))
+  if (failed(verifyBinaryVecNoMaskOp(op))) {
     return failure();
+  }
   auto lhsType = cast<VRegType>(op.getLhs().getType());
   Type elemType = lhsType.getElementType();
-  if (!elemType.isF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isF32()) {
     return op.emitOpError("requires f16 or f32 vector element type");
+  }
   return success();
 }
 
@@ -6362,8 +6867,9 @@ static LogicalResult verifyFloatBinaryVecMaskOp(BinaryVecMaskOp op) {
     return op.emitOpError("requires lhs, rhs, and result to share one vector type");
   auto lhsType = cast<VRegType>(op.getLhs().getType());
   Type elemType = lhsType.getElementType();
-  if (!elemType.isF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isF32()) {
     return op.emitOpError("requires f16 or f32 vector element type");
+  }
   return success();
 }
 
@@ -6378,21 +6884,25 @@ LogicalResult VexpdifOp::verify() {
   auto inputType = cast<VRegType>(getInput().getType());
   auto maxType = cast<VRegType>(getMax().getType());
   auto resultType = cast<VRegType>(getResult().getType());
-  if (inputType != maxType)
+  if (inputType != maxType) {
     return emitOpError("requires input and max to share one vector type");
+  }
 
   Type inputElemType = inputType.getElementType();
-  if (!inputElemType.isF16() && !inputElemType.isF32())
+  if (!inputElemType.isF16() && !inputElemType.isF32()) {
     return emitOpError("requires f16 or f32 input vector element type");
+  }
   auto expectedGranularity = getVdupMaskGranularity(inputElemType);
-  if (!expectedGranularity)
+  if (!expectedGranularity) {
     return emitOpError("requires input element type with supported predicate granularity");
+  }
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
                                                "mask type",
                                                *expectedGranularity)))
     return failure();
-  if (!resultType.getElementType().isF32())
+  if (!resultType.getElementType().isF32()) {
     return emitOpError("requires f32 result vector element type");
+  }
 
   auto inputBits = getVRegStorageBitWidth(inputType);
   auto resultBits = getVRegStorageBitWidth(resultType);
@@ -6401,8 +6911,9 @@ LogicalResult VexpdifOp::verify() {
         "requires source and result to preserve total vector storage width");
 
   StringRef part = getPart();
-  if (part != "EVEN" && part != "ODD")
+  if (part != "EVEN" && part != "ODD") {
     return emitOpError("part must be EVEN or ODD");
+  }
   return success();
 }
 
@@ -6415,20 +6926,24 @@ LogicalResult VaxpyOp::verify() {
   auto src0Type = cast<VRegType>(getSrc0().getType());
   auto src1Type = cast<VRegType>(getSrc1().getType());
   auto resultType = cast<VRegType>(getResult().getType());
-  if (src0Type != src1Type || src0Type != resultType)
+  if (src0Type != src1Type || src0Type != resultType) {
     return emitOpError("requires src0, src1, and result to share one vector type");
+  }
   Type elemType = src0Type.getElementType();
-  if (!elemType.isF16() && !elemType.isF32())
+  if (!elemType.isF16() && !elemType.isF32()) {
     return emitOpError("requires f16 or f32 vector element type");
+  }
   auto expectedGranularity = getVdupMaskGranularity(elemType);
-  if (!expectedGranularity)
+  if (!expectedGranularity) {
     return emitOpError("requires element type with supported predicate granularity");
+  }
   if (failed(verifyMaskTypeWithGranularityLike(*this, getMask().getType(),
                                                "mask type",
                                                *expectedGranularity)))
     return failure();
-  if (getAlpha().getType() != elemType)
+  if (getAlpha().getType() != elemType) {
     return emitOpError("requires alpha type to match vector element type");
+  }
   return success();
 }
 
@@ -6441,8 +6956,9 @@ static LogicalResult verifyFusedConvVecOp(ConvOp op) {
   auto lhsType = cast<VRegType>(op.getLhs().getType());
   auto rhsType = cast<VRegType>(op.getRhs().getType());
   auto resultType = cast<VRegType>(op.getResult().getType());
-  if (lhsType != rhsType)
+  if (lhsType != rhsType) {
     return op.emitOpError("requires lhs and rhs to share one vector type");
+  }
   if (!isIntegerOrFloatLike(lhsType.getElementType()) ||
       !isIntegerOrFloatLike(resultType.getElementType()))
     return op.emitOpError(
@@ -6467,19 +6983,24 @@ void Vldsx2Op::getEffects(
 }
 
 LogicalResult Vldsx2Op::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
-  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
-  if (!getOffset().getType().isIndex())
+  }
+  if (!getOffset().getType().isIndex()) {
     return emitOpError("requires index offset");
+  }
   if (failed(verifyVRegTypeLike(*this, getLow().getType(), "low result type")) ||
       failed(verifyVRegTypeLike(*this, getHigh().getType(), "high result type")))
     return failure();
-  if (getLow().getType() != getHigh().getType())
+  if (getLow().getType() != getHigh().getType()) {
     return emitOpError("requires low/high results to share one vector type");
-  if (!isSupportedVldx2DistToken(getDist()))
+  }
+  if (!isSupportedVldx2DistToken(getDist())) {
     return emitOpError("requires a supported x2 load distribution token");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getSource().getType())
     return emitOpError("requires updated base result to match base type");
@@ -6495,15 +7016,18 @@ void VstsOp::getEffects(
 
 template <typename StoreOp>
 static LogicalResult verifyVstsCommon(StoreOp op) {
-  if (failed(verifyVRegTypeLike(op, op.getValue().getType(), "value type")))
+  if (failed(verifyVRegTypeLike(op, op.getValue().getType(), "value type"))) {
     return failure();
+  }
 
-  if (!isBufferLike(op.getDestination().getType()))
+  if (!isBufferLike(op.getDestination().getType())) {
     return op.emitOpError("requires a pointer-like destination");
+  }
 
   MemoryRole destinationRole = classifyMemoryRole(op.getDestination().getType());
-  if (destinationRole == MemoryRole::GM)
+  if (destinationRole == MemoryRole::GM) {
     return op.emitOpError("requires a UB-backed destination");
+  }
 
   if (std::optional<StringRef> dist = op.getDist();
       dist && !isSupportedVstsDistToken(*dist)) {
@@ -6528,8 +7052,9 @@ static LogicalResult verifyVstsCommon(StoreOp op) {
 }
 
 LogicalResult VstsOp::verify() {
-  if (failed(verifyVstsCommon(*this)))
+  if (failed(verifyVstsCommon(*this))) {
     return failure();
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getDestination().getType())
     return emitOpError("requires updated base result to match base type");
@@ -6548,16 +7073,21 @@ LogicalResult Vstsx2Op::verify() {
       failed(verifyVRegTypeLike(*this, getHigh().getType(), "high value type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
     return failure();
-  if (getLow().getType() != getHigh().getType())
+  if (getLow().getType() != getHigh().getType()) {
     return emitOpError("requires low/high values to share one vector type");
-  if (!isBufferLike(getDestination().getType()))
+  }
+  if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
-  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
-  if (!getOffset().getType().isIndex())
+  }
+  if (!getOffset().getType().isIndex()) {
     return emitOpError("requires index offset");
-  if (!isSupportedVstsx2DistToken(getDist()))
+  }
+  if (!isSupportedVstsx2DistToken(getDist())) {
     return emitOpError("requires a supported x2 store distribution token");
+  }
   return success();
 }
 
@@ -6569,20 +7099,25 @@ void VscatterOp::getEffects(
 }
 
 LogicalResult VscatterOp::verify() {
-  if (failed(verifyVRegTypeLike(*this, getValue().getType(), "value type")))
+  if (failed(verifyVRegTypeLike(*this, getValue().getType(), "value type"))) {
     return failure();
-  if (!isBufferLike(getDestination().getType()))
+  }
+  if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
+  }
   auto offsetsType = dyn_cast<VRegType>(getOffsets().getType());
   auto valueType = dyn_cast<VRegType>(getValue().getType());
-  if (!offsetsType || !valueType)
+  if (!offsetsType || !valueType) {
     return emitOpError("value and offsets must be !pto.vreg<...>");
+  }
   auto offsetsElemType = dyn_cast<IntegerType>(offsetsType.getElementType());
-  if (!offsetsElemType)
+  if (!offsetsElemType) {
     return emitOpError("offset vector must use integer element type");
+  }
   unsigned valueElemWidth = getPTOStorageElemBitWidth(valueType.getElementType());
-  if (valueElemWidth != 8 && valueElemWidth != 16 && valueElemWidth != 32)
+  if (valueElemWidth != 8 && valueElemWidth != 16 && valueElemWidth != 32) {
     return emitOpError("requires 8-, 16-, or 32-bit value elements");
+  }
 
   unsigned expectedOffsetWidth = valueElemWidth == 32 ? 32 : 16;
   if (offsetsElemType.getWidth() != expectedOffsetWidth)
@@ -6607,8 +7142,9 @@ LogicalResult VscatterOp::verify() {
     return emitOpError(
         "requires destination element type to match value element type");
   MemoryRole destinationRole = classifyMemoryRole(getDestination().getType());
-  if (destinationRole == MemoryRole::GM)
+  if (destinationRole == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
+  }
   return success();
 }
 
@@ -6619,17 +7155,21 @@ void VsldbOp::getEffects(
 }
 
 LogicalResult VsldbOp::verify() {
-  if (!isBufferLike(getSource().getType()))
+  if (!isBufferLike(getSource().getType())) {
     return emitOpError("requires a pointer-like source");
-  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getSource().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed source");
+  }
   if (failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")) ||
       failed(verifyVRegTypeLike(*this, getResult().getType(), "result type")))
     return failure();
-  if (!getBlockStride().getType().isSignlessInteger(16))
+  if (!getBlockStride().getType().isSignlessInteger(16)) {
     return emitOpError("requires block_stride to be i16");
-  if (!getRepeatStride().getType().isSignlessInteger(16))
+  }
+  if (!getRepeatStride().getType().isSignlessInteger(16)) {
     return emitOpError("requires repeat_stride to be i16");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getSource().getType())
     return emitOpError("requires updated base result to match base type");
@@ -6651,16 +7191,21 @@ void PstiOp::getEffects(
 }
 
 LogicalResult PstiOp::verify() {
-  if (failed(verifyMaskTypeLike(*this, getValue().getType(), "value type")))
+  if (failed(verifyMaskTypeLike(*this, getValue().getType(), "value type"))) {
     return failure();
-  if (!isBufferLike(getDestination().getType()))
+  }
+  if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
-  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
-  if (!matchPattern(getOffset(), m_Constant()))
+  }
+  if (!matchPattern(getOffset(), m_Constant())) {
     return emitOpError("requires offset to be a constant index immediate");
-  if (!isSupportedPredicateStoreDist(getDist()))
+  }
+  if (!isSupportedPredicateStoreDist(getDist())) {
     return emitOpError("requires predicate store dist to be NORM or PK");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getDestination().getType())
     return emitOpError("requires updated base result to match base type");
@@ -6668,17 +7213,22 @@ LogicalResult PstiOp::verify() {
 }
 
 LogicalResult PstsOp::verify() {
-  if (failed(verifyMaskTypeLike(*this, getValue().getType(), "value type")))
+  if (failed(verifyMaskTypeLike(*this, getValue().getType(), "value type"))) {
     return failure();
-  if (!isBufferLike(getDestination().getType()))
+  }
+  if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
+  }
   MemoryRole destinationRole = classifyMemoryRole(getDestination().getType());
-  if (destinationRole == MemoryRole::GM)
+  if (destinationRole == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
-  if (!getOffset().getType().isIndex())
+  }
+  if (!getOffset().getType().isIndex()) {
     return emitOpError("requires index offset");
-  if (!isSupportedPredicateStoreDist(getDist()))
+  }
+  if (!isSupportedPredicateStoreDist(getDist())) {
     return emitOpError("requires predicate store dist to be NORM or PK");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getDestination().getType())
     return emitOpError("requires updated base result to match base type");
@@ -6696,14 +7246,18 @@ LogicalResult VsstbOp::verify() {
   if (failed(verifyVRegTypeLike(*this, getValue().getType(), "value type")) ||
       failed(verifyMaskTypeLike(*this, getMask().getType(), "mask type")))
     return failure();
-  if (!isBufferLike(getDestination().getType()))
+  if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
-  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
-  if (!getBlockStride().getType().isSignlessInteger(16))
+  }
+  if (!getBlockStride().getType().isSignlessInteger(16)) {
     return emitOpError("requires block_stride to be i16");
-  if (!getRepeatStride().getType().isSignlessInteger(16))
+  }
+  if (!getRepeatStride().getType().isSignlessInteger(16)) {
     return emitOpError("requires repeat_stride to be i16");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getDestination().getType())
     return emitOpError("requires updated base result to match base type");
@@ -6718,12 +7272,15 @@ void VstasOp::getEffects(
 }
 
 LogicalResult VstasOp::verify() {
-  if (failed(verifyStoreAlignChain(getValue(), *this, "value type")))
+  if (failed(verifyStoreAlignChain(getValue(), *this, "value type"))) {
     return failure();
-  if (!isBufferLike(getDestination().getType()))
+  }
+  if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
-  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
+  }
   if (getUpdatedBase() &&
       getUpdatedBase().getType() != getDestination().getType())
     return emitOpError("requires updated base result to match base type");
@@ -6738,12 +7295,15 @@ void VstarOp::getEffects(
 }
 
 LogicalResult VstarOp::verify() {
-  if (failed(verifyStoreAlignChain(getValue(), *this, "value type")))
+  if (failed(verifyStoreAlignChain(getValue(), *this, "value type"))) {
     return failure();
-  if (!isBufferLike(getDestination().getType()))
+  }
+  if (!isBufferLike(getDestination().getType())) {
     return emitOpError("requires a pointer-like destination");
-  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getDestination().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed destination");
+  }
   return success();
 }
 
@@ -6760,21 +7320,27 @@ LogicalResult PstuOp::verify() {
       failed(verifyMaskTypeLike(*this, getValue().getType(), "value type")) ||
       failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type")))
     return failure();
-  if (!isBufferLike(getBase().getType()) || !isBufferLike(getBaseOut().getType()))
+  if (!isBufferLike(getBase().getType()) || !isBufferLike(getBaseOut().getType())) {
     return emitOpError("requires pointer-like base and base_out");
-  if (getBase().getType() != getBaseOut().getType())
+  }
+  if (getBase().getType() != getBaseOut().getType()) {
     return emitOpError("requires base and base_out to have identical types");
-  if (classifyMemoryRole(getBase().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getBase().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed base");
+  }
   auto baseType = cast<pto::PtrType>(getBase().getType());
   auto maskType = cast<pto::MaskType>(getValue().getType());
   auto elemType = dyn_cast<IntegerType>(baseType.getElementType());
-  if (!elemType || elemType.isSigned() || (elemType.getWidth() != 16 && elemType.getWidth() != 32))
+  if (!elemType || elemType.isSigned() || (elemType.getWidth() != 16 && elemType.getWidth() != 32)) {
     return emitOpError("requires ui16/ui32 UB base type");
-  if (maskType.isB16() && elemType.getWidth() != 16)
+  }
+  if (maskType.isB16() && elemType.getWidth() != 16) {
     return emitOpError("requires !pto.mask<b16> to pair with !pto.ptr<ui16, ub>");
-  if (maskType.isB32() && elemType.getWidth() != 32)
+  }
+  if (maskType.isB32() && elemType.getWidth() != 32) {
     return emitOpError("requires !pto.mask<b32> to pair with !pto.ptr<ui32, ub>");
+  }
   return success();
 }
 
@@ -6791,12 +7357,15 @@ LogicalResult VstusOp::verify() {
       failed(verifyVRegTypeLike(*this, getValue().getType(), "value type")) ||
       failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type")))
     return failure();
-  if (!isBufferLike(getBase().getType()))
+  if (!isBufferLike(getBase().getType())) {
     return emitOpError("requires a pointer-like base");
-  if (classifyMemoryRole(getBase().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getBase().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed base");
-  if (getBaseOut() && getBaseOut().getType() != getBase().getType())
+  }
+  if (getBaseOut() && getBaseOut().getType() != getBase().getType()) {
     return emitOpError("requires updated base result to match base type");
+  }
   return success();
 }
 
@@ -6813,12 +7382,15 @@ LogicalResult VsturOp::verify() {
       failed(verifyVRegTypeLike(*this, getValue().getType(), "value type")) ||
       failed(verifyAlignTypeLike(*this, getAlignOut().getType(), "align_out type")))
     return failure();
-  if (!isBufferLike(getBase().getType()))
+  if (!isBufferLike(getBase().getType())) {
     return emitOpError("requires a pointer-like base");
-  if (classifyMemoryRole(getBase().getType()) == MemoryRole::GM)
+  }
+  if (classifyMemoryRole(getBase().getType()) == MemoryRole::GM) {
     return emitOpError("requires a UB-backed base");
-  if (!isSupportedPostMode(getMode()))
+  }
+  if (!isSupportedPostMode(getMode())) {
     return emitOpError("requires mode to be POST_UPDATE or NO_POST_UPDATE");
+  }
   return success();
 }
 
@@ -6839,14 +7411,18 @@ void MteUbGmOp::build(OpBuilder &builder, OperationState &state, Value source,
                        llvm::ArrayRef<pto::DmaLoopConfig> loops) {
   state.addOperands({source, destination, lenBurst, nburst.count,
                      nburst.srcStride, nburst.dstStride});
-  if (l2CacheCtl)
+  if (l2CacheCtl) {
     state.addOperands(l2CacheCtl);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.count);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.srcStride);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.dstStride);
+  }
 
   state.addAttribute(
       getOperandSegmentSizeAttr(),
@@ -6863,10 +7439,12 @@ void MteUbGmOp::build(OpBuilder &builder, OperationState &state, Value source,
                        std::optional<pto::DmaLoopConfig> loop1,
                        std::optional<pto::DmaLoopConfig> loop2) {
   SmallVector<pto::DmaLoopConfig> loops;
-  if (loop1)
+  if (loop1) {
     loops.push_back(*loop1);
-  if (loop2)
+  }
+  if (loop2) {
     loops.push_back(*loop2);
+  }
   build(builder, state, source, destination, lenBurst, nburst, l2CacheCtl,
         loops);
 }
@@ -6895,15 +7473,17 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
                                          parsedKeyword, loopGroupOperands))
       return failure();
-    if (parsedKeyword.empty())
+    if (parsedKeyword.empty()) {
       break;
+    }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
     loopDstStrideOperands.push_back(loopGroupOperands[2]);
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, lenBurstType, l2CacheCtlType;
   SmallVector<Type> nburstTypes, loopCountTypes, loopSrcStrideTypes,
@@ -6914,17 +7494,20 @@ ParseResult MteUbGmOp::parse(OpAsmParser &parser, OperationState &result) {
       parseDmaTripleTypes(parser, nburstTypes))
     return failure();
   if (hasL2CacheCtl) {
-    if (parser.parseComma() || parser.parseType(l2CacheCtlType))
+    if (parser.parseComma() || parser.parseType(l2CacheCtlType)) {
       return failure();
+    }
   }
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword))
+    if (parser.parseKeyword(&keyword)) {
       return failure();
+    }
     if (isDmaLoopKeyword(keyword)) {
       SmallVector<Type> loopGroupTypes;
-      if (parseDmaTripleTypes(parser, loopGroupTypes))
+      if (parseDmaTripleTypes(parser, loopGroupTypes)) {
         return failure();
+      }
       loopCountTypes.push_back(loopGroupTypes[0]);
       loopSrcStrideTypes.push_back(loopGroupTypes[1]);
       loopDstStrideTypes.push_back(loopGroupTypes[2]);
@@ -6977,8 +7560,9 @@ void MteUbGmOp::print(OpAsmPrinter &printer) {
           << getLenBurst();
   printDmaTripleGroup(printer, "nburst", getNBurst(), getNburstSrcStride(),
                       getNburstDstStride());
-  if (Value l2CacheCtl = getL2CacheCtl())
+  if (Value l2CacheCtl = getL2CacheCtl()) {
     printer << " l2_cache_ctl(" << l2CacheCtl << ")";
+  }
   for (auto [count, srcStride, dstStride] :
        llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
     printDmaTripleGroup(printer, "loop", count, srcStride, dstStride);
@@ -6988,8 +7572,9 @@ void MteUbGmOp::print(OpAsmPrinter &printer) {
           << ", " << getNburstSrcStride().getType()
           << ", "
           << getNburstDstStride().getType();
-  if (Value l2CacheCtl = getL2CacheCtl())
+  if (Value l2CacheCtl = getL2CacheCtl()) {
     printer << ", " << l2CacheCtl.getType();
+  }
   for (auto [count, srcStride, dstStride] :
        llvm::zip(getLoopCounts(), getLoopSrcStrides(), getLoopDstStrides()))
     printDmaTripleTypes(printer, "loop", count.getType(), srcStride.getType(),
@@ -7039,12 +7624,15 @@ void MteGmL1Op::build(OpBuilder &builder, OperationState &state, Value source,
   state.addOperands(
       {source, destination, lenBurst, nburst.count, nburst.srcStride,
        nburst.dstStride});
-  for (const pto::DmaLoopConfig &loop : loops)
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.count);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.srcStride);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.dstStride);
+  }
 
   state.addAttribute(
       getOperandSegmentSizeAttr(),
@@ -7061,10 +7649,12 @@ void MteGmL1Op::build(OpBuilder &builder, OperationState &state, Value source,
                        std::optional<pto::DmaLoopConfig> loop1,
                        std::optional<pto::DmaLoopConfig> loop2) {
   SmallVector<pto::DmaLoopConfig> loops;
-  if (loop1)
+  if (loop1) {
     loops.push_back(*loop1);
-  if (loop2)
+  }
+  if (loop2) {
     loops.push_back(*loop2);
+  }
   build(builder, state, source, destination, lenBurst, nburst, loops);
 }
 
@@ -7075,12 +7665,15 @@ void MteL1UbOp::build(OpBuilder &builder, OperationState &state, Value source,
   state.addOperands(
       {source, destination, lenBurst, nburst.count, nburst.srcStride,
        nburst.dstStride});
-  for (const pto::DmaLoopConfig &loop : loops)
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.count);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.srcStride);
-  for (const pto::DmaLoopConfig &loop : loops)
+  }
+  for (const pto::DmaLoopConfig &loop : loops) {
     state.addOperands(loop.dstStride);
+  }
 
   state.addAttribute(
       getOperandSegmentSizeAttr(),
@@ -7097,10 +7690,12 @@ void MteL1UbOp::build(OpBuilder &builder, OperationState &state, Value source,
                         std::optional<pto::DmaLoopConfig> loop1,
                         std::optional<pto::DmaLoopConfig> loop2) {
   SmallVector<pto::DmaLoopConfig> loops;
-  if (loop1)
+  if (loop1) {
     loops.push_back(*loop1);
-  if (loop2)
+  }
+  if (loop2) {
     loops.push_back(*loop2);
+  }
   build(builder, state, source, destination, lenBurst, nburst, loops);
 }
 
@@ -7117,8 +7712,9 @@ void MteGmL1FracOp::build(OpBuilder &builder, OperationState &state,
                      dstGroup.dstLoop3Stride, dstGroup.dstLoop4Stride,
                      ctrl.l2CacheCtrl, ctrl.smallc0En});
   bool hasSrcOuterStride = srcLayout.srcOuterStride.has_value();
-  if (hasSrcOuterStride)
+  if (hasSrcOuterStride) {
     state.addOperands(*srcLayout.srcOuterStride);
+  }
 
   state.addAttribute(getModeAttrName(state.name),
                      CubeLoadFracModeAttr::get(builder.getContext(), mode));
@@ -7141,15 +7737,17 @@ ParseResult MteGmL1Op::parse(OpAsmParser &parser, OperationState &result) {
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
                                          parsedKeyword, loopGroupOperands))
       return failure();
-    if (parsedKeyword.empty())
+    if (parsedKeyword.empty()) {
       break;
+    }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
     loopDstStrideOperands.push_back(loopGroupOperands[2]);
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, lenBurstType;
   SmallVector<Type> nburstTypes, loopCountTypes, loopSrcStrideTypes,
@@ -7161,13 +7759,16 @@ ParseResult MteGmL1Op::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword))
+    if (parser.parseKeyword(&keyword)) {
       return failure();
-    if (!isDmaLoopKeyword(keyword))
+    }
+    if (!isDmaLoopKeyword(keyword)) {
       return parser.emitError(parser.getCurrentLocation(), "expected 'loop'");
+    }
     SmallVector<Type> loopGroupTypes;
-    if (parseDmaTripleTypes(parser, loopGroupTypes))
+    if (parseDmaTripleTypes(parser, loopGroupTypes)) {
       return failure();
+    }
     loopCountTypes.push_back(loopGroupTypes[0]);
     loopSrcStrideTypes.push_back(loopGroupTypes[1]);
     loopDstStrideTypes.push_back(loopGroupTypes[2]);
@@ -7222,15 +7823,17 @@ ParseResult MteL1UbOp::parse(OpAsmParser &parser, OperationState &result) {
     if (parseOptionalDmaTripleGroupAlias(parser, {"loop", "loop1", "loop2"},
                                          parsedKeyword, loopGroupOperands))
       return failure();
-    if (parsedKeyword.empty())
+    if (parsedKeyword.empty()) {
       break;
+    }
     loopCountOperands.push_back(loopGroupOperands[0]);
     loopSrcStrideOperands.push_back(loopGroupOperands[1]);
     loopDstStrideOperands.push_back(loopGroupOperands[2]);
   }
 
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, lenBurstType;
   SmallVector<Type> nburstTypes, loopCountTypes, loopSrcStrideTypes,
@@ -7242,13 +7845,16 @@ ParseResult MteL1UbOp::parse(OpAsmParser &parser, OperationState &result) {
     return failure();
   while (succeeded(parser.parseOptionalComma())) {
     StringRef keyword;
-    if (parser.parseKeyword(&keyword))
+    if (parser.parseKeyword(&keyword)) {
       return failure();
-    if (!isDmaLoopKeyword(keyword))
+    }
+    if (!isDmaLoopKeyword(keyword)) {
       return parser.emitError(parser.getCurrentLocation(), "expected 'loop'");
+    }
     SmallVector<Type> loopGroupTypes;
-    if (parseDmaTripleTypes(parser, loopGroupTypes))
+    if (parseDmaTripleTypes(parser, loopGroupTypes)) {
       return failure();
+    }
     loopCountTypes.push_back(loopGroupTypes[0]);
     loopSrcStrideTypes.push_back(loopGroupTypes[1]);
     loopDstStrideTypes.push_back(loopGroupTypes[2]);
@@ -7307,8 +7913,9 @@ ParseResult MteGmL1FracOp::parse(OpAsmParser &parser, OperationState &result) {
       parseFixedKeywordOperandGroup(parser, "ctrl", 2, ctrlOperands))
     return failure();
 
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType;
   SmallVector<Type> shapeTypes;
@@ -7531,16 +8138,18 @@ void MteGmL1FracOp::print(OpAsmPrinter &printer) {
 }
 
 LogicalResult MteGmL1Op::verify() {
-  if (failed(verifyCopyGmToUbufOp(*this, true)))
+  if (failed(verifyCopyGmToUbufOp(*this, true))) {
     return failure();
+  }
   return verifyDmaLoadStoreLoopGroups(
       getOperation(), getLoopCounts(), getLoopSrcStrides(),
       getLoopDstStrides());
 }
 
 LogicalResult MteL1UbOp::verify() {
-  if (failed(verifyCopyCbufToUbufLikeOp(*this)))
+  if (failed(verifyCopyCbufToUbufLikeOp(*this))) {
     return failure();
+  }
   return verifyDmaLoadStoreLoopGroups(
       getOperation(), getLoopCounts(), getLoopSrcStrides(),
       getLoopDstStrides());
@@ -7548,20 +8157,24 @@ LogicalResult MteL1UbOp::verify() {
 
 LogicalResult MteL1BtOp::verify() {
   auto getBufferElementType = [](Type type) -> Type {
-    if (auto ptrType = dyn_cast<pto::PtrType>(type))
+    if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
       return ptrType.getElementType();
-    if (auto memrefType = dyn_cast<BaseMemRefType>(type))
+    }
+    if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
       return memrefType.getElementType();
+    }
     return {};
   };
 
   if (!isBufferLike(getSource().getType()) ||
       !isBufferLike(getDestination().getType()))
     return emitOpError("requires buffer-like source and destination");
-  if (getBufferAddressSpace(getSource().getType()) != pto::AddressSpace::MAT)
+  if (getBufferAddressSpace(getSource().getType()) != pto::AddressSpace::MAT) {
     return emitOpError("requires MAT source");
-  if (getBufferAddressSpace(getDestination().getType()) != pto::AddressSpace::BIAS)
+  }
+  if (getBufferAddressSpace(getDestination().getType()) != pto::AddressSpace::BIAS) {
     return emitOpError("requires BIAS destination");
+  }
 
   Type srcElem = getBufferElementType(getSource().getType());
   Type dstElem = getBufferElementType(getDestination().getType());
@@ -7584,14 +8197,17 @@ LogicalResult MteL1FbOp::verify() {
         "requires typed !pto.ptr or memref source and destination");
 
   auto getAddressSpace = [](Type type) -> std::optional<pto::AddressSpace> {
-    if (auto ptrType = dyn_cast<pto::PtrType>(type))
+    if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
       return ptrType.getMemorySpace().getAddressSpace();
+    }
     if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
       Attribute memorySpace = memrefType.getMemorySpace();
-      if (auto addrSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(memorySpace))
+      if (auto addrSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(memorySpace)) {
         return addrSpace.getAddressSpace();
-      if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace))
+      }
+      if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace)) {
         return static_cast<pto::AddressSpace>(intAttr.getInt());
+      }
     }
     return std::nullopt;
   };
@@ -7599,23 +8215,28 @@ LogicalResult MteL1FbOp::verify() {
   std::optional<pto::AddressSpace> sourceAS = getAddressSpace(getSource().getType());
   std::optional<pto::AddressSpace> destinationAS =
       getAddressSpace(getDestination().getType());
-  if (!sourceAS || !destinationAS)
+  if (!sourceAS || !destinationAS) {
     return emitOpError("requires source and destination with PTO address spaces");
-  if (*sourceAS != pto::AddressSpace::MAT)
+  }
+  if (*sourceAS != pto::AddressSpace::MAT) {
     return emitOpError("requires source in mat address space");
-  if (*destinationAS != pto::AddressSpace::SCALING)
+  }
+  if (*destinationAS != pto::AddressSpace::SCALING) {
     return emitOpError("requires destination in scaling address space");
+  }
   return success();
 }
 
 LogicalResult MteGmL1FracOp::verify() {
-  if (failed(verifyCopyGmToUbufOp(*this, true)))
+  if (failed(verifyCopyGmToUbufOp(*this, true))) {
     return failure();
+  }
 
   auto checkNonNegativeConst = [&](Value value, StringRef name) -> LogicalResult {
     APInt intValue;
-    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative())
+    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative()) {
       return emitOpError() << name << " must be non-negative";
+    }
     return success();
   };
   if (failed(checkNonNegativeConst(getGroupCount(), "group_count")) ||
@@ -7779,8 +8400,9 @@ static LogicalResult verifyCubeBridgeLoadStart(Operation *op, Value firstStart,
                                                StringRef secondName) {
   auto checkNonNegativeConst = [&](Value value, StringRef name) -> LogicalResult {
     APInt intValue;
-    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative())
+    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative()) {
       return op->emitOpError() << name << " must be non-negative";
+    }
     return success();
   };
 
@@ -7813,14 +8435,16 @@ struct MxLoadAsmOperand {
 static std::optional<unsigned>
 getMxLoadOperandIndex(StringRef keyword, ArrayRef<StringRef> shapeNames) {
   for (auto [index, name] : llvm::enumerate(shapeNames))
-    if (keyword == name)
+    if (keyword == name) {
       return index;
+    }
 
   static constexpr StringRef kFullNames[] = {
       "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
   for (auto [index, name] : llvm::enumerate(kFullNames))
-    if (keyword == name)
+    if (keyword == name) {
       return shapeNames.size() + index;
+    }
   return std::nullopt;
 }
 
@@ -7861,20 +8485,24 @@ static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
     StringRef keyword;
     if (succeeded(parser.parseOptionalKeyword(&keyword))) {
       usesNamedOperands = true;
-      if (parseNamedOperand(keyword))
+      if (parseNamedOperand(keyword)) {
         return failure();
+      }
       while (succeeded(parser.parseOptionalComma())) {
-        if (parser.parseKeyword(&keyword) || parseNamedOperand(keyword))
+        if (parser.parseKeyword(&keyword) || parseNamedOperand(keyword)) {
           return failure();
+        }
       }
     } else {
       OpAsmParser::UnresolvedOperand operand;
-      if (parser.parseOperand(operand))
+      if (parser.parseOperand(operand)) {
         return failure();
+      }
       legacyOperands.push_back(operand);
       while (succeeded(parser.parseOptionalComma())) {
-        if (parser.parseOperand(operand))
+        if (parser.parseOperand(operand)) {
           return failure();
+        }
         legacyOperands.push_back(operand);
       }
     }
@@ -7886,8 +8514,9 @@ static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
                             "expects either four shape-derived or six full "
                             "positional MX operands");
 
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType;
   Type destinationType;
@@ -7899,15 +8528,17 @@ static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
   if (usesNamedOperands) {
     for (unsigned index : namedOperandOrder) {
       Type type;
-      if (parser.parseComma() || parser.parseType(type))
+      if (parser.parseComma() || parser.parseType(type)) {
         return failure();
+      }
       namedOperands[index].type = type;
     }
   } else {
     for (size_t index = 0; index < legacyOperands.size(); ++index) {
       Type type;
-      if (parser.parseComma() || parser.parseType(type))
+      if (parser.parseComma() || parser.parseType(type)) {
         return failure();
+      }
       legacyTypes.push_back(type);
     }
   }
@@ -7922,8 +8553,9 @@ static ParseResult parseMteL1L0MxOp(OpAsmParser &parser,
 
   if (usesNamedOperands) {
     for (unsigned index = 0; index < namedOperands.size(); ++index) {
-      if (!namedOperands[index].present)
+      if (!namedOperands[index].present) {
         continue;
+      }
       segmentSizes[2 + index] = 1;
       if (parser.resolveOperand(namedOperands[index].operand,
                                 namedOperands[index].type,
@@ -7976,14 +8608,16 @@ static void printMteL1L0MxOp(OpAsmPrinter &printer, Operation *operation,
     }
   } else {
     for (auto [index, value] : llvm::enumerate(shapeOperands)) {
-      if (!value)
+      if (!value) {
         continue;
+      }
       printer << ", " << shapeNames[index] << "(" << value << ")";
       printedOperands.push_back(value);
     }
     for (auto [index, value] : llvm::enumerate(fullOperands)) {
-      if (!value)
+      if (!value) {
         continue;
+      }
       printer << ", " << fullNames[index] << "(" << value << ")";
       printedOperands.push_back(value);
     }
@@ -7992,8 +8626,9 @@ static void printMteL1L0MxOp(OpAsmPrinter &printer, Operation *operation,
   printer.printOptionalAttrDict(operation->getAttrs(),
                                 /*elidedAttrs=*/{"operandSegmentSizes"});
   printer << " : " << source.getType() << ", " << destination.getType();
-  for (Value value : printedOperands)
+  for (Value value : printedOperands) {
     printer << ", " << value.getType();
+  }
 }
 
 static LogicalResult verifyMxLoadOperands(Operation *op,
@@ -8003,8 +8638,9 @@ static LogicalResult verifyMxLoadOperands(Operation *op,
   auto checkNonNegativeConst = [&](Value value,
                                    StringRef name) -> LogicalResult {
     APInt intValue;
-    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative())
+    if (matchPattern(value, m_ConstantInt(&intValue)) && intValue.isNegative()) {
       return op->emitOpError() << name << " must be non-negative";
+    }
     return success();
   };
 
@@ -8033,8 +8669,9 @@ static LogicalResult verifyMxLoadOperands(Operation *op,
   static constexpr StringRef kFullNames[] = {
       "x_start", "y_start", "x_step", "y_step", "src_stride", "dst_stride"};
   for (auto [value, name] : llvm::zip(fullOperands, kFullNames))
-    if (!value)
+    if (!value) {
       return op->emitOpError() << "full MX form requires " << name;
+    }
   if (failed(verifyCubeBridgeLoadStart(op, fullOperands[0], "x_start",
                                        fullOperands[1], "y_start")))
     return failure();
@@ -8050,13 +8687,15 @@ static LogicalResult verifyMxPointerAlignment(Operation *op, Value pointer,
                                               StringRef pointerName,
                                               int64_t alignmentBytes) {
   auto pointerCast = pointer.getDefiningOp<CastPtrOp>();
-  if (!pointerCast || !isa<IntegerType>(pointerCast.getInput().getType()))
+  if (!pointerCast || !isa<IntegerType>(pointerCast.getInput().getType())) {
     return success();
+  }
 
   std::optional<int64_t> address =
       mlir::getConstantIntValue(pointerCast.getInput());
-  if (!address || (*address % alignmentBytes) == 0)
+  if (!address || (*address % alignmentBytes) == 0) {
     return success();
+  }
 
   return op->emitOpError()
          << "statically known LOAD.MX " << pointerName
@@ -8080,8 +8719,9 @@ static LogicalResult verifyExplicitCubeBridgeLoadControls(OpTy op) {
   auto checkConstRange = [&](Value value, StringRef name, int64_t min,
                              int64_t max) -> LogicalResult {
     APInt intValue;
-    if (!matchPattern(value, m_ConstantInt(&intValue)))
+    if (!matchPattern(value, m_ConstantInt(&intValue))) {
       return success();
+    }
     int64_t signedValue = intValue.getSExtValue();
     if (signedValue < min)
       return op.emitOpError()
@@ -8127,14 +8767,16 @@ LogicalResult MteL0cL1Op::verify() {
 }
 
 LogicalResult MteL1L0aOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT"))) {
     return failure();
+  }
   return verifyCubeBridgeLoadStart(*this);
 }
 
 LogicalResult MteL1L0bOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT"))) {
     return failure();
+  }
   return verifyCubeBridgeLoadStart(*this);
 }
 
@@ -8154,8 +8796,9 @@ void MteL1L0aMxOp::print(OpAsmPrinter &printer) {
 }
 
 LogicalResult MteL1L0aMxOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT"))) {
     return failure();
+  }
   if (failed(verifyMxLoadOperands(
           getOperation(), {getM(), getK(), getStartRow(), getStartCol()},
           {"m", "k", "start_row", "start_col"},
@@ -8181,8 +8824,9 @@ void MteL1L0bMxOp::print(OpAsmPrinter &printer) {
 }
 
 LogicalResult MteL1L0bMxOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT"))) {
     return failure();
+  }
   if (failed(verifyMxLoadOperands(
           getOperation(), {getK(), getN(), getStartRow(), getStartCol()},
           {"k", "n", "start_row", "start_col"},
@@ -8193,30 +8837,34 @@ LogicalResult MteL1L0bMxOp::verify() {
 }
 
 LogicalResult LoadCbufToCaMxOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT"))) {
     return failure();
+  }
   return verifyCubeBridgeLoadStart(getOperation(), getXStartPosition(),
                                    "x_start_position", getYStartPosition(),
                                    "y_start_position");
 }
 
 LogicalResult LoadCbufToCbMxOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT"))) {
     return failure();
+  }
   return verifyCubeBridgeLoadStart(getOperation(), getXStartPosition(),
                                    "x_start_position", getYStartPosition(),
                                    "y_start_position");
 }
 
 LogicalResult LoadCbufToCaOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::LEFT, "LEFT"))) {
     return failure();
+  }
   return verifyExplicitCubeBridgeLoadControls(*this);
 }
 
 LogicalResult LoadCbufToCbOp::verify() {
-  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT")))
+  if (failed(verifyCubeBridgeLoadLikeOp(*this, AddressSpace::RIGHT, "RIGHT"))) {
     return failure();
+  }
   return verifyExplicitCubeBridgeLoadControls(*this);
 }
 
@@ -8396,18 +9044,21 @@ ParseResult MteL0cUbOp::parse(OpAsmParser &parser, OperationState &result) {
       parseRequiredOperandWithComma(parser, srcStride) ||
       parseRequiredOperandWithComma(parser, dstStride))
     return failure();
-  if (parser.parseKeyword("dst_mode") || parser.parseLParen())
+  if (parser.parseKeyword("dst_mode") || parser.parseLParen()) {
     return failure();
+  }
   OptionalParseResult subBlockIdParse =
       parser.parseOptionalOperand(subBlockId);
   if (subBlockIdParse.has_value()) {
-    if (failed(*subBlockIdParse))
+    if (failed(*subBlockIdParse)) {
       return failure();
+    }
     hasSubBlockId = true;
   } else {
     StringRef dstModeKeyword;
-    if (parser.parseKeyword(&dstModeKeyword))
+    if (parser.parseKeyword(&dstModeKeyword)) {
       return failure();
+    }
     if (dstModeKeyword == "split_m") {
       dstMode = AccStoreUbDstMode::SplitM;
     } else if (dstModeKeyword == "split_n") {
@@ -8419,13 +9070,15 @@ ParseResult MteL0cUbOp::parse(OpAsmParser &parser, OperationState &result) {
           "dst_mode(split_n)");
     }
   }
-  if (parser.parseRParen())
+  if (parser.parseRParen()) {
     return failure();
+  }
   if (succeeded(parser.parseOptionalComma()) &&
       parseStructuredAccStoreClauses(parser, state))
     return failure();
-  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon())
+  if (parser.parseOptionalAttrDict(result.attributes) || parser.parseColon()) {
     return failure();
+  }
 
   Type sourceType, destinationType, mType, nType, srcStrideType, dstStrideType,
       subBlockIdType;
@@ -8438,8 +9091,9 @@ ParseResult MteL0cUbOp::parse(OpAsmParser &parser, OperationState &result) {
   if (hasSubBlockId &&
       (parser.parseComma() || parser.parseType(subBlockIdType)))
     return failure();
-  if (parseStructuredAccStoreTailTypes(parser, state))
+  if (parseStructuredAccStoreTailTypes(parser, state)) {
     return failure();
+  }
 
   setStructuredAccStoreSegmentSizes<MteL0cUbOp>(
       result, {1, 1, 1, 1, 1, 1, !state.preQuantOperands.empty() ? 1 : 0,
@@ -8524,8 +9178,9 @@ void MteL0cUbOp::print(OpAsmPrinter &printer) {
   printer << " : " << getSource().getType() << ", " << getDestination().getType()
           << ", " << getM().getType() << ", " << getN().getType() << ", "
           << getSrcStride().getType() << ", " << getDstStride().getType();
-  if (getSubBlockid())
+  if (getSubBlockid()) {
     printer << ", " << getSubBlockid().getType();
+  }
   printStructuredAccStoreOptionalTypes(
       printer, getPreQuant(), getPreRelu(), getClipValue(), getSplit(),
       getLoop0SrcStride(), getLoop3Count(), getLoop3SrcStride(),
@@ -8552,16 +9207,18 @@ LogicalResult MteL0cUbOp::verify() {
     return failure();
 
   if (getDstMode() == AccStoreUbDstMode::Single) {
-    if (!getSubBlockid())
+    if (!getSubBlockid()) {
       return emitOpError("dst_mode(%sub_blockid) requires a sub_blockid operand");
+    }
     APInt subBlockId;
     if (matchPattern(getSubBlockid(), m_ConstantInt(&subBlockId)) &&
         subBlockId.ugt(1))
       return emitOpError("sub_blockid must be 0 or 1");
     return success();
   }
-  if (getSubBlockid())
+  if (getSubBlockid()) {
     return emitOpError("split destination modes do not accept sub_blockid");
+  }
 
   if (getPreQuant() || getPreRelu() || getClipValue() || getPreQuantMode() ||
       getPreReluMode() || getSplit() || getLoop0SrcStride() ||
@@ -8569,8 +9226,9 @@ LogicalResult MteL0cUbOp::verify() {
     return emitOpError("dual destination mode cannot be combined with "
                        "pre_quant, pre_relu, clip, nz2dn, nz2nz, or loop3");
   }
-  if (getMode() && *getMode() != AccStoreMode::Nz2nd)
+  if (getMode() && *getMode() != AccStoreMode::Nz2nd) {
     return emitOpError("dual destination mode requires normal or nz2nd layout");
+  }
 
   APInt mValue;
   APInt nValue;
@@ -8810,8 +9468,9 @@ void UBVnotOp::getEffects(
 }
 
 LogicalResult UBVnotOp::verify() {
-  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType()))
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed operands");
@@ -8830,8 +9489,9 @@ void UBVabsOp::getEffects(
 }
 
 LogicalResult UBVabsOp::verify() {
-  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType()))
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed operands");
@@ -8850,8 +9510,9 @@ void UBVreluOp::getEffects(
 }
 
 LogicalResult UBVreluOp::verify() {
-  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType()))
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed operands");
@@ -8891,10 +9552,12 @@ void UBVdupOp::getEffects(
 }
 
 LogicalResult UBVdupOp::verify() {
-  if (!isBufferLike(getDst().getType()))
+  if (!isBufferLike(getDst().getType())) {
     return emitOpError("requires pointer-like dst operand");
-  if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB)
+  }
+  if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB) {
     return emitOpError("requires UB-backed dst operand");
+  }
   return success();
 }
 
@@ -8910,8 +9573,9 @@ void UBVshlOp::getEffects(
 }
 
 LogicalResult UBVshlOp::verify() {
-  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType()))
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed operands");
@@ -8930,8 +9594,9 @@ void UBVshrOp::getEffects(
 }
 
 LogicalResult UBVshrOp::verify() {
-  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType()))
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed operands");
@@ -8950,8 +9615,9 @@ void UBVmulSOp::getEffects(
 }
 
 LogicalResult UBVmulSOp::verify() {
-  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType()))
+  if (!isBufferLike(getDst().getType()) || !isBufferLike(getSrc().getType())) {
     return emitOpError("requires pointer-like operands");
+  }
   if (classifyMemoryRole(getDst().getType()) != MemoryRole::UB ||
       classifyMemoryRole(getSrc().getType()) != MemoryRole::UB)
     return emitOpError("requires UB-backed operands");

--- a/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncAnalysis.h
@@ -179,7 +179,6 @@ inline void printTileGroups(llvm::raw_ostream &os,
     for (unsigned j = 0; j < tileGroups[i].size(); ++j) {
       if (j > 0) os << " ; ";
       printTileValue(os, allTiles[tileGroups[i][j]].tileValue);
-      //printTileInfo(os, allTiles[tileGroups[i][j]]);
     }
     os << "]\n";
   }
@@ -195,7 +194,6 @@ inline void printVirtualBufIds(llvm::raw_ostream &os,
     for (unsigned i = 0; i < vbid.tiles.size(); ++i) {
       if (i > 0) os << " ; ";
       printTileValue(os, vbid.tiles[i].tileValue);
-      //printTileInfo(os, vbid.tiles[i]);
     }
     os << "]\n";
   }

--- a/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.cpp
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.cpp
@@ -308,7 +308,7 @@ void BufidSyncIdAlloc::reuseIds() {
   };
 
   int iteration = 0;
-  while (maxPhysicalIdUsed_ >= (int)physicalBufIdCount_) {
+  while (maxPhysicalIdUsed_ >= static_cast<int>(physicalBufIdCount_)) {
     ++iteration;
 
     DenseMap<int, SmallVector<PipelineType>> logicIdPipes;

--- a/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.h
+++ b/lib/PTO/Transforms/BufidSync/BufidSyncIdAlloc.h
@@ -27,7 +27,7 @@ public:
 
   void computeLifeIntervals();
   void linearScanAllocate();
-  bool needsReuse() const { return maxPhysicalIdUsed_ >= (int)physicalBufIdCount_; }
+  bool needsReuse() const { return maxPhysicalIdUsed_ >= static_cast<int>(physicalBufIdCount_); }
   void reuseIds();
   void compactPhysicalIds();
   bool validateNoSamePhysicalIdNesting(std::string *error = nullptr) const;

--- a/lib/PTO/Transforms/ConvertToPTOOp.cpp
+++ b/lib/PTO/Transforms/ConvertToPTOOp.cpp
@@ -39,15 +39,17 @@ namespace {
 //===---------------------------------------------------------------------===//
 
 std::optional<Value> getPadValue(std::optional<memref::AllocOp> maybeAlloc) {
-  if (!maybeAlloc.has_value())
+  if (!maybeAlloc.has_value()) {
     return std::nullopt;
+  }
   return std::nullopt;
 }
 
 std::optional<Value> getLeftPadNum(PatternRewriter &rewriter,
                                    std::optional<memref::AllocOp> maybeAlloc) {
-  if (!maybeAlloc.has_value())
+  if (!maybeAlloc.has_value()) {
     return std::nullopt;
+  }
 
   for (auto *user : maybeAlloc.value()->getUsers()) {
     if (auto subviewOp = llvm::dyn_cast<memref::SubViewOp>(user)) {
@@ -75,14 +77,16 @@ std::pair<std::optional<Operation *>, std::optional<Value>>
 getUniqueInitInfo(PatternRewriter &rewriter,
                   std::optional<memref::AllocOp> maybeAlloc,
                   pto::TLoadOp loadOp) {
-  if (!maybeAlloc.has_value())
+  if (!maybeAlloc.has_value()) {
     return {std::nullopt, std::nullopt};
+  }
 
   std::optional<Operation *> initOp = std::nullopt;
   std::optional<Value> initCondition = std::nullopt;
   for (auto *user : (*maybeAlloc)->getUsers()) {
-    if (llvm::isa<pto::TLoadOp>(user))
+    if (llvm::isa<pto::TLoadOp>(user)) {
       continue;
+    }
     auto maybeInitOp = getInitInfo(user, loadOp).first;
     if (maybeInitOp.has_value() && !initOp.has_value()) {
       std::tie(initOp, initCondition) = getInitInfo(user, loadOp);

--- a/lib/PTO/Transforms/CppPostprocess.cpp
+++ b/lib/PTO/Transforms/CppPostprocess.cpp
@@ -30,8 +30,9 @@ struct ParsedMarkerCall {
 static bool parseMarkerArgs(llvm::StringRef argsRef,
                             llvm::SmallVectorImpl<llvm::StringRef> &args) {
   args.clear();
-  if (argsRef.empty())
+  if (argsRef.empty()) {
     return true;
+  }
 
   int parenDepth = 0;
   size_t partBegin = 0;
@@ -42,8 +43,9 @@ static bool parseMarkerArgs(llvm::StringRef argsRef,
       continue;
     }
     if (c == ')') {
-      if (parenDepth > 0)
+      if (parenDepth > 0) {
         --parenDepth;
+      }
       continue;
     }
     if (c == ',' && parenDepth == 0) {
@@ -51,8 +53,9 @@ static bool parseMarkerArgs(llvm::StringRef argsRef,
       partBegin = i + 1;
     }
   }
-  if (partBegin > argsRef.size())
+  if (partBegin > argsRef.size()) {
     return false;
+  }
   args.push_back(argsRef.drop_front(partBegin).trim());
   return true;
 }
@@ -61,18 +64,21 @@ static bool parseLastUseMarkerName(llvm::StringRef markerName,
                                    std::string &callee,
                                    std::string &lastUseArgs) {
   static constexpr llvm::StringLiteral kPrefix = "PTOAS__LAST_USE__";
-  if (!markerName.starts_with(kPrefix))
+  if (!markerName.starts_with(kPrefix)) {
     return false;
+  }
 
   llvm::StringRef payload = markerName.drop_front(kPrefix.size());
   size_t split = payload.find("__");
-  if (split == llvm::StringRef::npos)
+  if (split == llvm::StringRef::npos) {
     return false;
+  }
 
   callee = payload.take_front(split).str();
   llvm::StringRef encoded = payload.drop_front(split + 2);
-  if (callee.empty() || encoded.empty())
+  if (callee.empty() || encoded.empty()) {
     return false;
+  }
 
   lastUseArgs.clear();
   size_t pos = 0;
@@ -81,8 +87,9 @@ static bool parseLastUseMarkerName(llvm::StringRef markerName,
     llvm::StringRef token =
         next == llvm::StringRef::npos ? encoded.drop_front(pos)
                                       : encoded.slice(pos, next);
-    if (token.empty())
+    if (token.empty()) {
       return false;
+    }
     if (!llvm::all_of(token, [](char c) { return std::isdigit(c); }))
       return false;
     if (!lastUseArgs.empty())
@@ -103,8 +110,9 @@ bool rewriteLastUseMarkersInCpp(std::string &cpp) {
   static constexpr llvm::StringLiteral kPrefix = "PTOAS__LAST_USE__";
   while (true) {
     size_t markerPos = cpp.find(kPrefix.str(), searchPos);
-    if (markerPos == std::string::npos)
+    if (markerPos == std::string::npos) {
       break;
+    }
 
     size_t lparenPos = markerPos + kPrefix.size();
     while (lparenPos < cpp.size() && cpp[lparenPos] != '(')
@@ -159,8 +167,9 @@ bool rewriteLastUseMarkersInCpp(std::string &cpp) {
     replacement.append(callee);
     replacement.push_back('(');
     for (size_t i = 0; i < call.args.size(); ++i) {
-      if (i)
+      if (i) {
         replacement.append(", ");
+      }
       replacement.append(call.args[i].str());
     }
     replacement.push_back(')');

--- a/lib/PTO/Transforms/ExpandTileOp.cpp
+++ b/lib/PTO/Transforms/ExpandTileOp.cpp
@@ -120,8 +120,9 @@ struct OperandTypeInfo {
 
   /// Equality for SpecKey caching — only compares fields relevant to each kind.
   bool operator==(const OperandTypeInfo &rhs) const {
-    if (kind != rhs.kind || dtype != rhs.dtype)
+    if (kind != rhs.kind || dtype != rhs.dtype) {
       return false;
+    }
     if (kind == OperandKind::Tile)
       return tileShape == rhs.tileShape &&
              tileValidShape == rhs.tileValidShape &&
@@ -129,10 +130,12 @@ struct OperandTypeInfo {
              blayout == rhs.blayout && slayout == rhs.slayout &&
              fractal == rhs.fractal && pad == rhs.pad &&
              compact == rhs.compact;
-    if (kind == OperandKind::Vector)
+    if (kind == OperandKind::Vector) {
       return vectorShape == rhs.vectorShape;
-    if (kind == OperandKind::Scalar)
+    }
+    if (kind == OperandKind::Scalar) {
       return scalarValue == rhs.scalarValue;
+    }
     return viewShape == rhs.viewShape &&
            viewStrides == rhs.viewStrides &&
            viewMemorySpace == rhs.viewMemorySpace &&
@@ -167,31 +170,39 @@ struct SpecKeyInfo : public llvm::DenseMapInfo<SpecKey> {
       if (op.kind == OperandKind::Tile) {
         h = llvm::hash_combine(h, op.tileMemorySpace, op.blayout,
                                op.slayout, op.fractal, op.pad, op.compact);
-        for (int64_t d : op.tileShape)
+        for (int64_t d : op.tileShape) {
           h = llvm::hash_combine(h, d);
-        for (int64_t d : op.tileValidShape)
+        }
+        for (int64_t d : op.tileValidShape) {
           h = llvm::hash_combine(h, d);
+        }
       } else if (op.kind == OperandKind::Vector) {
-        for (int64_t d : op.vectorShape)
+        for (int64_t d : op.vectorShape) {
           h = llvm::hash_combine(h, d);
+        }
       } else if (op.kind == OperandKind::Scalar) {
         h = llvm::hash_combine(h, op.scalarValue.has_value());
-        if (op.scalarValue)
+        if (op.scalarValue) {
           h = llvm::hash_combine(h, *op.scalarValue);
+        }
       }
       if (op.kind == OperandKind::View) {
         h = llvm::hash_combine(h, op.viewMemorySpace);
-        for (int64_t d : op.viewShape)
+        for (int64_t d : op.viewShape) {
           h = llvm::hash_combine(h, d);
-        for (int64_t d : op.viewStrides)
+        }
+        for (int64_t d : op.viewStrides) {
           h = llvm::hash_combine(h, d);
+        }
         h = llvm::hash_combine(h, op.viewLayout.has_value());
-        if (op.viewLayout)
+        if (op.viewLayout) {
           h = llvm::hash_combine(h, static_cast<int>(*op.viewLayout));
+        }
       }
     }
-    for (const auto &[attrName, attrValue] : key.contextAttrs)
+    for (const auto &[attrName, attrValue] : key.contextAttrs) {
       h = llvm::hash_combine(h, attrName, attrValue);
+    }
     return h;
   }
   static bool isEqual(const SpecKey &lhs, const SpecKey &rhs) {
@@ -202,28 +213,72 @@ struct SpecKeyInfo : public llvm::DenseMapInfo<SpecKey> {
 // Helpers
 // ============================================================================
 static std::string getDtypeString(Type elemTy) {
-  if (elemTy.isIndex()) return "i32";
-  if (elemTy.isInteger(1)) return "i1";
-  if (elemTy.isF32()) return "f32";
-  if (elemTy.isF16()) return "f16";
-  if (elemTy.isBF16()) return "bf16";
-  if (isa<Float8E4M3FNType>(elemTy)) return "f8e4m3";
-  if (isa<Float8E5M2Type>(elemTy)) return "f8e5m2";
-  if (isa<pto::HiF8Type>(elemTy)) return "hif8";
-  if (isa<pto::F4E1M2x2Type>(elemTy)) return "f4e1m2x2";
-  if (isa<pto::F4E2M1x2Type>(elemTy)) return "f4e2m1x2";
-  if (elemTy.isUnsignedInteger(64)) return "ui64";
-  if (elemTy.isUnsignedInteger(32)) return "ui32";
-  if (elemTy.isUnsignedInteger(16)) return "ui16";
-  if (elemTy.isUnsignedInteger(8)) return "ui8";
-  if (elemTy.isSignedInteger(64)) return "si64";
-  if (elemTy.isSignedInteger(32)) return "si32";
-  if (elemTy.isSignedInteger(16)) return "si16";
-  if (elemTy.isSignedInteger(8)) return "si8";
-  if (elemTy.isSignlessInteger(64)) return "i64";
-  if (elemTy.isSignlessInteger(32)) return "i32";
-  if (elemTy.isSignlessInteger(16)) return "i16";
-  if (elemTy.isSignlessInteger(8)) return "i8";
+  if (elemTy.isIndex()) {
+    return "i32";
+  }
+  if (elemTy.isInteger(1)) {
+    return "i1";
+  }
+  if (elemTy.isF32()) {
+    return "f32";
+  }
+  if (elemTy.isF16()) {
+    return "f16";
+  }
+  if (elemTy.isBF16()) {
+    return "bf16";
+  }
+  if (isa<Float8E4M3FNType>(elemTy)) {
+    return "f8e4m3";
+  }
+  if (isa<Float8E5M2Type>(elemTy)) {
+    return "f8e5m2";
+  }
+  if (isa<pto::HiF8Type>(elemTy)) {
+    return "hif8";
+  }
+  if (isa<pto::F4E1M2x2Type>(elemTy)) {
+    return "f4e1m2x2";
+  }
+  if (isa<pto::F4E2M1x2Type>(elemTy)) {
+    return "f4e2m1x2";
+  }
+  if (elemTy.isUnsignedInteger(64)) {
+    return "ui64";
+  }
+  if (elemTy.isUnsignedInteger(32)) {
+    return "ui32";
+  }
+  if (elemTy.isUnsignedInteger(16)) {
+    return "ui16";
+  }
+  if (elemTy.isUnsignedInteger(8)) {
+    return "ui8";
+  }
+  if (elemTy.isSignedInteger(64)) {
+    return "si64";
+  }
+  if (elemTy.isSignedInteger(32)) {
+    return "si32";
+  }
+  if (elemTy.isSignedInteger(16)) {
+    return "si16";
+  }
+  if (elemTy.isSignedInteger(8)) {
+    return "si8";
+  }
+  if (elemTy.isSignlessInteger(64)) {
+    return "i64";
+  }
+  if (elemTy.isSignlessInteger(32)) {
+    return "i32";
+  }
+  if (elemTy.isSignlessInteger(16)) {
+    return "i16";
+  }
+  if (elemTy.isSignlessInteger(8)) {
+    return "i8";
+  }
   return "";
 }
 
@@ -232,10 +287,12 @@ static std::string getDtypeString(Type elemTy) {
 static Value bridgeOperandToType(OpBuilder &builder, Location loc,
                                  Value operand, Type dstTy) {
   Type srcTy = operand.getType();
-  if (srcTy == dstTy)
+  if (srcTy == dstTy) {
     return operand;
-  if (srcTy.isIndex() && isa<IntegerType>(dstTy))
+  }
+  if (srcTy.isIndex() && isa<IntegerType>(dstTy)) {
     return builder.create<arith::IndexCastOp>(loc, dstTy, operand);
+  }
   return builder.create<UnrealizedConversionCastOp>(loc, dstTy, operand)
       .getResult(0);
 }
@@ -245,12 +302,14 @@ static StringRef getTileOpName(Operation *op) {
 }
 
 static std::string getTargetArchString(Operation *op) {
-  if (!op)
+  if (!op) {
     return "";
+  }
   for (ModuleOp current = op->getParentOfType<ModuleOp>(); current;
        current = current->getParentOfType<ModuleOp>()) {
-    if (auto targetAttr = current->getAttrOfType<StringAttr>("pto.target_arch"))
+    if (auto targetAttr = current->getAttrOfType<StringAttr>("pto.target_arch")) {
       return targetAttr.getValue().str();
+    }
   }
   return "";
 }
@@ -289,37 +348,44 @@ static std::string getMemorySpaceString(MemRefType mrTy) {
 }
 
 static std::string getBLayoutString(int32_t blayout) {
-  if (blayout == static_cast<int32_t>(pto::BLayout::ColMajor))
+  if (blayout == static_cast<int32_t>(pto::BLayout::ColMajor)) {
     return "col_major";
+  }
   return "row_major";
 }
 
 static std::string getSLayoutString(int32_t slayout) {
-  if (slayout == static_cast<int32_t>(pto::SLayout::RowMajor))
+  if (slayout == static_cast<int32_t>(pto::SLayout::RowMajor)) {
     return "row_major";
-  if (slayout == static_cast<int32_t>(pto::SLayout::ColMajor))
+  }
+  if (slayout == static_cast<int32_t>(pto::SLayout::ColMajor)) {
     return "col_major";
+  }
   return "none_box";
 }
 
 static constexpr llvm::StringLiteral kLayoutAttrName = "layout";
 
 static std::optional<pto::Layout> getLayoutAttrFromOp(Operation *op) {
-  if (!op)
+  if (!op) {
     return std::nullopt;
-  if (auto attr = op->getAttrOfType<pto::LayoutAttr>(kLayoutAttrName))
+  }
+  if (auto attr = op->getAttrOfType<pto::LayoutAttr>(kLayoutAttrName)) {
     return attr.getLayout();
+  }
   return std::nullopt;
 }
 
 static std::optional<pto::Layout> resolveViewLayout(Value value) {
-  if (!value)
+  if (!value) {
     return std::nullopt;
+  }
 
   Operation *def = value.getDefiningOp();
   while (def) {
-    if (auto layout = getLayoutAttrFromOp(def))
+    if (auto layout = getLayoutAttrFromOp(def)) {
       return layout;
+    }
     if (auto subview = dyn_cast<memref::SubViewOp>(def)) {
       value = subview.getSource();
       def = value.getDefiningOp();
@@ -346,8 +412,9 @@ static std::optional<pto::Layout> resolveViewLayout(Value value) {
 }
 
 static std::optional<std::string> getViewLayoutString(std::optional<pto::Layout> layout) {
-  if (!layout)
+  if (!layout) {
     return std::nullopt;
+  }
   return stringifyLayout(*layout).str();
 }
 
@@ -454,8 +521,9 @@ static bool tryAppendPrecisionType(
     SmallVectorImpl<std::pair<std::string, std::string>> &attrs,
     PrecisionT highPrecision) {
   auto typed = dyn_cast<OpT>(op);
-  if (!typed)
+  if (!typed) {
     return false;
+  }
 
   PrecisionT precision = typed.getPrecisionType();
   attrs.emplace_back("precisionType", getPrecisionTypeString(precision).str());
@@ -479,11 +547,13 @@ static LogicalResult appendOpContextAttrs(
     SmallVectorImpl<std::pair<std::string, std::string>> &attrs) {
   if (auto tcvt = dyn_cast<pto::TCvtOp>(op)) {
     std::optional<std::string> roundMode = getTCvtRoundModeString(tcvt);
-    if (roundMode)
+    if (roundMode) {
       attrs.emplace_back("round_mode", *roundMode);
+    }
   }
-  if (auto trandom = dyn_cast<pto::TRandomOp>(op))
+  if (auto trandom = dyn_cast<pto::TRandomOp>(op)) {
     attrs.emplace_back("rounds", getTRandomRoundsString(trandom));
+  }
   if (auto tcmp = dyn_cast<pto::TCmpOp>(op)) {
     if (auto cmpModeAttr = tcmp.getCmpModeAttr()) {
       attrs.emplace_back("cmp_mode",
@@ -519,8 +589,9 @@ static LogicalResult appendOpContextAttrs(
   }
   if (auto thistogram = dyn_cast<pto::THistogramOp>(op)) {
     int byte = 1;
-    if (auto byteAttr = thistogram.getByteAttr())
+    if (auto byteAttr = thistogram.getByteAttr()) {
       byte = byteAttr.getInt();
+    }
     attrs.emplace_back("byte", std::to_string(byte));
   }
   if (auto tci = dyn_cast<pto::TCIOp>(op)) {
@@ -593,14 +664,16 @@ static bool getStaticIntFromValue(Value value, int64_t &out) {
 static int64_t getStaticIntOrDynamic(OpFoldResult ofr) {
   if (isa<Attribute>(ofr)) {
     Attribute attr = cast<Attribute>(ofr);
-    if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+    if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
       return intAttr.getInt();
+    }
     return ShapedType::kDynamic;
   }
   Value value = cast<Value>(ofr);
   int64_t result = ShapedType::kDynamic;
-  if (getStaticIntFromValue(value, result))
+  if (getStaticIntFromValue(value, result)) {
     return result;
+  }
   return ShapedType::kDynamic;
 }
 
@@ -608,8 +681,9 @@ static void recordStaticSizes(ArrayRef<OpFoldResult> inputs,
                               SmallVectorImpl<int64_t> &out) {
   out.clear();
   out.reserve(inputs.size());
-  for (OpFoldResult ofr : inputs)
+  for (OpFoldResult ofr : inputs) {
     out.push_back(getStaticIntOrDynamic(ofr));
+  }
 }
 
 static SmallVector<int64_t> combineSubviewStrides(ArrayRef<int64_t> baseStrides,
@@ -631,8 +705,9 @@ static SmallVector<int64_t> combineSubviewStrides(ArrayRef<int64_t> baseStrides,
 static void populateViewShapeAndStrides(Value value,
                                         SmallVectorImpl<int64_t> &shape,
                                         SmallVectorImpl<int64_t> &strides) {
-  if (!value)
+  if (!value) {
     return;
+  }
 
   if (auto partition = value.getDefiningOp<pto::PartitionViewOp>()) {
     populateViewShapeAndStrides(partition.getSource(), shape, strides);
@@ -667,10 +742,12 @@ static void populateViewShapeAndStrides(Value value,
     populateViewShapeAndStrides(subview.getSource(), shape, strides);
     SmallVector<int64_t> subviewShape;
     recordStaticSizes(subview.getMixedSizes(), subviewShape);
-    if (!subviewShape.empty())
+    if (!subviewShape.empty()) {
       shape = subviewShape;
-    if (!strides.empty())
+    }
+    if (!strides.empty()) {
       strides = combineSubviewStrides(strides, subview.getMixedStrides());
+    }
     return;
   }
 
@@ -678,11 +755,13 @@ static void populateViewShapeAndStrides(Value value,
     if (shape.empty()) {
       SmallVector<int64_t> reinterpretShape;
       recordStaticSizes(reinterpret.getMixedSizes(), reinterpretShape);
-      if (!reinterpretShape.empty())
+      if (!reinterpretShape.empty()) {
         shape = reinterpretShape;
+      }
     }
-    if (strides.empty())
+    if (strides.empty()) {
       recordStaticSizes(reinterpret.getMixedStrides(), strides);
+    }
     return;
   }
 
@@ -692,8 +771,9 @@ static void populateViewShapeAndStrides(Value value,
   }
 
   if (auto memrefTy = dyn_cast<MemRefType>(value.getType())) {
-    if (shape.empty())
+    if (shape.empty()) {
       shape.assign(memrefTy.getShape().begin(), memrefTy.getShape().end());
+    }
     if (strides.empty()) {
       int64_t offset = ShapedType::kDynamic;
       if (succeeded(
@@ -711,12 +791,14 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
     OperandTypeInfo info;
     info.kind = OperandKind::Tile;
     info.dtype = getDtypeString(tbTy.getElementType());
-    if (info.dtype.empty())
+    if (info.dtype.empty()) {
       return std::nullopt;
+    }
     info.tileShape.assign(tbTy.getShape().begin(), tbTy.getShape().end());
     auto validShape = tbTy.getValidShape();
-    if (validShape.empty())
+    if (validShape.empty()) {
       info.tileValidShape.assign(tbTy.getShape().begin(), tbTy.getShape().end());
+    }
     else
       info.tileValidShape.assign(validShape.begin(), validShape.end());
     info.tileMemorySpace = getMemorySpaceString(tbTy);
@@ -738,13 +820,15 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
     OperandTypeInfo info;
     info.kind = OperandKind::View;
     info.dtype = getDtypeString(mrTy.getElementType());
-    if (info.dtype.empty())
+    if (info.dtype.empty()) {
       return std::nullopt;
+    }
     info.viewMemorySpace = getMemorySpaceString(mrTy);
     info.viewLayout = resolveViewLayout(value);
     populateViewShapeAndStrides(value, info.viewShape, info.viewStrides);
-    if (info.viewShape.empty())
+    if (info.viewShape.empty()) {
       info.viewShape.assign(mrTy.getShape().begin(), mrTy.getShape().end());
+    }
     if (info.viewStrides.empty()) {
       int64_t offset = ShapedType::kDynamic;
       if (succeeded(mlir::pto::getPTOMemRefStridesAndOffset(
@@ -759,15 +843,18 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
     OperandTypeInfo info;
     info.kind = OperandKind::View;
     info.dtype = getDtypeString(viewTy.getElementType());
-    if (info.dtype.empty())
+    if (info.dtype.empty()) {
       return std::nullopt;
+    }
     info.viewMemorySpace = "gm";
     info.viewLayout = resolveViewLayout(value);
     populateViewShapeAndStrides(value, info.viewShape, info.viewStrides);
-    if (info.viewShape.empty())
+    if (info.viewShape.empty()) {
       info.viewShape.assign(viewTy.getShape().begin(), viewTy.getShape().end());
-    if (info.viewStrides.empty())
+    }
+    if (info.viewStrides.empty()) {
       info.viewStrides.assign(viewTy.getRank(), ShapedType::kDynamic);
+    }
     return info;
   }
 
@@ -776,8 +863,9 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
     OperandTypeInfo info;
     info.kind = OperandKind::Vector;
     info.dtype = getDtypeString(vecTy.getElementType());
-    if (info.dtype.empty())
+    if (info.dtype.empty()) {
       return std::nullopt;
+    }
     info.vectorShape.assign(vecTy.getShape().begin(), vecTy.getShape().end());
     return info;
   }
@@ -786,11 +874,13 @@ static std::optional<OperandTypeInfo> buildOperandTypeInfo(Value value) {
   OperandTypeInfo info;
   info.kind = OperandKind::Scalar;
   info.dtype = getDtypeString(ty);
-  if (info.dtype.empty())
+  if (info.dtype.empty()) {
     return std::nullopt;
+  }
   int64_t scalarValue = 0;
-  if (getStaticIntFromValue(value, scalarValue))
+  if (getStaticIntFromValue(value, scalarValue)) {
     info.scalarValue = scalarValue;
+  }
   return info;
 }
 
@@ -814,8 +904,9 @@ static FailureOr<SpecKey> buildSpecKey(Operation *op) {
     return failure();
   }
 
-  if (failed(appendOpContextAttrs(op, key.contextAttrs)))
+  if (failed(appendOpContextAttrs(op, key.contextAttrs))) {
     return failure();
+  }
   return key;
 }
 
@@ -850,8 +941,9 @@ struct ExpandTileOpPass
 static void appendJsonIntArray(std::string &json, ArrayRef<int64_t> arr) {
   json += "[";
   for (size_t i = 0; i < arr.size(); ++i) {
-    if (i > 0)
+    if (i > 0) {
       json += ",";
+    }
     json += std::to_string(arr[i]);
   }
   json += "]";
@@ -862,8 +954,9 @@ static void appendJsonDimArray(std::string &json, ArrayRef<int64_t> arr,
                                bool negativeIsDynamic = false) {
   json += "[";
   for (size_t i = 0; i < arr.size(); ++i) {
-    if (i > 0)
+    if (i > 0) {
       json += ",";
+    }
     int64_t dim = arr[i];
     if (ShapedType::isDynamic(dim) || (negativeIsDynamic && dim < 0)) {
       json += "null";
@@ -878,8 +971,9 @@ static std::string buildOperandSpecsJson(const SpecKey &key) {
   std::string json = "[";
   for (size_t i = 0; i < key.operands.size(); ++i) {
     const auto &op = key.operands[i];
-    if (i > 0)
+    if (i > 0) {
       json += ",";
+    }
 
     if (op.kind == OperandKind::Tile) {
       json += "{\"kind\":\"tile\",\"dtype\":\"" + op.dtype + "\",\"shape\":";
@@ -909,10 +1003,12 @@ static std::string buildOperandSpecsJson(const SpecKey &key) {
       if (!op.viewStrides.empty()) {
         json += ",\"strides\":[";
         for (size_t dim = 0; dim < op.viewStrides.size(); ++dim) {
-          if (dim > 0)
+          if (dim > 0) {
             json += ",";
-          if (ShapedType::isDynamic(op.viewStrides[dim]))
+          }
+          if (ShapedType::isDynamic(op.viewStrides[dim])) {
             json += "null";
+          }
           else
             json += std::to_string(op.viewStrides[dim]);
         }
@@ -948,8 +1044,9 @@ static std::string buildOperandSpecsJson(const SpecKey &key) {
 }
 
 static std::string dimSuffix(int64_t dim) {
-  if (ShapedType::isDynamic(dim))
+  if (ShapedType::isDynamic(dim)) {
     return "d";
+  }
   return std::to_string(dim);
 }
 
@@ -962,10 +1059,12 @@ static std::string buildUniqueFunctionBaseName(const SpecKey &key) {
                                                   : "_scalar";
     uniqueName += "_" + op.dtype;
     if (op.kind == OperandKind::Tile) {
-      for (int64_t d : op.tileShape)
+      for (int64_t d : op.tileShape) {
         uniqueName += "_" + std::to_string(d);
-      for (int64_t d : op.tileValidShape)
+      }
+      for (int64_t d : op.tileValidShape) {
         uniqueName += "_v" + std::to_string(d);
+      }
       uniqueName += "_bl" + std::to_string(op.blayout);
       uniqueName += "_sl" + std::to_string(op.slayout);
       uniqueName += "_fr" + std::to_string(op.fractal);
@@ -974,30 +1073,36 @@ static std::string buildUniqueFunctionBaseName(const SpecKey &key) {
     } else if (op.kind == OperandKind::View) {
       uniqueName += "_ms_" + op.viewMemorySpace;
       uniqueName += "_shape";
-      for (int64_t d : op.viewShape)
+      for (int64_t d : op.viewShape) {
         uniqueName += "_" + dimSuffix(d);
+      }
       uniqueName += "_strides";
-      for (int64_t d : op.viewStrides)
+      for (int64_t d : op.viewStrides) {
         uniqueName += "_" + dimSuffix(d);
-      if (op.viewLayout)
+      }
+      if (op.viewLayout) {
         uniqueName += "_vl_" + stringifyLayout(*op.viewLayout).str();
+      }
     } else if (op.kind == OperandKind::Vector) {
-      for (int64_t d : op.vectorShape)
+      for (int64_t d : op.vectorShape) {
         uniqueName += "_" + std::to_string(d);
+      }
     } else if (op.kind == OperandKind::Scalar && op.scalarValue) {
       uniqueName += "_sv" + std::to_string(*op.scalarValue);
     }
   }
-  for (const auto &[attrName, attrValue] : key.contextAttrs)
+  for (const auto &[attrName, attrValue] : key.contextAttrs) {
     uniqueName += "_ctx_" + attrName + "_" + attrValue;
+  }
   return uniqueName;
 }
 
 static std::string buildUniqueFunctionName(const SpecKey &key,
                                            StringRef candidateId) {
   std::string uniqueName = buildUniqueFunctionBaseName(key);
-  if (!candidateId.empty())
+  if (!candidateId.empty()) {
     uniqueName += "__" + candidateId.str();
+  }
   return uniqueName;
 }
 
@@ -1005,8 +1110,9 @@ static std::string buildContextAttrsJson(const SpecKey &key) {
   std::string json = "{";
   for (size_t i = 0; i < key.contextAttrs.size(); ++i) {
     const auto &[attrName, attrValue] = key.contextAttrs[i];
-    if (i > 0)
+    if (i > 0) {
       json += ",";
+    }
     json += "\"";
     json += attrName;
     json += "\":\"";
@@ -1027,8 +1133,9 @@ func::FuncOp ExpandState::invokeInProcessTileLib(const SpecKey &key,
                                                  const std::string &uniqueName,
                                                  ModuleOp mod,
                                                  MLIRContext *ctx) {
-  if (!tileLibService)
+  if (!tileLibService) {
     return nullptr;
+  }
 
   pto::TileLibMaterializationRequest request;
   request.target = key.targetArch;
@@ -1054,8 +1161,9 @@ func::FuncOp ExpandState::invokeInProcessTileLib(const SpecKey &key,
     }
 
     SmallVector<func::FuncOp, 4> sourceFuncs;
-    for (func::FuncOp fn : sourceModule.getOps<func::FuncOp>())
+    for (func::FuncOp fn : sourceModule.getOps<func::FuncOp>()) {
       sourceFuncs.push_back(fn);
+    }
     if (sourceFuncs.empty()) {
       llvm::errs() << "ExpandTileOp: in-process PTODSL returned no func.func\n";
       return failure();
@@ -1094,8 +1202,9 @@ func::FuncOp ExpandState::invokeInProcessTileLib(const SpecKey &key,
           llvm::errs() << "ExpandTileOp: failed to rewrite imported symbol @"
                        << renamed.getKey() << " in @" << fn.getSymName()
                        << "\n";
-          for (func::FuncOp imported : clonedFuncs)
+          for (func::FuncOp imported : clonedFuncs) {
             imported.erase();
+          }
           return failure();
         }
       }
@@ -1151,8 +1260,9 @@ func::FuncOp ExpandState::invokeTileLib(const SpecKey &key,
 
   std::string uniqueName =
       buildUniqueFunctionName(key, selectedName.getValue());
-  if (auto existing = mod.lookupSymbol<func::FuncOp>(uniqueName))
+  if (auto existing = mod.lookupSymbol<func::FuncOp>(uniqueName)) {
     return existing;
+  }
 
   return invokeInProcessTileLib(key, selectedName.getValue(), uniqueName, mod,
                                 ctx);
@@ -1169,8 +1279,9 @@ LogicalResult ExpandState::expandTileOpsInFunction(func::FuncOp func,
   // Collect tile ops first (avoid modifying while iterating).
   SmallVector<Operation *, 16> tileOps;
   func.walk([&](Operation *op) {
-    if (pto::isTileLibExpandableOp(op))
+    if (pto::isTileLibExpandableOp(op)) {
       tileOps.push_back(op);
+    }
   });
 
   for (auto *op : tileOps) {
@@ -1224,8 +1335,9 @@ void ExpandTileOpPass::runOnOperation() {
     }
     return WalkResult::advance();
   });
-  if (!hasExpandableOps)
+  if (!hasExpandableOps) {
     return;
+  }
 
   std::shared_ptr<pto::TileLibService> tileLibService =
       pto::TileLibRuntime::getService();
@@ -1239,10 +1351,12 @@ void ExpandTileOpPass::runOnOperation() {
   state.tileLibService = tileLibService;
 
   for (auto func : mod.getOps<func::FuncOp>()) {
-    if (func.isExternal())
+    if (func.isExternal()) {
       continue;
-    if (failed(state.expandTileOpsInFunction(func, mod, ctx)))
+    }
+    if (failed(state.expandTileOpsInFunction(func, mod, ctx))) {
       return signalPassFailure();
+    }
   }
 }
 

--- a/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
+++ b/lib/PTO/Transforms/FoldTileBufIntrinsics.cpp
@@ -65,12 +65,15 @@ constexpr llvm::StringLiteral kTileOpValidShapeReadAttr =
     "__pto.tileop_valid_shape_abi";
 
 static FailureOr<FoldIntrinsicMode> parseFoldIntrinsicMode(StringRef mode) {
-  if (mode.empty() || mode == "all")
+  if (mode.empty() || mode == "all") {
     return FoldIntrinsicMode::All;
-  if (mode == "shape-only")
+  }
+  if (mode == "shape-only") {
     return FoldIntrinsicMode::ShapeOnly;
-  if (mode == "addr-only")
+  }
+  if (mode == "addr-only") {
     return FoldIntrinsicMode::AddrOnly;
+  }
   return failure();
 }
 
@@ -85,12 +88,14 @@ static bool shouldFoldAddrFamily(FoldIntrinsicMode mode) {
 static bool eraseDeadAllocTileOps(func::FuncOp func) {
   SmallVector<pto::AllocTileOp> deadAllocs;
   func.walk([&](pto::AllocTileOp alloc) {
-    if (alloc.getResult().use_empty())
+    if (alloc.getResult().use_empty()) {
       deadAllocs.push_back(alloc);
+    }
   });
 
-  for (pto::AllocTileOp alloc : llvm::reverse(deadAllocs))
+  for (pto::AllocTileOp alloc : llvm::reverse(deadAllocs)) {
     alloc.erase();
+  }
   return !deadAllocs.empty();
 }
 
@@ -113,8 +118,9 @@ static bool eraseDeadViewBridgeCasts(func::FuncOp func) {
       deadCasts.push_back(castOp);
   });
 
-  for (auto castOp : llvm::reverse(deadCasts))
+  for (auto castOp : llvm::reverse(deadCasts)) {
     castOp.erase();
+  }
   return !deadCasts.empty();
 }
 
@@ -127,8 +133,9 @@ static bool eraseDeadMemrefViewOps(func::FuncOp func) {
       deadMemrefOps.push_back(op);
   });
 
-  for (Operation *op : llvm::reverse(deadMemrefOps))
+  for (Operation *op : llvm::reverse(deadMemrefOps)) {
     op->erase();
+  }
   return !deadMemrefOps.empty();
 }
 
@@ -141,8 +148,9 @@ static bool eraseDeadTensorViewOps(func::FuncOp func) {
       deadViewOps.push_back(op);
   });
 
-  for (Operation *op : llvm::reverse(deadViewOps))
+  for (Operation *op : llvm::reverse(deadViewOps)) {
     op->erase();
+  }
   return !deadViewOps.empty();
 }
 
@@ -162,8 +170,9 @@ struct TileHandleInfo {
 static std::pair<Value, Value> findSetValidShapeOverride(Value tileBuf) {
   for (Operation *user : tileBuf.getUsers()) {
     auto setValid = dyn_cast<pto::SetValidShapeOp>(user);
-    if (!setValid || setValid.getSource() != tileBuf)
+    if (!setValid || setValid.getSource() != tileBuf) {
       continue;
+    }
     return {setValid.getValidRow(), setValid.getValidCol()};
   }
   return {Value(), Value()};
@@ -176,8 +185,9 @@ static std::pair<Value, Value> findSetValidShapeOverride(Value tileBuf) {
 static Value unwrapBridgingCasts(Value v) {
   while (v) {
     Operation *defOp = v.getDefiningOp();
-    if (!defOp)
+    if (!defOp) {
       break;
+    }
     if (auto cast = dyn_cast<UnrealizedConversionCastOp>(defOp)) {
       if (cast.getNumOperands() == 1 && cast.getNumResults() == 1) {
         v = cast.getOperand(0);
@@ -244,8 +254,9 @@ static std::optional<TileHandleInfo> resolveTileHandle(Value tileBuf,
 
   if (auto reshape = tileBuf.getDefiningOp<pto::TReshapeOp>()) {
     auto sourceInfo = resolveTileHandle(reshape.getSrc(), user);
-    if (!sourceInfo)
+    if (!sourceInfo) {
       return std::nullopt;
+    }
 
     auto tileTy = dyn_cast<pto::TileBufType>(reshape.getResult().getType());
     if (!tileTy) {
@@ -348,21 +359,26 @@ static bool getConstIndexValue(Value v, int64_t &out) {
       return true;
     }
   }
-  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>())
+  if (auto castOp = v.getDefiningOp<arith::IndexCastOp>()) {
     return getConstIndexValue(castOp.getIn(), out);
-  if (auto extOp = v.getDefiningOp<arith::ExtSIOp>())
+  }
+  if (auto extOp = v.getDefiningOp<arith::ExtSIOp>()) {
     return getConstIndexValue(extOp.getIn(), out);
-  if (auto extOp = v.getDefiningOp<arith::ExtUIOp>())
+  }
+  if (auto extOp = v.getDefiningOp<arith::ExtUIOp>()) {
     return getConstIndexValue(extOp.getIn(), out);
-  if (auto truncOp = v.getDefiningOp<arith::TruncIOp>())
+  }
+  if (auto truncOp = v.getDefiningOp<arith::TruncIOp>()) {
     return getConstIndexValue(truncOp.getIn(), out);
+  }
   return false;
 }
 
 static Value getValueOrCreateConstant(OpBuilder &builder, Location loc,
                                       OpFoldResult ofr) {
-  if (auto val = dyn_cast<Value>(ofr))
+  if (auto val = dyn_cast<Value>(ofr)) {
     return val;
+  }
   auto intAttr = dyn_cast<IntegerAttr>(cast<Attribute>(ofr));
   assert(intAttr && "expected integer attribute in OpFoldResult");
   return builder.create<arith::ConstantIndexOp>(loc, intAttr.getInt());
@@ -371,11 +387,13 @@ static Value getValueOrCreateConstant(OpBuilder &builder, Location loc,
 static bool isAllStaticZero(ArrayRef<OpFoldResult> ofrs) {
   for (OpFoldResult ofr : ofrs) {
     auto attr = dyn_cast<Attribute>(ofr);
-    if (!attr)
+    if (!attr) {
       return false;
+    }
     auto intAttr = dyn_cast<IntegerAttr>(attr);
-    if (!intAttr || intAttr.getInt() != 0)
+    if (!intAttr || intAttr.getInt() != 0) {
       return false;
+    }
   }
   return true;
 }
@@ -385,8 +403,9 @@ static Value computeResultStride(OpBuilder &builder, Location loc,
                                  OpFoldResult svStride) {
   if (auto attr = dyn_cast<Attribute>(svStride)) {
     auto intAttr = dyn_cast<IntegerAttr>(attr);
-    if (intAttr && intAttr.getInt() == 1)
+    if (intAttr && intAttr.getInt() == 1) {
       return getValueOrCreateConstant(builder, loc, rcStride);
+    }
   }
 
   Value lhs = getValueOrCreateConstant(builder, loc, rcStride);
@@ -401,16 +420,18 @@ static Value computeLinearOffset(OpBuilder &builder, Location loc,
   bool rcAllZero = isAllStaticZero(rcOffsets);
   bool svAllZero = isAllStaticZero(svOffsets);
 
-  if (rcAllZero && svAllZero)
+  if (rcAllZero && svAllZero) {
     return Value();
+  }
 
   Value svPart;
   if (!svAllZero) {
     for (auto [svOffset, rcStride] : llvm::zip(svOffsets, rcStrides)) {
       if (auto attr = dyn_cast<Attribute>(svOffset)) {
         auto intAttr = dyn_cast<IntegerAttr>(attr);
-        if (intAttr && intAttr.getInt() == 0)
+        if (intAttr && intAttr.getInt() == 0) {
           continue;
+        }
       }
 
       Value off = getValueOrCreateConstant(builder, loc, svOffset);
@@ -422,20 +443,23 @@ static Value computeLinearOffset(OpBuilder &builder, Location loc,
 
   Value rcPart;
   if (!rcAllZero) {
-    if (rcOffsets.empty())
+    if (rcOffsets.empty()) {
       return Value();
+    }
     rcPart = getValueOrCreateConstant(builder, loc, rcOffsets.front());
   }
 
-  if (rcPart && svPart)
+  if (rcPart && svPart) {
     return builder.create<arith::AddIOp>(loc, rcPart, svPart);
+  }
   return rcPart ? rcPart : svPart;
 }
 
 static Value unwrapPTOViewBridge(Value value) {
   while (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (cast.getNumOperands() != 1 || cast.getNumResults() != 1)
+    if (cast.getNumOperands() != 1 || cast.getNumResults() != 1) {
       break;
+    }
     value = cast.getOperand(0);
   }
   return value;
@@ -474,8 +498,9 @@ static Value resolvePTOViewStride(Value view, int64_t dim, OpBuilder &builder,
   if (Value projected = projectSCFIfViewResult(
           view, PTOViewProjectionKind::Stride, dim, {}, builder, user))
     return projected;
-  if (auto partition = view.getDefiningOp<pto::PartitionViewOp>())
+  if (auto partition = view.getDefiningOp<pto::PartitionViewOp>()) {
     return resolvePTOViewStride(partition.getSource(), dim, builder, user);
+  }
   if (auto makeView = view.getDefiningOp<pto::MakeTensorViewOp>()) {
     if (dim < 0 || dim >= static_cast<int64_t>(makeView.getStrides().size()))
       return {};
@@ -492,8 +517,9 @@ static Value resolvePTOViewAddress(Value view, pto::PtrType resultType,
     return projected;
   if (auto makeView = view.getDefiningOp<pto::MakeTensorViewOp>()) {
     Value ptr = makeView.getPtr();
-    if (ptr.getType() == resultType)
+    if (ptr.getType() == resultType) {
       return ptr;
+    }
     return builder.create<pto::CastPtrOp>(user->getLoc(), resultType, ptr);
   }
   auto partition = view.getDefiningOp<pto::PartitionViewOp>();
@@ -517,8 +543,9 @@ static Value resolvePTOViewAddress(Value view, pto::PtrType resultType,
       resolvePTOViewAddress(partition.getSource(), resultType, builder, user);
   if (!base)
     return {};
-  if (!linearOffset)
+  if (!linearOffset) {
     return base;
+  }
   return builder.create<pto::AddPtrOp>(user->getLoc(), resultType, base,
                                        linearOffset);
 }
@@ -527,8 +554,9 @@ static void cloneBlockWithoutTerminator(Block *source, Block *target,
                                         IRMapping &mapping,
                                         OpBuilder &builder) {
   builder.setInsertionPointToStart(target);
-  for (Operation &op : source->without_terminator())
+  for (Operation &op : source->without_terminator()) {
     builder.clone(op, mapping);
+  }
 }
 
 static Value projectSCFIfViewResult(Value view, PTOViewProjectionKind kind,
@@ -569,8 +597,9 @@ static Value projectSCFIfViewResult(Value view, PTOViewProjectionKind kind,
     cloneBlockWithoutTerminator(source, target, mapping, ifBuilder);
     SmallVector<Value> yields;
     yields.reserve(oldYield.getNumOperands() + 1);
-    for (Value operand : oldYield.getOperands())
+    for (Value operand : oldYield.getOperands()) {
       yields.push_back(mapping.lookupOrDefault(operand));
+    }
     Value yieldedView = yields[resultIndex];
     ifBuilder.setInsertionPointToEnd(target);
     Value projection;
@@ -635,8 +664,9 @@ struct FoldTileBufIntrinsicsPass
     // ops on tile_buf function arguments — they have no materialized tile
     // handle anchor to fold against and will be removed by later DCE. Skip
     // them.
-    if (func->hasAttr("pto.tilelang.instance"))
+    if (func->hasAttr("pto.tilelang.instance")) {
       return;
+    }
 
     SmallVector<pto::TileBufAddrOp, 8> addrOps;
     SmallVector<pto::TileValidRowsOp, 8> rowsOps;
@@ -647,8 +677,9 @@ struct FoldTileBufIntrinsicsPass
     SmallVector<pto::GetValidShapeOp, 8> getValidShapeOps;
 
     func.walk([&](Operation *op) {
-      if (auto addr = dyn_cast<pto::TileBufAddrOp>(op))
+      if (auto addr = dyn_cast<pto::TileBufAddrOp>(op)) {
         addrOps.push_back(addr);
+      }
       else if (auto rows = dyn_cast<pto::TileValidRowsOp>(op))
         rowsOps.push_back(rows);
       else if (auto cols = dyn_cast<pto::TileValidColsOp>(op))
@@ -671,10 +702,12 @@ struct FoldTileBufIntrinsicsPass
       // resolveTileHandle observe the overridden valid shape carried by a
       // treshape + set_validshape pair.
       for (auto gvsOp : getValidShapeOps) {
-        if (gvsOp->hasAttr(kTileOpValidShapeReadAttr))
+        if (gvsOp->hasAttr(kTileOpValidShapeReadAttr)) {
           continue;
-        if (!isa<pto::TileBufType>(gvsOp.getSource().getType()))
+        }
+        if (!isa<pto::TileBufType>(gvsOp.getSource().getType())) {
           continue;
+        }
 
         builder.setInsertionPoint(gvsOp);
         auto tileTy = cast<pto::TileBufType>(gvsOp.getSource().getType());
@@ -692,12 +725,15 @@ struct FoldTileBufIntrinsicsPass
 
         if (!rowReplacement || !colReplacement) {
           auto handleInfo = resolveTileHandle(gvsOp.getSource(), gvsOp);
-          if (!handleInfo)
+          if (!handleInfo) {
             return signalPassFailure();
-          if (!rowReplacement)
+          }
+          if (!rowReplacement) {
             rowReplacement = handleInfo->validRow;
-          if (!colReplacement)
+          }
+          if (!colReplacement) {
             colReplacement = handleInfo->validCol;
+          }
         }
 
         if (!rowReplacement || !colReplacement) {
@@ -723,8 +759,9 @@ struct FoldTileBufIntrinsicsPass
                 dyn_cast<MemRefType>(addrOp.getSrc().getType())) {
           if (auto resultMemrefType =
                   dyn_cast<MemRefType>(addrOp.getDst().getType())) {
-            if (srcMemrefType != resultMemrefType)
+            if (srcMemrefType != resultMemrefType) {
               addrOp.getDst().setType(srcMemrefType);
+            }
             addrOp.getDst().replaceAllUsesWith(addrOp.getSrc());
             addrOp.erase();
             continue;
@@ -749,12 +786,14 @@ struct FoldTileBufIntrinsicsPass
         // Keep tile_buf_addr attached to that handle; VPTO pointer
         // normalization converts it directly without choosing one branch's
         // allocation address here.
-        if (isSCFTileCarrier(addrOp.getSrc()))
+        if (isSCFTileCarrier(addrOp.getSrc())) {
           continue;
+        }
 
         auto handleInfo = resolveTileHandle(addrOp.getSrc(), addrOp);
-        if (!handleInfo)
+        if (!handleInfo) {
           return signalPassFailure();
+        }
 
         auto tileTy = dyn_cast<pto::TileBufType>(addrOp.getSrc().getType());
         if (!tileTy) {
@@ -803,8 +842,9 @@ struct FoldTileBufIntrinsicsPass
               builder.create<arith::ConstantIndexOp>(rowsOp.getLoc(), vRow);
         } else {
           auto handleInfo = resolveTileHandle(rowsOp.getSrc(), rowsOp);
-          if (!handleInfo)
+          if (!handleInfo) {
             return signalPassFailure();
+          }
           replacement = handleInfo->validRow;
           if (!replacement) {
             rowsOp.emitError(
@@ -836,8 +876,9 @@ struct FoldTileBufIntrinsicsPass
               builder.create<arith::ConstantIndexOp>(colsOp.getLoc(), vCol);
         } else {
           auto handleInfo = resolveTileHandle(colsOp.getSrc(), colsOp);
-          if (!handleInfo)
+          if (!handleInfo) {
             return signalPassFailure();
+          }
           replacement = handleInfo->validCol;
           if (!replacement) {
             colsOp.emitError(
@@ -870,8 +911,9 @@ struct FoldTileBufIntrinsicsPass
         }
 
         auto chain = traceViewChain(dimOp.getTensorView(), dimOp);
-        if (!chain)
+        if (!chain) {
           return signalPassFailure();
+        }
 
         auto svTy = cast<MemRefType>(chain->subview.getType());
         if (dimIdx < 0 || dimIdx >= svTy.getRank()) {
@@ -914,8 +956,9 @@ struct FoldTileBufIntrinsicsPass
         }
 
         auto chain = traceViewChain(strideOp.getTensorView(), strideOp);
-        if (!chain)
+        if (!chain) {
           return signalPassFailure();
+        }
 
         auto svTy = cast<MemRefType>(chain->subview.getType());
         if (dimIdx < 0 || dimIdx >= svTy.getRank()) {
@@ -951,15 +994,17 @@ struct FoldTileBufIntrinsicsPass
         }
 
         auto chain = traceViewChain(addrOp.getSrc(), addrOp);
-        if (!chain)
+        if (!chain) {
           return signalPassFailure();
+        }
 
         if (!resultPtrType) {
           if (auto resultMemrefType =
                   dyn_cast<MemRefType>(addrOp.getDst().getType())) {
             Value base = chain->baseMemref;
-            if (base.getType() != resultMemrefType)
+            if (base.getType() != resultMemrefType) {
               addrOp.getDst().setType(cast<MemRefType>(base.getType()));
+            }
             addrOp.getDst().replaceAllUsesWith(base);
             addrOp.erase();
             continue;
@@ -1000,8 +1045,9 @@ struct FoldTileBufIntrinsicsPass
               castOp.getResult(0).getType()))
         deadCasts.push_back(castOp);
     });
-    for (auto castOp : llvm::reverse(deadCasts))
+    for (auto castOp : llvm::reverse(deadCasts)) {
       castOp.erase();
+    }
 
     while (true) {
       SmallVector<Operation *, 8> deadMemrefOps;
@@ -1011,10 +1057,12 @@ struct FoldTileBufIntrinsicsPass
             op->use_empty())
           deadMemrefOps.push_back(op);
       });
-      if (deadMemrefOps.empty())
+      if (deadMemrefOps.empty()) {
         break;
-      for (auto *op : llvm::reverse(deadMemrefOps))
+      }
+      for (auto *op : llvm::reverse(deadMemrefOps)) {
         op->erase();
+      }
     }
 
     // Erase metadata writes only after every reader has been folded. TileOp
@@ -1032,8 +1080,9 @@ struct FoldTileBufIntrinsicsPass
         }
         return WalkResult::advance();
       });
-      if (!hasRuntimeReader)
+      if (!hasRuntimeReader) {
         op.erase();
+      }
     }
 
     // DCE tile-handle view / alloc ops left behind after valid-shape
@@ -1043,10 +1092,12 @@ struct FoldTileBufIntrinsicsPass
       tileDceChanged = false;
       SmallVector<Operation *, 8> deadTileOps;
       func.walk([&](Operation *op) {
-        if (!op->use_empty())
+        if (!op->use_empty()) {
           return;
-        if (isa<pto::TReshapeOp, pto::AllocTileOp>(op))
+        }
+        if (isa<pto::TReshapeOp, pto::AllocTileOp>(op)) {
           deadTileOps.push_back(op);
+        }
         else if (auto castOp = dyn_cast<UnrealizedConversionCastOp>(op)) {
           if (castOp.getNumOperands() == 1 &&
               isa<pto::TileBufType>(castOp.getResult(0).getType()))

--- a/lib/PTO/Transforms/GraphSyncSolver/Utility.cpp
+++ b/lib/PTO/Transforms/GraphSyncSolver/Utility.cpp
@@ -257,7 +257,6 @@ namespace mlir::pto::syncsolver {
 
 // Check if two integer ranges intersect (half-open semantics: [l, r) )
 bool checkRangesIntersect(int l1, int r1, int l2, int r2) {
-  // return !(r1 <= l2 || r2 <= l1);
   return r1 > l2 && r2 > l1;
 }
 

--- a/lib/PTO/Transforms/InferPTOLayout.cpp
+++ b/lib/PTO/Transforms/InferPTOLayout.cpp
@@ -52,13 +52,16 @@ static constexpr int64_t kNZFractalBytes = 512;
 using LayoutRankVector = SmallVector<int64_t, kPaddedLayoutRank>;
 
 static std::optional<int64_t> getConstInt(Value v) {
-  if (auto c = v.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto c = v.getDefiningOp<arith::ConstantIndexOp>()) {
     return c.value();
-  if (auto c = v.getDefiningOp<arith::ConstantIntOp>())
+  }
+  if (auto c = v.getDefiningOp<arith::ConstantIntOp>()) {
     return c.value();
+  }
   if (auto c = v.getDefiningOp<arith::ConstantOp>()) {
-    if (auto ia = dyn_cast<IntegerAttr>(c.getValue()))
+    if (auto ia = dyn_cast<IntegerAttr>(c.getValue())) {
       return ia.getInt();
+    }
   }
   return std::nullopt;
 }
@@ -66,8 +69,9 @@ static std::optional<int64_t> getConstInt(Value v) {
 static std::optional<int64_t> getConstInt(OpFoldResult ofr) {
   if (isa<Attribute>(ofr)) {
     Attribute attr = cast<Attribute>(ofr);
-    if (auto ia = dyn_cast<IntegerAttr>(attr))
+    if (auto ia = dyn_cast<IntegerAttr>(attr)) {
       return ia.getInt();
+    }
     return std::nullopt;
   }
   return getConstInt(cast<Value>(ofr));
@@ -110,10 +114,12 @@ static bool isMinor2DLayout(Layout layout) {
 
 static std::optional<ShapeStride5D> rightAlignTo5D(ArrayRef<int64_t> shape,
                                                    ArrayRef<int64_t> stride) {
-  if (shape.size() != stride.size())
+  if (shape.size() != stride.size()) {
     return std::nullopt;
-  if (shape.size() > kPaddedLayoutRank)
+  }
+  if (shape.size() > kPaddedLayoutRank) {
     return std::nullopt;
+  }
 
   ShapeStride5D out;
   out.shape.assign(kPaddedLayoutRank, kUnitExtent);
@@ -128,27 +134,32 @@ static std::optional<ShapeStride5D> rightAlignTo5D(ArrayRef<int64_t> shape,
 
   // Derive the padded leading strides with the same rule used in EmitC:
   // stride[i] = shape[i+1] * stride[i+1].
-  for (int i = shift - 1; i >= 0; --i)
+  for (int i = shift - 1; i >= 0; --i) {
     out.stride[i] = out.shape[i + 1] * out.stride[i + 1];
+  }
 
   return out;
 }
 
 static bool matchesNDMinor2D(int64_t rows, int64_t cols, int64_t rowStride,
                              int64_t colStride) {
-  if (cols != 1 && colStride != 1)
+  if (cols != 1 && colStride != 1) {
     return false;
-  if (rows == 1)
+  }
+  if (rows == 1) {
     return true;
+  }
   return cols == 1 ? rowStride == 1 : rowStride == cols;
 }
 
 static bool matchesDNMinor2D(int64_t rows, int64_t cols, int64_t rowStride,
                              int64_t colStride) {
-  if (rows != 1 && rowStride != 1)
+  if (rows != 1 && rowStride != 1) {
     return false;
-  if (cols == 1)
+  }
+  if (cols == 1) {
     return true;
+  }
   return rows == 1 ? colStride == 1 : colStride == rows;
 }
 
@@ -157,11 +168,13 @@ static std::optional<Layout> inferMinor2DLayout(
     std::optional<Layout> preferredMinor2D, bool *isMinor2DAmbiguous) {
   const bool nd = matchesNDMinor2D(rows, cols, rowStride, colStride);
   const bool dn = matchesDNMinor2D(rows, cols, rowStride, colStride);
-  if (!nd && !dn)
+  if (!nd && !dn) {
     return Layout::ND;
+  }
   if (nd && dn) {
-    if (isMinor2DAmbiguous)
+    if (isMinor2DAmbiguous) {
       *isMinor2DAmbiguous = true;
+    }
     if (preferredMinor2D &&
         (*preferredMinor2D == Layout::ND || *preferredMinor2D == Layout::DN)) {
       return *preferredMinor2D;
@@ -183,8 +196,9 @@ static std::optional<Layout> inferNZLayout(ArrayRef<int64_t> shape,
       (sh3 == kNZInnerRows) &&
       (sh3 * sh4 * static_cast<int64_t>(elemBytes) == kNZFractalBytes);
   bool strideMatch = (st5 == kUnitExtent) && (st4 == sh5);
-  if (alignMatch && strideMatch)
+  if (alignMatch && strideMatch) {
     return Layout::NZ;
+  }
   return std::nullopt;
 }
 
@@ -194,16 +208,20 @@ static std::optional<Layout> inferLayout5D(ArrayRef<int64_t> shape,
                                            std::optional<Layout> preferredMinor2D =
                                                std::nullopt,
                                            bool *isMinor2DAmbiguous = nullptr) {
-  if (shape.size() != strides.size() || elemBytes == 0)
+  if (shape.size() != strides.size() || elemBytes == 0) {
     return std::nullopt;
-  if (isMinor2DAmbiguous)
+  }
+  if (isMinor2DAmbiguous) {
     *isMinor2DAmbiguous = false;
+  }
   auto padded = rightAlignTo5D(shape, strides);
-  if (!padded)
+  if (!padded) {
     return std::nullopt;
+  }
 
-  if (auto nz = inferNZLayout(padded->shape, padded->stride, elemBytes))
+  if (auto nz = inferNZLayout(padded->shape, padded->stride, elemBytes)) {
     return nz;
+  }
 
   const int64_t rows = padded->shape[3];
   const int64_t cols = padded->shape[4];
@@ -215,11 +233,13 @@ static std::optional<Layout> inferLayout5D(ArrayRef<int64_t> shape,
 
 static std::optional<Layout> tileBLayoutToGlobalLayout(Type tileLikeTy) {
   auto tbTy = dyn_cast<TileBufType>(tileLikeTy);
-  if (!tbTy)
+  if (!tbTy) {
     return std::nullopt;
+  }
   auto bl = dyn_cast_or_null<BLayoutAttr>(tbTy.getBLayoutAttr());
-  if (!bl)
+  if (!bl) {
     return std::nullopt;
+  }
   switch (bl.getValue()) {
   case BLayout::RowMajor:
     return Layout::ND;
@@ -231,8 +251,9 @@ static std::optional<Layout> tileBLayoutToGlobalLayout(Type tileLikeTy) {
 
 static bool isVectorTileType(Type tileLikeTy) {
   auto tbTy = dyn_cast<TileBufType>(tileLikeTy);
-  if (!tbTy)
+  if (!tbTy) {
     return false;
+  }
   auto ms = dyn_cast_or_null<AddressSpaceAttr>(tbTy.getMemorySpace());
   return ms && ms.getAddressSpace() == AddressSpace::VEC;
 }
@@ -254,10 +275,11 @@ static ResolvedLayoutInfo resolveLayoutFromViewValue(Value v);
 
 static void setLayoutAttr(Operation *op, Layout layout, bool inferred) {
   op->setAttr(kLayoutAttrName, LayoutAttr::get(op->getContext(), layout));
-  if (inferred)
+  if (inferred) {
     op->setAttr(kInferredLayoutAttrName, BoolAttr::get(op->getContext(), true));
-  else
+  } else {
     op->removeAttr(kInferredLayoutAttrName);
+  }
 }
 
 template <typename SignalFailureFn>
@@ -306,8 +328,9 @@ static void maybeRepairMinor2DLoadStoreLayout(LoadStoreOp op, ViewGetter getView
   auto tilePref = isVectorTileType(getTile(op).getType())
                       ? tileBLayoutToGlobalLayout(getTile(op).getType())
                       : std::nullopt;
-  if (!tilePref || (*tilePref != Layout::ND && *tilePref != Layout::DN))
+  if (!tilePref || (*tilePref != Layout::ND && *tilePref != Layout::DN)) {
     return;
+  }
 
   auto viewInfo = resolveLayoutFromViewValue(getView(op));
   if (!viewInfo.owner || !viewInfo.layout || !viewInfo.inferred ||
@@ -315,13 +338,15 @@ static void maybeRepairMinor2DLoadStoreLayout(LoadStoreOp op, ViewGetter getView
     return;
   }
   auto tv = dyn_cast<MakeTensorViewOp>(viewInfo.owner);
-  if (!tv)
+  if (!tv) {
     return;
+  }
 
   SmallVector<int64_t> shape, strides;
   bool ambiguous = false;
-  if (!getStaticShapeAndStride(tv, shape, strides))
+  if (!getStaticShapeAndStride(tv, shape, strides)) {
     return;
+  }
   (void)inferLayout5D(
       shape, strides,
       elemByteSize(cast<TensorViewType>(tv.getResult().getType()).getElementType()),
@@ -360,8 +385,9 @@ struct LayoutPreference {
 static LayoutPreference collectPreferredLayoutFromConsumers(Value tensorView) {
   LayoutPreference result;
   auto mergePref = [&](std::optional<Layout> candidate) {
-    if (!candidate)
+    if (!candidate) {
       return;
+    }
     if (!result.preferred) {
       result.preferred = candidate;
       return;
@@ -378,8 +404,9 @@ static LayoutPreference collectPreferredLayoutFromConsumers(Value tensorView) {
       unsigned operandIndex = use.getOperandNumber();
 
       if (auto part = dyn_cast<PartitionViewOp>(owner)) {
-        if (operandIndex == 0)
+        if (operandIndex == 0) {
           self(self, part.getResult());
+        }
         continue;
       }
 
@@ -413,8 +440,9 @@ static LayoutPreference collectPreferredLayoutFromConsumers(Value tensorView) {
       }
 
       if (auto store = dyn_cast<pto::TStoreOp>(owner)) {
-        if (operandIndex == 1 && isVectorTileType(store.getSrc().getType()))
+        if (operandIndex == 1 && isVectorTileType(store.getSrc().getType())) {
           mergePref(tileBLayoutToGlobalLayout(store.getSrc().getType()));
+        }
         continue;
       }
     }
@@ -433,8 +461,9 @@ static std::optional<Layout> inferMakeTensorViewLayout(
        *pref.preferred == Layout::MX_B_NN))
     return pref.preferred;
   std::optional<Layout> preferredForAmbiguous = std::nullopt;
-  if (!pref.conflict && isMinorColsOne(shape))
+  if (!pref.conflict && isMinorColsOne(shape)) {
     preferredForAmbiguous = pref.preferred;
+  }
   return inferLayout5D(
       shape, strides,
       elemByteSize(
@@ -445,25 +474,30 @@ static std::optional<Layout> inferMakeTensorViewLayout(
 static void reconcileAmbiguousTensorViewLayout(MakeTensorViewOp op,
                                                ArrayRef<int64_t> shape) {
   auto pref = collectPreferredLayoutFromConsumers(op.getResult());
-  if (!isMinorColsOne(shape))
+  if (!isMinorColsOne(shape)) {
     return;
-  if (!op->getAttrOfType<BoolAttr>(kInferredLayoutAttrName))
+  }
+  if (!op->getAttrOfType<BoolAttr>(kInferredLayoutAttrName)) {
     return;
+  }
   auto cur = op->getAttrOfType<LayoutAttr>(kLayoutAttrName);
-  if (cur && pref.preferred && *pref.preferred != cur.getLayout())
+  if (cur && pref.preferred && *pref.preferred != cur.getLayout()) {
     setLayoutAttr(op.getOperation(), *pref.preferred, /*inferred=*/true);
+  }
 }
 
 static bool getStaticShapeAndStride(MakeTensorViewOp op,
                                     SmallVectorImpl<int64_t> &shape,
                                     SmallVectorImpl<int64_t> &strides) {
   auto tvTy = dyn_cast<TensorViewType>(op.getResult().getType());
-  if (!tvTy)
+  if (!tvTy) {
     return false;
+  }
 
   const size_t rank = op.getShape().size();
-  if (rank == 0 || rank > kPaddedLayoutRank)
+  if (rank == 0 || rank > kPaddedLayoutRank) {
     return false;
+  }
 
   shape.clear();
   shape.reserve(rank);
@@ -471,8 +505,9 @@ static bool getStaticShapeAndStride(MakeTensorViewOp op,
     int64_t dim = tvTy.getShape()[i];
     if (dim == ShapedType::kDynamic) {
       auto v = getConstInt(op.getShape()[i]);
-      if (!v)
+      if (!v) {
         return false;
+      }
       dim = *v;
     }
     shape.push_back(dim);
@@ -482,8 +517,9 @@ static bool getStaticShapeAndStride(MakeTensorViewOp op,
   strides.reserve(rank);
   for (Value s : op.getStrides()) {
     auto v = getConstInt(s);
-    if (!v)
+    if (!v) {
       return false;
+    }
     strides.push_back(*v);
   }
   return true;
@@ -543,16 +579,18 @@ static void inferMakeTensorViewLayoutAttr(MakeTensorViewOp op,
   auto inferred = inferMakeTensorViewLayout(op, shape, strides, isAmbiguous);
   verifyOrSetLayoutAttr(op.getOperation(), inferred, signalFailure,
                         isAmbiguous);
-  if (isAmbiguous)
+  if (isAmbiguous) {
     reconcileAmbiguousTensorViewLayout(op, shape);
+  }
 }
 
 template <typename SignalFailureFn>
 static void inferReinterpretCastLayoutAttr(memref::ReinterpretCastOp op,
                                            SignalFailureFn signalFailure) {
   auto mrTy = dyn_cast<MemRefType>(op.getType());
-  if (!mrTy || !isGlobalMemRef(mrTy))
+  if (!mrTy || !isGlobalMemRef(mrTy)) {
     return;
+  }
 
   const size_t rank = op.getMixedSizes().size();
   if (rank == 0 || rank > kPaddedLayoutRank) {
@@ -608,11 +646,13 @@ struct InferPTOLayoutPass
     // ------------------------------------------------------------------
     func.walk([&](memref::SubViewOp op) {
       auto resTy = dyn_cast<MemRefType>(op.getType());
-      if (!resTy || !isGlobalMemRef(resTy))
+      if (!resTy || !isGlobalMemRef(resTy)) {
         return;
+      }
 
-      if (op->getAttrOfType<LayoutAttr>(kLayoutAttrName))
+      if (op->getAttrOfType<LayoutAttr>(kLayoutAttrName)) {
         return;
+      }
 
       if (Operation *def = op.getSource().getDefiningOp()) {
         if (auto srcLayout = def->getAttrOfType<LayoutAttr>(kLayoutAttrName)) {

--- a/lib/PTO/Transforms/InferPTOMemScope.cpp
+++ b/lib/PTO/Transforms/InferPTOMemScope.cpp
@@ -39,9 +39,10 @@ namespace {
 static std::optional<memref::AllocOp> requireRootAlloc(Operation *op, Value value,
                                                        StringRef valueName) {
   auto alloc = tracebackMemRefToAlloc(value);
-  if (!alloc.has_value())
+  if (!alloc.has_value()) {
     emitError(op->getLoc()) << "Cannot find root memref.alloc for " << valueName
                             << " of this op.";
+  }
   return alloc;
 }
 
@@ -50,11 +51,13 @@ static LogicalResult propagateAllocScope(Operation *op, Value value,
                                          const AddressSpaceAttr &targetScope,
                                          MemScopeInferAndPropagateHelper &helper) {
   auto alloc = requireRootAlloc(op, value, valueName);
-  if (!alloc.has_value())
+  if (!alloc.has_value()) {
     return failure();
-  if (failed(helper.Run(*alloc, targetScope)))
+  }
+  if (failed(helper.Run(*alloc, targetScope))) {
     return op->emitOpError()
            << "Failed to infer/propagate memory scope for " << valueName;
+  }
   return success();
 }
 
@@ -117,8 +120,9 @@ propagateMemScopeToUser(MemScopeInferAndPropagateHelper &helper, Value val,
       })
       .Case<func::CallOp, gpu::LaunchFuncOp>([&](auto) { return success(); })
       .Default([&](Operation *op) {
-        if (op->getNumResults() == 0 || !hasMemRefResults(op))
+        if (op->getNumResults() == 0 || !hasMemRefResults(op)) {
           return success();
+        }
         op->emitOpError("Unsupported user for root alloc op.");
         return failure();
       });
@@ -189,27 +193,32 @@ static LogicalResult propagateOperandScopes(
     ArrayRef<std::tuple<Value, StringRef, AddressSpaceAttr>> specs) {
   MemScopeInferAndPropagateHelper helper;
   for (const auto &[value, valueName, targetScope] : specs) {
-    if (failed(propagateAllocScope(op, value, valueName, targetScope, helper)))
+    if (failed(propagateAllocScope(op, value, valueName, targetScope, helper))) {
       return failure();
+    }
   }
   return success();
 }
 
 LogicalResult pto::inferAndPropagateMemScopeForMovDps(pto::TMovOp op) {
-  if (failed(ensureDpsOnlyOp(op)))
+  if (failed(ensureDpsOnlyOp(op))) {
     return failure();
+  }
 
   auto dstAlloc = requireRootAlloc(op, op.getDst(), "mB");
-  if (!dstAlloc.has_value())
+  if (!dstAlloc.has_value()) {
     return failure();
+  }
 
   auto memRefType = dyn_cast<BaseMemRefType>(dstAlloc->getType());
-  if (!memRefType)
+  if (!memRefType) {
     return op->emitOpError("Failed to infer/propagate memory scope for mA");
+  }
 
   auto memSpace = memRefType.getMemorySpace();
-  if (!memSpace)
+  if (!memSpace) {
     return success();
+  }
 
   auto l0aSpaceAttr =
       getMemScopeAttr(op->getContext(), pto::AddressSpace::LEFT);
@@ -221,10 +230,12 @@ LogicalResult pto::inferAndPropagateMemScopeForMovDps(pto::TMovOp op) {
   auto ubSpaceAttr = getMemScopeAttr(op->getContext(), pto::AddressSpace::VEC);
   auto biasSpaceAttr =
       getMemScopeAttr(op->getContext(), pto::AddressSpace::BIAS);
-  if (memSpace == ubSpaceAttr)
+  if (memSpace == ubSpaceAttr) {
     return propagateOperandScopes(op, {{op.getSrc(), "mA", ubSpaceAttr}});
-  if (memSpace == l1SpaceAttr)
+  }
+  if (memSpace == l1SpaceAttr) {
     return propagateOperandScopes(op, {{op.getSrc(), "mA", l0cSpaceAttr}});
+  }
   if (memSpace == l0aSpaceAttr || memSpace == l0bSpaceAttr ||
       memSpace == biasSpaceAttr) {
     return propagateOperandScopes(op, {{op.getSrc(), "mA", l1SpaceAttr}});
@@ -233,8 +244,9 @@ LogicalResult pto::inferAndPropagateMemScopeForMovDps(pto::TMovOp op) {
 }
 
 LogicalResult pto::inferAndPropagateMemScopeForMatmulAccDps(pto::TMatmulAccOp op) {
-  if (failed(ensureDpsOnlyOp(op)))
+  if (failed(ensureDpsOnlyOp(op))) {
     return failure();
+  }
 
   return propagateOperandScopes(
       op, {{op.getAccIn(), "mAcc",
@@ -249,8 +261,9 @@ LogicalResult pto::inferAndPropagateMemScopeForMatmulAccDps(pto::TMatmulAccOp op
 
 
 LogicalResult pto::inferAndPropagateMemScopeForMatmulBiasDps(pto::TMatmulBiasOp op) {
-  if (failed(ensureDpsOnlyOp(op)))
+  if (failed(ensureDpsOnlyOp(op))) {
     return failure();
+  }
 
   return propagateOperandScopes(
       op, {{op.getA(), "mA",
@@ -264,8 +277,9 @@ LogicalResult pto::inferAndPropagateMemScopeForMatmulBiasDps(pto::TMatmulBiasOp 
 }
 
 LogicalResult pto::inferAndPropagateMemScopeForMatmulDps(pto::TMatmulOp op) {
-  if (failed(ensureDpsOnlyOp(op)))
+  if (failed(ensureDpsOnlyOp(op))) {
     return failure();
+  }
 
   return propagateOperandScopes(
       op, {{op.getLhs(), "mA",
@@ -284,12 +298,14 @@ LogicalResult InferPTOMemScopePass::fixDeviceCallSite(func::FuncOp op) {
     func::CallOp call = cast<func::CallOp>(use.getUser());
     // propagate call operand's memory scope
     for (auto [idx, callOperand] : llvm::enumerate(call.getArgOperands())) {
-      if (!isa<BaseMemRefType>(callOperand.getType()))
+      if (!isa<BaseMemRefType>(callOperand.getType())) {
         continue;
+      }
 
       auto funcOperandType = op.getFunctionType().getInput(idx);
-      if (!isa<BaseMemRefType>(funcOperandType))
+      if (!isa<BaseMemRefType>(funcOperandType)) {
         continue;
+      }
 
       LDBG("call operand: " << callOperand);
       if (failed(helper.Run(tracebackMemRef(callOperand),
@@ -302,12 +318,14 @@ LogicalResult InferPTOMemScopePass::fixDeviceCallSite(func::FuncOp op) {
     }
     // propagate call return value memory scope
     for (auto [idx, returnValue] : llvm::enumerate(call->getResults())) {
-      if (!isa<BaseMemRefType>(returnValue.getType()))
+      if (!isa<BaseMemRefType>(returnValue.getType())) {
         continue;
+      }
 
       auto funcReturnType = op.getFunctionType().getResult(idx);
-      if (!isa<BaseMemRefType>(funcReturnType))
+      if (!isa<BaseMemRefType>(funcReturnType)) {
         continue;
+      }
 
       if (failed(helper.Run(returnValue,
                             getPTOAddressSpaceAttr(funcReturnType)))) {
@@ -326,12 +344,14 @@ LogicalResult InferPTOMemScopePass::fixDeviceCallSite(func::FuncOp op) {
 /// information to update the function's type.
 [[maybe_unused]] LogicalResult InferPTOMemScopePass::fixHostFuncSignature(func::FuncOp op) {
   // Skip external host functions because we know nothing about it.
-  if (op.isExternal())
+  if (op.isExternal()) {
     return success();
+  }
 
   func::ReturnOp returnOp = getAssumedUniqueReturnOp(op);
-  if (!returnOp)
+  if (!returnOp) {
     return failure();
+  }
 
   SmallVector<Type> newArgsType(llvm::map_to_vector(
       op.getArguments(), [](const BlockArgument &ba) { return ba.getType(); }));
@@ -342,9 +362,10 @@ LogicalResult InferPTOMemScopePass::fixDeviceCallSite(func::FuncOp op) {
   return success();
 }
 
-LogicalResult inferAndPropagateMemScopeForExternFunc(func::FuncOp op) {
-  if (!op.isExternal())
+static LogicalResult inferAndPropagateMemScopeForExternFunc(func::FuncOp op) {
+  if (!op.isExternal()) {
     return failure();
+  }
 
   auto gmSpaceAttr =
       AddressSpaceAttr::get(op->getContext(), pto::AddressSpace::GM);
@@ -354,8 +375,9 @@ LogicalResult inferAndPropagateMemScopeForExternFunc(func::FuncOp op) {
   for (auto &argType : newArgTypes) {
     // If not base memref and already has memspace then skip
     if (auto memrefType = dyn_cast<BaseMemRefType>(argType)) {
-      if (memrefType.getMemorySpace())
+      if (memrefType.getMemorySpace()) {
         continue;
+      }
       argType = getBaseMemRefTypeWithNewScope(memrefType, gmSpaceAttr);
     }
   }
@@ -365,8 +387,9 @@ LogicalResult inferAndPropagateMemScopeForExternFunc(func::FuncOp op) {
   for (auto &resultType : newReturnTypes) {
     // If not base memref and already has memspace then skip
     if (auto memrefType = dyn_cast<BaseMemRefType>(resultType)) {
-      if (memrefType.getMemorySpace())
+      if (memrefType.getMemorySpace()) {
         continue;
+      }
       resultType = getBaseMemRefTypeWithNewScope(memrefType, gmSpaceAttr);
     }
   }
@@ -376,8 +399,9 @@ LogicalResult inferAndPropagateMemScopeForExternFunc(func::FuncOp op) {
 }
 
 LogicalResult pto::inferAndPropagateMemScopeForFunc(func::FuncOp op) {
-  if (op.isExternal())
+  if (op.isExternal()) {
     return inferAndPropagateMemScopeForExternFunc(op);
+  }
 
   LDBG("Begin infer and propagate memory scope for func" << op.getSymName());
   MemScopeInferAndPropagateHelper helper;
@@ -392,10 +416,11 @@ LogicalResult pto::inferAndPropagateMemScopeForFunc(func::FuncOp op) {
     }
 
     if (op->hasAttr(pto::VectorFunctionAttr::name)) {
-      if (failed(helper.Run(arg, ubSpaceAttr)))
+      if (failed(helper.Run(arg, ubSpaceAttr))) {
         return op->emitOpError()
                << "Failed to propagate UB memory scope for argument # in VF"
                << arg.getArgNumber();
+      }
     } else if (failed(helper.Run(arg, gmSpaceAttr))) {
       return op->emitOpError()
              << "Failed to propagate memory scope for argument #"
@@ -407,9 +432,10 @@ LogicalResult pto::inferAndPropagateMemScopeForFunc(func::FuncOp op) {
         op.getBody().front().getArgumentTypes(), op.getResultTypes());
     op.setFunctionType(newFt);
   }
-  if (op->getNumResults() > 0)
+  if (op->getNumResults() > 0) {
     op.emitWarning()
         << "non-externl function has return value after bufferization!";
+  }
 
   return success();
 }
@@ -446,8 +472,9 @@ LogicalResult pto::inferAndPropagateMemScopeForGpuFunc(gpu::GPUFuncOp op) {
 LogicalResult pto::inferAndPropagateUbufMemScope(memref::AllocOp op) {
   LDBG("Begin infer and propagate memory scope for: " << *op);
   auto memorySpace = op.getType().getMemorySpace();
-  if (memorySpace)
+  if (memorySpace) {
     return success();
+  }
 
   MemScopeInferAndPropagateHelper helper;
   auto ubSpaceAttr =
@@ -473,47 +500,55 @@ void InferPTOMemScopePass::runOnOperation() {
   });
 
   for (auto func : gpuFuncList) {
-    if (failed(inferAndPropagateMemScopeForGpuFunc(func)))
+    if (failed(inferAndPropagateMemScopeForGpuFunc(func))) {
       signalPassFailure();
+    }
   }
 
   // Infer and propagate memory scope for device functions.
   for (auto func : deviceFuncList) {
     // Set the memory scope of values related to `pto::MmadL1Op` to L1 or L0C.
     func->walk([&](mlir::pto::TMatmulOp op) {
-      if (failed(pto::inferAndPropagateMemScopeForMatmulDps(op)))
+      if (failed(pto::inferAndPropagateMemScopeForMatmulDps(op))) {
         signalPassFailure();
+      }
     });
 
     func->walk([&](mlir::pto::TMatmulAccOp op) {
-      if (failed(pto::inferAndPropagateMemScopeForMatmulAccDps(op)))
+      if (failed(pto::inferAndPropagateMemScopeForMatmulAccDps(op))) {
         signalPassFailure();
+      }
     });
 
     func->walk([&](mlir::pto::TMatmulBiasOp op) {
-      if (failed(pto::inferAndPropagateMemScopeForMatmulBiasDps(op)))
+      if (failed(pto::inferAndPropagateMemScopeForMatmulBiasDps(op))) {
         signalPassFailure();
+      }
     });
 
     func->walk([&](mlir::pto::TMovOp op) {
-      if (failed(pto::inferAndPropagateMemScopeForMovDps(op)))
+      if (failed(pto::inferAndPropagateMemScopeForMovDps(op))) {
         signalPassFailure();
+      }
     });
 
     // Set device function arguments' memory scope to GM.
-    if (failed(pto::inferAndPropagateMemScopeForFunc(func)))
+    if (failed(pto::inferAndPropagateMemScopeForFunc(func))) {
       signalPassFailure();
+    }
 
     // Finally, set the remaining memory scope in the device kernel to UB.
     func->walk([&](memref::AllocOp op) {
-      if (failed(pto::inferAndPropagateUbufMemScope(op)))
+      if (failed(pto::inferAndPropagateUbufMemScope(op))) {
         signalPassFailure();
+      }
     });
   }
 
   for (auto func : deviceFuncList) {
-    if (failed(fixDeviceCallSite(func)))
+    if (failed(fixDeviceCallSite(func))) {
       signalPassFailure();
+    }
   }
 }
 

--- a/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
+++ b/lib/PTO/Transforms/InsertSync/MemoryDependentAnalyzer.cpp
@@ -180,8 +180,8 @@ bool MemoryDependentAnalyzer::MemAlias(const BaseMemInfo *a,
     llvm::errs() << "  [MemAlias Check]\n";
     printValueDebug("    Root A", a->rootBuffer);
     printValueDebug("    Root B", b->rootBuffer);
-    llvm::errs() << "    Scope A: " << (int)as << ", Scope B: " << (int)bs
-                 << "\n";
+    llvm::errs() << "    Scope A: " << static_cast<int>(as)
+                 << ", Scope B: " << static_cast<int>(bs) << "\n";
   }
  
   if (as != bs) {

--- a/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
+++ b/lib/PTO/Transforms/InsertSync/SyncCommon.cpp
@@ -267,8 +267,8 @@ UNIT_FLAG CompoundInstanceElement::getUnitFlagMode() const {
   return it->second;
 }
 
-Value getIsNotDeadLoopValue(scf::ForOp forOp, Location loc,
-                            OpBuilder &rewriter) {
+static Value getIsNotDeadLoopValue(scf::ForOp forOp, Location loc,
+                                   OpBuilder &rewriter) {
   Value upperBound = forOp.getUpperBound();
   Value lowerBound = forOp.getLowerBound();
   return rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,

--- a/lib/PTO/Transforms/InsertTemplateAttributes.cpp
+++ b/lib/PTO/Transforms/InsertTemplateAttributes.cpp
@@ -55,50 +55,72 @@ struct CandidateMetadata {
 };
 
 static std::string getDtypeString(Type elementType) {
-  if (elementType.isIndex())
+  if (elementType.isIndex()) {
     return "i32";
-  if (elementType.isInteger(1))
+  }
+  if (elementType.isInteger(1)) {
     return "i1";
-  if (elementType.isF32())
+  }
+  if (elementType.isF32()) {
     return "f32";
-  if (elementType.isF16())
+  }
+  if (elementType.isF16()) {
     return "f16";
-  if (elementType.isBF16())
+  }
+  if (elementType.isBF16()) {
     return "bf16";
-  if (isa<Float8E4M3FNType>(elementType))
+  }
+  if (isa<Float8E4M3FNType>(elementType)) {
     return "f8e4m3";
-  if (isa<Float8E5M2Type>(elementType))
+  }
+  if (isa<Float8E5M2Type>(elementType)) {
     return "f8e5m2";
-  if (isa<pto::HiF8Type>(elementType))
+  }
+  if (isa<pto::HiF8Type>(elementType)) {
     return "hif8";
-  if (isa<pto::F4E1M2x2Type>(elementType))
+  }
+  if (isa<pto::F4E1M2x2Type>(elementType)) {
     return "f4e1m2x2";
-  if (isa<pto::F4E2M1x2Type>(elementType))
+  }
+  if (isa<pto::F4E2M1x2Type>(elementType)) {
     return "f4e2m1x2";
-  if (elementType.isUnsignedInteger(64))
+  }
+  if (elementType.isUnsignedInteger(64)) {
     return "ui64";
-  if (elementType.isUnsignedInteger(32))
+  }
+  if (elementType.isUnsignedInteger(32)) {
     return "ui32";
-  if (elementType.isUnsignedInteger(16))
+  }
+  if (elementType.isUnsignedInteger(16)) {
     return "ui16";
-  if (elementType.isUnsignedInteger(8))
+  }
+  if (elementType.isUnsignedInteger(8)) {
     return "ui8";
-  if (elementType.isSignedInteger(64))
+  }
+  if (elementType.isSignedInteger(64)) {
     return "si64";
-  if (elementType.isSignedInteger(32))
+  }
+  if (elementType.isSignedInteger(32)) {
     return "si32";
-  if (elementType.isSignedInteger(16))
+  }
+  if (elementType.isSignedInteger(16)) {
     return "si16";
-  if (elementType.isSignedInteger(8))
+  }
+  if (elementType.isSignedInteger(8)) {
     return "si8";
-  if (elementType.isSignlessInteger(64))
+  }
+  if (elementType.isSignlessInteger(64)) {
     return "i64";
-  if (elementType.isSignlessInteger(32))
+  }
+  if (elementType.isSignlessInteger(32)) {
     return "i32";
-  if (elementType.isSignlessInteger(16))
+  }
+  if (elementType.isSignlessInteger(16)) {
     return "i16";
-  if (elementType.isSignlessInteger(8))
+  }
+  if (elementType.isSignlessInteger(8)) {
     return "i8";
+  }
   return "";
 }
 
@@ -152,18 +174,21 @@ static StringRef getBLayoutString(pto::BLayout layout) {
 }
 
 static StringRef getSLayoutString(pto::SLayout layout) {
-  if (layout == pto::SLayout::RowMajor)
+  if (layout == pto::SLayout::RowMajor) {
     return "row_major";
-  if (layout == pto::SLayout::ColMajor)
+  }
+  if (layout == pto::SLayout::ColMajor) {
     return "col_major";
+  }
   return "none_box";
 }
 
 static void appendJsonIntArray(std::string &json, ArrayRef<int64_t> values) {
   json += "[";
   for (auto [index, value] : llvm::enumerate(values)) {
-    if (index != 0)
+    if (index != 0) {
       json += ",";
+    }
     json += std::to_string(value);
   }
   json += "]";
@@ -172,8 +197,9 @@ static void appendJsonIntArray(std::string &json, ArrayRef<int64_t> values) {
 static void appendJsonDimArray(std::string &json, ArrayRef<int64_t> values) {
   json += "[";
   for (auto [index, value] : llvm::enumerate(values)) {
-    if (index != 0)
+    if (index != 0) {
       json += ",";
+    }
     if (ShapedType::isDynamic(value)) {
       json += "null";
       continue;
@@ -198,14 +224,16 @@ static bool getStaticIntFromValue(Value value, int64_t &out) {
 static int64_t getStaticIntOrDynamic(OpFoldResult value) {
   if (isa<Attribute>(value)) {
     Attribute attr = cast<Attribute>(value);
-    if (auto integer = dyn_cast<IntegerAttr>(attr))
+    if (auto integer = dyn_cast<IntegerAttr>(attr)) {
       return integer.getInt();
+    }
     return ShapedType::kDynamic;
   }
 
   int64_t result = ShapedType::kDynamic;
-  if (getStaticIntFromValue(cast<Value>(value), result))
+  if (getStaticIntFromValue(cast<Value>(value), result)) {
     return result;
+  }
   return ShapedType::kDynamic;
 }
 
@@ -213,8 +241,9 @@ static void recordStaticSizes(ArrayRef<OpFoldResult> values,
                               SmallVectorImpl<int64_t> &out) {
   out.clear();
   out.reserve(values.size());
-  for (OpFoldResult value : values)
+  for (OpFoldResult value : values) {
     out.push_back(getStaticIntOrDynamic(value));
+  }
 }
 
 static SmallVector<int64_t>
@@ -237,16 +266,19 @@ combineSubviewStrides(ArrayRef<int64_t> baseStrides,
 static constexpr llvm::StringLiteral kLayoutAttrName = "layout";
 
 static std::optional<pto::Layout> getLayoutAttrFromOp(Operation *op) {
-  if (!op)
+  if (!op) {
     return std::nullopt;
-  if (auto attr = op->getAttrOfType<pto::LayoutAttr>(kLayoutAttrName))
+  }
+  if (auto attr = op->getAttrOfType<pto::LayoutAttr>(kLayoutAttrName)) {
     return attr.getLayout();
+  }
   return std::nullopt;
 }
 
 static std::optional<pto::Layout> resolveViewLayout(Value value) {
-  if (!value)
+  if (!value) {
     return std::nullopt;
+  }
 
   Operation *definingOp = value.getDefiningOp();
   while (definingOp) {
@@ -255,8 +287,9 @@ static std::optional<pto::Layout> resolveViewLayout(Value value) {
       definingOp = value.getDefiningOp();
       continue;
     }
-    if (auto layout = getLayoutAttrFromOp(definingOp))
+    if (auto layout = getLayoutAttrFromOp(definingOp)) {
       return layout;
+    }
     if (auto subview = dyn_cast<memref::SubViewOp>(definingOp)) {
       value = subview.getSource();
       definingOp = value.getDefiningOp();
@@ -281,8 +314,9 @@ static std::optional<pto::Layout> resolveViewLayout(Value value) {
 static void populatePTOViewShapeAndStrides(Value value,
                                            SmallVectorImpl<int64_t> &shape,
                                            SmallVectorImpl<int64_t> &strides) {
-  if (!value)
+  if (!value) {
     return;
+  }
 
   if (auto part = value.getDefiningOp<pto::PartitionViewOp>()) {
     if (shape.empty()) {
@@ -295,24 +329,27 @@ static void populatePTOViewShapeAndStrides(Value value,
       if (shape.empty()) {
         auto partTy =
             dyn_cast<pto::PartitionTensorViewType>(part.getResult().getType());
-        if (partTy)
+        if (partTy) {
           shape.assign(partTy.getShape().begin(), partTy.getShape().end());
+        }
       }
     }
     SmallVector<int64_t> sourceShape;
     SmallVector<int64_t> sourceStrides;
     populatePTOViewShapeAndStrides(part.getSource(), sourceShape,
                                    sourceStrides);
-    if (strides.empty() && !sourceStrides.empty())
+    if (strides.empty() && !sourceStrides.empty()) {
       strides = sourceStrides;
+    }
     return;
   }
 
   if (auto make = value.getDefiningOp<pto::MakeTensorViewOp>()) {
     if (shape.empty()) {
       auto viewTy = dyn_cast<pto::TensorViewType>(make.getResult().getType());
-      if (viewTy)
+      if (viewTy) {
         shape.assign(viewTy.getShape().begin(), viewTy.getShape().end());
+      }
     }
     if (strides.empty()) {
       strides.reserve(make.getStrides().size());
@@ -326,25 +363,29 @@ static void populatePTOViewShapeAndStrides(Value value,
   }
 
   if (auto viewTy = dyn_cast<pto::TensorViewType>(value.getType())) {
-    if (shape.empty())
+    if (shape.empty()) {
       shape.assign(viewTy.getShape().begin(), viewTy.getShape().end());
+    }
   }
 }
 
 static void populateViewShapeAndStrides(Value value,
                                         SmallVectorImpl<int64_t> &shape,
                                         SmallVectorImpl<int64_t> &strides) {
-  if (!value)
+  if (!value) {
     return;
+  }
 
   if (auto subview = value.getDefiningOp<memref::SubViewOp>()) {
     populateViewShapeAndStrides(subview.getSource(), shape, strides);
     SmallVector<int64_t> subviewShape;
     recordStaticSizes(subview.getMixedSizes(), subviewShape);
-    if (!subviewShape.empty())
+    if (!subviewShape.empty()) {
       shape = subviewShape;
-    if (!strides.empty())
+    }
+    if (!strides.empty()) {
       strides = combineSubviewStrides(strides, subview.getMixedStrides());
+    }
     return;
   }
 
@@ -353,11 +394,13 @@ static void populateViewShapeAndStrides(Value value,
     if (shape.empty()) {
       SmallVector<int64_t> reinterpretShape;
       recordStaticSizes(reinterpret.getMixedSizes(), reinterpretShape);
-      if (!reinterpretShape.empty())
+      if (!reinterpretShape.empty()) {
         shape = reinterpretShape;
+      }
     }
-    if (strides.empty())
+    if (strides.empty()) {
       recordStaticSizes(reinterpret.getMixedStrides(), strides);
+    }
     return;
   }
 
@@ -367,8 +410,9 @@ static void populateViewShapeAndStrides(Value value,
   }
 
   if (auto memrefType = dyn_cast<MemRefType>(value.getType())) {
-    if (shape.empty())
+    if (shape.empty()) {
       shape.assign(memrefType.getShape().begin(), memrefType.getShape().end());
+    }
     if (strides.empty()) {
       int64_t offset = ShapedType::kDynamic;
       (void)mlir::pto::getPTOMemRefStridesAndOffset(memrefType, strides,
@@ -379,8 +423,9 @@ static void populateViewShapeAndStrides(Value value,
 
 static std::optional<std::string>
 getViewLayoutString(std::optional<pto::Layout> layout) {
-  if (!layout)
+  if (!layout) {
     return std::nullopt;
+  }
   return stringifyLayout(*layout).str();
 }
 
@@ -468,8 +513,9 @@ template <typename OpT>
 static bool tryAppendPrecisionType(
     Operation *op, SmallVectorImpl<std::pair<std::string, std::string>> &attrs) {
   auto typed = dyn_cast<OpT>(op);
-  if (!typed)
+  if (!typed) {
     return false;
+  }
   attrs.emplace_back("precisionType",
                      getPrecisionTypeString(typed.getPrecisionType()).str());
   return true;
@@ -481,11 +527,13 @@ static bool tryAppendPrecisionType(
 static void appendOpContextAttrs(
     Operation *op, SmallVectorImpl<std::pair<std::string, std::string>> &attrs) {
   if (auto tcvt = dyn_cast<pto::TCvtOp>(op)) {
-    if (auto roundMode = getTCvtRoundModeString(tcvt))
+    if (auto roundMode = getTCvtRoundModeString(tcvt)) {
       attrs.emplace_back("round_mode", *roundMode);
+    }
   }
-  if (auto trandom = dyn_cast<pto::TRandomOp>(op))
+  if (auto trandom = dyn_cast<pto::TRandomOp>(op)) {
     attrs.emplace_back("rounds", std::to_string(trandom.getRounds()));
+  }
   if (auto tcmp = dyn_cast<pto::TCmpOp>(op)) {
     if (auto cmpModeAttr = tcmp.getCmpModeAttr())
       attrs.emplace_back("cmp_mode",
@@ -522,8 +570,9 @@ static void appendOpContextAttrs(
   }
   if (auto thistogram = dyn_cast<pto::THistogramOp>(op)) {
     int byte = 1;
-    if (auto byteAttr = thistogram.getByteAttr())
+    if (auto byteAttr = thistogram.getByteAttr()) {
       byte = byteAttr.getInt();
+    }
     attrs.emplace_back("byte", std::to_string(byte));
   }
   if (auto tscatter = dyn_cast<pto::TScatterOp>(op)) {
@@ -553,8 +602,9 @@ static std::string buildContextAttrsJson(Operation *operation) {
 
   std::string json = "{";
   for (auto [index, attr] : llvm::enumerate(attrs)) {
-    if (index != 0)
+    if (index != 0) {
       json += ",";
+    }
     json += "\"";
     json += attr.first;
     json += "\":\"";
@@ -585,8 +635,9 @@ static void appendTileOperandSpecJson(std::string &json,
   if (auto config = tileType.getConfigAttr()) {
     bLayout = config.getBLayout().getValue();
     sLayout = config.getSLayout().getValue();
-    if (config.getSFractalSize())
+    if (config.getSFractalSize()) {
       fractalSize = config.getSFractalSize().getInt();
+    }
     padValue = static_cast<uint64_t>(config.getPad().getValue());
     compactMode = static_cast<int32_t>(config.getCompactMode().getValue());
   }
@@ -611,8 +662,9 @@ static void appendViewOperandSpecJson(std::string &json, Value operand,
   SmallVector<int64_t> shape;
   SmallVector<int64_t> strides;
   populateViewShapeAndStrides(operand, shape, strides);
-  if (shape.empty())
+  if (shape.empty()) {
     shape.assign(memrefType.getShape().begin(), memrefType.getShape().end());
+  }
   appendJsonDimArray(json, shape);
   if (!strides.empty()) {
     json += ",\"strides\":";
@@ -636,8 +688,9 @@ static void appendViewOperandSpecJson(std::string &json, Value operand,
   SmallVector<int64_t> shape;
   SmallVector<int64_t> strides;
   populatePTOViewShapeAndStrides(operand, shape, strides);
-  if (shape.empty())
+  if (shape.empty()) {
     shape.assign(viewType.getShape().begin(), viewType.getShape().end());
+  }
   appendJsonDimArray(json, shape);
   if (!strides.empty()) {
     json += ",\"strides\":";
@@ -685,8 +738,9 @@ static std::optional<std::string>
 buildOperandSpecsJson(Operation *operation) {
   std::string json = "[";
   for (auto [index, operand] : llvm::enumerate(operation->getOperands())) {
-    if (index != 0)
+    if (index != 0) {
       json += ",";
+    }
 
     Type type = operand.getType();
     if (auto tileType = dyn_cast<pto::TileBufType>(type)) {
@@ -764,8 +818,9 @@ getTargetArch(Operation *operation) {
 
   for (ModuleOp current = module; current;
        current = current->getParentOfType<ModuleOp>()) {
-    if (auto target = current->getAttrOfType<StringAttr>("pto.target_arch"))
+    if (auto target = current->getAttrOfType<StringAttr>("pto.target_arch")) {
       return target.getValue().str();
+    }
   }
 
   operation->emitError(
@@ -842,8 +897,9 @@ parseCandidateAttributes(Operation *operation, StringRef metadataJson) {
   llvm::sort(parsedCandidates,
              [](const CandidateMetadata &left,
                 const CandidateMetadata &right) {
-               if (left.priority != right.priority)
+               if (left.priority != right.priority) {
                  return left.priority > right.priority;
+               }
                return left.name < right.name;
              });
   if (parsedCandidates.size() > 1 &&
@@ -891,11 +947,13 @@ struct InsertTemplateAttributesPass
 
     SmallVector<Operation *> tileOperations;
     module.walk([&](Operation *operation) {
-      if (pto::isTileLibExpandableOp(operation))
+      if (pto::isTileLibExpandableOp(operation)) {
         tileOperations.push_back(operation);
+      }
     });
-    if (tileOperations.empty())
+    if (tileOperations.empty()) {
       return;
+    }
     std::shared_ptr<pto::TileLibService> tileLibService =
         pto::TileLibRuntime::getService();
     if (!tileLibService) {
@@ -907,8 +965,9 @@ struct InsertTemplateAttributesPass
     for (Operation *operation : tileOperations) {
       auto target = getTargetArch(operation);
       auto operandSpecs = buildOperandSpecsJson(operation);
-      if (!target || !operandSpecs)
+      if (!target || !operandSpecs) {
         return signalPassFailure();
+      }
       pto::TileLibMaterializationRequest request;
       request.target = std::move(*target);
       request.op = operation->getName().getStringRef().str();
@@ -921,8 +980,9 @@ struct InsertTemplateAttributesPass
       }
 
       auto candidates = parseCandidateAttributes(operation, *metadata);
-      if (failed(candidates))
+      if (failed(candidates)) {
         return signalPassFailure();
+      }
       operation->setAttr(kCandidatesAttr, *candidates);
     }
   }

--- a/lib/PTO/Transforms/LowerPTOToUBufOps.cpp
+++ b/lib/PTO/Transforms/LowerPTOToUBufOps.cpp
@@ -41,7 +41,6 @@ namespace pto {
 } // namespace mlir
 
 namespace {
-
 static constexpr int64_t kRepeatMax = 255;
 static constexpr int64_t kRepeatStrideMax = 255;
 static constexpr int64_t kSmallRptBinOp = 4;
@@ -53,25 +52,31 @@ static constexpr unsigned kMaskLen = 64;
 //===----------------------------------------------------------------------===//
 
 static unsigned getElementSize(Type elemTy) {
-  if (elemTy.isF16() || elemTy.isBF16())
+  if (elemTy.isF16() || elemTy.isBF16()) {
     return 2;
-  if (elemTy.isF32())
+  }
+  if (elemTy.isF32()) {
     return 4;
+  }
   if (auto intTy = dyn_cast<IntegerType>(elemTy)) {
     unsigned width = intTy.getWidth();
-    if (width == 16 || width == 32)
+    if (width == 16 || width == 32) {
       return width / 8;
+    }
   }
   return 0;
 }
 
 static Type getStoredElemType(Type ty) {
-  if (auto tbTy = dyn_cast<pto::TileBufType>(ty))
+  if (auto tbTy = dyn_cast<pto::TileBufType>(ty)) {
     return tbTy.getElementType();
-  if (auto mrTy = dyn_cast<MemRefType>(ty))
+  }
+  if (auto mrTy = dyn_cast<MemRefType>(ty)) {
     return mrTy.getElementType();
-  if (auto ptrTy = dyn_cast<pto::PtrType>(ty))
+  }
+  if (auto ptrTy = dyn_cast<pto::PtrType>(ty)) {
     return ptrTy.getElementType();
+  }
   return Type();
 }
 
@@ -80,19 +85,22 @@ static std::optional<bool> isUBMemorySpaceImpl(Type ty) {
   if (auto tbTy = dyn_cast<pto::TileBufType>(ty)) {
     auto msAttr =
         dyn_cast_or_null<pto::AddressSpaceAttr>(tbTy.getMemorySpace());
-    if (!msAttr)
+    if (!msAttr) {
       return false;
+    }
     return msAttr.getAddressSpace() == pto::AddressSpace::VEC;
   }
   if (auto mrTy = dyn_cast<MemRefType>(ty)) {
     auto msAttr =
         dyn_cast_or_null<pto::AddressSpaceAttr>(mrTy.getMemorySpace());
-    if (!msAttr)
+    if (!msAttr) {
       return false;
+    }
     return msAttr.getAddressSpace() == pto::AddressSpace::VEC;
   }
-  if (auto ptrTy = dyn_cast<pto::PtrType>(ty))
+  if (auto ptrTy = dyn_cast<pto::PtrType>(ty)) {
     return ptrTy.getMemorySpace().getAddressSpace() == pto::AddressSpace::VEC;
+  }
   return std::nullopt;
 }
 
@@ -104,8 +112,9 @@ static bool isUBMemorySpace(Type ty) {
 
 static bool isRowMajor(pto::TileBufType tbTy) {
   auto config = tbTy.getConfigAttr();
-  if (!config)
+  if (!config) {
     return true;
+  }
   return config.getBLayout().getValue() != pto::BLayout::ColMajor;
 }
 
@@ -145,8 +154,9 @@ using TileShapeMap = DenseMap<Value, TileShapeMetadata>;
 static std::optional<TileShapeInfo> extractTileShapeInfoFromValue(
     Value opDst, const TileShapeMap &tileShapes) {
   Type dstTy = opDst.getType();
-  if (!isUBMemorySpace(dstTy))
+  if (!isUBMemorySpace(dstTy)) {
     return std::nullopt;
+  }
 
   Type elemTy;
   ArrayRef<int64_t> shape;
@@ -155,15 +165,17 @@ static std::optional<TileShapeInfo> extractTileShapeInfoFromValue(
     elemTy = tbTy.getElementType();
     shape = tbTy.getShape();
     validShape = tbTy.getValidShape();
-    if (!isRowMajor(tbTy))
+    if (!isRowMajor(tbTy)) {
       return std::nullopt;
+    }
   } else if (auto mrTy = dyn_cast<MemRefType>(dstTy)) {
     elemTy = mrTy.getElementType();
     shape = mrTy.getShape();
   } else if (isa<pto::PtrType>(dstTy)) {
     auto it = tileShapes.find(opDst);
-    if (it == tileShapes.end())
+    if (it == tileShapes.end()) {
       return std::nullopt;
+    }
     elemTy = cast<pto::PtrType>(dstTy).getElementType();
     shape = llvm::ArrayRef(it->second.shape);
     validShape = llvm::ArrayRef(it->second.validShape);
@@ -171,11 +183,13 @@ static std::optional<TileShapeInfo> extractTileShapeInfoFromValue(
     return std::nullopt;
   }
   unsigned elemSize = getElementSize(elemTy);
-  if (elemSize == 0)
+  if (elemSize == 0) {
     return std::nullopt;
+  }
 
-  if (shape.size() < 2)
+  if (shape.size() < 2) {
     return std::nullopt;
+  }
 
   int64_t rows = shape[0];
   int64_t cols = shape[1];
@@ -186,8 +200,9 @@ static std::optional<TileShapeInfo> extractTileShapeInfoFromValue(
                    validShape[1] != ShapedType::kDynamic)
                       ? validShape[1] : cols;
   if (vRows == ShapedType::kDynamic || vCols == ShapedType::kDynamic ||
-      rows == ShapedType::kDynamic || cols == ShapedType::kDynamic)
+      rows == ShapedType::kDynamic || cols == ShapedType::kDynamic) {
     return std::nullopt;
+  }
 
   TileShapeInfo info;
   info.vRows = vRows;
@@ -219,15 +234,18 @@ struct LowerPTOToUBufOpsPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
     auto mod = func->getParentOfType<ModuleOp>();
-    if (!mod)
+    if (!mod) {
       return;
+    }
     auto archAttr = mod->getAttrOfType<StringAttr>("pto.target_arch");
     if (!archAttr ||
-        (archAttr.getValue() != "a2" && archAttr.getValue() != "a3"))
+        (archAttr.getValue() != "a2" && archAttr.getValue() != "a3")) {
       return;
+    }
 
     MLIRContext *ctx = &getContext();
     OpBuilder builder(ctx);
@@ -277,15 +295,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TAddOp> ops;
       func.walk([&](pto::TAddOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVaddOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -297,15 +318,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TAddReluOp> ops;
       func.walk([&](pto::TAddReluOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVaddReluOp>(op.getLoc(), builder, dstPtr, src0Ptr,
                                     src1Ptr, ptrType, *info);
         op.erase();
@@ -317,15 +341,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TSubOp> ops;
       func.walk([&](pto::TSubOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVsubOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -337,15 +364,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TMulOp> ops;
       func.walk([&](pto::TMulOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVmulOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -357,15 +387,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TDivOp> ops;
       func.walk([&](pto::TDivOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVdivOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -377,15 +410,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TMaxOp> ops;
       func.walk([&](pto::TMaxOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVmaxOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -397,15 +433,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TMinOp> ops;
       func.walk([&](pto::TMinOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVminOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -417,15 +456,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TAndOp> ops;
       func.walk([&](pto::TAndOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVandOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -437,15 +479,18 @@ struct LowerPTOToUBufOpsPass
       SmallVector<pto::TOrOp> ops;
       func.walk([&](pto::TOrOp op) { ops.push_back(op); });
       for (auto op : ops) {
-        if (!canLower(op, tileShapes))
+        if (!canLower(op, tileShapes)) {
           continue;
+        }
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, ptrType] = lowerBinaryOpCommon(
             builder, ctx, op, op.getDst(), op.getSrc0(), op.getSrc1(), tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatch<pto::UBVorOp>(op.getLoc(), builder, dstPtr, src0Ptr, src1Ptr,
                                 ptrType, *info);
         op.erase();
@@ -459,13 +504,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TXorOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, src0Ptr, src1Ptr, tmpPtr, ptrType] =
             lowerXorOpCommon(builder, ctx, op, op.getDst(), op.getSrc0(),
                              op.getSrc1(), op.getTmp(), tileShapes);
-        if (!dstPtr || !tmpPtr)
+        if (!dstPtr || !tmpPtr) {
           continue;
+        }
         auto pipeV = pto::PipeAttr::get(ctx, pto::PIPE::PIPE_V);
         // tmp = src0 | src1
         dispatch<pto::UBVorOp>(op.getLoc(), builder, tmpPtr, src0Ptr, src1Ptr,
@@ -492,13 +539,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TNotOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchUnary<pto::UBVnotOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                      ptrType, *info);
         op.erase();
@@ -511,13 +560,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TAbsOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchUnary<pto::UBVabsOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                      ptrType, *info);
         op.erase();
@@ -530,13 +581,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TReluOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchUnary<pto::UBVreluOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                       ptrType, *info);
         op.erase();
@@ -549,13 +602,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TNegOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         Type elemTy = ptrType.getElementType();
         Value minusOneScalar;
         if (elemTy.isF32() || elemTy.isF16()) {
@@ -579,13 +634,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TRecipOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         Type elemTy = ptrType.getElementType();
         Value oneScalar = builder.create<arith::ConstantOp>(
             op.getLoc(), builder.getFloatAttr(elemTy, 1.0));
@@ -605,13 +662,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TExpOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchUnary<pto::UBVexpOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                      ptrType, *info);
         op.erase();
@@ -624,13 +683,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TLogOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchUnary<pto::UBVlnOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                     ptrType, *info);
         op.erase();
@@ -643,13 +704,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TSqrtOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchUnary<pto::UBVsqrtOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                       ptrType, *info);
         op.erase();
@@ -662,13 +725,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TRsqrtOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfoFromValue(op.getDst(), tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchUnary<pto::UBVrsqrtOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                        ptrType, *info);
         op.erase();
@@ -681,13 +746,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TAddSOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         Value scalarI64 = convertScalarToI64(builder, op.getLoc(), op.getScalar());
         dispatchShift<pto::UBVaddSOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                       scalarI64, ptrType, *info);
@@ -701,13 +768,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TMulSOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc0(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         Value scalarI64 = convertScalarToI64(builder, op.getLoc(), op.getScalar());
         dispatchShift<pto::UBVmulSOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                       scalarI64, ptrType, *info);
@@ -721,13 +790,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TMaxSOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         Value scalarI64 = convertScalarToI64(builder, op.getLoc(), op.getScalar());
         dispatchShift<pto::UBVmaxSOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                       scalarI64, ptrType, *info);
@@ -741,13 +812,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TMinSOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         Value scalarI64 = convertScalarToI64(builder, op.getLoc(), op.getScalar());
         dispatchShift<pto::UBVminSOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                       scalarI64, ptrType, *info);
@@ -761,13 +834,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TShlSOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchShift<pto::UBVshlOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                      op.getScalar(), ptrType, *info);
         op.erase();
@@ -780,13 +855,15 @@ struct LowerPTOToUBufOpsPass
       func.walk([&](pto::TShrSOp op) { ops.push_back(op); });
       for (auto op : ops) {
         auto info = extractTileShapeInfo(op, tileShapes);
-        if (!info)
+        if (!info) {
           continue;
+        }
         auto [dstPtr, srcPtr, ptrType] =
             lowerShiftOpCommon(builder, ctx, op, op.getDst(), op.getSrc(),
                                tileShapes);
-        if (!dstPtr)
+        if (!dstPtr) {
           continue;
+        }
         dispatchShift<pto::UBVshrOp>(op.getLoc(), builder, dstPtr, srcPtr,
                                      op.getScalar(), ptrType, *info);
         op.erase();
@@ -798,8 +875,9 @@ struct LowerPTOToUBufOpsPass
     func.walk([&](pto::TLoadOp op) { tloadOps.push_back(op); });
     for (auto op : tloadOps) {
       builder.setInsertionPoint(op);
-      if (succeeded(lowerTLoad(op, builder, tileShapes)))
+      if (succeeded(lowerTLoad(op, builder, tileShapes))) {
         op.erase();
+      }
     }
 
     // ---- tstore → mte_ub_gm ----
@@ -807,20 +885,23 @@ struct LowerPTOToUBufOpsPass
     func.walk([&](pto::TStoreOp op) { tstoreOps.push_back(op); });
     for (auto op : tstoreOps) {
       builder.setInsertionPoint(op);
-      if (succeeded(lowerTStore(op, builder, tileShapes)))
+      if (succeeded(lowerTStore(op, builder, tileShapes))) {
         op.erase();
+      }
     }
 
     // ---- cleanup dead PTO ops ----
     SmallVector<Operation *> toErase;
     func.walk([&](Operation *op) {
       if (isa<pto::PartitionViewOp, pto::MakeTensorViewOp,
-              memref::SubViewOp, memref::ReinterpretCastOp, memref::CastOp>(op))
+              memref::SubViewOp, memref::ReinterpretCastOp, memref::CastOp>(op)) {
         toErase.push_back(op);
+      }
     });
     for (auto *op : llvm::reverse(toErase)) {
-      if (op->use_empty())
+      if (op->use_empty()) {
         op->erase();
+      }
     }
   }
 
@@ -879,8 +960,9 @@ private:
     auto ptrType = getUBPtrType(ctx, elemTy);
 
     auto emitAddr = [&](Value tile) -> Value {
-      if (isa<pto::PtrType>(tile.getType()))
+      if (isa<pto::PtrType>(tile.getType())) {
         return tile;
+      }
       auto addrOp = builder.create<pto::TileBufAddrOp>(loc, ptrType, tile);
       return addrOp.getDst();
     };
@@ -901,8 +983,9 @@ private:
     auto ptrType = getUBPtrType(ctx, elemTy);
 
     auto emitAddr = [&](Value tile) -> Value {
-      if (isa<pto::PtrType>(tile.getType()))
+      if (isa<pto::PtrType>(tile.getType())) {
         return tile;
+      }
       auto addrOp = builder.create<pto::TileBufAddrOp>(loc, ptrType, tile);
       return addrOp.getDst();
     };
@@ -921,8 +1004,9 @@ private:
       Value asInt = builder.create<arith::BitcastOp>(loc, intTy, scalar);
       return builder.create<arith::ExtSIOp>(loc, builder.getI64Type(), asInt);
     }
-    if (scalar.getType().isInteger(64))
+    if (scalar.getType().isInteger(64)) {
       return scalar;
+    }
     return builder.create<arith::ExtSIOp>(loc, builder.getI64Type(), scalar);
   }
 
@@ -935,8 +1019,9 @@ private:
     auto ptrType = getUBPtrType(ctx, elemTy);
 
     auto emitAddr = [&](Value tile) -> Value {
-      if (isa<pto::PtrType>(tile.getType()))
+      if (isa<pto::PtrType>(tile.getType())) {
         return tile;
+      }
       auto addrOp = builder.create<pto::TileBufAddrOp>(loc, ptrType, tile);
       return addrOp.getDst();
     };
@@ -972,9 +1057,10 @@ private:
 
     auto emitShift = [&](Value d, Value s) {
       Value scalarI64 = scalar;
-      if (scalarI64.getType() != b.getI64Type())
+      if (scalarI64.getType() != b.getI64Type()) {
         scalarI64 = b.create<arith::ExtSIOp>(
             loc, b.getI64Type(), scalar);
+      }
       b.create<UBop>(loc, d, s, scalarI64,
                      i64c1(loc, b), i64c1(loc, b), i64c1(loc, b),
                      i64c8(loc, b), i64c8(loc, b));
@@ -1095,8 +1181,9 @@ private:
     }
     auto emit = [&](Value rd) {
       Value scalarI64 = scalar;
-      if (scalarI64.getType() != b.getI64Type())
+      if (scalarI64.getType() != b.getI64Type()) {
         scalarI64 = b.create<arith::ExtSIOp>(loc, b.getI64Type(), scalar);
+      }
       b.create<pto::UBVdupOp>(loc, rd, scalarI64,
                               i64c1(loc, b), i64c1(loc, b), i64c1(loc, b),
                               i64c8(loc, b), i64c0(loc, b));
@@ -1215,15 +1302,17 @@ private:
     while (Operation *def = view.getDefiningOp()) {
       if (auto subview = dyn_cast<memref::SubViewOp>(def)) {
         auto strides = subview.getStaticStrides();
-        if (strides.empty() || strides.back() != 1)
+        if (strides.empty() || strides.back() != 1) {
           return false;
+        }
         view = subview.getSource();
         continue;
       }
       if (auto reinterpret = dyn_cast<memref::ReinterpretCastOp>(def)) {
         auto strides = reinterpret.getConstifiedMixedStrides();
-        if (strides.empty())
+        if (strides.empty()) {
           return false;
+        }
         auto stride = getConstantIntValue(strides.back());
         return stride && *stride == 1;
       }
@@ -1234,8 +1323,9 @@ private:
       break;
     }
     auto memTy = dyn_cast<MemRefType>(view.getType());
-    if (!memTy)
+    if (!memTy) {
       return false;
+    }
     auto strides = memTy.getStridesAndOffset().first;
     return !strides.empty() && strides.back() == 1;
   }
@@ -1244,8 +1334,9 @@ private:
     auto pvOp = op.getSrc().getDefiningOp<pto::PartitionViewOp>();
     if (pvOp) {
       auto mtvOp = pvOp.getSource().getDefiningOp<pto::MakeTensorViewOp>();
-      if (!mtvOp)
+      if (!mtvOp) {
         return failure();
+      }
       DmaViewInfo info;
       info.gmPtr = mtvOp.getPtr();
       info.sizes.assign(pvOp.getSizes().begin(), pvOp.getSizes().end());
@@ -1266,8 +1357,9 @@ private:
     auto pvOp = op.getDst().getDefiningOp<pto::PartitionViewOp>();
     if (pvOp) {
       auto mtvOp = pvOp.getSource().getDefiningOp<pto::MakeTensorViewOp>();
-      if (!mtvOp)
+      if (!mtvOp) {
         return failure();
+      }
       DmaViewInfo info;
       info.gmPtr = mtvOp.getPtr();
       info.sizes.assign(pvOp.getSizes().begin(), pvOp.getSizes().end());
@@ -1286,14 +1378,17 @@ private:
   static FailureOr<DmaViewInfo> extractDmaMemRefViewInfo(Location loc, Value view,
                                                          MLIRContext *ctx) {
     auto memTy = dyn_cast<MemRefType>(view.getType());
-    if (!memTy)
+    if (!memTy) {
       return failure();
+    }
     auto msAttr = dyn_cast_or_null<pto::AddressSpaceAttr>(memTy.getMemorySpace());
-    if (!msAttr || msAttr.getAddressSpace() != pto::AddressSpace::GM)
+    if (!msAttr || msAttr.getAddressSpace() != pto::AddressSpace::GM) {
       return failure();
+    }
     ArrayRef<int64_t> shape = memTy.getShape();
-    if (shape.size() < 2)
+    if (shape.size() < 2) {
       return failure();
+    }
     if (!hasUnitInnermostStride(view)) {
       emitError(loc) << "A2/A3 DMA lowering requires a unit innermost stride";
       return failure();
@@ -1344,31 +1439,35 @@ private:
                         i < viewInfo.strides.size(); ++i) {
       APInt constOff;
       if (matchPattern(viewInfo.offsets[i], m_ConstantInt(&constOff)) &&
-          constOff.isZero())
+          constOff.isZero()) {
         continue;
+      }
       Value dimOff = b.create<arith::MulIOp>(loc, viewInfo.offsets[i],
                                              viewInfo.strides[i]).getResult();
       totalOff = b.create<arith::AddIOp>(loc, totalOff, dimOff).getResult();
     }
-    if (elemSize > 1)
+    if (elemSize > 1) {
       totalOff = b.create<arith::MulIOp>(loc, totalOff,
                                          idxc(elemSize, loc, b)).getResult();
+    }
     return totalOff;
   }
 
   Value offsetGMPtrByBytes(Location loc, OpBuilder &b, Value gmPtr,
                            Value byteOff) {
     APInt constOff;
-    if (matchPattern(byteOff, m_ConstantInt(&constOff)) && constOff.isZero())
+    if (matchPattern(byteOff, m_ConstantInt(&constOff)) && constOff.isZero()) {
       return gmPtr;
+    }
     auto origPtrTy = cast<pto::PtrType>(gmPtr.getType());
     auto bytePtrTy = pto::PtrType::get(b.getContext(), b.getI8Type(),
                                        origPtrTy.getMemorySpace());
     Value bytePtr = b.create<pto::CastPtrOp>(loc, bytePtrTy, gmPtr);
     Value offIdx = byteOff;
-    if (!offIdx.getType().isIndex())
+    if (!offIdx.getType().isIndex()) {
       offIdx = b.create<arith::IndexCastOp>(loc, b.getIndexType(), byteOff)
                    .getResult();
+    }
     Value offsetBytePtr =
         b.create<pto::AddPtrOp>(loc, bytePtrTy, bytePtr, offIdx);
     return b.create<pto::CastPtrOp>(loc, origPtrTy, offsetBytePtr);
@@ -1382,11 +1481,15 @@ private:
   LogicalResult emitMteGmUb(Location loc, OpBuilder &b, Value gmPtr,
                              Value ubPtr, const DmaViewInfo &viewInfo,
                              Type elemTy, ArrayRef<int64_t> tileShape) {
-    if (tileShape.size() < 2) return failure();
+    if (tileShape.size() < 2) {
+      return failure();
+    }
     int64_t ubCols = tileShape[1];
     unsigned elemSize = getElementSize(elemTy);
     unsigned nd = viewInfo.sizes.size();
-    if (nd < 2) return failure();
+    if (nd < 2) {
+      return failure();
+    }
 
     Value nburstCount = viewInfo.sizes[nd - 2];
     Value lenBurstElts = viewInfo.sizes[nd - 1];
@@ -1411,7 +1514,7 @@ private:
               viewInfo.strides[i]).getResult(),
           i64c(elemSize, loc, b)).getResult();
       Value innerElems = i64c1(loc, b);
-      for (int j = i + 1; j < (int)nd; ++j) {
+      for (int j = i + 1; j < static_cast<int>(nd); ++j) {
         Value dimSize = b.create<arith::IndexCastOp>(loc, b.getI64Type(),
             viewInfo.sizes[j]).getResult();
         innerElems = b.create<arith::MulIOp>(loc, innerElems, dimSize).getResult();
@@ -1428,11 +1531,15 @@ private:
   LogicalResult emitMteUbGm(Location loc, OpBuilder &b, Value ubPtr,
                              Value gmPtr, const DmaViewInfo &viewInfo,
                              Type elemTy, ArrayRef<int64_t> tileShape) {
-    if (tileShape.size() < 2) return failure();
+    if (tileShape.size() < 2) {
+      return failure();
+    }
     int64_t ubCols = tileShape[1];
     unsigned elemSize = getElementSize(elemTy);
     unsigned nd = viewInfo.sizes.size();
-    if (nd < 2) return failure();
+    if (nd < 2) {
+      return failure();
+    }
 
     Value nburstCount = viewInfo.sizes[nd - 2];
     Value lenBurstElts = viewInfo.sizes[nd - 1];
@@ -1453,7 +1560,7 @@ private:
       Value count = b.create<arith::IndexCastOp>(loc, b.getI64Type(),
           viewInfo.sizes[i]).getResult();
       Value innerElems = i64c1(loc, b);
-      for (int j = i + 1; j < (int)nd; ++j) {
+      for (int j = i + 1; j < static_cast<int>(nd); ++j) {
         Value dimSize = b.create<arith::IndexCastOp>(loc, b.getI64Type(),
             viewInfo.sizes[j]).getResult();
         innerElems = b.create<arith::MulIOp>(loc, innerElems, dimSize).getResult();
@@ -1475,16 +1582,26 @@ private:
                            const TileShapeMap &tileShapes) {
     Location loc = op.getLoc();
     auto viewInfo = extractDmaViewInfo(op);
-    if (failed(viewInfo)) return failure();
+    if (failed(viewInfo)) {
+      return failure();
+    }
     Type dstType = op.getDst().getType();
-    if (!isUBMemorySpace(dstType)) return failure();
+    if (!isUBMemorySpace(dstType)) {
+      return failure();
+    }
     Type elemTy = getStoredElemType(dstType);
-    if (!elemTy) return failure();
+    if (!elemTy) {
+      return failure();
+    }
     unsigned elemSize = getElementSize(elemTy);
-    if (elemSize == 0) return failure();
+    if (elemSize == 0) {
+      return failure();
+    }
 
     auto it = tileShapes.find(op.getDst());
-    if (it == tileShapes.end()) return failure();
+    if (it == tileShapes.end()) {
+      return failure();
+    }
 
     Value byteOff = computeGMByteOffset(loc, b, *viewInfo, elemSize);
     Value gmPtr = offsetGMPtrByBytes(loc, b, viewInfo->gmPtr, byteOff);
@@ -1496,17 +1613,27 @@ private:
                             const TileShapeMap &tileShapes) {
     Location loc = op.getLoc();
     Type srcType = op.getSrc().getType();
-    if (!isUBMemorySpace(srcType)) return failure();
+    if (!isUBMemorySpace(srcType)) {
+      return failure();
+    }
     Type elemTy = getStoredElemType(srcType);
-    if (!elemTy) return failure();
+    if (!elemTy) {
+      return failure();
+    }
     unsigned elemSize = getElementSize(elemTy);
-    if (elemSize == 0) return failure();
+    if (elemSize == 0) {
+      return failure();
+    }
 
     auto it = tileShapes.find(op.getSrc());
-    if (it == tileShapes.end()) return failure();
+    if (it == tileShapes.end()) {
+      return failure();
+    }
 
     auto viewInfo = extractDmaViewInfo(op);
-    if (failed(viewInfo)) return failure();
+    if (failed(viewInfo)) {
+      return failure();
+    }
 
     Value byteOff = computeGMByteOffset(loc, b, *viewInfo, elemSize);
     Value gmPtr = offsetGMPtrByBytes(loc, b, viewInfo->gmPtr, byteOff);
@@ -1538,10 +1665,11 @@ private:
       int64_t totalV = vRows * vCols;
       int64_t totalRpts = (totalV + epr - 1) / epr;
 
-      if (totalRpts > kRepeatMax)
+      if (totalRpts > kRepeatMax) {
         modeCount1L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
-      else
+      } else {
         modeNorm1L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+      }
       return;
     }
 
@@ -1550,10 +1678,11 @@ private:
     if (normColRepeat > 1 && vRows * normColRepeat < kSmallRptBinOp) {
       modeCount2L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
     } else if (vRows < normColRepeat + 1) {
-      if (vCols % epr > 0)
+      if (vCols % epr > 0) {
         modeCount2L<UBop>(loc, b, dst, s0, s1, ptrTy, info);
-      else
+      } else {
         modeColVLAlign<UBop>(loc, b, dst, s0, s1, ptrTy, info);
+      }
     } else {
       modeRowRpt<UBop>(loc, b, dst, s0, s1, ptrTy, info);
     }
@@ -1669,10 +1798,11 @@ private:
     int64_t rs = rowStride / be;
     bool condRowRpt = (info.vRows <= kRepeatMax) && (rs <= kRepeatStrideMax);
 
-    if (condRowRpt)
+    if (condRowRpt) {
       rowRptFast<UBop>(loc, b, dst, s0, s1, ptrTy, info, rs);
-    else
+    } else {
       rowRptChunked<UBop>(loc, b, dst, s0, s1, ptrTy, info, rowStride, rs);
+    }
   }
 
   template <typename UBop>
@@ -1709,8 +1839,9 @@ private:
     int64_t remainElem = info.vCols % epr;
 
     if (info.vRows > static_cast<int64_t>(epr)) {
-      if (rptPerLine > 0)
+      if (rptPerLine > 0) {
         headRows<UBop>(loc, b, dst, s0, s1, ptrTy, info, rowStride, rptPerLine);
+      }
       if (remainElem > 0) {
         Value off = idxc(rptPerLine * epr, loc, b);
         tailRows<UBop>(loc, b, addPtr(loc, b, dst, ptrTy, off),
@@ -1802,20 +1933,22 @@ private:
                                         idxc(numLoop, loc, b), idxc1(loc, b));
       b.setInsertionPointToStart(forOp.getBody());
       Value iv = forOp.getInductionVar();
-      if (strideOver)
+      if (strideOver) {
         tailStrideOverChunk<UBop>(loc, b, iv, dst, s0, s1, ptrTy, rowStride);
-      else
+      } else {
         tailStrideOkChunk<UBop>(loc, b, iv, dst, s0, s1, ptrTy, rowStride, rs);
+      }
       b.setInsertionPointAfter(forOp);
     }
 
     if (remainAfterLoop > 0) {
-      if (strideOver)
+      if (strideOver) {
         tailStrideOverRemain<UBop>(loc, b, dst, s0, s1, ptrTy, rowStride, numLoop,
                              remainAfterLoop);
-      else
+      } else {
         tailStrideOkRemain<UBop>(loc, b, dst, s0, s1, ptrTy, rowStride, rs, numLoop,
                            remainAfterLoop);
+      }
     }
 
     fullMask(loc, b);
@@ -1879,7 +2012,6 @@ private:
          i64c(remain, loc, b), i64c(rs, loc, b));
   }
 };
-
 } // namespace
 
 namespace mlir {

--- a/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
+++ b/lib/PTO/Transforms/PTOA5NormalizeTMovPass.cpp
@@ -128,11 +128,13 @@ static pto::TileBufConfigAttr buildRowMajorConfig(MLIRContext *ctx,
 static FailureOr<pto::TileBufType>
 buildRowMajorReinterpretType(MLIRContext *ctx, pto::TileBufType srcType) {
   ArrayRef<int64_t> shape = srcType.getShape();
-  if (shape.size() != kTileRank2D)
+  if (shape.size() != kTileRank2D) {
     return failure();
+  }
   if (shape[kFirstTileDim] == ShapedType::kDynamic ||
-      shape[kSecondTileDim] == ShapedType::kDynamic)
+      shape[kSecondTileDim] == ShapedType::kDynamic) {
     return failure();
+  }
 
   SmallVector<int64_t, kTileRank2D> swappedShape{shape[kSecondTileDim],
                                                  shape[kFirstTileDim]};
@@ -160,8 +162,9 @@ buildRowMajorReinterpretType(MLIRContext *ctx, pto::TileBufType srcType) {
 static void setSwappedDynamicValidShapeIfNeeded(
     IRRewriter &rewriter, Location loc, Value sourceTile, Value reshapedTile,
     pto::TileBufType reshapedType) {
-  if (!reshapedType.hasDynamicValid())
+  if (!reshapedType.hasDynamicValid()) {
     return;
+  }
 
   auto validShape = rewriter.create<pto::GetValidShapeOp>(loc, sourceTile);
   rewriter.create<pto::SetValidShapeOp>(
@@ -179,15 +182,17 @@ struct PTOA5NormalizeTMovPass
     func.walk([&](pto::TGetScaleAddrOp op) { scaleAddrOps.push_back(op); });
     for (pto::TGetScaleAddrOp op : scaleAddrOps) {
       auto matchingTMov = findMatchingScaleTileTMov(op);
-      if (!matchingTMov)
+      if (!matchingTMov) {
         continue;
+      }
       op->moveBefore(matchingTMov);
     }
 
     SmallVector<pto::TMovOp, kRiskyOpReserveSize> riskyOps;
     func.walk([&](pto::TMovOp op) {
-      if (isA5RiskyVecVecColMajorTMov(op))
+      if (isA5RiskyVecVecColMajorTMov(op)) {
         riskyOps.push_back(op);
+      }
     });
 
     IRRewriter rewriter(func.getContext());
@@ -238,16 +243,18 @@ struct PTOA5NormalizeTMovPass
 
     bool hasResidualRisk = false;
     func.walk([&](pto::TMovOp op) {
-      if (!isA5RiskyVecVecColMajorTMov(op))
+      if (!isA5RiskyVecVecColMajorTMov(op)) {
         return WalkResult::advance();
+      }
       op.emitOpError(
           "A5 vec->vec TMOV on col_major/none_box tile is unsupported; "
           "expected normalization to row_major via pto.treshape");
       hasResidualRisk = true;
       return WalkResult::interrupt();
     });
-    if (hasResidualRisk)
+    if (hasResidualRisk) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/PTOAssignDefaultFrontendPipeIdPass.cpp
+++ b/lib/PTO/Transforms/PTOAssignDefaultFrontendPipeIdPass.cpp
@@ -25,8 +25,9 @@ namespace {
 
 template <typename OpT>
 static void assignDefaultIdIfMissing(OpT op, IntegerAttr zeroAttr) {
-  if (!op.getIdAttr())
+  if (!op.getIdAttr()) {
     op.setIdAttr(zeroAttr);
+  }
 }
 
 struct PTOAssignDefaultFrontendPipeIdPass

--- a/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
+++ b/lib/PTO/Transforms/PTOCanonicalizeIR.cpp
@@ -129,8 +129,9 @@ buildCanonicalStrides(MakeTensorViewOp op, IRRewriter &rewriter) {
   Value leadingStride = rewriter.create<arith::MulIOp>(
       loc, op.getShape().front(), op.getStrides().front());
 
-  for (unsigned i = 0; i < shift; ++i)
+  for (unsigned i = 0; i < shift; ++i) {
     result[i] = leadingStride;
+  }
   return result;
 }
 
@@ -177,8 +178,9 @@ static Type canonicalViewType(Type type) {
 static bool canonicalizeValueType(Value value) {
   Type oldType = value.getType();
   Type newType = canonicalViewType(oldType);
-  if (newType == oldType)
+  if (newType == oldType) {
     return false;
+  }
   value.setType(newType);
   return true;
 }
@@ -277,8 +279,9 @@ static void canonicalizeFunctionType(func::FuncOp func) {
     results.push_back(newType);
   }
 
-  if (changed)
+  if (changed) {
     func.setFunctionType(FunctionType::get(func.getContext(), inputs, results));
+  }
 }
 
 static void canonicalizeValueTypes(func::FuncOp func) {
@@ -362,8 +365,9 @@ struct PTOCanonicalizeIRPass
         return;
       }
     }
-    for (auto [op, dimIndex, rank] : dimIndexOps)
+    for (auto [op, dimIndex, rank] : dimIndexOps) {
       rewriteTensorViewDimOperand(op, dimIndex, rank, rewriter);
+    }
     canonicalizeValueTypes(func);
     for (PartitionViewOp op : partitionViews) {
       if (failed(rewritePartitionView(op, rewriter))) {

--- a/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
+++ b/lib/PTO/Transforms/PTOInferVPTOVecScope.cpp
@@ -102,19 +102,22 @@ static bool isVectorScopeBoundaryOperation(Operation *op) {
 
 static bool hasVecScopeTypedOperandOrResult(Operation *op) {
   for (Type type : op->getOperandTypes()) {
-    if (isVecScopeType(type))
+    if (isVecScopeType(type)) {
       return true;
+    }
   }
   for (Type type : op->getResultTypes()) {
-    if (isVecScopeType(type))
+    if (isVecScopeType(type)) {
       return true;
+    }
   }
   return false;
 }
 
 static bool requiresVectorScope(Operation *op) {
-  if (!isPTOOperation(op))
+  if (!isPTOOperation(op)) {
     return false;
+  }
 
   return hasVecScopeTypedOperandOrResult(op) ||
          isa<pto::MemBarOp, pto::SprclrOp>(op);
@@ -125,24 +128,31 @@ static bool isAtomicControlFlowCandidate(Operation *op) {
 }
 
 static bool isSafeScalarOperation(Operation *op) {
-  if (op->getNumRegions() != 0)
+  if (op->getNumRegions() != 0) {
     return false;
-  if (op->hasTrait<OpTrait::IsTerminator>())
+  }
+  if (op->hasTrait<OpTrait::IsTerminator>()) {
     return false;
-  if (isa<func::CallOp>(op))
+  }
+  if (isa<func::CallOp>(op)) {
     return false;
-  if (isPTOOperation(op) && !isMemoryEffectFree(op))
+  }
+  if (isPTOOperation(op) && !isMemoryEffectFree(op)) {
     return false;
+  }
   return isMemoryEffectFree(op);
 }
 
 static bool isRematerializableVecScopeProducer(Operation *op) {
-  if (!op || op->getNumRegions() != 0)
+  if (!op || op->getNumRegions() != 0) {
     return false;
-  if (op->hasTrait<OpTrait::IsTerminator>())
+  }
+  if (op->hasTrait<OpTrait::IsTerminator>()) {
     return false;
-  if (isa<func::CallOp>(op))
+  }
+  if (isa<func::CallOp>(op)) {
     return false;
+  }
   return isMemoryEffectFree(op);
 }
 
@@ -150,8 +160,9 @@ static void summarizeNestedRegionForAtomicCluster(
     Region &region, NestedRegionSummary &summary) {
   for (Block &block : region) {
     for (Operation &op : block) {
-      if (op.hasTrait<OpTrait::IsTerminator>())
+      if (op.hasTrait<OpTrait::IsTerminator>()) {
         continue;
+      }
 
       switch (classifyOperationForInference(&op)) {
       case VPTOInferenceOpClass::Vector:
@@ -168,41 +179,52 @@ static void summarizeNestedRegionForAtomicCluster(
 }
 
 static bool canTreatAsAtomicControlFlow(Operation *op) {
-  if (!isAtomicControlFlowCandidate(op))
+  if (!isAtomicControlFlowCandidate(op)) {
     return false;
+  }
 
   NestedRegionSummary summary;
   for (Region &region : op->getRegions()) {
     summarizeNestedRegionForAtomicCluster(region, summary);
-    if (summary.hasBoundaryOperation)
+    if (summary.hasBoundaryOperation) {
       return false;
+    }
   }
   return summary.hasVectorOperation;
 }
 
 static VPTOInferenceOpClass classifyOperationForInference(Operation *op) {
-  if (!op)
+  if (!op) {
     return VPTOInferenceOpClass::Boundary;
+  }
 
-  if (isExplicitVectorScopeCarrier(op))
+  if (isExplicitVectorScopeCarrier(op)) {
     return VPTOInferenceOpClass::Boundary;
-  if (op->hasTrait<OpTrait::IsTerminator>())
+  }
+  if (op->hasTrait<OpTrait::IsTerminator>()) {
     return VPTOInferenceOpClass::Boundary;
-  if (isa<func::CallOp>(op))
+  }
+  if (isa<func::CallOp>(op)) {
     return VPTOInferenceOpClass::Boundary;
-  if (isVectorScopeBoundaryOperation(op))
+  }
+  if (isVectorScopeBoundaryOperation(op)) {
     return VPTOInferenceOpClass::Boundary;
-  if (isForbiddenInsideInferredVectorScope(op))
+  }
+  if (isForbiddenInsideInferredVectorScope(op)) {
     return VPTOInferenceOpClass::Boundary;
+  }
 
-  if (requiresVectorScope(op))
+  if (requiresVectorScope(op)) {
     return VPTOInferenceOpClass::Vector;
+  }
 
-  if (canTreatAsAtomicControlFlow(op))
+  if (canTreatAsAtomicControlFlow(op)) {
     return VPTOInferenceOpClass::Vector;
+  }
 
-  if (isSafeScalarOperation(op))
+  if (isSafeScalarOperation(op)) {
     return VPTOInferenceOpClass::SafeScalar;
+  }
 
   return VPTOInferenceOpClass::Boundary;
 }
@@ -216,8 +238,9 @@ static bool hasVectorOperation(ArrayRef<Operation *> ops) {
 static bool isUserInsideCluster(Operation *user,
                                 const llvm::SmallPtrSetImpl<Operation *> &ops) {
   for (Operation *cur = user; cur; cur = cur->getParentOp()) {
-    if (ops.contains(cur))
+    if (ops.contains(cur)) {
       return true;
+    }
   }
   return false;
 }
@@ -225,8 +248,9 @@ static bool isUserInsideCluster(Operation *user,
 static bool anyUserIsMoved(Value result,
                            const llvm::SmallPtrSetImpl<Operation *> &movedOps) {
   for (Operation *user : result.getUsers()) {
-    if (isUserInsideCluster(user, movedOps))
+    if (isUserInsideCluster(user, movedOps)) {
       return true;
+    }
   }
   return false;
 }
@@ -235,8 +259,9 @@ static llvm::SmallPtrSet<Operation *, 16>
 computeMovedOpsForResultlessScope(ArrayRef<Operation *> ops) {
   llvm::SmallPtrSet<Operation *, 16> movedOps;
   for (Operation *op : ops) {
-    if (classifyOperationForInference(op) == VPTOInferenceOpClass::Vector)
+    if (classifyOperationForInference(op) == VPTOInferenceOpClass::Vector) {
       movedOps.insert(op);
+    }
   }
 
   bool changed = true;
@@ -261,8 +286,9 @@ computeMovedOpsForResultlessScope(ArrayRef<Operation *> ops) {
             break;
           }
         }
-        if (!allUsersMoved)
+        if (!allUsersMoved) {
           break;
+        }
       }
 
       if (hasMovedUser && allUsersMoved) {
@@ -276,8 +302,9 @@ computeMovedOpsForResultlessScope(ArrayRef<Operation *> ops) {
 
 static Operation *getAncestorInBlock(Operation *op, Block &block) {
   for (Operation *cur = op; cur; cur = cur->getParentOp()) {
-    if (cur->getBlock() == &block)
+    if (cur->getBlock() == &block) {
       return cur;
+    }
   }
   return nullptr;
 }
@@ -288,33 +315,39 @@ cloneVecScopeProducerForUse(
     SegmentRematCache &cache, MLIRContext *context,
     llvm::DenseMap<Operation *, Operation *> &clones) {
   auto result = dyn_cast<OpResult>(value);
-  if (!result)
+  if (!result) {
     return failure();
+  }
 
   if (auto cacheIt = cache.find(value); cacheIt != cache.end()) {
     auto anchorIt = cacheIt->second.find(logicalScopeAnchor);
-    if (anchorIt != cacheIt->second.end())
+    if (anchorIt != cacheIt->second.end()) {
       return anchorIt->second.getDefiningOp();
+    }
   }
 
   Operation *producer = result.getOwner();
   auto existing = clones.find(producer);
-  if (existing != clones.end())
+  if (existing != clones.end()) {
     return existing->second;
+  }
 
-  if (!isRematerializableVecScopeProducer(producer))
+  if (!isRematerializableVecScopeProducer(producer)) {
     return failure();
+  }
 
   IRMapping mapping;
   for (Value operand : producer->getOperands()) {
-    if (!isVecScopeType(operand.getType()))
+    if (!isVecScopeType(operand.getType())) {
       continue;
+    }
 
     FailureOr<Operation *> clonedOperandProducer =
         cloneVecScopeProducerForUse(operand, user, logicalScopeAnchor, cache,
                                     context, clones);
-    if (failed(clonedOperandProducer))
+    if (failed(clonedOperandProducer)) {
       return failure();
+    }
 
     auto operandResult = cast<OpResult>(operand);
     mapping.map(operand, (*clonedOperandProducer)
@@ -339,8 +372,9 @@ static void collectGreedyLogicalScopePlans(
 
     for (size_t end = ops.size(); end > begin; --end) {
       ArrayRef<Operation *> candidate = ops.slice(begin, end - begin);
-      if (!hasVectorOperation(candidate))
+      if (!hasVectorOperation(candidate)) {
         continue;
+      }
 
       ResultlessScopePlan plan;
       EscapingMovedValue candidateEscapingValue;
@@ -370,11 +404,13 @@ static void assignLogicalScopeAnchorsForCluster(
 
   llvm::DenseMap<Operation *, Operation *> scopeAnchorByMovedOp;
   for (const LogicalScopePlan &plan : plans) {
-    if (plan.plan.moveOps.empty())
+    if (plan.plan.moveOps.empty()) {
       continue;
+    }
     Operation *scopeAnchor = plan.plan.moveOps.front();
-    for (Operation *movedOp : plan.plan.moveOps)
+    for (Operation *movedOp : plan.plan.moveOps) {
       scopeAnchorByMovedOp[movedOp] = scopeAnchor;
+    }
   }
 
   Operation *currentNonScopeAnchor = nullptr;
@@ -386,8 +422,9 @@ static void assignLogicalScopeAnchorsForCluster(
       continue;
     }
 
-    if (!currentNonScopeAnchor)
+    if (!currentNonScopeAnchor) {
       currentNonScopeAnchor = op;
+    }
     logicalScopeAnchors[op] = currentNonScopeAnchor;
   }
 }
@@ -398,8 +435,9 @@ computeLogicalScopeAnchors(Block &block) {
   SmallVector<Operation *, 32> pending;
 
   auto flush = [&]() {
-    if (pending.empty())
+    if (pending.empty()) {
       return;
+    }
     assignLogicalScopeAnchorsForCluster(pending, logicalScopeAnchors);
     pending.clear();
   };
@@ -423,8 +461,9 @@ static LogicalResult rematerializeEscapingValueForUserSegments(
     Value value, const llvm::SmallPtrSetImpl<Operation *> &movedOps,
     Block &block, SegmentRematCache &cache, MLIRContext *context) {
   auto result = dyn_cast<OpResult>(value);
-  if (!result)
+  if (!result) {
     return failure();
+  }
 
   llvm::DenseMap<Operation *, Operation *> logicalScopeAnchors =
       computeLogicalScopeAnchors(block);
@@ -432,22 +471,26 @@ static LogicalResult rematerializeEscapingValueForUserSegments(
 
   for (OpOperand &use : result.getUses()) {
     Operation *user = use.getOwner();
-    if (isUserInsideCluster(user, movedOps))
+    if (isUserInsideCluster(user, movedOps)) {
       continue;
+    }
 
     Operation *ancestor = getAncestorInBlock(user, block);
-    if (!ancestor)
+    if (!ancestor) {
       return failure();
+    }
 
     auto anchorIt = logicalScopeAnchors.find(ancestor);
-    if (anchorIt == logicalScopeAnchors.end())
+    if (anchorIt == logicalScopeAnchors.end()) {
       return failure();
+    }
 
     usesBySegment[anchorIt->second].push_back(&use);
   }
 
-  if (usesBySegment.empty())
+  if (usesBySegment.empty()) {
     return failure();
+  }
 
   for (auto &entry : usesBySegment) {
     Operation *logicalScopeAnchor = entry.first;
@@ -455,28 +498,32 @@ static LogicalResult rematerializeEscapingValueForUserSegments(
     Value replacement;
     if (auto cacheIt = cache.find(value); cacheIt != cache.end()) {
       auto anchorIt = cacheIt->second.find(logicalScopeAnchor);
-      if (anchorIt != cacheIt->second.end())
+      if (anchorIt != cacheIt->second.end()) {
         replacement = anchorIt->second;
+      }
     }
 
     if (!replacement) {
-      if (!logicalScopeAnchor)
+      if (!logicalScopeAnchor) {
         return failure();
+      }
 
       llvm::DenseMap<Operation *, Operation *> clones;
       FailureOr<Operation *> clonedProducer =
           cloneVecScopeProducerForUse(value, logicalScopeAnchor,
                                       logicalScopeAnchor, cache, context,
                                       clones);
-      if (failed(clonedProducer))
+      if (failed(clonedProducer)) {
         return failure();
+      }
 
       replacement = (*clonedProducer)->getResult(result.getResultNumber());
       cache[value][logicalScopeAnchor] = replacement;
     }
 
-    for (OpOperand *use : uses)
+    for (OpOperand *use : uses) {
       use->set(replacement);
+    }
   }
 
   return success();
@@ -488,8 +535,9 @@ static bool findEscapingMovedResult(
   for (Operation *op : movedOps) {
     for (Value result : op->getResults()) {
       for (Operation *user : result.getUsers()) {
-        if (isUserInsideCluster(user, movedOps))
+        if (isUserInsideCluster(user, movedOps)) {
           continue;
+        }
 
         escapingValue.value = result;
         escapingValue.producer = op;
@@ -505,18 +553,21 @@ static bool findEscapingMovedResult(
 static LogicalResult
 emitEscapingVectorScopeValueError(const EscapingMovedValue &escapingValue) {
   Operation *producer = escapingValue.producer;
-  if (!producer)
+  if (!producer) {
     return failure();
+  }
 
   InFlightDiagnostic diag = producer->emitOpError()
                             << "cannot infer resultless pto.vecscope because "
                                "VPTO vector-scope data cannot have external "
                                "users";
-  if (escapingValue.value)
+  if (escapingValue.value) {
     diag << "; escaping value type is " << escapingValue.value.getType();
-  if (escapingValue.user)
+  }
+  if (escapingValue.user) {
     diag.attachNote(escapingValue.user->getLoc())
         << "external user is here";
+  }
   return failure();
 }
 
@@ -527,16 +578,19 @@ emitEscapingVectorScopeValueError(const EscapingMovedValue &escapingValue) {
 static LogicalResult
 buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
                          EscapingMovedValue &escapingValue) {
-  if (ops.empty() || !hasVectorOperation(ops))
+  if (ops.empty() || !hasVectorOperation(ops)) {
     return failure();
+  }
 
   llvm::SmallPtrSet<Operation *, 16> movedOps =
       computeMovedOpsForResultlessScope(ops);
-  if (movedOps.empty())
+  if (movedOps.empty()) {
     return failure();
+  }
 
-  if (findEscapingMovedResult(movedOps, escapingValue))
+  if (findEscapingMovedResult(movedOps, escapingValue)) {
     return failure();
+  }
 
   llvm::SmallPtrSet<Operation *, 16> hoistedOps;
   for (Operation *op : ops) {
@@ -569,8 +623,9 @@ buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
             break;
           }
         }
-        if (feedsHoistedOp)
+        if (feedsHoistedOp) {
           break;
+        }
       }
 
       if (feedsHoistedOp) {
@@ -583,17 +638,20 @@ buildResultlessScopePlan(ArrayRef<Operation *> ops, ResultlessScopePlan &plan,
   plan.hoistOps.clear();
   plan.moveOps.clear();
   for (Operation *op : ops) {
-    if (hoistedOps.contains(op))
+    if (hoistedOps.contains(op)) {
       plan.hoistOps.push_back(op);
-    if (movedOps.contains(op))
+    }
+    if (movedOps.contains(op)) {
       plan.moveOps.push_back(op);
+    }
   }
   return success();
 }
 
 static void wrapCluster(const ResultlessScopePlan &plan, MLIRContext *context) {
-  if (plan.moveOps.empty())
+  if (plan.moveOps.empty()) {
     return;
+  }
 
   Operation *first = plan.moveOps.front();
   Block *parentBlock = first->getBlock();
@@ -604,8 +662,9 @@ static void wrapCluster(const ResultlessScopePlan &plan, MLIRContext *context) {
   scope.getBody().push_back(new Block());
 
   for (Operation *op : plan.hoistOps) {
-    if (op->getBlock() == parentBlock && scope->isBeforeInBlock(op))
+    if (op->getBlock() == parentBlock && scope->isBeforeInBlock(op)) {
       op->moveBefore(scope);
+    }
   }
 
   Block &scopeBody = scope.getBody().front();
@@ -626,8 +685,9 @@ static LogicalResult wrapGreedySubclusters(ArrayRef<Operation *> ops,
 
     for (size_t end = ops.size(); end > begin; --end) {
       ArrayRef<Operation *> candidate = ops.slice(begin, end - begin);
-      if (!hasVectorOperation(candidate))
+      if (!hasVectorOperation(candidate)) {
         continue;
+      }
 
       // Prefer the largest suffix-preserving candidate that actually needs a
       // vecscope and can be moved into today's resultless pto.vecscope form.
@@ -673,8 +733,9 @@ static FailureOr<bool> fixOneEscapingSubcluster(ArrayRef<Operation *> ops,
 
     for (size_t end = ops.size(); end > begin; --end) {
       ArrayRef<Operation *> candidate = ops.slice(begin, end - begin);
-      if (!hasVectorOperation(candidate))
+      if (!hasVectorOperation(candidate)) {
         continue;
+      }
 
       ResultlessScopePlan ignoredPlan;
       EscapingMovedValue candidateEscapingValue;
@@ -702,8 +763,9 @@ static FailureOr<bool> fixOneEscapingSubcluster(ArrayRef<Operation *> ops,
         llvm::SmallPtrSet<Operation *, 16> movedOps =
             computeMovedOpsForResultlessScope(escapingCandidate);
         Block *block = ops.front()->getBlock();
-        if (!block)
+        if (!block) {
           return false;
+        }
 
         if (succeeded(rematerializeEscapingValueForUserSegments(
                 escapingValue.value, movedOps, *block, cache, context)))
@@ -728,8 +790,9 @@ static LogicalResult repairEscapingSubclusters(Block &block,
     bool changedInIteration = false;
     SmallVector<Operation *, 32> pending;
     SmallVector<Operation *, 32> ops;
-    for (Operation &op : block)
+    for (Operation &op : block) {
       ops.push_back(&op);
+    }
 
     auto flush = [&]() -> FailureOr<bool> {
       FailureOr<bool> changed =
@@ -746,45 +809,53 @@ static LogicalResult repairEscapingSubclusters(Block &block,
         break;
       case VPTOInferenceOpClass::Boundary: {
         FailureOr<bool> changed = flush();
-        if (failed(changed))
+        if (failed(changed)) {
           return failure();
+        }
         changedInIteration |= *changed;
         break;
       }
       }
-      if (changedInIteration)
+      if (changedInIteration) {
         break;
+      }
     }
 
-    if (changedInIteration)
+    if (changedInIteration) {
       continue;
+    }
 
     FailureOr<bool> changed = flush();
-    if (failed(changed))
+    if (failed(changed)) {
       return failure();
-    if (!*changed)
+    }
+    if (!*changed) {
       return success();
+    }
   }
 
   return failure();
 }
 
 static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
-  if (failed(repairEscapingSubclusters(block, context)))
+  if (failed(repairEscapingSubclusters(block, context))) {
     return failure();
+  }
 
   SmallVector<Operation *, 16> pending;
 
   auto flush = [&]() -> LogicalResult {
-    if (failed(wrapGreedySubclusters(pending, context)))
+    if (failed(wrapGreedySubclusters(pending, context))) {
       return failure();
+    }
     pending.clear();
     return success();
   };
 
   SmallVector<Operation *, 32> ops;
-  for (Operation &op : block)
+  for (Operation &op : block) {
     ops.push_back(&op);
+  }
 
   for (Operation *op : ops) {
     switch (classifyOperationForInference(op)) {
@@ -793,24 +864,29 @@ static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
       pending.push_back(op);
       continue;
     case VPTOInferenceOpClass::Boundary:
-      if (failed(flush()))
+      if (failed(flush())) {
         return failure();
+      }
       continue;
     }
   }
-  if (failed(flush()))
+  if (failed(flush())) {
     return failure();
+  }
 
   SmallVector<Operation *, 32> remainingOps;
-  for (Operation &op : block)
+  for (Operation &op : block) {
     remainingOps.push_back(&op);
+  }
 
   for (Operation *op : remainingOps) {
-    if (isExplicitVectorScopeCarrier(op))
+    if (isExplicitVectorScopeCarrier(op)) {
       continue;
+    }
     for (Region &nested : op->getRegions()) {
-      if (failed(inferVecScopesInRegion(nested, context)))
+      if (failed(inferVecScopesInRegion(nested, context))) {
         return failure();
+      }
     }
   }
   return success();
@@ -819,8 +895,9 @@ static LogicalResult inferVecScopesInBlock(Block &block, MLIRContext *context) {
 static LogicalResult inferVecScopesInRegion(Region &region,
                                             MLIRContext *context) {
   for (Block &block : region) {
-    if (failed(inferVecScopesInBlock(block, context)))
+    if (failed(inferVecScopesInBlock(block, context))) {
       return failure();
+    }
   }
   return success();
 }
@@ -830,8 +907,9 @@ struct PTOInferVPTOVecScopePass
           PTOInferVPTOVecScopePass> {
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (failed(inferVecScopesInRegion(func.getBody(), &getContext())))
+    if (failed(inferVecScopesInRegion(func.getBody(), &getContext()))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
+++ b/lib/PTO/Transforms/PTOInferValidatePipeInitPass.cpp
@@ -77,8 +77,9 @@ template <typename InitOpT> static Value getLocalAddrOperand(InitOpT op) {
 
 template <typename InitOpT>
 static std::optional<bool> getNoSplitAttr(InitOpT op) {
-  if (auto attr = op.getNosplitAttr())
+  if (auto attr = op.getNosplitAttr()) {
     return attr.getValue();
+  }
   return std::nullopt;
 }
 
@@ -105,19 +106,23 @@ static PipeSplitUsage classifyPipeUsage(Value pipe) {
       continue;
     }
 
-    if (split == 0)
+    if (split == 0) {
       sawNoSplit = true;
-    else
+    } else {
       sawSplit = true;
+    }
 
-    if (sawNoSplit && sawSplit)
+    if (sawNoSplit && sawSplit) {
       return PipeSplitUsage::Mixed;
+    }
   }
 
-  if (sawNoSplit)
+  if (sawNoSplit) {
     return PipeSplitUsage::NoSplitOnly;
-  if (sawSplit)
+  }
+  if (sawSplit) {
     return PipeSplitUsage::SplitOnly;
+  }
   return PipeSplitUsage::Unknown;
 }
 
@@ -141,10 +146,11 @@ static std::string getFuncSymbol(func::FuncOp funcOp) {
 
 static PipePeerKey getGlobalTensorPipeKey(Operation *op, int8_t dirMask) {
   std::string id = "unknown";
-  if (auto idAttr = op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName))
+  if (auto idAttr = op->getAttrOfType<IntegerAttr>(kFrontendPipeIdAttrName)) {
     id = std::to_string(idAttr.getInt());
-  else
+  } else {
     id = std::to_string(reinterpret_cast<uintptr_t>(op));
+  }
   return PipePeerKey{"__pto_globaltensor_pipe", "id_" + id, dirMask};
 }
 
@@ -176,8 +182,9 @@ resolveNoSplitComponent(ArrayRef<PipeInitInfo *> component, OpBuilder &builder) 
           "same logical pipe");
     }
 
-    if (!info->explicitNoSplit)
+    if (!info->explicitNoSplit) {
       continue;
+    }
     if (explicitNoSplit && *explicitNoSplit != *info->explicitNoSplit) {
       return info->op->emitOpError(
           "conflicting explicit 'nosplit' across peer pipe init ops");
@@ -187,8 +194,9 @@ resolveNoSplitComponent(ArrayRef<PipeInitInfo *> component, OpBuilder &builder) 
 
   for (PipeInitInfo *info : component) {
     auto usageNoSplit = getUsageNoSplit(info->usage);
-    if (!usageNoSplit)
+    if (!usageNoSplit) {
       continue;
+    }
     if (inferredNoSplit && *inferredNoSplit != *usageNoSplit) {
       return info->op->emitOpError(
           "conflicting pipe split usage across peer pipe init ops");
@@ -198,8 +206,9 @@ resolveNoSplitComponent(ArrayRef<PipeInitInfo *> component, OpBuilder &builder) 
 
   if (explicitNoSplit && inferredNoSplit && *explicitNoSplit != *inferredNoSplit) {
     for (PipeInitInfo *info : component) {
-      if (!info->explicitNoSplit || *info->explicitNoSplit == *inferredNoSplit)
+      if (!info->explicitNoSplit || *info->explicitNoSplit == *inferredNoSplit) {
         continue;
+      }
       if (*info->explicitNoSplit) {
         return info->op->emitOpError(
             "explicit 'nosplit = true' conflicts with downstream users that "
@@ -216,14 +225,16 @@ resolveNoSplitComponent(ArrayRef<PipeInitInfo *> component, OpBuilder &builder) 
   auto noSplitAttr = builder.getBoolAttr(finalNoSplit);
   for (PipeInitInfo *info : component) {
     if (auto initOp = dyn_cast<InitializeL2LPipeOp>(info->op)) {
-      if (!initOp.getNosplitAttr())
+      if (!initOp.getNosplitAttr()) {
         setNoSplitAttr(initOp, noSplitAttr);
+      }
       continue;
     }
 
     auto initOp = cast<InitializeL2G2LPipeOp>(info->op);
-    if (!initOp.getNosplitAttr())
+    if (!initOp.getNosplitAttr()) {
       setNoSplitAttr(initOp, noSplitAttr);
+    }
   }
 
   return success();
@@ -248,11 +259,13 @@ struct PTOInferValidatePipeInitPass
       adjacency[info.op];
 
       auto recordAddr = [&](Value addr, int8_t effectiveDirMask) {
-        if (!addr)
+        if (!addr) {
           return;
+        }
         auto key = getPipePeerKey(addr, info.funcOp);
-        if (!key)
+        if (!key) {
           return;
+        }
         key->dirMask = effectiveDirMask;
         keyedInits[*key].push_back(info.op);
       };
@@ -275,8 +288,9 @@ struct PTOInferValidatePipeInitPass
 
       if (info.dirMask == kBidirectionalDirMask) {
         recordAddr(getLocalAddrOperand(initOp), kC2VDirMask);
-        if (Value peerAddr = initOp.getPeerLocalAddr())
+        if (Value peerAddr = initOp.getPeerLocalAddr()) {
           recordAddr(peerAddr, kV2CDirMask);
+        }
         return;
       }
 
@@ -289,11 +303,13 @@ struct PTOInferValidatePipeInitPass
     for (const auto &it : keyedInits) {
       SmallVector<Operation *> uniqueOps;
       for (Operation *op : it.second) {
-        if (std::find(uniqueOps.begin(), uniqueOps.end(), op) == uniqueOps.end())
+        if (std::find(uniqueOps.begin(), uniqueOps.end(), op) == uniqueOps.end()) {
           uniqueOps.push_back(op);
+        }
       }
-      if (uniqueOps.size() < kMinPeerPipeInitCount)
+      if (uniqueOps.size() < kMinPeerPipeInitCount) {
         continue;
+      }
 
       for (size_t i = 0; i < uniqueOps.size(); ++i) {
         for (size_t j = i + 1; j < uniqueOps.size(); ++j) {
@@ -304,14 +320,16 @@ struct PTOInferValidatePipeInitPass
     }
 
     llvm::DenseMap<Operation *, PipeInitInfo *> infoByOp;
-    for (PipeInitInfo &info : initInfos)
+    for (PipeInitInfo &info : initInfos) {
       infoByOp[info.op] = &info;
+    }
 
     OpBuilder builder(moduleOp.getContext());
     llvm::SmallPtrSet<Operation *, kVisitedInitReserveSize> visited;
     for (PipeInitInfo &rootInfo : initInfos) {
-      if (!visited.insert(rootInfo.op).second)
+      if (!visited.insert(rootInfo.op).second) {
         continue;
+      }
 
       SmallVector<Operation *> stack{rootInfo.op};
       SmallVector<PipeInitInfo *> component;
@@ -319,8 +337,9 @@ struct PTOInferValidatePipeInitPass
         Operation *current = stack.pop_back_val();
         component.push_back(infoByOp[current]);
         for (Operation *neighbor : adjacency[current]) {
-          if (visited.insert(neighbor).second)
+          if (visited.insert(neighbor).second) {
             stack.push_back(neighbor);
+          }
         }
       }
 

--- a/lib/PTO/Transforms/PTOInstantiateAndInlineOpLib.cpp
+++ b/lib/PTO/Transforms/PTOInstantiateAndInlineOpLib.cpp
@@ -87,11 +87,13 @@ static Operation *cloneOpForInlineWithFix(OpBuilder &builder, Operation &op,
                                           IRMapping &mapping) {
   if (auto alloc = dyn_cast<pto::AllocTileOp>(&op)) {
     auto mapOperand = [&](Value operand, Type expectedType) -> Value {
-      if (!operand)
+      if (!operand) {
         return Value();
+      }
       Value mapped = mapping.lookupOrNull(operand);
-      if (!mapped)
+      if (!mapped) {
         mapped = operand;
+      }
       return maybeUnwrapCastToExpected(mapped, expectedType);
     };
 
@@ -121,39 +123,48 @@ static void eraseDeadBridgeCasts(func::FuncOp func) {
 
     SmallVector<UnrealizedConversionCastOp, 8> deadUnrealized;
     func.walk([&](UnrealizedConversionCastOp cast) {
-      if (cast->use_empty())
+      if (cast->use_empty()) {
         deadUnrealized.push_back(cast);
+      }
     });
 
     SmallVector<memref::CastOp, 8> deadMemrefCasts;
     func.walk([&](memref::CastOp cast) {
-      if (cast->use_empty())
+      if (cast->use_empty()) {
         deadMemrefCasts.push_back(cast);
+      }
     });
 
-    if (deadUnrealized.empty() && deadMemrefCasts.empty())
+    if (deadUnrealized.empty() && deadMemrefCasts.empty()) {
       break;
+    }
 
-    for (UnrealizedConversionCastOp cast : llvm::reverse(deadUnrealized))
+    for (UnrealizedConversionCastOp cast : llvm::reverse(deadUnrealized)) {
       cast.erase();
-    for (memref::CastOp cast : llvm::reverse(deadMemrefCasts))
+    }
+    for (memref::CastOp cast : llvm::reverse(deadMemrefCasts)) {
       cast.erase();
+    }
     changed = true;
   }
 }
 
 static LogicalResult inlineCall(func::CallOp call, func::FuncOp callee) {
-  if (callee.isExternal())
+  if (callee.isExternal()) {
     return call.emitOpError("callee must have a body before inlining");
+  }
 
   Block &entry = callee.getBody().front();
-  if (entry.getNumArguments() != call.getNumOperands())
+  if (entry.getNumArguments() != call.getNumOperands()) {
     return call.emitOpError("callee argument count mismatch during inlining");
+  }
   auto returnOp = dyn_cast<func::ReturnOp>(entry.getTerminator());
-  if (!returnOp)
+  if (!returnOp) {
     return call.emitOpError("callee must terminate with func.return");
-  if (returnOp.getNumOperands() != call.getNumResults())
+  }
+  if (returnOp.getNumOperands() != call.getNumResults()) {
     return call.emitOpError("callee return/result arity mismatch during inlining");
+  }
 
   OpBuilder builder(call);
   IRMapping mapping;
@@ -164,10 +175,12 @@ static LogicalResult inlineCall(func::CallOp call, func::FuncOp callee) {
   for (Operation &op : entry.without_terminator()) {
     FailureOr<bool> handledOr =
         pto::tryCloneOpLibInlineBridgeOp(builder, op, mapping);
-    if (failed(handledOr))
+    if (failed(handledOr)) {
       return call.emitOpError("failed to remap OP-Lib inline bridge op");
-    if (*handledOr)
+    }
+    if (*handledOr) {
       continue;
+    }
 
     Operation *newOp = cloneOpForInlineWithFix(builder, op, mapping);
     for (auto [oldRes, newRes] :
@@ -178,8 +191,9 @@ static LogicalResult inlineCall(func::CallOp call, func::FuncOp callee) {
   for (auto [callResult, returnOperand] :
        llvm::zip(call.getResults(), returnOp.getOperands())) {
     Value mapped = mapping.lookupOrNull(returnOperand);
-    if (!mapped)
+    if (!mapped) {
       mapped = returnOperand;
+    }
     callResult.replaceAllUsesWith(mapped);
   }
 
@@ -218,25 +232,29 @@ static LogicalResult validateInlineableCalleesHaveBodies(
     ModuleOp module, InlinePredicate &&shouldInline) {
   for (ModuleOp funcModule : collectFuncModules(module)) {
     for (func::FuncOp func : funcModule.getOps<func::FuncOp>()) {
-      if (func.isExternal() || func.empty())
+      if (func.isExternal() || func.empty()) {
         continue;
+      }
 
       bool failed = false;
       func.walk([&](func::CallOp call) {
         auto calleeAttr = call.getCalleeAttr();
-        if (!calleeAttr)
+        if (!calleeAttr) {
           return;
+        }
 
         func::FuncOp callee =
             funcModule.lookupSymbol<func::FuncOp>(calleeAttr.getValue());
-        if (!callee || !shouldInline(callee) || !callee.isExternal())
+        if (!callee || !shouldInline(callee) || !callee.isExternal()) {
           return;
+        }
 
         emitMissingInstanceBodyError(call, callee);
         failed = true;
       });
-      if (failed)
+      if (failed) {
         return failure();
+      }
     }
   }
 
@@ -249,12 +267,15 @@ static LogicalResult inlineMatchingCalls(
     llvm::StringRef debugTag, int &inlinedCalls, int &touchedFuncs) {
   for (ModuleOp funcModule : collectFuncModules(module)) {
     for (func::FuncOp func : funcModule.getOps<func::FuncOp>()) {
-      if (func.isExternal())
+      if (func.isExternal()) {
         continue;
-      if (isInstanceFunc(func))
+      }
+      if (isInstanceFunc(func)) {
         continue;
-      if (func.empty())
+      }
+      if (func.empty()) {
         continue;
+      }
 
       bool changedThisFunc = false;
       bool madeProgress = true;
@@ -265,17 +286,20 @@ static LogicalResult inlineMatchingCalls(
         func.walk([&](func::CallOp call) { calls.push_back(call); });
 
         for (func::CallOp oldCall : calls) {
-          if (!oldCall || !oldCall->getBlock())
+          if (!oldCall || !oldCall->getBlock()) {
             continue;
+          }
 
           auto calleeAttr = oldCall.getCalleeAttr();
-          if (!calleeAttr)
+          if (!calleeAttr) {
             continue;
+          }
 
           func::FuncOp callee =
               funcModule.lookupSymbol<func::FuncOp>(calleeAttr.getValue());
-          if (!callee || !shouldInline(callee))
+          if (!callee || !shouldInline(callee)) {
             continue;
+          }
 
           if (callee.isExternal()) {
             oldCall.emitOpError("callee must have a body before inlining");
@@ -304,8 +328,9 @@ static LogicalResult inlineMatchingCalls(
             oldResult.replaceAllUsesWith(newResult);
           call.erase();
 
-          if (failed(inlineCall(newCall, callee)))
+          if (failed(inlineCall(newCall, callee))) {
             return failure();
+          }
 
           ++inlinedCalls;
           changedThisFunc = true;
@@ -334,16 +359,20 @@ static void eraseDeadMatchingPrivateFuncs(ModuleOp module,
     SymbolTable symbolTable(funcModule);
     SmallVector<func::FuncOp, 8> deadFuncs;
     for (func::FuncOp func : funcModule.getOps<func::FuncOp>()) {
-      if (!predicate(func))
+      if (!predicate(func)) {
         continue;
-      if (func.isPublic())
+      }
+      if (func.isPublic()) {
         continue;
+      }
       auto uses = symbolTable.getSymbolUses(func, funcModule);
-      if (uses && uses->empty())
+      if (uses && uses->empty()) {
         deadFuncs.push_back(func);
+      }
     }
-    for (func::FuncOp func : deadFuncs)
+    for (func::FuncOp func : deadFuncs) {
       func.erase();
+    }
   }
 }
 

--- a/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
+++ b/lib/PTO/Transforms/PTOLowerFrontendPipeOpsPass.cpp
@@ -64,8 +64,9 @@ static LogicalResult requireFrontendGmSlotBuffer(InitOpT initOp) {
 template <typename InitOpT>
 static void propagateFrontendIdAttr(InitOpT initOp, Operation *pipeOp,
                                     IRRewriter &rewriter) {
-  if (!pipeOp)
+  if (!pipeOp) {
     return;
+  }
   pipeOp->setAttr(kFrontendPipeIdAttrName,
                   rewriter.getI32IntegerAttr(initOp.getId()));
 }
@@ -74,12 +75,14 @@ template <typename InitOpT>
 static void propagateFixpipePeerKeyAttrs(InitOpT initOp, Operation *pipeOp,
                                          IRRewriter &rewriter) {
   if (!pipeOp || !initOp.getAccPushEpilogueAttr() ||
-      initOp.getDirMask() != kC2VDirMask || !initOp.getC2vConsumerBuf())
+      initOp.getDirMask() != kC2VDirMask || !initOp.getC2vConsumerBuf()) {
     return;
+  }
 
   auto currentFunc = initOp->template getParentOfType<func::FuncOp>();
-  if (!currentFunc)
+  if (!currentFunc) {
     return;
+  }
 
   auto setPeerKeyAttrs = [&](FlatSymbolRefAttr ownerFuncAttr,
                              StringRef reserveName) {
@@ -108,8 +111,9 @@ static void propagateFixpipePeerKeyAttrs(InitOpT initOp, Operation *pipeOp,
 
 template <typename InitOpT>
 static int32_t getFrontendSlotNum(InitOpT initOp) {
-  if (auto slotNumAttr = initOp.getSlotNumAttr())
+  if (auto slotNumAttr = initOp.getSlotNumAttr()) {
     return slotNumAttr.getInt();
+  }
   return initOp.getDirMask() == kBidirectionalDirMask
              ? kBidirectionalSlotNum
              : kSingleDirectionSlotNum;
@@ -127,12 +131,14 @@ static std::optional<int64_t> getStaticIndexLikeValue(Value value) {
 
 static SmallVector<int64_t> getStaticTensorViewStrides(Value tensor) {
   SmallVector<int64_t> strides;
-  if (!tensor)
+  if (!tensor) {
     return strides;
+  }
 
   auto makeView = tensor.getDefiningOp<MakeTensorViewOp>();
-  if (!makeView)
+  if (!makeView) {
     return strides;
+  }
 
   auto tvTy = dyn_cast<TensorViewType>(makeView.getResult().getType());
   if (!tvTy ||
@@ -142,8 +148,9 @@ static SmallVector<int64_t> getStaticTensorViewStrides(Value tensor) {
   strides.reserve(makeView.getStrides().size());
   for (Value stride : makeView.getStrides()) {
     auto staticStride = getStaticIndexLikeValue(stride);
-    if (!staticStride)
+    if (!staticStride) {
       return {};
+    }
     strides.push_back(*staticStride);
   }
   return strides;
@@ -152,8 +159,9 @@ static SmallVector<int64_t> getStaticTensorViewStrides(Value tensor) {
 static void propagateGlobalTensorStrides(DeclareGlobalOp decl,
                                          ArrayRef<int64_t> strides,
                                          IRRewriter &rewriter) {
-  if (strides.empty())
+  if (strides.empty()) {
     return;
+  }
   decl->setAttr(kGlobalTensorStridesAttrName,
                 rewriter.getDenseI64ArrayAttr(strides));
 }
@@ -176,8 +184,9 @@ static FailureOr<Value> createFrontendGlobalTensorPipe(InitOpT initOp,
   IntegerAttr localSlotNumAttr;
   if (localAddr) {
     localSlotNumAttr = initOp.getLocalSlotNumAttr();
-    if (!localSlotNumAttr)
+    if (!localSlotNumAttr) {
       localSlotNumAttr = rewriter.getI32IntegerAttr(slotNum);
+    }
   }
   auto pipe = rewriter.create<InitializeL2G2LPipeOp>(
       loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, localSlotNumAttr,
@@ -217,13 +226,15 @@ static FailureOr<Value> createFrontendLocalPipe(InitOpT initOp,
 
   if (failed(requireFrontendGmSlotBuffer(initOp)))
     return failure();
-  if (!localAddr)
+  if (!localAddr) {
     return initOp.emitOpError(
         "requires local consumer buffer operands for local FIFO pipe lowering");
+  }
 
   IntegerAttr localSlotNumAttr = initOp.getLocalSlotNumAttr();
-  if (!localSlotNumAttr)
+  if (!localSlotNumAttr) {
     localSlotNumAttr = rewriter.getI32IntegerAttr(slotNum);
+  }
   auto pipe = rewriter.create<InitializeL2G2LPipeOp>(
       loc, pipeTy, dirAttr, slotSizeAttr, slotNumAttr, localSlotNumAttr,
       IntegerAttr{}, noSplitAttr, accPushEpilogueAttr, initOp.getGmSlotBuffer(),
@@ -317,21 +328,25 @@ template <typename InitOpT>
 static void propagateFrontendNoSplitAttr(InitOpT initOp,
                                          const FrontendPipeHandles &handles) {
   auto noSplitAttr = initOp.getNosplitAttr();
-  if (!noSplitAttr)
+  if (!noSplitAttr) {
     return;
+  }
 
-  if (handles.anchorOp)
+  if (handles.anchorOp) {
     handles.anchorOp->setAttr("nosplit", noSplitAttr);
+  }
 
   Operation *c2vOp =
       handles.c2vPipe ? handles.c2vPipe.getDefiningOp() : nullptr;
   Operation *v2cOp =
       handles.v2cPipe ? handles.v2cPipe.getDefiningOp() : nullptr;
 
-  if (c2vOp && c2vOp != handles.anchorOp)
+  if (c2vOp && c2vOp != handles.anchorOp) {
     c2vOp->setAttr("nosplit", noSplitAttr);
-  if (v2cOp && v2cOp != handles.anchorOp && v2cOp != c2vOp)
+  }
+  if (v2cOp && v2cOp != handles.anchorOp && v2cOp != c2vOp) {
     v2cOp->setAttr("nosplit", noSplitAttr);
+  }
 }
 
 template <typename InitOpT>
@@ -383,8 +398,9 @@ static FailureOr<FrontendPipeHandleMap> lowerInitIfPresent(func::FuncOp funcOp,
     return WalkResult::advance();
   });
 
-  if (hasDuplicateId)
+  if (hasDuplicateId) {
     return failure();
+  }
 
   if (hasAicInit && hasAivInit) {
     funcOp.emitOpError("cannot mix pto.aic_initialize_pipe and "

--- a/lib/PTO/Transforms/PTOLowerToOpLibCalls.cpp
+++ b/lib/PTO/Transforms/PTOLowerToOpLibCalls.cpp
@@ -19,12 +19,14 @@ FailureOr<bool> mlir::pto::tryCloneOpLibInlineBridgeOp(OpBuilder &builder,
                                                        Operation &op,
                                                        IRMapping &mapping) {
   if (auto cast = dyn_cast<UnrealizedConversionCastOp>(&op)) {
-    if (cast->getNumOperands() != 1 || cast->getNumResults() != 1)
+    if (cast->getNumOperands() != 1 || cast->getNumResults() != 1) {
       return failure();
+    }
 
     Value mappedSrc = mapping.lookupOrNull(cast.getOperand(0));
-    if (!mappedSrc)
+    if (!mappedSrc) {
       return failure();
+    }
 
     Type dstTy = cast.getResult(0).getType();
     if (mappedSrc.getType() == dstTy) {

--- a/lib/PTO/Transforms/PTOMaterializeSIMTPersistentFragment.cpp
+++ b/lib/PTO/Transforms/PTOMaterializeSIMTPersistentFragment.cpp
@@ -309,8 +309,9 @@ buildPersistentTransformWorklist(const PersistentMaterializationPlan &plan,
               accessLane.op
                   ? accessLane.op->getParentOfType<pto::SectionSimtOp>()
                   : pto::SectionSimtOp();
-          if (accessSection == section)
-            localAccesses.push_back(accessLane);
+if (accessSection == section) {
+          localAccesses.push_back(accessLane);
+        }
         }
         sectionWorklist.elements.push_back(
             {&fragment, &residentElement, std::move(localAccesses)});
@@ -412,8 +413,9 @@ static LogicalResult
 materializeSection(const PersistentSectionWorklist &sectionWorklist,
                    const DataLayout &dataLayout, DominanceInfo &dominance) {
   const auto &elements = sectionWorklist.elements;
-  if (elements.empty())
+  if (elements.empty()) {
     return success();
+  }
 
   pto::SectionSimtOp section = sectionWorklist.section;
   Block &body = section.getBody().front();
@@ -439,8 +441,9 @@ materializeSection(const PersistentSectionWorklist &sectionWorklist,
     const PersistentFragmentAnalysis &fragment = *element.fragment;
     const ResidentElementPlan &residentElement = *element.residentElement;
     LLVM::AllocaOp allocaOp = fragment.allocaOp;
-    if (section == fragment.initSection)
+    if (section == fragment.initSection) {
       continue;
+    }
 
     rewrites[elementIndex].resumeValue =
         entryBuilder
@@ -453,8 +456,9 @@ materializeSection(const PersistentSectionWorklist &sectionWorklist,
   // its accesses. Carry sections seed it from resume; init sections rely on
   // the previously validated first-store initialization.
   for (auto [elementIndex, element] : llvm::enumerate(elements)) {
-    if (element.accesses.empty())
+    if (element.accesses.empty()) {
       continue;
+    }
 
     const PersistentFragmentAnalysis &fragment = *element.fragment;
     LLVM::AllocaOp allocaOp = fragment.allocaOp;
@@ -477,8 +481,9 @@ materializeSection(const PersistentSectionWorklist &sectionWorklist,
   size_t rewrittenAccessCount = 0;
   for (Operation &op : llvm::make_early_inc_range(body)) {
     auto accessIt = laneRewritesByAccess.find(&op);
-    if (accessIt == laneRewritesByAccess.end())
+    if (accessIt == laneRewritesByAccess.end()) {
       continue;
+    }
     if (failed(rewritePersistentAccess(&op, accessIt->second, rewrites)))
       return failure();
     ++rewrittenAccessCount;
@@ -523,8 +528,9 @@ materializeSection(const PersistentSectionWorklist &sectionWorklist,
   promotionBuilder.setInsertionPointToStart(&body);
   for (auto [elementIndex, element] : llvm::enumerate(elements)) {
     LLVM::AllocaOp proxy = rewrites[elementIndex].proxy;
-    if (!proxy)
+    if (!proxy) {
       continue;
+    }
     SmallVector<PromotableAllocationOpInterface, 1> allocators{
         cast<PromotableAllocationOpInterface>(proxy.getOperation())};
     if (failed(tryToPromoteMemorySlots(allocators, promotionBuilder, dataLayout,
@@ -536,8 +542,9 @@ materializeSection(const PersistentSectionWorklist &sectionWorklist,
     }
   }
 
-  if (proxyArraySize && proxyArraySize.use_empty())
+  if (proxyArraySize && proxyArraySize.use_empty()) {
     proxyArraySize.getDefiningOp()->erase();
+  }
   return success();
 }
 

--- a/lib/PTO/Transforms/PTOMaterializeTileOpSections.cpp
+++ b/lib/PTO/Transforms/PTOMaterializeTileOpSections.cpp
@@ -120,8 +120,9 @@ static std::optional<unsigned> traceToFunctionArgument(Value value,
 static void applyEffectToAllTileArguments(func::FuncOp function, uint8_t effect,
                                           SmallVectorImpl<uint8_t> &effects) {
   for (auto [index, type] : llvm::enumerate(function.getArgumentTypes()))
-    if (isa<TileBufType>(type))
+    if (isa<TileBufType>(type)) {
       effects[index] |= effect;
+    }
 }
 
 static SmallVector<uint8_t>
@@ -141,8 +142,9 @@ collectDirectArgumentEffects(func::FuncOp function) {
         effect = ReadEffect;
       else if (isa<MemoryEffects::Write>(instance.getEffect()))
         effect = WriteEffect;
-      if (effect == NoEffect || !instance.getValue())
+      if (effect == NoEffect || !instance.getValue()) {
         continue;
+      }
 
       if (auto argument =
               traceToFunctionArgument(instance.getValue(), function))
@@ -168,8 +170,9 @@ static void summarizeSimtLaunchEffects(func::FuncOp helper, SimtLaunchOp launch,
   SmallVector<uint8_t> calleeEffects = collectDirectArgumentEffects(callee);
   for (auto [argument, calleeEffect] :
        llvm::zip_equal(launch.getArgs(), calleeEffects)) {
-    if (calleeEffect == NoEffect)
+    if (calleeEffect == NoEffect) {
       continue;
+    }
     if (auto helperArgument = traceToFunctionArgument(argument, helper))
       effects[*helperArgument] |= calleeEffect;
     else
@@ -206,8 +209,9 @@ static bool addValidShapeRequirement(ValidShapeRequirements &requirements,
                                      func::FuncOp function,
                                      unsigned argumentIndex) {
   auto &indices = requirements[function.getOperation()];
-  if (llvm::is_contained(indices, argumentIndex))
+  if (llvm::is_contained(indices, argumentIndex)) {
     return false;
+  }
   indices.push_back(argumentIndex);
   llvm::sort(indices);
   return true;
@@ -238,8 +242,9 @@ collectTileOpValidShapeRequirements(func::FuncOp helper,
     }
 
     unsigned dimension = isa<TileValidRowsOp>(op) ? 0 : 1;
-    if (tileType.getValidShape()[dimension] < 0)
+    if (tileType.getValidShape()[dimension] < 0) {
       addValidShapeRequirement(requirements, helper, argument.getArgNumber());
+    }
     return WalkResult::advance();
   });
   return status;
@@ -257,11 +262,13 @@ propagateValidShapeRequirements(ModuleOp module,
     for (func::CallOp call : calls) {
       auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
           call.getOperation(), call.getCalleeAttr());
-      if (!callee)
+      if (!callee) {
         continue;
+      }
       auto required = requirements.find(callee.getOperation());
-      if (required == requirements.end())
+      if (required == requirements.end()) {
         continue;
+      }
       SmallVector<unsigned, 2> requiredArguments(required->second);
 
       auto caller = call->getParentOfType<func::FuncOp>();
@@ -270,17 +277,20 @@ propagateValidShapeRequirements(ModuleOp module,
             "cannot propagate Tile valid-shape metadata without a caller "
             "function");
       for (unsigned calleeArgument : requiredArguments) {
-        if (calleeArgument >= call.getNumOperands())
+        if (calleeArgument >= call.getNumOperands()) {
           return call.emitOpError(
               "TileOp call has fewer operands than its helper ABI");
+        }
         auto callerArgument =
             traceToFunctionArgument(call.getOperand(calleeArgument), caller);
-        if (!callerArgument)
+        if (!callerArgument) {
           continue;
+        }
         auto tileType = dyn_cast<TileBufType>(
             caller.getArgument(*callerArgument).getType());
-        if (!tileType || !tileType.hasDynamicValid())
+        if (!tileType || !tileType.hasDynamicValid()) {
           continue;
+        }
         changed |=
             addValidShapeRequirement(requirements, caller, *callerArgument);
       }
@@ -335,8 +345,9 @@ static std::optional<std::pair<Value, Value>>
 resolveCallValidShape(Value tile, Operation *anchor, func::FuncOp caller,
                       const ExpandedValidShapeArguments &expandedArguments,
                       OpBuilder &builder) {
-  if (!tile)
+  if (!tile) {
     return std::nullopt;
+  }
 
   auto tileType = dyn_cast<TileBufType>(tile.getType());
   if (tileType && tileType.getValidShape().size() == 2 &&
@@ -357,8 +368,9 @@ resolveCallValidShape(Value tile, Operation *anchor, func::FuncOp caller,
     }
   }
 
-  if (!tileType || tileType.getValidShape().size() != 2)
+  if (!tileType || tileType.getValidShape().size() != 2) {
     return std::nullopt;
+  }
 
   // set_validshape mutates the Tile metadata in place. Reading it at the call
   // preserves the executed update across sequential and structured control
@@ -378,19 +390,22 @@ static LogicalResult expandValidShapeCallOperands(
   for (func::CallOp call : calls) {
     auto callee = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
         call.getOperation(), call.getCalleeAttr());
-    if (!callee)
+    if (!callee) {
       continue;
+    }
     auto required = requirements.find(callee.getOperation());
-    if (required == requirements.end())
+    if (required == requirements.end()) {
       continue;
+    }
 
     auto caller = call->getParentOfType<func::FuncOp>();
     OpBuilder builder(call);
     SmallVector<Value> metadataOperands;
     for (unsigned argumentIndex : required->second) {
-      if (argumentIndex >= call.getNumOperands())
+      if (argumentIndex >= call.getNumOperands()) {
         return call.emitOpError(
             "TileOp call has fewer operands than its helper ABI");
+      }
       auto metadata =
           resolveCallValidShape(call.getOperand(argumentIndex), call, caller,
                                 expandedArguments, builder);
@@ -479,14 +494,16 @@ materializeTileOpValidShapeABI(ModuleOp module,
 
 static LogicalResult verifyTileOpABI(func::FuncOp helper) {
   for (auto [index, type] : llvm::enumerate(helper.getArgumentTypes())) {
-    if (!isTileOrScalarType(type))
+    if (!isTileOrScalarType(type)) {
       return helper.emitOpError()
              << "tileop argument #" << index
              << " must be !pto.tile_buf or a PTO scalar, got " << type;
+    }
   }
-  if (helper.getNumResults() != 0)
+  if (helper.getNumResults() != 0) {
     return helper.emitOpError("tileop helpers must not return values; write "
                               "results through mutable Tile parameters");
+  }
   return success();
 }
 
@@ -584,8 +601,9 @@ static LogicalResult inferTileOpKind(func::FuncOp helper,
     return WalkResult::advance();
   });
 
-  if (failed(status))
+  if (failed(status)) {
     return failure();
+  }
   if (firstVector && firstCube) {
     InFlightDiagnostic diag = helper.emitOpError(
         "mixes Vector and Cube compute operations in one tileop helper");
@@ -593,9 +611,10 @@ static LogicalResult inferTileOpKind(func::FuncOp helper,
     diag.attachNote(firstCube->getLoc()) << "first Cube operation is here";
     return failure();
   }
-  if (!firstVector && !firstCube)
+  if (!firstVector && !firstCube) {
     return helper.emitOpError("contains no Vector or Cube compute operation "
                               "from which to infer tileop kind");
+  }
   kind = firstVector ? PhysicalSectionKind::Vector : PhysicalSectionKind::Cube;
   return success();
 }
@@ -610,10 +629,12 @@ static LogicalResult materializeTileOpSection(func::FuncOp helper,
     return helper.emitOpError("requires a func.return terminator");
 
   SmallVector<Operation *> roots;
-  for (Operation &op : entry.without_terminator())
+  for (Operation &op : entry.without_terminator()) {
     roots.push_back(&op);
-  if (roots.empty())
+  }
+  if (roots.empty()) {
     return helper.emitOpError("contains no materializable compute body");
+  }
 
   OpBuilder builder(roots.front());
   Operation *sectionOperation =
@@ -626,8 +647,9 @@ static LogicalResult materializeTileOpSection(func::FuncOp helper,
   auto *sectionBlock = new Block();
   sectionBody.push_back(sectionBlock);
 
-  for (Operation *root : roots)
+  for (Operation *root : roots) {
     root->moveBefore(sectionBlock, sectionBlock->end());
+  }
   helper->setAttr(
       kTileOpKindAttr,
       StringAttr::get(helper.getContext(),

--- a/lib/PTO/Transforms/PTONarrowVPTOLoopCounters.cpp
+++ b/lib/PTO/Transforms/PTONarrowVPTOLoopCounters.cpp
@@ -118,8 +118,9 @@ struct NarrowVecScopeLoopCounterPattern : public OpRewritePattern<scf::ForOp> {
 
     Block *oldBody = forOp.getBody();
     Block *newBody = newFor.getBody();
-    if (!newBody->empty())
+    if (!newBody->empty()) {
       rewriter.eraseOp(newBody->getTerminator());
+    }
 
     rewriter.setInsertionPointToStart(newBody);
     Value restoredInductionVar = restoreInductionVariableType(

--- a/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
+++ b/lib/PTO/Transforms/PTONormalizeUncoveredTileSections.cpp
@@ -43,13 +43,16 @@ struct UncoveredTopLevelSegment {
 
 static void mergeSegmentSummary(UncoveredTopLevelSegment &dst,
                                 const UncoveredTopLevelSegment &src) {
-  if (!src.firstOp)
+  if (!src.firstOp) {
     return;
-  if (!dst.firstOp)
+  }
+  if (!dst.firstOp) {
     dst.firstOp = src.firstOp;
+  }
   dst.lastOp = src.lastOp;
-  if (!dst.firstTileCarrierOp)
+  if (!dst.firstTileCarrierOp) {
     dst.firstTileCarrierOp = src.firstTileCarrierOp;
+  }
   dst.containsTileOp |= src.containsTileOp;
   dst.containsNestedExplicitSection |= src.containsNestedExplicitSection;
   dst.vectorTileOpCount += src.vectorTileOpCount;
@@ -63,8 +66,9 @@ static bool isExplicitSection(Operation *op) {
 }
 
 static bool isTileLikeOp(Operation *op) {
-  if (!op)
+  if (!op) {
     return false;
+  }
   return isa<OpPipeInterface>(op) &&
          op->getName().getStringRef().starts_with("pto.t");
 }
@@ -73,8 +77,9 @@ static bool isTileLikeOp(Operation *op) {
 // section inference conservative: only operations with an unambiguous engine
 // ownership are treated as section carriers.
 static bool isRawSectionCarrierOp(Operation *op) {
-  if (isa<SetFlagDynOp>(op) || isa<WaitFlagDynOp>(op))
+  if (isa<SetFlagDynOp>(op) || isa<WaitFlagDynOp>(op)) {
     return false;
+  }
   return op &&
          isa<VectorMicroOpInterface, CubeMicroOpInterface, MteOpInterface,
              SetFlagOp, WaitFlagOp, SyncSetOp, SyncWaitOp>(op);
@@ -112,31 +117,39 @@ static std::optional<InferredSectionKind>
 classifyMteOpByAddressSpace(MteOpInterface mteOp) {
   Value sourceValue = mteOp.getSource();
   std::optional<AddressSpace> source;
-  if (sourceValue)
+  if (sourceValue) {
     source = getBufferAddressSpace(sourceValue.getType());
+  }
   Value destinationValue = mteOp.getDestination();
   if (auto ptoDpsOp = dyn_cast<PTO_DpsInitOpInterface>(mteOp.getOperation())) {
     OperandRange inits = ptoDpsOp.getDpsInits();
-    if (!inits.empty())
+    if (!inits.empty()) {
       destinationValue = inits.front();
+    }
   }
   std::optional<AddressSpace> destination;
-  if (destinationValue)
+  if (destinationValue) {
     destination = getBufferAddressSpace(destinationValue.getType());
+  }
 
-  if (source && *source == AddressSpace::ACC)
+  if (source && *source == AddressSpace::ACC) {
     return InferredSectionKind::Cube;
-  if (source && *source == AddressSpace::VEC)
+  }
+  if (source && *source == AddressSpace::VEC) {
     return InferredSectionKind::Vector;
-  if (!destination)
+  }
+  if (!destination) {
     return std::nullopt;
+  }
   if (*destination == AddressSpace::MAT || *destination == AddressSpace::LEFT ||
       *destination == AddressSpace::RIGHT ||
       *destination == AddressSpace::BIAS ||
-      *destination == AddressSpace::SCALING)
+      *destination == AddressSpace::SCALING) {
     return InferredSectionKind::Cube;
-  if (*destination == AddressSpace::VEC)
+  }
+  if (*destination == AddressSpace::VEC) {
     return InferredSectionKind::Vector;
+  }
   return std::nullopt;
 }
 
@@ -144,10 +157,12 @@ static std::optional<InferredSectionKind>
 classifyRawSectionCarrierOp(Operation *op) {
   if (!isRawSectionCarrierOp(op))
     return std::nullopt;
-  if (isa<VectorMicroOpInterface>(op))
+  if (isa<VectorMicroOpInterface>(op)) {
     return InferredSectionKind::Vector;
-  if (isa<CubeMicroOpInterface>(op))
+  }
+  if (isa<CubeMicroOpInterface>(op)) {
     return InferredSectionKind::Cube;
+  }
   if (auto mteOp = dyn_cast<MteOpInterface>(op)) {
     if (auto kind = classifyMteOpByAddressSpace(mteOp))
       return kind;
@@ -158,16 +173,18 @@ classifyRawSectionCarrierOp(Operation *op) {
     // therefore determines physical ownership even when the consumer pipe is
     // shared; a shared source remains ambiguous and must not inherit ownership
     // from its peer.
-    if (isSharedSyncPipe(setFlag.getSrcPipe().getPipe()))
+    if (isSharedSyncPipe(setFlag.getSrcPipe().getPipe())) {
       return std::nullopt;
+    }
     return classifySyncPipe(setFlag.getSrcPipe().getPipe());
   }
   if (auto waitFlag = dyn_cast<WaitFlagOp>(op)) {
     // wait_flag executes on the consumer (destination) pipe.  Mirror the
     // producer rule above instead of rejecting a uniquely owned consumer just
     // because its producer uses a shared pipe.
-    if (isSharedSyncPipe(waitFlag.getDstPipe().getPipe()))
+    if (isSharedSyncPipe(waitFlag.getDstPipe().getPipe())) {
       return std::nullopt;
+    }
     return classifySyncPipe(waitFlag.getDstPipe().getPipe());
   }
   if (auto syncSet = dyn_cast<SyncSetOp>(op))
@@ -186,15 +203,18 @@ static bool isRawVPTOVectorTransientType(Type type) {
 }
 
 static bool isRawVPTOVectorLikeOp(Operation *op) {
-  if (!op)
+  if (!op) {
     return false;
+  }
   for (Value operand : op->getOperands()) {
-    if (isRawVPTOVectorTransientType(operand.getType()))
+    if (isRawVPTOVectorTransientType(operand.getType())) {
       return true;
+    }
   }
   for (Value result : op->getResults()) {
-    if (isRawVPTOVectorTransientType(result.getType()))
+    if (isRawVPTOVectorTransientType(result.getType())) {
       return true;
+    }
   }
   return false;
 }
@@ -248,13 +268,15 @@ static std::optional<AddressSpace> getBufferAddressSpace(Type type) {
 
 static void collectTileAddressSpaces(Type type,
                                      SmallVectorImpl<AddressSpace> &spaces) {
-  if (std::optional<AddressSpace> addressSpace = getBufferAddressSpace(type))
+  if (std::optional<AddressSpace> addressSpace = getBufferAddressSpace(type)) {
     spaces.push_back(*addressSpace);
+  }
 }
 
 static std::optional<int8_t> getPipeHandleDirMask(Value pipeHandle) {
-  if (!pipeHandle)
+  if (!pipeHandle) {
     return std::nullopt;
+  }
   if (auto init = pipeHandle.getDefiningOp<InitializeL2LPipeOp>())
     return init.getDirMask();
   if (auto init = pipeHandle.getDefiningOp<InitializeL2G2LPipeOp>())
@@ -286,50 +308,63 @@ static std::optional<InferredSectionKind>
 classifyInternalPipeTileOp(Operation *op) {
   if (auto push = dyn_cast<TPushOp>(op)) {
     std::optional<int8_t> dirMask = getPipeHandleDirMask(push.getPipeHandle());
-    if (!dirMask)
+    if (!dirMask) {
       return std::nullopt;
-    if (*dirMask == 1)
+    }
+    if (*dirMask == 1) {
       return InferredSectionKind::Cube;
-    if (*dirMask == 2)
+    }
+    if (*dirMask == 2) {
       return InferredSectionKind::Vector;
+    }
     return classifyTileSectionByAddressSpace(
         getBufferAddressSpace(push.getTile().getType()));
   }
 
   if (auto pop = dyn_cast<TPopOp>(op)) {
     std::optional<int8_t> dirMask = getPipeHandleDirMask(pop.getPipeHandle());
-    if (!dirMask)
+    if (!dirMask) {
       return std::nullopt;
-    if (*dirMask == 1)
+    }
+    if (*dirMask == 1) {
       return InferredSectionKind::Vector;
-    if (*dirMask == 2)
+    }
+    if (*dirMask == 2) {
       return InferredSectionKind::Cube;
+    }
     return classifyTileSectionByAddressSpace(
         getBufferAddressSpace(pop.getTile().getType()));
   }
 
   if (auto free = dyn_cast<TFreeOp>(op)) {
     std::optional<int8_t> dirMask = getPipeHandleDirMask(free.getPipeHandle());
-    if (!dirMask)
+    if (!dirMask) {
       return std::nullopt;
-    if (*dirMask == 1)
+    }
+    if (*dirMask == 1) {
       return InferredSectionKind::Vector;
-    if (*dirMask == 2)
+    }
+    if (*dirMask == 2) {
       return InferredSectionKind::Cube;
-    if (!free.getEntry())
+    }
+    if (!free.getEntry()) {
       return std::nullopt;
+    }
     return classifyTileSectionByAddressSpace(
         getBufferAddressSpace(free.getEntry().getType()));
   }
 
   if (auto alloc = dyn_cast<TAllocOp>(op)) {
     std::optional<int8_t> dirMask = getPipeHandleDirMask(alloc.getPipeHandle());
-    if (!dirMask)
+    if (!dirMask) {
       return std::nullopt;
-    if (*dirMask == 1)
+    }
+    if (*dirMask == 1) {
       return InferredSectionKind::Cube;
-    if (*dirMask == 2)
+    }
+    if (*dirMask == 2) {
       return InferredSectionKind::Vector;
+    }
     return std::nullopt;
   }
 
@@ -386,25 +421,30 @@ classifyTileOpByAddressSpace(Operation *op) {
     }
   }
 
-  if (sawCubeOnly)
+  if (sawCubeOnly) {
     return InferredSectionKind::Cube;
-  if (sawVec)
+  }
+  if (sawVec) {
     return InferredSectionKind::Vector;
-  if (sawMat)
+  }
+  if (sawMat) {
     return classifyTileOpByPipe(op);
+  }
   return std::nullopt;
 }
 
 static std::optional<InferredSectionKind>
 classifyTLoadByDestinationAddressSpace(Operation *op) {
-  if (!isa<TLoadOp>(op))
+  if (!isa<TLoadOp>(op)) {
     return std::nullopt;
+  }
 
   auto tload = cast<TLoadOp>(op);
   std::optional<AddressSpace> dstSpace =
       getBufferAddressSpace(tload.getDst().getType());
-  if (!dstSpace)
+  if (!dstSpace) {
     return std::nullopt;
+  }
 
   switch (*dstSpace) {
   case AddressSpace::VEC:
@@ -423,14 +463,16 @@ classifyTLoadByDestinationAddressSpace(Operation *op) {
 
 static std::optional<InferredSectionKind>
 classifyTStoreBySourceAddressSpace(Operation *op) {
-  if (!isa<TStoreOp>(op))
+  if (!isa<TStoreOp>(op)) {
     return std::nullopt;
+  }
 
   auto tstore = cast<TStoreOp>(op);
   std::optional<AddressSpace> srcSpace =
       getBufferAddressSpace(tstore.getSrc().getType());
-  if (!srcSpace)
+  if (!srcSpace) {
     return std::nullopt;
+  }
 
   switch (*srcSpace) {
   case AddressSpace::VEC:
@@ -448,19 +490,24 @@ classifyTStoreBySourceAddressSpace(Operation *op) {
 }
 
 static std::optional<InferredSectionKind> classifyTileOp(Operation *op) {
-  if (std::optional<InferredSectionKind> kind = classifyTileOpByName(op))
+  if (std::optional<InferredSectionKind> kind = classifyTileOpByName(op)) {
     return kind;
-  if (std::optional<InferredSectionKind> kind = classifyInternalPipeTileOp(op))
+  }
+  if (std::optional<InferredSectionKind> kind = classifyInternalPipeTileOp(op)) {
     return kind;
+  }
   if (std::optional<InferredSectionKind> kind =
-          classifyTLoadByDestinationAddressSpace(op))
+          classifyTLoadByDestinationAddressSpace(op)) {
     return kind;
+  }
   if (std::optional<InferredSectionKind> kind =
-          classifyTStoreBySourceAddressSpace(op))
+          classifyTStoreBySourceAddressSpace(op)) {
     return kind;
+  }
   if (std::optional<InferredSectionKind> kind =
-          classifyTileOpByAddressSpace(op))
+          classifyTileOpByAddressSpace(op)) {
     return kind;
+  }
   return classifyTileOpByPipe(op);
 }
 
@@ -479,12 +526,15 @@ enum class FunctionKindCacheState : uint8_t {
 
 static void inspectModuleKindOperation(Operation *op,
                                        ModuleKindSummary &summary) {
-  if (!op)
+  if (!op) {
     return;
-  if (isa<SectionSimtOp, SimtLaunchOp>(op) || isa<SimtOpInterface>(op))
+  }
+  if (isa<SectionSimtOp, SimtLaunchOp>(op) || isa<SimtOpInterface>(op)) {
     ++summary.vectorCount;
-  if (isExplicitSection(op))
+  }
+  if (isExplicitSection(op)) {
     return;
+  }
 
   if (isRawSectionCarrierOp(op)) {
     if (std::optional<InferredSectionKind> kind =
@@ -540,8 +590,9 @@ decodeFunctionKind(FunctionKindCacheState state) {
 }
 
 static func::CallOp getTransparentWrapperCall(func::FuncOp funcOp) {
-  if (!funcOp || funcOp.isDeclaration() || !funcOp.getBody().hasOneBlock())
+  if (!funcOp || funcOp.isDeclaration() || !funcOp.getBody().hasOneBlock()) {
     return nullptr;
+  }
 
   Block &entryBlock = funcOp.getBody().front();
   func::CallOp callOp;
@@ -551,21 +602,26 @@ static func::CallOp getTransparentWrapperCall(func::FuncOp funcOp) {
       returnOp = ret;
       continue;
     }
-    if (callOp)
+    if (callOp) {
       return nullptr;
+    }
     callOp = dyn_cast<func::CallOp>(op);
-    if (!callOp)
+    if (!callOp) {
       return nullptr;
+    }
   }
 
-  if (!callOp || !returnOp)
+  if (!callOp || !returnOp) {
     return nullptr;
-  if (returnOp.getNumOperands() != callOp.getNumResults())
+  }
+  if (returnOp.getNumOperands() != callOp.getNumResults()) {
     return nullptr;
+  }
   for (auto [returned, forwarded] :
        llvm::zip(returnOp.getOperands(), callOp.getResults())) {
-    if (returned != forwarded)
+    if (returned != forwarded) {
       return nullptr;
+    }
   }
   return callOp;
 }
@@ -573,13 +629,15 @@ static func::CallOp getTransparentWrapperCall(func::FuncOp funcOp) {
 static std::optional<InferredSectionKind> inferWholeFunctionKind(
     func::FuncOp funcOp,
     llvm::DenseMap<Operation *, FunctionKindCacheState> &cache) {
-  if (!funcOp || funcOp.isDeclaration())
+  if (!funcOp || funcOp.isDeclaration()) {
     return std::nullopt;
+  }
 
   auto cacheIt = cache.find(funcOp.getOperation());
   if (cacheIt != cache.end()) {
-    if (cacheIt->second == FunctionKindCacheState::InProgress)
+    if (cacheIt->second == FunctionKindCacheState::InProgress) {
       return std::nullopt;
+    }
     return decodeFunctionKind(cacheIt->second);
   }
   cache[funcOp.getOperation()] = FunctionKindCacheState::InProgress;
@@ -589,10 +647,11 @@ static std::optional<InferredSectionKind> inferWholeFunctionKind(
   std::optional<InferredSectionKind> inferredKind;
   if (summary.ambiguousOps.empty() &&
       !(summary.vectorCount && summary.cubeCount)) {
-    if (summary.vectorCount)
+    if (summary.vectorCount) {
       inferredKind = InferredSectionKind::Vector;
-    else if (summary.cubeCount)
+    } else if (summary.cubeCount) {
       inferredKind = InferredSectionKind::Cube;
+    }
   }
 
   if (!inferredKind) {
@@ -618,8 +677,9 @@ static void assignModuleKernelKind(ModuleOp module, InferredSectionKind kind) {
 
 static void assignFunctionKernelKind(func::FuncOp funcOp,
                                      InferredSectionKind kind) {
-  if (!funcOp)
+  if (!funcOp) {
     return;
+  }
 
   FunctionKernelKind kernelKind = kind == InferredSectionKind::Vector
                                       ? FunctionKernelKind::Vector
@@ -629,50 +689,59 @@ static void assignFunctionKernelKind(func::FuncOp funcOp,
 }
 
 static LogicalResult tryAssignWholeModuleKernelKind(ModuleOp module) {
-  if (!module || module->hasAttr(FunctionKernelKindAttr::name))
+  if (!module || module->hasAttr(FunctionKernelKindAttr::name)) {
     return success();
+  }
 
   SmallVector<func::FuncOp> defs;
   for (auto funcOp : module.getOps<func::FuncOp>()) {
-    if (!funcOp.isDeclaration())
+    if (!funcOp.isDeclaration()) {
       defs.push_back(funcOp);
+    }
   }
-  if (defs.empty())
+  if (defs.empty()) {
     return success();
+  }
 
   llvm::DenseMap<Operation *, FunctionKindCacheState> cache;
   std::optional<InferredSectionKind> commonKind;
   for (func::FuncOp funcOp : defs) {
-    if (hasAnySection(funcOp))
+    if (hasAnySection(funcOp)) {
       return success();
+    }
     std::optional<InferredSectionKind> funcKind =
         inferWholeFunctionKind(funcOp, cache);
-    if (!funcKind)
+    if (!funcKind) {
       return success();
+    }
     if (!commonKind) {
       commonKind = funcKind;
       continue;
     }
-    if (*commonKind != *funcKind)
+    if (*commonKind != *funcKind) {
       return success();
+    }
   }
 
-  if (!commonKind)
+  if (!commonKind) {
     return success();
+  }
   assignModuleKernelKind(module, *commonKind);
   return success();
 }
 
 static LogicalResult tryAssignWholeFunctionKernelKind(func::FuncOp funcOp) {
   if (!funcOp || funcOp.isDeclaration() || hasAnySection(funcOp) ||
-      hasKnownKernelKindContext(funcOp))
+      hasKnownKernelKindContext(funcOp)) {
     return success();
+  }
 
   llvm::DenseMap<Operation *, FunctionKindCacheState> cache;
   std::optional<InferredSectionKind> kind =
       inferWholeFunctionKind(funcOp, cache);
-  if (!kind)
+  if (!kind) {
     return success();
+  }
 
   assignFunctionKernelKind(funcOp, *kind);
   return success();
@@ -680,8 +749,9 @@ static LogicalResult tryAssignWholeFunctionKernelKind(func::FuncOp funcOp) {
 
 static void inspectSegmentOperation(Operation *op,
                                     UncoveredTopLevelSegment &segment) {
-  if (!op)
+  if (!op) {
     return;
+  }
 
   if (isTileLikeOp(op) || isRawSectionCarrierOp(op)) {
     segment.containsTileOp = true;
@@ -712,14 +782,18 @@ static void inspectSegmentOperation(Operation *op,
 
 static std::optional<InferredSectionKind>
 inferSegmentKind(const UncoveredTopLevelSegment &segment) {
-  if (!segment.ambiguousTileOps.empty())
+  if (!segment.ambiguousTileOps.empty()) {
     return std::nullopt;
-  if (segment.vectorTileOpCount && segment.cubeTileOpCount)
+  }
+  if (segment.vectorTileOpCount && segment.cubeTileOpCount) {
     return std::nullopt;
-  if (segment.vectorTileOpCount)
+  }
+  if (segment.vectorTileOpCount) {
     return InferredSectionKind::Vector;
-  if (segment.cubeTileOpCount)
+  }
+  if (segment.cubeTileOpCount) {
     return InferredSectionKind::Cube;
+  }
   return std::nullopt;
 }
 
@@ -731,8 +805,9 @@ static UncoveredTopLevelSegment summarizeTopLevelOperation(Operation *op) {
   summary.firstOp = op;
   summary.lastOp = op;
   inspectSegmentOperation(op, summary);
-  if (summary.containsTileOp)
+  if (summary.containsTileOp) {
     summary.firstTileCarrierOp = op;
+  }
   return summary;
 }
 
@@ -745,8 +820,9 @@ static void collectUncoveredTopLevelSegments(
   UncoveredTopLevelSegment current;
 
   auto flushCurrent = [&]() {
-    if (!current.firstOp)
+    if (!current.firstOp) {
       return;
+    }
     segments.push_back(current);
     current = {};
   };
@@ -797,8 +873,9 @@ wrapUncoveredTopLevelSegment(func::FuncOp funcOp,
   Block &entryBlock = funcOp.getBody().front();
   Operation *firstOp = segment.firstOp;
   Operation *lastOp = segment.lastOp;
-  if (!firstOp || !lastOp)
+  if (!firstOp || !lastOp) {
     return;
+  }
 
   OpBuilder builder(firstOp);
   auto sectionOp = builder.create<SectionOpT>(firstOp->getLoc());
@@ -854,18 +931,21 @@ emitResidualUncoveredTileSegmentError(func::FuncOp funcOp,
 }
 
 static LogicalResult normalizeFunction(func::FuncOp funcOp) {
-  if (hasKnownKernelKindContext(funcOp))
+  if (hasKnownKernelKindContext(funcOp)) {
     return success();
+  }
 
   SmallVector<UncoveredTopLevelSegment, 4> segments;
   collectUncoveredTopLevelSegments(funcOp, segments);
   for (const UncoveredTopLevelSegment &segment : llvm::reverse(segments)) {
-    if (!segment.containsTileOp || segment.containsNestedExplicitSection)
+    if (!segment.containsTileOp || segment.containsNestedExplicitSection) {
       continue;
+    }
 
     std::optional<InferredSectionKind> kind = inferSegmentKind(segment);
-    if (!kind)
+    if (!kind) {
       return emitSegmentInferenceError(funcOp, segment);
+    }
 
     switch (*kind) {
     case InferredSectionKind::Cube:
@@ -881,14 +961,16 @@ static LogicalResult normalizeFunction(func::FuncOp funcOp) {
 
 static LogicalResult
 verifyFunctionHasNoResidualUncoveredTileSegments(func::FuncOp funcOp) {
-  if (hasKnownKernelKindContext(funcOp))
+  if (hasKnownKernelKindContext(funcOp)) {
     return success();
+  }
 
   SmallVector<UncoveredTopLevelSegment, 4> segments;
   collectUncoveredTopLevelSegments(funcOp, segments);
   for (const UncoveredTopLevelSegment &segment : segments) {
-    if (!segment.containsTileOp)
+    if (!segment.containsTileOp) {
       continue;
+    }
     return emitResidualUncoveredTileSegmentError(funcOp, segment);
   }
   return success();

--- a/lib/PTO/Transforms/PTOOutlineSIMTSections.cpp
+++ b/lib/PTO/Transforms/PTOOutlineSIMTSections.cpp
@@ -43,12 +43,14 @@ using namespace mlir;
 namespace {
 
 static bool isDefinedInside(Operation *scope, Value value) {
-  if (Operation *defOp = value.getDefiningOp())
+  if (Operation *defOp = value.getDefiningOp()) {
     return scope->isAncestor(defOp);
+  }
 
   auto blockArg = dyn_cast<BlockArgument>(value);
-  if (!blockArg)
+  if (!blockArg) {
     return false;
+  }
 
   Operation *owner = blockArg.getOwner()->getParentOp();
   return owner && scope->isAncestor(owner);
@@ -61,14 +63,17 @@ static LogicalResult collectCaptures(pto::SectionSimtOp sectionOp,
 
   sectionOp.getBody().walk([&](Operation *op) {
     for (Value operand : op->getOperands()) {
-      if (isDefinedInside(scope, operand))
+      if (isDefinedInside(scope, operand)) {
         continue;
-      if (Operation *defOp = operand.getDefiningOp()) {
-        if (defOp->hasTrait<OpTrait::ConstantLike>())
-          continue;
       }
-      if (seen.insert(operand).second)
+      if (Operation *defOp = operand.getDefiningOp()) {
+        if (defOp->hasTrait<OpTrait::ConstantLike>()) {
+          continue;
+        }
+      }
+      if (seen.insert(operand).second) {
         captures.push_back(operand);
+      }
     }
   });
 
@@ -85,21 +90,25 @@ static void cloneExternalConstants(pto::SectionSimtOp sectionOp,
     for (Value operand : op->getOperands()) {
       Operation *defOp = operand.getDefiningOp();
       if (!defOp || isDefinedInside(scope, operand) ||
-          !defOp->hasTrait<OpTrait::ConstantLike>())
+          !defOp->hasTrait<OpTrait::ConstantLike>()) {
         continue;
-      if (seen.insert(defOp).second)
+      }
+      if (seen.insert(defOp).second) {
         constants.push_back(defOp);
+      }
     }
   });
 
-  for (Operation *constant : constants)
+  for (Operation *constant : constants) {
     builder.clone(*constant, mapping);
+  }
 }
 
 static LogicalResult verifySectionCanBeOutlined(pto::SectionSimtOp sectionOp) {
   func::FuncOp parentFunc = sectionOp->getParentOfType<func::FuncOp>();
-  if (!parentFunc)
+  if (!parentFunc) {
     return sectionOp.emitOpError("must be nested in a func.func");
+  }
 
   if (parentFunc->hasAttr(pto::kPTOSimtEntryAttrName)) {
     return sectionOp.emitOpError()
@@ -107,11 +116,13 @@ static LogicalResult verifySectionCanBeOutlined(pto::SectionSimtOp sectionOp) {
            << pto::kPTOSimtEntryAttrName << "'";
   }
 
-  if (!sectionOp.getBody().hasOneBlock())
+  if (!sectionOp.getBody().hasOneBlock()) {
     return sectionOp.emitOpError("requires a single-block body");
+  }
 
-  if (sectionOp.getBody().front().getNumArguments() != 0)
+  if (sectionOp.getBody().front().getNumArguments() != 0) {
     return sectionOp.emitOpError("does not support region block arguments");
+  }
 
   bool hasNestedSection = false;
   sectionOp.getBody().walk([&](pto::SectionSimtOp nested) {
@@ -121,15 +132,17 @@ static LogicalResult verifySectionCanBeOutlined(pto::SectionSimtOp sectionOp) {
     }
     return WalkResult::advance();
   });
-  if (hasNestedSection)
+  if (hasNestedSection) {
     return sectionOp.emitOpError("does not support nested pto.section.simt");
+  }
 
   Operation *scope = sectionOp.getOperation();
   WalkResult escapeCheck = sectionOp.getBody().walk([&](Operation *op) {
     for (Value result : op->getResults()) {
       for (Operation *user : result.getUsers()) {
-        if (!scope->isAncestor(user))
+        if (!scope->isAncestor(user)) {
           return WalkResult::interrupt();
+        }
       }
     }
     return WalkResult::advance();
@@ -149,8 +162,9 @@ static std::string getUniqueHelperName(ModuleOp module, func::FuncOp parentFunc,
   do {
     std::string candidate =
         (Twine(parentName) + "_simt_" + Twine(outlineIndex++)).str();
-    if (!module.lookupSymbol<func::FuncOp>(candidate))
+    if (!module.lookupSymbol<func::FuncOp>(candidate)) {
       return candidate;
+    }
   } while (true);
 }
 
@@ -185,8 +199,9 @@ static func::FuncOp createOutlinedHelper(ModuleOp module,
 
   SmallVector<Type> argTypes;
   argTypes.reserve(captures.size());
-  for (Value capture : captures)
+  for (Value capture : captures) {
     argTypes.push_back(capture.getType());
+  }
 
   OpBuilder moduleBuilder(module.getBodyRegion());
   moduleBuilder.setInsertionPointToEnd(&module.getBodyRegion().front());
@@ -208,8 +223,9 @@ static func::FuncOp createOutlinedHelper(ModuleOp module,
 
   OpBuilder bodyBuilder = OpBuilder::atBlockEnd(entry);
   cloneExternalConstants(sectionOp, bodyBuilder, mapping);
-  for (Operation &op : sectionOp.getBody().front())
+  for (Operation &op : sectionOp.getBody().front()) {
     bodyBuilder.clone(op, mapping);
+  }
   bodyBuilder.create<func::ReturnOp>(loc);
 
   return helper;
@@ -234,16 +250,19 @@ static void replaceSectionWithLaunch(pto::SectionSimtOp sectionOp,
 static LogicalResult outlineSection(ModuleOp module,
                                     pto::SectionSimtOp sectionOp,
                                     unsigned &outlineIndex) {
-  if (failed(verifySectionCanBeOutlined(sectionOp)))
+  if (failed(verifySectionCanBeOutlined(sectionOp))) {
     return failure();
+  }
 
   FailureOr<int64_t> maxThreads = getSimtThreadCount(sectionOp);
-  if (failed(maxThreads))
+  if (failed(maxThreads)) {
     return failure();
+  }
 
   SmallVector<Value> captures;
-  if (failed(collectCaptures(sectionOp, captures)))
+  if (failed(collectCaptures(sectionOp, captures))) {
     return failure();
+  }
 
   func::FuncOp parentFunc = sectionOp->getParentOfType<func::FuncOp>();
   std::string helperName =

--- a/lib/PTO/Transforms/PTOPlanMemory.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemory.cpp
@@ -65,26 +65,30 @@ struct LocalMemSpec {
 static std::optional<int64_t> getTileBufferFootprintBytes(TileBufType type) {
   ArrayRef<int64_t> shape = type.getShape();
   unsigned elemBytes = getPTOStorageElemByteSize(type.getElementType());
-  if (elemBytes == 0)
+  if (elemBytes == 0) {
     return std::nullopt;
+  }
 
   if (type.getCompactModeI32() !=
       static_cast<int32_t>(pto::CompactMode::RowPlusOne)) {
     std::optional<int64_t> totalStaticSize = getStaticTotalSize(shape);
-    if (!totalStaticSize.has_value())
+    if (!totalStaticSize.has_value()) {
       return std::nullopt;
+    }
     return totalStaticSize.value() * static_cast<int64_t>(elemBytes);
   }
 
-  if (shape.size() != 2 || llvm::is_contained(shape, ShapedType::kDynamic))
+  if (shape.size() != 2 || llvm::is_contained(shape, ShapedType::kDynamic)) {
     return std::nullopt;
+  }
 
   bool rowMajor =
       type.getBLayoutValueI32() == static_cast<int32_t>(pto::BLayout::RowMajor);
   int64_t major = rowMajor ? shape[0] : shape[1];
   int64_t minor = rowMajor ? shape[1] : shape[0];
-  if (major == 0 || minor == 0)
+  if (major == 0 || minor == 0) {
     return 0;
+  }
   return ((major - 1) * (minor + 1) + minor) *
          static_cast<int64_t>(elemBytes);
 }
@@ -95,11 +99,13 @@ static int64_t ceilDivBitsToBytes(int64_t bits) {
 
 static int64_t alignUpBytes(int64_t value, int64_t align) {
   int64_t safeAlign = std::max<int64_t>(align, 1);
-  if (safeAlign == 1)
+  if (safeAlign == 1) {
     return value;
+  }
   int64_t rem = value % safeAlign;
-  if (rem == 0)
+  if (rem == 0) {
     return value;
+  }
   return value + (safeAlign - rem);
 }
 
@@ -130,19 +136,22 @@ static bool isIgnoredA5TmpOperandUse(OpOperand &use) {
   StringRef name = owner->getName().getStringRef();
 
   if (auto dpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(owner)) {
-    if (llvm::is_contained(dpsOp.getDpsInits(), use.get()))
+    if (llvm::is_contained(dpsOp.getDpsInits(), use.get())) {
       return false;
+    }
   } else if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(owner)) {
-    if (llvm::is_contained(dpsOp.getDpsInits(), use.get()))
+    if (llvm::is_contained(dpsOp.getDpsInits(), use.get())) {
       return false;
+    }
   }
 
   if (isNameIn(name, {"pto.trowargmax", "pto.trowargmin", "pto.trowmax",
                      "pto.trowmin", "pto.trowsum", "pto.trowprod"}))
     return operandNo == 1;
 
-  if (name == "pto.txors")
+  if (name == "pto.txors") {
     return operandNo == 2;
+  }
 
   if (isNameIn(name, {"pto.tprelu", "pto.txor", "pto.tsels",
                      "pto.trowexpand", "pto.tcolexpand",
@@ -155,23 +164,27 @@ static bool isIgnoredA5TmpOperandUse(OpOperand &use) {
                      "pto.tcolexpandmul", "pto.tcolexpandsub"}))
     return operandNo == 2;
 
-  if (name == "pto.tsel")
+  if (name == "pto.tsel") {
     return operandNo == 3;
+  }
 
   return false;
 }
 
 static bool isA5IgnoredTmpAlloc(pto::AllocTileOp allocTile) {
-  if (getTargetArch(allocTile.getOperation()) != PTOArch::A5)
+  if (getTargetArch(allocTile.getOperation()) != PTOArch::A5) {
     return false;
+  }
 
   Value value = allocTile.getResult();
-  if (value.use_empty())
+  if (value.use_empty()) {
     return false;
+  }
 
   for (OpOperand &use : value.getUses()) {
-    if (!isIgnoredA5TmpOperandUse(use))
+    if (!isIgnoredA5TmpOperandUse(use)) {
       return false;
+    }
   }
   return true;
 }
@@ -181,8 +194,9 @@ static void collectStableValueOrder(Region &region,
                                     DenseMap<Value, std::string> &stableValueKeys,
                                     SmallVectorImpl<Value> &seenValues) {
   auto recordValue = [&](Value value) {
-    if (stableValueKeys.find(value) != stableValueKeys.end())
+    if (stableValueKeys.find(value) != stableValueKeys.end()) {
       return;
+    }
     std::string key;
     llvm::raw_string_ostream os(key);
     value.printAsOperand(os, asmState);
@@ -191,14 +205,17 @@ static void collectStableValueOrder(Region &region,
   };
 
   for (Block &block : region) {
-    for (BlockArgument blockArg : block.getArguments())
+    for (BlockArgument blockArg : block.getArguments()) {
       recordValue(blockArg);
+    }
     for (Operation &op : block) {
-      for (Value result : op.getResults())
+      for (Value result : op.getResults()) {
         recordValue(result);
-      for (Region &nestedRegion : op.getRegions())
+      }
+      for (Region &nestedRegion : op.getRegions()) {
         collectStableValueOrder(nestedRegion, asmState, stableValueKeys,
                                 seenValues);
+      }
     }
   }
 }
@@ -212,22 +229,25 @@ static StableValueOrderMap buildStableValueOrder(func::FuncOp func) {
   llvm::sort(seenValues, [&](Value lhs, Value rhs) {
     const std::string &lhsKey = stableValueKeys.find(lhs)->second;
     const std::string &rhsKey = stableValueKeys.find(rhs)->second;
-    if (lhsKey != rhsKey)
+    if (lhsKey != rhsKey) {
       return lhsKey < rhsKey;
+    }
     return isLessValue(lhs, rhs);
   });
 
   StableValueOrderMap stableValueOrder;
-  for (auto [index, value] : llvm::enumerate(seenValues))
+  for (auto [index, value] : llvm::enumerate(seenValues)) {
     stableValueOrder[value] = index;
+  }
   return stableValueOrder;
 }
 
 static uint32_t lookupStableValueOrder(
     Value value, const StableValueOrderMap &stableValueOrder) {
   auto it = stableValueOrder.find(value);
-  if (it != stableValueOrder.end())
+  if (it != stableValueOrder.end()) {
     return it->second;
+  }
   return std::numeric_limits<uint32_t>::max();
 }
 
@@ -237,8 +257,9 @@ static void sortValuesByStableOrder(
   llvm::sort(values, [&](Value lhs, Value rhs) {
     uint32_t lhsOrder = lookupStableValueOrder(lhs, stableValueOrder);
     uint32_t rhsOrder = lookupStableValueOrder(rhs, stableValueOrder);
-    if (lhsOrder != rhsOrder)
+    if (lhsOrder != rhsOrder) {
       return lhsOrder < rhsOrder;
+    }
     return isLessValue(lhs, rhs);
   });
 }
@@ -248,25 +269,31 @@ static SmallVector<Value> getScratchBuffersFromEffects(Operation *op,
                                                        const StableValueOrderMap &stableValueOrder) {
   SmallVector<Value> scratchBuffers;
   auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!memEffect)
+  if (!memEffect) {
     return scratchBuffers;
+  }
 
   SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>,
               kMemoryEffectReserveSize>
       effects;
   memEffect.getEffects(effects);
   for (const auto &effect : effects) {
-    if (!isa<MemoryEffects::Write>(effect.getEffect()))
+    if (!isa<MemoryEffects::Write>(effect.getEffect())) {
       continue;
+    }
     Value value = effect.getValue();
-    if (!value)
+    if (!value) {
       continue;
-    if (!llvm::is_contained(op->getOperands(), value))
+    }
+    if (!llvm::is_contained(op->getOperands(), value)) {
       continue;
-    if (llvm::is_contained(dpsInits, value))
+    }
+    if (llvm::is_contained(dpsInits, value)) {
       continue;
-    if (!llvm::is_contained(scratchBuffers, value))
+    }
+    if (!llvm::is_contained(scratchBuffers, value)) {
       scratchBuffers.push_back(value);
+    }
   }
   sortValuesByStableOrder(scratchBuffers, stableValueOrder);
   return scratchBuffers;
@@ -277,21 +304,25 @@ getMemoryEffectBufferOperands(Operation *op,
                               const StableValueOrderMap &stableValueOrder) {
   SmallVector<Value> buffers;
   auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!memEffect)
+  if (!memEffect) {
     return buffers;
+  }
 
   SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>,
               kMemoryEffectReserveSize>
       effects;
   memEffect.getEffects(effects);
   for (const auto &effect : effects) {
-    if (!isa<MemoryEffects::Read, MemoryEffects::Write>(effect.getEffect()))
+    if (!isa<MemoryEffects::Read, MemoryEffects::Write>(effect.getEffect())) {
       continue;
+    }
     Value value = effect.getValue();
-    if (!value || !GetBufferSpaceAttr(value))
+    if (!value || !GetBufferSpaceAttr(value)) {
       continue;
-    if (!llvm::is_contained(buffers, value))
+    }
+    if (!llvm::is_contained(buffers, value)) {
       buffers.push_back(value);
+    }
   }
   sortValuesByStableOrder(buffers, stableValueOrder);
   return buffers;
@@ -305,8 +336,9 @@ getScratchConflictPairsFromEffects(Operation *op, ValueRange dpsInits,
       getScratchBuffersFromEffects(op, dpsInits, stableValueOrder);
   for (Value scratch : scratchBuffers) {
     for (Value dst : dpsInits) {
-      if (!scratch || !dst || scratch == dst)
+      if (!scratch || !dst || scratch == dst) {
         continue;
+      }
       conflictPairs.emplace_back(scratch, dst);
     }
   }
@@ -336,14 +368,16 @@ static LogicalResult analyzeReserveBufferPlans(func::FuncOp funcOp,
   funcOp.walk(
       [&](ReserveBufferOp reserveOp) { reserveOps.push_back(reserveOp); });
 
-  if (reserveOps.empty())
+  if (reserveOps.empty()) {
     return success();
+  }
 
   for (ReserveBufferOp reserveOp : reserveOps) {
     AddressSpace as = reserveOp.getLocation().getAddressSpace();
     auto spec = getLocalMemSpec(reserveOp.getOperation(), as);
-    if (spec.capacityBits <= 0 || spec.alignBytes <= 0)
+    if (spec.capacityBits <= 0 || spec.alignBytes <= 0) {
       return reserveOp.emitOpError("unsupported reserve_buffer location");
+    }
 
     int64_t capacityBytes = spec.capacityBits / kBitsPerByte;
     int64_t sizeBytes = reserveOp.getSize();
@@ -370,8 +404,9 @@ static LogicalResult analyzeReserveBufferPlans(func::FuncOp funcOp,
     // In manual mode, reserve_buffer.base is already fixed by the frontend or
     // an earlier stage. Only basic validation is needed here.
     auto baseAttr = reserveOp.getBaseAttr();
-    if (!baseAttr)
+    if (!baseAttr) {
       return reserveOp.emitOpError("expects 'base' when 'auto' is false");
+    }
 
     int64_t baseBytes = baseAttr.getInt();
     if (baseBytes % spec.alignBytes != 0) {
@@ -401,8 +436,9 @@ static LogicalResult assignAutoReserveBufferBases(
     const BufferInfo &bufferInfo = it.second;
 
     auto offsetsIt = buffer2Offsets.find(buffer);
-    if (offsetsIt == buffer2Offsets.end())
+    if (offsetsIt == buffer2Offsets.end()) {
       continue;
+    }
 
     // Reserve-buffer allocation intentionally happens after normal MemPlan.
     // Reconstruct the already occupied byte ranges from the planned local
@@ -437,12 +473,14 @@ static LogicalResult assignAutoReserveBufferBases(
     ranges.swap(merged);
   };
 
-  for (auto &it : occupiedByAddressSpace)
+  for (auto &it : occupiedByAddressSpace) {
     normalizeRanges(it.second);
+  }
 
   for (ReserveBufferPlan &plan : plans) {
-    if (plan.mode != ReserveBufferMode::Auto || !plan.reserveOp)
+    if (plan.mode != ReserveBufferMode::Auto || !plan.reserveOp) {
       continue;
+    }
 
     SmallVector<OccupiedByteRange> &occupied =
         occupiedByAddressSpace[plan.addressSpace];
@@ -453,8 +491,9 @@ static LogicalResult assignAutoReserveBufferBases(
     int64_t candidateBase = 0;
     for (const OccupiedByteRange &range : occupied) {
       candidateBase = alignUpBytes(candidateBase, plan.alignBytes);
-      if (candidateBase + plan.sizeBytes <= range.begin)
+      if (candidateBase + plan.sizeBytes <= range.begin) {
         break;
+      }
       candidateBase = std::max(candidateBase, range.end);
     }
     candidateBase = alignUpBytes(candidateBase, plan.alignBytes);
@@ -538,8 +577,9 @@ void MemLivenessAnalysis::RecursionIR(Region *region, Liveness live) {
       if (allocTileOp.getAddr()) {
         return WalkResult::advance();
       }
-      if (isA5IgnoredTmpAlloc(allocTileOp))
+      if (isA5IgnoredTmpAlloc(allocTileOp)) {
         return WalkResult::advance();
+      }
       auto memorySpaceAttr = GetBufferSpaceAttr(allocTileOp.getResult());
       if (!isLocalBuffer(memorySpaceAttr)) {
         allocTileOp.emitError("Alloc tile buffer not at local space");
@@ -562,8 +602,9 @@ void MemLivenessAnalysis::RecursionIR(Region *region, Liveness live) {
       return WalkResult::advance();
     } else if (isLocalMemPlan() && dyn_cast<pto::AllocMultiTileOp>(op)) {
       auto allocMultiOp = cast<pto::AllocMultiTileOp>(op);
-      if (allocMultiOp.getAddr())
+      if (allocMultiOp.getAddr()) {
         return WalkResult::advance();
+      }
       auto memorySpaceAttr = GetBufferSpaceAttr(allocMultiOp.getResult());
       if (!isLocalBuffer(memorySpaceAttr)) {
         allocMultiOp.emitError("Alloc multi tile buffer not at local space");
@@ -700,8 +741,9 @@ void MemLivenessAnalysis::UpdateForOpBufferAlias(scf::ForOp forOp) {
       UpdateBufferAlias(forOp.getYieldedValues()[i], arg);
     }
   }
-  if (forOp->getResults().size() != forOp.getYieldedValues().size())
+  if (forOp->getResults().size() != forOp.getYieldedValues().size()) {
     llvm::report_fatal_error("scf.for result/yield sizes are inconsistent");
+  }
   for (auto [i, arg] : llvm::enumerate(forOp.getYieldedValues())) {
     // forOp result values alias region iter yielded values.
     UpdateBufferAlias(forOp->getResult(i), arg);
@@ -723,8 +765,9 @@ void MemLivenessAnalysis::UpdateForOpInitArgsAlias(scf::ForOp forOp) {
   if (forOp.getInitArgs().empty()) {
     return;
   }
-  if (forOp.getInitArgs().size() != forOp.getRegionIterArgs().size())
+  if (forOp.getInitArgs().size() != forOp.getRegionIterArgs().size()) {
     llvm::report_fatal_error("scf.for init/iter-arg sizes are inconsistent");
+  }
   for (auto [i, arg] : llvm::enumerate(forOp.getInitArgs())) {
     // init args alias region iter args.
     UpdateBufferAlias(forOp.getRegionIterArgs()[i], arg);
@@ -736,8 +779,9 @@ void MemLivenessAnalysis::UpdateIfOpBufferAlias(scf::IfOp ifOp,
   if (ifOp.getResults().empty()) {
     return;
   }
-  if (ifOp->getResults().size() != yieldOp->getOperands().size())
+  if (ifOp->getResults().size() != yieldOp->getOperands().size()) {
     llvm::report_fatal_error("scf.if result/yield sizes are inconsistent");
+  }
   for (auto [i, arg] : llvm::enumerate(yieldOp->getOperands())) {
     // Multiple buffers involved, requiring one-to-one correspondence.
     UpdateBufferAlias(ifOp->getResult(i), arg);
@@ -762,8 +806,9 @@ void MemLivenessAnalysis::RecursiveIfOp(scf::IfOp ifOp, Liveness live) {
 
 void MemLivenessAnalysis::UpdateFusionRegionBufferAlias(
     pto::FusionRegionOp fusionRegion, pto::YieldOp yieldOp) {
-  if (fusionRegion.getResults().empty())
+  if (fusionRegion.getResults().empty()) {
     return;
+  }
   if (fusionRegion->getResults().size() != yieldOp->getOperands().size()) {
     llvm::report_fatal_error(
         "pto.fusion_region result/yield sizes are inconsistent");
@@ -780,8 +825,9 @@ void MemLivenessAnalysis::RecursiveFusionRegionOp(pto::FusionRegionOp fusionRegi
 
   auto yieldOp =
       dyn_cast<pto::YieldOp>(fusionRegion.getBody().front().getTerminator());
-  if (!yieldOp)
+  if (!yieldOp) {
     llvm::report_fatal_error("pto.fusion_region must terminate with pto.yield");
+  }
   UpdateFusionRegionBufferAlias(fusionRegion, yieldOp);
 
   auto regionEnd = UpdateLinearOperation(fusionRegion.getOperation());
@@ -807,8 +853,9 @@ SmallVector<Value> MemLivenessAnalysis::GetLiveBuffersInLoop(scf::ForOp forOp,
     aliasBuffers.insert(operand);
     for (auto Buffer : aliasBuffers) {
       auto iter = buffer2status.find(Buffer);
-      if (iter != buffer2status.end())
+      if (iter != buffer2status.end()) {
         allocBeforeLoopBuffers.push_back(Buffer);
+      }
     }
   }
   sortValuesByStableOrder(allocBeforeLoopBuffers, stableValueOrder);
@@ -818,7 +865,6 @@ SmallVector<Value> MemLivenessAnalysis::GetLiveBuffersInLoop(scf::ForOp forOp,
 bool MemLivenessAnalysis::isSkippableOp(Operation *op) const {
   // Call-like ops are still modeled explicitly. Only pure terminators and
   // dim queries are skipped here.
-  //
   return isa<func::ReturnOp, scf::YieldOp, pto::YieldOp>(op);
 }
 
@@ -871,8 +917,9 @@ SetVector<Value> MemLivenessAnalysis::Union(SetVector<Value> set1,
 }
 
 SetVector<Value> MemLivenessAnalysis::GetAliasBuffers(Value aliasBuffer) {
-  if (!aliasBuffer)
+  if (!aliasBuffer) {
     return {};
+  }
 
   auto trueVar = buffer2AliasVec.find(aliasBuffer);
   if (trueVar != buffer2AliasVec.end()) {
@@ -909,8 +956,9 @@ void MemLivenessAnalysis::UpdateOpGenInfo(OpInfo *opInfo,
 
 void MemLivenessAnalysis::UpdateOperandGenInfo(OpInfo *opInfo, Value operand) {
   auto iter_buffer = buffer2status.find(operand);
-  if (iter_buffer == buffer2status.end())
+  if (iter_buffer == buffer2status.end()) {
     return;
+  }
   if (iter_buffer->second == BufferStatus::DEFFINED) {
     genKillMap[opInfo].gen.push_back(operand);
     buffer2status[iter_buffer->first] = BufferStatus::GENED;
@@ -942,8 +990,9 @@ void MemLivenessAnalysis::UpdateOpKillInfo(OpInfo *opInfo, Value operand,
   aliasBuffers.insert(operand);
   for (Value aliasBuffer : aliasBuffers) {
     auto iterBuffer = buffer2status.find(aliasBuffer);
-    if (iterBuffer == buffer2status.end())
+    if (iterBuffer == buffer2status.end()) {
       return;
+    }
     if (iterBuffer->second == BufferStatus::GENED &&
         IsInSameBlock(iterBuffer->first.getDefiningOp(), opInfo->operation) &&
         AllDeadAfter(opInfo->operation, aliasBuffers, live)) {
@@ -974,24 +1023,29 @@ void MemLivenessAnalysis::RecordSemanticConflict(Value lhs, Value rhs) {
   rhsAliases.insert(rhs);
 
   auto appendUniquePair = [&](Value a, Value b) {
-    if (!a || !b || a == b)
+    if (!a || !b || a == b) {
       return;
+    }
     ValuePair pair = isLessValue(a, b) ? ValuePair(a, b) : ValuePair(b, a);
-    if (!llvm::is_contained(semanticConflictPairs, pair))
+    if (!llvm::is_contained(semanticConflictPairs, pair)) {
       semanticConflictPairs.push_back(pair);
+    }
   };
 
-  for (Value a : lhsAliases)
-    for (Value b : rhsAliases)
+  for (Value a : lhsAliases) {
+    for (Value b : rhsAliases) {
       appendUniquePair(a, b);
+    }
+  }
 }
 
 BufferInfo MemLivenessAnalysis::GenerateBufferInfo(Operation *op,
                                                    Value operand) {
   auto memorySpaceAttr = GetBufferSpaceAttr(operand);
   if (isLocalMemPlan() && isLocalBuffer(memorySpaceAttr)) {
-    if (!memorySpaceAttr.has_value())
+    if (!memorySpaceAttr.has_value()) {
       llvm::report_fatal_error("local buffer must have memory space");
+    }
     return GetBufferInfo(op, operand,
                          memorySpaceAttr.value().getAddressSpace());
   }
@@ -1017,9 +1071,10 @@ BufferInfo MemLivenessAnalysis::GetBufferInfo(Operation *op, Value operand,
     llvm_unreachable("local memory planner expects tile buffer roots");
   }
   bufferInfo.bufferType = elementType;
-  if (!footprintBytes.has_value())
+  if (!footprintBytes.has_value()) {
     llvm::report_fatal_error(
         "failed to obtain buffer static physical footprint");
+  }
   bufferInfo.constBits = footprintBytes.value() * kBitsPerByte;
   return bufferInfo;
 }
@@ -1042,8 +1097,9 @@ void MemLivenessAnalysis::GenerateBufferLife() {
     // Time given to buffer end.
     for (const Value &killBuffer : it->second.kill) {
       auto iter = buffer2Life.find(killBuffer);
-      if (iter == buffer2Life.end())
+      if (iter == buffer2Life.end()) {
         llvm::report_fatal_error("buffer lifetime killed before generation");
+      }
       iter->second->freeTime = scopeTime;
     }
     scopeTime++;
@@ -1062,8 +1118,9 @@ StorageEntry::GetBufferLifeByValue(const Value v) const {
 }
 
 bool MemPlan::IsReusePTOOp(Operation *op) const {
-  if (restrictInplaceAsISA)
+  if (restrictInplaceAsISA) {
     return false;
+  }
 
   // not in ISA but confirmed with hardware developers:
   // elementwise ops with the same shape and the same bitwidth operands can also
@@ -1078,8 +1135,9 @@ SmallVector<ValuePair> MemPlan::GenerateInplaceList() {
                      inplacePairList.end());
   for (auto &operationSeq : linearOperation) {
     auto it = genKillMap.find(operationSeq.get());
-    if (it == genKillMap.end())
+    if (it == genKillMap.end()) {
       continue;
+    }
     if (hasTouchOp[operationSeq->operation]) {
       continue;
     }
@@ -1091,16 +1149,18 @@ SmallVector<ValuePair> MemPlan::GenerateInplaceList() {
 
     for (const Value &genBuffer : genBuffers) {
       auto genBufferIter = bufferInfos.find(genBuffer);
-      if (genBufferIter == bufferInfos.end())
+      if (genBufferIter == bufferInfos.end()) {
         llvm::report_fatal_error("gen buffer missing from buffer info map");
+      }
       if (genBufferIter->second.ignoreInplace) {
         continue;
       }
 
       for (const Value &killBuffer : killBuffers) {
         auto killBufferIter = bufferInfos.find(killBuffer);
-        if (killBufferIter == bufferInfos.end())
+        if (killBufferIter == bufferInfos.end()) {
           llvm::report_fatal_error("kill buffer missing from buffer info map");
+        }
         if (killBufferIter->second.ignoreInplace) {
           continue;
         }
@@ -1122,8 +1182,9 @@ SmallVector<ValuePair> MemPlan::GenerateInplaceList() {
 }
 
 void MemPlan::EmitPlanMemoryFailureInfo() {
-  if (failApplyBufferInfo.empty())
+  if (failApplyBufferInfo.empty()) {
     return;
+  }
   for (auto &iter : failApplyBufferInfo) {
     AddressSpace space = iter.first;
     func_.emitError() << stringifyEnum(space) << " overflow, requires "
@@ -1165,8 +1226,9 @@ bool MemPlan::RecordOverflowIfAny() {
 
 bool MemPlan::HasSemanticConflict(const StorageEntry *entry,
                                   const BufferLifeVec &bufferLives) const {
-  if (!entry || semanticConflictPairs.empty() || bufferLives.empty())
+  if (!entry || semanticConflictPairs.empty() || bufferLives.empty()) {
     return false;
+  }
 
   auto containsPair = [&](Value lhs, Value rhs) {
     ValuePair pair = isLessValue(lhs, rhs) ? ValuePair(lhs, rhs)
@@ -1176,13 +1238,16 @@ bool MemPlan::HasSemanticConflict(const StorageEntry *entry,
 
   for (Value entryBuffer : entry->inplaceBuffers) {
     for (const auto &life : bufferLives) {
-      if (!life)
+      if (!life) {
         continue;
+      }
       Value otherBuffer = life->buffer;
-      if (!otherBuffer || entryBuffer == otherBuffer)
+      if (!otherBuffer || entryBuffer == otherBuffer) {
         continue;
-      if (containsPair(entryBuffer, otherBuffer))
+      }
+      if (containsPair(entryBuffer, otherBuffer)) {
         return true;
+      }
     }
   }
   return false;
@@ -1257,8 +1322,9 @@ void MemPlan::GenerateStorageEntry() {
   // create new storage entry.
   for (auto &operation : linearOperation) {
     auto it = genKillMap.find(operation.get());
-    if (it == genKillMap.end())
+    if (it == genKillMap.end()) {
       continue;
+    }
     SmallVector<Value> genBuffers(it->second.gen.begin(), it->second.gen.end());
     sortValuesByStableOrder(genBuffers, stableValueOrder);
     for (const Value &genBuffer : genBuffers) {
@@ -1286,8 +1352,9 @@ void MemPlan::GenerateStorageEntry() {
 void MemPlan::PrintSuccessfulAllocatedMaxBits() {
   auto it = memscope2rootStorageEntry.find(pto::AddressSpace::VEC);
   if (it != memscope2rootStorageEntry.end()) {
-    if (!it->second)
+    if (!it->second) {
       llvm::report_fatal_error("missing root storage entry for VEC scope");
+    }
     uint64_t ubAllocBits = it->second->alignedConstBits + it->second->bitsOffset;
     for (auto& child : it->second->mergedChildren) {
       ubAllocBits = std::max(ubAllocBits, child->bitsOffset + child->alignedConstBits);
@@ -1298,12 +1365,15 @@ void MemPlan::PrintSuccessfulAllocatedMaxBits() {
 }
 
 void MemPlan::ValidateParameters(std::unique_ptr<StorageEntry> &e) const {
-  if (!e->bufInfo->operation)
+  if (!e->bufInfo->operation) {
     llvm::report_fatal_error("storage entry missing defining operation");
-  if (e->bufInfo->constBits < 0U)
+  }
+  if (e->bufInfo->constBits < 0U) {
     llvm::report_fatal_error("storage entry has invalid memory size");
-  if (e->bufferLifeVec.empty())
+  }
+  if (e->bufferLifeVec.empty()) {
     llvm::report_fatal_error("storage entry missing lifetime information");
+  }
 }
 
 void MemPlan::UpdateBuffer2Offsets() {
@@ -1313,16 +1383,18 @@ void MemPlan::UpdateBuffer2Offsets() {
     // skip the sibling offsets would be appended in StorageEntryVec order
     // rather than slot order, breaking the runtime contract that
     // `buffer2Offsets[buffer][k]` is slot k's physical offset.
-    if (e->isMultiBufferSlot)
+    if (e->isMultiBufferSlot) {
       continue;
+    }
     for (Value &buffer : e->inplaceBuffers) {
       buffer2Offsets[buffer].push_back(
           (e->bitsOffset + kBitsToByte - 1) / kBitsToByte);
       // Multi-buffer primary: append sibling offsets in slot order so the
       // final offsets list is [slot0, slot1, ..., slotN-1].
       for (auto *sibling : e->relationOtherBuffers) {
-        if (!sibling)
+        if (!sibling) {
           continue;
+        }
         buffer2Offsets[buffer].push_back(
             (sibling->bitsOffset + kBitsToByte - 1) / kBitsToByte);
       }
@@ -1359,8 +1431,9 @@ void MemPlan::MergeInplaceSE() {
       // already same storageEntry, no need to inplace.
       continue;
     }
-    if (genSE == nullptr || killSE == nullptr)
+    if (genSE == nullptr || killSE == nullptr) {
       llvm::report_fatal_error("invalid storage entry during inplace merge");
+    }
     BufferLifeVec mergedBufferLifeVec;
     mergedBufferLifeVec.insert(mergedBufferLifeVec.end(),
                                genSE->bufferLifeVec.begin(),
@@ -1463,8 +1536,9 @@ void MemPlan::ExpandMultiBufferStorageEntry() {
   size_t size = StorageEntryVec.size();
   for (size_t i = 0; i < size; i++) {
     auto *primary = StorageEntryVec[i].get();
-    if (primary->multiBufferNum <= 1)
+    if (primary->multiBufferNum <= 1) {
       continue;
+    }
     uint32_t n = primary->multiBufferNum;
     for (uint32_t slot = 1; slot < n; ++slot) {
       auto entry = std::make_unique<StorageEntry>();
@@ -1477,8 +1551,9 @@ void MemPlan::ExpandMultiBufferStorageEntry() {
       primary->relationOtherBuffers.push_back(entry.get());
       StorageEntryVec.push_back(std::move(entry));
     }
-    if (!primary->relationOtherBuffers.empty())
+    if (!primary->relationOtherBuffers.empty()) {
       primary->relationPongEntry = primary->relationOtherBuffers.front();
+    }
   }
 }
 
@@ -1487,8 +1562,9 @@ bool MemPlan::IsEnoughForBuffersNoReuse(StorageEntry *rootStorageEntry,
                                         size_t alignUnit) {
   auto iter =
       bufferScope2RequiredSize.find(rootStorageEntry->bufInfo->bufferScope);
-  if (iter == bufferScope2RequiredSize.end())
+  if (iter == bufferScope2RequiredSize.end()) {
     llvm::report_fatal_error("missing required-size entry for buffer scope");
+  }
   if (iter->second < restBufferSize) {
     // Even when the scope fits without reuse (no peak to save), honor
     // largest-first placement so the option means the same thing on both paths:
@@ -1595,16 +1671,18 @@ PlanStatus MemPlan::PlanMemAddressOfWholeLocalBuffer() {
     size_t maxBits = bufferSpaceInfo.second;
     if (rootStorageEntry->mergedChildren.empty()) {
       PlanStatus status = PlanSingleLocalBuffer(rootStorageEntry, align, maxBits);
-      if (status != PlanStatus::PLAN_SUCCESS)
+      if (status != PlanStatus::PLAN_SUCCESS) {
         return status;
+      }
       continue;
     }
     if (IsEnoughForBuffersNoReuse(rootStorageEntry, maxBits, align)) {
       continue;
     }
     PlanStatus status = PlanReusableLocalBuffer(rootStorageEntry, align, maxBits);
-    if (status != PlanStatus::PLAN_SUCCESS)
+    if (status != PlanStatus::PLAN_SUCCESS) {
       return status;
+    }
   }
   planStatus = PlanStatus::PLAN_SUCCESS;
   return planStatus;
@@ -1666,8 +1744,9 @@ PlanStatus MemPlan::PlanReusableLocalBuffer(StorageEntry *rootStorageEntry,
         return status;
       }
     }
-    if (si.childIdx >= childrenNum)
+    if (si.childIdx >= childrenNum) {
       break;
+    }
     curEntry = rootStorageEntry->mergedChildren[si.childIdx];
   }
   return PlanStatus::PLAN_SUCCESS;
@@ -1932,8 +2011,9 @@ MemPlan::GetBufferParentLoop(const SmallVector<Value> &buffers) {
   llvm::SmallSet<LoopLikeOpInterface, 1> parentLoopVec;
   for (auto buffer : buffers) {
     if (!buffer.getDefiningOp()) {
-      if (!isa<scf::ForOp>(buffer.getParentBlock()->getParentOp()))
+      if (!isa<scf::ForOp>(buffer.getParentBlock()->getParentOp())) {
         llvm::report_fatal_error("expected loop-carried block argument");
+      }
       // Init args and region iter arg are inplace, ignore Region Iter Arg
       // without DefineOp.
       continue;
@@ -2035,8 +2115,9 @@ void MemPlan::SpecAllocRelationPongEntry(MemBoundList &outline, PlanRecHis &his,
       if (e->multiBufferNum == kDoubleBufferCount && e->relationPongEntry) {
         pongStorageEntry = e->relationPongEntry;
       }
-      if (!pongStorageEntry)
+      if (!pongStorageEntry) {
         llvm::report_fatal_error("pong storage entry not found");
+      }
       UpdateOutline(outline, his, pongStorageEntry,
                     OutlineSectionInfo(start, end, size, true), SPEC_LEVEL_1);
       return;
@@ -2048,8 +2129,9 @@ bool MemPlan::IsBufferLifeVecConflict(PlanRecord &r, uint64_t offset,
                                       const StorageEntry *e) const {
   if ((r.firstMemBound->offset + r.allExtent > offset) &&
       (r.firstMemBound->offset < offset + e->alignedConstBits)) {
-    if (HasSemanticConflict(e, r.firstMemBound->bufferLifeVec))
+    if (HasSemanticConflict(e, r.firstMemBound->bufferLifeVec)) {
       return true;
+    }
     DenseMap<ValuePair, BufferLife> intersection =
         GetOverlapBufferLife(r.entry->bufferLifeVec, e->bufferLifeVec);
     return !intersection.empty();
@@ -2266,8 +2348,9 @@ bool MemPlan::IsSamePlanAsLastRollBack(uint64_t allocOffset, int curChildIdx,
 inline bool
 MemPlan::VerifyConflictStage0(StorageEntry *e,
                               const std::shared_ptr<MemoryBound> &last) {
-  if (HasSemanticConflict(e, last->bufferLifeVec))
+  if (HasSemanticConflict(e, last->bufferLifeVec)) {
     return true;
+  }
   // level_0: offset = 0, offset means life distance
   DenseMap<ValuePair, BufferLife> intersection =
       GetOverlapBufferLife(e->bufferLifeVec, last->bufferLifeVec);
@@ -2368,8 +2451,9 @@ void MemPlan::ReportAllocatedEntryDebugInfo(StorageEntry *rootStorageEntry) {
       LDBG("\n");
     }
     size_t num = allocatedEntry.size() - 1;
-    if (rootStorageEntry->mergedChildren.size() <= num)
+    if (rootStorageEntry->mergedChildren.size() <= num) {
       llvm::report_fatal_error("missing failed storage entry");
+    }
     const StorageEntry *failedSe = rootStorageEntry->mergedChildren[num];
     printRecord(failedSe);
     LDBG("alloc fail,because exceed bound of memory \n"
@@ -2522,16 +2606,19 @@ public:
 
   LogicalResult matchAndRewrite(pto::AllocTileOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op.getAddr())
+    if (op.getAddr()) {
       return failure();
+    }
 
     auto tileType = dyn_cast<TileBufType>(op.getResult().getType());
-    if (!tileType)
+    if (!tileType) {
       return failure();
+    }
 
     auto it = buffer2Offsets.find(op.getResult());
-    if (it == buffer2Offsets.end() || it->second.empty())
+    if (it == buffer2Offsets.end() || it->second.empty()) {
       return failure();
+    }
 
     if (it->second.size() != 1) {
       return rewriter.notifyMatchFailure(
@@ -2545,8 +2632,9 @@ public:
         op.getValidRow() ? op.getValidRow() : Value(),
         op.getValidCol() ? op.getValidCol() : Value());
     for (NamedAttribute attr : op->getAttrs()) {
-      if (attr.getName().getValue() == "operandSegmentSizes")
+      if (attr.getName().getValue() == "operandSegmentSizes") {
         continue;
+      }
       planned->setAttr(attr.getName(), attr.getValue());
     }
 
@@ -2569,11 +2657,13 @@ public:
 
   LogicalResult matchAndRewrite(pto::AllocMultiTileOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op.getAddr() || op->hasAttr(pto::kPtoMultiBufferAddrsAttrName))
+    if (op.getAddr() || op->hasAttr(pto::kPtoMultiBufferAddrsAttrName)) {
       return failure();
+    }
     auto it = buffer2Offsets.find(op.getResult());
-    if (it == buffer2Offsets.end() || it->second.empty())
+    if (it == buffer2Offsets.end() || it->second.empty()) {
       return failure();
+    }
     if (it->second.size() != op.getResult().getType().getCount()) {
       return rewriter.notifyMatchFailure(
           op, "planned address count does not match multi_tile_buf count");
@@ -2581,8 +2671,9 @@ public:
 
     SmallVector<int64_t> addrs;
     addrs.reserve(it->second.size());
-    for (uint64_t offset : it->second)
+    for (uint64_t offset : it->second) {
       addrs.push_back(static_cast<int64_t>(offset));
+    }
     rewriter.modifyOpInPlace(op, [&] {
       op->setAttr(pto::kPtoMultiBufferAddrsAttrName,
                   rewriter.getDenseI64ArrayAttr(addrs));
@@ -2599,8 +2690,9 @@ static FailureOr<MemPlanMode> parseLegacyMemPlanMode(func::FuncOp func,
   if (memMode.equals_insensitive("local") ||
       memMode.equals_insensitive("local-mem-plan"))
     return MemPlanMode::LOCAL_MEM_PLAN;
-  if (memMode.equals_insensitive("global-work-space-plan"))
+  if (memMode.equals_insensitive("global-work-space-plan")) {
     return MemPlanMode::GLOBAL_WORKSPACE_PLAN;
+  }
   func.emitError("unsupported mem-mode '")
       << memMode << "'; only 'local' is supported by the PTOAS pipeline";
   return failure();
@@ -2635,14 +2727,16 @@ void PlanMemoryPass::runOnOperation() {
     // TileOp helpers only contain compute code and deliberately do not own
     // alloc_tile/reserve_buffer lifetimes.  All other functions, including
     // ordinary functions in backend child modules, must be planned.
-    if (!funcOp->hasAttr("pto.tileop.helper"))
+    if (!funcOp->hasAttr("pto.tileop.helper")) {
       funcs.push_back(funcOp);
+    }
   });
 
   for (func::FuncOp funcOp : funcs) {
     auto parsedMode = parseLegacyMemPlanMode(funcOp, this->memMode);
-    if (failed(parsedMode))
+    if (failed(parsedMode)) {
       return signalPassFailure();
+    }
     MemPlanMode mode = *parsedMode;
     ReserveBufferPlans reservePlans;
     if (mode == MemPlanMode::LOCAL_MEM_PLAN &&
@@ -2651,8 +2745,9 @@ void PlanMemoryPass::runOnOperation() {
     }
     if (mode == MemPlanMode::LOCAL_MEM_PLAN) {
       for (ReserveBufferPlan &reservePlan : reservePlans) {
-        if (reservePlan.mode != ReserveBufferMode::Manual)
+        if (reservePlan.mode != ReserveBufferMode::Manual) {
           continue;
+        }
         reservePlan.reserveOp.emitOpError(
             "pto.reserve_buffer with explicit 'base' (auto = false) is not "
             "supported in PlanMemory; use --pto-level=level3 or set auto = true");
@@ -2700,18 +2795,22 @@ void PlanMemoryPass::runOnOperation() {
 
     bool hasUnplannedAllocTile = false;
     funcOp.walk([&](pto::AllocTileOp op) {
-      if (op.getAddr())
+      if (op.getAddr()) {
         return;
-      if (op->use_empty())
+      }
+      if (op->use_empty()) {
         return;
-      if (isA5IgnoredTmpAlloc(op))
+      }
+      if (isA5IgnoredTmpAlloc(op)) {
         return;
+      }
       op.emitError(
           "PTOPlanMemory failed to assign an address to pto.alloc_tile");
       hasUnplannedAllocTile = true;
     });
-    if (hasUnplannedAllocTile)
+    if (hasUnplannedAllocTile) {
       return signalPassFailure();
+    }
   }
 }
 

--- a/lib/PTO/Transforms/PTOPlanMemory.h
+++ b/lib/PTO/Transforms/PTOPlanMemory.h
@@ -37,7 +37,7 @@ struct ValueComparator {
 using StableValueOrderMap = DenseMap<Value, uint32_t>;
 
 /// Various states when collecting gen-kill.
-enum BufferStatus { UNDEFFINED = 0, DEFFINED, GENED, KILLED };
+enum class BufferStatus { UNDEFFINED = 0, DEFFINED, GENED, KILLED };
 
 /// Pair of inplace Value.
 using ValuePair = std::pair<Value, Value>;
@@ -48,7 +48,7 @@ enum class MemPlanMode {
 };
 
 /// Result status after plan memory.
-enum PlanStatus {
+enum class PlanStatus {
   PLAN_SUCCESS = 0,
   RESTART_NEW_PLAN,
   CONTINUE_PLAN,
@@ -116,7 +116,7 @@ struct GenKillEntry {
 struct BufferLife {
   BufferLife(Value buffer, int64_t start, int64_t end)
       : buffer(buffer), allocTime(start), freeTime(end) {}
-  BufferLife(Value buffer) : buffer(buffer) {}
+  explicit BufferLife(Value buffer) : buffer(buffer) {}
   /// buffer value.
   Value buffer;
   /// the buffer allocate time.
@@ -805,7 +805,6 @@ private:
 
   /// The device's SCALING storage size
   int scalingSpaceSize{0};
-
 };
 } // namespace pto
 } // namespace mlir

--- a/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
+++ b/lib/PTO/Transforms/PTOPlanMemoryModern.cpp
@@ -95,21 +95,24 @@ struct ReuseGroup {
 };
 
 static uint64_t alignUp(uint64_t value, uint64_t align) {
-  if (align == 0)
+  if (align == 0) {
     return value;
+  }
   return ((value + align - 1) / align) * align;
 }
 
 static std::optional<AddressSpace> getBufferAddressSpace(Type type) {
   if (auto tileType = dyn_cast<TileBufType>(type)) {
     if (auto attr =
-            dyn_cast_or_null<AddressSpaceAttr>(tileType.getMemorySpace()))
+            dyn_cast_or_null<AddressSpaceAttr>(tileType.getMemorySpace())) {
       return attr.getAddressSpace();
+    }
     return std::nullopt;
   }
 
-  if (auto multiType = dyn_cast<MultiTileBufType>(type))
+  if (auto multiType = dyn_cast<MultiTileBufType>(type)) {
     return getBufferAddressSpace(multiType.getSlotType());
+  }
 
   return std::nullopt;
 }
@@ -133,19 +136,23 @@ static bool isIgnoredA5TmpOperandUse(OpOperand &use) {
   StringRef name = owner->getName().getStringRef();
 
   if (auto dpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(owner)) {
-    if (llvm::is_contained(dpsOp.getDpsInits(), use.get()))
+    if (llvm::is_contained(dpsOp.getDpsInits(), use.get())) {
       return false;
+    }
   } else if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(owner)) {
-    if (llvm::is_contained(dpsOp.getDpsInits(), use.get()))
+    if (llvm::is_contained(dpsOp.getDpsInits(), use.get())) {
       return false;
+    }
   }
 
   if (isNameIn(name, {"pto.trowargmax", "pto.trowargmin", "pto.trowmax",
-                     "pto.trowmin", "pto.trowsum", "pto.trowprod"}))
+                     "pto.trowmin", "pto.trowsum", "pto.trowprod"})) {
     return operandNo == 1;
+  }
 
-  if (name == "pto.txors")
+  if (name == "pto.txors") {
     return operandNo == 2;
+  }
 
   if (isNameIn(name, {"pto.tprelu", "pto.txor", "pto.tsels",
                      "pto.trowexpand", "pto.tcolexpand",
@@ -158,23 +165,27 @@ static bool isIgnoredA5TmpOperandUse(OpOperand &use) {
                      "pto.tcolexpandmul", "pto.tcolexpandsub"}))
     return operandNo == 2;
 
-  if (name == "pto.tsel")
+  if (name == "pto.tsel") {
     return operandNo == 3;
+  }
 
   return false;
 }
 
 static bool isA5IgnoredTmpAlloc(pto::AllocTileOp allocTile) {
-  if (getTargetArch(allocTile.getOperation()) != PTOArch::A5)
+  if (getTargetArch(allocTile.getOperation()) != PTOArch::A5) {
     return false;
+  }
 
   Value value = allocTile.getResult();
-  if (value.use_empty())
+  if (value.use_empty()) {
     return false;
+  }
 
   for (OpOperand &use : value.getUses()) {
-    if (!isIgnoredA5TmpOperandUse(use))
+    if (!isIgnoredA5TmpOperandUse(use)) {
       return false;
+    }
   }
   return true;
 }
@@ -182,18 +193,18 @@ static bool isA5IgnoredTmpAlloc(pto::AllocTileOp allocTile) {
 static MemSpec getMemSpec(PTOArch arch, AddressSpace space) {
   switch (space) {
   case AddressSpace::VEC:
-    return {arch == PTOArch::A5 ? 253952ull : 196608ull, 256};
+    return {arch == PTOArch::A5 ? 253952ULL : 196608ULL, 256};
   case AddressSpace::MAT:
-    return {524288ull, 256};
+    return {524288ULL, 256};
   case AddressSpace::LEFT:
   case AddressSpace::RIGHT:
-    return {65536ull, 4096};
+    return {65536ULL, 4096};
   case AddressSpace::ACC:
-    return {arch == PTOArch::A5 ? 262144ull : 131072ull, 4096};
+    return {arch == PTOArch::A5 ? 262144ULL : 131072ULL, 4096};
   case AddressSpace::BIAS:
-    return {65536ull, 256};
+    return {65536ULL, 256};
   case AddressSpace::SCALING:
-    return {arch == PTOArch::A5 ? 253952ull : 196608ull, 256};
+    return {arch == PTOArch::A5 ? 253952ULL : 196608ULL, 256};
   case AddressSpace::GM:
   case AddressSpace::Zero:
     break;
@@ -205,50 +216,58 @@ static FailureOr<uint64_t> computeStaticBufferBytes(Value value) {
   auto computeTileBytes = [](TileBufType type) -> FailureOr<uint64_t> {
     ArrayRef<int64_t> shape = type.getShape();
     uint64_t elemBytes = getPTOStorageElemByteSize(type.getElementType());
-    if (elemBytes == 0)
+    if (elemBytes == 0) {
       return failure();
+    }
 
     if (type.getCompactModeI32() ==
         static_cast<int32_t>(CompactMode::RowPlusOne)) {
       if (shape.size() != 2 ||
-          llvm::is_contained(shape, ShapedType::kDynamic))
+          llvm::is_contained(shape, ShapedType::kDynamic)) {
         return failure();
+      }
 
       bool rowMajor = type.getBLayoutValueI32() ==
                       static_cast<int32_t>(BLayout::RowMajor);
       uint64_t major = static_cast<uint64_t>(rowMajor ? shape[0] : shape[1]);
       uint64_t minor = static_cast<uint64_t>(rowMajor ? shape[1] : shape[0]);
-      if (major == 0 || minor == 0)
+      if (major == 0 || minor == 0) {
         return uint64_t{0};
+      }
       return ((major - 1) * (minor + 1) + minor) * elemBytes;
     }
 
     uint64_t numel = 1;
     for (int64_t dim : shape) {
-      if (dim == ShapedType::kDynamic)
+      if (dim == ShapedType::kDynamic) {
         return failure();
+      }
       numel *= static_cast<uint64_t>(dim);
     }
     return numel * elemBytes;
   };
 
-  if (auto tileType = dyn_cast<TileBufType>(value.getType()))
+  if (auto tileType = dyn_cast<TileBufType>(value.getType())) {
     return computeTileBytes(tileType);
-  if (auto multiType = dyn_cast<MultiTileBufType>(value.getType()))
+  }
+  if (auto multiType = dyn_cast<MultiTileBufType>(value.getType())) {
     return computeTileBytes(multiType.getSlotType());
+  }
   return failure();
 }
 
 static void appendUniqueRoot(RootList &roots, Value root) {
-  if (llvm::is_contained(roots, root))
+  if (llvm::is_contained(roots, root)) {
     return;
+  }
   roots.push_back(root);
 }
 
 static RootList unionRoots(const RootList &lhs, const RootList &rhs) {
   RootList result = lhs;
-  for (Value root : rhs)
+  for (Value root : rhs) {
     appendUniqueRoot(result, root);
+  }
   return result;
 }
 
@@ -314,39 +333,48 @@ static SmallVector<Value> getWrittenNonDpsOperands(Operation *op,
                                                    ValueRange dpsInits) {
   SmallVector<Value> scratchOperands;
   auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!memEffect)
+  if (!memEffect) {
     return scratchOperands;
+  }
 
   SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 8> effects;
   memEffect.getEffects(effects);
   for (const auto &effect : effects) {
-    if (!isa<MemoryEffects::Write>(effect.getEffect()))
+    if (!isa<MemoryEffects::Write>(effect.getEffect())) {
       continue;
+    }
     Value value = effect.getValue();
-    if (!value)
+    if (!value) {
       continue;
-    if (!llvm::is_contained(op->getOperands(), value))
+    }
+    if (!llvm::is_contained(op->getOperands(), value)) {
       continue;
-    if (llvm::is_contained(dpsInits, value))
+    }
+    if (llvm::is_contained(dpsInits, value)) {
       continue;
-    if (!llvm::is_contained(scratchOperands, value))
+    }
+    if (!llvm::is_contained(scratchOperands, value)) {
       scratchOperands.push_back(value);
+    }
   }
   return scratchOperands;
 }
 
 static bool hasReadEffectOnValue(Operation *op, Value value) {
   auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!memEffect)
+  if (!memEffect) {
     return false;
+  }
 
   SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 8> effects;
   memEffect.getEffects(effects);
   for (const auto &effect : effects) {
-    if (!isa<MemoryEffects::Read>(effect.getEffect()))
+    if (!isa<MemoryEffects::Read>(effect.getEffect())) {
       continue;
-    if (effect.getValue() == value)
+    }
+    if (effect.getValue() == value) {
       return true;
+    }
   }
   return false;
 }
@@ -357,10 +385,12 @@ static bool isInsideLoop(Operation *op) {
 }
 
 static ValueRange getDpsInits(Operation *op) {
-  if (auto dpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op))
+  if (auto dpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {
     return dpsOp.getDpsInits();
-  if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op))
+  }
+  if (auto dpsOp = dyn_cast<DestinationStyleOpInterface>(op)) {
     return dpsOp.getDpsInits();
+  }
   return ValueRange();
 }
 
@@ -382,30 +412,35 @@ struct PlannerAnalysis {
 
   RootList getRoots(Value value) const {
     auto it = valueToRoots.find(value);
-    if (it == valueToRoots.end())
+    if (it == valueToRoots.end()) {
       return {};
+    }
     return it->second;
   }
 
   void setRoots(Value value, const RootList &roots) {
-    if (roots.empty())
+    if (roots.empty()) {
       return;
+    }
     valueToRoots[value] = roots;
   }
 
   void mergeRoots(Value value, const RootList &roots) {
-    if (roots.empty())
+    if (roots.empty()) {
       return;
+    }
     setRoots(value, unionRoots(getRoots(value), roots));
   }
 
   void addRoot(Value value, Operation *defOp) {
-    if (rootIndexByValue.count(value))
+    if (rootIndexByValue.count(value)) {
       return;
+    }
 
     auto space = getBufferAddressSpace(value.getType());
-    if (!isPlannableLocalSpace(space))
+    if (!isPlannableLocalSpace(space)) {
       return;
+    }
 
     auto bytesOr = computeStaticBufferBytes(value);
     if (mlir::failed(bytesOr)) {
@@ -416,8 +451,9 @@ struct PlannerAnalysis {
     }
 
     uint64_t slotCount = 1;
-    if (auto multiType = dyn_cast<MultiTileBufType>(value.getType()))
+    if (auto multiType = dyn_cast<MultiTileBufType>(value.getType())) {
       slotCount = multiType.getCount();
+    }
     else if (auto attr =
                  defOp->getAttrOfType<IntegerAttr>(pto::kPtoMultiBufferAttrName))
       slotCount = attr.getValue().getZExtValue();
@@ -441,13 +477,16 @@ struct PlannerAnalysis {
   void markUse(Value value, unsigned index) {
     for (Value root : getRoots(value)) {
       auto found = rootIndexByValue.find(root);
-      if (found == rootIndexByValue.end())
+      if (found == rootIndexByValue.end()) {
         continue;
+      }
       RootInfo &info = roots[found->second];
-      if (!info.hasWriter)
+      if (!info.hasWriter) {
         info.hasUseBeforeFirstWrite = true;
-      if (index < info.allocIndex)
+      }
+      if (index < info.allocIndex) {
         info.allocIndex = index;
+      }
       info.freeIndex = std::max(info.freeIndex, index);
     }
   }
@@ -455,12 +494,14 @@ struct PlannerAnalysis {
   void markWrite(Value value, unsigned index, bool pureOverwrite) {
     for (Value root : getRoots(value)) {
       auto found = rootIndexByValue.find(root);
-      if (found == rootIndexByValue.end())
+      if (found == rootIndexByValue.end()) {
         continue;
+      }
       RootInfo &info = roots[found->second];
       if (!info.hasWriter) {
-        if (pureOverwrite && !info.hasUseBeforeFirstWrite)
+        if (pureOverwrite && !info.hasUseBeforeFirstWrite) {
           info.allocIndex = index;
+        }
         info.hasWriter = true;
       }
       info.freeIndex = std::max(info.freeIndex, index);
@@ -468,33 +509,40 @@ struct PlannerAnalysis {
   }
 
   void addForbidAlias(Value a, Value b) {
-    if (a == b)
+    if (a == b) {
       return;
-    if (!rootIndexByValue.count(a) || !rootIndexByValue.count(b))
+    }
+    if (!rootIndexByValue.count(a) || !rootIndexByValue.count(b)) {
       return;
+    }
     appendUniqueRoot(facts.forbidAlias[a], b);
     appendUniqueRoot(facts.forbidAlias[b], a);
   }
 
   bool hasForbidAlias(Value a, Value b) const {
-    if (a == b)
+    if (a == b) {
       return false;
+    }
     auto it = facts.forbidAlias.find(a);
-    if (it == facts.forbidAlias.end())
+    if (it == facts.forbidAlias.end()) {
       return false;
+    }
     return llvm::is_contained(it->second, b);
   }
 
   void addForbidAliasBetweenRoots(const RootList &lhsRoots,
                                   const RootList &rhsRoots) {
-    for (Value lhs : lhsRoots)
-      for (Value rhs : rhsRoots)
+    for (Value lhs : lhsRoots) {
+      for (Value rhs : rhsRoots) {
         addForbidAlias(lhs, rhs);
+      }
+    }
   }
 
   void markRoots(DenseSet<Value> &set, const RootList &roots) {
-    for (Value root : roots)
+    for (Value root : roots) {
       set.insert(root);
+    }
   }
 
   bool rootsContain(const DenseSet<Value> &set, const RootList &roots) const {
@@ -518,53 +566,64 @@ struct PlannerAnalysis {
   }
 
   void propagateSplitTpopDerived(Value result, ValueRange sources) {
-    if (!result)
+    if (!result) {
       return;
+    }
     if (llvm::any_of(sources, [&](Value source) {
           return isSplitTpopDerived(source);
-        }))
+        })) {
       splitTpopDerivedValues.insert(result);
+    }
   }
 
   void propagateSplitTpopDerivedFromRoots(Value result, Value source) {
-    if (!result || !source)
+    if (!result || !source) {
       return;
-    if (isSplitTpopDerived(source))
+    }
+    if (isSplitTpopDerived(source)) {
       splitTpopDerivedValues.insert(result);
+    }
   }
 
   void propagateSplitTpopDerivedFromOperands(Operation *op) {
-    if (!operandsContainSplitTpopDerived(op))
+    if (!operandsContainSplitTpopDerived(op)) {
       return;
-    for (Value result : op->getResults())
+    }
+    for (Value result : op->getResults()) {
       splitTpopDerivedValues.insert(result);
+    }
   }
 
   bool isRootDefinedInRegion(Value root, Region &region) const {
     auto it = rootIndexByValue.find(root);
-    if (it == rootIndexByValue.end())
+    if (it == rootIndexByValue.end()) {
       return false;
+    }
 
     Operation *defOp = roots[it->second].defOp;
     for (Operation *cur = defOp; cur; cur = cur->getParentOp()) {
-      if (cur->getParentRegion() == &region)
+      if (cur->getParentRegion() == &region) {
         return true;
+      }
     }
     return false;
   }
 
   void addBranchExclusivePair(Value lhs, Value rhs) {
-    if (lhs == rhs)
+    if (lhs == rhs) {
       return;
-    if (!rootIndexByValue.count(lhs) || !rootIndexByValue.count(rhs))
+    }
+    if (!rootIndexByValue.count(lhs) || !rootIndexByValue.count(rhs)) {
       return;
+    }
     appendUniqueRoot(facts.branchExclusiveRoots[lhs], rhs);
     appendUniqueRoot(facts.branchExclusiveRoots[rhs], lhs);
   }
 
   void recordIfBranchExclusivity(scf::IfOp ifOp) {
-    if (ifOp.getNumResults() == 0)
+    if (ifOp.getNumResults() == 0) {
       return;
+    }
 
     auto thenYield = cast<scf::YieldOp>(ifOp.thenBlock()->getTerminator());
     auto elseYield = cast<scf::YieldOp>(ifOp.elseBlock()->getTerminator());
@@ -572,31 +631,40 @@ struct PlannerAnalysis {
          llvm::zip(thenYield.getResults(), elseYield.getResults())) {
       RootList thenLocalRoots;
       RootList elseLocalRoots;
-      for (Value root : getRoots(thenVal))
-        if (isRootDefinedInRegion(root, ifOp.getThenRegion()))
+      for (Value root : getRoots(thenVal)) {
+        if (isRootDefinedInRegion(root, ifOp.getThenRegion())) {
           appendUniqueRoot(thenLocalRoots, root);
-      for (Value root : getRoots(elseVal))
-        if (isRootDefinedInRegion(root, ifOp.getElseRegion()))
+        }
+      }
+      for (Value root : getRoots(elseVal)) {
+        if (isRootDefinedInRegion(root, ifOp.getElseRegion())) {
           appendUniqueRoot(elseLocalRoots, root);
+        }
+      }
 
-      for (Value thenRoot : thenLocalRoots)
-        for (Value elseRoot : elseLocalRoots)
+      for (Value thenRoot : thenLocalRoots) {
+        for (Value elseRoot : elseLocalRoots) {
           addBranchExclusivePair(thenRoot, elseRoot);
+        }
+      }
     }
   }
 
   void recordDpsScratchConflicts(Operation *op, ValueRange dpsInits) {
     RootList outputRoots;
-    for (Value init : dpsInits)
+    for (Value init : dpsInits) {
       outputRoots = unionRoots(outputRoots, getRoots(init));
-    if (outputRoots.empty())
+    }
+    if (outputRoots.empty()) {
       return;
+    }
 
     for (Value scratch : getWrittenNonDpsOperands(op, dpsInits)) {
       addForbidAliasBetweenRoots(getRoots(scratch), outputRoots);
       for (Value operand : op->getOperands()) {
-        if (operand == scratch || llvm::is_contained(dpsInits, operand))
+        if (operand == scratch || llvm::is_contained(dpsInits, operand)) {
           continue;
+        }
         addForbidAliasBetweenRoots(getRoots(scratch), getRoots(operand));
       }
     }
@@ -604,34 +672,40 @@ struct PlannerAnalysis {
 
   void recordInplacePolicyConflicts(Operation *op, ValueRange dpsInits) {
     RootList outputRoots;
-    for (Value init : dpsInits)
+    for (Value init : dpsInits) {
       outputRoots = unionRoots(outputRoots, getRoots(init));
-    if (outputRoots.empty())
+    }
+    if (outputRoots.empty()) {
       return;
+    }
 
     InplacePolicy policy = getInplacePolicy(op);
     if (policy.notInplaceSafe) {
       for (Value operand : op->getOperands()) {
-        if (llvm::is_contained(dpsInits, operand))
+        if (llvm::is_contained(dpsInits, operand)) {
           continue;
+        }
         addForbidAliasBetweenRoots(getRoots(operand), outputRoots);
       }
     }
 
     for (unsigned operandIndex : policy.forbidOutputAliasOperands) {
-      if (operandIndex >= op->getNumOperands())
+      if (operandIndex >= op->getNumOperands()) {
         continue;
+      }
       Value operand = op->getOperand(operandIndex);
-      if (llvm::is_contained(dpsInits, operand))
+      if (llvm::is_contained(dpsInits, operand)) {
         continue;
+      }
       addForbidAliasBetweenRoots(getRoots(operand), outputRoots);
     }
   }
 
   void recordDpsInplaceConflicts(Operation *op) {
     auto dpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op);
-    if (!dpsOp)
+    if (!dpsOp) {
       return;
+    }
 
     ValueRange dpsInits = dpsOp.getDpsInits();
     recordDpsScratchConflicts(op, dpsInits);
@@ -639,35 +713,42 @@ struct PlannerAnalysis {
   }
 
   void recordLoadDerivedRoots(Operation *op, ValueRange dpsInits) {
-    if (!isa<pto::TLoadOp, pto::TPrefetchOp>(op))
+    if (!isa<pto::TLoadOp, pto::TPrefetchOp>(op)) {
       return;
+    }
 
-    for (Value init : dpsInits)
+    for (Value init : dpsInits) {
       markRoots(facts.loadDerivedRoots, getRoots(init));
+    }
   }
 
   void recordTpopConsumerRoots(Operation *op, ValueRange dpsInits,
                                unsigned opIndex) {
-    if (!facts.targetHazardEnabled)
+    if (!facts.targetHazardEnabled) {
       return;
-    if (!operandsContainSplitTpopDerived(op) || !operandsContainLoadDerivedRoot(op))
+    }
+    if (!operandsContainSplitTpopDerived(op) || !operandsContainLoadDerivedRoot(op)) {
       return;
+    }
 
     RootList outputRoots;
-    for (Value init : dpsInits)
+    for (Value init : dpsInits) {
       outputRoots = unionRoots(outputRoots, getRoots(init));
+    }
     markRoots(facts.tpopConsumerRoots, outputRoots);
     for (Value root : outputRoots) {
       SmallVector<unsigned> &indices = facts.tpopConsumerWriteIndices[root];
-      if (!llvm::is_contained(indices, opIndex))
+      if (!llvm::is_contained(indices, opIndex)) {
         indices.push_back(opIndex);
+      }
     }
   }
 
   void recordDpsTargetHazardFacts(Operation *op, unsigned opIndex) {
     auto dpsOp = dyn_cast<pto::PTO_DpsInitOpInterface>(op);
-    if (!dpsOp)
+    if (!dpsOp) {
       return;
+    }
 
     ValueRange dpsInits = dpsOp.getDpsInits();
     recordLoadDerivedRoots(op, dpsInits);
@@ -675,34 +756,41 @@ struct PlannerAnalysis {
   }
 
   void appendAccessRoots(RootList &dst, Value value) {
-    for (Value root : getRoots(value))
+    for (Value root : getRoots(value)) {
       appendUniqueRoot(dst, root);
+    }
   }
 
   void recordRootAccessStats(ArrayRef<Value> accessRoots, PIPE pipe,
                              bool isWrite, bool inLoop) {
     for (Value root : accessRoots) {
       auto found = rootIndexByValue.find(root);
-      if (found == rootIndexByValue.end())
+      if (found == rootIndexByValue.end()) {
         continue;
+      }
       RootInfo &info = roots[found->second];
       ++info.accessCount;
-      if (isWrite)
+      if (isWrite) {
         ++info.writeAccessCount;
-      if (inLoop)
+      }
+      if (inLoop) {
         ++info.loopAccessCount;
-      if (pipe == PIPE::PIPE_V)
+      }
+      if (pipe == PIPE::PIPE_V) {
         ++info.pipeVAccessCount;
-      if (pipe == PIPE::PIPE_MTE2 || pipe == PIPE::PIPE_MTE3)
+      }
+      if (pipe == PIPE::PIPE_MTE2 || pipe == PIPE::PIPE_MTE3) {
         ++info.mteAccessCount;
+      }
     }
   }
 
   void recordOpAccess(Operation *op, ValueRange dpsInits) {
     auto pipeOp = dyn_cast<pto::OpPipeInterface>(op);
     auto memEffect = dyn_cast<MemoryEffectOpInterface>(op);
-    if (!pipeOp || !memEffect)
+    if (!pipeOp || !memEffect) {
       return;
+    }
 
     OpAccess access;
     access.op = op;
@@ -714,19 +802,23 @@ struct PlannerAnalysis {
     memEffect.getEffects(effects);
     for (const auto &effect : effects) {
       Value value = effect.getValue();
-      if (!value)
+      if (!value) {
         continue;
-      if (isa<MemoryEffects::Read>(effect.getEffect()))
+      }
+      if (isa<MemoryEffects::Read>(effect.getEffect())) {
         appendAccessRoots(access.reads, value);
-      if (isa<MemoryEffects::Write>(effect.getEffect()))
+      }
+      if (isa<MemoryEffects::Write>(effect.getEffect())) {
         appendAccessRoots(access.writes, value);
+      }
     }
 
     // Some PTO tile ops expose DPS destinations through the project-specific
     // interface even when a future op forgets to model MemoryEffects. Keep the
     // performance side table conservative by treating DPS inits as writes.
-    for (Value init : dpsInits)
+    for (Value init : dpsInits) {
       appendAccessRoots(access.writes, init);
+    }
 
     if (!access.reads.empty() || !access.writes.empty()) {
       recordRootAccessStats(access.reads, access.pipe, /*isWrite=*/false,
@@ -738,18 +830,21 @@ struct PlannerAnalysis {
   }
 
   void recordSplitTpopDerivedValue(Operation *op) {
-    if (!facts.targetHazardEnabled)
+    if (!facts.targetHazardEnabled) {
       return;
+    }
 
     if (auto pop = dyn_cast<pto::TPopFromAicOp>(op)) {
-      if (pop.getSplit() != 0)
+      if (pop.getSplit() != 0) {
         splitTpopDerivedValues.insert(pop.getTile());
+      }
       return;
     }
 
     if (auto pop = dyn_cast<pto::TPopOp>(op)) {
-      if (pop.getSplit() != 0)
+      if (pop.getSplit() != 0) {
         splitTpopDerivedValues.insert(pop.getTile());
+      }
       return;
     }
 
@@ -757,8 +852,9 @@ struct PlannerAnalysis {
   }
 
   void seedForIterArgAliases(scf::ForOp forOp) {
-    if (forOp.getRegion().empty())
+    if (forOp.getRegion().empty()) {
       return;
+    }
     Block &body = forOp.getRegion().front();
     for (auto [iterArg, initArg] :
          llvm::zip(body.getArguments().drop_front(1), forOp.getInitArgs())) {
@@ -777,8 +873,9 @@ struct PlannerAnalysis {
     SmallVector<RegionSuccessor> successors;
     branchOp.getSuccessorRegions(RegionBranchPoint::parent(), successors);
     for (RegionSuccessor successor : successors) {
-      if (successor.isParent())
+      if (successor.isParent()) {
         continue;
+      }
       mapRegionBranchValues(branchOp.getEntrySuccessorOperands(successor),
                             successor.getSuccessorInputs());
     }
@@ -786,21 +883,24 @@ struct PlannerAnalysis {
 
   void finalizeRegionBranchAliasesFromRegion(RegionBranchOpInterface branchOp,
                                              Region &region) {
-    if (region.empty())
+    if (region.empty()) {
       return;
+    }
 
     SmallVector<RegionSuccessor> successors;
     branchOp.getSuccessorRegions(region, successors);
     for (RegionSuccessor successor : successors) {
       ValueRange destinations = successor.getSuccessorInputs();
-      if (destinations.empty())
+      if (destinations.empty()) {
         continue;
+      }
 
       for (Block &block : region) {
         auto terminator =
             dyn_cast<RegionBranchTerminatorOpInterface>(block.getTerminator());
-        if (!terminator)
+        if (!terminator) {
           continue;
+        }
         mapRegionBranchValues(terminator.getSuccessorOperands(successor),
                               destinations);
       }
@@ -808,8 +908,9 @@ struct PlannerAnalysis {
   }
 
   void finalizeRegionBranchAliases(RegionBranchOpInterface branchOp) {
-    for (Region &region : branchOp->getRegions())
+    for (Region &region : branchOp->getRegions()) {
       finalizeRegionBranchAliasesFromRegion(branchOp, region);
+    }
   }
 
   void finalizeForLoopLiveness(scf::ForOp forOp, unsigned loopStartIndex,
@@ -818,10 +919,12 @@ struct PlannerAnalysis {
     // across the back-edge, even if its last use appears before a loop-local
     // allocation in the linear walk.
     for (RootInfo &info : roots) {
-      if (isRootDefinedInRegion(info.root, forOp.getRegion()))
+      if (isRootDefinedInRegion(info.root, forOp.getRegion())) {
         continue;
-      if (info.freeIndex >= loopStartIndex)
+      }
+      if (info.freeIndex >= loopStartIndex) {
         info.freeIndex = std::max(info.freeIndex, loopEndIndex);
+      }
     }
 
     auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
@@ -838,8 +941,9 @@ struct PlannerAnalysis {
       // do not apply branch-exclusivity from one iteration across the back-edge.
       for (Value root : loopCarriedRoots) {
         auto found = rootIndexByValue.find(root);
-        if (found == rootIndexByValue.end())
+        if (found == rootIndexByValue.end()) {
           continue;
+        }
         facts.loopCarriedRoots.insert(root);
         RootInfo &info = roots[found->second];
         info.allocIndex = std::min(info.allocIndex, loopStartIndex);
@@ -856,26 +960,31 @@ struct PlannerAnalysis {
     // cycle so a later linear operation in one region cannot reuse storage that
     // a future iteration still reads.
     RootList loopCarriedRoots;
-    for (Value init : whileOp.getInits())
+    for (Value init : whileOp.getInits()) {
       loopCarriedRoots = unionRoots(loopCarriedRoots, getRoots(init));
-    for (Value result : whileOp.getResults())
+    }
+    for (Value result : whileOp.getResults()) {
       loopCarriedRoots = unionRoots(loopCarriedRoots, getRoots(result));
+    }
     for (Region &region : whileOp->getRegions()) {
       for (Block &block : region) {
-        for (BlockArgument arg : block.getArguments())
+        for (BlockArgument arg : block.getArguments()) {
           loopCarriedRoots = unionRoots(loopCarriedRoots, getRoots(arg));
+        }
         if (auto terminator = dyn_cast<RegionBranchTerminatorOpInterface>(
                 block.getTerminator())) {
-          for (Value operand : terminator->getOperands())
+          for (Value operand : terminator->getOperands()) {
             loopCarriedRoots = unionRoots(loopCarriedRoots, getRoots(operand));
+          }
         }
       }
     }
 
     for (Value root : loopCarriedRoots) {
       auto found = rootIndexByValue.find(root);
-      if (found == rootIndexByValue.end())
+      if (found == rootIndexByValue.end()) {
         continue;
+      }
       facts.loopCarriedRoots.insert(root);
       RootInfo &info = roots[found->second];
       info.allocIndex = std::min(info.allocIndex, loopStartIndex);
@@ -893,11 +1002,13 @@ struct PlannerAnalysis {
 
         if (auto allocTile = dyn_cast<pto::AllocTileOp>(op)) {
           if (!allocTile.getAddr()) {
-            if (isA5IgnoredTmpAlloc(allocTile))
+            if (isA5IgnoredTmpAlloc(allocTile)) {
               continue;
+            }
             addRoot(allocTile.getResult(), op);
-            if (failed)
+            if (failed) {
               return;
+            }
             auto found = rootIndexByValue.find(allocTile.getResult());
             if (found != rootIndexByValue.end()) {
               roots[found->second].allocIndex = index;
@@ -907,8 +1018,9 @@ struct PlannerAnalysis {
         } else if (auto allocMulti = dyn_cast<pto::AllocMultiTileOp>(op)) {
           if (!allocMulti.getAddr()) {
             addRoot(allocMulti.getResult(), op);
-            if (failed)
+            if (failed) {
               return;
+            }
             auto found = rootIndexByValue.find(allocMulti.getResult());
             if (found != rootIndexByValue.end()) {
               roots[found->second].allocIndex = index;
@@ -946,38 +1058,44 @@ struct PlannerAnalysis {
 
         ValueRange dpsInits = getDpsInits(op);
         for (Value operand : op->getOperands()) {
-          if (llvm::is_contained(dpsInits, operand))
+          if (llvm::is_contained(dpsInits, operand)) {
             continue;
+          }
           markUse(operand, index);
         }
         for (Value init : dpsInits) {
           bool readsOldValue = hasReadEffectOnValue(op, init);
-          if (readsOldValue)
+          if (readsOldValue) {
             markUse(init, index);
+          }
           markWrite(init, index, /*pureOverwrite=*/!readsOldValue);
         }
 
         if (auto branchOp = dyn_cast<RegionBranchOpInterface>(op)) {
           for (Region &nested : op->getRegions()) {
             walkRegion(nested);
-            if (failed)
+            if (failed) {
               return;
+            }
             finalizeRegionBranchAliasesFromRegion(branchOp, nested);
           }
         } else {
           for (Region &nested : op->getRegions()) {
             walkRegion(nested);
-            if (failed)
+            if (failed) {
               return;
+            }
           }
         }
 
-        if (auto branchOp = dyn_cast<RegionBranchOpInterface>(op))
+        if (auto branchOp = dyn_cast<RegionBranchOpInterface>(op)) {
           finalizeRegionBranchAliases(branchOp);
+        }
 
         if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
-          if (ifOp.getNumResults() != 0)
+          if (ifOp.getNumResults() != 0) {
             recordIfBranchExclusivity(ifOp);
+          }
         } else if (auto forOp = dyn_cast<scf::ForOp>(op)) {
           unsigned loopEndIndex =
               linearOps.empty() ? index : linearOps.size() - 1;
@@ -990,8 +1108,9 @@ struct PlannerAnalysis {
           auto yieldOp = cast<pto::YieldOp>(
               fusionRegion.getBody().front().getTerminator());
           for (auto [result, yielded] :
-               llvm::zip(fusionRegion.getResults(), yieldOp.getOperands()))
+               llvm::zip(fusionRegion.getResults(), yieldOp.getOperands())) {
             setRoots(result, getRoots(yielded));
+          }
         }
 
         recordSplitTpopDerivedValue(op);
@@ -1009,18 +1128,21 @@ static bool lifetimesStrictlyOverlap(const RootInfo &lhs, const RootInfo &rhs) {
 
 static bool areBranchExclusive(Value lhs, Value rhs, const ConflictFacts &facts) {
   if (facts.loopCarriedRoots.contains(lhs) ||
-      facts.loopCarriedRoots.contains(rhs))
+      facts.loopCarriedRoots.contains(rhs)) {
     return false;
+  }
   auto it = facts.branchExclusiveRoots.find(lhs);
-  if (it == facts.branchExclusiveRoots.end())
+  if (it == facts.branchExclusiveRoots.end()) {
     return false;
+  }
   return llvm::is_contained(it->second, rhs);
 }
 
 static bool gateLifetimeAndPhi(const RootInfo &lhs, const RootInfo &rhs,
                                const ConflictFacts &facts) {
-  if (!lifetimesStrictlyOverlap(lhs, rhs))
+  if (!lifetimesStrictlyOverlap(lhs, rhs)) {
     return true;
+  }
 
   // Gate 5 is intentionally embedded in Gate 1: branch-local roots yielded from
   // opposite scf.if branches are mutually exclusive at runtime, so their
@@ -1030,16 +1152,19 @@ static bool gateLifetimeAndPhi(const RootInfo &lhs, const RootInfo &rhs,
 
 static bool hasTargetHazard(const RootInfo &input, const RootInfo &writer,
                             const ConflictFacts &facts) {
-  if (!facts.targetHazardEnabled)
+  if (!facts.targetHazardEnabled) {
     return false;
+  }
 
   if (!facts.loadDerivedRoots.contains(input.root) ||
-      !facts.tpopConsumerRoots.contains(writer.root))
+      !facts.tpopConsumerRoots.contains(writer.root)) {
     return false;
+  }
 
   auto found = facts.tpopConsumerWriteIndices.find(writer.root);
-  if (found == facts.tpopConsumerWriteIndices.end())
+  if (found == facts.tpopConsumerWriteIndices.end()) {
     return false;
+  }
 
   return llvm::is_contained(found->second, input.freeIndex);
 }
@@ -1064,11 +1189,13 @@ static bool canShare(const RootInfo &lhs, const RootInfo &rhs,
 
 static bool canJoinReuseGroup(const RootInfo &info, const ReuseGroup &group,
                               const PlannerAnalysis &analysis) {
-  if (info.space != group.space)
+  if (info.space != group.space) {
     return false;
+  }
   for (const RootInfo *member : group.members) {
-    if (!canShare(info, *member, analysis))
+    if (!canShare(info, *member, analysis)) {
       return false;
+    }
   }
   return true;
 }
@@ -1116,8 +1243,9 @@ static uint64_t loopWeightedPenalty(uint64_t penalty, const OpAccess &lhs,
 
 static uint64_t getRootPairReuseCost(Value lhsRoot, Value rhsRoot,
                                      const ConflictFacts &facts) {
-  if (lhsRoot == rhsRoot)
+  if (lhsRoot == rhsRoot) {
     return 0;
+  }
 
   constexpr unsigned kPipeVLookahead = 1;
   constexpr unsigned kMteLookahead = 1;
@@ -1126,14 +1254,17 @@ static uint64_t getRootPairReuseCost(Value lhsRoot, Value rhsRoot,
 
   uint64_t cost = 0;
   for (const OpAccess &lhs : facts.opAccesses) {
-    if (!accessesRoot(lhs, lhsRoot) && !accessesRoot(lhs, rhsRoot))
+    if (!accessesRoot(lhs, lhsRoot) && !accessesRoot(lhs, rhsRoot)) {
       continue;
+    }
 
     for (const OpAccess &rhs : facts.opAccesses) {
-      if (lhs.opIndex >= rhs.opIndex)
+      if (lhs.opIndex >= rhs.opIndex) {
         continue;
-      if (!accessesRoot(rhs, lhsRoot) && !accessesRoot(rhs, rhsRoot))
+      }
+      if (!accessesRoot(rhs, lhsRoot) && !accessesRoot(rhs, rhsRoot)) {
         continue;
+      }
 
       if (lhs.pipe == PIPE::PIPE_V && rhs.pipe == PIPE::PIPE_V &&
           isNearNeighbor(lhs, rhs, kPipeVLookahead) &&
@@ -1148,8 +1279,9 @@ static uint64_t getRootPairReuseCost(Value lhsRoot, Value rhsRoot,
              containsRoot(rhs.writes, rhsRoot)) ||
             (containsRoot(lhs.reads, rhsRoot) &&
              containsRoot(rhs.writes, lhsRoot));
-        if (storeSourceThenLoadDst)
+        if (storeSourceThenLoadDst) {
           cost += loopWeightedPenalty(kMte3ToMte2Penalty, lhs, rhs);
+        }
       }
     }
   }
@@ -1160,16 +1292,18 @@ static uint64_t getGroupReuseCost(const RootInfo &info,
                                   const ReuseGroup &group,
                                   const ConflictFacts &facts) {
   uint64_t cost = 0;
-  for (const RootInfo *member : group.members)
+  for (const RootInfo *member : group.members) {
     cost += getRootPairReuseCost(info.root, member->root, facts);
+  }
   return cost;
 }
 
 static bool isHotRoot(const RootInfo &info) {
   if (info.loopAccessCount > 0 &&
       (info.accessCount >= 2 || info.pipeVAccessCount > 0 ||
-       info.mteAccessCount > 0))
+       info.mteAccessCount > 0)) {
     return true;
+  }
 
   // Some PTODSL kernels express repeated work through task/block parallelism
   // rather than an explicit scf.for in PTO IR. Repeated local accesses on
@@ -1189,8 +1323,9 @@ static uint64_t getRootHotness(const RootInfo &info) {
 
 static uint64_t getHotClusterReuseCost(const RootInfo &info,
                                        const ReuseGroup &group) {
-  if (!isHotRoot(info))
+  if (!isHotRoot(info)) {
     return 0;
+  }
 
   constexpr uint64_t kHotClusterPenalty = 6;
   constexpr uint64_t kLoopHotClusterPenalty = 12;
@@ -1200,22 +1335,25 @@ static uint64_t getHotClusterReuseCost(const RootInfo &info,
   uint64_t cost = 0;
   uint64_t infoHotness = getRootHotness(info);
   for (const RootInfo *member : group.members) {
-    if (!isHotRoot(*member))
+    if (!isHotRoot(*member)) {
       continue;
+    }
 
     uint64_t pairHotness =
         std::min<uint64_t>(infoHotness, getRootHotness(*member));
     cost += kHotClusterPenalty + pairHotness;
-    if (info.loopAccessCount > 0 && member->loopAccessCount > 0)
+    if (info.loopAccessCount > 0 && member->loopAccessCount > 0) {
       cost += kLoopHotClusterPenalty;
+    }
 
     // Exact co-location is the strongest possible same-bank signal. The
     // planner does not materialize final byte intervals yet, so only model the
     // bank pattern that is known for a reuse candidate: the new root would
     // start at the same offset as every member in this group.
     if (info.alignmentBytes <= kBankConflictModuloBytes &&
-        member->alignmentBytes <= kBankConflictModuloBytes)
+        member->alignmentBytes <= kBankConflictModuloBytes) {
       cost += kBankConflictPenalty;
+    }
   }
   return cost;
 }
@@ -1252,8 +1390,9 @@ static ReuseGroup *chooseReuseGroupByCost(
   bool bestFits = false;
 
   for (auto [index, group] : llvm::enumerate(groups)) {
-    if (!canJoinReuseGroup(info, group, analysis))
+    if (!canJoinReuseGroup(info, group, analysis)) {
       continue;
+    }
 
     uint64_t projectedBytes =
         getProjectedPackedBytes(groups, info, static_cast<unsigned>(index));
@@ -1284,27 +1423,31 @@ static ReuseGroup *chooseReuseGroupByCost(
   // when local capacity is available.
   uint64_t freshCost = groups.empty() ? 0 : 1;
   unsigned freshOrder = groups.size();
-  if (!bestGroup)
+  if (!bestGroup) {
     return nullptr;
+  }
 
   // The cost model is a performance hint, not a correctness gate. When local
   // memory is already tight, do not let a fresh address outrank a legal reuse
   // group; future roots may still need the remaining tail bytes.
-  if (bestFits && freshFits && freshSlack < pressureReserve)
+  if (bestFits && freshFits && freshSlack < pressureReserve) {
     return bestGroup;
+  }
 
   auto isBetter = [](bool lhsFits, uint64_t lhsCost, uint64_t lhsBytes,
                      unsigned lhsOrder, bool rhsFits, uint64_t rhsCost,
                      uint64_t rhsBytes, unsigned rhsOrder) {
-    if (lhsFits != rhsFits)
+    if (lhsFits != rhsFits) {
       return lhsFits;
+    }
     return std::tie(lhsCost, lhsBytes, lhsOrder) <
            std::tie(rhsCost, rhsBytes, rhsOrder);
   };
 
   if (isBetter(freshFits, freshCost, freshProjectedBytes, freshOrder, bestFits,
-               bestCost, bestProjectedBytes, bestOrder))
+               bestCost, bestProjectedBytes, bestOrder)) {
     return nullptr;
+  }
   return bestGroup;
 }
 
@@ -1312,8 +1455,9 @@ static SmallVector<uint64_t> buildSlotOffsets(uint64_t base, uint64_t slotBytes,
                                               uint64_t slotCount) {
   SmallVector<uint64_t> offsets;
   offsets.reserve(slotCount);
-  for (uint64_t slot = 0; slot < slotCount; ++slot)
+  for (uint64_t slot = 0; slot < slotCount; ++slot) {
     offsets.push_back(base + slot * slotBytes);
+  }
   return offsets;
 }
 
@@ -1338,13 +1482,15 @@ static FailureOr<uint64_t> planReserveBufferBase(
   uint64_t cursor = 0;
   for (const auto &interval : merged) {
     cursor = alignUp(cursor, spec.alignmentBytes);
-    if (cursor + sizeBytes <= interval.first)
+    if (cursor + sizeBytes <= interval.first) {
       return cursor;
+    }
     cursor = std::max(cursor, interval.second);
   }
   cursor = alignUp(cursor, spec.alignmentBytes);
-  if (cursor + sizeBytes > spec.capacityBytes)
+  if (cursor + sizeBytes > spec.capacityBytes) {
     return failure();
+  }
   occupied.push_back({cursor, cursor + sizeBytes});
   return cursor;
 }
@@ -1353,13 +1499,15 @@ static LogicalResult
 validateManualReserveBufferBase(pto::ReserveBufferOp reserveOp,
                                 const MemSpec &spec) {
   auto baseAttr = reserveOp.getBaseAttr();
-  if (!baseAttr)
+  if (!baseAttr) {
     return reserveOp.emitError("expects 'base' when 'auto' is false");
+  }
 
   int64_t signedBase = baseAttr.getInt();
-  if (signedBase < 0)
+  if (signedBase < 0) {
     return reserveOp.emitError(
         "expects 'base' to be non-negative when present");
+  }
 
   uint64_t base = static_cast<uint64_t>(signedBase);
   if (base % spec.alignmentBytes != 0) {
@@ -1393,8 +1541,9 @@ validateReserveBufferForPlanMemory(pto::ReserveBufferOp reserveOp,
     return success();
   }
 
-  if (mlir::failed(validateManualReserveBufferBase(reserveOp, spec)))
+  if (mlir::failed(validateManualReserveBufferBase(reserveOp, spec))) {
     return failure();
+  }
 
   return reserveOp.emitError(
       "pto.reserve_buffer with explicit 'base' (auto = false) is not "
@@ -1412,16 +1561,19 @@ public:
 
   LogicalResult matchAndRewrite(pto::AllocTileOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op.getAddr())
+    if (op.getAddr()) {
       return failure();
+    }
 
     auto tileType = dyn_cast<TileBufType>(op.getResult().getType());
-    if (!tileType)
+    if (!tileType) {
       return failure();
+    }
 
     auto it = buffer2Offsets.find(op.getResult());
-    if (it == buffer2Offsets.end() || it->second.empty())
+    if (it == buffer2Offsets.end() || it->second.empty()) {
       return failure();
+    }
 
     if (it->second.size() != 1) {
       return rewriter.notifyMatchFailure(
@@ -1435,8 +1587,9 @@ public:
         op.getValidRow() ? op.getValidRow() : Value(),
         op.getValidCol() ? op.getValidCol() : Value());
     for (NamedAttribute attr : op->getAttrs()) {
-      if (attr.getName().getValue() == "operandSegmentSizes")
+      if (attr.getName().getValue() == "operandSegmentSizes") {
         continue;
+      }
       planned->setAttr(attr.getName(), attr.getValue());
     }
 
@@ -1459,12 +1612,14 @@ public:
 
   LogicalResult matchAndRewrite(pto::AllocMultiTileOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op.getAddr() || op->hasAttr(pto::kPtoMultiBufferAddrsAttrName))
+    if (op.getAddr() || op->hasAttr(pto::kPtoMultiBufferAddrsAttrName)) {
       return failure();
+    }
 
     auto it = buffer2Offsets.find(op.getResult());
-    if (it == buffer2Offsets.end() || it->second.empty())
+    if (it == buffer2Offsets.end() || it->second.empty()) {
       return failure();
+    }
     if (it->second.size() != op.getResult().getType().getCount()) {
       return rewriter.notifyMatchFailure(
           op, "planned address count does not match multi_tile_buf count");
@@ -1472,8 +1627,9 @@ public:
 
     SmallVector<int64_t> addrs;
     addrs.reserve(it->second.size());
-    for (uint64_t offset : it->second)
+    for (uint64_t offset : it->second) {
       addrs.push_back(static_cast<int64_t>(offset));
+    }
     rewriter.modifyOpInPlace(op, [&] {
       op->setAttr(pto::kPtoMultiBufferAddrsAttrName,
                   rewriter.getDenseI64ArrayAttr(addrs));
@@ -1492,8 +1648,9 @@ static LogicalResult materializePlannedOffsets(
                                                     buffer2Offsets);
   patterns.add<AllocMultiTileOpAddPlannedAddressesPattern>(
       patterns.getContext(), buffer2Offsets);
-  if (mlir::failed(applyPatternsGreedily(func, std::move(patterns))))
+  if (mlir::failed(applyPatternsGreedily(func, std::move(patterns)))) {
     return failure();
+  }
   return success();
 }
 
@@ -1516,8 +1673,9 @@ LogicalResult mlir::pto::runModernPlanMemory(func::FuncOp func,
 
   DenseMap<Value, SmallVector<uint64_t>> buffer2Offsets;
   llvm::MapVector<AddressSpace, SmallVector<RootInfo *>> rootsBySpace;
-  for (RootInfo &info : analysis.roots)
+  for (RootInfo &info : analysis.roots) {
     rootsBySpace[info.space].push_back(&info);
+  }
 
   for (auto &entry : rootsBySpace) {
     AddressSpace space = entry.first;
@@ -1526,10 +1684,12 @@ LogicalResult mlir::pto::runModernPlanMemory(func::FuncOp func,
 
     bool sizeFirstForSpace = orderBySize && !isCubeLocalSpace(space);
     llvm::stable_sort(roots, [&](const RootInfo *lhs, const RootInfo *rhs) {
-      if (sizeFirstForSpace && lhs->totalBytes != rhs->totalBytes)
+      if (sizeFirstForSpace && lhs->totalBytes != rhs->totalBytes) {
         return lhs->totalBytes > rhs->totalBytes;
-      if (lhs->allocIndex != rhs->allocIndex)
+      }
+      if (lhs->allocIndex != rhs->allocIndex) {
         return lhs->allocIndex < rhs->allocIndex;
+      }
       return lhs->stableOrder < rhs->stableOrder;
     });
 
@@ -1577,15 +1737,17 @@ LogicalResult mlir::pto::runModernPlanMemory(func::FuncOp func,
       return failure();
     }
 
-    for (RootInfo *info : roots)
+    for (RootInfo *info : roots) {
       buffer2Offsets[info->root] = info->offsets;
+    }
   }
 
   DenseMap<AddressSpace, SmallVector<std::pair<uint64_t, uint64_t>>>
       occupiedBySpace;
   for (const RootInfo &info : analysis.roots) {
-    if (info.offsets.empty())
+    if (info.offsets.empty()) {
       continue;
+    }
     occupiedBySpace[info.space].push_back(
         {info.offsets.front(), info.offsets.front() + info.totalBytes});
   }
@@ -1621,17 +1783,21 @@ LogicalResult mlir::pto::runModernPlanMemory(func::FuncOp func,
 
   bool hasUnplannedAllocTile = false;
   func.walk([&](pto::AllocTileOp op) {
-    if (op.getAddr())
+    if (op.getAddr()) {
       return;
-    if (op->use_empty())
+    }
+    if (op->use_empty()) {
       return;
-    if (isA5IgnoredTmpAlloc(op))
+    }
+    if (isA5IgnoredTmpAlloc(op)) {
       return;
+    }
     op.emitError("PTOPlanMemory failed to assign an address to pto.alloc_tile");
     hasUnplannedAllocTile = true;
   });
-  if (hasUnplannedAllocTile)
+  if (hasUnplannedAllocTile) {
     return failure();
+  }
   return success();
 }
 
@@ -1664,8 +1830,9 @@ struct PlanMemoryModernPass
       // `pto.tileop.helper` identifies compute-only helpers, not whether a
       // child module needs memory planning.  Skip those helpers themselves,
       // while planning every ordinary function in nested backend modules.
-      if (!funcOp->hasAttr("pto.tileop.helper"))
+      if (!funcOp->hasAttr("pto.tileop.helper")) {
         funcs.push_back(funcOp);
+      }
     });
 
     for (func::FuncOp funcOp : funcs) {

--- a/lib/PTO/Transforms/PTORematerializeFixpipeVectorQuant.cpp
+++ b/lib/PTO/Transforms/PTORematerializeFixpipeVectorQuant.cpp
@@ -53,8 +53,9 @@ struct PTORematerializeFixpipeVectorQuantPass
     auto processBlock = [&](auto &&self, Block &block) -> LogicalResult {
       llvm::DenseMap<int32_t, SetQuantVectorOp> activeVectorById;
       SmallVector<Operation *> originalOps;
-      for (Operation &op : block)
+      for (Operation &op : block) {
         originalOps.push_back(&op);
+      }
 
       for (Operation *op : originalOps) {
         if (auto setQuantVector = dyn_cast<SetQuantVectorOp>(op)) {
@@ -91,8 +92,9 @@ struct PTORematerializeFixpipeVectorQuantPass
       }
     }
 
-    for (Operation *op : eraseList)
+    for (Operation *op : eraseList) {
       op->erase();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
+++ b/lib/PTO/Transforms/PTORemoveIdentityTMov.cpp
@@ -49,42 +49,48 @@ static std::optional<APInt> tryEvalIntegerLikeConstant(Value value);
 static std::optional<APInt> evalSignedCast(Value input, Type resultType) {
   std::optional<APInt> inputValue = tryEvalIntegerLikeConstant(input);
   std::optional<unsigned> resultWidth = getIntegerLikeBitWidth(resultType);
-  if (!inputValue || !resultWidth)
+  if (!inputValue || !resultWidth) {
     return std::nullopt;
+  }
   return inputValue->sextOrTrunc(*resultWidth);
 }
 
 static std::optional<APInt> evalUnsignedCast(Value input, Type resultType) {
   std::optional<APInt> inputValue = tryEvalIntegerLikeConstant(input);
   std::optional<unsigned> resultWidth = getIntegerLikeBitWidth(resultType);
-  if (!inputValue || !resultWidth)
+  if (!inputValue || !resultWidth) {
     return std::nullopt;
+  }
   return inputValue->zextOrTrunc(*resultWidth);
 }
 
 static std::optional<APInt> evalTruncCast(Value input, Type resultType) {
   std::optional<APInt> inputValue = tryEvalIntegerLikeConstant(input);
   std::optional<unsigned> resultWidth = getIntegerLikeBitWidth(resultType);
-  if (!inputValue || !resultWidth || *resultWidth > inputValue->getBitWidth())
+  if (!inputValue || !resultWidth || *resultWidth > inputValue->getBitWidth()) {
     return std::nullopt;
+  }
   return inputValue->trunc(*resultWidth);
 }
 
 static std::optional<APInt> tryEvalIntegerLikeConstant(Value value) {
-  if (!value)
+  if (!value) {
     return std::nullopt;
+  }
 
   APInt apInt;
   if (matchPattern(value, m_ConstantInt(&apInt))) {
     std::optional<unsigned> width = getIntegerLikeBitWidth(value.getType());
-    if (!width)
+    if (!width) {
       return std::nullopt;
+    }
     return apInt.sextOrTrunc(*width);
   }
 
   Operation *defOp = value.getDefiningOp();
-  if (!defOp)
+  if (!defOp) {
     return std::nullopt;
+  }
 
   if (auto castOp = dyn_cast<arith::IndexCastOp>(defOp))
     return evalSignedCast(castOp.getIn(), castOp.getType());
@@ -102,8 +108,9 @@ static std::optional<APInt> tryEvalIntegerLikeConstant(Value value) {
 
 static std::optional<int64_t> tryEvalI64Constant(Value value) {
   std::optional<APInt> apInt = tryEvalIntegerLikeConstant(value);
-  if (!apInt || apInt->getBitWidth() > 64)
+  if (!apInt || apInt->getBitWidth() > 64) {
     return std::nullopt;
+  }
   return apInt->getSExtValue();
 }
 
@@ -125,22 +132,26 @@ static bool isDeadDstTMov(TMovOp op) {
 static const BaseMemInfo *
 getSingleMemInfo(const Buffer2MemInfoMap &buffer2MemInfoMap, Value value) {
   auto it = buffer2MemInfoMap.find(value);
-  if (it == buffer2MemInfoMap.end() || it->second.size() != 1)
+  if (it == buffer2MemInfoMap.end() || it->second.size() != 1) {
     return nullptr;
+  }
   return it->second.front().get();
 }
 
 static std::optional<int64_t>
 tryGetConcreteRootAddress(const BaseMemInfo *info) {
-  if (!info)
+  if (!info) {
     return std::nullopt;
+  }
 
-  if (auto direct = tryEvalI64Constant(info->rootBuffer))
+  if (auto direct = tryEvalI64Constant(info->rootBuffer)) {
     return direct;
+  }
 
   Operation *defOp = info->rootBuffer.getDefiningOp();
-  if (!defOp)
+  if (!defOp) {
     return std::nullopt;
+  }
 
   if (auto alloc = dyn_cast<pto::AllocTileOp>(defOp))
     return tryEvalI64Constant(alloc.getAddr());
@@ -158,20 +169,23 @@ static bool isStaticallyAddressableValue(Value value) {
   constexpr int kMaxDepth = 32;
   while (value && depth++ < kMaxDepth) {
     Operation *defOp = value.getDefiningOp();
-    if (!defOp)
+    if (!defOp) {
       return false;
+    }
 
     if (auto subView = dyn_cast<memref::SubViewOp>(defOp)) {
       if (hasDynamicStaticList(subView.getStaticOffsets()) ||
           hasDynamicStaticList(subView.getStaticSizes()) ||
-          hasDynamicStaticList(subView.getStaticStrides()))
+          hasDynamicStaticList(subView.getStaticStrides())) {
         return false;
+      }
       value = subView.getSource();
       continue;
     }
 
-    if (isa<memref::ReinterpretCastOp>(defOp))
+    if (isa<memref::ReinterpretCastOp>(defOp)) {
       return false;
+    }
 
     if (auto cast = dyn_cast<memref::CastOp>(defOp)) {
       value = cast.getSource();
@@ -186,8 +200,9 @@ static bool isStaticallyAddressableValue(Value value) {
       continue;
     }
     if (auto view = dyn_cast<memref::ViewOp>(defOp)) {
-      if (view.getByteShift())
+      if (view.getByteShift()) {
         return false;
+      }
       value = view.getSource();
       continue;
     }
@@ -200,27 +215,35 @@ static bool isStaticallyAddressableValue(Value value) {
 
 static bool hasExactSameAddressRange(const BaseMemInfo *srcInfo,
                                      const BaseMemInfo *dstInfo) {
-  if (!srcInfo || !dstInfo)
+  if (!srcInfo || !dstInfo) {
     return false;
-  if (srcInfo->scope != dstInfo->scope)
+  }
+  if (srcInfo->scope != dstInfo->scope) {
     return false;
-  if (srcInfo->allocateSize == 0 || dstInfo->allocateSize == 0)
+  }
+  if (srcInfo->allocateSize == 0 || dstInfo->allocateSize == 0) {
     return false;
-  if (srcInfo->allocateSize != dstInfo->allocateSize)
+  }
+  if (srcInfo->allocateSize != dstInfo->allocateSize) {
     return false;
-  if (srcInfo->baseAddresses.empty() || dstInfo->baseAddresses.empty())
+  }
+  if (srcInfo->baseAddresses.empty() || dstInfo->baseAddresses.empty()) {
     return false;
-  if (srcInfo->baseAddresses != dstInfo->baseAddresses)
+  }
+  if (srcInfo->baseAddresses != dstInfo->baseAddresses) {
     return false;
+  }
   return true;
 }
 
 static bool hasSameConcreteAddressRange(const BaseMemInfo *srcInfo,
                                         const BaseMemInfo *dstInfo) {
-  if (!hasExactSameAddressRange(srcInfo, dstInfo))
+  if (!hasExactSameAddressRange(srcInfo, dstInfo)) {
     return false;
-  if (srcInfo->rootBuffer == dstInfo->rootBuffer)
+  }
+  if (srcInfo->rootBuffer == dstInfo->rootBuffer) {
     return true;
+  }
   auto srcRootAddr = tryGetConcreteRootAddress(srcInfo);
   auto dstRootAddr = tryGetConcreteRootAddress(dstInfo);
   return srcRootAddr && dstRootAddr && *srcRootAddr == *dstRootAddr;
@@ -228,8 +251,9 @@ static bool hasSameConcreteAddressRange(const BaseMemInfo *srcInfo,
 
 static Operation *getAncestorInBlock(Operation *op, Block *block) {
   for (Operation *cur = op; cur; cur = cur->getParentOp()) {
-    if (cur->getBlock() == block)
+    if (cur->getBlock() == block) {
       return cur;
+    }
   }
   return nullptr;
 }
@@ -238,13 +262,16 @@ static bool hasUseAfterOp(Value value, Operation *currentOp) {
   Block *block = currentOp->getBlock();
   for (OpOperand &use : value.getUses()) {
     Operation *owner = use.getOwner();
-    if (owner == currentOp)
+    if (owner == currentOp) {
       continue;
+    }
     Operation *ancestor = getAncestorInBlock(owner, block);
-    if (!ancestor)
+    if (!ancestor) {
       return true;
-    if (ancestor != currentOp && currentOp->isBeforeInBlock(ancestor))
+    }
+    if (ancestor != currentOp && currentOp->isBeforeInBlock(ancestor)) {
       return true;
+    }
   }
   return false;
 }
@@ -254,13 +281,15 @@ static bool hasLaterUseOfSameAddressRange(
     const Buffer2MemInfoMap &buffer2MemInfoMap) {
   for (const auto &entry : buffer2MemInfoMap) {
     // Later reads of the source itself do not make this no-op TMOV a bridge.
-    if (entry.first == op.getSrc())
+    if (entry.first == op.getSrc()) {
       continue;
+    }
     bool sameRange = llvm::any_of(entry.second, [&](const auto &info) {
       return hasSameConcreteAddressRange(info.get(), dstInfo);
     });
-    if (sameRange && hasUseAfterOp(entry.first, op))
+    if (sameRange && hasUseAfterOp(entry.first, op)) {
       return true;
+    }
   }
   return false;
 }
@@ -271,11 +300,13 @@ static bool hasPlainTMovSemantics(TMovOp op) {
 }
 
 static bool hasCompatibleIdentityTypes(TMovOp op) {
-  if (op.getSrc().getType() != op.getDst().getType())
+  if (op.getSrc().getType() != op.getDst().getType()) {
     return false;
+  }
   for (OpResult result : op->getResults()) {
-    if (result.getType() != op.getDst().getType())
+    if (result.getType() != op.getDst().getType()) {
       return false;
+    }
   }
   return true;
 }
@@ -305,13 +336,15 @@ isIdentityTMovByMemInfo(TMovOp op, const Buffer2MemInfoMap &buffer2MemInfoMap) {
   Value src = op.getSrc();
   Value dst = op.getDst();
 
-  if (!isStaticallyAddressableValue(src) || !isStaticallyAddressableValue(dst))
+  if (!isStaticallyAddressableValue(src) || !isStaticallyAddressableValue(dst)) {
     return false;
+  }
 
   const BaseMemInfo *srcInfo = getSingleMemInfo(buffer2MemInfoMap, src);
   const BaseMemInfo *dstInfo = getSingleMemInfo(buffer2MemInfoMap, dst);
-  if (!hasSameConcreteAddressRange(srcInfo, dstInfo))
+  if (!hasSameConcreteAddressRange(srcInfo, dstInfo)) {
     return false;
+  }
 
   return isDeadDstTMov(op) &&
          !hasLaterUseOfSameAddressRange(op, dstInfo, buffer2MemInfoMap);
@@ -327,8 +360,9 @@ struct PTORemoveIdentityTMovPass
 
     func.walk([&](TMovOp op) {
       if (!hasPlainTMovSemantics(op) || !hasCompatibleIdentityTypes(op) ||
-          touchesLowPrecisionElement(op))
+          touchesLowPrecisionElement(op)) {
         return;
+      }
       if (op.getSrc() == op.getDst()) {
         identityMoves.push_back(op);
         return;
@@ -345,14 +379,16 @@ struct PTORemoveIdentityTMovPass
       translator.Build();
 
       for (TMovOp op : memInfoCandidates) {
-        if (isIdentityTMovByMemInfo(op, buffer2MemInfoMap))
+        if (isIdentityTMovByMemInfo(op, buffer2MemInfoMap)) {
           identityMoves.push_back(op);
+        }
       }
     }
 
     for (TMovOp op : identityMoves) {
-      for (OpResult result : op->getResults())
+      for (OpResult result : op->getResults()) {
         result.replaceAllUsesWith(op.getDst());
+      }
       op.erase();
     }
   }

--- a/lib/PTO/Transforms/PTORemoveRedundantBarrier.cpp
+++ b/lib/PTO/Transforms/PTORemoveRedundantBarrier.cpp
@@ -8,19 +8,19 @@
 
 #include "PTO/IR/PTO.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/SCF/IR/SCF.h" 
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include <memory>
- 
+
 using namespace mlir;
 using namespace mlir::pto;
- 
+
 namespace {
- 
+
 // ==========================================================
 // 更严格的活跃性分析
 // ==========================================================
@@ -29,12 +29,15 @@ namespace {
 // Wait 和 Set 不算作实质性操作。
 // 只有真正消耗计算或带宽的指令才算"活跃"。
 bool isResourceOp(Operation *op, Attribute targetPipe) {
-    if (auto loadOp = dyn_cast<pto::TLoadOp>(op)) 
+    if (auto loadOp = dyn_cast<pto::TLoadOp>(op)) {
         return pto::PipeAttr::get(op->getContext(), pto::PIPE::PIPE_MTE2) == targetPipe;
-    if (auto storeOp = dyn_cast<pto::TStoreOp>(op)) 
+    }
+    if (auto storeOp = dyn_cast<pto::TStoreOp>(op)) {
         return pto::PipeAttr::get(op->getContext(), pto::PIPE::PIPE_MTE3) == targetPipe;
-    if (auto addfOp = dyn_cast<pto::TAddOp>(op)) 
+    }
+    if (auto addfOp = dyn_cast<pto::TAddOp>(op)) {
         return pto::PipeAttr::get(op->getContext(), pto::PIPE::PIPE_V) == targetPipe;
+    }
     return false;
 }
  
@@ -44,11 +47,15 @@ bool isPipeUsedInRegion(Region &region, Attribute targetPipe) {
     for (Block &block : region) {
         for (Operation &op : block) {
             // 1. 如果是实质性操作，返回 True
-            if (isResourceOp(&op, targetPipe)) return true;
-            
+            if (isResourceOp(&op, targetPipe)) {
+              return true;
+            }
+
             // 2. 递归检查嵌套 (if/for)
             for (Region &nestedRegion : op.getRegions()) {
-                if (isPipeUsedInRegion(nestedRegion, targetPipe)) return true;
+                if (isPipeUsedInRegion(nestedRegion, targetPipe)) {
+                  return true;
+                }
             }
         }
     }
@@ -60,15 +67,19 @@ bool isPipeUsedInRegion(Region &region, Attribute targetPipe) {
 // 如果一个 Pipe 后面只剩 Wait，说明它已经完成了工作，发给它的信号是多余的。
 static bool hasPipelineActivityAfterOp(Operation *parentOp, Attribute targetPipe) {
     Block *parentBlock = parentOp ? parentOp->getBlock() : nullptr;
-    if (!parentBlock)
+    if (!parentBlock) {
       return false;
+    }
     for (auto it = std::next(parentOp->getIterator()); it != parentBlock->end(); ++it) {
-        if (isResourceOp(&*it, targetPipe))
+        if (isResourceOp(&*it, targetPipe)) {
           return true;
-        if (it->getNumRegions() > 0)
+        }
+        if (it->getNumRegions() > 0) {
           return true;
-        if (isa<func::ReturnOp>(&*it))
+        }
+        if (isa<func::ReturnOp>(&*it)) {
           return false;
+        }
     }
     return false;
 }
@@ -76,34 +87,40 @@ static bool hasPipelineActivityAfterOp(Operation *parentOp, Attribute targetPipe
 bool isPipelineActiveFuture(Block *block, Block::iterator startIt, Attribute targetPipe) {
     for (auto it = startIt; it != block->end(); ++it) {
         Operation *op = &*it;
-        
-        // 1. 遇到实质性操作 -> 活跃
-        if (isResourceOp(op, targetPipe)) return true;
- 
+
+// 1. 遇到实质性操作 -> 活跃
+        if (isResourceOp(op, targetPipe)) {
+          return true;
+        }
+
         // [注意] 这里故意跳过了 WaitOp 的检查。
         // WaitOp 只是同步原语，不代表该 Pipeline 在"干活"。
- 
+
         // 2. 递归检查嵌套区域 (scf.if, scf.for)
         for (Region &region : op->getRegions()) {
-            if (isPipeUsedInRegion(region, targetPipe)) return true;
+            if (isPipeUsedInRegion(region, targetPipe)) {
+              return true;
+            }
         }
- 
+
         // 3. 处理 Terminator (跨 Block 检查)
         if (op->hasTrait<OpTrait::IsTerminator>()) {
             // 如果是 Return，肯定死了
-            if (isa<func::ReturnOp>(op)) return false;
+            if (isa<func::ReturnOp>(op)) {
+              return false;
+            }
             return hasPipelineActivityAfterOp(block->getParentOp(), targetPipe);
         }
     }
     return false;
 }
- 
+
 // ==========================================================
 // Pass 实现
 // ==========================================================
 struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarrierPass, OperationPass<func::FuncOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PTORemoveRedundantBarrierPass)
- 
+
   void runOnOperation() override {
     func::FuncOp func = getOperation();
     MLIRContext *ctx = &getContext();
@@ -111,11 +128,17 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
     Attribute attrMTE2 = pto::PipeAttr::get(ctx, pto::PIPE::PIPE_MTE2);
     Attribute attrMTE3 = pto::PipeAttr::get(ctx, pto::PIPE::PIPE_MTE3);
     Attribute attrVec  = pto::PipeAttr::get(ctx, pto::PIPE::PIPE_V);
- 
+
     auto getOpPipe = [&](Operation *op) -> Attribute {
-      if (isa<pto::TLoadOp>(op)) return attrMTE2;
-      if (isa<pto::TStoreOp>(op)) return attrMTE3;
-      if (isa<pto::TAddOp>(op)) return attrVec;
+      if (isa<pto::TLoadOp>(op)) {
+        return attrMTE2;
+      }
+      if (isa<pto::TStoreOp>(op)) {
+        return attrMTE3;
+      }
+      if (isa<pto::TAddOp>(op)) {
+        return attrVec;
+      }
       return {};
     };
 
@@ -130,8 +153,9 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
       if (opName == "pto.set_flag_dyn" || opName == "pto.set_flag_d") {
         auto srcAttr = op->getAttrOfType<pto::PipeAttr>("src_pipe");
         auto dstAttr = op->getAttrOfType<pto::PipeAttr>("dst_pipe");
-        if (!srcAttr || !dstAttr)
+        if (!srcAttr || !dstAttr) {
           return false;
+        }
         src = srcAttr;
         dst = dstAttr;
         return true;
@@ -147,31 +171,32 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
       StringRef opName = op->getName().getStringRef();
       if (opName == "pto.wait_flag_dyn" || opName == "pto.wait_flag_d") {
         auto dstAttr = op->getAttrOfType<pto::PipeAttr>("dst_pipe");
-        if (!dstAttr)
+        if (!dstAttr) {
           return false;
+        }
         dst = dstAttr;
         return true;
       }
       return false;
     };
- 
+
     llvm::SmallVector<Operation*> opsToErase;
- 
+
     func.walk([&](Block *block) {
       // 记录 Block 内脏状态 (Intra-Block Dirty State)
       // 用于判断是否需要发广播
       llvm::DenseSet<Attribute> intraPipeDirtySet;
- 
+
       for (auto it = block->begin(); it != block->end(); ++it) {
         Operation *op = &*it;
         Attribute pipe = getOpPipe(op);
- 
+
         // === 1. 状态更新 ===
         if (pipe) {
             intraPipeDirtySet.insert(pipe);
             continue; 
         }
- 
+
         // === 2. Barrier 消除 ===
         if (auto barrierOp = dyn_cast<pto::BarrierOp>(op)) {
             Attribute bPipe = barrierOp.getPipe();
@@ -203,7 +228,7 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
             // 如果 Barrier 留下了，管线变干净
             intraPipeDirtySet.erase(bPipe);
         }
- 
+
         // === 3. Wait 消除 (幽灵 Wait 消除) ===
         Attribute waitDst;
         if (getWaitSyncDst(op, waitDst)) {
@@ -215,12 +240,12 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
                 continue;
             }
         }
- 
+
         // === 4. Set 消除 (死信 & 陈旧广播消除) ===
         Attribute setSrc;
         Attribute setDst;
         if (getSetSyncPipes(op, setSrc, setDst)) {
- 
+
             // 规则 A: Dead Receiver (死信)
             // 如果 dst 后面没有 Resource Op，发信号也没人用。
             // 注意：因为 isPipelineActiveFuture 忽略了 WaitOp，
@@ -242,7 +267,9 @@ struct PTORemoveRedundantBarrierPass : public PassWrapper<PTORemoveRedundantBarr
       }
     });
  
-    for (Operation *op : opsToErase) op->erase();
+    for (Operation *op : opsToErase) {
+      op->erase();
+    }
   }
 };
  

--- a/lib/PTO/Transforms/PTOResolveBufferSelect.cpp
+++ b/lib/PTO/Transforms/PTOResolveBufferSelect.cpp
@@ -42,20 +42,25 @@ using namespace mlir;
 namespace {
 
 static uint64_t alignUp(uint64_t value, uint64_t align) {
-  if (align == 0)
+  if (align == 0) {
     return value;
+  }
   return ((value + align - 1) / align) * align;
 }
 
 static Value ensureI64(Value value, IRRewriter &rewriter, Location loc) {
-  if (!value)
+  if (!value) {
     return {};
-  if (value.getType().isInteger(64))
+  }
+  if (value.getType().isInteger(64)) {
     return value;
-  if (value.getType().isIndex())
+  }
+  if (value.getType().isIndex()) {
     return rewriter.create<arith::IndexCastOp>(loc, rewriter.getI64Type(), value);
-  if (isa<IntegerType>(value.getType()))
+  }
+  if (isa<IntegerType>(value.getType())) {
     return rewriter.create<arith::ExtSIOp>(loc, rewriter.getI64Type(), value);
+  }
   return {};
 }
 
@@ -78,8 +83,9 @@ static bool getTilePointerStrides(pto::TileBufType type, int64_t &rowStride,
   }
 
   unsigned elemBytes = pto::getPTOStorageElemByteSize(type.getElementType());
-  if (elemBytes == 0)
+  if (elemBytes == 0) {
     return false;
+  }
   int64_t innerRows = 1;
   int64_t innerCols = 1;
   int32_t fractal = config.getSFractalSize().getInt();
@@ -100,8 +106,9 @@ static bool getTilePointerStrides(pto::TileBufType type, int64_t &rowStride,
   }
 
   if (bl == 1) {
-    if (sl != 1)
+    if (sl != 1) {
       return false;
+    }
     rowStride = innerCols;
     colStride =
         shape[0] +
@@ -167,8 +174,9 @@ static Value computeTileAddress(Value value, IRRewriter &rewriter,
     Value elements = rewriter.create<arith::AddIOp>(loc, row, col);
     int64_t elemBytes = static_cast<int64_t>(
         pto::getPTOStorageElemByteSize(sourceType.getElementType()));
-    if (elemBytes == 0)
+    if (elemBytes == 0) {
       return {};
+    }
     Value byteScale = rewriter.create<arith::ConstantIntOp>(loc, elemBytes, 64);
     Value bytes = rewriter.create<arith::MulIOp>(loc, elements, byteScale);
     return rewriter.create<arith::AddIOp>(loc, base, bytes);
@@ -231,8 +239,9 @@ static LogicalResult resolveTileNativeSubviews(ModuleOp module,
     // A tile function argument is a symbolic runtime-bound handle. Keep its
     // subview tile-native; only planned local roots can be normalized to an
     // addressed alloc_tile here.
-    if (!addr)
+    if (!addr) {
       continue;
+    }
     pto::TileBufType physicalType = getSubviewPhysicalType(op);
     auto alloc = rewriter.create<pto::AllocTileOp>(
         op.getLoc(), physicalType, addr,
@@ -246,12 +255,14 @@ static LogicalResult resolveTileNativeSubviews(ModuleOp module,
 
 static FailureOr<uint64_t> getStaticSlotBytes(pto::TileBufType slotType) {
   uint64_t elemBytes = pto::getPTOStorageElemByteSize(slotType.getElementType());
-  if (elemBytes == 0)
+  if (elemBytes == 0) {
     return failure();
+  }
   uint64_t bytes = elemBytes;
   for (int64_t dim : slotType.getShape()) {
-    if (dim == ShapedType::kDynamic)
+    if (dim == ShapedType::kDynamic) {
       return failure();
+    }
     bytes *= static_cast<uint64_t>(dim);
   }
   return bytes;
@@ -263,8 +274,9 @@ static LogicalResult getMultiTileAddresses(pto::AllocMultiTileOp alloc,
   uint32_t count = alloc.getResult().getType().getCount();
   if (auto planned = alloc->getAttrOfType<DenseI64ArrayAttr>(
           pto::kPtoMultiBufferAddrsAttrName)) {
-    if (planned.size() != count)
+    if (planned.size() != count) {
       return alloc.emitError("planned address count does not match slot count");
+    }
     for (int64_t address : planned.asArrayRef())
       addrs.push_back(rewriter.create<arith::ConstantIntOp>(
           alloc.getLoc(), address, 64));
@@ -272,13 +284,15 @@ static LogicalResult getMultiTileAddresses(pto::AllocMultiTileOp alloc,
   }
 
   Value base = alloc.getAddr();
-  if (!base)
+  if (!base) {
     return alloc.emitError(
         "has neither a level3 base address nor planner-assigned slot addresses");
+  }
   auto slotBytes = getStaticSlotBytes(alloc.getResult().getType().getSlotType());
-  if (failed(slotBytes))
+  if (failed(slotBytes)) {
     return alloc.emitError(
         "requires a static slot shape and known element byte size");
+  }
 
   uint64_t slotStride =
       alignUp(*slotBytes,
@@ -309,8 +323,9 @@ static LogicalResult resolveTileNativeMultiGets(ModuleOp module,
     IRRewriter rewriter(ctx);
     rewriter.setInsertionPoint(op);
     SmallVector<Value, 8> addrs;
-    if (failed(getMultiTileAddresses(alloc, rewriter, addrs)))
+    if (failed(getMultiTileAddresses(alloc, rewriter, addrs))) {
       return failure();
+    }
 
     Value selectedAddr;
     IntegerAttr constSlotAttr;
@@ -340,9 +355,10 @@ static LogicalResult resolveTileNativeMultiGets(ModuleOp module,
   SmallVector<pto::AllocMultiTileOp, 8> allocs;
   module.walk([&](pto::AllocMultiTileOp op) { allocs.push_back(op); });
   for (pto::AllocMultiTileOp alloc : allocs) {
-    if (!alloc.getResult().use_empty())
+    if (!alloc.getResult().use_empty()) {
       return alloc.emitError(
           "has unsupported uses after resolving pto.multi_tile_get");
+    }
     alloc.erase();
   }
   return success();

--- a/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
+++ b/lib/PTO/Transforms/PTOResolveReservedBuffersPass.cpp
@@ -130,8 +130,9 @@ static std::optional<PipePeerKey> getPipePeerKey(Value localAddr,
     auto peerFunc =
         lookupPeerFuncAcrossContainer(importOp.getOperation(),
                                       importOp.getPeerFuncAttr());
-    if (!peerFunc)
+    if (!peerFunc) {
       return std::nullopt;
+    }
     return PipePeerKey{getFuncSymbol(peerFunc), importOp.getName().str(), 0};
   }
 
@@ -176,11 +177,13 @@ static LogicalResult collectPeerAwareInit(InitOpT initOp,
   }
 
   auto recordAddr = [&](Value addr, int8_t effectiveDirMask) {
-    if (!addr)
+    if (!addr) {
       return false;
+    }
     auto key = getPipePeerKey(addr, info.funcOp);
-    if (!key)
+    if (!key) {
       return false;
+    }
     key->dirMask = effectiveDirMask;
     keyedInits[*key].push_back(info.op);
     return true;
@@ -195,10 +198,12 @@ static LogicalResult collectPeerAwareInit(InitOpT initOp,
     recorded = recordAddr(getLocalAddrOperand(initOp), info.dirMask);
   }
 
-  if (recorded)
+  if (recorded) {
     initInfos.push_back(info);
-  if (recorded || getFlagBaseAttr(initOp))
+  }
+  if (recorded || getFlagBaseAttr(initOp)) {
     return success();
+  }
 
   return initOp.emitOpError(
       "requires local_addr to come from pto.reserve_buffer or "
@@ -249,8 +254,9 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
   for (const auto &it : keyedInits) {
     SmallVector<Operation *> uniqueOps;
     for (Operation *op : it.second) {
-      if (std::find(uniqueOps.begin(), uniqueOps.end(), op) == uniqueOps.end())
+      if (std::find(uniqueOps.begin(), uniqueOps.end(), op) == uniqueOps.end()) {
         uniqueOps.push_back(op);
+      }
     }
     for (size_t i = 0; i < uniqueOps.size(); ++i) {
       for (size_t j = i + 1; j < uniqueOps.size(); ++j) {
@@ -263,8 +269,9 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
   SmallVector<PipeComponent> components;
   llvm::SmallPtrSet<Operation *, kVisitedInitReserveSize> visited;
   for (const PipeInitInfo &rootInfo : initInfos) {
-    if (!visited.insert(rootInfo.op).second)
+    if (!visited.insert(rootInfo.op).second) {
       continue;
+    }
 
     SmallVector<Operation *> stack{rootInfo.op};
     PipeComponent component;
@@ -272,8 +279,9 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
       Operation *current = stack.pop_back_val();
       component.ops.push_back(current);
       for (Operation *neighbor : adjacency[current]) {
-        if (visited.insert(neighbor).second)
+        if (visited.insert(neighbor).second) {
           stack.push_back(neighbor);
+        }
       }
     }
 
@@ -327,10 +335,11 @@ buildPeerAwareComponents(const SmallVectorImpl<PipeInitInfo> &initInfos,
         // producer/consumer functions. Keep the smallest observed id only as a
         // stable component sort key; cross-function pairing is determined by
         // the peer buffer contract instead of frontend id equality.
-        if (component.frontendId)
+        if (component.frontendId) {
           component.frontendId = std::min(*component.frontendId, *frontendId);
-        else
+        } else {
           component.frontendId = *frontendId;
+        }
       }
     }
 
@@ -408,8 +417,9 @@ static FailureOr<int32_t> chooseFlagBaseForComponent(const PipeComponent &compon
         nextCandidate = std::max(nextCandidate, alignToEven(used.end));
       }
     }
-    if (!conflict)
+    if (!conflict) {
       break;
+    }
     candidateBase = nextCandidate;
   }
 
@@ -451,8 +461,9 @@ struct PTOResolveReservedBuffersPass
       if (failed(chosenBaseOr))
         return failure();
       auto flagBaseAttr = builder.getI32IntegerAttr(*chosenBaseOr);
-      for (Operation *op : component.ops)
+      for (Operation *op : component.ops) {
         setFlagBaseAttr(op, flagBaseAttr);
+      }
     }
 
     return success();
@@ -523,8 +534,9 @@ struct PTOResolveReservedBuffersPass
       }
     }
 
-    for (Operation *op : eraseOps)
+    for (Operation *op : eraseOps) {
       op->erase();
+    }
 
     return success();
   }

--- a/lib/PTO/Transforms/PTOToEmitC.cpp
+++ b/lib/PTO/Transforms/PTOToEmitC.cpp
@@ -249,10 +249,11 @@ buildDefaultLastUseTileSlotOrder(Operation *op) {
   for (OpOperand &operand : op->getOpOperands()) {
     if (!isa<pto::TileBufType>(operand.get().getType()))
       continue;
-    if (isDpsInitOperand(operand))
+    if (isDpsInitOperand(operand)) {
       dpsInitTileOperands.push_back(operand.getOperandNumber());
-    else
+    } else {
       nonDpsTileOperands.push_back(operand.getOperandNumber());
+    }
   }
 
   // Most tile intrinsics lower as `CALLEE(dst, src0, src1, ...)`. When an op
@@ -421,39 +422,53 @@ static bool isF8E8M0ElemType(Type elemTy) {
 }
 
 static std::string getEmitCScalarTypeToken(Type elemTy) {
-  if (pto::isPTOFloat8E4M3LikeType(elemTy))
+  if (pto::isPTOFloat8E4M3LikeType(elemTy)) {
     return "float8_e4m3_t";
-  if (pto::isPTOFloat8E5M2LikeType(elemTy))
+  }
+  if (pto::isPTOFloat8E5M2LikeType(elemTy)) {
     return "float8_e5m2_t";
-  if (isF8E8M0ElemType(elemTy))
+  }
+  if (isF8E8M0ElemType(elemTy)) {
     return "float8_e8m0_t";
-  if (isa<pto::HiF8Type>(elemTy))
+  }
+  if (isa<pto::HiF8Type>(elemTy)) {
     return "hifloat8_t";
-  if (isa<pto::F4E1M2x2Type>(elemTy))
+  }
+  if (isa<pto::F4E1M2x2Type>(elemTy)) {
     return "float4_e1m2x2_t";
-  if (isa<pto::F4E2M1x2Type>(elemTy))
+  }
+  if (isa<pto::F4E2M1x2Type>(elemTy)) {
     return "float4_e2m1x2_t";
-  if (elemTy.isF16())
+  }
+  if (elemTy.isF16()) {
     return "half";
-  if (elemTy.isBF16())
+  }
+  if (elemTy.isBF16()) {
     return "bfloat16_t";
-  if (elemTy.isF32())
+  }
+  if (elemTy.isF32()) {
     return "float";
-  if (elemTy.isF64())
+  }
+  if (elemTy.isF64()) {
     return "double";
-  if (elemTy.isInteger(8))
+  }
+  if (elemTy.isInteger(8)) {
     return (elemTy.isSignlessInteger(8) || elemTy.isSignedInteger(8)) ? "int8_t"
                                                                        : "uint8_t";
-  if (elemTy.isInteger(16))
+  }
+  if (elemTy.isInteger(16)) {
     return (elemTy.isSignlessInteger(16) || elemTy.isSignedInteger(16))
                ? "int16_t"
                : "uint16_t";
-  if (elemTy.isInteger(32))
+  }
+  if (elemTy.isInteger(32)) {
     return (elemTy.isSignlessInteger(32) || elemTy.isSignedInteger(32))
                ? "int32_t"
                : "uint32_t";
-  if (elemTy.isInteger(64))
+  }
+  if (elemTy.isInteger(64)) {
     return cast<IntegerType>(elemTy).isUnsigned() ? "uint64_t" : "int64_t";
+  }
   return "float";
 }
 
@@ -835,14 +850,24 @@ public:
     // 1. 基本类型 (f32, i32, index)
     // ---------------------------------------------------------
     addConversion([Ctx](FloatType type) -> Type {
-      if (pto::isPTOFloat8E4M3LikeType(type))
+      if (pto::isPTOFloat8E4M3LikeType(type)) {
         return emitc::OpaqueType::get(Ctx, "float8_e4m3_t");
-      if (pto::isPTOFloat8E5M2LikeType(type))
+      }
+      if (pto::isPTOFloat8E5M2LikeType(type)) {
         return emitc::OpaqueType::get(Ctx, "float8_e5m2_t");
-      if (type.isF32()) return emitc::OpaqueType::get(Ctx, "float");
-      if (type.isF16()) return emitc::OpaqueType::get(Ctx, "half");
-      if (type.isBF16()) return emitc::OpaqueType::get(Ctx, "bfloat16_t");
-      if (type.isF64()) return emitc::OpaqueType::get(Ctx, "double");
+      }
+      if (type.isF32()) {
+        return emitc::OpaqueType::get(Ctx, "float");
+      }
+      if (type.isF16()) {
+        return emitc::OpaqueType::get(Ctx, "half");
+      }
+      if (type.isBF16()) {
+        return emitc::OpaqueType::get(Ctx, "bfloat16_t");
+      }
+      if (type.isF64()) {
+        return emitc::OpaqueType::get(Ctx, "double");
+      }
       llvm::errs() << "[Debug] Unsupported FloatType: " << type << "\n";
       return Type{};
     });
@@ -1042,15 +1067,21 @@ public:
     // ---------------------------------------------------------
     addConversion([this](FunctionType type) -> Type {
       SmallVector<Type> inputs;
-      if (failed(convertTypes(type.getInputs(), inputs))) return Type{};
+      if (failed(convertTypes(type.getInputs(), inputs))) {
+        return Type{};
+      }
       SmallVector<Type> results;
-      if (failed(convertTypes(type.getResults(), results))) return Type{};
+      if (failed(convertTypes(type.getResults(), results))) {
+        return Type{};
+      }
       return FunctionType::get(type.getContext(), inputs, results);
     });
 
     auto materializeCast = [](OpBuilder &Builder, Type ResultType,
                               ValueRange Inputs, Location Loc) -> Value {
-      if (Inputs.size() != 1) return Value();
+      if (Inputs.size() != 1) {
+        return Value();
+      }
       return Builder.create<UnrealizedConversionCastOp>(Loc, ResultType, Inputs[0]).getResult(0);
     };
 
@@ -1526,10 +1557,11 @@ adaptCallOperandForEmitC(const TypeConverter *typeConverter,
   } else if (auto memrefTy = dyn_cast<MemRefType>(originalCalleeArgTy)) {
     elemTy = memrefTy.getElementType();
     if (auto asAttr =
-            dyn_cast_or_null<pto::AddressSpaceAttr>(memrefTy.getMemorySpace()))
+            dyn_cast_or_null<pto::AddressSpaceAttr>(memrefTy.getMemorySpace())) {
       as = asAttr.getAddressSpace();
-    else
+    } else {
       as = pto::AddressSpace::GM;
+    }
   }
 
   if (elemTy && as) {
@@ -2619,10 +2651,10 @@ struct ArithMulExtendedToEmitC : public OpConversionPattern<ArithOp> {
     Type lowDstTy = newResultTypes[0];
     Type highDstTy = newResultTypes[1];
 
-    Type wideTy = isUnsigned ? (Type)getWiderUnsignedIntOpaqueType(rewriter.getContext(),
-                                                                   bitWidth)
-                             : (Type)getWiderSignedIntOpaqueType(rewriter.getContext(),
-                                                                 bitWidth);
+    Type wideTy = isUnsigned ? static_cast<Type>(getWiderUnsignedIntOpaqueType(rewriter.getContext(),
+                                                                               bitWidth))
+                             : static_cast<Type>(getWiderSignedIntOpaqueType(rewriter.getContext(),
+                                                                             bitWidth));
 
     Value lhsWide;
     Value rhsWide;
@@ -3539,12 +3571,22 @@ enum class KernelKind { VecAdd, Matmul, Unknown };
   bool hasAdd = false;
   bool hasMM  = false;
   f.walk([&](Operation *op) {
-    if (isa<mlir::pto::TAddOp>(op)) hasAdd = true;
-    if (isa<mlir::pto::TMatmulOp>(op)) hasMM = true;
-    if (isa<mlir::pto::TMatmulAccOp>(op)) hasMM = true;
+    if (isa<mlir::pto::TAddOp>(op)) {
+      hasAdd = true;
+    }
+    if (isa<mlir::pto::TMatmulOp>(op)) {
+      hasMM = true;
+    }
+    if (isa<mlir::pto::TMatmulAccOp>(op)) {
+      hasMM = true;
+    }
   });
-  if (hasMM)  return KernelKind::Matmul;
-  if (hasAdd) return KernelKind::VecAdd;
+  if (hasMM) {
+    return KernelKind::Matmul;
+  }
+  if (hasAdd) {
+    return KernelKind::VecAdd;
+  }
   return KernelKind::Unknown;
 }
 
@@ -3556,12 +3598,14 @@ enum class KernelKind { VecAdd, Matmul, Unknown };
   auto readShape2D = [&](memref::SubViewOp sv, int &d0, int &d1) {
     auto resTy = mlir::cast<MemRefType>(sv.getResult().getType());
     if (resTy.getRank() == 2 && resTy.hasStaticShape()) {
-      d0 = (int)resTy.getDimSize(0);
-      d1 = (int)resTy.getDimSize(1);
+      d0 = static_cast<int>(resTy.getDimSize(0));
+      d1 = static_cast<int>(resTy.getDimSize(1));
     }
   };
 
-  if (subs.empty()) return;
+  if (subs.empty()) {
+    return;
+  }
 
   int a0=32, a1=32;
   readShape2D(subs[0], a0, a1);
@@ -3893,7 +3937,7 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
 
         // B. 获取 Stride (用于指针计算)
         Value strideVal = mkIndex(1);
-        if (i < (int)sourceStrides.size()) {
+        if (i < static_cast<int>(sourceStrides.size())) {
             strideVal = ofrToEmitCValue(sourceStrides[i]);
         }
 
@@ -4002,11 +4046,12 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
         shapeParamsVec.push_back(resShape[i]);
       }
       // size 值：优先从 op.getMixedSizes() 取（可动态/静态），否则退化为类型里的静态 shape。
-      if (i < (int)mixedSizes.size())
+      if (i < static_cast<int>(mixedSizes.size())) {
         sizeValues.push_back(ofrToEmitCValue(mixedSizes[i]));
-      else
+      } else {
         sizeValues.push_back(
             mkIndex(resShape[i] == ShapedType::kDynamic ? 1 : resShape[i]));
+      }
     }
 
     // 3. 生成 Stride 模板参数 + 运行时 stride 值（考虑 subview step）
@@ -4017,9 +4062,9 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
     auto subViewSteps = op.getMixedStrides();
     for (int i = 0; i < rank; ++i) {
       OpFoldResult srcStrideOfr =
-          (i < (int)sourceStrides.size()) ? sourceStrides[i]
-                                          : rewriter.getIndexAttr(1);
-      OpFoldResult stepOfr = (i < (int)subViewSteps.size())
+          (i < static_cast<int>(sourceStrides.size())) ? sourceStrides[i]
+                                                       : rewriter.getIndexAttr(1);
+      OpFoldResult stepOfr = (i < static_cast<int>(subViewSteps.size()))
                                  ? subViewSteps[i]
                                  : rewriter.getIndexAttr(1);
 
@@ -4036,13 +4081,14 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
       Value srcV = ofrToEmitCValue(srcStrideOfr);
       Value stepV = ofrToEmitCValue(stepOfr);
       // 尽量避免乘以 1 生成冗余指令
-      if (stepStatic && *stepStatic == 1)
+      if (stepStatic && *stepStatic == 1) {
         strideValues.push_back(srcV);
-      else if (srcStatic && *srcStatic == 1)
+      } else if (srcStatic && *srcStatic == 1) {
         strideValues.push_back(stepV);
-      else
+      } else {
         strideValues.push_back(
             rewriter.create<emitc::MulOp>(loc, indexTy, srcV, stepV));
+      }
     }
 
     // 3.1 右对齐到 5 维：shape 补 1；已有维度继承原 stride；
@@ -4124,13 +4170,15 @@ struct SubviewToEmitCPattern : public OpConversionPattern<memref::SubViewOp> {
           layoutTag = 2; // NZ
         } else {
           bool isRow = finalStride[4] == 1;
-          for (int i = 3; i >= 0; --i)
+          for (int i = 3; i >= 0; --i) {
             isRow &= (finalStride[i] ==
                       multiplyOrDynamic(finalStride[i + 1], finalShape[i + 1]));
+          }
           bool isCol = finalStride[0] == 1;
-          for (int i = 0; i < 4; ++i)
+          for (int i = 0; i < 4; ++i) {
             isCol &= (finalStride[i + 1] ==
                       multiplyOrDynamic(finalStride[i], finalShape[i]));
+          }
           if (isCol)
             layoutTag = 1; // DN
           else
@@ -4514,15 +4562,16 @@ static Value materializeGlobalTensorDataPointer(
     return value;
 
   Type elemType;
-  if (auto tvTy = dyn_cast<pto::TensorViewType>(sourceType))
+  if (auto tvTy = dyn_cast<pto::TensorViewType>(sourceType)) {
     elemType = tvTy.getElementType();
-  else if (auto partitionTy =
-               dyn_cast<pto::PartitionTensorViewType>(sourceType))
+  } else if (auto partitionTy =
+                 dyn_cast<pto::PartitionTensorViewType>(sourceType)) {
     elemType = partitionTy.getElementType();
-  else if (auto memrefTy = dyn_cast<MemRefType>(sourceType))
+  } else if (auto memrefTy = dyn_cast<MemRefType>(sourceType)) {
     elemType = memrefTy.getElementType();
-  else
+  } else {
     return value;
+  }
 
   auto *ctx = rewriter.getContext();
   std::string elemTypeStr = getElemTypeStringForGT(elemType);
@@ -5460,13 +5509,15 @@ struct PTOFenceToEmitC : public OpConversionPattern<FenceOp> {
                                 ConversionPatternRewriter &rewriter) const override {
     (void)adaptor;
     if (op.getScope().getScope() != pto::FenceScope::GM &&
-        op.getScope().getScope() != pto::FenceScope::All)
+        op.getScope().getScope() != pto::FenceScope::All) {
       return rewriter.notifyMatchFailure(op, "unsupported fence scope");
+    }
 
-    if (isInVectorKernel(op))
+    if (isInVectorKernel(op)) {
       emitPipeBarrier(rewriter, op.getLoc(), "PIPE_ALL");
-    else
+    } else {
       emitConservativeGmFencePipeDrains(rewriter, op.getLoc());
+    }
     emitDsbDdr(rewriter, op.getLoc());
     rewriter.eraseOp(op);
     return success();
@@ -6139,7 +6190,6 @@ struct PTOGetBlockIdxToEmitC
   LogicalResult
   matchAndRewrite(mlir::pto::GetBlockIdxOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, op.getType(), "get_block_idx", ValueRange{}, ArrayAttr{},
         ArrayAttr{});
@@ -6156,7 +6206,6 @@ struct PTOGetBlockNumToEmitC
   LogicalResult
   matchAndRewrite(mlir::pto::GetBlockNumOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, op.getType(), "get_block_num", ValueRange{}, ArrayAttr{},
         ArrayAttr{});
@@ -6173,7 +6222,6 @@ struct PTOGetSubBlockIdxToEmitC
   LogicalResult
   matchAndRewrite(mlir::pto::GetSubBlockIdxOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, op.getType(), "get_subblockid", ValueRange{}, ArrayAttr{},
         ArrayAttr{});
@@ -6190,7 +6238,6 @@ struct PTOGetSubBlockNumToEmitC
   LogicalResult
   matchAndRewrite(mlir::pto::GetSubBlockNumOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, op.getType(), "get_subblockdim", ValueRange{}, ArrayAttr{},
         ArrayAttr{});
@@ -6853,20 +6900,22 @@ struct PTOInitializeL2G2LPipeToEmitC
 
     Value c2vBuf = zero;
     Value v2cBuf = zero;
-    if (op.getDirMask() == 1)
+    if (op.getDirMask() == 1) {
       c2vBuf = localAddr ? localAddr : zero;
-    else if (op.getDirMask() == 2)
+    } else if (op.getDirMask() == 2) {
       v2cBuf = localAddr ? localAddr : zero;
-    else if (op.getDirMask() == 3) {
+    } else if (op.getDirMask() == 3) {
       if (localAddr) {
-        if (!op.getPeerLocalAddr())
+        if (!op.getPeerLocalAddr()) {
           return rewriter.notifyMatchFailure(
               op, "bidirectional l2g2l pipe requires peer local buffer");
+        }
         c2vBuf = localAddr;
         v2cBuf = peelUnrealized(adaptor.getPeerLocalAddr());
       }
-    } else
+    } else {
       return rewriter.notifyMatchFailure(op, "unsupported dir_mask");
+    }
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, TypeRange{emitPipeTy}, *tpipeTok, ArrayAttr{}, ArrayAttr{},
@@ -6905,15 +6954,16 @@ struct PTOInitializeL2LPipeToEmitC
 
     Value c2vBuf = zero;
     Value v2cBuf = zero;
-    if (op.getDirMask() == 1)
+    if (op.getDirMask() == 1) {
       c2vBuf = localAddr;
-    else if (op.getDirMask() == 2)
+    } else if (op.getDirMask() == 2) {
       v2cBuf = localAddr;
-    else if (op.getDirMask() == 3) {
+    } else if (op.getDirMask() == 3) {
       c2vBuf = localAddr;
       v2cBuf = peelUnrealized(adaptor.getPeerLocalAddr());
-    } else
+    } else {
       return rewriter.notifyMatchFailure(op, "unsupported dir_mask");
+    }
 
     rewriter.replaceOpWithNewOp<emitc::CallOpaqueOp>(
         op, TypeRange{emitPipeTy}, *tpipeTok, ArrayAttr{}, ArrayAttr{},
@@ -8076,12 +8126,13 @@ struct PTOGetTensorViewMetadataToEmitC : public OpConversionPattern<OpTy> {
       ConversionPatternRewriter &rewriter) const override {
     Type sourceType = op.getTensorView().getType();
     int64_t rank = 0;
-    if (auto type = dyn_cast<pto::TensorViewType>(sourceType))
+    if (auto type = dyn_cast<pto::TensorViewType>(sourceType)) {
       rank = type.getRank();
-    else if (auto type = dyn_cast<pto::PartitionTensorViewType>(sourceType))
+    } else if (auto type = dyn_cast<pto::PartitionTensorViewType>(sourceType)) {
       rank = type.getRank();
-    else
+    } else {
       return rewriter.notifyMatchFailure(op, "expected PTO tensor view");
+    }
 
     Value result = getRuntimeGlobalTensorMetadata(
         rewriter, op.getLoc(), peelUnrealized(adaptor.getTensorView()),
@@ -8098,7 +8149,7 @@ static LogicalResult getStaticTensorViewStrides(
   strides.clear();
 
   if (auto makeView = source.getDefiningOp<pto::MakeTensorViewOp>()) {
-    if ((int64_t)makeView.getStrides().size() != rank)
+    if (static_cast<int64_t>(makeView.getStrides().size()) != rank)
       return failure();
     for (Value strideValue : makeView.getStrides()) {
       auto cst = getStaticIndexLikeValue(strideValue);
@@ -8115,7 +8166,7 @@ static LogicalResult getStaticTensorViewStrides(
     StringRef token = opaqueTy.getValue();
     if ((parseIntegerTemplateList(token, "pto::Stride<", stride5D) ||
          parseIntegerTemplateList(token, "Stride<", stride5D)) &&
-        (int64_t)stride5D.size() >= rank) {
+        static_cast<int64_t>(stride5D.size()) >= rank) {
       strides.append(stride5D.end() - rank, stride5D.end());
       return success();
     }
@@ -8625,10 +8676,11 @@ struct ReinterpretCastToEmitC : public OpConversionPattern<memref::ReinterpretCa
       roleTok = "TileType::Vec";
       break;
     case pto::AddressSpace::SCALING:
-      if (const char *inferredRole = inferScalingRoleFromValue(source))
+      if (const char *inferredRole = inferScalingRoleFromValue(source)) {
         roleTok = inferredRole;
-      else
+      } else {
         roleTok = "TileType::Scaling";
+      }
       break;
     }
 
@@ -8895,10 +8947,11 @@ struct PTOTCIToEmitC : public OpConversionPattern<pto::TCIOp> {
     std::string scalarTok = "int32_t";
     if (auto it = dyn_cast<IntegerType>(op->getOperand(0).getType())) {
       bool isUnsigned = it.isUnsigned();
-      if (it.getWidth() == 16)
+      if (it.getWidth() == 16) {
         scalarTok = isUnsigned ? "uint16_t" : "int16_t";
-      else
+      } else {
         scalarTok = isUnsigned ? "uint32_t" : "int32_t";
+      }
     }
 
     // descending -> "0"/"1"
@@ -9864,7 +9917,6 @@ struct PTOFillPadToEmitC : public OpConversionPattern<pto::TFillPadOp> {
 //===----------------------------------------------------------------------===//
 
 [[maybe_unused]] static std::string maskPatternTok(mlir::pto::MaskPatternAttr a) {
-
   auto v = a.getValue(); // enum
   return (std::string("pto::MaskPattern::") + mlir::pto::stringifyMaskPattern(v).str());
 }
@@ -11199,10 +11251,11 @@ struct PTORowExpandAddToEmitC : public OpConversionPattern<pto::TRowExpandAddOp>
     Value dst = peelUnrealized(adaptor.getDst());
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src0, src1, tmp});
-    else
+    } else {
       operands.assign({dst, src0, src1});
+    }
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TROWEXPANDADD",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -11227,10 +11280,11 @@ struct PTORowExpandExpdifToEmitC
     Value tmp  = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src0, src1, tmp});
-    else
+    } else {
       operands.assign({dst, src0, src1});
+    }
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TROWEXPANDEXPDIF",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -11247,10 +11301,11 @@ static void replaceOrEraseWithOpaqueCallAndReturnDst(Operation *op, Value dst,
                                                      ArrayAttr templateArgs,
                                                      ConversionPatternRewriter &rewriter) {
   createLastUseAwareOpaqueCall(rewriter, op, TypeRange{}, callee, args, ArrayAttr{}, templateArgs);
-  if (op->getNumResults() == 1)
+  if (op->getNumResults() == 1) {
     rewriter.replaceOp(op, dst);
-  else
+  } else {
     rewriter.eraseOp(op);
+  }
 }
 
 // ---------- TOp ----------
@@ -11431,10 +11486,11 @@ struct PTORowExpandDivToEmitC : public OpConversionPattern<pto::TRowExpandDivOp>
     Value tmp  = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src0, src1, tmp});
-    else
+    } else {
       operands.assign({dst, src0, src1});
+    }
     ArrayAttr templateArgs;
     if (op.getPrecisionType() != pto::DivPrecision::Default) {
       StringRef precisionTok;
@@ -11471,10 +11527,11 @@ struct PTORowExpandMulToEmitC : public OpConversionPattern<pto::TRowExpandMulOp>
     Value tmp  = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src0, src1, tmp});
-    else
+    } else {
       operands.assign({dst, src0, src1});
+    }
     createLastUseAwareOpaqueCall(rewriter, op.getOperation(), TypeRange{},
                                  "TROWEXPANDMUL", operands);
 
@@ -11500,10 +11557,11 @@ struct PTORowExpandSubToEmitC : public OpConversionPattern<pto::TRowExpandSubOp>
     Value tmp  = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src0, src1, tmp});
-    else
+    } else {
       operands.assign({dst, src0, src1});
+    }
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TROWEXPANDSUB",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -11527,10 +11585,11 @@ struct PTORowExpandMaxToEmitC : public OpConversionPattern<pto::TRowExpandMaxOp>
     Value tmp  = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src0, src1, tmp});
-    else
+    } else {
       operands.assign({dst, src0, src1});
+    }
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TROWEXPANDMAX",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -11554,10 +11613,11 @@ struct PTORowExpandMinToEmitC : public OpConversionPattern<pto::TRowExpandMinOp>
     Value tmp  = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src0, src1, tmp});
-    else
+    } else {
       operands.assign({dst, src0, src1});
+    }
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TROWEXPANDMIN",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -11952,10 +12012,11 @@ struct PTOSORT32SToEmitC : public OpConversionPattern<pto::TSort32Op> {
     Value tmp = op.getTmp() ? peelUnrealized(adaptor.getTmp()) : Value();
 
     SmallVector<Value, 4> operands;
-    if (tmp)
+    if (tmp) {
       operands.assign({dst, src, idx, tmp});
-    else
+    } else {
       operands.assign({dst, src, idx});
+    }
     rewriter.create<emitc::CallOpaqueOp>(
         loc, TypeRange{}, "TSORT32",
         /*args=*/ArrayAttr{}, /*templateArgs=*/ArrayAttr{},
@@ -12255,14 +12316,15 @@ struct PTOPrintOpToEmitC : public OpConversionPattern<pto::PrintOp> {
       fmt = "%f";
     std::string quoted = "\"";
     for (char c : fmt) {
-      if (c == '"' || c == '\\')
+      if (c == '"' || c == '\\') {
         quoted += '\\';
-      else if (c == '\n')
+      } else if (c == '\n') {
         quoted += "\\n";
-      else if (c == '\t')
+      } else if (c == '\t') {
         quoted += "\\t";
-      else
+      } else {
         quoted += c;
+      }
     }
     quoted += "\"";
 

--- a/lib/PTO/Transforms/PTOVPTOPtrBoundary.cpp
+++ b/lib/PTO/Transforms/PTOVPTOPtrBoundary.cpp
@@ -30,12 +30,14 @@ namespace {
 
 static Type convertVPTOBoundaryMemRefType(Type type) {
   auto memrefType = dyn_cast<BaseMemRefType>(type);
-  if (!memrefType)
+  if (!memrefType) {
     return type;
+  }
   auto memorySpace =
       dyn_cast_or_null<pto::AddressSpaceAttr>(memrefType.getMemorySpace());
-  if (!memorySpace)
+  if (!memorySpace) {
     return {};
+  }
   return pto::PtrType::get(type.getContext(), memrefType.getElementType(),
                            memorySpace);
 }
@@ -56,29 +58,33 @@ static LogicalResult eraseDeadVPTOMemRefScaffold(ModuleOp module) {
           trivialCasts.push_back(castOp);
           return;
         }
-        if (castOp->use_empty())
+        if (castOp->use_empty()) {
           deadOps.push_back(op);
+        }
         return;
       }
 
-      if (!op->use_empty())
+      if (!op->use_empty()) {
         return;
+      }
       if (isa<memref::ReinterpretCastOp, memref::SubViewOp,
               memref::MemorySpaceCastOp>(op))
         deadOps.push_back(op);
     });
 
     for (pto::CastPtrOp castOp : trivialCasts) {
-      if (!castOp->getBlock())
+      if (!castOp->getBlock()) {
         continue;
+      }
       castOp.getResult().replaceAllUsesWith(castOp.getInput());
       castOp.erase();
       erasedAny = true;
     }
 
     for (Operation *op : deadOps) {
-      if (!op->getBlock())
+      if (!op->getBlock()) {
         continue;
+      }
       op->erase();
       erasedAny = true;
     }
@@ -88,23 +94,29 @@ static LogicalResult eraseDeadVPTOMemRefScaffold(ModuleOp module) {
 
 static Type getVPTOBufferElementType(Value value) {
   Type type = value.getType();
-  if (auto tileType = dyn_cast<pto::TileBufType>(type))
+  if (auto tileType = dyn_cast<pto::TileBufType>(type)) {
     return tileType.getElementType();
-  if (auto memrefType = dyn_cast<BaseMemRefType>(type))
+  }
+  if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
     return memrefType.getElementType();
-  if (auto ptrType = dyn_cast<pto::PtrType>(type))
+  }
+  if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
     return ptrType.getElementType();
+  }
   return {};
 }
 
 static Attribute getVPTOBufferMemorySpace(Value value) {
   Type type = value.getType();
-  if (auto tileType = dyn_cast<pto::TileBufType>(type))
+  if (auto tileType = dyn_cast<pto::TileBufType>(type)) {
     return tileType.getMemorySpace();
-  if (auto memrefType = dyn_cast<BaseMemRefType>(type))
+  }
+  if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
     return memrefType.getMemorySpace();
-  if (auto ptrType = dyn_cast<pto::PtrType>(type))
+  }
+  if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
     return ptrType.getMemorySpace();
+  }
   return {};
 }
 
@@ -125,21 +137,25 @@ static LogicalResult canonicalizeBoundaryCastPtrOps(ModuleOp module,
                                                     llvm::raw_ostream *diagOS) {
   SmallVector<pto::CastPtrOp> castsToRewrite;
   module.walk([&](pto::CastPtrOp castOp) {
-    if (!isa<BaseMemRefType, pto::TileBufType>(castOp.getInput().getType()))
+    if (!isa<BaseMemRefType, pto::TileBufType>(castOp.getInput().getType())) {
       return;
-    if (!isa<pto::PtrType>(castOp.getResult().getType()))
+    }
+    if (!isa<pto::PtrType>(castOp.getResult().getType())) {
       return;
+    }
     castsToRewrite.push_back(castOp);
   });
 
   PatternRewriter rewriter(module.getContext());
   for (pto::CastPtrOp castOp : castsToRewrite) {
-    if (!castOp->getBlock())
+    if (!castOp->getBlock()) {
       continue;
+    }
 
     auto resultType = dyn_cast<pto::PtrType>(castOp.getResult().getType());
-    if (!resultType)
+    if (!resultType) {
       continue;
+    }
 
     rewriter.setInsertionPoint(castOp);
     Value ptrValue = pto::materializeBufferPointer(
@@ -166,8 +182,9 @@ static LogicalResult canonicalizeSupportedVPTOBufferLikeOps(
     ModuleOp module, llvm::raw_ostream *diagOS) {
   SmallVector<Operation *> opsToRewrite;
   module.walk([&](Operation *op) {
-    if (isSupportedVPTOBufferLikeBoundaryOp(op))
+    if (isSupportedVPTOBufferLikeBoundaryOp(op)) {
       opsToRewrite.push_back(op);
+    }
   });
 
   PatternRewriter rewriter(module.getContext());
@@ -213,8 +230,9 @@ static LogicalResult canonicalizeSupportedVPTOBufferLikeOps(
       newOperands.push_back(ptrValue);
     }
 
-    if (!changed)
+    if (!changed) {
       continue;
+    }
 
     OperationState state(op->getLoc(), op->getName().getStringRef());
     state.addOperands(newOperands);
@@ -235,8 +253,9 @@ struct PTOVPTOPtrBoundaryPass
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
-    if (failed(pto::convertVPTOEmissionBoundaryToPtr(module, &llvm::errs())))
+    if (failed(pto::convertVPTOEmissionBoundaryToPtr(module, &llvm::errs()))) {
       signalPassFailure();
+    }
   }
 };
 
@@ -248,13 +267,15 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
   // function ABI keeps only the same-space base pointer, while shape/stride
   // state remains in SSA. Body-level op canonicalization is added on top of
   // this entry rewrite in follow-up tasks.
-  if (failed(eraseDeadVPTOMemRefScaffold(module)))
+  if (failed(eraseDeadVPTOMemRefScaffold(module))) {
     return failure();
+  }
 
   bool sawFailure = false;
   for (func::FuncOp func : module.getOps<func::FuncOp>()) {
-    if (func.isExternal())
+    if (func.isExternal()) {
       continue;
+    }
 
     FunctionType functionType = func.getFunctionType();
     SmallVector<Type> newInputs(functionType.getInputs().begin(),
@@ -263,8 +284,9 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
 
     for (auto [idx, inputType] : llvm::enumerate(functionType.getInputs())) {
       auto memrefType = dyn_cast<BaseMemRefType>(inputType);
-      if (!memrefType)
+      if (!memrefType) {
         continue;
+      }
 
       Type newType = convertVPTOBoundaryMemRefType(inputType);
       if (!newType) {
@@ -284,8 +306,9 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
 
       for (Operation *user : users) {
         if (auto cast = dyn_cast<CastPtrOp>(user)) {
-          if (cast.getInput() != arg)
+          if (cast.getInput() != arg) {
             continue;
+          }
           if (cast.getResult().getType() == newType) {
             cast.getResult().replaceAllUsesWith(arg);
             cast.erase();
@@ -300,8 +323,9 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
           continue;
         }
 
-        if (isSupportedVPTOBufferLikeBoundaryOp(user))
+        if (isSupportedVPTOBufferLikeBoundaryOp(user)) {
           continue;
+        }
 
         if (diagOS) {
           *diagOS << "VPTO emission-boundary ptr rewrite failed: argument "
@@ -315,8 +339,9 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
     }
 
     for (Type resultType : functionType.getResults()) {
-      if (!isa<BaseMemRefType>(resultType))
+      if (!isa<BaseMemRefType>(resultType)) {
         continue;
+      }
       if (diagOS)
         *diagOS << "VPTO emission-boundary ptr rewrite failed: memref result "
                    "is unsupported for "
@@ -330,14 +355,17 @@ LogicalResult mlir::pto::convertVPTOEmissionBoundaryToPtr(
     }
   }
 
-  if (sawFailure)
+  if (sawFailure) {
     return failure();
+  }
 
-  if (failed(canonicalizeBoundaryCastPtrOps(module, diagOS)))
+  if (failed(canonicalizeBoundaryCastPtrOps(module, diagOS))) {
     return failure();
+  }
 
-  if (failed(canonicalizeSupportedVPTOBufferLikeOps(module, diagOS)))
+  if (failed(canonicalizeSupportedVPTOBufferLikeOps(module, diagOS))) {
     return failure();
+  }
 
   return eraseDeadVPTOMemRefScaffold(module);
 }

--- a/lib/PTO/Transforms/PTOValidateIntToPtrUses.cpp
+++ b/lib/PTO/Transforms/PTOValidateIntToPtrUses.cpp
@@ -27,8 +27,9 @@ using namespace mlir::pto;
 
 static bool isAllowedIntToPtrUse(Value ptr, OpOperand &use) {
   Operation *user = use.getOwner();
-  if (isa<LoadScalarOp, StoreScalarOp>(user))
+  if (isa<LoadScalarOp, StoreScalarOp>(user)) {
     return use.getOperandNumber() == 0 && user->getOperand(0) == ptr;
+  }
   return false;
 }
 

--- a/lib/PTO/Transforms/PTOValidatePhysicalSectionBoundaries.cpp
+++ b/lib/PTO/Transforms/PTOValidatePhysicalSectionBoundaries.cpp
@@ -32,41 +32,48 @@ namespace {
 static Operation *getNearestPhysicalSection(Operation *op) {
   for (Operation *current = op; current;
        current = current->getParentOp()) {
-    if (isa<SectionCubeOp, SectionVectorOp>(current))
+    if (isa<SectionCubeOp, SectionVectorOp>(current)) {
       return current;
+    }
   }
   return nullptr;
 }
 
 static Operation *getNearestPhysicalSection(BlockArgument argument) {
-  if (!argument)
+  if (!argument) {
     return nullptr;
+  }
   return getNearestPhysicalSection(argument.getOwner()->getParentOp());
 }
 
 static Operation *getDefiningPhysicalSection(Value value) {
-  if (auto blockArgument = dyn_cast<BlockArgument>(value))
+  if (auto blockArgument = dyn_cast<BlockArgument>(value)) {
     return getNearestPhysicalSection(blockArgument);
-  if (Operation *definingOp = value.getDefiningOp())
+  }
+  if (Operation *definingOp = value.getDefiningOp()) {
     return getNearestPhysicalSection(definingOp);
+  }
   return nullptr;
 }
 
 static StringRef getPhysicalSectionKind(Operation *section) {
-  if (!section)
+  if (!section) {
     return "outside a physical section";
+  }
   return isa<SectionCubeOp>(section) ? "pto.section.cube"
                                      : "pto.section.vector";
 }
 
 static LogicalResult verifyOperandBoundary(Operation *user, OpOperand &operand) {
   Operation *definingSection = getDefiningPhysicalSection(operand.get());
-  if (!definingSection)
+  if (!definingSection) {
     return success();
+  }
 
   Operation *usingSection = getNearestPhysicalSection(user);
-  if (definingSection == usingSection)
+  if (definingSection == usingSection) {
     return success();
+  }
 
   return user->emitOpError()
          << "value defined in " << getPhysicalSectionKind(definingSection)
@@ -81,8 +88,9 @@ static LogicalResult verifyOperandBoundary(Operation *user, OpOperand &operand) 
 static LogicalResult verifyFunction(func::FuncOp function) {
   LogicalResult result = success();
   function.walk([&](Operation *op) {
-    if (failed(result))
+    if (failed(result)) {
       return WalkResult::interrupt();
+    }
     for (OpOperand &operand : op->getOpOperands()) {
       if (failed(verifyOperandBoundary(op, operand))) {
         result = failure();
@@ -101,13 +109,15 @@ struct PTOValidatePhysicalSectionBoundariesPass
     ModuleOp module = getOperation();
     LogicalResult result = success();
     module.walk([&](func::FuncOp function) {
-      if (failed(result))
+      if (failed(result)) {
         return WalkResult::interrupt();
+      }
       result = verifyFunction(function);
       return failed(result) ? WalkResult::interrupt() : WalkResult::advance();
     });
-    if (failed(result))
+    if (failed(result)) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/PTOValidateVMIIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVMIIR.cpp
@@ -41,8 +41,9 @@ namespace {
 bool isVMIType(Type type) { return isa<VMIVRegType, VMIMaskType>(type); }
 
 bool containsVMIType(Type type) {
-  if (isVMIType(type))
+  if (isVMIType(type)) {
     return true;
+  }
 
   if (auto functionType = dyn_cast<FunctionType>(type)) {
     return llvm::any_of(functionType.getInputs(),
@@ -52,51 +53,63 @@ bool containsVMIType(Type type) {
            });
   }
 
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return containsVMIType(shapedType.getElementType());
+  }
 
   return false;
 }
 
 bool containsVMIType(Attribute attr) {
-  if (!attr)
+  if (!attr) {
     return false;
+  }
 
-  if (auto typeAttr = dyn_cast<TypeAttr>(attr))
-    if (containsVMIType(typeAttr.getValue()))
+  if (auto typeAttr = dyn_cast<TypeAttr>(attr)) {
+    if (containsVMIType(typeAttr.getValue())) {
       return true;
+    }
+  }
 
-  if (auto typedAttr = dyn_cast<TypedAttr>(attr))
-    if (containsVMIType(typedAttr.getType()))
+  if (auto typedAttr = dyn_cast<TypedAttr>(attr)) {
+    if (containsVMIType(typedAttr.getType())) {
       return true;
+    }
+  }
 
-  if (auto arrayAttr = dyn_cast<ArrayAttr>(attr))
+  if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
     return llvm::any_of(arrayAttr, [](Attribute element) {
       return containsVMIType(element);
     });
+  }
 
-  if (auto dictAttr = dyn_cast<DictionaryAttr>(attr))
+  if (auto dictAttr = dyn_cast<DictionaryAttr>(attr)) {
     return llvm::any_of(dictAttr, [](NamedAttribute namedAttr) {
       return containsVMIType(namedAttr.getValue());
     });
+  }
 
   return false;
 }
 
 bool isSurfaceVMIType(Type type) {
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     return !vregType.getLayout();
-  if (auto maskType = dyn_cast<VMIMaskType>(type))
+  }
+  if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     return maskType.isPred() && !maskType.getLayout();
+  }
   return false;
 }
 
 bool isLayoutAssignedVMIType(Type type) {
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     return static_cast<bool>(vregType.getLayoutAttr());
-  if (auto maskType = dyn_cast<VMIMaskType>(type))
+  }
+  if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     return maskType.getLayoutAttr() &&
            VMIMaskType::isConcreteGranularity(maskType.getGranularity());
+  }
   return false;
 }
 
@@ -132,16 +145,18 @@ bool hasVMIType(Operation *op) {
     return true;
   for (Region &region : op->getRegions()) {
     for (Block &block : region) {
-      if (llvm::any_of(block.getArgumentTypes(), isVMIType))
+      if (llvm::any_of(block.getArgumentTypes(), isVMIType)) {
         return true;
+      }
     }
   }
   return false;
 }
 
 void mirrorDiagnostic(llvm::raw_ostream *diagOS, Twine message) {
-  if (diagOS)
+  if (diagOS) {
     *diagOS << message << "\n";
+  }
 }
 
 LogicalResult emitInvariant(Operation *op, llvm::raw_ostream *diagOS,
@@ -171,8 +186,9 @@ LogicalResult emitLayoutSupportContract(Operation *op,
 
   bool printedAny = false;
   auto printValueType = [&](StringRef kind, int64_t index, Type type) {
-    if (!isVMIType(type))
+    if (!isVMIType(type)) {
       return;
+    }
     if (!printedAny) {
       os << "; VMI types:";
       printedAny = true;
@@ -180,10 +196,12 @@ LogicalResult emitLayoutSupportContract(Operation *op,
     os << " " << kind << "#" << index << "=" << type;
   };
 
-  for (auto [index, operand] : llvm::enumerate(op->getOperands()))
+  for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
     printValueType("operand", static_cast<int64_t>(index), operand.getType());
-  for (auto [index, result] : llvm::enumerate(op->getResults()))
+  }
+  for (auto [index, result] : llvm::enumerate(op->getResults())) {
     printValueType("result", static_cast<int64_t>(index), result.getType());
+  }
 
   os.flush();
   return emitLayoutContract(op, diagOS, text);
@@ -200,8 +218,9 @@ emitHelperMaterializationContract(Operation *helper, Type sourceType,
             " has no registered materialization support: " + reason);
   };
 
-  if (helper->getNumResults() != 1 || !helper->getResult(0).hasOneUse())
+  if (helper->getNumResults() != 1 || !helper->getResult(0).hasOneUse()) {
     return emitFallback();
+  }
 
   OpOperand &use = *helper->getResult(0).use_begin();
   Operation *requester = use.getOwner();
@@ -234,20 +253,26 @@ LogicalResult verifyBoundaryType(Operation *owner, Type type,
 
 LogicalResult verifyBoundaryTypeTree(Operation *owner, Type type,
                                      llvm::raw_ostream *diagOS) {
-  if (failed(verifyBoundaryType(owner, type, diagOS)))
+  if (failed(verifyBoundaryType(owner, type, diagOS))) {
     return failure();
-
-  if (auto functionType = dyn_cast<FunctionType>(type)) {
-    for (Type input : functionType.getInputs())
-      if (failed(verifyBoundaryTypeTree(owner, input, diagOS)))
-        return failure();
-    for (Type result : functionType.getResults())
-      if (failed(verifyBoundaryTypeTree(owner, result, diagOS)))
-        return failure();
   }
 
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto functionType = dyn_cast<FunctionType>(type)) {
+    for (Type input : functionType.getInputs()) {
+      if (failed(verifyBoundaryTypeTree(owner, input, diagOS))) {
+        return failure();
+      }
+    }
+    for (Type result : functionType.getResults()) {
+      if (failed(verifyBoundaryTypeTree(owner, result, diagOS))) {
+        return failure();
+      }
+    }
+  }
+
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return verifyBoundaryTypeTree(owner, shapedType.getElementType(), diagOS);
+  }
 
   return success();
 }
@@ -265,21 +290,27 @@ LogicalResult verifyLayoutAssignedType(Operation *owner, Type type,
 
 LogicalResult verifyLayoutAssignedTypeTree(Operation *owner, Type type,
                                            llvm::raw_ostream *diagOS) {
-  if (failed(verifyLayoutAssignedType(owner, type, diagOS)))
+  if (failed(verifyLayoutAssignedType(owner, type, diagOS))) {
     return failure();
-
-  if (auto functionType = dyn_cast<FunctionType>(type)) {
-    for (Type input : functionType.getInputs())
-      if (failed(verifyLayoutAssignedTypeTree(owner, input, diagOS)))
-        return failure();
-    for (Type result : functionType.getResults())
-      if (failed(verifyLayoutAssignedTypeTree(owner, result, diagOS)))
-        return failure();
   }
 
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto functionType = dyn_cast<FunctionType>(type)) {
+    for (Type input : functionType.getInputs()) {
+      if (failed(verifyLayoutAssignedTypeTree(owner, input, diagOS))) {
+        return failure();
+      }
+    }
+    for (Type result : functionType.getResults()) {
+      if (failed(verifyLayoutAssignedTypeTree(owner, result, diagOS))) {
+        return failure();
+      }
+    }
+  }
+
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return verifyLayoutAssignedTypeTree(owner, shapedType.getElementType(),
                                         diagOS);
+  }
 
   return success();
 }
@@ -288,28 +319,37 @@ template <typename TypeVerifier>
 LogicalResult verifyAttributeTypes(Operation *owner, Attribute attr,
                                    llvm::raw_ostream *diagOS,
                                    TypeVerifier verifyType) {
-  if (!attr)
+  if (!attr) {
     return success();
+  }
 
-  if (auto typeAttr = dyn_cast<TypeAttr>(attr))
-    if (failed(verifyType(owner, typeAttr.getValue(), diagOS)))
+  if (auto typeAttr = dyn_cast<TypeAttr>(attr)) {
+    if (failed(verifyType(owner, typeAttr.getValue(), diagOS))) {
       return failure();
+    }
+  }
 
-  if (auto typedAttr = dyn_cast<TypedAttr>(attr))
-    if (failed(verifyType(owner, typedAttr.getType(), diagOS)))
+  if (auto typedAttr = dyn_cast<TypedAttr>(attr)) {
+    if (failed(verifyType(owner, typedAttr.getType(), diagOS))) {
       return failure();
+    }
+  }
 
   if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
-    for (Attribute element : arrayAttr)
-      if (failed(verifyAttributeTypes(owner, element, diagOS, verifyType)))
+    for (Attribute element : arrayAttr) {
+      if (failed(verifyAttributeTypes(owner, element, diagOS, verifyType))) {
         return failure();
+      }
+    }
   }
 
   if (auto dictAttr = dyn_cast<DictionaryAttr>(attr)) {
-    for (NamedAttribute namedAttr : dictAttr)
+    for (NamedAttribute namedAttr : dictAttr) {
       if (failed(verifyAttributeTypes(owner, namedAttr.getValue(), diagOS,
-                                      verifyType)))
+                                      verifyType))) {
         return failure();
+      }
+    }
   }
 
   return success();
@@ -321,45 +361,58 @@ bool isFunctionTypeAttr(Operation *op, NamedAttribute attr) {
 
 LogicalResult verifyNoHiddenVMIAttributeType(Operation *op, NamedAttribute attr,
                                              llvm::raw_ostream *diagOS) {
-  if (isFunctionTypeAttr(op, attr))
+  if (isFunctionTypeAttr(op, attr)) {
     return success();
-  if (containsVMIType(attr.getValue()))
+  }
+  if (containsVMIType(attr.getValue())) {
     return emitInvariant(op, diagOS,
                          "VMI type appears in a non-signature attribute");
+  }
   return success();
 }
 
 LogicalResult verifyOperationTypes(Operation *op, llvm::raw_ostream *diagOS) {
   if (auto funcOp = dyn_cast<func::FuncOp>(op)) {
     FunctionType functionType = funcOp.getFunctionType();
-    for (Type type : functionType.getInputs())
-      if (failed(verifyBoundaryTypeTree(op, type, diagOS)))
+    for (Type type : functionType.getInputs()) {
+      if (failed(verifyBoundaryTypeTree(op, type, diagOS))) {
         return failure();
-    for (Type type : functionType.getResults())
-      if (failed(verifyBoundaryTypeTree(op, type, diagOS)))
+      }
+    }
+    for (Type type : functionType.getResults()) {
+      if (failed(verifyBoundaryTypeTree(op, type, diagOS))) {
         return failure();
+      }
+    }
   }
 
-  for (Type type : op->getOperandTypes())
-    if (failed(verifyBoundaryTypeTree(op, type, diagOS)))
+  for (Type type : op->getOperandTypes()) {
+    if (failed(verifyBoundaryTypeTree(op, type, diagOS))) {
       return failure();
-  for (Type type : op->getResultTypes())
-    if (failed(verifyBoundaryTypeTree(op, type, diagOS)))
+    }
+  }
+  for (Type type : op->getResultTypes()) {
+    if (failed(verifyBoundaryTypeTree(op, type, diagOS))) {
       return failure();
+    }
+  }
   for (Region &region : op->getRegions()) {
     for (Block &block : region) {
       for (Type type : block.getArgumentTypes()) {
-        if (failed(verifyBoundaryTypeTree(op, type, diagOS)))
+        if (failed(verifyBoundaryTypeTree(op, type, diagOS))) {
           return failure();
+        }
       }
     }
   }
   for (NamedAttribute attr : op->getAttrs()) {
-    if (failed(verifyNoHiddenVMIAttributeType(op, attr, diagOS)))
+    if (failed(verifyNoHiddenVMIAttributeType(op, attr, diagOS))) {
       return failure();
+    }
     if (failed(verifyAttributeTypes(op, attr.getValue(), diagOS,
-                                    verifyBoundaryTypeTree)))
+                                    verifyBoundaryTypeTree))) {
       return failure();
+    }
   }
   return success();
 }
@@ -368,34 +421,45 @@ LogicalResult verifyLayoutAssignedOperationTypes(Operation *op,
                                                  llvm::raw_ostream *diagOS) {
   if (auto funcOp = dyn_cast<func::FuncOp>(op)) {
     FunctionType functionType = funcOp.getFunctionType();
-    for (Type type : functionType.getInputs())
-      if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS)))
+    for (Type type : functionType.getInputs()) {
+      if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS))) {
         return failure();
-    for (Type type : functionType.getResults())
-      if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS)))
+      }
+    }
+    for (Type type : functionType.getResults()) {
+      if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS))) {
         return failure();
+      }
+    }
   }
 
-  for (Type type : op->getOperandTypes())
-    if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS)))
+  for (Type type : op->getOperandTypes()) {
+    if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS))) {
       return failure();
-  for (Type type : op->getResultTypes())
-    if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS)))
+    }
+  }
+  for (Type type : op->getResultTypes()) {
+    if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS))) {
       return failure();
+    }
+  }
   for (Region &region : op->getRegions()) {
     for (Block &block : region) {
       for (Type type : block.getArgumentTypes()) {
-        if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS)))
+        if (failed(verifyLayoutAssignedTypeTree(op, type, diagOS))) {
           return failure();
+        }
       }
     }
   }
   for (NamedAttribute attr : op->getAttrs()) {
-    if (failed(verifyNoHiddenVMIAttributeType(op, attr, diagOS)))
+    if (failed(verifyNoHiddenVMIAttributeType(op, attr, diagOS))) {
       return failure();
+    }
     if (failed(verifyAttributeTypes(op, attr.getValue(), diagOS,
-                                    verifyLayoutAssignedTypeTree)))
+                                    verifyLayoutAssignedTypeTree))) {
       return failure();
+    }
   }
   return success();
 }
@@ -408,19 +472,23 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
 
 LogicalResult verifyOperationBoundary(Operation *op,
                                       llvm::raw_ostream *diagOS) {
-  if (failed(verifyOperationTypes(op, diagOS)))
+  if (failed(verifyOperationTypes(op, diagOS))) {
     return failure();
+  }
 
-  if (!hasVMIType(op))
+  if (!hasVMIType(op)) {
     return success();
+  }
 
-  if (isVMIHelperOp(op))
+  if (isVMIHelperOp(op)) {
     return emitInvariant(
         op, diagOS,
         "VMI helper op appears before layout assignment or VMI-to-VPTO");
+  }
 
-  if (isVMISemanticOp(op) || isStructuralOp(op))
+  if (isVMISemanticOp(op) || isStructuralOp(op)) {
     return success();
+  }
 
   return emitInvariant(op, diagOS,
                        "VMI typed value is used by a non-VMI semantic op");
@@ -429,25 +497,30 @@ LogicalResult verifyOperationBoundary(Operation *op,
 LogicalResult verifyLayoutAssignedOperation(Operation *op,
                                             llvm::raw_ostream *diagOS,
                                             bool verifyHelperSupports = true) {
-  if (failed(verifyLayoutAssignedOperationTypes(op, diagOS)))
+  if (failed(verifyLayoutAssignedOperationTypes(op, diagOS))) {
     return failure();
+  }
 
-  if (!hasVMIType(op))
+  if (!hasVMIType(op)) {
     return success();
+  }
 
   if (isVMIHelperOp(op)) {
-    if (isVMILayoutHelperOp(op))
+    if (isVMILayoutHelperOp(op)) {
       return verifyHelperSupports ? verifyLayoutHelperSupport(op, diagOS)
                                   : success();
+    }
     return emitInvariant(
         op, diagOS,
         "VMI pack/unpack helper appears before VMI-to-VPTO physicalization");
   }
 
-  if (isVMISemanticOp(op))
+  if (isVMISemanticOp(op)) {
     return verifyLayoutSemanticSupport(op, diagOS);
-  if (isStructuralOp(op))
+  }
+  if (isStructuralOp(op)) {
     return success();
+  }
 
   return emitInvariant(op, diagOS,
                        "VMI typed value is used by a non-VMI semantic op");
@@ -461,9 +534,10 @@ LogicalResult verifyLayoutHelperSupport(Operation *op,
     auto sourceType = cast<VMIVRegType>(ensure.getSource().getType());
     auto resultType = cast<VMIVRegType>(ensure.getResult().getType());
     std::string reason;
-    if (failed(supports.getEnsureLayoutFact(sourceType, resultType, &reason)))
+    if (failed(supports.getEnsureLayoutFact(sourceType, resultType, &reason))) {
       return emitHelperMaterializationContract(
           op, sourceType, resultType, "pto.vmi.ensure_layout", reason, diagOS);
+    }
     return success();
   }
 
@@ -472,10 +546,11 @@ LogicalResult verifyLayoutHelperSupport(Operation *op,
     auto resultType = cast<VMIMaskType>(ensure.getResult().getType());
     std::string reason;
     if (failed(
-            supports.getEnsureMaskLayoutFact(sourceType, resultType, &reason)))
+            supports.getEnsureMaskLayoutFact(sourceType, resultType, &reason))) {
       return emitHelperMaterializationContract(op, sourceType, resultType,
                                                "pto.vmi.ensure_mask_layout",
                                                reason, diagOS);
+    }
     return success();
   }
 
@@ -489,8 +564,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto store = dyn_cast<VMIStoreOp>(op)) {
     auto valueType = cast<VMIVRegType>(store.getValue().getType());
     VMILayoutAttr layout = valueType.getLayoutAttr();
-    if (!layout || layout.isContiguous())
+    if (!layout || layout.isContiguous()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getStoreLayoutFact(valueType, &reason)))
@@ -504,8 +580,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto load = dyn_cast<VMIGroupLoadOp>(op)) {
     auto resultType = cast<VMIVRegType>(load.getResult().getType());
     VMILayoutAttr layout = resultType.getLayoutAttr();
-    if (!layout)
+    if (!layout) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupLoadLayoutFact(load, &reason)))
@@ -539,8 +616,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto store = dyn_cast<VMIGroupStoreOp>(op)) {
     auto valueType = cast<VMIVRegType>(store.getValue().getType());
     VMILayoutAttr layout = valueType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots())
+    if (!layout || !layout.isGroupSlots()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupStoreLayoutFact(
@@ -555,8 +633,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto reduce = dyn_cast<VMIGroupReduceAddFOp>(op)) {
     auto resultType = cast<VMIVRegType>(reduce.getResult().getType());
     VMILayoutAttr layout = resultType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots())
+    if (!layout || !layout.isGroupSlots()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupReduceAddFSupport(reduce, &reason)))
@@ -571,8 +650,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto reduce = dyn_cast<VMIGroupReduceMaxFOp>(op)) {
     auto resultType = cast<VMIVRegType>(reduce.getResult().getType());
     VMILayoutAttr layout = resultType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots())
+    if (!layout || !layout.isGroupSlots()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupReduceMaxFSupport(reduce, &reason)))
@@ -587,8 +667,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
     auto resultType = cast<VMIVRegType>(reduce.getResult().getType());
     VMILayoutAttr layout = resultType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots())
+    if (!layout || !layout.isGroupSlots()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupReduceMinFSupport(reduce, &reason)))
@@ -603,8 +684,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto reduce = dyn_cast<VMIGroupReduceAddIOp>(op)) {
     auto resultType = cast<VMIVRegType>(reduce.getResult().getType());
     VMILayoutAttr layout = resultType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots())
+    if (!layout || !layout.isGroupSlots()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupReduceAddISupport(reduce, &reason)))
@@ -619,8 +701,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto reduce = dyn_cast<VMIGroupReduceMaxIOp>(op)) {
     auto resultType = cast<VMIVRegType>(reduce.getResult().getType());
     VMILayoutAttr layout = resultType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots())
+    if (!layout || !layout.isGroupSlots()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupReduceMaxISupport(reduce, &reason)))
@@ -635,8 +718,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
     auto resultType = cast<VMIVRegType>(reduce.getResult().getType());
     VMILayoutAttr layout = resultType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots())
+    if (!layout || !layout.isGroupSlots()) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupReduceMinISupport(reduce, &reason)))
@@ -651,8 +735,9 @@ LogicalResult verifyLayoutSemanticSupport(Operation *op,
   if (auto broadcast = dyn_cast<VMIGroupBroadcastOp>(op)) {
     auto sourceType = cast<VMIVRegType>(broadcast.getSource().getType());
     VMILayoutAttr layout = sourceType.getLayoutAttr();
-    if (!layout || !layout.isGroupSlots() || layout.getSlots() <= 0)
+    if (!layout || !layout.isGroupSlots() || layout.getSlots() <= 0) {
       return success();
+    }
 
     std::string reason;
     if (failed(supports.getGroupBroadcastSupport(broadcast, &reason)))
@@ -714,8 +799,9 @@ struct PTOValidateVMIIRPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PTOValidateVMIIRPass)
 
   void runOnOperation() override {
-    if (failed(validateVMIProducerBoundaryIR(getOperation(), &llvm::errs())))
+    if (failed(validateVMIProducerBoundaryIR(getOperation(), &llvm::errs()))) {
       signalPassFailure();
+    }
   }
 };
 
@@ -725,8 +811,9 @@ struct PTOValidateVMILayoutIRPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PTOValidateVMILayoutIRPass)
 
   void runOnOperation() override {
-    if (failed(validateVMILayoutAssignedIR(getOperation(), &llvm::errs())))
+    if (failed(validateVMILayoutAssignedIR(getOperation(), &llvm::errs()))) {
       signalPassFailure();
+    }
   }
 };
 
@@ -736,8 +823,9 @@ LogicalResult
 mlir::pto::validateVMIProducerBoundaryIR(ModuleOp module,
                                          llvm::raw_ostream *diagOS) {
   WalkResult result = module.walk([&](Operation *op) {
-    if (failed(verifyOperationBoundary(op, diagOS)))
+    if (failed(verifyOperationBoundary(op, diagOS))) {
       return WalkResult::interrupt();
+    }
     return WalkResult::advance();
   });
   return failure(result.wasInterrupted());
@@ -746,8 +834,9 @@ mlir::pto::validateVMIProducerBoundaryIR(ModuleOp module,
 LogicalResult mlir::pto::validateVMILayoutAssignedIR(
     ModuleOp module, llvm::raw_ostream *diagOS, bool verifyHelperSupports) {
   WalkResult result = module.walk([&](Operation *op) {
-    if (failed(verifyLayoutAssignedOperation(op, diagOS, verifyHelperSupports)))
+    if (failed(verifyLayoutAssignedOperation(op, diagOS, verifyHelperSupports))) {
       return WalkResult::interrupt();
+    }
     return WalkResult::advance();
   });
   return failure(result.wasInterrupted());

--- a/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
+++ b/lib/PTO/Transforms/PTOValidateVPTOIR.cpp
@@ -51,21 +51,25 @@ LogicalResult validateVPTOEmissionIR(ModuleOp module,
 namespace detail {
 
 static Operation *getFirstNonConstantLikeOp(Block *block) {
-  if (!block)
+  if (!block) {
     return nullptr;
+  }
   for (Operation &op : *block) {
-    if (!op.hasTrait<OpTrait::ConstantLike>())
+    if (!op.hasTrait<OpTrait::ConstantLike>()) {
       return &op;
+    }
   }
   return nullptr;
 }
 
 static bool isOpInRange(Operation *op, Operation *first, Operation *last) {
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
-    if (cur == op)
+    if (cur == op) {
       return true;
-    if (cur == last)
+    }
+    if (cur == last) {
       return false;
+    }
   }
   return false;
 }
@@ -74,14 +78,17 @@ static constexpr int64_t kSimtKeepResumeSlotLimit = 123;
 
 static std::optional<unsigned> getSimtKeepResumeRegisterCount(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (intType.getWidth() <= 32)
+    if (intType.getWidth() <= 32) {
       return 1;
-    if (intType.getWidth() == 64)
+    }
+    if (intType.getWidth() == 64) {
       return 2;
+    }
     return std::nullopt;
   }
-  if (type.isF16() || type.isBF16() || type.isF32())
+  if (type.isF16() || type.isBF16() || type.isF32()) {
     return 1;
+  }
   return std::nullopt;
 }
 
@@ -102,8 +109,9 @@ template <typename OpT>
 static LogicalResult verifySimtKeepResumeSlotRange(OpT op) {
   std::optional<unsigned> registerCount =
       getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
-  if (!registerCount)
+  if (!registerCount) {
     return success();
+  }
   int64_t slot = op.getSlot();
   if (slot < 0 || slot >= kSimtKeepResumeSlotLimit)
     return op.emitOpError()
@@ -127,15 +135,18 @@ static bool overlapsEarlierSimtKeepResumeSlotUse(OpT op,
                                                  SmallVectorImpl<int64_t> &used) {
   std::optional<unsigned> registerCount =
       getSimtKeepResumeRegisterCount(getSimtKeepResumeValueType(op));
-  if (!registerCount)
+  if (!registerCount) {
     return false;
+  }
   int64_t slot = op.getSlot();
   for (int64_t word = slot; word < slot + *registerCount; ++word) {
-    if (llvm::is_contained(used, word))
+    if (llvm::is_contained(used, word)) {
       return true;
+    }
   }
-  for (int64_t word = slot; word < slot + *registerCount; ++word)
+  for (int64_t word = slot; word < slot + *registerCount; ++word) {
     used.push_back(word);
+  }
   return false;
 }
 
@@ -144,8 +155,9 @@ static LogicalResult verifyUniqueResumeGroupSlots(ResumeOp current,
   SmallVector<int64_t, 4> slots;
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
     auto resume = dyn_cast<ResumeOp>(cur);
-    if (!resume)
+    if (!resume) {
       break;
+    }
     if (overlapsEarlierSimtKeepResumeSlotUse(resume, slots) &&
         resume.getOperation() == current.getOperation())
       return current.emitOpError()
@@ -161,15 +173,17 @@ static LogicalResult verifyUniqueKeepGroupSlots(KeepOp current,
   SmallVector<int64_t, 4> slots;
   for (Operation *cur = first; cur; cur = cur->getNextNode()) {
     auto keep = dyn_cast<KeepOp>(cur);
-    if (!keep)
+    if (!keep) {
       break;
+    }
     if (overlapsEarlierSimtKeepResumeSlotUse(keep, slots) &&
         keep.getOperation() == current.getOperation())
       return current.emitOpError()
              << "duplicates an earlier slot " << keep.getSlot()
              << " in the SIMT keep epilogue group";
-    if (cur == last)
+    if (cur == last) {
       break;
+    }
   }
   return success();
 }
@@ -203,8 +217,9 @@ public:
 
   SmallVector<func::FuncOp> getFunctions() {
     SmallVector<func::FuncOp> funcs;
-    for (func::FuncOp func : module.getOps<func::FuncOp>())
+    for (func::FuncOp func : module.getOps<func::FuncOp>()) {
       funcs.push_back(func);
+    }
     return funcs;
   }
 
@@ -217,8 +232,9 @@ public:
   }
 
   static bool requiresVecScope(Operation *op) {
-    if (!isPTOp(op))
+    if (!isPTOp(op)) {
       return false;
+    }
 
     return llvm::any_of(op->getOperandTypes(), isLegalityTypedValue) ||
            llvm::any_of(op->getResultTypes(), isLegalityTypedValue);
@@ -233,34 +249,40 @@ public:
   }
 
   static bool isAnyVectorScopeCarrier(Operation *op) {
-    if (auto loop = dyn_cast_or_null<scf::ForOp>(op))
+    if (auto loop = dyn_cast_or_null<scf::ForOp>(op)) {
       return isAIVectorScopeCarrier(loop);
+    }
     return isDedicatedVecScopeCarrier(op);
   }
 
   static Operation *getEnclosingVectorScopeCarrier(Operation *op) {
     for (Operation *parent = op ? op->getParentOp() : nullptr; parent;
          parent = parent->getParentOp()) {
-      if (isAnyVectorScopeCarrier(parent))
+      if (isAnyVectorScopeCarrier(parent)) {
         return parent;
+      }
     }
     return nullptr;
   }
 
   static std::optional<VPTOMaskGranularity> getMaskGranularity(Type type) {
     auto maskType = dyn_cast<MaskType>(type);
-    if (!maskType)
+    if (!maskType) {
       return std::nullopt;
+    }
     return getMaskGranularity(maskType);
   }
 
   static std::optional<VPTOMaskGranularity> getMaskGranularity(MaskType type) {
-    if (type.isB8())
+    if (type.isB8()) {
       return VPTOMaskGranularity::B8;
-    if (type.isB16())
+    }
+    if (type.isB16()) {
       return VPTOMaskGranularity::B16;
-    if (type.isB32())
+    }
+    if (type.isB32()) {
       return VPTOMaskGranularity::B32;
+    }
     return std::nullopt;
   }
 
@@ -278,17 +300,21 @@ public:
 
   static std::optional<VPTOMaskGranularity>
   inferMaskGranularityFromType(Type type) {
-    if (auto vregType = dyn_cast<VRegType>(type))
+    if (auto vregType = dyn_cast<VRegType>(type)) {
       type = vregType.getElementType();
+    }
 
-    if (type.isF32())
+    if (type.isF32()) {
       return VPTOMaskGranularity::B32;
-    if (type.isF16() || type.isBF16())
+    }
+    if (type.isF16() || type.isBF16()) {
       return VPTOMaskGranularity::B16;
+    }
 
     auto intType = dyn_cast<IntegerType>(type);
-    if (!intType)
+    if (!intType) {
       return std::nullopt;
+    }
 
     switch (intType.getWidth()) {
     case 8:
@@ -305,21 +331,26 @@ public:
   static std::optional<VPTOMaskGranularity>
   inferMaskGranularityFromFamily(Operation *op) {
     StringRef mnemonic = getPTOpMnemonic(op);
-    if (mnemonic.empty())
+    if (mnemonic.empty()) {
       return std::nullopt;
+    }
 
-    if (mnemonic.ends_with("_b8"))
+    if (mnemonic.ends_with("_b8")) {
       return VPTOMaskGranularity::B8;
-    if (mnemonic.ends_with("_b16"))
+    }
+    if (mnemonic.ends_with("_b16")) {
       return VPTOMaskGranularity::B16;
-    if (mnemonic.ends_with("_b32"))
+    }
+    if (mnemonic.ends_with("_b32")) {
       return VPTOMaskGranularity::B32;
+    }
     return std::nullopt;
   }
 
   static VPTOBufferAddressFamily classifyBufferAddressFamily(Operation *op) {
-    if (!op)
+    if (!op) {
       return VPTOBufferAddressFamily::None;
+    }
 
     if (isa<CopyGmToUbufOp, CopyUbufToUbufOp, CopyUbufToGmOp,
             CopyCbufToUbufOp, CopyUbufToCbufOp>(op))
@@ -353,8 +384,9 @@ public:
   static SmallVector<OpOperand *> collectBufferOperands(Operation *op) {
     SmallVector<OpOperand *> bufferOperands;
     for (OpOperand &operand : op->getOpOperands()) {
-      if (isBufferLikeValue(operand.get().getType()))
+      if (isBufferLikeValue(operand.get().getType())) {
         bufferOperands.push_back(&operand);
+      }
     }
     return bufferOperands;
   }
@@ -365,8 +397,9 @@ private:
   }
 
   static StringRef getPTOpMnemonic(Operation *op) {
-    if (!isPTOp(op))
+    if (!isPTOp(op)) {
       return {};
+    }
     StringRef mnemonic = op->getName().getStringRef();
     (void)mnemonic.consume_front("pto.");
     return mnemonic;
@@ -393,8 +426,9 @@ public:
       return failure();
     }
 
-    if (failed(validateAuthoringRules()))
+    if (failed(validateAuthoringRules())) {
       return failure();
+    }
 
     if (stage == VPTOLegalityStage::Emission &&
         failed(validateEmissionRules()))
@@ -405,18 +439,22 @@ public:
 
 private:
   LogicalResult validateAuthoringRules() {
-    if (failed(validateAuthoringFunctionSurface()))
+    if (failed(validateAuthoringFunctionSurface())) {
       return failure();
-    if (failed(validateAuthoringOperationSurface()))
+    }
+    if (failed(validateAuthoringOperationSurface())) {
       return failure();
+    }
     return success();
   }
 
   LogicalResult validateEmissionRules() {
-    if (failed(validateEmissionFunctionSurface()))
+    if (failed(validateEmissionFunctionSurface())) {
       return failure();
-    if (failed(validateEmissionOperationSurface()))
+    }
+    if (failed(validateEmissionOperationSurface())) {
       return failure();
+    }
     return success();
   }
 
@@ -435,8 +473,9 @@ private:
                                                        StringRef vectorRole) {
     auto actual = VPTOLegalityHelper::getMaskGranularity(maskType);
     auto expected = VPTOLegalityHelper::inferMaskGranularityFromType(vectorType);
-    if (!actual || !expected || *actual == *expected)
+    if (!actual || !expected || *actual == *expected) {
       return success();
+    }
 
     return op->emitOpError()
            << maskRole << " " << maskType << " does not match " << vectorRole
@@ -447,18 +486,21 @@ private:
   static std::optional<VPTOMaskGranularity>
   inferVstsMaskGranularityOverride(Operation *op) {
     Value value;
-    if (auto vsts = dyn_cast<VstsOp>(op))
+    if (auto vsts = dyn_cast<VstsOp>(op)) {
       value = vsts.getValue();
-    else
+    } else {
       return std::nullopt;
+    }
 
     auto valueType = dyn_cast<VRegType>(value.getType());
-    if (!valueType)
+    if (!valueType) {
       return std::nullopt;
+    }
 
     auto distAttr = op->getAttrOfType<StringAttr>("dist");
-    if (!distAttr)
+    if (!distAttr) {
       return std::nullopt;
+    }
 
     StringRef dist = distAttr.getValue();
     auto elementType = valueType.getElementType();
@@ -476,38 +518,45 @@ private:
     }
 
     if (dist == "PK_B16") {
-      if (width == 8)
+      if (width == 8) {
         return VPTOMaskGranularity::B16;
+      }
       return std::nullopt;
     }
     if (dist == "PK_B32") {
-      if (width == 16)
+      if (width == 16) {
         return VPTOMaskGranularity::B32;
+      }
       return std::nullopt;
     }
     if (dist == "PK_B64") {
-      if (width == 32)
+      if (width == 32) {
         return VPTOMaskGranularity::B32;
+      }
       return std::nullopt;
     }
     if (dist == "PK4_B32") {
-      if (width == 8)
+      if (width == 8) {
         return VPTOMaskGranularity::B32;
+      }
       return std::nullopt;
     }
     if (dist == "MRG4CHN_B8") {
-      if (width == 8)
+      if (width == 8) {
         return VPTOMaskGranularity::B32;
+      }
       return std::nullopt;
     }
     if (dist == "MRG2CHN_B8") {
-      if (width == 8)
+      if (width == 8) {
         return VPTOMaskGranularity::B16;
+      }
       return std::nullopt;
     }
     if (dist == "MRG2CHN_B16") {
-      if (width == 16)
+      if (width == 16) {
         return VPTOMaskGranularity::B32;
+      }
     }
     return std::nullopt;
   }
@@ -518,8 +567,9 @@ private:
                                                    StringRef rhsRole) {
     auto lhs = VPTOLegalityHelper::getMaskGranularity(lhsType);
     auto rhs = VPTOLegalityHelper::getMaskGranularity(rhsType);
-    if (!lhs || !rhs || *lhs == *rhs)
+    if (!lhs || !rhs || *lhs == *rhs) {
       return success();
+    }
 
     return op->emitOpError() << lhsRole << " " << lhsType << " does not match "
                              << rhsRole << " " << rhsType;
@@ -589,8 +639,9 @@ private:
               inferVstsMaskGranularityOverride(op.getOperation())) {
         auto actual =
             VPTOLegalityHelper::getMaskGranularity(op.getMask().getType());
-        if (!actual || *actual == *expected)
+        if (!actual || *actual == *expected) {
           return success();
+        }
         return op.emitOpError()
                << "mask type " << op.getMask().getType()
                << " does not match value vector type "
@@ -607,8 +658,9 @@ private:
     auto emitForStore = [&](auto storeOp) {
       Operation *store = storeOp.getOperation();
       auto distAttr = store->getAttrOfType<StringAttr>("dist");
-      if (!distAttr)
+      if (!distAttr) {
         return;
+      }
 
       StringRef dist = distAttr.getValue();
       if (dist == "MRG4CHN_B8" || dist == "MRG2CHN_B8" || dist == "MRG2CHN_B16")
@@ -718,8 +770,9 @@ private:
   static LogicalResult validatePredicateMovementContract(
       PredicateMovementOp op) {
     auto expected = VPTOLegalityHelper::inferMaskGranularityFromFamily(op);
-    if (!expected)
+    if (!expected) {
       return success();
+    }
 
     if (failed(validateSameMaskGranularity(op, op.getLhs().getType(),
                                            "lhs mask type",
@@ -732,12 +785,14 @@ private:
         failed(validateSameMaskGranularity(op, op.getLhs().getType(),
                                            "lhs mask type",
                                            op.getHigh().getType(),
-                                           "high mask type")))
+                                           "high mask type"))) {
       return failure();
+    }
 
     auto lhs = VPTOLegalityHelper::getMaskGranularity(op.getLhs().getType());
-    if (!lhs || *lhs == *expected)
+    if (!lhs || *lhs == *expected) {
       return success();
+    }
 
     return op.emitOpError()
            << "predicate movement family requires "
@@ -750,8 +805,9 @@ private:
                                                       StringRef resultRole) {
     auto expected = VPTOLegalityHelper::inferMaskGranularityFromFamily(op);
     auto actual = VPTOLegalityHelper::getMaskGranularity(resultType);
-    if (!expected || !actual || *expected == *actual)
+    if (!expected || !actual || *expected == *actual) {
       return success();
+    }
 
     return op->emitOpError()
            << "family suffix requires " << resultRole << " to be "
@@ -777,13 +833,15 @@ private:
     return llvm::TypeSwitch<Operation *, LogicalResult>(op)
         .Case<VreluOp>([](VreluOp concreteOp) {
           auto vecType = dyn_cast<VRegType>(concreteOp.getInput().getType());
-          if (!vecType)
+          if (!vecType) {
             return success();
+          }
 
           Type elemType = vecType.getElementType();
           if (auto intType = dyn_cast<IntegerType>(elemType)) {
-            if (intType.getWidth() == 32 && !intType.isUnsigned())
+            if (intType.getWidth() == 32 && !intType.isUnsigned()) {
               return success();
+            }
           } else if (elemType.isF16() || elemType.isF32()) {
             return success();
           }
@@ -866,8 +924,9 @@ private:
           [&](StringRef attrName, int64_t upperBound,
               StringRef description) -> LogicalResult {
         Attribute attr = func->getAttr(attrName);
-        if (!attr)
+        if (!attr) {
           return success();
+        }
 
         auto intAttr = dyn_cast<IntegerAttr>(attr);
         if (!intAttr || !intAttr.getType().isSignlessInteger(32))
@@ -896,11 +955,13 @@ private:
       if (failed(validatePositiveI32FuncAttr(pto::kPTOSimtMaxThreadsAttrName,
                                              2048, "SIMT max threads")) ||
           failed(validatePositiveI32FuncAttr(pto::kPTOSimtMaxRegistersAttrName,
-                                             128, "SIMT max registers")))
+                                             128, "SIMT max registers"))) {
         return failure();
+      }
 
-      if (!func->hasAttr(pto::kPTOSimtEntryAttrName))
+      if (!func->hasAttr(pto::kPTOSimtEntryAttrName)) {
         continue;
+      }
 
       WalkResult walkResult = func.walk([&](StoreVfSimtInfoOp op) {
         op.emitOpError()
@@ -910,13 +971,15 @@ private:
                "instead";
         return WalkResult::interrupt();
       });
-      if (walkResult.wasInterrupted())
+      if (walkResult.wasInterrupted()) {
         return failure();
+      }
     }
 
     WalkResult keepResumeWalk = helper.getModule().walk([&](Operation *op) {
-      if (!isa<KeepOp, ResumeOp, SyncthreadsOp>(op))
+      if (!isa<KeepOp, ResumeOp, SyncthreadsOp>(op)) {
         return WalkResult::advance();
+      }
       func::FuncOp func = op->getParentOfType<func::FuncOp>();
       if (!func || !func->hasAttr(pto::kPTOSimtEntryAttrName)) {
         op->emitOpError()
@@ -926,8 +989,9 @@ private:
       }
       Block *block = op->getBlock();
       if (auto resume = dyn_cast<ResumeOp>(op)) {
-        if (failed(verifySimtKeepResumeSlotRange(resume)))
+        if (failed(verifySimtKeepResumeSlotRange(resume))) {
           return WalkResult::interrupt();
+        }
         Operation *first = getFirstNonConstantLikeOp(block);
         if (!first || !isa<ResumeOp>(first)) {
           op->emitOpError()
@@ -937,8 +1001,9 @@ private:
         }
         bool found = false;
         for (Operation *cur = first; cur; cur = cur->getNextNode()) {
-          if (!isa<ResumeOp>(cur))
+          if (!isa<ResumeOp>(cur)) {
             break;
+          }
           if (cur == op) {
             found = true;
             break;
@@ -950,12 +1015,14 @@ private:
                  "constant-like operations";
           return WalkResult::interrupt();
         }
-        if (failed(verifyUniqueResumeGroupSlots(resume, first)))
+        if (failed(verifyUniqueResumeGroupSlots(resume, first))) {
           return WalkResult::interrupt();
+        }
       }
       if (auto keep = dyn_cast<KeepOp>(op)) {
-        if (failed(verifySimtKeepResumeSlotRange(keep)))
+        if (failed(verifySimtKeepResumeSlotRange(keep))) {
           return WalkResult::interrupt();
+        }
         Operation *terminator = block ? block->getTerminator() : nullptr;
         if (!terminator || !isa<func::ReturnOp>(terminator)) {
           op->emitOpError()
@@ -964,8 +1031,9 @@ private:
         }
 
         Operation *cur = terminator->getPrevNode();
-        while (cur && isa<SyncthreadsOp>(cur))
+        while (cur && isa<SyncthreadsOp>(cur)) {
           cur = cur->getPrevNode();
+        }
         Operation *lastKeep = cur;
         if (!lastKeep || !isa<KeepOp>(lastKeep)) {
           op->emitOpError()
@@ -977,8 +1045,9 @@ private:
 
         Operation *firstKeep = lastKeep;
         while (Operation *prev = firstKeep->getPrevNode()) {
-          if (!isa<KeepOp>(prev))
+          if (!isa<KeepOp>(prev)) {
             break;
+          }
           firstKeep = prev;
         }
         if (!isOpInRange(op, firstKeep, lastKeep)) {
@@ -994,8 +1063,9 @@ private:
       }
       return WalkResult::advance();
     });
-    if (keepResumeWalk.wasInterrupted())
+    if (keepResumeWalk.wasInterrupted()) {
       return failure();
+    }
     return success();
   }
 
@@ -1004,27 +1074,32 @@ private:
         helper.getModule().walk([&](arith::ConstantOp constant) {
           Type resultType = constant.getType();
           Type elementType = resultType;
-          if (auto vectorType = dyn_cast<VectorType>(resultType))
+          if (auto vectorType = dyn_cast<VectorType>(resultType)) {
             elementType = vectorType.getElementType();
-          if (!pto::isPTOFloat8Type(elementType))
+          }
+          if (!pto::isPTOFloat8Type(elementType)) {
             return WalkResult::advance();
+          }
 
           constant.emitOpError()
               << "does not support directly constructed FP8 constants in "
                  "the VPTO backend; produce FP8 values with pto.convert";
           return WalkResult::interrupt();
         });
-    if (constantWalkResult.wasInterrupted())
+    if (constantWalkResult.wasInterrupted()) {
       return failure();
+    }
 
     WalkResult loopWalkResult = helper.getModule().walk([&](scf::ForOp loop) {
-      if (!VPTOLegalityHelper::isAIVectorScopeCarrier(loop))
+      if (!VPTOLegalityHelper::isAIVectorScopeCarrier(loop)) {
         return WalkResult::advance();
+      }
 
       Operation *parentScope =
           VPTOLegalityHelper::getEnclosingVectorScopeCarrier(loop);
-      if (!parentScope)
+      if (!parentScope) {
         return WalkResult::advance();
+      }
 
       if (isa<scf::ForOp>(parentScope)) {
         loop.emitOpError() << "does not allow nested scf.for with '"
@@ -1037,35 +1112,41 @@ private:
              "pto.vecscope/pto.strict_vecscope";
       return WalkResult::interrupt();
     });
-    if (loopWalkResult.wasInterrupted())
+    if (loopWalkResult.wasInterrupted()) {
       return failure();
+    }
 
     WalkResult vecScopeWalkResult = helper.getModule().walk([&](Operation *op) {
-      if (!VPTOLegalityHelper::isDedicatedVecScopeCarrier(op))
+      if (!VPTOLegalityHelper::isDedicatedVecScopeCarrier(op)) {
         return WalkResult::advance();
+      }
 
-      if (!VPTOLegalityHelper::getEnclosingVectorScopeCarrier(op))
+      if (!VPTOLegalityHelper::getEnclosingVectorScopeCarrier(op)) {
         return WalkResult::advance();
+      }
 
       op->emitOpError()
           << "does not allow nested dedicated pto.vecscope/pto.strict_vecscope";
       return WalkResult::interrupt();
     });
-    if (vecScopeWalkResult.wasInterrupted())
+    if (vecScopeWalkResult.wasInterrupted()) {
       return failure();
+    }
 
     WalkResult opWalkResult = helper.getModule().walk([&](Operation *op) {
       (void)VPTOLegalityHelper::inferMaskGranularityFromFamily(op);
       (void)VPTOLegalityHelper::classifyBufferAddressFamily(op);
 
-      if (!VPTOLegalityHelper::requiresVecScope(op))
+      if (!VPTOLegalityHelper::requiresVecScope(op)) {
         return WalkResult::advance();
+      }
 
       if (VPTOLegalityHelper::getEnclosingVectorScopeCarrier(op)) {
         if (failed(validateFamilySuffixMaskContracts(op)) ||
             failed(validateUnaryElementTypeContracts(op)) ||
-            failed(validateMaskGranularityContracts(op)))
+            failed(validateMaskGranularityContracts(op))) {
           return WalkResult::interrupt();
+        }
         emitHardwareSupportWarnings(op);
         return WalkResult::advance();
       }
@@ -1085,16 +1166,18 @@ private:
       FunctionType functionType = func.getFunctionType();
 
       for (auto [idx, inputType] : llvm::enumerate(functionType.getInputs())) {
-        if (!isa<BaseMemRefType>(inputType))
+        if (!isa<BaseMemRefType>(inputType)) {
           continue;
+        }
         return func.emitError()
                << "emission-stage VPTO legality rejects memref argument #"
                << idx << ": " << inputType;
       }
 
       for (auto [idx, resultType] : llvm::enumerate(functionType.getResults())) {
-        if (!isa<BaseMemRefType>(resultType))
+        if (!isa<BaseMemRefType>(resultType)) {
           continue;
+        }
         return func.emitError()
                << "emission-stage VPTO legality rejects memref result #"
                << idx << ": " << resultType;
@@ -1119,8 +1202,9 @@ private:
       if (family == VPTOBufferAddressFamily::BufferLike) {
         for (OpOperand *operand : VPTOLegalityHelper::collectBufferOperands(op)) {
           Type operandType = operand->get().getType();
-          if (!isa<BaseMemRefType>(operandType))
+          if (!isa<BaseMemRefType>(operandType)) {
             continue;
+          }
 
           op->emitOpError()
               << "emission-stage VPTO legality rejects memref-form buffer "
@@ -1143,8 +1227,9 @@ private:
   }
 
   void writeDiagnostic(StringRef message) const {
-    if (diagOS)
+    if (diagOS) {
       *diagOS << message;
+    }
   }
 
   VPTOLegalityHelper helper;
@@ -1168,8 +1253,9 @@ struct PTOValidateVPTOIRPass
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
-    if (failed(validateVPTOAuthoringIR(module, &llvm::errs())))
+    if (failed(validateVPTOAuthoringIR(module, &llvm::errs()))) {
       signalPassFailure();
+    }
   }
 };
 
@@ -1188,8 +1274,9 @@ struct PTOValidateVPTOEmissionIRPass
 
   void runOnOperation() override {
     ModuleOp module = getOperation();
-    if (failed(validateVPTOEmissionIR(module, &llvm::errs())))
+    if (failed(validateVPTOEmissionIR(module, &llvm::errs()))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/PTOVerifyTFreePass.cpp
+++ b/lib/PTO/Transforms/PTOVerifyTFreePass.cpp
@@ -35,8 +35,9 @@ static TFreeOp findMatchingTFree(TPopOp tpopOp) {
   for (auto it = std::next(tpopOp->getIterator()), end = block->end();
        it != end; ++it) {
     if (auto tfreeOp = dyn_cast<TFreeOp>(&*it)) {
-      if (tfreeOp.getPipeHandle() == pipeHandle)
+      if (tfreeOp.getPipeHandle() == pipeHandle) {
         return tfreeOp;
+      }
     }
   }
   return {};
@@ -46,8 +47,9 @@ static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
   Operation *current = op;
   while (current && current->getBlock() != block) {
     Region *parentRegion = current->getParentRegion();
-    if (!parentRegion)
+    if (!parentRegion) {
       return nullptr;
+    }
     current = parentRegion->getParentOp();
   }
   return current;
@@ -57,8 +59,9 @@ static bool hasSamePipeTPopInRegion(Operation *op, Value pipeHandle,
                                     TPopOp current) {
   bool found = false;
   op->walk([&](TPopOp nestedTpop) {
-    if (nestedTpop == current)
+    if (nestedTpop == current) {
       return WalkResult::advance();
+    }
     if (nestedTpop.getPipeHandle() == pipeHandle) {
       found = true;
       return WalkResult::interrupt();
@@ -70,8 +73,9 @@ static bool hasSamePipeTPopInRegion(Operation *op, Value pipeHandle,
 
 static LogicalResult verifySingleOutstandingUntil(TPopOp tpopOp,
                                                   Operation *freeBoundary) {
-  if (!freeBoundary || freeBoundary == tpopOp.getOperation())
+  if (!freeBoundary || freeBoundary == tpopOp.getOperation()) {
     return success();
+  }
 
   Value pipeHandle = tpopOp.getPipeHandle();
   Block *block = tpopOp->getBlock();
@@ -82,8 +86,9 @@ static LogicalResult verifySingleOutstandingUntil(TPopOp tpopOp,
       return tpopOp.emitOpError(
           "multiple outstanding pops on the same pipe are not supported");
     }
-    if (op == freeBoundary)
+    if (op == freeBoundary) {
       break;
+    }
   }
 
   return success();
@@ -126,8 +131,9 @@ struct PTOVerifyTFreePass
     funcOp.walk([&](TPopOp op) { tpops.push_back(op); });
 
     for (TPopOp tpopOp : tpops) {
-      if (!isInsideSectionOrAttributedKernel(tpopOp, funcOp))
+      if (!isInsideSectionOrAttributedKernel(tpopOp, funcOp)) {
         continue;
+      }
 
       TFreeOp existingTFree = findMatchingTFree(tpopOp);
       if (!existingTFree) {

--- a/lib/PTO/Transforms/SIMTPersistentFragmentAnalysis.cpp
+++ b/lib/PTO/Transforms/SIMTPersistentFragmentAnalysis.cpp
@@ -394,14 +394,16 @@ collectResidentElements(pto::SectionSimtOp initSection,
                         llvm::DenseSet<int64_t> &residentElementSet) {
   for (Operation &op : initSection.getBody().front()) {
     auto accessIt = discovery.accessIndices.find(&op);
-    if (accessIt == discovery.accessIndices.end())
+    if (accessIt == discovery.accessIndices.end()) {
       continue;
+    }
 
     for (unsigned accessIndex : accessIt->second) {
       const NormalizedPersistentAccess &access =
           discovery.accesses[accessIndex];
-      if (!residentElementSet.insert(access.elementOffset).second)
+      if (!residentElementSet.insert(access.elementOffset).second) {
         continue;
+      }
 
       if (!isa<LLVM::StoreOp>(access.op)) {
         return access.op->emitOpError()
@@ -559,8 +561,9 @@ materializeResidentAccessLanes(const PersistentMaterializationPlan &plan,
     }
     for (Operation &op : section.getBody().front()) {
       auto accessIt = discovery.accessIndices.find(&op);
-      if (accessIt == discovery.accessIndices.end())
+      if (accessIt == discovery.accessIndices.end()) {
         continue;
+      }
 
       for (unsigned accessIndex : accessIt->second) {
         if (accessIndex >= discovery.accesses.size()) {
@@ -713,8 +716,9 @@ SIMTPersistentFragmentAnalysis::SIMTPersistentFragmentAnalysis(
     func::FuncOp func) {
   SmallVector<LLVM::AllocaOp> persistentAllocas;
   func.walk([&](LLVM::AllocaOp allocaOp) {
-    if (allocaOp->hasAttr(kPersistentAttrName))
+    if (allocaOp->hasAttr(kPersistentAttrName)) {
       persistentAllocas.push_back(allocaOp);
+    }
   });
 
   // A function without persistent allocations has a valid empty plan and does

--- a/lib/PTO/Transforms/SlotAffineAnalysis.cpp
+++ b/lib/PTO/Transforms/SlotAffineAnalysis.cpp
@@ -60,8 +60,9 @@ struct SlotForm {
 
 static bool tryGetConstantInt(Value v, int64_t &out) {
   IntegerAttr attr;
-  if (!matchPattern(v, m_Constant(&attr)))
+  if (!matchPattern(v, m_Constant(&attr))) {
     return false;
+  }
   out = attr.getValue().getSExtValue();
   return true;
 }
@@ -71,8 +72,9 @@ static bool tryGetConstantInt(Value v, int64_t &out) {
 // neither side is a constant.
 static bool peelAddSubConst(Value v, Value &remaining, int64_t &offset) {
   Operation *op = v.getDefiningOp();
-  if (!op)
+  if (!op) {
     return false;
+  }
   Value lhs, rhs;
   bool isSub = false;
   if (auto add = dyn_cast<arith::AddIOp>(op)) {
@@ -106,8 +108,9 @@ static bool peelAddSubConst(Value v, Value &remaining, int64_t &offset) {
 // without a `remui`, treat N as the caller-supplied `expectN` and reduce.
 // Returns false if the form is not representable.
 static bool extractSlotForm(Value slot, uint32_t expectN, SlotForm &out) {
-  if (!slot)
+  if (!slot) {
     return false;
+  }
 
   out.innerSym = Value();
   out.innerOffset = 0;
@@ -118,8 +121,9 @@ static bool extractSlotForm(Value slot, uint32_t expectN, SlotForm &out) {
   // Case 1: `arith.remui inner, %const_N`.
   if (auto remOp = dyn_cast_if_present<arith::RemUIOp>(def)) {
     int64_t n;
-    if (!tryGetConstantInt(remOp.getRhs(), n) || n <= 0)
+    if (!tryGetConstantInt(remOp.getRhs(), n) || n <= 0) {
       return false;
+    }
     out.N = static_cast<uint32_t>(n);
     Value inner = remOp.getLhs();
     int64_t offset = 0;
@@ -161,8 +165,9 @@ static bool extractSlotForm(Value slot, uint32_t expectN, SlotForm &out) {
 
 static int64_t pyMod(int64_t a, int64_t n) {
   int64_t r = a % n;
-  if (r < 0)
+  if (r < 0) {
     r += n;
+  }
   return r;
 }
 
@@ -203,12 +208,14 @@ SlotRelation compareSlotSSA(Value a, Value b, uint32_t N) {
 
   // One side const, other symbolic: cannot prove disjoint without
   // assuming a value range on the symbol. Equality also unprovable.
-  if (!fa.innerSym || !fb.innerSym)
+  if (!fa.innerSym || !fb.innerSym) {
     return SlotRelation::kUnknown;
+  }
 
   // Both symbolic. Need same symbol to reason about (a - b) mod N.
-  if (fa.innerSym != fb.innerSym)
+  if (fa.innerSym != fb.innerSym) {
     return SlotRelation::kUnknown;
+  }
 
   int64_t diff = pyMod(fa.innerOffset - fb.innerOffset, N);
   return diff == 0 ? SlotRelation::kEqual : SlotRelation::kDisjoint;

--- a/lib/PTO/Transforms/TileFusion/FusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/FusionAnalysis.cpp
@@ -23,12 +23,15 @@ namespace pto {
 namespace {
 
 static int64_t getConstantIndexOrDynamic(Value value) {
-  if (!value)
+  if (!value) {
     return ShapedType::kDynamic;
-  if (auto cst = value.getDefiningOp<arith::ConstantIndexOp>())
+  }
+  if (auto cst = value.getDefiningOp<arith::ConstantIndexOp>()) {
     return cst.value();
-  if (auto cst = value.getDefiningOp<arith::ConstantIntOp>())
+  }
+  if (auto cst = value.getDefiningOp<arith::ConstantIntOp>()) {
     return cst.value();
+  }
   return ShapedType::kDynamic;
 }
 
@@ -50,14 +53,18 @@ static SmallVector<int64_t, 4> getValidShapeVec(Type type) {
 /// result, so that two such ops with the same name, attributes and equivalent
 /// operands are guaranteed to produce the same value.
 static bool isShapeComputableOp(Operation *op) {
-  if (!op)
+  if (!op) {
     return false;
-  if (op->getNumRegions() != 0)
+  }
+  if (op->getNumRegions() != 0) {
     return false;
-  if (op->getNumResults() != 1)
+  }
+  if (op->getNumResults() != 1) {
     return false;
-  if (!isMemoryEffectFree(op))
+  }
+  if (!isMemoryEffectFree(op)) {
     return false;
+  }
 
   // Only allow arith ops that appear in typical valid-shape computations
   // (minsi, maxsi, cmpi, select, addi, subi, muli, divsi, divui,
@@ -87,10 +94,12 @@ public:
     Attribute attrs;
 
     bool operator==(const Key &rhs) const {
-      if (opNamePtr != rhs.opNamePtr)
+      if (opNamePtr != rhs.opNamePtr) {
         return false;
-      if (operands.size() != rhs.operands.size())
+      }
+      if (operands.size() != rhs.operands.size()) {
         return false;
+      }
       for (auto [l, r] : llvm::zip(operands, rhs.operands))
         if (l != r)
           return false;
@@ -133,12 +142,14 @@ private:
 static Value canonicalizeValue(Value value,
                                DenseMap<Value, Value> &canonicalByValue,
                                StructuralSignatureMap &signatureMap) {
-  if (!value)
+  if (!value) {
     return value;
+  }
 
   auto cachedIt = canonicalByValue.find(value);
-  if (cachedIt != canonicalByValue.end())
+  if (cachedIt != canonicalByValue.end()) {
     return cachedIt->second;
+  }
 
   // BlockArguments are their own canonical form.
   if (auto arg = dyn_cast<BlockArgument>(value)) {
@@ -182,7 +193,7 @@ static Value canonicalizeValue(Value value,
   return representative;
 }
 
-static constexpr unsigned kInvalidShapeDim = ~0u;
+static constexpr unsigned kInvalidShapeDim = ~0U;
 
 struct ShapeValueDims {
   unsigned rows = kInvalidShapeDim;
@@ -206,26 +217,31 @@ public:
 
   unsigned find(unsigned dim) {
     assert(dim < parent.size() && "shape dim out of range");
-    if (parent[dim] == dim)
+    if (parent[dim] == dim) {
       return dim;
+    }
     parent[dim] = find(parent[dim]);
     return parent[dim];
   }
 
   void merge(unsigned lhs, unsigned rhs) {
-    if (lhs == kInvalidShapeDim || rhs == kInvalidShapeDim)
+    if (lhs == kInvalidShapeDim || rhs == kInvalidShapeDim) {
       return;
+    }
 
     unsigned lhsRoot = find(lhs);
     unsigned rhsRoot = find(rhs);
-    if (lhsRoot == rhsRoot)
+    if (lhsRoot == rhsRoot) {
       return;
+    }
 
-    if (rank[lhsRoot] < rank[rhsRoot])
+    if (rank[lhsRoot] < rank[rhsRoot]) {
       std::swap(lhsRoot, rhsRoot);
+    }
     parent[rhsRoot] = lhsRoot;
-    if (rank[lhsRoot] == rank[rhsRoot])
+    if (rank[lhsRoot] == rank[rhsRoot]) {
       ++rank[lhsRoot];
+    }
 
     conflicts[lhsRoot] = conflicts[lhsRoot] || conflicts[rhsRoot];
     if (constants[lhsRoot] && constants[rhsRoot] &&
@@ -236,25 +252,29 @@ public:
   }
 
   void bindConstant(unsigned dim, int64_t value) {
-    if (dim == kInvalidShapeDim || value == ShapedType::kDynamic)
+    if (dim == kInvalidShapeDim || value == ShapedType::kDynamic) {
       return;
+    }
 
     unsigned root = find(dim);
-    if (constants[root] && *constants[root] != value)
+    if (constants[root] && *constants[root] != value) {
       conflicts[root] = true;
-    else
+    } else {
       constants[root] = value;
+    }
   }
 
   bool hasConflict(unsigned dim) {
-    if (dim == kInvalidShapeDim)
+    if (dim == kInvalidShapeDim) {
       return true;
+    }
     return conflicts[find(dim)];
   }
 
   std::optional<int64_t> getConstant(unsigned dim) {
-    if (dim == kInvalidShapeDim)
+    if (dim == kInvalidShapeDim) {
       return std::nullopt;
+    }
     return constants[find(dim)];
   }
 
@@ -262,8 +282,9 @@ public:
   /// buildIterationDomainInfo from proving a consistent shape.  Used when a
   /// runtime set_validshape invalidates alloc-time shape assumptions.
   void markConflict(unsigned dim) {
-    if (dim == kInvalidShapeDim)
+    if (dim == kInvalidShapeDim) {
       return;
+    }
     conflicts[find(dim)] = true;
   }
 
@@ -279,8 +300,9 @@ static void bindDimToValue(ShapeConstraintSolver &solver,
                            DenseMap<Value, Value> &canonicalByValue,
                            StructuralSignatureMap &signatureMap,
                            unsigned dim, Value value) {
-  if (!value || dim == kInvalidShapeDim)
+  if (!value || dim == kInvalidShapeDim) {
     return;
+  }
 
   int64_t constant = getConstantIndexOrDynamic(value);
   if (constant != ShapedType::kDynamic) {
@@ -294,8 +316,9 @@ static void bindDimToValue(ShapeConstraintSolver &solver,
       canonicalizeValue(value, canonicalByValue, signatureMap);
   auto [it, inserted] =
       symbolDimByValue.try_emplace(canonical, kInvalidShapeDim);
-  if (inserted)
+  if (inserted) {
     it->second = solver.createDim();
+  }
   solver.merge(dim, it->second);
 }
 
@@ -341,18 +364,21 @@ static ShapeValueDims getValueDims(
     DenseMap<Value, Value> &canonicalByValue,
     StructuralSignatureMap &signatureMap, Value value) {
   auto existing = dimsByValue.find(value);
-  if (existing != dimsByValue.end())
+  if (existing != dimsByValue.end()) {
     return existing->second;
+  }
 
   ShapeValueDims dims;
   SmallVector<int64_t, 4> validShape = getValidShapeVec(value.getType());
   if (validShape.size() >= 2) {
     dims.rows = solver.createDim();
     dims.cols = solver.createDim();
-    if (!ShapedType::isDynamic(validShape[0]))
+    if (!ShapedType::isDynamic(validShape[0])) {
       solver.bindConstant(dims.rows, validShape[0]);
-    if (!ShapedType::isDynamic(validShape[1]))
+    }
+    if (!ShapedType::isDynamic(validShape[1])) {
       solver.bindConstant(dims.cols, validShape[1]);
+    }
     bindExplicitValidDims(solver, symbolDimByValue, canonicalByValue,
                          signatureMap, value, dims);
   }
@@ -382,8 +408,9 @@ static void mergeAllShapes(
     DenseMap<Value, unsigned> &symbolDimByValue,
     DenseMap<Value, Value> &canonicalByValue,
     StructuralSignatureMap &signatureMap, ArrayRef<Value> values) {
-  if (values.empty())
+  if (values.empty()) {
     return;
+  }
   ShapeValueDims anchor = getValueDims(solver, dimsByValue, symbolDimByValue,
                                         canonicalByValue, signatureMap,
                                         values.front());
@@ -414,8 +441,9 @@ static void applyShapeConstraintsForNode(
                    signatureMap, semantics.tileOutputs);
     return;
   case FusionComputeFamily::RowBroadcastBinary: {
-    if (semantics.tileOutputs.empty())
+    if (semantics.tileOutputs.empty()) {
       return;
+    }
     ShapeValueDims output = getValueDims(
         solver, dimsByValue, symbolDimByValue, canonicalByValue, signatureMap,
         semantics.tileOutputs.front());
@@ -442,8 +470,9 @@ static void applyShapeConstraintsForNode(
   case FusionComputeFamily::ReduceCol: {
     mergeAllShapes(solver, dimsByValue, symbolDimByValue, canonicalByValue,
                    signatureMap, semantics.tileInputs);
-    if (semantics.tileInputs.empty() || semantics.tileOutputs.empty())
+    if (semantics.tileInputs.empty() || semantics.tileOutputs.empty()) {
       return;
+    }
     ShapeValueDims input = getValueDims(
         solver, dimsByValue, symbolDimByValue, canonicalByValue, signatureMap,
         semantics.tileInputs.front());
@@ -504,8 +533,9 @@ static ShapeValueDims getIterationDomainDimsForNode(
 static IterationDomainInfo
 buildIterationDomainInfo(ShapeConstraintSolver &solver, ShapeValueDims dims) {
   IterationDomainInfo info;
-  if (!dims.isValid())
+  if (!dims.isValid()) {
     return info;
+  }
   if (solver.hasConflict(dims.rows) || solver.hasConflict(dims.cols)) {
     info.unprovenReason = IterationDomainUnprovenReason::InconsistentShape;
     return info;
@@ -513,10 +543,12 @@ buildIterationDomainInfo(ShapeConstraintSolver &solver, ShapeValueDims dims) {
 
   info.proof = IterationDomainProof::Proven;
   info.unprovenReason = IterationDomainUnprovenReason::None;
-  if (std::optional<int64_t> row = solver.getConstant(dims.rows))
+  if (std::optional<int64_t> row = solver.getConstant(dims.rows)) {
     info.vRow = *row;
-  if (std::optional<int64_t> col = solver.getConstant(dims.cols))
+  }
+  if (std::optional<int64_t> col = solver.getConstant(dims.cols)) {
     info.vCol = *col;
+  }
   return info;
 }
 
@@ -572,8 +604,9 @@ struct Rank2IterationSpace {
 
 static std::optional<Rank2IterationSpace> getRank2IterationSpace(Value value) {
   SmallVector<int64_t, 4> validShape = getValidShapeVec(value.getType());
-  if (validShape.size() < 2)
+  if (validShape.size() < 2) {
     return std::nullopt;
+  }
   return Rank2IterationSpace{validShape[0], validShape[1]};
 }
 
@@ -581,8 +614,9 @@ static void mergeIterationDim(int64_t &mergedDim, int64_t dim,
                               IterationDomainInfo &info) {
   if (mergedDim == ShapedType::kDynamic || dim == ShapedType::kDynamic) {
     mergedDim = ShapedType::kDynamic;
-    if (info.unprovenReason == IterationDomainUnprovenReason::None)
+    if (info.unprovenReason == IterationDomainUnprovenReason::None) {
       info.unprovenReason = IterationDomainUnprovenReason::DynamicShape;
+    }
     return;
   }
 
@@ -597,19 +631,22 @@ inferConsensusIterationDomain(ArrayRef<Value> anchorValues) {
   IterationDomainInfo info;
   info.unprovenReason = IterationDomainUnprovenReason::None;
 
-  if (anchorValues.empty())
+  if (anchorValues.empty()) {
     return info;
+  }
 
   std::optional<Rank2IterationSpace> firstSpace =
       getRank2IterationSpace(anchorValues.front());
-  if (!firstSpace)
+  if (!firstSpace) {
     return info;
+  }
 
   info.vRow = firstSpace->rows;
   info.vCol = firstSpace->cols;
 
-  if (info.vRow == ShapedType::kDynamic || info.vCol == ShapedType::kDynamic)
+  if (info.vRow == ShapedType::kDynamic || info.vCol == ShapedType::kDynamic) {
     info.unprovenReason = IterationDomainUnprovenReason::DynamicShape;
+  }
 
   for (Value value : ArrayRef<Value>(anchorValues).drop_front()) {
     std::optional<Rank2IterationSpace> space = getRank2IterationSpace(value);
@@ -629,8 +666,9 @@ inferConsensusIterationDomain(ArrayRef<Value> anchorValues) {
     return info;
   }
 
-  if (info.unprovenReason == IterationDomainUnprovenReason::None)
+  if (info.unprovenReason == IterationDomainUnprovenReason::None) {
     info.unprovenReason = IterationDomainUnprovenReason::DynamicShape;
+  }
   return info;
 }
 
@@ -730,8 +768,9 @@ static LogicalResult inferDynamicIterationDomain(FusionBlockAnalysis &analysis) 
   if (analysis.block) {
     for (Operation &op : *analysis.block) {
       auto setVS = dyn_cast<pto::SetValidShapeOp>(op);
-      if (!setVS)
+      if (!setVS) {
         continue;
+      }
       Value source = setVS.getSource();
       auto dimsIt = dimsByValue.find(source);
       if (dimsIt != dimsByValue.end()) {
@@ -780,10 +819,12 @@ static Value getWriteInstanceStorageValue(Operation *op, unsigned outputIndex,
   if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {
     unsigned tileOutputIndex = 0;
     for (Value init : dpsIface.getDpsInits()) {
-      if (!isa<pto::TileBufType>(init.getType()))
+      if (!isa<pto::TileBufType>(init.getType())) {
         continue;
-      if (tileOutputIndex == outputIndex)
+      }
+      if (tileOutputIndex == outputIndex) {
         return init;
+      }
       ++tileOutputIndex;
     }
   }
@@ -803,14 +844,16 @@ static unsigned getOrCreateLivenessSlot(DenseMap<Value, unsigned> &slotByValue,
 }
 
 static void appendUniqueNode(SmallVectorImpl<unsigned> &nodes, unsigned nodeId) {
-  if (!llvm::is_contained(nodes, nodeId))
+  if (!llvm::is_contained(nodes, nodeId)) {
     nodes.push_back(nodeId);
+  }
 }
 
 static void recordLastLocalConsumer(std::optional<unsigned> &lastLocalConsumer,
                                     unsigned consumerId) {
-  if (!lastLocalConsumer || consumerId > *lastLocalConsumer)
+  if (!lastLocalConsumer || consumerId > *lastLocalConsumer) {
     lastLocalConsumer = consumerId;
+  }
 }
 
 static void finalizeBlockLiveness(
@@ -827,17 +870,20 @@ static void finalizeBlockLiveness(
       }
 
       auto kindIt = kindByOp.find(user);
-      if (kindIt == kindByOp.end())
+      if (kindIt == kindByOp.end()) {
         continue;
+      }
 
-      if (user->hasTrait<OpTrait::IsTerminator>())
+      if (user->hasTrait<OpTrait::IsTerminator>()) {
         state.live.escapesBlock = true;
+      }
 
       switch (kindIt->second) {
       case FusionOpKind::Compute: {
         auto nodeIt = computeNodeByOp.find(user);
-        if (nodeIt == computeNodeByOp.end())
+        if (nodeIt == computeNodeByOp.end()) {
           continue;
+        }
         unsigned consumerId = nodeIt->second;
         appendUniqueNode(state.live.consumerNodes, consumerId);
         recordLastLocalConsumer(state.live.lastLocalConsumer, consumerId);
@@ -858,11 +904,13 @@ static std::optional<unsigned> findReachingWriteInstance(
     ArrayRef<unsigned> writeInstanceIds,
     ArrayRef<MutableWriteInstance> mutableWriteInstances,
     std::optional<unsigned> userBlockOrder) {
-  if (writeInstanceIds.empty())
+  if (writeInstanceIds.empty()) {
     return std::nullopt;
+  }
 
-  if (!userBlockOrder)
+  if (!userBlockOrder) {
     return writeInstanceIds.back();
+  }
 
   for (unsigned writeInstanceId : llvm::reverse(writeInstanceIds)) {
     if (mutableWriteInstances[writeInstanceId].producerBlockOrder <
@@ -874,8 +922,9 @@ static std::optional<unsigned> findReachingWriteInstance(
 
 static bool isDpsInitOperandUse(OpOperand &use) {
   auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(use.getOwner());
-  if (!dpsIface)
+  if (!dpsIface) {
     return false;
+  }
 
   for (OpOperand &dpsInit : dpsIface.getDpsInitsMutable())
     if (&dpsInit == &use)
@@ -890,27 +939,31 @@ static void finalizeWriteInstances(
     ArrayRef<MutableLiveness> mutableLiveness,
     SmallVectorImpl<MutableWriteInstance> &mutableWriteInstances) {
   for (const MutableLiveness &storageState : mutableLiveness) {
-    if (storageState.live.writeInstances.empty())
+    if (storageState.live.writeInstances.empty()) {
       continue;
+    }
 
     for (OpOperand &use : storageState.live.value.getUses()) {
-      if (isDpsInitOperandUse(use))
+      if (isDpsInitOperandUse(use)) {
         continue;
+      }
 
       Operation *user = use.getOwner();
       bool isInBlock = user->getBlock() == &block;
       std::optional<unsigned> userBlockOrder;
       if (isInBlock) {
         auto orderIt = blockOrderByOp.find(user);
-        if (orderIt != blockOrderByOp.end())
+        if (orderIt != blockOrderByOp.end()) {
           userBlockOrder = orderIt->second;
+        }
       }
 
       std::optional<unsigned> writeInstanceId = findReachingWriteInstance(
           storageState.live.writeInstances, mutableWriteInstances,
           userBlockOrder);
-      if (!writeInstanceId)
+      if (!writeInstanceId) {
         continue;
+      }
 
       FusionWriteInstanceLiveness &writeLive =
           mutableWriteInstances[*writeInstanceId].live;
@@ -922,17 +975,20 @@ static void finalizeWriteInstances(
       }
 
       auto kindIt = kindByOp.find(user);
-      if (kindIt == kindByOp.end())
+      if (kindIt == kindByOp.end()) {
         continue;
+      }
 
-      if (user->hasTrait<OpTrait::IsTerminator>())
+      if (user->hasTrait<OpTrait::IsTerminator>()) {
         writeLive.escapesBlock = true;
+      }
 
       switch (kindIt->second) {
       case FusionOpKind::Compute: {
         auto nodeIt = computeNodeByOp.find(user);
-        if (nodeIt == computeNodeByOp.end())
+        if (nodeIt == computeNodeByOp.end()) {
           continue;
+        }
         unsigned consumerId = nodeIt->second;
         appendUniqueNode(writeLive.consumerNodes, consumerId);
         recordLastLocalConsumer(writeLive.lastLocalConsumer, consumerId);
@@ -980,10 +1036,12 @@ static FailureOr<FusionBlockAnalysis> analyzeBlockDFG(Block &block) {
     kindByOp[&op] = semanticsOr->kind;
 
     if (semanticsOr->kind == FusionOpKind::LocalBoundary) {
-      for (Value input : semanticsOr->tileInputs)
+      for (Value input : semanticsOr->tileInputs) {
         getOrCreateLivenessSlot(livenessSlotByValue, mutableLiveness, input);
-      for (Value output : semanticsOr->tileOutputs)
+      }
+      for (Value output : semanticsOr->tileOutputs) {
         getOrCreateLivenessSlot(livenessSlotByValue, mutableLiveness, output);
+      }
       ++blockOrder;
       continue;
     }
@@ -1026,8 +1084,9 @@ static FailureOr<FusionBlockAnalysis> analyzeBlockDFG(Block &block) {
                               node.id);
 
       auto producerIt = producerByValue.find(input);
-      if (producerIt == producerByValue.end())
+      if (producerIt == producerByValue.end()) {
         continue;
+      }
 
       FusionDFGEdge edge;
       edge.producerNode = producerIt->second;
@@ -1037,8 +1096,9 @@ static FailureOr<FusionBlockAnalysis> analyzeBlockDFG(Block &block) {
       unsigned edgeId = analysis.edges.size();
       analysis.edges.push_back(edge);
       node.incomingEdges.push_back(edgeId);
-      if (edge.producerNode < analysis.computeNodes.size())
+      if (edge.producerNode < analysis.computeNodes.size()) {
         analysis.computeNodes[edge.producerNode].outgoingEdges.push_back(edgeId);
+      }
     }
 
     analysis.computeNodes.push_back(std::move(node));
@@ -1050,11 +1110,13 @@ static FailureOr<FusionBlockAnalysis> analyzeBlockDFG(Block &block) {
                          mutableLiveness, mutableWriteInstances);
 
   analysis.liveness.reserve(mutableLiveness.size());
-  for (MutableLiveness &state : mutableLiveness)
+  for (MutableLiveness &state : mutableLiveness) {
     analysis.liveness.push_back(std::move(state.live));
+  }
   analysis.writeInstances.reserve(mutableWriteInstances.size());
-  for (MutableWriteInstance &state : mutableWriteInstances)
+  for (MutableWriteInstance &state : mutableWriteInstances) {
     analysis.writeInstances.push_back(std::move(state.live));
+  }
 
   return std::move(analysis);
 }
@@ -1063,8 +1125,9 @@ static LogicalResult analyzeRegionDFG(Region &region,
                                       SmallVectorImpl<FusionBlockAnalysis> &blocks) {
   for (Block &block : region.getBlocks()) {
     FailureOr<FusionBlockAnalysis> blockAnalysis = analyzeBlockDFG(block);
-    if (failed(blockAnalysis))
+    if (failed(blockAnalysis)) {
       return failure();
+    }
     blocks.push_back(std::move(*blockAnalysis));
     for (Operation &op : block)
       for (Region &nested : op.getRegions())
@@ -1079,8 +1142,9 @@ static LogicalResult analyzeRegionDFG(Region &region,
 FailureOr<PreFusionAnalysisResult>
 buildPreFusionAnalysisDFG(func::FuncOp func) {
   PreFusionAnalysisResult result;
-  if (failed(analyzeRegionDFG(func.getRegion(), result.blocks)))
+  if (failed(analyzeRegionDFG(func.getRegion(), result.blocks))) {
     return failure();
+  }
   return std::move(result);
 }
 
@@ -1088,11 +1152,13 @@ LogicalResult inferIterationDomainClasses(PreFusionAnalysisResult &result,
                                           bool enableShapeInference) {
   for (FusionBlockAnalysis &block : result.blocks) {
     if (enableShapeInference) {
-      if (failed(inferDynamicIterationDomain(block)))
+      if (failed(inferDynamicIterationDomain(block))) {
         return failure();
+      }
     } else {
-      if (failed(inferStaticIterationDomain(block)))
+      if (failed(inferStaticIterationDomain(block))) {
         return failure();
+      }
     }
   }
   return success();
@@ -1101,10 +1167,12 @@ LogicalResult inferIterationDomainClasses(PreFusionAnalysisResult &result,
 FailureOr<PreFusionAnalysisResult>
 buildPreFusionAnalysis(func::FuncOp func, bool enableShapeInference) {
   FailureOr<PreFusionAnalysisResult> result = buildPreFusionAnalysisDFG(func);
-  if (failed(result))
+  if (failed(result)) {
     return failure();
-  if (failed(inferIterationDomainClasses(*result, enableShapeInference)))
+  }
+  if (failed(inferIterationDomainClasses(*result, enableShapeInference))) {
     return failure();
+  }
   return std::move(*result);
 }
 

--- a/lib/PTO/Transforms/TileFusion/FusionOpSemantics.cpp
+++ b/lib/PTO/Transforms/TileFusion/FusionOpSemantics.cpp
@@ -42,8 +42,9 @@ static SmallVector<Value, 2> collectNormalizedTileOutputs(Operation *op) {
 
   if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(op)) {
     for (Value init : dpsIface.getDpsInits()) {
-      if (isTileFusionTileValue(init))
+      if (isTileFusionTileValue(init)) {
         outputs.push_back(init);
+      }
     }
     if (!outputs.empty())
       return outputs;
@@ -103,10 +104,11 @@ FailureOr<FusionOpSemantics> getFusionOpSemantics(Operation *op) {
       continue;
 
     Value value = operand.get();
-    if (isTileFusionTileValue(value))
+    if (isTileFusionTileValue(value)) {
       semantics.tileInputs.push_back(value);
-    else
+    } else {
       semantics.scalarInputs.push_back(value);
+    }
   }
 
   if (semantics.tileInputs.empty()) {

--- a/lib/PTO/Transforms/TileFusion/PTOFlattenFusionRegion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFlattenFusionRegion.cpp
@@ -28,8 +28,9 @@ namespace {
 static LogicalResult flattenFusionRegion(pto::FusionRegionOp fusionRegion) {
   Block &body = fusionRegion.getBody().front();
   auto yieldOp = dyn_cast<pto::YieldOp>(body.getTerminator());
-  if (!yieldOp)
+  if (!yieldOp) {
     return fusionRegion.emitOpError("expects body to terminate with pto.yield");
+  }
 
   SmallVector<Value, 8> yieldedValues(yieldOp.getValues().begin(),
                                       yieldOp.getValues().end());
@@ -60,8 +61,9 @@ struct PTOFlattenFusionRegionPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     SmallVector<pto::FusionRegionOp, 8> fusionRegions;
     func.walk<WalkOrder::PostOrder>([&](pto::FusionRegionOp fusionRegion) {

--- a/lib/PTO/Transforms/TileFusion/PTOFusionLoadStoreElision.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionLoadStoreElision.cpp
@@ -55,20 +55,27 @@ static bool areEquivalentValueRanges(ArrayRef<Value> lhs, ArrayRef<Value> rhs) {
 }
 
 static bool areEquivalentOperations(Operation *lhs, Operation *rhs) {
-  if (!lhs || !rhs)
+  if (!lhs || !rhs) {
     return false;
-  if (lhs->getName() != rhs->getName())
+  }
+  if (lhs->getName() != rhs->getName()) {
     return false;
-  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0)
+  }
+  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0) {
     return false;
-  if (lhs->getNumResults() != rhs->getNumResults())
+  }
+  if (lhs->getNumResults() != rhs->getNumResults()) {
     return false;
-  if (lhs->getNumOperands() != rhs->getNumOperands())
+  }
+  if (lhs->getNumOperands() != rhs->getNumOperands()) {
     return false;
-  if (lhs->getAttrDictionary() != rhs->getAttrDictionary())
+  }
+  if (lhs->getAttrDictionary() != rhs->getAttrDictionary()) {
     return false;
-  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes()))
+  }
+  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes())) {
     return false;
+  }
 
   if (auto lhsDim = dyn_cast<memref::DimOp>(lhs)) {
     auto rhsDim = cast<memref::DimOp>(rhs);
@@ -78,19 +85,23 @@ static bool areEquivalentOperations(Operation *lhs, Operation *rhs) {
 
   for (auto [lhsOperand, rhsOperand] :
        llvm::zip(lhs->getOperands(), rhs->getOperands())) {
-    if (!areEquivalentValues(lhsOperand, rhsOperand))
+    if (!areEquivalentValues(lhsOperand, rhsOperand)) {
       return false;
+    }
   }
   return true;
 }
 
 static bool areEquivalentValues(Value lhs, Value rhs) {
-  if (lhs == rhs)
+  if (lhs == rhs) {
     return true;
-  if (!lhs || !rhs)
+  }
+  if (!lhs || !rhs) {
     return false;
-  if (lhs.getType() != rhs.getType())
+  }
+  if (lhs.getType() != rhs.getType()) {
     return false;
+  }
 
   auto lhsArg = dyn_cast<BlockArgument>(lhs);
   auto rhsArg = dyn_cast<BlockArgument>(rhs);
@@ -111,22 +122,25 @@ static bool isPureNoRegionOp(Operation *op) {
 }
 
 static bool isSupportedLoopPreludeOp(Operation *op) {
-  if (isa<pto::UvldOp>(op))
+  if (isa<pto::UvldOp>(op)) {
     return true;
+  }
   return isPureNoRegionOp(op);
 }
 
 static bool isSupportedLeafOp(Operation *op) {
-  if (isa<pto::VldsOp, pto::VstsOp>(op))
+  if (isa<pto::VldsOp, pto::VstsOp>(op)) {
     return true;
+  }
   return isPureNoRegionOp(op);
 }
 
 static Value getCanonicalTrackedValue(Value value) {
   while (value) {
     Operation *def = value.getDefiningOp();
-    if (!def)
+    if (!def) {
       break;
+    }
 
     if (auto tileBufAddr = dyn_cast<pto::TileBufAddrOp>(def)) {
       value = tileBufAddr.getSrc();
@@ -177,8 +191,9 @@ static Value getCanonicalTrackedValue(Value value) {
       continue;
     }
     if (auto cast = dyn_cast<UnrealizedConversionCastOp>(def)) {
-      if (cast.getInputs().empty())
+      if (cast.getInputs().empty()) {
         break;
+      }
       if (auto result = dyn_cast<OpResult>(value)) {
         unsigned resultNumber = result.getResultNumber();
         if (resultNumber < cast.getInputs().size()) {
@@ -206,27 +221,32 @@ static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
 static Region *getDirectRegionUnderAncestor(Operation *op, Operation *ancestor) {
   for (Operation *cur = op; cur; cur = cur->getParentOp()) {
     Operation *parent = cur->getParentOp();
-    if (parent == ancestor)
+    if (parent == ancestor) {
       return cur->getBlock() ? cur->getBlock()->getParent() : nullptr;
+    }
   }
   return nullptr;
 }
 
 static bool areMutuallyExclusiveByIfRegion(Operation *lhs, Operation *rhs) {
-  if (!lhs || !rhs)
+  if (!lhs || !rhs) {
     return false;
+  }
 
   for (Operation *ancestor = lhs; ancestor; ancestor = ancestor->getParentOp()) {
     auto ifOp = dyn_cast<scf::IfOp>(ancestor);
-    if (!ifOp)
+    if (!ifOp) {
       continue;
+    }
 
     Region *lhsRegion = getDirectRegionUnderAncestor(lhs, ifOp);
     Region *rhsRegion = getDirectRegionUnderAncestor(rhs, ifOp);
-    if (!lhsRegion || !rhsRegion)
+    if (!lhsRegion || !rhsRegion) {
       continue;
-    if (lhsRegion != rhsRegion)
+    }
+    if (lhsRegion != rhsRegion) {
       return true;
+    }
   }
 
   return false;
@@ -236,8 +256,9 @@ static std::optional<FusionRegionStoreContext>
 buildFusionRegionStoreContext(pto::FusionRegionOp fusionRegion) {
   Block &body = fusionRegion.getBody().front();
   auto yieldOp = dyn_cast<pto::YieldOp>(body.getTerminator());
-  if (!yieldOp)
+  if (!yieldOp) {
     return std::nullopt;
+  }
 
   FusionRegionStoreContext context;
   context.body = &body;
@@ -246,23 +267,26 @@ buildFusionRegionStoreContext(pto::FusionRegionOp fusionRegion) {
 
   for (Value yielded : yieldOp.getValues()) {
     Value canonical = getCanonicalTrackedValue(yielded);
-    if (canonical)
+    if (canonical) {
       context.yieldedValues.insert(canonical);
+    }
   }
 
   return context;
 }
 
 static bool isSupportedLoopRoot(scf::ForOp loop) {
-  if (!loop)
+  if (!loop) {
     return false;
+  }
   return isa<pto::FusionRegionOp, pto::VecScopeOp, pto::StrictVecScopeOp>(
       loop->getParentOp());
 }
 
 static Block *getLeafLoopBody(scf::ForOp carrierLoop) {
-  if (!carrierLoop)
+  if (!carrierLoop) {
     return nullptr;
+  }
 
   scf::ForOp currentLoop = carrierLoop;
   while (currentLoop) {
@@ -271,16 +295,18 @@ static Block *getLeafLoopBody(scf::ForOp carrierLoop) {
     for (Operation &op : currentLoop.getBody()->without_terminator()) {
       bodyOps.push_back(&op);
       if (auto loop = dyn_cast<scf::ForOp>(op)) {
-        if (innerLoop)
+        if (innerLoop) {
           return nullptr;
+        }
         innerLoop = loop;
       }
     }
 
     if (!innerLoop) {
       Block *leafBody = currentLoop.getBody();
-      if (!leafBody)
+      if (!leafBody) {
         return nullptr;
+      }
       for (Operation &op : leafBody->without_terminator())
         if (!isSupportedLeafOp(&op))
           return nullptr;
@@ -293,8 +319,9 @@ static Block *getLeafLoopBody(scf::ForOp carrierLoop) {
         seenInnerLoop = true;
         continue;
       }
-      if (seenInnerLoop || !isSupportedLoopPreludeOp(op))
+      if (seenInnerLoop || !isSupportedLoopPreludeOp(op)) {
         return nullptr;
+      }
     }
 
     currentLoop = innerLoop;
@@ -314,26 +341,31 @@ static Value inferVPTOLoadUserMask(pto::VldsOp load) {
   Value inferredMask;
   for (OpOperand &use : load.getResult().getUses()) {
     Operation *owner = use.getOwner();
-    if (!owner || owner->getNumRegions() != 0)
+    if (!owner || owner->getNumRegions() != 0) {
       return Value();
+    }
 
     Value ownerMask;
     for (Value operand : owner->getOperands()) {
-      if (!isa<pto::MaskType>(operand.getType()))
+      if (!isa<pto::MaskType>(operand.getType())) {
         continue;
-      if (!ownerMask)
+      }
+      if (!ownerMask) {
         ownerMask = operand;
-      else if (!areEquivalentMaskValues(ownerMask, operand))
+      } else if (!areEquivalentMaskValues(ownerMask, operand)) {
         return Value();
+      }
     }
 
-    if (!ownerMask)
+    if (!ownerMask) {
       return Value();
+    }
 
-    if (!inferredMask)
+    if (!inferredMask) {
       inferredMask = ownerMask;
-    else if (!areEquivalentMaskValues(inferredMask, ownerMask))
+    } else if (!areEquivalentMaskValues(inferredMask, ownerMask)) {
       return Value();
+    }
   }
   return inferredMask;
 }
@@ -367,20 +399,24 @@ static bool shouldElideTailStore(
     Operation *scopeOp,
     const llvm::SmallPtrSetImpl<Operation *> &scheduledForErase) {
   Value canonicalBase = getCanonicalTrackedValue(store.base);
-  if (!canonicalBase)
+  if (!canonicalBase) {
     return false;
+  }
   Operation *localScopeOp = scopeOp ? scopeOp : store.op;
-  if (!localScopeOp)
+  if (!localScopeOp) {
     return false;
+  }
   // Yielded frontier is still region-observable in v1, so its final
   // materializing store must be preserved even if there is no reload.
-  if (context.yieldedValues.contains(canonicalBase))
+  if (context.yieldedValues.contains(canonicalBase)) {
     return false;
+  }
 
   for (OpOperand &use : canonicalBase.getUses()) {
     Operation *owner = use.getOwner();
-    if (!owner || scheduledForErase.contains(owner))
+    if (!owner || scheduledForErase.contains(owner)) {
       continue;
+    }
     if (context.regionOp->isProperAncestor(owner)) {
       // Uses nested under the current carrier loop are fine: erasing the tail
       // store only affects memory materialization, while SSA users still
@@ -388,15 +424,19 @@ static bool shouldElideTailStore(
       // fusion region may still require the buffer to stay materialized, so
       // keep the store.
       Operation *topLevelUser = getTopLevelAncestorInBlock(owner, context.body);
-      if (!topLevelUser)
+      if (!topLevelUser) {
         return false;
-      if (scheduledForErase.contains(topLevelUser))
+      }
+      if (scheduledForErase.contains(topLevelUser)) {
         continue;
-      if (topLevelUser == localScopeOp)
+      }
+      if (topLevelUser == localScopeOp) {
         continue;
+      }
       if (localScopeOp->getBlock() == topLevelUser->getBlock() &&
-          localScopeOp->isBeforeInBlock(topLevelUser))
+          localScopeOp->isBeforeInBlock(topLevelUser)) {
         return false;
+      }
       continue;
     }
 
@@ -405,16 +445,20 @@ static bool shouldElideTailStore(
     Operation *topLevelUser =
         getTopLevelAncestorInBlock(owner, context.parentBlock);
     if (!topLevelUser) {
-      if (areMutuallyExclusiveByIfRegion(localScopeOp, owner))
+      if (areMutuallyExclusiveByIfRegion(localScopeOp, owner)) {
         continue;
+      }
       return false;
     }
-    if (scheduledForErase.contains(topLevelUser))
+    if (scheduledForErase.contains(topLevelUser)) {
       continue;
-    if (topLevelUser == context.regionOp)
+    }
+    if (topLevelUser == context.regionOp) {
       continue;
-    if (context.regionOp->isBeforeInBlock(topLevelUser))
+    }
+    if (context.regionOp->isBeforeInBlock(topLevelUser)) {
       return false;
+    }
   }
   return true;
 }
@@ -480,21 +524,24 @@ static bool elideLoadStoreRoundTripsInLeafBody(
       continue;
     }
 
-    if (!isPureNoRegionOp(&op))
+    if (!isPureNoRegionOp(&op)) {
       trackedStores.clear();
+    }
   }
 
   if (context) {
     for (const TrackedStore &store : trackedStores) {
-      if (!shouldElideTailStore(store, *context, scopeOp, scheduledForErase))
+      if (!shouldElideTailStore(store, *context, scopeOp, scheduledForErase)) {
         continue;
+      }
       scheduleErase(store.op);
       changed = true;
     }
   }
 
-  for (Operation *op : eraseOrder)
+  for (Operation *op : eraseOrder) {
     op->erase();
+  }
   return changed;
 }
 
@@ -506,8 +553,9 @@ struct PTOFusionLoadStoreElisionPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     bool changed = false;
 
@@ -515,32 +563,37 @@ struct PTOFusionLoadStoreElisionPass
     func.walk([&](pto::FusionRegionOp fusionRegion) {
       std::optional<FusionRegionStoreContext> context =
           buildFusionRegionStoreContext(fusionRegion);
-      if (!context)
+      if (!context) {
         return;
+      }
       regionContexts.try_emplace(fusionRegion.getOperation(),
                                  std::move(*context));
     });
 
     func.walk([&](pto::FusionRegionOp fusionRegion) {
       auto it = regionContexts.find(fusionRegion.getOperation());
-      if (it == regionContexts.end())
+      if (it == regionContexts.end()) {
         return;
+      }
 
       Block &body = fusionRegion.getBody().front();
-      if (!isSupportedStraightLineBlock(body))
+      if (!isSupportedStraightLineBlock(body)) {
         return;
+      }
 
       changed |= elideLoadStoreRoundTripsInLeafBody(body, &it->second, nullptr);
     });
 
     auto runElisionForLeafBody = [&](Block *leafBody, Operation *scopeOp,
                                      pto::FusionRegionOp fusionRegion) {
-      if (!leafBody || !fusionRegion)
+      if (!leafBody || !fusionRegion) {
         return;
+      }
 
       auto it = regionContexts.find(fusionRegion.getOperation());
-      if (it == regionContexts.end())
+      if (it == regionContexts.end()) {
         return;
+      }
 
       changed |=
           elideLoadStoreRoundTripsInLeafBody(*leafBody, &it->second, scopeOp);
@@ -548,28 +601,32 @@ struct PTOFusionLoadStoreElisionPass
 
     func.walk([&](pto::VecScopeOp vecscope) {
       if (auto fusionRegion = vecscope->getParentOfType<pto::FusionRegionOp>()) {
-        if (isSupportedStraightLineBlock(vecscope.getBody().front()))
+        if (isSupportedStraightLineBlock(vecscope.getBody().front())) {
           runElisionForLeafBody(&vecscope.getBody().front(), vecscope,
                                 fusionRegion);
+        }
       }
     });
     func.walk([&](pto::StrictVecScopeOp vecscope) {
       if (auto fusionRegion = vecscope->getParentOfType<pto::FusionRegionOp>()) {
-        if (isSupportedStraightLineBlock(vecscope.getBody().front()))
+        if (isSupportedStraightLineBlock(vecscope.getBody().front())) {
           runElisionForLeafBody(&vecscope.getBody().front(), vecscope,
                                 fusionRegion);
+        }
       }
     });
 
     func.walk([&](scf::ForOp loop) {
-      if (!isSupportedLoopRoot(loop))
+      if (!isSupportedLoopRoot(loop)) {
         return;
+      }
       runElisionForLeafBody(getLeafLoopBody(loop), loop.getOperation(),
                             loop->getParentOfType<pto::FusionRegionOp>());
     });
 
-    if (!changed)
+    if (!changed) {
       markAllAnalysesPreserved();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPlan.cpp
@@ -91,8 +91,9 @@ static bool isCurrentlyPlannableOp(StringRef opName) {
 static bool isProvenIterationDomain(
     const pto::FusionBlockAnalysis &blockAnalysis,
     const pto::FusionComputeNode &node) {
-  if (node.iterationDomainClass >= blockAnalysis.iterationDomainClasses.size())
+  if (node.iterationDomainClass >= blockAnalysis.iterationDomainClasses.size()) {
     return false;
+  }
   return blockAnalysis.iterationDomainClasses[node.iterationDomainClass]
              .info.proof == pto::IterationDomainProof::Proven;
 }
@@ -128,10 +129,12 @@ static bool dependsOnPreviousNode(
     const pto::FusionComputeNode &previous,
     const pto::FusionComputeNode &current) {
   for (unsigned edgeId : current.incomingEdges) {
-    if (edgeId >= blockAnalysis.edges.size())
+    if (edgeId >= blockAnalysis.edges.size()) {
       continue;
-    if (blockAnalysis.edges[edgeId].producerNode == previous.id)
+    }
+    if (blockAnalysis.edges[edgeId].producerNode == previous.id) {
       return true;
+    }
   }
 
   for (Value output : previous.semantics.tileOutputs)
@@ -147,8 +150,9 @@ buildStableInGroupOrder(ArrayRef<const pto::FusionComputeNode *> members) {
                                                          members.end());
   llvm::stable_sort(ordered, [](const pto::FusionComputeNode *lhs,
                                 const pto::FusionComputeNode *rhs) {
-    if (lhs->blockOrder != rhs->blockOrder)
+    if (lhs->blockOrder != rhs->blockOrder) {
       return lhs->blockOrder < rhs->blockOrder;
+    }
     return lhs->id < rhs->id;
   });
   return ordered;
@@ -159,15 +163,17 @@ static void assignStableGroupMetadata(ArrayRef<PlannedFusionGroup> groups,
                                       int64_t &nextGroupId) {
   SmallVector<const PlannedFusionGroup *, 8> orderedGroups;
   orderedGroups.reserve(groups.size());
-  for (const PlannedFusionGroup &group : groups)
+  for (const PlannedFusionGroup &group : groups) {
     orderedGroups.push_back(&group);
+  }
 
   llvm::stable_sort(orderedGroups, [](const PlannedFusionGroup *lhs,
                                       const PlannedFusionGroup *rhs) {
     const pto::FusionComputeNode *lhsFirst = lhs->members.front();
     const pto::FusionComputeNode *rhsFirst = rhs->members.front();
-    if (lhsFirst->blockOrder != rhsFirst->blockOrder)
+    if (lhsFirst->blockOrder != rhsFirst->blockOrder) {
       return lhsFirst->blockOrder < rhsFirst->blockOrder;
+    }
     return lhsFirst->id < rhsFirst->id;
   });
 
@@ -201,10 +207,12 @@ countEdgesFromGroup(const pto::FusionBlockAnalysis &blockAnalysis,
 
   unsigned count = 0;
   for (unsigned edgeId : candidate.incomingEdges) {
-    if (edgeId >= blockAnalysis.edges.size())
+    if (edgeId >= blockAnalysis.edges.size()) {
       continue;
-    if (producerIds.contains(blockAnalysis.edges[edgeId].producerNode))
+    }
+    if (producerIds.contains(blockAnalysis.edges[edgeId].producerNode)) {
       ++count;
+    }
   }
   return count;
 }
@@ -218,17 +226,21 @@ static bool nodesHaveDirectDataFlowConnection(
     const pto::FusionBlockAnalysis &blockAnalysis,
     const pto::FusionComputeNode &lhs, const pto::FusionComputeNode &rhs) {
   for (unsigned edgeId : lhs.outgoingEdges) {
-    if (edgeId >= blockAnalysis.edges.size())
+    if (edgeId >= blockAnalysis.edges.size()) {
       continue;
-    if (blockAnalysis.edges[edgeId].consumerNode == rhs.id)
+    }
+    if (blockAnalysis.edges[edgeId].consumerNode == rhs.id) {
       return true;
+    }
   }
 
   for (unsigned edgeId : lhs.incomingEdges) {
-    if (edgeId >= blockAnalysis.edges.size())
+    if (edgeId >= blockAnalysis.edges.size()) {
       continue;
-    if (blockAnalysis.edges[edgeId].producerNode == rhs.id)
+    }
+    if (blockAnalysis.edges[edgeId].producerNode == rhs.id) {
       return true;
+    }
   }
 
   for (Value output : lhs.semantics.tileOutputs)
@@ -269,8 +281,9 @@ computeGroupFootprint(ArrayRef<const pto::FusionComputeNode *> members) {
   for (const pto::FusionComputeNode *member : members) {
     for (Value input : member->semantics.tileInputs) {
       touchedTiles.insert(input);
-      if (!producedTiles.contains(input))
+      if (!producedTiles.contains(input)) {
         externalInputs.insert(input);
+      }
     }
   }
 
@@ -300,8 +313,9 @@ public:
   evaluateSeed(const PlanningContext &ctx,
                const pto::FusionComputeNode &candidate) const override {
     PlanningDecision decision;
-    if (!isSupportedPlanningNode(candidate))
+    if (!isSupportedPlanningNode(candidate)) {
       return decision;
+    }
 
     if (!isProvenIterationDomain(ctx.blockAnalysis, candidate)) {
       decision.cost.rejectedForDynamicShape = true;
@@ -317,8 +331,9 @@ public:
                  ArrayRef<const pto::FusionComputeNode *> currentGroup,
                  const pto::FusionComputeNode &candidate) const override {
     PlanningDecision seedDecision = evaluateSeed(ctx, candidate);
-    if (!seedDecision.accept)
+    if (!seedDecision.accept) {
       return seedDecision;
+    }
 
     PlanningDecision decision;
     if (currentGroup.empty()) {
@@ -333,8 +348,9 @@ public:
         candidate.blockOrder == previous.blockOrder + 1;
     const bool directlyDependent =
         dependsOnPreviousNode(ctx.blockAnalysis, previous, candidate);
-    if (!sameDomainClass || !contiguousInBlock || !directlyDependent)
+    if (!sameDomainClass || !contiguousInBlock || !directlyDependent) {
       return decision;
+    }
 
     SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
         currentGroup.begin(), currentGroup.end());
@@ -360,8 +376,9 @@ public:
   evaluateSeed(const PlanningContext &ctx,
                const pto::FusionComputeNode &candidate) const override {
     PlanningDecision decision;
-    if (!isSupportedPlanningNode(candidate))
+    if (!isSupportedPlanningNode(candidate)) {
       return decision;
+    }
 
     if (!isProvenIterationDomain(ctx.blockAnalysis, candidate)) {
       decision.cost.rejectedForDynamicShape = true;
@@ -377,8 +394,9 @@ public:
                  ArrayRef<const pto::FusionComputeNode *> currentGroup,
                  const pto::FusionComputeNode &candidate) const override {
     PlanningDecision seedDecision = evaluateSeed(ctx, candidate);
-    if (!seedDecision.accept)
+    if (!seedDecision.accept) {
       return seedDecision;
+    }
 
     PlanningDecision decision;
     if (currentGroup.empty()) {
@@ -390,13 +408,15 @@ public:
         candidate.iterationDomainClass)
       return decision;
 
-    if (hasHardBoundaryToGroup(currentGroup, candidate))
+    if (hasHardBoundaryToGroup(currentGroup, candidate)) {
       return decision;
+    }
 
     const unsigned connectionCount =
         countConnectionsToGroup(ctx.blockAnalysis, currentGroup, candidate);
-    if (connectionCount == 0)
+    if (connectionCount == 0) {
       return decision;
+    }
 
     SmallVector<const pto::FusionComputeNode *, 8> proposedGroup(
         currentGroup.begin(), currentGroup.end());
@@ -479,12 +499,14 @@ public:
     DenseSet<unsigned> assignedNodes;
 
     for (const pto::FusionComputeNode &seed : ctx.blockAnalysis.computeNodes) {
-      if (assignedNodes.contains(seed.id))
+      if (assignedNodes.contains(seed.id)) {
         continue;
+      }
 
       PlanningDecision seedDecision = costModel.evaluateSeed(ctx, seed);
-      if (!seedDecision.accept)
+      if (!seedDecision.accept) {
         continue;
+      }
 
       SmallVector<const pto::FusionComputeNode *, 8> groupMembers;
       DenseSet<unsigned> groupNodeIds;
@@ -502,8 +524,9 @@ public:
 
           PlanningDecision appendDecision =
               costModel.evaluateAppend(ctx, groupMembers, candidate);
-          if (!appendDecision.accept)
+          if (!appendDecision.accept) {
             continue;
+          }
 
           groupMembers.push_back(&candidate);
           groupNodeIds.insert(candidate.id);
@@ -511,14 +534,16 @@ public:
         }
       }
 
-      if (groupMembers.size() < 2)
+      if (groupMembers.size() < 2) {
         continue;
+      }
 
       PlannedFusionGroup group;
       group.members = buildStableInGroupOrder(groupMembers);
       groups.push_back(group);
-      for (const pto::FusionComputeNode *member : group.members)
+      for (const pto::FusionComputeNode *member : group.members) {
         assignedNodes.insert(member->id);
+      }
     }
 
     return groups;
@@ -554,8 +579,9 @@ struct FusionPlanPass : public pto::impl::FusionPlanBase<FusionPlanPass> {
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     clearPlanningAttrs(func);
 

--- a/lib/PTO/Transforms/TileFusion/PTOFusionPredicateElision.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionPredicateElision.cpp
@@ -122,17 +122,20 @@ static std::optional<PltCandidate> buildPltCandidate(Operation *op) {
 
 static std::optional<ForIterArgInfo> getForIterArgInfo(Value value) {
   auto arg = dyn_cast<BlockArgument>(value);
-  if (!arg || arg.getArgNumber() == 0)
+  if (!arg || arg.getArgNumber() == 0) {
     return std::nullopt;
+  }
 
   auto forOp =
       dyn_cast_or_null<scf::ForOp>(arg.getParentRegion()->getParentOp());
-  if (!forOp || arg.getOwner() != forOp.getBody())
+  if (!forOp || arg.getOwner() != forOp.getBody()) {
     return std::nullopt;
+  }
 
   unsigned iterArgIndex = arg.getArgNumber() - 1;
-  if (iterArgIndex >= forOp.getInitArgs().size())
+  if (iterArgIndex >= forOp.getInitArgs().size()) {
     return std::nullopt;
+  }
   return ForIterArgInfo{forOp, iterArgIndex};
 }
 
@@ -140,12 +143,14 @@ static std::optional<PltScalarOutInfo> getPltScalarOutInfo(Value value) {
   // Element-wise templates keep the remaining element count as index while
   // plt consumes and returns an integer scalar. Look through the cast used to
   // feed the scalar result back to scf.for.
-  if (auto indexCast = value.getDefiningOp<arith::IndexCastOp>())
+  if (auto indexCast = value.getDefiningOp<arith::IndexCastOp>()) {
     value = indexCast.getIn();
+  }
 
   auto result = dyn_cast<OpResult>(value);
-  if (!result || result.getResultNumber() != 1)
+  if (!result || result.getResultNumber() != 1) {
     return std::nullopt;
+  }
 
   if (auto plt = dyn_cast<pto::PltB8Op>(result.getOwner()))
     return PltScalarOutInfo{plt.getScalar(), 8};
@@ -160,10 +165,12 @@ static bool areEquivalentLoopCarriedValues(Value lhs, Value rhs,
                                            ValueEquivalenceContext &context) {
   std::optional<ForIterArgInfo> lhsInfo = getForIterArgInfo(lhs);
   std::optional<ForIterArgInfo> rhsInfo = getForIterArgInfo(rhs);
-  if (!lhsInfo || !rhsInfo)
+  if (!lhsInfo || !rhsInfo) {
     return false;
-  if (lhsInfo->forOp != rhsInfo->forOp)
+  }
+  if (lhsInfo->forOp != rhsInfo->forOp) {
     return false;
+  }
 
   if (lhsInfo->forOp.getRegionIterArgs().size() !=
       lhsInfo->forOp.getInitArgs().size())
@@ -182,24 +189,29 @@ static bool areEquivalentLoopCarriedValues(Value lhs, Value rhs,
       getPltScalarOutInfo(yieldedValues[lhsInfo->iterArgIndex]);
   std::optional<PltScalarOutInfo> rhsYieldInfo =
       getPltScalarOutInfo(yieldedValues[rhsInfo->iterArgIndex]);
-  if (!lhsYieldInfo || !rhsYieldInfo)
+  if (!lhsYieldInfo || !rhsYieldInfo) {
     return false;
-  if (lhsYieldInfo->bitWidth != rhsYieldInfo->bitWidth)
+  }
+  if (lhsYieldInfo->bitWidth != rhsYieldInfo->bitWidth) {
     return false;
+  }
 
   Value lhsRecurrenceInput = lhsYieldInfo->scalar;
   Value rhsRecurrenceInput = rhsYieldInfo->scalar;
-  if (auto indexCast = lhsRecurrenceInput.getDefiningOp<arith::IndexCastOp>())
+  if (auto indexCast = lhsRecurrenceInput.getDefiningOp<arith::IndexCastOp>()) {
     lhsRecurrenceInput = indexCast.getIn();
-  if (auto indexCast = rhsRecurrenceInput.getDefiningOp<arith::IndexCastOp>())
+  }
+  if (auto indexCast = rhsRecurrenceInput.getDefiningOp<arith::IndexCastOp>()) {
     rhsRecurrenceInput = indexCast.getIn();
+  }
 
   // Stay conservative on unsupported cyclic proofs. The only accepted
   // recurrence cycle is the direct iter_arg -> plt.scalar_out self recursion
   // for the same value pair, optionally bridged by the index casts required by
   // the plt/scf type boundary; more complex cycles remain unsupported.
-  if (areSameValuePair(lhs, rhs, lhsRecurrenceInput, rhsRecurrenceInput))
+  if (areSameValuePair(lhs, rhs, lhsRecurrenceInput, rhsRecurrenceInput)) {
     return true;
+  }
 
   return areEquivalentValues(lhsYieldInfo->scalar, rhsYieldInfo->scalar,
                              context);
@@ -207,39 +219,51 @@ static bool areEquivalentLoopCarriedValues(Value lhs, Value rhs,
 
 static bool areEquivalentOperations(Operation *lhs, Operation *rhs,
                                     ValueEquivalenceContext &context) {
-  if (!lhs || !rhs)
+  if (!lhs || !rhs) {
     return false;
-  if (lhs->getName() != rhs->getName())
+  }
+  if (lhs->getName() != rhs->getName()) {
     return false;
-  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0)
+  }
+  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0) {
     return false;
-  if (lhs->getNumResults() != rhs->getNumResults())
+  }
+  if (lhs->getNumResults() != rhs->getNumResults()) {
     return false;
-  if (lhs->getNumOperands() != rhs->getNumOperands())
+  }
+  if (lhs->getNumOperands() != rhs->getNumOperands()) {
     return false;
-  if (lhs->getAttrDictionary() != rhs->getAttrDictionary())
+  }
+  if (lhs->getAttrDictionary() != rhs->getAttrDictionary()) {
     return false;
-  if (!isMemoryEffectFree(lhs) || !isMemoryEffectFree(rhs))
+  }
+  if (!isMemoryEffectFree(lhs) || !isMemoryEffectFree(rhs)) {
     return false;
-  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes()))
+  }
+  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes())) {
     return false;
+  }
 
   for (auto [lhsOperand, rhsOperand] :
        llvm::zip(lhs->getOperands(), rhs->getOperands())) {
-    if (!areEquivalentValues(lhsOperand, rhsOperand, context))
+    if (!areEquivalentValues(lhsOperand, rhsOperand, context)) {
       return false;
+    }
   }
   return true;
 }
 
 static bool areEquivalentValues(Value lhs, Value rhs,
                                 ValueEquivalenceContext &context) {
-  if (lhs == rhs)
+  if (lhs == rhs) {
     return true;
-  if (!lhs || !rhs)
+  }
+  if (!lhs || !rhs) {
     return false;
-  if (lhs.getType() != rhs.getType())
+  }
+  if (lhs.getType() != rhs.getType()) {
     return false;
+  }
 
   if (std::optional<EquivalenceState> state =
           lookupEquivalenceState(context, lhs, rhs)) {
@@ -273,13 +297,15 @@ static void populateDominatingCandidateIndices(
     MutableArrayRef<PltCandidate> candidates, DominanceInfo &dominanceInfo) {
   for (unsigned current = 0; current < candidates.size(); ++current) {
     for (unsigned previous = 0; previous < current; ++previous) {
-      if (candidates[previous].bitWidth != candidates[current].bitWidth)
+      if (candidates[previous].bitWidth != candidates[current].bitWidth) {
         continue;
+      }
       // Only reuse an earlier plt when its whole result pair dominates the
       // later one. This keeps replacement local and SSA-safe.
       if (!dominanceInfo.properlyDominates(candidates[previous].op,
-                                           candidates[current].op))
+                                           candidates[current].op)) {
         continue;
+      }
       candidates[current].dominatingCandidates.push_back(previous);
     }
   }
@@ -292,8 +318,9 @@ buildFusionRegionPredicateContext(pto::FusionRegionOp fusionRegion,
   context.fusionRegion = fusionRegion;
 
   fusionRegion.walk([&](Operation *op) -> WalkResult {
-    if (op != fusionRegion.getOperation() && isa<pto::FusionRegionOp>(op))
+    if (op != fusionRegion.getOperation() && isa<pto::FusionRegionOp>(op)) {
       return WalkResult::skip();
+    }
 
     if (std::optional<PltCandidate> candidate = buildPltCandidate(op))
       context.pltCandidates.push_back(std::move(*candidate));
@@ -316,8 +343,9 @@ findEquivalentDominatingCandidate(FusionRegionPredicateContext &context,
   const PltCandidate &current = context.pltCandidates[currentIndex];
   Value currentScalar = getCurrentScalarOperand(current);
   for (unsigned previousIndex : current.dominatingCandidates) {
-    if (erased.contains(previousIndex))
+    if (erased.contains(previousIndex)) {
       continue;
+    }
     const PltCandidate &previous = context.pltCandidates[previousIndex];
     // Equivalence is checked on the scalar input; when it holds, both plt
     // results are reused as a pair.
@@ -337,14 +365,16 @@ elideEquivalentPltCandidates(FusionRegionPredicateContext &context) {
 
   for (unsigned currentIndex = 0; currentIndex < context.pltCandidates.size();
        ++currentIndex) {
-    if (erased.contains(currentIndex))
+    if (erased.contains(currentIndex)) {
       continue;
+    }
 
     std::optional<unsigned> previousIndex =
         findEquivalentDominatingCandidate(context, valueContext, currentIndex,
                                           erased);
-    if (!previousIndex)
+    if (!previousIndex) {
       continue;
+    }
 
     PltCandidate &current = context.pltCandidates[currentIndex];
     PltCandidate &previous = context.pltCandidates[*previousIndex];
@@ -355,8 +385,9 @@ elideEquivalentPltCandidates(FusionRegionPredicateContext &context) {
     changed = true;
   }
 
-  for (Operation *op : opsToErase)
+  for (Operation *op : opsToErase) {
     op->erase();
+  }
 
   return changed;
 }
@@ -369,24 +400,28 @@ struct PTOFusionPredicateElisionPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     DominanceInfo &dominanceInfo = getAnalysis<DominanceInfo>();
     SmallVector<FusionRegionPredicateContext, 4> fusionContexts;
     func.walk([&](pto::FusionRegionOp fusionRegion) {
       FusionRegionPredicateContext context =
           buildFusionRegionPredicateContext(fusionRegion, dominanceInfo);
-      if (!context.pltCandidates.empty())
+      if (!context.pltCandidates.empty()) {
         fusionContexts.push_back(std::move(context));
+      }
     });
 
     bool changed = false;
-    for (FusionRegionPredicateContext &context : fusionContexts)
+    for (FusionRegionPredicateContext &context : fusionContexts) {
       changed |= elideEquivalentPltCandidates(context);
+    }
 
-    if (!changed)
+    if (!changed) {
       markAllAnalysesPreserved();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOFusionRegionGen.cpp
@@ -69,8 +69,9 @@ struct PreFusionAnalysisIndex {
 
 static std::optional<int64_t> getRequiredI64Attr(Operation *op,
                                                  StringRef attrName) {
-  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName))
+  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName)) {
     return attr.getInt();
+  }
   return std::nullopt;
 }
 
@@ -87,8 +88,9 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
   GroupSpan current;
 
   auto flush = [&]() -> LogicalResult {
-    if (current.members.empty())
+    if (current.members.empty()) {
       return success();
+    }
 
     current.block = &block;
     auto [it, inserted] =
@@ -115,8 +117,9 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
     std::optional<int64_t> groupId =
         getRequiredI64Attr(&op, kFusionGroupIdAttr);
     if (!groupId) {
-      if (failed(flush()))
+      if (failed(flush())) {
         return failure();
+      }
       continue;
     }
 
@@ -133,8 +136,9 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
     }
 
     if (current.groupId != *groupId) {
-      if (failed(flush()))
+      if (failed(flush())) {
         return failure();
+      }
       current.groupId = *groupId;
     }
 
@@ -166,8 +170,9 @@ static bool isNestedInSpan(Operation *op, const DenseSet<Operation *> &spanOps) 
 
 static void appendUniqueValue(SmallVectorImpl<Value> &values,
                               DenseSet<Value> &seen, Value value) {
-  if (seen.insert(value).second)
+  if (seen.insert(value).second) {
     values.push_back(value);
+  }
 }
 
 static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
@@ -180,8 +185,9 @@ static Operation *getTopLevelAncestorInBlock(Operation *op, Block *block) {
 static bool canReplaceUseWithRegionResult(OpOperand &use, Operation *boundary) {
   Operation *topLevel =
       getTopLevelAncestorInBlock(use.getOwner(), boundary->getBlock());
-  if (!topLevel || topLevel == boundary)
+  if (!topLevel || topLevel == boundary) {
     return false;
+  }
   return boundary->isBeforeInBlock(topLevel);
 }
 
@@ -189,10 +195,12 @@ static bool hasReplaceableUseOutsideSpan(Value value,
                                          const DenseSet<Operation *> &spanOps,
                                          Operation *boundary) {
   for (OpOperand &use : value.getUses()) {
-    if (isNestedInSpan(use.getOwner(), spanOps))
+    if (isNestedInSpan(use.getOwner(), spanOps)) {
       continue;
-    if (canReplaceUseWithRegionResult(use, boundary))
+    }
+    if (canReplaceUseWithRegionResult(use, boundary)) {
       return true;
+    }
   }
   return false;
 }
@@ -207,30 +215,36 @@ static bool hasAnyUseOutsideSpan(Value value,
 
 static const FusionBlockAnalysisIndex *
 getBlockAnalysisIndex(const PreFusionAnalysisIndex *analysisIndex, Block *block) {
-  if (!analysisIndex)
+  if (!analysisIndex) {
     return nullptr;
+  }
   auto it = analysisIndex->blocks.find(block);
-  if (it == analysisIndex->blocks.end())
+  if (it == analysisIndex->blocks.end()) {
     return nullptr;
+  }
   return &it->second;
 }
 
 static const pto::FusionWriteInstanceLiveness *
 getProducedWriteInstance(const FusionBlockAnalysisIndex *blockAnalysis,
                          Operation *op, unsigned tileOutputIndex) {
-  if (!blockAnalysis)
+  if (!blockAnalysis) {
     return nullptr;
+  }
 
   auto nodeIt = blockAnalysis->nodeIdByOp.find(op);
-  if (nodeIt == blockAnalysis->nodeIdByOp.end())
+  if (nodeIt == blockAnalysis->nodeIdByOp.end()) {
     return nullptr;
+  }
 
   auto writeIt =
       blockAnalysis->writeInstancesByProducerNode.find(nodeIt->second);
-  if (writeIt == blockAnalysis->writeInstancesByProducerNode.end())
+  if (writeIt == blockAnalysis->writeInstancesByProducerNode.end()) {
     return nullptr;
-  if (tileOutputIndex >= writeIt->second.size())
+  }
+  if (tileOutputIndex >= writeIt->second.size()) {
     return nullptr;
+  }
   return writeIt->second[tileOutputIndex];
 }
 
@@ -251,18 +265,22 @@ writeInstanceEscapesSpan(const pto::FusionWriteInstanceLiveness &writeInstance,
 static bool canSinkAllocTileDefToRegion(Value value, const GroupSpan &span,
                                         const DenseSet<Operation *> &spanOps) {
   auto alloc = dyn_cast_or_null<pto::AllocTileOp>(value.getDefiningOp());
-  if (!alloc || alloc->getBlock() != span.block)
+  if (!alloc || alloc->getBlock() != span.block) {
     return false;
+  }
 
   Operation *firstOp = span.members.front().op;
-  if (!alloc->isBeforeInBlock(firstOp))
+  if (!alloc->isBeforeInBlock(firstOp)) {
     return false;
+  }
 
   for (OpOperand &use : value.getUses()) {
-    if (isNestedInSpan(use.getOwner(), spanOps))
+    if (isNestedInSpan(use.getOwner(), spanOps)) {
       continue;
-    if (!canReplaceUseWithRegionResult(use, firstOp))
+    }
+    if (!canReplaceUseWithRegionResult(use, firstOp)) {
       return false;
+    }
   }
 
   return true;
@@ -281,11 +299,13 @@ buildGroupSpanInterface(const GroupSpan &span,
 
   for (const GroupSpanMember &member : span.members) {
     spanOps.insert(member.op);
-    if (!blockAnalysis)
+    if (!blockAnalysis) {
       continue;
+    }
     auto nodeIt = blockAnalysis->nodeIdByOp.find(member.op);
-    if (nodeIt != blockAnalysis->nodeIdByOp.end())
+    if (nodeIt != blockAnalysis->nodeIdByOp.end()) {
       spanNodeIds.insert(nodeIt->second);
+    }
   }
 
   for (const GroupSpanMember &member : span.members) {
@@ -296,8 +316,9 @@ buildGroupSpanInterface(const GroupSpan &span,
     if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(member.op)) {
       unsigned tileOutputIndex = 0;
       for (Value init : dpsIface.getDpsInits()) {
-        if (!isa<pto::TileBufType>(init.getType()))
+        if (!isa<pto::TileBufType>(init.getType())) {
           continue;
+        }
 
         const pto::FusionWriteInstanceLiveness *writeInstance =
             getProducedWriteInstance(blockAnalysis, member.op, tileOutputIndex);
@@ -305,12 +326,14 @@ buildGroupSpanInterface(const GroupSpan &span,
 
         bool escapesSpan =
             hasReplaceableUseOutsideSpan(init, spanOps, boundary);
-        if (writeInstance)
+        if (writeInstance) {
           escapesSpan =
               escapesSpan && writeInstanceEscapesSpan(*writeInstance, spanNodeIds);
+        }
 
-        if (escapesSpan)
+        if (escapesSpan) {
           appendUniqueValue(iface.externallyVisibleValues, seenOutputs, init);
+        }
       }
     }
   }
@@ -321,15 +344,19 @@ buildGroupSpanInterface(const GroupSpan &span,
   for (const GroupSpanMember &member : span.members) {
     if (auto dpsIface = dyn_cast<pto::PTO_DpsInitOpInterface>(member.op)) {
       for (Value init : dpsIface.getDpsInits()) {
-        if (!isa<pto::TileBufType>(init.getType()))
+        if (!isa<pto::TileBufType>(init.getType())) {
           continue;
-        if (!canSinkAllocTileDefToRegion(init, span, spanOps))
+        }
+        if (!canSinkAllocTileDefToRegion(init, span, spanOps)) {
           continue;
-        if (hasAnyUseOutsideSpan(init, spanOps) && !visibleValues.contains(init))
+        }
+        if (hasAnyUseOutsideSpan(init, spanOps) && !visibleValues.contains(init)) {
           continue;
+        }
         Operation *defOp = init.getDefiningOp();
-        if (seenLocalDefs.insert(defOp).second)
+        if (seenLocalDefs.insert(defOp).second) {
           iface.localDefs.push_back(defOp);
+        }
       }
     }
   }
@@ -395,23 +422,27 @@ getCommonSpanI64Attr(const GroupSpan &span, StringRef attrName) {
 static LogicalResult
 encapsulateGroupSpan(const GroupSpan &span,
                      const PreFusionAnalysisIndex *analysisIndex) {
-  if (span.members.empty())
+  if (span.members.empty()) {
     return success();
+  }
 
   GroupSpanInterface iface = buildGroupSpanInterface(span, analysisIndex);
   FailureOr<std::optional<int64_t>> commonRowUnroll =
       getCommonSpanI64Attr(span, kFusionRowUnrollAttr);
-  if (failed(commonRowUnroll))
+  if (failed(commonRowUnroll)) {
     return failure();
+  }
   FailureOr<std::optional<int64_t>> commonColUnroll =
       getCommonSpanI64Attr(span, kFusionColUnrollAttr);
-  if (failed(commonColUnroll))
+  if (failed(commonColUnroll)) {
     return failure();
+  }
 
   SmallVector<Type, 8> outputTypes;
   outputTypes.reserve(iface.externallyVisibleValues.size());
-  for (Value output : iface.externallyVisibleValues)
+  for (Value output : iface.externallyVisibleValues) {
     outputTypes.push_back(output.getType());
+  }
 
   Operation *firstOp = span.members.front().op;
   Location loc = firstOp->getLoc();
@@ -420,33 +451,39 @@ encapsulateGroupSpan(const GroupSpan &span,
       builder.create<pto::FusionRegionOp>(loc, TypeRange(outputTypes));
   fusionRegion->setAttr(kFusionGroupIdAttr,
                         builder.getI64IntegerAttr(span.groupId));
-  if (*commonRowUnroll)
+  if (*commonRowUnroll) {
     fusionRegion->setAttr(kFusionRowUnrollAttr,
                           builder.getI64IntegerAttr(**commonRowUnroll));
-  if (*commonColUnroll)
+  }
+  if (*commonColUnroll) {
     fusionRegion->setAttr(kFusionColUnrollAttr,
                           builder.getI64IntegerAttr(**commonColUnroll));
+  }
 
   Block *body = new Block();
   fusionRegion.getBody().push_back(body);
 
-  for (Operation *localDef : iface.localDefs)
+  for (Operation *localDef : iface.localDefs) {
     localDef->moveBefore(body, body->end());
-  for (const GroupSpanMember &member : span.members)
+  }
+  for (const GroupSpanMember &member : span.members) {
     member.op->moveBefore(body, body->end());
+  }
 
   clearSpanFusionMetadata(span);
 
   SmallVector<Value, 8> yieldValues;
   yieldValues.reserve(iface.externallyVisibleValues.size());
-  for (Value output : iface.externallyVisibleValues)
+  for (Value output : iface.externallyVisibleValues) {
     yieldValues.push_back(output);
+  }
 
   OpBuilder bodyBuilder = OpBuilder::atBlockEnd(body);
   bodyBuilder.create<pto::YieldOp>(loc, ValueRange(yieldValues));
 
-  if (failed(verify(fusionRegion.getOperation())))
+  if (failed(verify(fusionRegion.getOperation()))) {
     return failure();
+  }
 
   replaceEscapingUsesOutsideRegion(fusionRegion, iface.externallyVisibleValues);
   return success();
@@ -465,8 +502,9 @@ static LogicalResult processRegion(Region &region,
         return failure();
 
     SmallVector<GroupSpan, 8> spans;
-    if (failed(collectGroupSpansInBlock(block, spans)))
+    if (failed(collectGroupSpansInBlock(block, spans))) {
       return failure();
+    }
 
     for (const GroupSpan &span : spans)
       if (failed(encapsulateGroupSpan(span, analysisIndex)))
@@ -482,8 +520,9 @@ struct PTOFusionRegionGenPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     // Reuse the shared pre-fusion dataflow graph cached by the analysis
     // manager (built once, by FusionPlan or lazily here).  FusionRegionGen
@@ -501,19 +540,22 @@ struct PTOFusionRegionGenPass
     PreFusionAnalysisIndex analysisIndex;
     for (const pto::FusionBlockAnalysis &blockAnalysis : analysis.blocks) {
       FusionBlockAnalysisIndex &index = analysisIndex.blocks[blockAnalysis.block];
-      for (const pto::FusionComputeNode &node : blockAnalysis.computeNodes)
+      for (const pto::FusionComputeNode &node : blockAnalysis.computeNodes) {
         index.nodeIdByOp.try_emplace(node.op, node.id);
+      }
       for (const pto::FusionWriteInstanceLiveness &writeInstance :
            blockAnalysis.writeInstances) {
-        if (!writeInstance.producerNode)
+        if (!writeInstance.producerNode) {
           continue;
+        }
         index.writeInstancesByProducerNode[*writeInstance.producerNode]
             .push_back(&writeInstance);
       }
     }
 
-    if (failed(processRegion(func.getRegion(), &analysisIndex)))
+    if (failed(processRegion(func.getRegion(), &analysisIndex))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/TileFusion/PTOLowLevelLoopFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOLowLevelLoopFusion.cpp
@@ -85,20 +85,27 @@ static bool isInterstageSetupOp(Operation *op) {
 }
 
 static bool areEquivalentOperations(Operation *lhs, Operation *rhs) {
-  if (!lhs || !rhs)
+  if (!lhs || !rhs) {
     return false;
-  if (lhs->getName() != rhs->getName())
+  }
+  if (lhs->getName() != rhs->getName()) {
     return false;
-  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0)
+  }
+  if (lhs->getNumRegions() != 0 || rhs->getNumRegions() != 0) {
     return false;
-  if (lhs->getNumResults() != rhs->getNumResults())
+  }
+  if (lhs->getNumResults() != rhs->getNumResults()) {
     return false;
-  if (lhs->getNumOperands() != rhs->getNumOperands())
+  }
+  if (lhs->getNumOperands() != rhs->getNumOperands()) {
     return false;
-  if (lhs->getAttrDictionary() != rhs->getAttrDictionary())
+  }
+  if (lhs->getAttrDictionary() != rhs->getAttrDictionary()) {
     return false;
-  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes()))
+  }
+  if (!llvm::equal(lhs->getResultTypes(), rhs->getResultTypes())) {
     return false;
+  }
 
   if (auto lhsDim = dyn_cast<memref::DimOp>(lhs)) {
     auto rhsDim = cast<memref::DimOp>(rhs);
@@ -108,19 +115,23 @@ static bool areEquivalentOperations(Operation *lhs, Operation *rhs) {
 
   for (auto [lhsOperand, rhsOperand] :
        llvm::zip(lhs->getOperands(), rhs->getOperands())) {
-    if (!areEquivalentValues(lhsOperand, rhsOperand))
+    if (!areEquivalentValues(lhsOperand, rhsOperand)) {
       return false;
+    }
   }
   return true;
 }
 
 static bool areEquivalentValues(Value lhs, Value rhs) {
-  if (lhs == rhs)
+  if (lhs == rhs) {
     return true;
-  if (!lhs || !rhs)
+  }
+  if (!lhs || !rhs) {
     return false;
-  if (lhs.getType() != rhs.getType())
+  }
+  if (lhs.getType() != rhs.getType()) {
     return false;
+  }
 
   auto lhsArg = dyn_cast<BlockArgument>(lhs);
   auto rhsArg = dyn_cast<BlockArgument>(rhs);
@@ -143,8 +154,9 @@ static Value traceAliasRootOneStep(Value value) {
   }
 
   Operation *def = value.getDefiningOp();
-  if (!def)
+  if (!def) {
     return {};
+  }
 
   if (auto subview = dyn_cast<memref::SubViewOp>(def))
     return subview.getSource();
@@ -163,22 +175,26 @@ static Value traceAliasRootOneStep(Value value) {
   if (auto reshape = dyn_cast<pto::TReshapeOp>(def))
     return reshape.getSrc();
   if (auto cast = dyn_cast<UnrealizedConversionCastOp>(def)) {
-    if (cast.getInputs().empty())
+    if (cast.getInputs().empty()) {
       return {};
+    }
     if (auto result = dyn_cast<OpResult>(value)) {
       unsigned resultNumber = result.getResultNumber();
-      if (resultNumber < cast.getInputs().size())
+      if (resultNumber < cast.getInputs().size()) {
         return cast.getInputs()[resultNumber];
+      }
     }
-    if (cast.getInputs().size() == 1)
+    if (cast.getInputs().size() == 1) {
       return cast.getInputs().front();
+    }
     return {};
   }
   if (auto forOp = dyn_cast<scf::ForOp>(def)) {
     if (auto result = dyn_cast<OpResult>(value)) {
       unsigned resultNumber = result.getResultNumber();
-      if (resultNumber < forOp.getInitArgs().size())
+      if (resultNumber < forOp.getInitArgs().size()) {
         return forOp.getInitArgs()[resultNumber];
+      }
     }
   }
 
@@ -189,41 +205,48 @@ static Value traceAliasRoot(Value value) {
   int loopBound = 256;
   while (value) {
     Value upward = traceAliasRootOneStep(value);
-    if (!upward)
+    if (!upward) {
       break;
+    }
     value = upward;
-    if (loopBound-- <= 0)
+    if (loopBound-- <= 0) {
       break;
+    }
   }
   return value;
 }
 
 static LogicalResult collectAliasRelevantRoots(
     Operation *op, SmallVectorImpl<Value> &roots) {
-  if (isMemoryEffectFree(op))
+  if (isMemoryEffectFree(op)) {
     return success();
+  }
 
   auto effectsOp = dyn_cast<MemoryEffectOpInterface>(op);
-  if (!effectsOp)
+  if (!effectsOp) {
     return failure();
+  }
 
   SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>, 4> effects;
   effectsOp.getEffects(effects);
   for (const auto &effect : effects) {
     Value effectValue = effect.getValue();
-    if (!effectValue)
+    if (!effectValue) {
       return failure();
+    }
 
     Type effectType = effectValue.getType();
     if (!isa<BaseMemRefType, pto::PtrType>(effectType)) {
-      if (isa<MemoryEffects::Write>(effect.getEffect()))
+      if (isa<MemoryEffects::Write>(effect.getEffect())) {
         return failure();
+      }
       continue;
     }
 
     Value root = traceAliasRoot(effectValue);
-    if (!root)
+    if (!root) {
       return failure();
+    }
     roots.push_back(root);
   }
   return success();
@@ -343,16 +366,18 @@ static LogicalResult analyzeStage(scf::ForOp outerLoop, StageInfo &stage) {
     for (Operation &op : currentLoop.getBody()->without_terminator()) {
       bodyOps.push_back(&op);
       if (auto nestedLoop = dyn_cast<scf::ForOp>(op)) {
-        if (childLoop)
+        if (childLoop) {
           return failure();
+        }
         childLoop = nestedLoop;
       }
     }
 
     if (!childLoop) {
       for (Operation *op : bodyOps) {
-        if (!isSupportedLeafOp(op))
+        if (!isSupportedLeafOp(op)) {
           return failure();
+        }
         stage.leafOps.push_back(op);
       }
       return failure(stage.leafOps.empty());
@@ -366,16 +391,18 @@ static LogicalResult analyzeStage(scf::ForOp outerLoop, StageInfo &stage) {
       }
       if (!seenChildLoop) {
         // Ops before the child loop are prelude ops.
-        if (!isSupportedPreludeOp(op))
+        if (!isSupportedPreludeOp(op)) {
           return failure();
+        }
         currentLevel.preludeOps.push_back(op);
       } else {
         // Ops after the child loop are epilogue ops (e.g. row-reduction
         // result stores in trowmax/trowsum).  They must be supported
         // leaf-like ops (no regions) so we can clone them into the fused
         // loop after all inner body ops.
-        if (!isSupportedPreludeOp(op))
+        if (!isSupportedPreludeOp(op)) {
           return failure();
+        }
         currentLevel.epilogueOps.push_back(op);
       }
     }
@@ -392,9 +419,10 @@ static SmallVector<StageInfo, 8> collectStageRunFrom(scf::ForOp firstLoop,
 
   StageInfo firstStage;
   if (failed(analyzeStage(firstLoop, firstStage))) {
-    if (debugOS)
+    if (debugOS) {
       *debugOS << "[op-fusion] reject loop stage at " << firstLoop.getLoc()
                << ": stage analysis failed\n";
+    }
     return stages;
   }
   stages.push_back(std::move(firstStage));
@@ -406,9 +434,10 @@ static SmallVector<StageInfo, 8> collectStageRunFrom(scf::ForOp firstLoop,
       nextStage.setupOps = pendingSetup;
       pendingSetup.clear();
       if (failed(analyzeStage(nextLoop, nextStage))) {
-        if (debugOS)
+        if (debugOS) {
           *debugOS << "[op-fusion] stop stage run before " << nextLoop.getLoc()
                    << ": next stage analysis failed\n";
+        }
         break;
       }
       stages.push_back(std::move(nextStage));
@@ -416,9 +445,10 @@ static SmallVector<StageInfo, 8> collectStageRunFrom(scf::ForOp firstLoop,
     }
 
     if (!isInterstageSetupOp(op)) {
-      if (debugOS)
+      if (debugOS) {
         *debugOS << "[op-fusion] stop stage run at op " << op->getName()
                  << "\n";
+      }
       break;
     }
     pendingSetup.push_back(op);
@@ -428,8 +458,9 @@ static SmallVector<StageInfo, 8> collectStageRunFrom(scf::ForOp firstLoop,
 }
 
 static bool sameLoopNestShape(const StageInfo &lhs, const StageInfo &rhs) {
-  if (lhs.getDepth() != rhs.getDepth())
+  if (lhs.getDepth() != rhs.getDepth()) {
     return false;
+  }
   return llvm::all_of(llvm::zip(lhs.levels, rhs.levels), [](auto pair) {
     return sameForHeader(std::get<0>(pair).loop, std::get<1>(pair).loop);
   });
@@ -445,8 +476,9 @@ static void cloneOpAndMapResults(OpBuilder &builder, Operation *op,
 
 static void appendMappedValues(ValueRange values, IRMapping &mapping,
                                SmallVectorImpl<Value> &mappedValues) {
-  for (Value value : values)
+  for (Value value : values) {
     mappedValues.push_back(mapValueOrSelf(value, mapping));
+  }
 }
 
 static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
@@ -535,22 +567,25 @@ static scf::ForOp buildFusedLoopNestAtLevel(OpBuilder &builder,
 static bool fuseStageRun(SmallVectorImpl<StageInfo> &stages,
                          llvm::raw_ostream *debugOS) {
   if (stages.size() < 2) {
-    if (debugOS)
+    if (debugOS) {
       *debugOS << "[op-fusion] reject loop run: need at least 2 stages, got "
                << stages.size() << "\n";
+    }
     return false;
   }
 
   StageInfo &first = stages.front();
   for (StageInfo &stage : llvm::drop_begin(stages)) {
     if (!sameLoopNestShape(first, stage)) {
-      if (debugOS)
+      if (debugOS) {
         *debugOS << "[op-fusion] reject loop run: loop nest shape mismatch\n";
+      }
       return false;
     }
   }
-  if (!arePreludeReordersLegal(stages, debugOS))
+  if (!arePreludeReordersLegal(stages, debugOS)) {
     return false;
+  }
 
   OpBuilder blockBuilder(first.getOuterLoop());
   SmallVector<IRMapping, 8> stageMappings(stages.size());
@@ -561,8 +596,9 @@ static bool fuseStageRun(SmallVectorImpl<StageInfo> &stages,
     for (Operation *setupOp : stage.setupOps)
       setupOp->moveBefore(fusedOuterLoop);
 
-  for (StageInfo &stage : llvm::reverse(stages))
+  for (StageInfo &stage : llvm::reverse(stages)) {
     stage.getOuterLoop().erase();
+  }
 
   return true;
 }
@@ -575,13 +611,15 @@ static bool fuseStageRunsInBlock(Block &block, llvm::raw_ostream *debugOS) {
     localChange = false;
     for (Operation &op : block) {
       auto firstLoop = dyn_cast<scf::ForOp>(op);
-      if (!firstLoop)
+      if (!firstLoop) {
         continue;
+      }
 
       SmallVector<StageInfo, 8> stages =
           collectStageRunFrom(firstLoop, debugOS);
-      if (!fuseStageRun(stages, debugOS))
+      if (!fuseStageRun(stages, debugOS)) {
         continue;
+      }
 
       changed = true;
       localChange = true;
@@ -606,19 +644,23 @@ struct PTOLowLevelLoopFusionPass
 
     int fusedFuncs = 0;
     for (func::FuncOp func : module.getOps<func::FuncOp>()) {
-      if (func.isExternal())
+      if (func.isExternal()) {
         continue;
-      if (func.getSymName().starts_with("__pto_oplib_"))
+      }
+      if (func.getSymName().starts_with("__pto_oplib_")) {
         continue;
-      if (func.empty())
+      }
+      if (func.empty()) {
         continue;
+      }
 
       bool changed = false;
       func.walk([&](pto::FusionRegionOp fusionRegion) {
         changed |= fuseStageRunsInBlock(fusionRegion.getBody().front(), traceOS);
       });
-      if (changed)
+      if (changed) {
         ++fusedFuncs;
+      }
     }
 
     if (traceEnabled) {

--- a/lib/PTO/Transforms/TileFusion/PTOMarkLastUse.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOMarkLastUse.cpp
@@ -79,16 +79,18 @@ static bool isTileInputOperand(OpOperand &operand) {
 static SmallVector<OpOperand *, 4> collectTileOperands(Operation *op) {
   SmallVector<OpOperand *, 4> tileOperands;
   for (OpOperand &operand : op->getOpOperands()) {
-    if (isTileOperand(operand))
+    if (isTileOperand(operand)) {
       tileOperands.push_back(&operand);
+    }
   }
   return tileOperands;
 }
 
 static std::optional<int64_t> getRequiredI64Attr(Operation *op,
                                                  StringRef attrName) {
-  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName))
+  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName)) {
     return attr.getInt();
+  }
   return std::nullopt;
 }
 
@@ -138,8 +140,9 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
         // different group.
         continue;
       }
-      if (failed(flush()))
+      if (failed(flush())) {
         return failure();
+      }
       continue;
     }
 
@@ -175,17 +178,21 @@ collectGroupSpansInBlock(Block &block, SmallVectorImpl<GroupSpan> &spans) {
 
 static bool isSpanLocalLastUseCandidate(Value value, Operation *currentOp,
                                         Block *block) {
-  if (!value)
+  if (!value) {
     return false;
+  }
 
   for (OpOperand &use : value.getUses()) {
     Operation *user = use.getOwner();
-    if (user == currentOp)
+    if (user == currentOp) {
       continue;
-    if (user->getBlock() != block)
+    }
+    if (user->getBlock() != block) {
       return false;
-    if (currentOp->isBeforeInBlock(user))
+    }
+    if (currentOp->isBeforeInBlock(user)) {
       return false;
+    }
   }
   return true;
 }
@@ -193,43 +200,51 @@ static bool isSpanLocalLastUseCandidate(Value value, Operation *currentOp,
 static bool hasLaterUseAfterSpan(Value value, Operation *spanEnd, Block *block) {
   for (OpOperand &use : value.getUses()) {
     Operation *user = use.getOwner();
-    if (user->getBlock() != block)
+    if (user->getBlock() != block) {
       return true;
-    if (spanEnd->isBeforeInBlock(user))
+    }
+    if (spanEnd->isBeforeInBlock(user)) {
       return true;
+    }
   }
   return false;
 }
 
 static bool isHardSpanBarrier(Operation *op) {
-  if (op->hasTrait<OpTrait::IsTerminator>() || !op->getRegions().empty())
+  if (op->hasTrait<OpTrait::IsTerminator>() || !op->getRegions().empty()) {
     return true;
-  if (isa<CallOpInterface>(op))
+  }
+  if (isa<CallOpInterface>(op)) {
     return true;
+  }
   return false;
 }
 
 static bool hasHardBarrierInSpan(const GroupSpan &span) {
-  if (span.members.size() < 2)
+  if (span.members.size() < 2) {
     return false;
+  }
   for (size_t i = 0; i + 1 < span.members.size(); ++i) {
     Operation *cur = span.members[i].op;
     Operation *next = span.members[i + 1].op;
     for (Operation *cursor = cur->getNextNode(); cursor && cursor != next;
          cursor = cursor->getNextNode()) {
-      if (isHardSpanBarrier(cursor))
+      if (isHardSpanBarrier(cursor)) {
         return true;
+      }
     }
   }
   return false;
 }
 
 static void markGroupSpanLastUse(const GroupSpan &span) {
-  if (span.members.empty())
+  if (span.members.empty()) {
     return;
+  }
 
-  if (hasHardBarrierInSpan(span))
+  if (hasHardBarrierInSpan(span)) {
     return;
+  }
 
   Block &block = *span.block;
   Operation *spanEnd = span.members.back().op;
@@ -265,15 +280,18 @@ static void markGroupSpanLastUse(const GroupSpan &span) {
 static LogicalResult markRegionLastUse(Region &region) {
   for (Block &block : region.getBlocks()) {
     SmallVector<GroupSpan, 8> spans;
-    if (failed(collectGroupSpansInBlock(block, spans)))
+    if (failed(collectGroupSpansInBlock(block, spans))) {
       return failure();
-    for (const GroupSpan &span : spans)
+    }
+    for (const GroupSpan &span : spans) {
       markGroupSpanLastUse(span);
+    }
 
     for (Operation &op : block)
       for (Region &nestedRegion : op.getRegions())
-        if (failed(markRegionLastUse(nestedRegion)))
+        if (failed(markRegionLastUse(nestedRegion))) {
           return failure();
+        }
   }
   return success();
 }
@@ -285,8 +303,9 @@ struct PTOMarkLastUsePass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     if (failed(markRegionLastUse(func.getRegion()))) {
       signalPassFailure();

--- a/lib/PTO/Transforms/TileFusion/PTOOpScheduling.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOOpScheduling.cpp
@@ -59,8 +59,9 @@ struct ScheduledGroup {
 
 static std::optional<int64_t> getRequiredI64Attr(Operation *op,
                                                  StringRef attrName) {
-  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName))
+  if (auto attr = op->getAttrOfType<IntegerAttr>(attrName)) {
     return attr.getInt();
+  }
   return std::nullopt;
 }
 
@@ -96,8 +97,9 @@ static SchedulingBarrierKind classifySchedulingBarrier(Operation *op) {
       return SchedulingBarrierKind::HardBoundary;
     }
   }
-  if (!isMemoryEffectFree(op))
+  if (!isMemoryEffectFree(op)) {
     return SchedulingBarrierKind::HardBoundary;
+  }
   return SchedulingBarrierKind::Movable;
 }
 
@@ -109,8 +111,9 @@ static bool hasTileDependency(Operation *opA, Operation *opB) {
 
   FailureOr<pto::FusionOpSemantics> aSemOr = pto::getFusionOpSemantics(opA);
   FailureOr<pto::FusionOpSemantics> bSemOr = pto::getFusionOpSemantics(opB);
-  if (failed(aSemOr) || failed(bSemOr))
+  if (failed(aSemOr) || failed(bSemOr)) {
     return true;
+  }
 
   const pto::FusionOpSemantics &a = *aSemOr;
   const pto::FusionOpSemantics &b = *bSemOr;
@@ -123,15 +126,17 @@ static bool hasTileDependency(Operation *opA, Operation *opB) {
 static bool crossesOperandDefinition(Operation *movingOp, Operation *candidate) {
   for (Value operand : movingOp->getOperands()) {
     Operation *defOp = operand.getDefiningOp();
-    if (defOp == candidate)
+    if (defOp == candidate) {
       return true;
+    }
   }
   return false;
 }
 
 static bool canMoveEarlierAcross(Operation *movingOp, Operation *candidate) {
-  if (crossesOperandDefinition(movingOp, candidate))
+  if (crossesOperandDefinition(movingOp, candidate)) {
     return false;
+  }
 
   switch (classifySchedulingBarrier(candidate)) {
   case SchedulingBarrierKind::Movable:
@@ -146,8 +151,9 @@ static bool canMoveEarlierAcross(Operation *movingOp, Operation *candidate) {
 static bool canMoveLaterAcross(Operation *movingOp, Operation *candidate) {
   for (Value operand : candidate->getOperands()) {
     Operation *defOp = operand.getDefiningOp();
-    if (defOp == movingOp)
+    if (defOp == movingOp) {
       return false;
+    }
   }
 
   switch (classifySchedulingBarrier(candidate)) {
@@ -161,15 +167,18 @@ static bool canMoveLaterAcross(Operation *movingOp, Operation *candidate) {
 }
 
 static bool canMoveAfter(Operation *movingOp, Operation *anchorOp) {
-  if (!movingOp || !anchorOp || movingOp == anchorOp)
+  if (!movingOp || !anchorOp || movingOp == anchorOp) {
     return false;
-  if (movingOp->getBlock() != anchorOp->getBlock())
+  }
+  if (movingOp->getBlock() != anchorOp->getBlock()) {
     return false;
+  }
 
   Operation *cursor = anchorOp->getNextNode();
   while (cursor && cursor != movingOp) {
-    if (!canMoveEarlierAcross(movingOp, cursor))
+    if (!canMoveEarlierAcross(movingOp, cursor)) {
       return false;
+    }
     cursor = cursor->getNextNode();
   }
   return cursor == movingOp;
@@ -214,15 +223,17 @@ collectScheduledGroups(Block &block, SmallVectorImpl<ScheduledGroup> &groups) {
   }
 
   llvm::sort(groups, [](const ScheduledGroup &lhs, const ScheduledGroup &rhs) {
-    if (lhs.firstOriginalIndex != rhs.firstOriginalIndex)
+    if (lhs.firstOriginalIndex != rhs.firstOriginalIndex) {
       return lhs.firstOriginalIndex < rhs.firstOriginalIndex;
+    }
     return lhs.groupId < rhs.groupId;
   });
 
   for (ScheduledGroup &group : groups) {
     llvm::sort(group.members, [](const GroupMember &lhs, const GroupMember &rhs) {
-      if (lhs.order != rhs.order)
+      if (lhs.order != rhs.order) {
         return lhs.order < rhs.order;
+      }
       return lhs.originalIndex < rhs.originalIndex;
     });
 
@@ -249,10 +260,12 @@ collectScheduledGroups(Block &block, SmallVectorImpl<ScheduledGroup> &groups) {
 static bool canPrefixMoveLaterAcross(
     ArrayRef<GroupMember> members, Operation *placement, Operation *barrier) {
   for (const GroupMember &prevMember : members) {
-    if (!canMoveLaterAcross(prevMember.op, barrier))
+    if (!canMoveLaterAcross(prevMember.op, barrier)) {
       return false;
-    if (prevMember.op == placement)
+    }
+    if (prevMember.op == placement) {
       break;
+    }
   }
   return true;
 }
@@ -264,14 +277,16 @@ static void movePrefixPastBarrier(ArrayRef<GroupMember> members,
   for (const GroupMember &prevMember : members) {
     prevMember.op->moveAfter(anchor);
     anchor = prevMember.op;
-    if (prevMember.op == placement)
+    if (prevMember.op == placement) {
       break;
+    }
   }
 }
 
 static void scheduleGroup(ScheduledGroup &group) {
-  if (group.members.size() < 2)
+  if (group.members.size() < 2) {
     return;
+  }
 
   Operation *placement = group.members.front().op;
   for (GroupMember &member : llvm::drop_begin(group.members)) {
@@ -287,8 +302,9 @@ static void scheduleGroup(ScheduledGroup &group) {
           !canMoveLaterAcross(placement, blockingOp))
         break;
 
-      if (!canPrefixMoveLaterAcross(group.members, placement, blockingOp))
+      if (!canPrefixMoveLaterAcross(group.members, placement, blockingOp)) {
         break;
+      }
 
       movePrefixPastBarrier(group.members, placement, blockingOp);
     }
@@ -301,8 +317,9 @@ static LogicalResult scheduleRegion(Region &region) {
     SmallVector<ScheduledGroup, 8> groups;
     if (failed(collectScheduledGroups(block, groups)))
       return failure();
-    for (ScheduledGroup &group : groups)
+    for (ScheduledGroup &group : groups) {
       scheduleGroup(group);
+    }
 
     for (Operation &op : block)
       for (Region &nestedRegion : op.getRegions())
@@ -351,8 +368,9 @@ collectPhysicalFusionSpans(Block &block,
   bool hasCurrent = false;
 
   auto flush = [&]() {
-    if (!hasCurrent)
+    if (!hasCurrent) {
       return;
+    }
     spans.push_back(std::move(current));
     current = FusionSpan{};
     hasCurrent = false;
@@ -394,8 +412,9 @@ static LogicalResult
 normalizeBlockFusionMetadata(Block &block, MLIRContext *context,
                             int64_t &nextGroupId) {
   SmallVector<FusionSpan, 8> spans;
-  if (failed(collectPhysicalFusionSpans(block, spans)))
+  if (failed(collectPhysicalFusionSpans(block, spans))) {
     return failure();
+  }
 
   // Remove all old metadata before assigning canonical groups, so that
   // surviving span ids never collide with stale ids left on singleton or
@@ -407,8 +426,9 @@ normalizeBlockFusionMetadata(Block &block, MLIRContext *context,
 
   const IntegerType i64 = IntegerType::get(context, 64);
   for (FusionSpan &span : spans) {
-    if (span.members.size() < 2)
+    if (span.members.size() < 2) {
       continue;
+    }
 
     const int64_t newGroupId = nextGroupId++;
     for (auto [order, op] : llvm::enumerate(span.members)) {
@@ -425,8 +445,9 @@ static LogicalResult
 normalizeScheduledFusionMetadata(Region &region, MLIRContext *context,
                                  int64_t &nextGroupId) {
   for (Block &block : region.getBlocks()) {
-    if (failed(normalizeBlockFusionMetadata(block, context, nextGroupId)))
+    if (failed(normalizeBlockFusionMetadata(block, context, nextGroupId))) {
       return failure();
+    }
 
     // Recurse into nested regions in the same pre-order walk used by
     // scheduleRegion, so the function-wide id counter stays deterministic.
@@ -445,8 +466,9 @@ struct OpSchedulingPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     if (failed(scheduleRegion(func.getRegion()))) {
       signalPassFailure();

--- a/lib/PTO/Transforms/TileFusion/PTOPreFusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOPreFusionAnalysis.cpp
@@ -31,8 +31,9 @@ struct PreFusionAnalysisPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     const auto &analysis = getAnalysis<pto::PreFusionAnalysis>();
     if (!analysis.isValid()) {

--- a/lib/PTO/Transforms/TileFusion/PTOPrintPreFusionAnalysis.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOPrintPreFusionAnalysis.cpp
@@ -87,8 +87,9 @@ static StringRef stringifyWriteInstanceEscapeClass(
 static void appendIndexList(llvm::raw_ostream &os, ArrayRef<unsigned> values) {
   os << "[";
   for (auto [idx, value] : llvm::enumerate(values)) {
-    if (idx)
+    if (idx) {
       os << ", ";
+    }
     os << value;
   }
   os << "]";
@@ -105,11 +106,12 @@ static void appendOptionalIndex(llvm::raw_ostream &os,
 
 static void appendDomain(llvm::raw_ostream &os,
                          const pto::IterationDomainInfo &info) {
-  auto printDim = [&](int64_t dim) {
-    if (dim == ShapedType::kDynamic)
+  auto printDim = [&os](int64_t dim) {
+    if (dim == ShapedType::kDynamic) {
       os << "?";
-    else
+    } else {
       os << dim;
+    }
   };
 
   os << "(";
@@ -145,8 +147,9 @@ buildValueLabels(Block &block, const pto::FusionBlockAnalysis &analysis) {
   for (Operation &op : block) {
     FailureOr<pto::FusionOpSemantics> semanticsOr =
         pto::getFusionOpSemantics(&op);
-    if (failed(semanticsOr))
+    if (failed(semanticsOr)) {
       continue;
+    }
 
     if (semanticsOr->kind == pto::FusionOpKind::LocalBoundary) {
       for (Value input : semanticsOr->tileInputs)
@@ -201,8 +204,9 @@ struct PrintPreFusionAnalysisPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     const auto &analysis = getAnalysis<pto::PreFusionAnalysis>();
     if (!analysis.isValid()) {

--- a/lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp
+++ b/lib/PTO/Transforms/TileFusion/PTOUnrollAfterLoopFusion.cpp
@@ -51,8 +51,9 @@ static int64_t getEffectiveFactor(pto::FusionRegionOp region,
                                   llvm::StringRef attrName) {
   if (auto attr = region->getAttrOfType<IntegerAttr>(attrName)) {
     int64_t v = attr.getInt();
-    if (v > 1)
+    if (v > 1) {
       return v;
+    }
   }
   return 0;
 }
@@ -74,8 +75,9 @@ static std::optional<int64_t> getConstantTripCount(scf::ForOp forOp) {
   std::optional<int64_t> lb = getConstantIntValue(forOp.getLowerBound());
   std::optional<int64_t> ub = getConstantIntValue(forOp.getUpperBound());
   std::optional<int64_t> step = getConstantIntValue(forOp.getStep());
-  if (!lb || !ub || !step || *step <= 0 || *ub <= *lb)
+  if (!lb || !ub || !step || *step <= 0 || *ub <= *lb) {
     return std::nullopt;
+  }
   return (*ub - *lb + *step - 1) / *step; // ceilDiv
 }
 
@@ -180,8 +182,9 @@ struct PTOUnrollAfterLoopFusion
     SmallVector<scf::ForOp, 4> candidates;
     func.walk([&](scf::ForOp forOp) { candidates.push_back(forOp); });
 
-    for (scf::ForOp forOp : candidates)
+    for (scf::ForOp forOp : candidates) {
       (void)tryUnrollLeafForOp(forOp);
+    }
   }
 };
 

--- a/lib/PTO/Transforms/Utils.cpp
+++ b/lib/PTO/Transforms/Utils.cpp
@@ -122,8 +122,9 @@ inferTFillPadLoweringKindAfterMemoryPlanning(TFillPadOp op) {
 std::optional<PhysicalSectionKind>
 inferPhysicalSectionKindFromPipe(Operation *op) {
   auto pipeOp = dyn_cast_or_null<OpPipeInterface>(op);
-  if (!pipeOp)
+  if (!pipeOp) {
     return std::nullopt;
+  }
 
   switch (pipeOp.getPipe()) {
   case PIPE::PIPE_M:
@@ -142,8 +143,9 @@ func::ReturnOp getAssumedUniqueReturnOp(func::FuncOp funcOp) {
   func::ReturnOp returnOp;
   for (Block &b : funcOp.getBody()) {
     if (auto candidateOp = dyn_cast<func::ReturnOp>(b.getTerminator())) {
-      if (returnOp)
+      if (returnOp) {
         return nullptr;
+      }
       returnOp = candidateOp;
     }
   }
@@ -230,8 +232,9 @@ void setBaseMemRefTypeScope(Value val, AddressSpaceAttr targetMemScope) {
 
   if (auto curMemScope = dyn_cast_if_present<AddressSpaceAttr>(
           dyn_cast<BaseMemRefType>(type).getMemorySpace())) {
-    if (curMemScope != targetMemScope)
+    if (curMemScope != targetMemScope) {
       llvm::report_fatal_error("memref scope mismatch while propagating PTO address space");
+    }
     return;
   }
 
@@ -325,7 +328,7 @@ std::optional<std::pair<Value, Value>> getOperationAliasInfo(Operation *op) {
   return std::nullopt;
 }
 
-Value tracebackImpl(Value memrefVal) {
+static Value tracebackImpl(Value memrefVal) {
   // case 1: v is the iter_arg of a scf.for
   if (auto arg = dyn_cast<BlockArgument>(memrefVal)) {
     if (auto forOp =
@@ -389,13 +392,14 @@ Value tracebackImpl(Value memrefVal) {
   return result;
 }
 
-bool isAllocLikeOp(Operation *op) {
-  if (!op)
+static bool isAllocLikeOp(Operation *op) {
+  if (!op) {
     return false;
+  }
   return isa<memref::AllocOp>(op) || isa<memref::AllocaOp>(op);
 }
 
-bool isAllocLikeOp(Value val) {
+static bool isAllocLikeOp(Value val) {
   return isAllocLikeOp(val.getDefiningOp());
 }
 
@@ -411,8 +415,9 @@ std::optional<int64_t> getStaticTotalSize(const ArrayRef<int64_t> &shapes) {
 }
 
 uint64_t AlignUp(uint64_t lhs, uint64_t rhs) {
-  if (rhs == 0)
+  if (rhs == 0) {
     return lhs;
+  }
   if (lhs % rhs != 0) {
     lhs += rhs - (lhs % rhs);
   }
@@ -466,7 +471,7 @@ bool isLocalBuffer(std::optional<AddressSpaceAttr> memorySpaceAttr) {
   llvm_unreachable("Currently only support (UB | L1 | L0C) allocation");
 }
 
-SmallVector<Value> getOpTouchBuffer(Operation *op) {
+static SmallVector<Value> getOpTouchBuffer(Operation *op) {
   SmallVector<Value> touchBuffer;
   touchBuffer.insert(touchBuffer.end(), op->getResults().begin(),
                      op->getResults().end());
@@ -496,7 +501,7 @@ ModuleOp getTopLevelModuleOp(Operation *op) {
 }
 
 /// Index of yielded value where is alias of targetVal.
-std::optional<int> getYieldValueIdx(Value targetVal, ValueRange yieldedValues) {
+static std::optional<int> getYieldValueIdx(Value targetVal, ValueRange yieldedValues) {
   auto it = std::find(yieldedValues.begin(), yieldedValues.end(), targetVal);
   if (it != yieldedValues.end()) {
     return it - yieldedValues.begin();
@@ -506,8 +511,9 @@ std::optional<int> getYieldValueIdx(Value targetVal, ValueRange yieldedValues) {
 }
 
 LoopLikeOpInterface getParentLoop(Value val) {
-  if (!val.getDefiningOp())
+  if (!val.getDefiningOp()) {
     return nullptr;
+  }
 
   // Firstly, get parent loop
   LoopLikeOpInterface parentLoop =
@@ -518,8 +524,9 @@ LoopLikeOpInterface getParentLoop(Value val) {
 
   // Need to determine whether val is yielded by the loop.
   auto yieldedValues = parentLoop.getYieldedValues();
-  if (yieldedValues.empty())
+  if (yieldedValues.empty()) {
     return parentLoop;
+  }
 
   auto idxLoopRes = getYieldValueIdx(val, yieldedValues);
   if (idxLoopRes.has_value()) {
@@ -530,8 +537,9 @@ LoopLikeOpInterface getParentLoop(Value val) {
 
   // Need to determine whether val is yielded by if/else.
   auto parentIf = val.getDefiningOp()->getParentOfType<scf::IfOp>();
-  if (!parentIf || parentIf.getResults().empty())
+  if (!parentIf || parentIf.getResults().empty()) {
     return parentLoop;
+  }
 
   auto thenYieldOp = parentIf.thenYield();
   auto thenYieldOpers = thenYieldOp.getOperands();

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -129,7 +129,7 @@ struct LayoutSolver {
   unsigned addDataValue(Value value) {
     auto type = dyn_cast<VMIVRegType>(value.getType());
     if (!type)
-      return ~0u;
+      return ~0U;
     auto [it, inserted] = dataIds.try_emplace(value, dataNodes.size());
     if (inserted) {
       dataNodes.push_back(
@@ -144,7 +144,7 @@ struct LayoutSolver {
   unsigned addMaskValue(Value value) {
     auto type = dyn_cast<VMIMaskType>(value.getType());
     if (!type)
-      return ~0u;
+      return ~0U;
     auto [it, inserted] = maskIds.try_emplace(value, maskNodes.size());
     if (inserted)
       maskNodes.push_back(
@@ -176,7 +176,7 @@ struct LayoutSolver {
   LogicalResult uniteDataEquivalent(Value lhs, Value rhs, Operation *op) {
     unsigned lhsId = addDataValue(lhs);
     unsigned rhsId = addDataValue(rhs);
-    if (lhsId == ~0u || rhsId == ~0u)
+    if (lhsId == ~0U || rhsId == ~0U)
       return success();
     unsigned lhsRoot = find(lhsId);
     unsigned rhsRoot = find(rhsId);
@@ -207,7 +207,7 @@ struct LayoutSolver {
   LogicalResult uniteMask(Value lhs, Value rhs, Operation *op) {
     unsigned lhsId = addMaskValue(lhs);
     unsigned rhsId = addMaskValue(rhs);
-    if (lhsId == ~0u || rhsId == ~0u)
+    if (lhsId == ~0U || rhsId == ~0U)
       return success();
     unsigned lhsRoot = findMask(lhsId);
     unsigned rhsRoot = findMask(rhsId);
@@ -231,7 +231,7 @@ struct LayoutSolver {
   setNaturalLayout(Value value, VMILayoutAttr layout, Operation *op,
                    DataLayoutSeedPhase phase = DataLayoutSeedPhase::Other) {
     unsigned id = addDataValue(value);
-    if (id == ~0u || !layout)
+    if (id == ~0U || !layout)
       return success();
     unsigned root = find(id);
     VMILayoutAttr existing = dataNodes[root].naturalLayout;
@@ -248,7 +248,7 @@ struct LayoutSolver {
   setPreferredLayout(Value value, VMILayoutAttr layout, Operation *op,
                      DataLayoutSeedPhase phase = DataLayoutSeedPhase::Other) {
     unsigned id = addDataValue(value);
-    if (id == ~0u || !layout)
+    if (id == ~0U || !layout)
       return success();
     unsigned root = find(id);
     VMILayoutAttr existing = dataNodes[root].preferredLayout;
@@ -284,7 +284,7 @@ struct LayoutSolver {
 
   bool hasDataLayoutSeed(Value value) {
     unsigned id = addDataValue(value);
-    if (id == ~0u)
+    if (id == ~0U)
       return false;
     DataNode &node = dataNodes[find(id)];
     return static_cast<bool>(node.naturalLayout || node.preferredLayout);
@@ -481,7 +481,7 @@ struct LayoutSolver {
 
   VMILayoutAttr getDataLayout(Value value) {
     unsigned id = addDataValue(value);
-    if (id == ~0u)
+    if (id == ~0U)
       return {};
     unsigned root = find(id);
     if (dataNodes[root].naturalLayout)

--- a/lib/PTO/Transforms/VMILayoutSupport.cpp
+++ b/lib/PTO/Transforms/VMILayoutSupport.cpp
@@ -142,9 +142,9 @@ template <int64_t... Counts> static constexpr ElementCountPattern G() {
 static constexpr ElementCountPattern anyN() { return {{}, 0, true}; }
 static constexpr ElementCountPattern anyG() { return anyN(); }
 
-static constexpr MaskGranularityPattern mb8() { return {1u << 0}; }
-static constexpr MaskGranularityPattern mb16() { return {1u << 1}; }
-static constexpr MaskGranularityPattern mb32() { return {1u << 2}; }
+static constexpr MaskGranularityPattern mb8() { return {1U << 0}; }
+static constexpr MaskGranularityPattern mb16() { return {1U << 1}; }
+static constexpr MaskGranularityPattern mb32() { return {1U << 2}; }
 
 static bool matchesElementBitsPattern(ElementBitsPattern pattern,
                                       int64_t bits) {
@@ -180,9 +180,9 @@ static bool matchesPhysicalChunkCountPattern(
 
 static bool matchesMaskGranularityPattern(MaskGranularityPattern pattern,
                                           StringRef granularity) {
-  uint8_t mask = granularity == "b8"    ? 1u << 0
-                 : granularity == "b16" ? 1u << 1
-                 : granularity == "b32" ? 1u << 2
+  uint8_t mask = granularity == "b8"    ? 1U << 0
+                 : granularity == "b16" ? 1U << 1
+                 : granularity == "b32" ? 1U << 2
                                         : 0;
   return mask != 0 && (pattern.mask & mask) != 0;
 }
@@ -2804,11 +2804,11 @@ VMILayoutSupport::getHighPriorityGroupStoreLayoutFact(
               "high-priority group_store table row");
 }
 
-LogicalResult getGroupReduceAddSupportImpl(VMIVRegType sourceType,
-                                           VMIMaskType maskType,
-                                           VMIVRegType resultType,
-                                           int64_t numGroups,
-                                           std::string *reason) {
+static LogicalResult getGroupReduceAddSupportImpl(VMIVRegType sourceType,
+                                                  VMIMaskType maskType,
+                                                  VMIVRegType resultType,
+                                                  int64_t numGroups,
+                                                  std::string *reason) {
   FailureOr<VMIGroupReduceLayoutFact> fact =
       VMILayoutSupport().getGroupReduceLayoutFactForLayouts(
           sourceType, maskType, resultType, numGroups, reason);

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -1598,7 +1598,6 @@ void VMILowerUnifiedToLegacyPass::runOnOperation() {
       continue;
     }
   }
-
 }
 
 std::unique_ptr<Pass> mlir::pto::createVMILowerUnifiedToLegacyPass() {

--- a/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
+++ b/lib/PTO/Transforms/VMIMaskGranularityAssignment.cpp
@@ -94,7 +94,7 @@ struct MaskGranularitySolver {
   unsigned addMaskValue(Value value) {
     auto type = dyn_cast<VMIMaskType>(value.getType());
     if (!type)
-      return ~0u;
+      return ~0U;
     auto [it, inserted] = maskIds.try_emplace(value, maskNodes.size());
     if (inserted) {
       std::string granularity;
@@ -115,7 +115,7 @@ struct MaskGranularitySolver {
   LogicalResult uniteMask(Value lhs, Value rhs, Operation *op) {
     unsigned lhsId = addMaskValue(lhs);
     unsigned rhsId = addMaskValue(rhs);
-    if (lhsId == ~0u || rhsId == ~0u)
+    if (lhsId == ~0U || rhsId == ~0U)
       return success();
     unsigned lhsRoot = findMask(lhsId);
     unsigned rhsRoot = findMask(rhsId);
@@ -139,7 +139,7 @@ struct MaskGranularitySolver {
 
   LogicalResult requestMask(Value mask, StringRef granularity, Operation *op) {
     unsigned id = addMaskValue(mask);
-    if (id == ~0u)
+    if (id == ~0U)
       return success();
     if (granularity.empty())
       return op->emitError() << kVMIDiagLayoutContractPrefix

--- a/lib/PTO/Transforms/VMINormalizeSignlessIntToUnsigned.cpp
+++ b/lib/PTO/Transforms/VMINormalizeSignlessIntToUnsigned.cpp
@@ -100,7 +100,7 @@ static void insertNormalizeCastAfter(Operation *op, OpResult result,
 // ---------------------------------------------------------------------------
 
 struct NormalizeSignlessPattern : public RewritePattern {
-  NormalizeSignlessPattern(MLIRContext *ctx)
+  explicit NormalizeSignlessPattern(MLIRContext *ctx)
       : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, ctx) {}
 
   LogicalResult matchAndRewrite(Operation *op,

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -59,8 +59,9 @@ std::optional<std::string> getPointStoreDistToken(Type elementType);
 bool isVMIType(Type type) { return isa<VMIVRegType, VMIMaskType>(type); }
 
 bool containsVMIType(Type type) {
-  if (isVMIType(type))
+  if (isVMIType(type)) {
     return true;
+  }
 
   if (auto functionType = dyn_cast<FunctionType>(type))
     return llvm::any_of(functionType.getInputs(),
@@ -68,8 +69,9 @@ bool containsVMIType(Type type) {
            llvm::any_of(functionType.getResults(),
                         [](Type result) { return containsVMIType(result); });
 
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return containsVMIType(shapedType.getElementType());
+  }
 
   return false;
 }
@@ -94,10 +96,12 @@ struct VMISupportResult {
   bool isSupported() const { return supported; }
 
   LogicalResult toLogicalResult(std::string *outReason = nullptr) const {
-    if (supported)
+    if (supported) {
       return mlir::success();
-    if (outReason)
+    }
+    if (outReason) {
       *outReason = reason;
+    }
     return mlir::failure();
   }
 };
@@ -107,16 +111,19 @@ bool hasVMIType(FunctionType type) {
 }
 
 bool hasVMIType(Attribute attr) {
-  if (!attr)
+  if (!attr) {
     return false;
+  }
 
   if (auto typeAttr = dyn_cast<TypeAttr>(attr))
-    if (containsVMIType(typeAttr.getValue()))
+    if (containsVMIType(typeAttr.getValue())) {
       return true;
+    }
 
   if (auto typedAttr = dyn_cast<TypedAttr>(attr))
-    if (containsVMIType(typedAttr.getType()))
+    if (containsVMIType(typedAttr.getType())) {
       return true;
+    }
 
   if (auto arrayAttr = dyn_cast<ArrayAttr>(attr))
     return llvm::any_of(arrayAttr,
@@ -132,17 +139,21 @@ bool hasVMIType(Attribute attr) {
 
 bool hasVMIType(Operation *op) {
   if (auto func = dyn_cast<func::FuncOp>(op))
-    if (hasVMIType(func.getFunctionType()))
+    if (hasVMIType(func.getFunctionType())) {
       return true;
-  if (hasVMIType(op->getOperandTypes()) || hasVMIType(op->getResultTypes()))
+    }
+  if (hasVMIType(op->getOperandTypes()) || hasVMIType(op->getResultTypes())) {
     return true;
+  }
   for (Region &region : op->getRegions())
     for (Block &block : region)
-      if (hasVMIType(block.getArgumentTypes()))
+      if (hasVMIType(block.getArgumentTypes())) {
         return true;
+      }
   for (NamedAttribute attr : op->getAttrs())
-    if (hasVMIType(attr.getValue()))
+    if (hasVMIType(attr.getValue())) {
       return true;
+    }
   return false;
 }
 
@@ -155,14 +166,16 @@ StringRef getTruncFRoundModeForResult(Type resultElementType) {
 }
 
 StringRef getTruncFRoundMode(VMITruncFOp op, Type resultElementType) {
-  if (auto roundingAttr = op->getAttrOfType<StringAttr>("rounding"))
+  if (auto roundingAttr = op->getAttrOfType<StringAttr>("rounding")) {
     return roundingAttr.getValue();
+  }
   return getTruncFRoundModeForResult(resultElementType);
 }
 
 bool isLayoutAssignedVMIType(Type type) {
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     return static_cast<bool>(vregType.getLayoutAttr());
+  }
   if (auto maskType = dyn_cast<VMIMaskType>(type))
     return maskType.getLayoutAttr() &&
            VMIMaskType::isConcreteGranularity(maskType.getGranularity());
@@ -176,41 +189,49 @@ LogicalResult verifyLayoutAssignedVMITypeTree(Operation *op, Type type) {
 
   if (auto functionType = dyn_cast<FunctionType>(type)) {
     for (Type input : functionType.getInputs())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, input)))
+      if (failed(verifyLayoutAssignedVMITypeTree(op, input))) {
         return failure();
+      }
     for (Type result : functionType.getResults())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, result)))
+      if (failed(verifyLayoutAssignedVMITypeTree(op, result))) {
         return failure();
+      }
   }
 
-  if (auto shapedType = dyn_cast<ShapedType>(type))
+  if (auto shapedType = dyn_cast<ShapedType>(type)) {
     return verifyLayoutAssignedVMITypeTree(op, shapedType.getElementType());
+  }
 
   return success();
 }
 
 LogicalResult verifyVMIToVPTOInputAttribute(Operation *op, Attribute attr) {
-  if (!attr)
+  if (!attr) {
     return success();
+  }
 
   if (auto typeAttr = dyn_cast<TypeAttr>(attr))
-    if (failed(verifyLayoutAssignedVMITypeTree(op, typeAttr.getValue())))
+    if (failed(verifyLayoutAssignedVMITypeTree(op, typeAttr.getValue()))) {
       return failure();
+    }
 
   if (auto typedAttr = dyn_cast<TypedAttr>(attr))
-    if (failed(verifyLayoutAssignedVMITypeTree(op, typedAttr.getType())))
+    if (failed(verifyLayoutAssignedVMITypeTree(op, typedAttr.getType()))) {
       return failure();
+    }
 
   if (auto arrayAttr = dyn_cast<ArrayAttr>(attr)) {
     for (Attribute element : arrayAttr)
-      if (failed(verifyVMIToVPTOInputAttribute(op, element)))
+      if (failed(verifyVMIToVPTOInputAttribute(op, element))) {
         return failure();
+      }
   }
 
   if (auto dictAttr = dyn_cast<DictionaryAttr>(attr)) {
     for (NamedAttribute namedAttr : dictAttr)
-      if (failed(verifyVMIToVPTOInputAttribute(op, namedAttr.getValue())))
+      if (failed(verifyVMIToVPTOInputAttribute(op, namedAttr.getValue()))) {
         return failure();
+      }
   }
 
   return success();
@@ -218,35 +239,42 @@ LogicalResult verifyVMIToVPTOInputAttribute(Operation *op, Attribute attr) {
 
 LogicalResult verifyVMIToVPTOInputTypes(Operation *op) {
   for (Type type : op->getOperandTypes())
-    if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+    if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
       return failure();
+    }
   for (Type type : op->getResultTypes())
-    if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+    if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
       return failure();
+    }
   if (auto func = dyn_cast<func::FuncOp>(op)) {
     FunctionType functionType = func.getFunctionType();
     for (Type type : functionType.getInputs())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+      if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
         return failure();
+      }
     for (Type type : functionType.getResults())
-      if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+      if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
         return failure();
+      }
   }
   for (Region &region : op->getRegions())
     for (Block &block : region)
       for (Type type : block.getArgumentTypes())
-        if (failed(verifyLayoutAssignedVMITypeTree(op, type)))
+        if (failed(verifyLayoutAssignedVMITypeTree(op, type))) {
           return failure();
+        }
   for (NamedAttribute attr : op->getAttrs())
-    if (failed(verifyVMIToVPTOInputAttribute(op, attr.getValue())))
+    if (failed(verifyVMIToVPTOInputAttribute(op, attr.getValue()))) {
       return failure();
+    }
   return success();
 }
 
 LogicalResult verifyVMIToVPTOInputIR(ModuleOp module) {
   WalkResult result = module.walk([&](Operation *op) {
-    if (failed(verifyVMIToVPTOInputTypes(op)))
+    if (failed(verifyVMIToVPTOInputTypes(op))) {
       return WalkResult::interrupt();
+    }
     return WalkResult::advance();
   });
   return failure(result.wasInterrupted());
@@ -254,8 +282,9 @@ LogicalResult verifyVMIToVPTOInputIR(ModuleOp module) {
 
 static Value materializeVPTOToVMI(OpBuilder &builder, Type resultType,
                                   ValueRange inputs, Location loc) {
-  if (!isVMIType(resultType))
+  if (!isVMIType(resultType)) {
     return {};
+  }
   return builder.create<VMIPackOp>(loc, resultType, inputs).getResult();
 }
 
@@ -263,19 +292,23 @@ static SmallVector<Value> materializeVMIToVPTO(OpBuilder &builder,
                                                TypeRange resultTypes,
                                                ValueRange inputs,
                                                Location loc) {
-  if (inputs.size() != 1 || !isVMIType(inputs.front().getType()))
+  if (inputs.size() != 1 || !isVMIType(inputs.front().getType())) {
     return {};
+  }
   auto unpackOp = builder.create<VMIUnpackOp>(loc, resultTypes, inputs.front());
   return SmallVector<Value>(unpackOp->getResults());
 }
 
 static int64_t getMaskGranularityBits(StringRef granularity) {
-  if (granularity == "b8")
+  if (granularity == "b8") {
     return 8;
-  if (granularity == "b16")
+  }
+  if (granularity == "b16") {
     return 16;
-  if (granularity == "b32")
+  }
+  if (granularity == "b32") {
     return 32;
+  }
   return 0;
 }
 
@@ -294,16 +327,18 @@ static StringRef getMaskGranularityForBits(int64_t bits) {
 
 static FailureOr<StringRef> getVMIMaskPhysicalGranularity(VMIMaskType type) {
   int64_t bits = getMaskGranularityBits(type.getGranularity());
-  if (bits == 0)
+  if (bits == 0) {
     return failure();
+  }
 
   VMILayoutAttr layout = type.getLayoutAttr();
   int64_t laneStride = layout && layout.hasLaneStride() ? layout.getLaneStride()
                                                         : 1;
   int64_t physicalBits = bits * laneStride;
   StringRef physicalGranularity = getMaskGranularityForBits(physicalBits);
-  if (physicalGranularity.empty())
+  if (physicalGranularity.empty()) {
     return failure();
+  }
   return physicalGranularity;
 }
 
@@ -315,12 +350,14 @@ public:
                      SmallVectorImpl<Type> &results) -> LogicalResult {
       FailureOr<int64_t> arity = getVMIPhysicalArity(type);
       Type physicalElementType = getVMIPhysicalDataElementType(type);
-      if (failed(arity))
+      if (failed(arity)) {
         return failure();
+      }
       FailureOr<int64_t> lanesPerPart =
           getDataLanesPerPart(physicalElementType);
-      if (failed(lanesPerPart))
+      if (failed(lanesPerPart)) {
         return failure();
+      }
       for (int64_t i = 0; i < *arity; ++i)
         results.push_back(VRegType::get(type.getContext(), *lanesPerPart,
                                         physicalElementType));
@@ -331,8 +368,9 @@ public:
           FailureOr<int64_t> arity = getVMIPhysicalArity(type);
           FailureOr<StringRef> physicalGranularity =
               getVMIMaskPhysicalGranularity(type);
-          if (failed(arity) || failed(physicalGranularity))
+          if (failed(arity) || failed(physicalGranularity)) {
             return failure();
+          }
           for (int64_t i = 0; i < *arity; ++i)
             results.push_back(
                 MaskType::get(type.getContext(), *physicalGranularity));
@@ -346,8 +384,9 @@ public:
 FailureOr<SmallVector<Type>>
 getConvertedResultTypes(Operation *op, unsigned resultIndex,
                         const TypeConverter &typeConverter) {
-  if (resultIndex >= op->getNumResults())
+  if (resultIndex >= op->getNumResults()) {
     return failure();
+  }
   SmallVector<Type> resultTypes;
   if (failed(typeConverter.convertType(op->getResult(resultIndex).getType(),
                                        resultTypes)))
@@ -358,8 +397,9 @@ getConvertedResultTypes(Operation *op, unsigned resultIndex,
 FailureOr<SmallVector<Type>>
 getConvertedResultTypes(Operation *op, const TypeConverter &typeConverter) {
   SmallVector<Type> resultTypes;
-  if (failed(typeConverter.convertTypes(op->getResultTypes(), resultTypes)))
+  if (failed(typeConverter.convertTypes(op->getResultTypes(), resultTypes))) {
     return failure();
+  }
   return resultTypes;
 }
 
@@ -369,8 +409,9 @@ getConvertedVRegTypesWithLayout(VMIVRegType type, VMILayoutAttr layout,
   auto relayoutType = VMIVRegType::get(type.getContext(), type.getElementCount(),
                                        type.getElementType(), layout);
   SmallVector<Type> convertedTypes;
-  if (failed(typeConverter.convertType(relayoutType, convertedTypes)))
+  if (failed(typeConverter.convertType(relayoutType, convertedTypes))) {
     return failure();
+  }
   return convertedTypes;
 }
 
@@ -378,15 +419,18 @@ FailureOr<int64_t> getVRegPhysicalFootprintBytes(TypeRange types) {
   int64_t totalBytes = 0;
   for (Type type : types) {
     auto vregType = dyn_cast<VRegType>(type);
-    if (!vregType)
+    if (!vregType) {
       return failure();
+    }
     unsigned elementBits =
         pto::getPTOStorageElemBitWidth(vregType.getElementType());
-    if (elementBits == 0)
+    if (elementBits == 0) {
       return failure();
+    }
     int64_t chunkBits = vregType.getElementCount() * elementBits;
-    if (chunkBits % 8 != 0)
+    if (chunkBits % 8 != 0) {
       return failure();
+    }
     totalBytes += chunkBits / 8;
   }
   return totalBytes;
@@ -398,8 +442,9 @@ FailureOr<bool> hasNoWiderFootprintThanContiguous(TypeRange assignedTypes,
       getVRegPhysicalFootprintBytes(assignedTypes);
   FailureOr<int64_t> contiguousBytes =
       getVRegPhysicalFootprintBytes(contiguousTypes);
-  if (failed(assignedBytes) || failed(contiguousBytes))
+  if (failed(assignedBytes) || failed(contiguousBytes)) {
     return failure();
+  }
   return *assignedBytes <= *contiguousBytes;
 }
 
@@ -431,19 +476,22 @@ void replaceOpWithFlatConvertedValues(
 SmallVector<Value>
 flattenOneToNOperands(ArrayRef<ValueRange> operands) {
   SmallVector<Value> flat;
-  for (ValueRange operand : operands)
+  for (ValueRange operand : operands) {
     llvm::append_range(flat, operand);
+  }
   return flat;
 }
 
 bool isIdentityOneToNValueMapping(ValueRange originalValues,
                                   ArrayRef<ValueRange> convertedValues) {
-  if (originalValues.size() != convertedValues.size())
+  if (originalValues.size() != convertedValues.size()) {
     return false;
+  }
   for (auto [original, converted] :
        llvm::zip_equal(originalValues, convertedValues)) {
-    if (converted.size() != 1 || converted.front() != original)
+    if (converted.size() != 1 || converted.front() != original) {
       return false;
+    }
   }
   return true;
 }
@@ -452,8 +500,9 @@ TypeRange getConvertedSignatureTypes(
     const TypeConverter::SignatureConversion &conversion,
     unsigned originalIndex) {
   TypeRange convertedTypes = conversion.getConvertedTypes();
-  if (auto mapping = conversion.getInputMapping(originalIndex))
+  if (auto mapping = conversion.getInputMapping(originalIndex)) {
     return convertedTypes.slice(mapping->inputNo, mapping->size);
+  }
   return {};
 }
 
@@ -462,8 +511,9 @@ bool hasNonIdentitySignatureConversion(
     const TypeConverter::SignatureConversion &conversion) {
   for (auto [index, originalType] : llvm::enumerate(originalTypes)) {
     TypeRange convertedTypes = getConvertedSignatureTypes(conversion, index);
-    if (convertedTypes.size() != 1 || convertedTypes.front() != originalType)
+    if (convertedTypes.size() != 1 || convertedTypes.front() != originalType) {
       return true;
+    }
   }
   return false;
 }
@@ -494,12 +544,15 @@ FailureOr<Value> createAllTrueMaskForVReg(Location loc, VRegType vregType,
 FailureOr<MaskType> getMaskTypeForVReg(VRegType vregType, MLIRContext *ctx) {
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(vregType.getElementType());
-  if (elementBits == 8)
+  if (elementBits == 8) {
     return MaskType::get(ctx, "b8");
-  if (elementBits == 16)
+  }
+  if (elementBits == 16) {
     return MaskType::get(ctx, "b16");
-  if (elementBits == 32)
+  }
+  if (elementBits == 32) {
     return MaskType::get(ctx, "b32");
+  }
   return failure();
 }
 
@@ -563,15 +616,18 @@ FailureOr<Value> createPrefixMask(Location loc, MaskType maskType,
 }
 
 bool areEquivalentReductionMasks(Value lhs, Value rhs) {
-  if (lhs == rhs)
+  if (lhs == rhs) {
     return true;
-  if (lhs.getType() != rhs.getType())
+  }
+  if (lhs.getType() != rhs.getType()) {
     return false;
+  }
 
   Operation *lhsOp = lhs.getDefiningOp();
   Operation *rhsOp = rhs.getDefiningOp();
-  if (!lhsOp || !rhsOp || lhsOp->getName() != rhsOp->getName())
+  if (!lhsOp || !rhsOp || lhsOp->getName() != rhsOp->getName()) {
     return false;
+  }
 
   bool isPatternMask =
       isa<PsetB8Op, PsetB16Op, PsetB32Op, PgeB8Op, PgeB16Op, PgeB32Op>(
@@ -630,15 +686,17 @@ createRuntimePrefixMask(Location loc, MaskType maskType, Value activeLanes,
 LogicalResult
 checkSupportedMaskableVReg(VMIVRegType type, std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
   FailureOr<int64_t> arity = getVMIPhysicalArity(type);
-  if (failed(lanesPerPart) || failed(arity) || *arity < 1)
+  if (failed(lanesPerPart) || failed(arity) || *arity < 1) {
     return fail("requires computable non-empty physical vreg parts");
+  }
 
   return success();
 }
@@ -656,8 +714,9 @@ Value createI16Constant(Location loc, int64_t value,
 FailureOr<Value> createPrefixMaskForActiveLanes(Location loc, MaskType maskType,
                                                 int64_t activeLanes,
                                                 PatternRewriter &rewriter) {
-  if (activeLanes <= 0)
+  if (activeLanes <= 0) {
     return createPrefixMask(loc, maskType, "PAT_ALLF", rewriter);
+  }
 
   switch (activeLanes) {
   case 1:
@@ -674,8 +733,9 @@ FailureOr<Value> createPrefixMaskForActiveLanes(Location loc, MaskType maskType,
   default: {
     FailureOr<std::pair<Value, Value>> dynamicMask = createRuntimePrefixMask(
         loc, maskType, createI32Constant(loc, activeLanes, rewriter), rewriter);
-    if (failed(dynamicMask))
+    if (failed(dynamicMask)) {
       return failure();
+    }
     return dynamicMask->first;
   }
   }
@@ -695,8 +755,9 @@ Value clampDynamicActiveLanes(Location loc, Value activeLanes,
 Value createPartitionActiveLanes(Location loc, Value activeLanesI32,
                                  int64_t factor, int64_t part,
                                  PatternRewriter &rewriter) {
-  if (factor == 1)
+  if (factor == 1) {
     return activeLanesI32;
+  }
   int64_t bias = factor - 1 - part;
   Value biased = activeLanesI32;
   if (bias != 0)
@@ -707,8 +768,9 @@ Value createPartitionActiveLanes(Location loc, Value activeLanesI32,
 }
 
 std::optional<int64_t> getPowerOfTwoLog2(int64_t value) {
-  if (value <= 0 || (value & (value - 1)) != 0)
+  if (value <= 0 || (value & (value - 1)) != 0) {
     return std::nullopt;
+  }
   int64_t log2 = 0;
   while (value > 1) {
     value >>= 1;
@@ -719,10 +781,12 @@ std::optional<int64_t> getPowerOfTwoLog2(int64_t value) {
 
 std::optional<std::string> getPrefixPattern(int64_t activeLanes,
                                             int64_t lanesPerPart) {
-  if (activeLanes <= 0)
+  if (activeLanes <= 0) {
     return std::string("PAT_ALLF");
-  if (activeLanes >= lanesPerPart)
+  }
+  if (activeLanes >= lanesPerPart) {
     return std::string("PAT_ALL");
+  }
   switch (activeLanes) {
   case 1:
   case 2:
@@ -755,16 +819,18 @@ static int64_t ceilDivNonNegative(int64_t lhs, int64_t rhs) {
 
 FailureOr<int64_t> getDataLayoutFactor(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return failure();
+  }
   return layout.isDenseSplit() ? layout.getFactor() : 1;
 }
 
 FailureOr<int64_t> getDataChunksInPart(VMIVRegType type, int64_t part) {
   FailureOr<int64_t> factor = getDataLayoutFactor(type);
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (failed(factor) || failed(lanesPerPart) || part < 0 || part >= *factor)
+  if (failed(factor) || failed(lanesPerPart) || part < 0 || part >= *factor) {
     return failure();
+  }
 
   int64_t logicalLanesInPart =
       (type.getElementCount() + *factor - 1 - part) / *factor;
@@ -774,50 +840,59 @@ FailureOr<int64_t> getDataChunksInPart(VMIVRegType type, int64_t part) {
 FailureOr<int64_t> getDataFlatPartIndex(VMIVRegType type, int64_t part,
                                         int64_t chunk) {
   FailureOr<int64_t> factor = getDataLayoutFactor(type);
-  if (failed(factor) || part < 0 || part >= *factor || chunk < 0)
+  if (failed(factor) || part < 0 || part >= *factor || chunk < 0) {
     return failure();
+  }
 
   int64_t flatIndex = 0;
   for (int64_t currentPart = 0; currentPart < part; ++currentPart) {
     FailureOr<int64_t> chunks = getDataChunksInPart(type, currentPart);
-    if (failed(chunks))
+    if (failed(chunks)) {
       return failure();
+    }
     flatIndex += *chunks;
   }
 
   FailureOr<int64_t> chunks = getDataChunksInPart(type, part);
-  if (failed(chunks) || chunk >= *chunks)
+  if (failed(chunks) || chunk >= *chunks) {
     return failure();
+  }
   return flatIndex + chunk;
 }
 
 FailureOr<int64_t> checkFullDataPhysicalChunks(VMIVRegType type,
                                                std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<int64_t> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known physical lanes per part");
+  }
 
   FailureOr<int64_t> factor = getDataLayoutFactor(type);
-  if (failed(factor))
+  if (failed(factor)) {
     return fail("requires assigned layout");
+  }
 
   for (int64_t part = 0; part < *factor; ++part) {
     FailureOr<int64_t> chunks = getDataChunksInPart(type, part);
-    if (failed(chunks))
+    if (failed(chunks)) {
       return fail("requires known physical chunks");
+    }
     for (int64_t chunk = 0; chunk < *chunks; ++chunk) {
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding = isPaddingLane(type, part, chunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to map physical padding lane");
-        if (*padding)
+        }
+        if (*padding) {
           return fail("found padding lane in physical chunk");
+        }
       }
     }
   }
@@ -827,24 +902,29 @@ FailureOr<int64_t> checkFullDataPhysicalChunks(VMIVRegType type,
 
 FailureOr<int64_t> getVMITypeLayoutFactor(Type type) {
   Attribute layout;
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     layout = vregType.getLayout();
+  }
   else if (auto maskType = dyn_cast<VMIMaskType>(type))
     layout = maskType.getLayout();
-  else
+  else {
     return failure();
+  }
 
   auto layoutAttr = dyn_cast_or_null<VMILayoutAttr>(layout);
-  if (!layoutAttr)
+  if (!layoutAttr) {
     return failure();
+  }
   return layoutAttr.isDenseSplit() ? layoutAttr.getFactor() : 1;
 }
 
 FailureOr<int64_t> getVMITypeElementCount(Type type) {
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     return vregType.getElementCount();
-  if (auto maskType = dyn_cast<VMIMaskType>(type))
+  }
+  if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     return maskType.getElementCount();
+  }
   return failure();
 }
 
@@ -855,8 +935,9 @@ FailureOr<int64_t> getVMITypeLanesPerPart(Type type) {
   if (auto maskType = dyn_cast<VMIMaskType>(type)) {
     FailureOr<StringRef> physicalGranularity =
         getVMIMaskPhysicalGranularity(maskType);
-    if (failed(physicalGranularity))
+    if (failed(physicalGranularity)) {
       return failure();
+    }
     return getMaskLanesPerPart(*physicalGranularity);
   }
   return failure();
@@ -871,17 +952,20 @@ FailureOr<int64_t> getVMITypeChunksInPart(Type type, int64_t part) {
     return failure();
 
   VMILayoutAttr layout;
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     layout = vregType.getLayoutAttr();
+  }
   else if (auto maskType = dyn_cast<VMIMaskType>(type))
     layout = maskType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return failure();
+  }
 
   int64_t logicalLanesInPart = (*elementCount + *factor - 1 - part) / *factor;
   int64_t laneStride = 1;
-  if (isa<VMIVRegType>(type) && layout.isDense())
+  if (isa<VMIVRegType>(type) && layout.isDense()) {
     laneStride = layout.getLaneStride();
+  }
   int64_t physicalLanes =
       logicalLanesInPart == 0 ? 0 : (logicalLanesInPart - 1) * laneStride + 1;
   return ceilDivNonNegative(physicalLanes, *lanesPerPart);
@@ -889,27 +973,32 @@ FailureOr<int64_t> getVMITypeChunksInPart(Type type, int64_t part) {
 
 LogicalResult checkFullVMIPhysicalChunks(Type type, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<int64_t> factor = getVMITypeLayoutFactor(type);
   FailureOr<int64_t> lanesPerPart = getVMITypeLanesPerPart(type);
-  if (failed(factor) || failed(lanesPerPart))
+  if (failed(factor) || failed(lanesPerPart)) {
     return fail("requires assigned layout with known physical lanes per part");
+  }
 
   for (int64_t part = 0; part < *factor; ++part) {
     FailureOr<int64_t> chunks = getVMITypeChunksInPart(type, part);
-    if (failed(chunks))
+    if (failed(chunks)) {
       return fail("requires known physical chunks");
+    }
     for (int64_t chunk = 0; chunk < *chunks; ++chunk) {
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding = isPaddingLane(type, part, chunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to map physical padding lane");
-        if (*padding)
+        }
+        if (*padding) {
           return fail("found padding lane in physical chunk");
+        }
       }
     }
   }
@@ -923,44 +1012,53 @@ FailureOr<int64_t> getContiguousMaterializationPartCount(Type type,
 FailureOr<int64_t> getContiguousMaterializationPartCount(Type type,
                                                          std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<int64_t> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<int64_t> arity = getVMIPhysicalArity(type);
   FailureOr<int64_t> factor = getVMITypeLayoutFactor(type);
-  if (failed(arity) || failed(factor))
+  if (failed(arity) || failed(factor)) {
     return fail("requires computable physical arity and assigned layout");
+  }
 
   Attribute layoutAttr;
-  if (auto vregType = dyn_cast<VMIVRegType>(type))
+  if (auto vregType = dyn_cast<VMIVRegType>(type)) {
     layoutAttr = vregType.getLayout();
+  }
   else if (auto maskType = dyn_cast<VMIMaskType>(type))
     layoutAttr = maskType.getLayout();
-  else
+  else {
     return fail("requires VMI data or mask type");
+  }
 
   auto layout = dyn_cast_or_null<VMILayoutAttr>(layoutAttr);
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned layout");
-  if (layout.isContiguous() && layout.getLaneStride() == 1)
+  }
+  if (layout.isContiguous() && layout.getLaneStride() == 1) {
     return *arity;
+  }
   if (!layout.isDenseSplit() ||
       (layout.getFactor() != 2 && layout.getFactor() != 4))
     return fail("requires contiguous, deinterleaved=2/4, or "
                 "block_deinterleaved=2/4 layout");
 
   FailureOr<int64_t> chunksPerGroup = getVMITypeChunksInPart(type, 0);
-  if (failed(chunksPerGroup))
+  if (failed(chunksPerGroup)) {
     return fail("requires known physical chunks per part");
-  if (*chunksPerGroup == 0)
+  }
+  if (*chunksPerGroup == 0) {
     return fail("requires at least one physical chunk per part");
+  }
 
   for (int64_t part = 1; part < *factor; ++part) {
     FailureOr<int64_t> chunks = getVMITypeChunksInPart(type, part);
-    if (failed(chunks))
+    if (failed(chunks)) {
       return fail("requires known physical chunks per part");
+    }
     if (layout.getFactor() == 2 && *chunks != *chunksPerGroup)
       return fail("requires every deinterleaved part to have the same "
                   "physical chunk count");
@@ -988,11 +1086,13 @@ LogicalResult checkCanMaterializeToContiguous(Type type, std::string *reason) {
 }
 
 std::optional<int64_t> getConstantIndexValue(Value value) {
-  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>())
+  if (auto constant = value.getDefiningOp<arith::ConstantIndexOp>()) {
     return constant.value();
+  }
   if (auto constant = value.getDefiningOp<arith::ConstantOp>()) {
-    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue()))
+    if (auto integerAttr = dyn_cast<IntegerAttr>(constant.getValue())) {
       return integerAttr.getInt();
+    }
   }
   return std::nullopt;
 }
@@ -1004,22 +1104,29 @@ static int64_t normalizeRemainder(int64_t value, int64_t modulus) {
 
 std::optional<int64_t> getKnownIndexRemainder(Value value, int64_t modulus,
                                               int depth = 0) {
-  if (modulus <= 1)
+  if (modulus <= 1) {
     return 0;
-  if (depth > 6)
+  }
+  if (depth > 6) {
     return std::nullopt;
-  if (std::optional<int64_t> constant = getConstantIndexValue(value))
+  }
+  if (std::optional<int64_t> constant = getConstantIndexValue(value)) {
     return normalizeRemainder(*constant, modulus);
+  }
 
-  if (auto cast = value.getDefiningOp<arith::IndexCastOp>())
+  if (auto cast = value.getDefiningOp<arith::IndexCastOp>()) {
     return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
-  if (auto cast = value.getDefiningOp<arith::ExtSIOp>())
+  }
+  if (auto cast = value.getDefiningOp<arith::ExtSIOp>()) {
     return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
-  if (auto cast = value.getDefiningOp<arith::ExtUIOp>())
+  }
+  if (auto cast = value.getDefiningOp<arith::ExtUIOp>()) {
     return getKnownIndexRemainder(cast.getIn(), modulus, depth + 1);
+  }
   if (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (cast->getNumOperands() == 1 && cast->getNumResults() == 1)
+    if (cast->getNumOperands() == 1 && cast->getNumResults() == 1) {
       return getKnownIndexRemainder(cast.getOperand(0), modulus, depth + 1);
+    }
   }
 
   if (auto add = value.getDefiningOp<arith::AddIOp>()) {
@@ -1027,8 +1134,9 @@ std::optional<int64_t> getKnownIndexRemainder(Value value, int64_t modulus,
         getKnownIndexRemainder(add.getLhs(), modulus, depth + 1);
     std::optional<int64_t> rhs =
         getKnownIndexRemainder(add.getRhs(), modulus, depth + 1);
-    if (lhs && rhs)
+    if (lhs && rhs) {
       return normalizeRemainder(*lhs + *rhs, modulus);
+    }
     return std::nullopt;
   }
   if (auto sub = value.getDefiningOp<arith::SubIOp>()) {
@@ -1036,8 +1144,9 @@ std::optional<int64_t> getKnownIndexRemainder(Value value, int64_t modulus,
         getKnownIndexRemainder(sub.getLhs(), modulus, depth + 1);
     std::optional<int64_t> rhs =
         getKnownIndexRemainder(sub.getRhs(), modulus, depth + 1);
-    if (lhs && rhs)
+    if (lhs && rhs) {
       return normalizeRemainder(*lhs - *rhs, modulus);
+    }
     return std::nullopt;
   }
   if (auto mul = value.getDefiningOp<arith::MulIOp>()) {
@@ -1045,10 +1154,12 @@ std::optional<int64_t> getKnownIndexRemainder(Value value, int64_t modulus,
         getKnownIndexRemainder(mul.getLhs(), modulus, depth + 1);
     std::optional<int64_t> rhs =
         getKnownIndexRemainder(mul.getRhs(), modulus, depth + 1);
-    if ((lhs && *lhs == 0) || (rhs && *rhs == 0))
+    if ((lhs && *lhs == 0) || (rhs && *rhs == 0)) {
       return 0;
-    if (lhs && rhs)
+    }
+    if (lhs && rhs) {
       return normalizeRemainder(*lhs * *rhs, modulus);
+    }
     return std::nullopt;
   }
 
@@ -1058,23 +1169,28 @@ std::optional<int64_t> getKnownIndexRemainder(Value value, int64_t modulus,
 std::optional<int64_t> getKnownPointerByteRemainder(Value pointer,
                                                     int64_t alignmentBytes,
                                                     int depth = 0) {
-  if (alignmentBytes <= 1)
+  if (alignmentBytes <= 1) {
     return 0;
-  if (depth > 6)
+  }
+  if (depth > 6) {
     return std::nullopt;
+  }
 
   // A raw PTO pointer block argument is a base address. Its required
   // address-space alignment is an ABI precondition; derived pointers must
   // prove that their element offsets preserve that alignment.
-  if (isa<BlockArgument>(pointer))
+  if (isa<BlockArgument>(pointer)) {
     return 0;
+  }
 
   if (auto cast = pointer.getDefiningOp<CastPtrOp>()) {
     Value input = cast.getInput();
-    if (isa<PtrType>(input.getType()))
+    if (isa<PtrType>(input.getType())) {
       return getKnownPointerByteRemainder(input, alignmentBytes, depth + 1);
-    if (isa<IntegerType>(input.getType()))
+    }
+    if (isa<IntegerType>(input.getType())) {
       return getKnownIndexRemainder(input, alignmentBytes, depth + 1);
+    }
     return std::nullopt;
   }
 
@@ -1089,19 +1205,22 @@ std::optional<int64_t> getKnownPointerByteRemainder(Value pointer,
     std::optional<int64_t> base =
         getKnownPointerByteRemainder(add.getPtr(), alignmentBytes, depth + 1);
     auto pointerType = dyn_cast<PtrType>(add.getPtr().getType());
-    if (!base || !pointerType)
+    if (!base || !pointerType) {
       return std::nullopt;
+    }
     unsigned elementBits =
         pto::getPTOStorageElemBitWidth(pointerType.getElementType());
-    if (elementBits == 0 || elementBits % 8 != 0)
+    if (elementBits == 0 || elementBits % 8 != 0) {
       return std::nullopt;
+    }
     int64_t elementBytes = elementBits / 8;
     int64_t offsetModulus =
         alignmentBytes / std::gcd(alignmentBytes, elementBytes);
     std::optional<int64_t> offset =
         getKnownIndexRemainder(add.getOffset(), offsetModulus, depth + 1);
-    if (!offset)
+    if (!offset) {
       return std::nullopt;
+    }
     return normalizeRemainder(*base + *offset * elementBytes, alignmentBytes);
   }
 
@@ -1114,36 +1233,42 @@ bool isKnown32ByteAlignedAddress(Value pointer, Value elementOffset,
   std::optional<int64_t> base =
       getKnownPointerByteRemainder(pointer, alignmentBytes);
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (!base || elementBits == 0 || elementBits % 8 != 0)
+  if (!base || elementBits == 0 || elementBits % 8 != 0) {
     return false;
+  }
 
   int64_t elementBytes = elementBits / 8;
   int64_t offsetModulus =
       alignmentBytes / std::gcd(alignmentBytes, elementBytes);
   std::optional<int64_t> offset =
       getKnownIndexRemainder(elementOffset, offsetModulus);
-  if (!offset)
+  if (!offset) {
     return false;
+  }
   return normalizeRemainder(*base + *offset * elementBytes, alignmentBytes) ==
          0;
 }
 
 FailureOr<int64_t> getStaticMemRefElementCount(Type type) {
   auto memrefType = dyn_cast<MemRefType>(type);
-  if (!memrefType || !memrefType.hasStaticShape())
+  if (!memrefType || !memrefType.hasStaticShape()) {
     return failure();
+  }
 
   int64_t elements = 1;
-  for (int64_t dim : memrefType.getShape())
+  for (int64_t dim : memrefType.getShape()) {
     elements *= dim;
+  }
   return elements;
 }
 
 static Type getMemoryElementType(Type type) {
-  if (auto ptrType = dyn_cast<PtrType>(type))
+  if (auto ptrType = dyn_cast<PtrType>(type)) {
     return ptrType.getElementType();
-  if (auto memrefType = dyn_cast<MemRefType>(type))
+  }
+  if (auto memrefType = dyn_cast<MemRefType>(type)) {
     return memrefType.getElementType();
+  }
   return {};
 }
 
@@ -1235,16 +1360,18 @@ buildContiguousIdentityLaneAddressMap(int64_t constantOffset,
                                       VMIVRegType resultType,
                                       std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> FailureOr<VMIMemoryLaneAddressMap> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(resultType.getElementType());
   FailureOr<int64_t> arity = getVMIPhysicalArity(resultType);
-  if (failed(lanesPerPart) || failed(arity))
+  if (failed(lanesPerPart) || failed(arity)) {
     return fail("requires computable physical read footprint");
+  }
 
   VMIMemoryLaneAddressMap map;
   map.baseElementOffset = constantOffset;
@@ -1255,8 +1382,9 @@ buildContiguousIdentityLaneAddressMap(int64_t constantOffset,
 VMISupportResult requireIdentityMemRefLayout(Type memoryType, StringRef role,
                                              Value memoryValue = {}) {
   auto memrefType = dyn_cast<MemRefType>(memoryType);
-  if (!memrefType || memrefType.getLayout().isIdentity())
+  if (!memrefType || memrefType.getLayout().isIdentity()) {
     return VMISupportResult::success();
+  }
   std::string reason =
       (Twine(role) +
        " memref layout is non-identity; current VMI memory access plan "
@@ -1280,24 +1408,28 @@ computeSafeFullReadProof(Type sourceType, std::optional<int64_t> constantOffset,
     return proof;
   };
 
-  if (!constantOffset)
+  if (!constantOffset) {
     return fail("requires constant index offset");
+  }
 
   FailureOr<int64_t> staticElements = getStaticMemRefElementCount(sourceType);
-  if (failed(staticElements))
+  if (failed(staticElements)) {
     return fail("requires statically shaped memref source");
+  }
   int64_t elements = *staticElements;
   proof.staticElementCount = elements;
 
-  if (*constantOffset < 0)
+  if (*constantOffset < 0) {
     return fail("requires non-negative offset");
+  }
 
   std::string addressMapReason;
   FailureOr<VMIMemoryLaneAddressMap> addressMap =
       buildContiguousIdentityLaneAddressMap(*constantOffset, resultType,
                                             &addressMapReason);
-  if (failed(addressMap))
+  if (failed(addressMap)) {
     return fail(addressMapReason);
+  }
   proof.laneAddressMap = *addressMap;
 
   proof.physicalFootprint = addressMap->physicalLaneFootprint;
@@ -1370,20 +1502,23 @@ FailureOr<int64_t> verifyFullOrSafeReadVRegChunks(Operation *op,
   std::string fullChunkReason;
   FailureOr<int64_t> lanesPerPart =
       checkFullDataPhysicalChunks(type, &fullChunkReason);
-  if (succeeded(lanesPerPart))
+  if (succeeded(lanesPerPart)) {
     return *lanesPerPart;
+  }
 
   VMIMemorySafeReadProof safeReadProof =
       computeSafeFullReadProof(sourceType, getConstantIndexValue(offset), type);
   if (safeReadProof.proven) {
     lanesPerPart = getDataLanesPerPart(type.getElementType());
-    if (succeeded(lanesPerPart))
+    if (succeeded(lanesPerPart)) {
       return *lanesPerPart;
+    }
   }
 
   lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (succeeded(lanesPerPart))
+  if (succeeded(lanesPerPart)) {
     return *lanesPerPart;
+  }
 
   (void)rewriter.notifyMatchFailure(
       op, Twine("memory lowering ") + fullChunkReason +
@@ -1396,26 +1531,31 @@ checkSupportedLoadShape(VMIVRegType type, Value source, Type sourceType,
                         std::optional<int64_t> constantOffset,
                         std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMIMemoryAccessPlan accessPlan =
       buildReadAccessPlan(source, sourceType, type,
                           constantOffset, VMIMemoryValidMaskKind::AllTrue);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
+  }
 
   VMILayoutSupport supports;
-  if (failed(supports.getLoadLayoutFact(type, reason)))
+  if (failed(supports.getLoadLayoutFact(type, reason))) {
     return failure();
+  }
 
-  if (getDenseLaneStrideLoadDistToken(type))
+  if (getDenseLaneStrideLoadDistToken(type)) {
     return success();
+  }
 
-  if (failed(getDataLanesPerPart(type.getElementType())))
+  if (failed(getDataLanesPerPart(type.getElementType()))) {
     return fail("requires element type with known physical lane width");
+  }
   return success();
 }
 
@@ -1423,8 +1563,9 @@ LogicalResult checkSupportedDeinterleaveLoadShape(
     VMIDeinterleaveLoadOp op,
     std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1434,17 +1575,20 @@ LogicalResult checkSupportedDeinterleaveLoadShape(
   if (failed(supports.getDeinterleaveLoadLayoutFactForLayouts(
           lowType, highType, reason)))
     return failure();
-  if (!getX2MemoryDistToken(lowType.getElementType(), "DINTLV"))
+  if (!getX2MemoryDistToken(lowType.getElementType(), "DINTLV")) {
     return fail("requires 8/16/32-bit element type for vldsx2 DINTLV");
+  }
 
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), lowType,
       getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
+  }
 
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   return success();
 }
 
@@ -1455,42 +1599,52 @@ checkSupportedStoreShape(VMIVRegType type, Value destination,
       buildWriteAccessPlan(destination, destinationType, type,
                            VMIMemoryWriteMaskKind::AllTrue);
   if (!accessPlan.layoutSupport.isSupported()) {
-    if (reason)
+    if (reason) {
       *reason = accessPlan.layoutSupport.reason;
+    }
     return failure();
   }
 
-  if (failed(checkSupportedMaskableVReg(type, reason)))
+  if (failed(checkSupportedMaskableVReg(type, reason))) {
     return failure();
+  }
 
   VMILayoutSupport supports;
-  if (failed(supports.getStoreLayoutFact(type, reason)))
+  if (failed(supports.getStoreLayoutFact(type, reason))) {
     return failure();
+  }
 
-  if (getDenseLaneStrideStoreDistToken(type))
+  if (getDenseLaneStrideStoreDistToken(type)) {
     return success();
+  }
 
   std::string fullChunkReason;
-  if (succeeded(checkFullDataPhysicalChunks(type, &fullChunkReason)))
+  if (succeeded(checkFullDataPhysicalChunks(type, &fullChunkReason))) {
     return success();
+  }
 
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires assigned layout");
-  if (failed(getDataLanesPerPart(type.getElementType())))
+  }
+  if (failed(getDataLanesPerPart(type.getElementType()))) {
     return fail("requires known physical lanes per part");
-  if (layout.isContiguous() && layout.getLaneStride() == 1)
+  }
+  if (layout.isContiguous() && layout.getLaneStride() == 1) {
     return success();
+  }
 
   std::string materializationReason;
-  if (succeeded(checkCanMaterializeToContiguous(type, &materializationReason)))
+  if (succeeded(checkCanMaterializeToContiguous(type, &materializationReason))) {
     return success();
+  }
   return fail(Twine("partial/tail store requires contiguous layout or "
                     "deinterleaved layout that can materialize to contiguous; "
                     "value ") +
@@ -1501,8 +1655,9 @@ LogicalResult checkSupportedInterleaveStoreShape(
     VMIInterleaveStoreOp op,
     std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1516,19 +1671,23 @@ LogicalResult checkSupportedInterleaveStoreShape(
   if (lowType.getElementCount() != highType.getElementCount() ||
       lowType.getElementType() != highType.getElementType())
     return fail("requires matching low/high input shape and element type");
-  if (!getX2MemoryDistToken(lowType.getElementType(), "INTLV"))
+  if (!getX2MemoryDistToken(lowType.getElementType(), "INTLV")) {
     return fail("requires 8/16/32-bit element type for vstsx2 INTLV");
+  }
 
   VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(op.getDestination(), op.getDestination().getType(), lowType,
       VMIMemoryWriteMaskKind::AllTrue);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (failed(checkSupportedMaskableVReg(lowType, reason)))
+  }
+  if (failed(checkSupportedMaskableVReg(lowType, reason))) {
     return failure();
+  }
 
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(lowType, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   return success();
 }
 
@@ -1536,34 +1695,41 @@ FailureOr<int64_t> getGroupSizeFromNumGroups(VMIVRegType type,
                                              int64_t numGroups,
                                              std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> FailureOr<int64_t> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
-  if (numGroups <= 0)
+  if (numGroups <= 0) {
     return fail("requires num_groups to be positive");
-  if (type.getElementCount() % numGroups != 0)
+  }
+  if (type.getElementCount() % numGroups != 0) {
     return fail("requires num_groups to evenly divide logical lane count");
+  }
   return type.getElementCount() / numGroups;
 }
 
 LogicalResult checkSupportedGroupChunkShape(VMIVRegType type, int64_t groupSize,
                                             std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return fail("requires assigned contiguous layout");
+  }
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   FailureOr<int64_t> lanesPerPart = getDataLanesPerPart(type.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known physical lanes per part");
+  }
   if (groupSize <= 0 || type.getElementCount() % groupSize != 0)
     return fail("requires derived group size to evenly divide logical lane "
                 "count");
@@ -1578,8 +1744,9 @@ LogicalResult checkDeinterleaved2GroupStoreChunkShape(
     int64_t *groupCount, int64_t *chunksPerGroupPerPart,
     std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1588,19 +1755,23 @@ LogicalResult checkDeinterleaved2GroupStoreChunkShape(
       layout.getLaneStride() != 1)
     return fail("requires deinterleaved=2 value layout");
   std::string fullChunkReason;
-  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason)))
+  if (failed(checkFullDataPhysicalChunks(type, &fullChunkReason))) {
     return fail(Twine("requires full physical chunks; ") + fullChunkReason);
+  }
   FailureOr<int64_t> lanes = getDataLanesPerPart(type.getElementType());
-  if (failed(lanes))
+  if (failed(lanes)) {
     return fail("requires known physical lanes per part");
-  if (!getX2MemoryDistToken(type.getElementType(), "INTLV"))
+  }
+  if (!getX2MemoryDistToken(type.getElementType(), "INTLV")) {
     return fail("requires 8/16/32-bit element type for vstsx2 INTLV");
+  }
   if (groupSize <= 0 || type.getElementCount() % groupSize != 0)
     return fail("requires derived group size to evenly divide logical lane "
                 "count");
   int64_t pairLanes = 2 * *lanes;
-  if (groupSize % pairLanes != 0)
+  if (groupSize % pairLanes != 0) {
     return fail("requires group size to be a multiple of two physical chunks");
+  }
 
   FailureOr<int64_t> part0Chunks = getDataChunksInPart(type, /*part=*/0);
   FailureOr<int64_t> part1Chunks = getDataChunksInPart(type, /*part=*/1);
@@ -1611,51 +1782,59 @@ LogicalResult checkDeinterleaved2GroupStoreChunkShape(
   *lanesPerPart = *lanes;
   *groupCount = type.getElementCount() / groupSize;
   *chunksPerGroupPerPart = groupSize / pairLanes;
-  if (*part0Chunks != *groupCount * *chunksPerGroupPerPart)
+  if (*part0Chunks != *groupCount * *chunksPerGroupPerPart) {
     return fail("requires deinterleaved chunks to align with group rows");
+  }
   return success();
 }
 
 LogicalResult
 checkSupportedGroupLoadShape(VMIGroupLoadOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!resultLayout)
+  if (!resultLayout) {
     return fail("requires assigned result layout");
+  }
   FailureOr<int64_t> groupSize = getGroupSizeFromNumGroups(
       resultType, op.getNumGroupsAttr().getInt(), reason);
-  if (failed(groupSize))
+  if (failed(groupSize)) {
     return failure();
+  }
 
   if (resultLayout.isContiguous()) {
     VMILayoutSupport supports;
-    if (failed(supports.getGroupLoadLayoutFact(op, reason)))
+    if (failed(supports.getGroupLoadLayoutFact(op, reason))) {
       return failure();
+    }
     if (failed(checkSupportedLoadShape(resultType, op.getSource(),
                                        op.getSource().getType(), std::nullopt,
                                        reason)))
       return failure();
     std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
-    if (rowStride && *rowStride == *groupSize)
+    if (rowStride && *rowStride == *groupSize) {
       return success();
+    }
     return checkSupportedGroupChunkShape(resultType, *groupSize, reason);
   }
 
   if (resultLayout.isBlockDeinterleaved() &&
       resultType.getElementType().isF32()) {
     VMILayoutSupport supports;
-    if (failed(supports.getGroupLoadLayoutFact(op, reason)))
+    if (failed(supports.getGroupLoadLayoutFact(op, reason))) {
       return failure();
+    }
     VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
         getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
-    if (!accessPlan.layoutSupport.isSupported())
+    if (!accessPlan.layoutSupport.isSupported()) {
       return fail(accessPlan.layoutSupport.reason);
+    }
     if (!isa<PtrType>(op.getSource().getType()))
       return fail(
           "block_deinterleaved group_load requires !pto.ptr source");
@@ -1682,8 +1861,9 @@ LogicalResult checkSupportedGroupSlotLoadShape(
     VMIGroupSlotLoadOp op,
     std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1691,15 +1871,18 @@ LogicalResult checkSupportedGroupSlotLoadShape(
   VMILayoutSupport supports;
   FailureOr<VMIGroupSlotLayoutFact> fact = supports.getGroupSlotLoadLayoutFact(
       resultType, op.getNumGroupsAttr().getInt(), reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
 
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
       getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!isa<PtrType>(op.getSource().getType()))
+  }
+  if (!isa<PtrType>(op.getSource().getType())) {
     return fail("group_slot_load requires !pto.ptr source");
+  }
 
   if (fact->slots == 8) {
     std::optional<int64_t> sourceGroupStride =
@@ -1712,8 +1895,9 @@ LogicalResult checkSupportedGroupSlotLoadShape(
 
   unsigned elementBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
-  if (elementBits == 0 || 256 % elementBits != 0)
+  if (elementBits == 0 || 256 % elementBits != 0) {
     return fail("slots=1 group_slot_load requires supported element width");
+  }
   int64_t alignedStrideElems = 256 / elementBits;
   std::optional<int64_t> sourceGroupStride =
       getConstantIndexValue(op.getSourceGroupStride());
@@ -1732,21 +1916,25 @@ LogicalResult checkSupportedGroupBroadcastLoadShape(
     VMIGroupBroadcastLoadOp op,
     std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutSupport supports;
-  if (failed(supports.getGroupBroadcastLoadSupport(op, reason)))
+  if (failed(supports.getGroupBroadcastLoadSupport(op, reason))) {
     return failure();
+  }
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(),
       cast<VMIVRegType>(op.getResult().getType()),
       getConstantIndexValue(op.getOffset()), VMIMemoryValidMaskKind::AllTrue);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!isa<PtrType>(op.getSource().getType()))
+  }
+  if (!isa<PtrType>(op.getSource().getType())) {
     return fail("group_broadcast_load requires !pto.ptr source");
+  }
   return success();
 }
 
@@ -1779,8 +1967,9 @@ FailureOr<OneBlockGroupStorePlan> getOneBlockGroupStorePlan(
     const VMIGroupStoreLayoutFact &fact, std::string *reason) {
   auto fail = [&](const Twine &message)
       -> FailureOr<OneBlockGroupStorePlan> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1792,8 +1981,9 @@ FailureOr<OneBlockGroupStorePlan> getOneBlockGroupStorePlan(
       fact.lanesPerPart <= 0 ||
       fact.lanesPerPart % fact.groupSize != 0)
     return fail("one-block group_store requires one 32B group per VCG block");
-  if (!isa<PtrType>(op.getDestination().getType()))
+  if (!isa<PtrType>(op.getDestination().getType())) {
     return fail("one-block group_store requires !pto.ptr destination");
+  }
 
   std::optional<int64_t> rowStride =
       getConstantIndexValue(op.getRowStride());
@@ -1813,8 +2003,9 @@ FailureOr<OneBlockGroupStorePlan> getOneBlockGroupStorePlan(
 LogicalResult
 checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1823,32 +2014,37 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
   std::optional<int64_t> rowStride = getConstantIndexValue(op.getRowStride());
   if (isCompactSmallGroupStore(layout, valueType,
                                op.getNumGroupsAttr().getInt(), rowStride)) {
-    if (!isa<PtrType>(op.getDestination().getType()))
+    if (!isa<PtrType>(op.getDestination().getType())) {
       return fail("compact small group_store requires !pto.ptr destination");
+    }
     VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(
         op.getDestination(), op.getDestination().getType(), valueType,
         VMIMemoryWriteMaskKind::AllTrue);
-    if (!accessPlan.layoutSupport.isSupported())
+    if (!accessPlan.layoutSupport.isSupported()) {
       return fail(accessPlan.layoutSupport.reason);
+    }
     return success();
   }
   if (layout && layout.isGroupSlots()) {
     VMILayoutSupport supports;
     FailureOr<VMIGroupSlotLayoutFact> fact = supports.getGroupStoreLayoutFact(
         valueType, op.getNumGroupsAttr().getInt(), reason);
-    if (failed(fact))
+    if (failed(fact)) {
       return failure();
+    }
 
     VMIMemoryAccessPlan accessPlan = buildWriteAccessPlan(op.getDestination(), op.getDestination().getType(),
         valueType, VMIMemoryWriteMaskKind::AllTrue);
-    if (!accessPlan.layoutSupport.isSupported())
+    if (!accessPlan.layoutSupport.isSupported()) {
       return fail(accessPlan.layoutSupport.reason);
+    }
 
     if (fact->slots == 1) {
       unsigned elementBits =
           pto::getPTOStorageElemBitWidth(valueType.getElementType());
-      if (elementBits == 0 || 256 % elementBits != 0)
+      if (elementBits == 0 || 256 % elementBits != 0) {
         return fail("slots=1 group_store requires supported element width");
+      }
       std::optional<int64_t> rowStride =
           getConstantIndexValue(op.getRowStride());
       if (rowStride && *rowStride <= 0)
@@ -1869,15 +2065,17 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
   VMILayoutSupport supports;
   FailureOr<VMIGroupStoreLayoutFact> fact =
       supports.getGroupStoreLayoutFact(op, valueType, reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
   if (failed(checkSupportedStoreShape(valueType,
                                       op.getDestination(),
                                       op.getDestination().getType(), reason)))
     return failure();
   if (fact->blockClass == VMIGroupBlockClass::OneBlock) {
-    if (failed(getOneBlockGroupStorePlan(op, valueType, *fact, reason)))
+    if (failed(getOneBlockGroupStorePlan(op, valueType, *fact, reason))) {
       return failure();
+    }
     return success();
   }
   if (succeeded(
@@ -1895,8 +2093,9 @@ checkSupportedGroupStoreShape(VMIGroupStoreOp op, std::string *reason) {
 LogicalResult
 checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1909,20 +2108,24 @@ checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
       getConstantIndexValue(op.getOffset()),
       VMIMemoryValidMaskKind::ExplicitMask);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!resultLayout || !passthruLayout || !maskLayout)
+  }
+  if (!resultLayout || !passthruLayout || !maskLayout) {
     return fail("requires assigned result, passthru, and mask layouts");
+  }
   if (!resultLayout.isContiguous() || !passthruLayout.isContiguous() ||
       !maskLayout.isContiguous())
     return fail("requires contiguous result, passthru, and mask layouts");
 
   std::string fullChunkReason;
-  if (succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
+  if (succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason))) {
     return success();
+  }
 
-  if (accessPlan.safeReadProof.proven)
+  if (accessPlan.safeReadProof.proven) {
     return success();
+  }
   requireUnavailableReadFallback(accessPlan);
   return fail(Twine("partial/tail masked_load requires statically safe "
                     "full-read footprint; value ") +
@@ -1934,8 +2137,9 @@ checkSupportedMaskedLoadShape(VMIMaskedLoadOp op, std::string *reason) {
 LogicalResult
 checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -1962,8 +2166,9 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
   unsigned resultBits =
       pto::getPTOStorageElemBitWidth(resultType.getElementType());
   auto indexElementType = dyn_cast<IntegerType>(indicesType.getElementType());
-  if (!indexElementType || indexElementType.isSigned())
+  if (!indexElementType || indexElementType.isSigned()) {
     return fail("requires signless or unsigned integer indices");
+  }
   bool isU16Gather = resultBits == 16 && indexElementType.isUnsigned() &&
                      indexElementType.getWidth() == 16 &&
                      maskType.getGranularity() == "b16";
@@ -1999,8 +2204,9 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
     if (failed(checkFullDataPhysicalChunks(passthruType, &passthruReason)))
       return fail(Twine("passthru requires full physical chunks; ") +
                   passthruReason);
-    if (failed(checkFullVMIPhysicalChunks(maskType, &maskReason)))
+    if (failed(checkFullVMIPhysicalChunks(maskType, &maskReason))) {
       return fail(Twine("mask requires full physical chunks; ") + maskReason);
+    }
   } else if (*resultArity != 1) {
     return fail("ui16 gather currently supports one physical chunk");
   }
@@ -2011,8 +2217,9 @@ checkSupportedGatherShape(VMIGatherOp op, std::string *reason) {
 LogicalResult
 checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2022,8 +2229,9 @@ checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   VMILayoutAttr valueLayout = valueType.getLayoutAttr();
   VMILayoutAttr indicesLayout = indicesType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !indicesLayout || !maskLayout)
+  if (!valueLayout || !indicesLayout || !maskLayout) {
     return fail("requires assigned value, indices, and mask layouts");
+  }
   if (!valueLayout.isContiguous() || !indicesLayout.isContiguous() ||
       !maskLayout.isContiguous())
     return fail("requires contiguous value, indices, and mask layouts");
@@ -2035,8 +2243,9 @@ checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   unsigned valueBits =
       pto::getPTOStorageElemBitWidth(valueType.getElementType());
   auto indexElementType = dyn_cast<IntegerType>(indicesType.getElementType());
-  if (!indexElementType || indexElementType.isSigned())
+  if (!indexElementType || indexElementType.isSigned()) {
     return fail("requires signless or unsigned integer indices");
+  }
   bool isB8Scatter = valueBits == 8 &&
                      indexElementType.getWidth() == 16 &&
                      maskType.getGranularity() == "b16";
@@ -2054,8 +2263,9 @@ checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   FailureOr<int64_t> valueArity = getVMIPhysicalArity(valueType);
   FailureOr<int64_t> indicesArity = getVMIPhysicalArity(indicesType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  if (failed(valueArity) || failed(indicesArity) || failed(maskArity))
+  if (failed(valueArity) || failed(indicesArity) || failed(maskArity)) {
     return fail("requires computable physical arity");
+  }
   if (*valueArity != *indicesArity || *valueArity != *maskArity)
     return fail("requires value, indices, and mask to have the same physical "
                 "arity");
@@ -2063,13 +2273,15 @@ checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
   std::string valueReason;
   std::string indicesReason;
   std::string maskReason;
-  if (failed(checkFullDataPhysicalChunks(valueType, &valueReason)))
+  if (failed(checkFullDataPhysicalChunks(valueType, &valueReason))) {
     return fail(Twine("value requires full physical chunks; ") + valueReason);
+  }
   if (failed(checkFullDataPhysicalChunks(indicesType, &indicesReason)))
     return fail(Twine("indices require full physical chunks; ") +
                 indicesReason);
-  if (failed(checkFullVMIPhysicalChunks(maskType, &maskReason)))
+  if (failed(checkFullVMIPhysicalChunks(maskType, &maskReason))) {
     return fail(Twine("mask requires full physical chunks; ") + maskReason);
+  }
 
   return success();
 }
@@ -2077,8 +2289,9 @@ checkSupportedScatterShape(VMIScatterOp op, std::string *reason) {
 LogicalResult
 checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2086,10 +2299,12 @@ checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   VMILayoutAttr valueLayout = valueType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !maskLayout)
+  if (!valueLayout || !maskLayout) {
     return fail("requires assigned value and mask layouts");
-  if (!valueLayout.isContiguous() || !maskLayout.isContiguous())
+  }
+  if (!valueLayout.isContiguous() || !maskLayout.isContiguous()) {
     return fail("requires contiguous value and mask layouts");
+  }
 
   if (!isa<PtrType>(op.getDestination().getType()))
     return fail("requires !pto.ptr destination because pto.vsstb is "
@@ -2101,18 +2316,21 @@ checkSupportedStrideStoreShape(VMIStrideStoreOp op, std::string *reason) {
 
   FailureOr<int64_t> valueArity = getVMIPhysicalArity(valueType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  if (failed(valueArity) || failed(maskArity))
+  if (failed(valueArity) || failed(maskArity)) {
     return fail("requires computable physical arity");
-  if (*valueArity != 1 || *maskArity != 1)
+  }
+  if (*valueArity != 1 || *maskArity != 1) {
     return fail("currently supports one physical value/mask chunk");
+  }
   return success();
 }
 
 LogicalResult
 checkSupportedStrideLoadShape(VMIStrideLoadOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2120,20 +2338,25 @@ checkSupportedStrideLoadShape(VMIStrideLoadOp op, std::string *reason) {
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!resultLayout || !maskLayout)
+  if (!resultLayout || !maskLayout) {
     return fail("requires assigned result and mask layouts");
-  if (!resultLayout.isContiguous() || !maskLayout.isContiguous())
+  }
+  if (!resultLayout.isContiguous() || !maskLayout.isContiguous()) {
     return fail("requires contiguous result and mask layouts");
+  }
 
-  if (!isa<PtrType>(op.getSource().getType()))
+  if (!isa<PtrType>(op.getSource().getType())) {
     return fail("requires !pto.ptr source because pto.vsldb is pointer-only");
+  }
 
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  if (failed(resultArity) || failed(maskArity))
+  if (failed(resultArity) || failed(maskArity)) {
     return fail("requires computable physical arity");
-  if (*resultArity != 1 || *maskArity != 1)
+  }
+  if (*resultArity != 1 || *maskArity != 1) {
     return fail("currently supports one physical result/mask chunk");
+  }
   return success();
 }
 
@@ -2155,19 +2378,22 @@ bool isStaticAllActiveMask(Value mask, int64_t expectedLanes,
                            std::string *reason = nullptr) {
   mask = stripMaskMaterialization(mask);
   auto fail = [&](const Twine &message) {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return false;
   };
 
   if (auto createMask = mask.getDefiningOp<VMICreateMaskOp>()) {
     auto activeConstant =
         createMask.getActiveLanes().getDefiningOp<arith::ConstantOp>();
-    if (!activeConstant)
+    if (!activeConstant) {
       return fail("create_mask active_lanes is dynamic");
+    }
     auto activeAttr = dyn_cast<IntegerAttr>(activeConstant.getValue());
-    if (!activeAttr)
+    if (!activeAttr) {
       return fail("create_mask active_lanes is not an integer constant");
+    }
     return activeAttr.getInt() >= expectedLanes
                ? true
                : fail("create_mask active_lanes is smaller than the logical "
@@ -2176,15 +2402,17 @@ bool isStaticAllActiveMask(Value mask, int64_t expectedLanes,
 
   if (auto constantMask = mask.getDefiningOp<VMIConstantMaskOp>()) {
     auto denseAttr = dyn_cast<DenseIntElementsAttr>(constantMask.getValue());
-    if (!denseAttr)
+    if (!denseAttr) {
       return fail("constant_mask is not a dense integer mask");
+    }
     if (denseAttr.getNumElements() != expectedLanes)
       return fail("constant_mask element count does not match the logical "
                   "lane count");
     auto values = denseAttr.getValues<bool>();
     for (bool value : values)
-      if (!value)
+      if (!value) {
         return fail("constant_mask contains an inactive lane");
+      }
     return true;
   }
 
@@ -2194,8 +2422,9 @@ bool isStaticAllActiveMask(Value mask, int64_t expectedLanes,
 LogicalResult
 checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2208,10 +2437,12 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   VMIMemoryAccessPlan accessPlan = buildReadAccessPlan(op.getSource(), op.getSource().getType(), resultType,
       getConstantIndexValue(op.getOffset()),
       VMIMemoryValidMaskKind::ExplicitMask);
-  if (!accessPlan.layoutSupport.isSupported())
+  if (!accessPlan.layoutSupport.isSupported()) {
     return fail(accessPlan.layoutSupport.reason);
-  if (!resultLayout || !passthruLayout || !maskLayout)
+  }
+  if (!resultLayout || !passthruLayout || !maskLayout) {
     return fail("requires assigned result, passthru, and mask layouts");
+  }
   if (!resultLayout.isContiguous() || !passthruLayout.isContiguous() ||
       !maskLayout.isContiguous())
     return fail("requires contiguous result, passthru, and mask layouts");
@@ -2225,8 +2456,9 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
       succeeded(checkFullDataPhysicalChunks(resultType, &fullChunkReason)))
     return success();
 
-  if (staticAllActive && accessPlan.safeReadProof.proven)
+  if (staticAllActive && accessPlan.safeReadProof.proven) {
     return success();
+  }
 
   std::string allActivePathReason;
   if (!staticAllActive) {
@@ -2250,14 +2482,16 @@ checkSupportedExpandLoadShape(VMIExpandLoadOp op, std::string *reason) {
   if (pto::getPTOStorageElemBitWidth(resultType.getElementType()) != 32)
     return fail("runtime-mask path currently requires 32-bit result element "
                 "type so prefix indices and gather result lane counts match");
-  if (maskType.getGranularity() != "b32")
+  if (maskType.getGranularity() != "b32") {
     return fail("runtime-mask path requires b32 mask granularity");
+  }
 
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
   FailureOr<int64_t> passthruArity = getVMIPhysicalArity(passthruType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  if (failed(resultArity) || failed(passthruArity) || failed(maskArity))
+  if (failed(resultArity) || failed(passthruArity) || failed(maskArity)) {
     return fail("runtime-mask path requires computable physical arity");
+  }
   if (*resultArity != 1 || *passthruArity != 1 || *maskArity != 1)
     return fail("runtime-mask path currently supports only one physical "
                 "chunk because prefix indices must not reset across chunks");
@@ -2285,8 +2519,9 @@ checkSupportedMaskedStoreShape(VMIVRegType valueType, VMIMaskType maskType,
       buildWriteAccessPlan(destination, destinationType,
                            valueType, VMIMemoryWriteMaskKind::ExplicitMask);
   if (!accessPlan.layoutSupport.isSupported()) {
-    if (reason)
+    if (reason) {
       *reason = accessPlan.layoutSupport.reason;
+    }
     return failure();
   }
 
@@ -2297,20 +2532,23 @@ checkSupportedMaskedStoreShape(VMIVRegType valueType, VMIMaskType maskType,
     return success();
 
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr valueLayout = valueType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !maskLayout)
+  if (!valueLayout || !maskLayout) {
     return fail("requires assigned value and mask layouts");
+  }
 
   FailureOr<int64_t> valueArity = getVMIPhysicalArity(valueType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  if (failed(valueArity) || failed(maskArity) || *valueArity != *maskArity)
+  if (failed(valueArity) || failed(maskArity) || *valueArity != *maskArity) {
     return fail("requires matching value/mask physical arity");
+  }
 
   if (valueLayout.hasDenseLaneStride()) {
     VMILayoutSupport supports;
@@ -2343,8 +2581,9 @@ FailureOr<int64_t> getContiguousActiveDataLanes(VMIVRegType vmiType,
                                                 int64_t chunk) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   int64_t remaining = vmiType.getElementCount() - chunk * *lanesPerPart;
   return std::clamp<int64_t>(remaining, 0, *lanesPerPart);
@@ -2354,16 +2593,19 @@ FailureOr<int64_t> getActiveDataLanesInPhysicalChunk(VMIVRegType vmiType,
                                                      int64_t chunk) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   int64_t active = 0;
   for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
     FailureOr<bool> padding = isPaddingLane(vmiType, /*part=*/0, chunk, lane);
-    if (failed(padding))
+    if (failed(padding)) {
       return failure();
-    if (!*padding)
+    }
+    if (!*padding) {
       ++active;
+    }
   }
   return active;
 }
@@ -2373,23 +2615,28 @@ FailureOr<Value> createContiguousStoreMask(Location loc, VMIVRegType vmiType,
                                            PatternRewriter &rewriter) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   FailureOr<int64_t> activeLanes = getContiguousActiveDataLanes(vmiType, chunk);
-  if (failed(activeLanes))
+  if (failed(activeLanes)) {
     return failure();
-  if (*activeLanes == *lanesPerPart)
+  }
+  if (*activeLanes == *lanesPerPart) {
     return createAllTrueMaskForVReg(loc, vregType, rewriter);
+  }
 
   FailureOr<MaskType> maskType =
       getMaskTypeForVReg(vregType, rewriter.getContext());
-  if (failed(maskType))
+  if (failed(maskType)) {
     return failure();
+  }
   FailureOr<std::pair<Value, Value>> maskAndRemaining = createRuntimePrefixMask(
       loc, *maskType, createI32Constant(loc, *activeLanes, rewriter), rewriter);
-  if (failed(maskAndRemaining))
+  if (failed(maskAndRemaining)) {
     return failure();
+  }
   return maskAndRemaining->first;
 }
 
@@ -2399,23 +2646,28 @@ FailureOr<Value> createMaskedStorePredicate(Location loc, VMIVRegType vmiType,
                                             PatternRewriter &rewriter) {
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(vmiType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return failure();
+  }
 
   FailureOr<int64_t> activeLanes = getContiguousActiveDataLanes(vmiType, chunk);
-  if (failed(activeLanes))
+  if (failed(activeLanes)) {
     return failure();
-  if (*activeLanes == *lanesPerPart)
+  }
+  if (*activeLanes == *lanesPerPart) {
     return userMask;
+  }
 
   auto maskType = dyn_cast<MaskType>(userMask.getType());
-  if (!maskType)
+  if (!maskType) {
     return failure();
+  }
   FailureOr<Value> tailMask =
       createContiguousStoreMask(loc, vmiType, chunk, vregType, rewriter);
   FailureOr<Value> allTrue = createAllTrueMask(loc, maskType, rewriter);
-  if (failed(tailMask) || failed(allTrue))
+  if (failed(tailMask) || failed(allTrue)) {
     return failure();
+  }
   return rewriter.create<PandOp>(loc, maskType, userMask, *tailMask, *allTrue)
       .getResult();
 }
@@ -2424,13 +2676,15 @@ FailureOr<Value> createDenseLaneStrideStorePredicate(
     Location loc, VMIVRegType vmiType, int64_t chunk, Value userMask,
     StringRef targetGranularity, PatternRewriter &rewriter) {
   auto sourceMaskType = dyn_cast<MaskType>(userMask.getType());
-  if (!sourceMaskType)
+  if (!sourceMaskType) {
     return failure();
+  }
   auto targetMaskType = MaskType::get(rewriter.getContext(), targetGranularity);
   Value compactMask = userMask;
   VMILayoutAttr layout = vmiType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return failure();
+  }
 
   auto lower = rewriter.getStringAttr("LOWER");
   StringRef sourceGranularity = sourceMaskType.getGranularity();
@@ -2456,16 +2710,19 @@ FailureOr<Value> createDenseLaneStrideStorePredicate(
   FailureOr<int64_t> activeLanes =
       getActiveDataLanesInPhysicalChunk(vmiType, chunk);
   FailureOr<int64_t> maskLanes = getMaskLanesPerPart(targetGranularity);
-  if (failed(activeLanes) || failed(maskLanes))
+  if (failed(activeLanes) || failed(maskLanes)) {
     return failure();
-  if (*activeLanes == *maskLanes)
+  }
+  if (*activeLanes == *maskLanes) {
     return compactMask;
+  }
 
   FailureOr<Value> tailMask = createPrefixMaskForActiveLanes(
       loc, targetMaskType, *activeLanes, rewriter);
   FailureOr<Value> allTrue = createAllTrueMask(loc, targetMaskType, rewriter);
-  if (failed(tailMask) || failed(allTrue))
+  if (failed(tailMask) || failed(allTrue)) {
     return failure();
+  }
   return rewriter
       .create<PandOp>(loc, targetMaskType, compactMask, *tailMask, *allTrue)
       .getResult();
@@ -2474,8 +2731,9 @@ FailureOr<Value> createDenseLaneStrideStorePredicate(
 FailureOr<SmallVector<int64_t>>
 computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<SmallVector<int64_t>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2483,23 +2741,27 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(sourceType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known lanes per physical part");
+  }
 
   ArrayRef<int64_t> indices = op.getIndices();
-  if (indices.empty())
+  if (indices.empty()) {
     return fail("requires non-empty indices");
+  }
 
   FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
-  if (failed(resultFactor))
+  if (failed(resultFactor)) {
     return fail("requires assigned result layout");
+  }
 
   SmallVector<int64_t> sourceFlatIndices;
   for (int64_t resultPart = 0; resultPart < *resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
         getDataChunksInPart(resultType, resultPart);
-    if (failed(resultChunks))
+    if (failed(resultChunks)) {
       return fail("requires known result physical chunks");
+    }
 
     for (int64_t resultChunk = 0; resultChunk < *resultChunks; ++resultChunk) {
       std::optional<int64_t> sourcePart;
@@ -2507,10 +2769,12 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding =
             isPaddingLane(resultType, resultPart, resultChunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to classify result padding lanes");
-        if (*padding)
+        }
+        if (*padding) {
           continue;
+        }
 
         FailureOr<int64_t> resultLogicalLane =
             mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
@@ -2520,10 +2784,12 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
 
         FailureOr<VMIPhysicalLane> sourcePhysical =
             mapLogicalLaneToPhysical(sourceType, indices[*resultLogicalLane]);
-        if (failed(sourcePhysical))
+        if (failed(sourcePhysical)) {
           return fail("failed to map source lane");
-        if (sourcePhysical->lane != lane)
+        }
+        if (sourcePhysical->lane != lane) {
           return fail("requires same-lane physical chunks");
+        }
 
         if (!sourcePart) {
           sourcePart = sourcePhysical->part;
@@ -2535,12 +2801,14 @@ computeShuffleForwardingSourceParts(VMIShuffleOp op, std::string *reason) {
           return fail("requires one source chunk per result chunk");
       }
 
-      if (!sourcePart || !sourceChunk)
+      if (!sourcePart || !sourceChunk) {
         return fail("requires at least one logical lane per result chunk");
+      }
       FailureOr<int64_t> sourceFlatIndex =
           getDataFlatPartIndex(sourceType, *sourcePart, *sourceChunk);
-      if (failed(sourceFlatIndex))
+      if (failed(sourceFlatIndex)) {
         return fail("source part range is out of bounds");
+      }
       sourceFlatIndices.push_back(*sourceFlatIndex);
     }
   }
@@ -2557,26 +2825,30 @@ struct ShuffleVselrPlan {
 FailureOr<int64_t> computeShuffleLane0SplatSourcePart(VMIShuffleOp op,
                                                       std::string *reason) {
   auto fail = [&](const Twine &message) -> FailureOr<int64_t> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   ArrayRef<int64_t> indices = op.getIndices();
-  if (indices.empty())
+  if (indices.empty()) {
     return fail("requires non-empty indices");
+  }
   if (!llvm::all_of(indices, [](int64_t index) { return index == 0; }))
     return fail("requires every result lane to select source lane 0");
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   FailureOr<VMIPhysicalLane> sourceLane =
       mapLogicalLaneToPhysical(sourceType, 0);
-  if (failed(sourceLane))
+  if (failed(sourceLane)) {
     return fail("failed to map source lane 0");
+  }
   FailureOr<int64_t> sourceFlatIndex =
       getDataFlatPartIndex(sourceType, sourceLane->part, sourceLane->chunk);
-  if (failed(sourceFlatIndex))
+  if (failed(sourceFlatIndex)) {
     return fail("source lane 0 part range is out of bounds");
+  }
   return *sourceFlatIndex;
 }
 
@@ -2584,8 +2856,9 @@ FailureOr<SmallVector<ShuffleVselrPlan>>
 computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
   auto fail =
       [&](const Twine &message) -> FailureOr<SmallVector<ShuffleVselrPlan>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -2593,23 +2866,27 @@ computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(sourceType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known lanes per physical part");
+  }
 
   ArrayRef<int64_t> indices = op.getIndices();
-  if (indices.empty())
+  if (indices.empty()) {
     return fail("requires non-empty indices");
+  }
 
   FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
-  if (failed(resultFactor))
+  if (failed(resultFactor)) {
     return fail("requires assigned result layout");
+  }
 
   SmallVector<ShuffleVselrPlan> plans;
   for (int64_t resultPart = 0; resultPart < *resultFactor; ++resultPart) {
     FailureOr<int64_t> resultChunks =
         getDataChunksInPart(resultType, resultPart);
-    if (failed(resultChunks))
+    if (failed(resultChunks)) {
       return fail("requires known result physical chunks");
+    }
 
     for (int64_t resultChunk = 0; resultChunk < *resultChunks; ++resultChunk) {
       std::optional<int64_t> sourcePart;
@@ -2619,8 +2896,9 @@ computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding =
             isPaddingLane(resultType, resultPart, resultChunk, lane);
-        if (failed(padding) || *padding)
+        if (failed(padding) || *padding) {
           return fail("requires full physical result chunks");
+        }
 
         FailureOr<int64_t> resultLogicalLane =
             mapPhysicalLaneToLogical(resultType, resultPart, resultChunk, lane);
@@ -2630,8 +2908,9 @@ computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
 
         FailureOr<VMIPhysicalLane> sourcePhysical =
             mapLogicalLaneToPhysical(sourceType, indices[*resultLogicalLane]);
-        if (failed(sourcePhysical))
+        if (failed(sourcePhysical)) {
           return fail("failed to map source lane");
+        }
 
         if (!sourcePart) {
           sourcePart = sourcePhysical->part;
@@ -2648,22 +2927,25 @@ computeShuffleVselrPlans(VMIShuffleOp op, std::string *reason) {
         int64_t descExpected = *baseLane - lane;
         bool asc = sourcePhysical->lane == ascExpected;
         bool desc = sourcePhysical->lane == descExpected;
-        if (!asc && !desc)
+        if (!asc && !desc) {
           return fail("requires ASC or DESC affine source lane indices");
+        }
 
         bool laneDescending = desc && !asc;
         if (!descending) {
           descending = laneDescending;
           continue;
         }
-        if (*descending != laneDescending)
+        if (*descending != laneDescending) {
           return fail("requires one index order per result chunk");
+        }
       }
 
       FailureOr<int64_t> sourceFlatIndex =
           getDataFlatPartIndex(sourceType, *sourcePart, *sourceChunk);
-      if (failed(sourceFlatIndex))
+      if (failed(sourceFlatIndex)) {
         return fail("source part range is out of bounds");
+      }
       plans.push_back(ShuffleVselrPlan{*sourceFlatIndex, *baseLane,
                                        descending.value_or(false)});
     }
@@ -2680,14 +2962,16 @@ FailureOr<SmallVector<ConstantMaskChunkMaterialization>>
 computeConstantMaskMaterialization(VMIConstantMaskOp op, std::string *reason) {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<ConstantMaskChunkMaterialization>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   auto denseAttr = dyn_cast<DenseIntElementsAttr>(op.getValue());
-  if (!denseAttr)
+  if (!denseAttr) {
     return fail("only dense integer mask constants are supported");
+  }
 
   auto resultVMIType = cast<VMIMaskType>(op.getResult().getType());
   VMILayoutAttr layout = resultVMIType.getLayoutAttr();
@@ -2701,8 +2985,9 @@ computeConstantMaskMaterialization(VMIConstantMaskOp op, std::string *reason) {
       failed(physicalGranularity)
           ? FailureOr<int64_t>(failure())
           : getMaskLanesPerPart(*physicalGranularity);
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known physical mask lanes per part");
+  }
 
   auto boolValues = denseAttr.getValues<bool>();
   int64_t factor = layout.isDenseSplit() ? layout.getFactor() : 1;
@@ -2715,8 +3000,9 @@ computeConstantMaskMaterialization(VMIConstantMaskOp op, std::string *reason) {
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding =
             isPaddingLane(resultVMIType, part, chunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to map physical padding lane");
+        }
         if (*padding) {
           materialization.activeLanes.push_back(0);
           continue;
@@ -2725,12 +3011,14 @@ computeConstantMaskMaterialization(VMIConstantMaskOp op, std::string *reason) {
 
         FailureOr<int64_t> logicalLane =
             mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
-        if (failed(logicalLane))
+        if (failed(logicalLane)) {
           return fail("failed to map physical lane");
+        }
         materialization.activeLanes.push_back(boolValues[*logicalLane] ? 1 : 0);
       }
-      if (!anyLane)
+      if (!anyLane) {
         break;
+      }
       materializations.push_back(std::move(materialization));
     }
   }
@@ -2744,18 +3032,21 @@ computeGroupMaskMaterializationForType(VMICreateGroupMaskOp op,
                                        std::string *reason) {
   auto fail = [&](const Twine &message)
       -> FailureOr<SmallVector<ConstantMaskChunkMaterialization>> {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   auto activeConstant =
       op.getActiveElemsPerGroup().getDefiningOp<arith::ConstantOp>();
-  if (!activeConstant)
+  if (!activeConstant) {
     return fail("requires constant active_elems_per_group");
+  }
   auto activeAttr = dyn_cast<IntegerAttr>(activeConstant.getValue());
-  if (!activeAttr)
+  if (!activeAttr) {
     return fail("active_elems_per_group must be an integer constant");
+  }
 
   VMILayoutAttr layout = resultVMIType.getLayoutAttr();
   if (!layout ||
@@ -2768,8 +3059,9 @@ computeGroupMaskMaterializationForType(VMICreateGroupMaskOp op,
       failed(physicalGranularity)
           ? FailureOr<int64_t>(failure())
           : getMaskLanesPerPart(*physicalGranularity);
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return fail("requires known physical mask lanes per part");
+  }
 
   int64_t numGroups = op.getNumGroupsAttr().getInt();
   int64_t groupSize = op.getGroupSizeAttr().getInt();
@@ -2778,10 +3070,12 @@ computeGroupMaskMaterializationForType(VMICreateGroupMaskOp op,
     return fail("requires result lane count to match num_groups * group_size");
 
   int64_t activeElems = activeAttr.getInt();
-  if (activeElems < 0)
+  if (activeElems < 0) {
     activeElems = 0;
-  if (activeElems > groupSize)
+  }
+  if (activeElems > groupSize) {
     activeElems = groupSize;
+  }
 
   int64_t factor = layout.isDenseSplit() ? layout.getFactor() : 1;
   SmallVector<ConstantMaskChunkMaterialization> materializations;
@@ -2793,8 +3087,9 @@ computeGroupMaskMaterializationForType(VMICreateGroupMaskOp op,
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding =
             isPaddingLane(resultVMIType, part, chunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to map physical padding lane");
+        }
         if (*padding) {
           materialization.activeLanes.push_back(0);
           continue;
@@ -2803,14 +3098,16 @@ computeGroupMaskMaterializationForType(VMICreateGroupMaskOp op,
 
         FailureOr<int64_t> logicalLane =
             mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
-        if (failed(logicalLane))
+        if (failed(logicalLane)) {
           return fail("failed to map physical lane");
+        }
         int64_t laneInGroup = *logicalLane % groupSize;
         materialization.activeLanes.push_back(laneInGroup < activeElems ? 1
                                                                         : 0);
       }
-      if (!anyLane)
+      if (!anyLane) {
         break;
+      }
       materializations.push_back(std::move(materialization));
     }
   }
@@ -2831,16 +3128,19 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
 FailureOr<Value> createPowerOfTwoRemainder(Location loc, Value value,
                                            int64_t modulus, Value allMask,
                                            PatternRewriter &rewriter) {
-  if (modulus <= 0)
+  if (modulus <= 0) {
     return failure();
+  }
 
   auto vectorType = dyn_cast<VRegType>(value.getType());
-  if (!vectorType)
+  if (!vectorType) {
     return failure();
+  }
 
   std::optional<int64_t> shift = getPowerOfTwoLog2(modulus);
-  if (!shift)
+  if (!shift) {
     return failure();
+  }
   if (*shift == 0) {
     Value zero = createI32Constant(loc, 0, rewriter);
     return rewriter.create<VdupOp>(loc, vectorType, zero, allMask,
@@ -2869,10 +3169,12 @@ FailureOr<SmallVector<Value>> materializeDynamicGroupMaskForType(
   };
 
   VMILayoutAttr layout = resultVMIType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("dynamic create_group_mask requires assigned layout");
-  if (layout.getLaneStride() != 1)
+  }
+  if (layout.getLaneStride() != 1) {
     return fail("dynamic create_group_mask requires lane_stride=1 layout");
+  }
   if (resultVMIType.getGranularity() != "b32")
     return fail("dynamic create_group_mask currently requires b32 "
                 "granularity");
@@ -2894,8 +3196,9 @@ FailureOr<SmallVector<Value>> materializeDynamicGroupMaskForType(
   if (failed(lanesPerPart) || failed(arity) || *arity < 1)
     return fail("dynamic create_group_mask requires computable physical "
                 "mask chunks");
-  if (static_cast<int64_t>(resultTypes.size()) != *arity)
+  if (static_cast<int64_t>(resultTypes.size()) != *arity) {
     return fail("dynamic create_group_mask physical result count mismatch");
+  }
 
   std::optional<int64_t> groupShift = getPowerOfTwoLog2(groupSize);
   if (!groupShift)
@@ -2926,12 +3229,14 @@ FailureOr<SmallVector<Value>> materializeDynamicGroupMaskForType(
     for (int64_t chunk = 0; chunk < chunksPerPart; ++chunk) {
       Type resultType = resultTypes[part * chunksPerPart + chunk];
       auto maskType = dyn_cast<MaskType>(resultType);
-      if (!maskType || !maskType.isB32())
+      if (!maskType || !maskType.isB32()) {
         return fail("dynamic create_group_mask result must be b32 mask");
+      }
 
       FailureOr<Value> allMask = createAllTrueMask(loc, maskType, rewriter);
-      if (failed(allMask))
+      if (failed(allMask)) {
         return fail("failed to create dynamic create_group_mask all mask");
+      }
 
       Value chunkBase = createI32Constant(loc, chunk * *lanesPerPart, rewriter);
       Value indexInPart =
@@ -2993,8 +3298,9 @@ FailureOr<SmallVector<Value>> materializeDynamicGroupMaskForType(
 
       FailureOr<Value> laneInGroup = createPowerOfTwoRemainder(
           loc, logicalLane, groupSize, *allMask, rewriter);
-      if (failed(laneInGroup))
+      if (failed(laneInGroup)) {
         return fail("failed to compute dynamic create_group_mask lane index");
+      }
 
       Value predicate =
           rewriter
@@ -3008,8 +3314,9 @@ FailureOr<SmallVector<Value>> materializeDynamicGroupMaskForType(
       for (int64_t lane = 0; lane < *lanesPerPart; ++lane) {
         FailureOr<bool> padding =
             isPaddingLane(resultVMIType, part, chunk, lane);
-        if (failed(padding))
+        if (failed(padding)) {
           return fail("failed to classify dynamic create_group_mask padding");
+        }
         validLanes.push_back(*padding ? 0 : 1);
         hasPadding |= *padding;
       }
@@ -3037,8 +3344,9 @@ std::optional<int64_t> getPrefixActiveLaneCount(ArrayRef<int8_t> activeLanes) {
   int64_t activeCount = 0;
   for (int8_t active : activeLanes) {
     if (active) {
-      if (seenInactive)
+      if (seenInactive) {
         return std::nullopt;
+      }
       ++activeCount;
       continue;
     }
@@ -3053,13 +3361,15 @@ FailureOr<Value> materializePrefixMask(Location loc, MaskType maskType,
                                        PatternRewriter &rewriter) {
   std::optional<std::string> pattern =
       getPrefixPattern(activeLanes, lanesPerPart);
-  if (pattern)
+  if (pattern) {
     return createPatternMask(loc, maskType, *pattern, rewriter);
+  }
 
   FailureOr<std::pair<Value, Value>> maskAndRemaining = createRuntimePrefixMask(
       loc, maskType, createI32Constant(loc, activeLanes, rewriter), rewriter);
-  if (failed(maskAndRemaining))
+  if (failed(maskAndRemaining)) {
     return failure();
+  }
   return maskAndRemaining->first;
 }
 
@@ -3078,33 +3388,39 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
                                  rewriter);
 
   FailureOr<Value> allTrue = createAllTrueMask(loc, maskType, rewriter);
-  if (failed(allTrue))
+  if (failed(allTrue)) {
     return failure();
+  }
 
   Value result;
   int64_t lane = 0;
   while (lane < *lanesPerPart) {
-    while (lane < *lanesPerPart && !activeLanes[lane])
+    while (lane < *lanesPerPart && !activeLanes[lane]) {
       ++lane;
-    if (lane >= *lanesPerPart)
+    }
+    if (lane >= *lanesPerPart) {
       break;
+    }
 
     int64_t runBegin = lane;
-    while (lane < *lanesPerPart && activeLanes[lane])
+    while (lane < *lanesPerPart && activeLanes[lane]) {
       ++lane;
+    }
     int64_t runEnd = lane;
 
     FailureOr<Value> prefixEnd =
         materializePrefixMask(loc, maskType, runEnd, *lanesPerPart, rewriter);
-    if (failed(prefixEnd))
+    if (failed(prefixEnd)) {
       return failure();
+    }
 
     Value runMask = *prefixEnd;
     if (runBegin != 0) {
       FailureOr<Value> prefixBegin = materializePrefixMask(
           loc, maskType, runBegin, *lanesPerPart, rewriter);
-      if (failed(prefixBegin))
+      if (failed(prefixBegin)) {
         return failure();
+      }
       Value notPrefixBegin =
           rewriter.create<PnotOp>(loc, maskType, *prefixBegin, *allTrue)
               .getResult();
@@ -3122,8 +3438,9 @@ FailureOr<Value> materializeConstantMaskChunk(Location loc, MaskType maskType,
                  .getResult();
   }
 
-  if (result)
+  if (result) {
     return result;
+  }
   return materializePrefixMask(loc, maskType, 0, *lanesPerPart, rewriter);
 }
 
@@ -3133,8 +3450,9 @@ FailureOr<Value> createScalarOffsetConstant(Location loc, Type type,
 
 Value createChunkOffset(Location loc, Value baseOffset, int64_t laneOffset,
                         PatternRewriter &rewriter) {
-  if (laneOffset == 0)
+  if (laneOffset == 0) {
     return baseOffset;
+  }
   Value delta = rewriter.create<arith::ConstantIndexOp>(loc, laneOffset);
   return rewriter.create<arith::AddIOp>(loc, baseOffset, delta).getResult();
 }
@@ -3160,13 +3478,16 @@ LogicalResult checkContiguousFullGroupChunks(
   };
 
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return fail("group op requires contiguous VMI layout");
-  if (failed(checkFullDataPhysicalChunks(type, nullptr)))
+  }
+  if (failed(checkFullDataPhysicalChunks(type, nullptr))) {
     return fail("group op requires full physical chunks");
+  }
   FailureOr<int64_t> lanes = getDataLanesPerPart(type.getElementType());
-  if (failed(lanes))
+  if (failed(lanes)) {
     return fail("group op requires known physical lanes per part");
+  }
   if (groupSize <= 0 || type.getElementCount() % groupSize != 0)
     return fail("group op requires derived group size to evenly divide lane "
                 "count");
@@ -3185,8 +3506,9 @@ FailureOr<Value> createZeroVector(Location loc, VRegType type,
   FailureOr<Value> zero =
       createScalarOffsetConstant(loc, type.getElementType(), 0, rewriter);
   FailureOr<Value> mask = createAllTrueMaskForVReg(loc, type, rewriter);
-  if (failed(zero) || failed(mask))
+  if (failed(zero) || failed(mask)) {
     return failure();
+  }
   return rewriter
       .create<VdupOp>(loc, type, *zero, *mask,
                       /*position=*/nullptr)
@@ -3198,11 +3520,13 @@ FailureOr<Value> createLaneRangeMask(Location loc, MaskType maskType,
                                      PatternRewriter &rewriter) {
   FailureOr<int64_t> lanesPerPart =
       getMaskLanesPerPart(maskType.getGranularity());
-  if (failed(lanesPerPart) || begin < 0 || begin > end || end > *lanesPerPart)
+  if (failed(lanesPerPart) || begin < 0 || begin > end || end > *lanesPerPart) {
     return failure();
+  }
   SmallVector<int8_t> active(*lanesPerPart, 0);
-  for (int64_t lane = begin; lane < end; ++lane)
+  for (int64_t lane = begin; lane < end; ++lane) {
     active[lane] = 1;
+  }
   return materializeConstantMaskChunk(loc, maskType, active, rewriter);
 }
 
@@ -3218,16 +3542,19 @@ FailureOr<Value> createGroupSlotIndexVector(Location loc, VRegType indexType,
   FailureOr<MaskType> maskType =
       getMaskTypeForVReg(indexType, rewriter.getContext());
   FailureOr<Value> allMask = createAllTrueMaskForVReg(loc, indexType, rewriter);
-  if (failed(baseScalar) || failed(maskType) || failed(allMask))
+  if (failed(baseScalar) || failed(maskType) || failed(allMask)) {
     return failure();
+  }
   Value result = rewriter
                      .create<VdupOp>(loc, indexType, *baseScalar, *allMask,
                                      /*position=*/nullptr)
                      .getResult();
-  if (groupSize >= lanesPerPart)
+  if (groupSize >= lanesPerPart) {
     return result;
-  if (lanesPerPart % groupSize != 0)
+  }
+  if (lanesPerPart % groupSize != 0) {
     return failure();
+  }
 
   int64_t groupsPerChunk = lanesPerPart / groupSize;
   for (int64_t localGroup = 1; localGroup < groupsPerChunk; ++localGroup) {
@@ -3237,8 +3564,9 @@ FailureOr<Value> createGroupSlotIndexVector(Location loc, VRegType indexType,
     FailureOr<Value> laneMask =
         createLaneRangeMask(loc, *maskType, localGroup * groupSize,
                             (localGroup + 1) * groupSize, rewriter);
-    if (failed(groupScalar) || failed(laneMask))
+    if (failed(groupScalar) || failed(laneMask)) {
       return failure();
+    }
     Value splat = rewriter
                       .create<VdupOp>(loc, indexType, *groupScalar, *allMask,
                                       /*position=*/nullptr)
@@ -3252,96 +3580,115 @@ FailureOr<Value> createGroupSlotIndexVector(Location loc, VRegType indexType,
 std::optional<std::string> getX2MemoryDistToken(Type elementType,
                                                 StringRef prefix) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return std::nullopt;
+  }
   return (Twine(prefix) + "_B" + Twine(elementBits)).str();
 }
 
 std::optional<std::string> getDenseLaneStrideLoadDistToken(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
   if (layout.getLaneStride() == 2 &&
       (elementBits == 8 || elementBits == 16 || elementBits == 32))
     return (Twine("UNPK_B") + Twine(elementBits)).str();
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  if (layout.getLaneStride() == 4 && elementBits == 8) {
     return std::string("UNPK4");
+  }
   return std::nullopt;
 }
 
 std::optional<std::string>
 getLaneStrideStoreDistToken(VMILayoutAttr layout, Type elementType) {
-  if (!layout || !layout.hasLaneStride())
+  if (!layout || !layout.hasLaneStride()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (layout.getLaneStride() == 2 && elementBits == 8)
+  if (layout.getLaneStride() == 2 && elementBits == 8) {
     return std::string("PK_B16");
-  if (layout.getLaneStride() == 2 && elementBits == 16)
+  }
+  if (layout.getLaneStride() == 2 && elementBits == 16) {
     return std::string("PK_B32");
-  if (layout.getLaneStride() == 2 && elementBits == 32)
+  }
+  if (layout.getLaneStride() == 2 && elementBits == 32) {
     return std::string("PK_B64");
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  }
+  if (layout.getLaneStride() == 4 && elementBits == 8) {
     return std::string("PK4_B32");
+  }
   return std::nullopt;
 }
 
 std::optional<std::string> getDenseLaneStrideStoreDistToken(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   return getLaneStrideStoreDistToken(layout, type.getElementType());
 }
 
 std::optional<StringRef>
 getLaneStrideStoreMaskGranularity(VMILayoutAttr layout, Type elementType) {
-  if (!layout || !layout.hasLaneStride())
+  if (!layout || !layout.hasLaneStride()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (layout.getLaneStride() == 2 && elementBits == 8)
+  if (layout.getLaneStride() == 2 && elementBits == 8) {
     return StringRef("b16");
+  }
   if (layout.getLaneStride() == 2 &&
       (elementBits == 16 || elementBits == 32))
     return StringRef("b32");
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  if (layout.getLaneStride() == 4 && elementBits == 8) {
     return StringRef("b32");
+  }
   return std::nullopt;
 }
 
 std::optional<StringRef>
 getDenseLaneStrideStoreMaskGranularity(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   return getLaneStrideStoreMaskGranularity(layout, type.getElementType());
 }
 
 std::optional<StringRef>
 getDenseLaneStrideMaskedStoreMaskGranularity(VMIVRegType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout || !layout.isContiguous())
+  if (!layout || !layout.isContiguous()) {
     return std::nullopt;
+  }
   unsigned elementBits = pto::getPTOStorageElemBitWidth(type.getElementType());
-  if (layout.getLaneStride() == 2 && elementBits == 8)
+  if (layout.getLaneStride() == 2 && elementBits == 8) {
     return StringRef("b16");
-  if (layout.getLaneStride() == 2 && elementBits == 16)
+  }
+  if (layout.getLaneStride() == 2 && elementBits == 16) {
     return StringRef("b32");
-  if (layout.getLaneStride() == 4 && elementBits == 8)
+  }
+  if (layout.getLaneStride() == 4 && elementBits == 8) {
     return StringRef("b32");
+  }
   return std::nullopt;
 }
 
 std::optional<std::string> getPointStoreDistToken(Type elementType) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return std::nullopt;
+  }
   return (Twine("1PT_B") + Twine(elementBits)).str();
 }
 
 std::optional<std::string> getScalarBroadcastLoadDistToken(Type elementType) {
   unsigned elementBits = pto::getPTOStorageElemBitWidth(elementType);
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return std::nullopt;
+  }
   return (Twine("BRC_B") + Twine(elementBits)).str();
 }
 
@@ -3354,24 +3701,31 @@ std::optional<VPTOCmpMode> getVPTOCmpFMode(StringRef predicate) {
   if (predicate == "eq" || predicate == "ne" || predicate == "lt" ||
       predicate == "le" || predicate == "gt" || predicate == "ge")
     return VPTOCmpMode{predicate, std::nullopt};
-  if (predicate == "oeq")
+  if (predicate == "oeq") {
     return VPTOCmpMode{StringRef("eq"), std::nullopt};
-  if (predicate == "one")
+  }
+  if (predicate == "one") {
     return VPTOCmpMode{StringRef("ne"), std::nullopt};
-  if (predicate == "olt")
+  }
+  if (predicate == "olt") {
     return VPTOCmpMode{StringRef("lt"), std::nullopt};
-  if (predicate == "ole")
+  }
+  if (predicate == "ole") {
     return VPTOCmpMode{StringRef("le"), std::nullopt};
-  if (predicate == "ogt")
+  }
+  if (predicate == "ogt") {
     return VPTOCmpMode{StringRef("gt"), std::nullopt};
-  if (predicate == "oge")
+  }
+  if (predicate == "oge") {
     return VPTOCmpMode{StringRef("ge"), std::nullopt};
+  }
   return std::nullopt;
 }
 
 std::optional<VPTOCmpMode> getVPTOCmpIMode(StringRef predicate) {
-  if (predicate == "eq" || predicate == "ne")
+  if (predicate == "eq" || predicate == "ne") {
     return VPTOCmpMode{predicate, std::nullopt};
+  }
   if (predicate == "ult")
     return VPTOCmpMode{
         StringRef("lt"), IntegerType::SignednessSemantics::Unsigned};
@@ -3401,10 +3755,12 @@ std::optional<VPTOCmpMode> getVPTOCmpIMode(StringRef predicate) {
 
 template <typename SourceOp>
 std::optional<VPTOCmpMode> getVPTOCmpMode(StringRef predicate) {
-  if constexpr (std::is_same_v<SourceOp, VMICmpIOp>)
+  if constexpr (std::is_same_v<SourceOp, VMICmpIOp>) {
     return getVPTOCmpIMode(predicate);
-  else
+  }
+  else {
     return getVPTOCmpFMode(predicate);
+  }
 }
 
 template <typename SourceOp>
@@ -3412,15 +3768,17 @@ StringRef getSupportedComparePredicateMessage() {
   if constexpr (std::is_same_v<SourceOp, VMICmpIOp>)
     return "eq/ne, unsigned integer forms ult/ule/ugt/uge, and signed "
            "integer forms slt/sle/sgt/sge";
-  else
+  else {
     return "eq/ne/lt/le/gt/ge and ordered FP forms oeq/one/olt/ole/ogt/oge";
+  }
 }
 
 template <typename SourceOp>
 LogicalResult checkSupportedComparePredicate(Operation *op,
                                              StringRef predicate) {
-  if (getVPTOCmpMode<SourceOp>(predicate))
+  if (getVPTOCmpMode<SourceOp>(predicate)) {
     return success();
+  }
   return op->emitError()
          << kVMIDiagUnsupportedPrefix << "compare predicate " << predicate
          << " cannot be lowered to pto.vcmp; supported predicates are "
@@ -3477,8 +3835,9 @@ LogicalResult verifyIdentityPartForwarding(Operation *op,
 
 FailureOr<VRegType> getUnsignedCarrierVRegType(MLIRContext *ctx,
                                                unsigned elementBits) {
-  if (elementBits != 8 && elementBits != 16 && elementBits != 32)
+  if (elementBits != 8 && elementBits != 16 && elementBits != 32) {
     return failure();
+  }
   auto elementType = IntegerType::get(
       ctx, elementBits, IntegerType::SignednessSemantics::Unsigned);
   return VRegType::get(ctx, 2048 / elementBits, elementType);
@@ -3488,8 +3847,9 @@ FailureOr<VRegType>
 getSignednessCarrierVRegType(VRegType inputType,
                              IntegerType::SignednessSemantics signedness) {
   auto inputElementType = dyn_cast<IntegerType>(inputType.getElementType());
-  if (!inputElementType)
+  if (!inputElementType) {
     return failure();
+  }
   if ((signedness == IntegerType::SignednessSemantics::Signed &&
        !inputElementType.isUnsigned()) ||
       (signedness == IntegerType::SignednessSemantics::Unsigned &&
@@ -3503,22 +3863,26 @@ getSignednessCarrierVRegType(VRegType inputType,
 
 FailureOr<Value> bitcastVReg(Location loc, Value value, Type resultType,
                              PatternRewriter &rewriter) {
-  if (value.getType() == resultType)
+  if (value.getType() == resultType) {
     return value;
+  }
   auto inputType = dyn_cast<VRegType>(value.getType());
   auto outputType = dyn_cast<VRegType>(resultType);
-  if (!inputType || !outputType)
+  if (!inputType || !outputType) {
     return failure();
+  }
   return rewriter.create<VbitcastOp>(loc, outputType, value).getResult();
 }
 
 FailureOr<VRegType> getVcaddResultType(VRegType inputType) {
   auto inputIntegerType = dyn_cast<IntegerType>(inputType.getElementType());
-  if (!inputIntegerType || inputIntegerType.getWidth() == 32)
+  if (!inputIntegerType || inputIntegerType.getWidth() == 32) {
     return inputType;
+  }
   unsigned inputWidth = inputIntegerType.getWidth();
-  if (inputWidth != 8 && inputWidth != 16)
+  if (inputWidth != 8 && inputWidth != 16) {
     return failure();
+  }
   auto resultElementType = IntegerType::get(
       inputType.getContext(), inputWidth * 2,
       inputIntegerType.getSignedness());
@@ -3531,8 +3895,9 @@ FailureOr<Value> unpackToNextCarrier(Location loc, Value source,
                                      PatternRewriter &rewriter) {
   FailureOr<VRegType> resultType =
       getUnsignedCarrierVRegType(rewriter.getContext(), sourceBits * 2);
-  if (failed(resultType))
+  if (failed(resultType)) {
     return failure();
+  }
   Value part = rewriter.create<arith::ConstantIndexOp>(loc, partIndex);
   return rewriter.create<VzunpackOp>(loc, *resultType, source, part)
       .getResult();
@@ -3544,8 +3909,9 @@ FailureOr<Value> packToPreviousCarrier(Location loc, Value source,
                                        PatternRewriter &rewriter) {
   FailureOr<VRegType> resultType =
       getUnsignedCarrierVRegType(rewriter.getContext(), resultBits);
-  if (failed(resultType))
+  if (failed(resultType)) {
     return failure();
+  }
   return rewriter
       .create<VpackOp>(loc, *resultType, source,
                        rewriter.getStringAttr(part))
@@ -3576,38 +3942,44 @@ FailureOr<SmallVector<Value>> materializeContiguousToLaneStride(
   MLIRContext *ctx = rewriter.getContext();
   FailureOr<VRegType> inputCarrier =
       getUnsignedCarrierVRegType(ctx, elementBits);
-  if (failed(inputCarrier))
+  if (failed(inputCarrier)) {
     return failure();
+  }
 
   SmallVector<Value> results;
   results.reserve(resultTypes.size());
   for (auto [resultIndex, resultType] : llvm::enumerate(resultTypes)) {
     int64_t sourceIndex = resultIndex / laneStride;
-    if (sourceIndex >= static_cast<int64_t>(sourceParts.size()))
+    if (sourceIndex >= static_cast<int64_t>(sourceParts.size())) {
       return failure();
+    }
     Value source = sourceParts[sourceIndex];
     FailureOr<Value> current =
         bitcastVReg(op->getLoc(), source, *inputCarrier, rewriter);
-    if (failed(current))
+    if (failed(current)) {
       return failure();
+    }
     int64_t part = resultIndex % laneStride;
     FailureOr<Value> unpacked =
         unpackToNextCarrier(op->getLoc(), *current, elementBits,
                             laneStride == 4 ? part / 2 : part, rewriter);
-    if (failed(unpacked))
+    if (failed(unpacked)) {
       return failure();
+    }
     current = *unpacked;
     if (laneStride == 4) {
       unpacked = unpackToNextCarrier(op->getLoc(), *current, elementBits * 2,
                                      part % 2, rewriter);
-      if (failed(unpacked))
+      if (failed(unpacked)) {
         return failure();
+      }
       current = *unpacked;
     }
     FailureOr<Value> result =
         bitcastVReg(op->getLoc(), *current, resultType, rewriter);
-    if (failed(result))
+    if (failed(result)) {
       return failure();
+    }
     results.push_back(*result);
   }
   return results;
@@ -3638,8 +4010,9 @@ FailureOr<SmallVector<Value>> materializeLaneStrideToContiguous(
       static_cast<unsigned>(elementBits * static_cast<unsigned>(laneStride));
   FailureOr<VRegType> sourceCarrier =
       getUnsignedCarrierVRegType(rewriter.getContext(), carrierBits);
-  if (failed(sourceCarrier))
+  if (failed(sourceCarrier)) {
     return failure();
+  }
 
   SmallVector<Value> results;
   results.reserve(resultTypes.size());
@@ -3652,8 +4025,9 @@ FailureOr<SmallVector<Value>> materializeLaneStrideToContiguous(
     for (Value source : sourceParts.slice(sourceBegin, sourceEnd - sourceBegin)) {
       FailureOr<Value> carrier =
           bitcastVReg(op->getLoc(), source, *sourceCarrier, rewriter);
-      if (failed(carrier))
+      if (failed(carrier)) {
         return failure();
+      }
       currentLevel.push_back(*carrier);
     }
 
@@ -3665,8 +4039,9 @@ FailureOr<SmallVector<Value>> materializeLaneStrideToContiguous(
         FailureOr<Value> low = packToPreviousCarrier(
             op->getLoc(), currentLevel[index], currentBits / 2, "LOWER",
             rewriter);
-        if (failed(low))
+        if (failed(low)) {
           return failure();
+        }
         Value merged = *low;
         if (index + 1 < currentLevel.size()) {
           FailureOr<Value> high = packToPreviousCarrier(
@@ -3674,8 +4049,9 @@ FailureOr<SmallVector<Value>> materializeLaneStrideToContiguous(
               "HIGHER", rewriter);
           FailureOr<Value> mask = createAllTrueMaskForVReg(
               op->getLoc(), cast<VRegType>((*low).getType()), rewriter);
-          if (failed(high) || failed(mask))
+          if (failed(high) || failed(mask)) {
             return failure();
+          }
           merged = rewriter
                        .create<VorOp>(op->getLoc(), (*low).getType(), *low,
                                       *high, *mask)
@@ -3686,12 +4062,14 @@ FailureOr<SmallVector<Value>> materializeLaneStrideToContiguous(
       currentLevel = std::move(nextLevel);
       currentBits /= 2;
     }
-    if (currentLevel.size() != 1)
+    if (currentLevel.size() != 1) {
       return failure();
+    }
     FailureOr<Value> result =
         bitcastVReg(op->getLoc(), currentLevel.front(), resultType, rewriter);
-    if (failed(result))
+    if (failed(result)) {
       return failure();
+    }
     results.push_back(*result);
   }
   return results;
@@ -3726,19 +4104,22 @@ FailureOr<SmallVector<Value>> materializeGroupSlotLaneStride(
     unsigned carrierBits = elementBits * sourceStride;
     FailureOr<VRegType> carrierType =
         getUnsignedCarrierVRegType(rewriter.getContext(), carrierBits);
-    if (failed(carrierType))
+    if (failed(carrierType)) {
       return fail("failed to derive group-slot source carrier type");
+    }
     FailureOr<Value> current =
         bitcastVReg(op->getLoc(), source, *carrierType, rewriter);
-    if (failed(current))
+    if (failed(current)) {
       return fail("failed to bitcast group-slot source carrier");
+    }
 
     int64_t currentStride = sourceStride;
     while (currentStride < resultStride) {
       FailureOr<Value> unpacked = unpackToNextCarrier(
           op->getLoc(), *current, carrierBits, /*partIndex=*/0, rewriter);
-      if (failed(unpacked))
+      if (failed(unpacked)) {
         return fail("failed to unpack group-slot lane_stride carrier");
+      }
       current = *unpacked;
       currentStride *= 2;
       carrierBits *= 2;
@@ -3746,8 +4127,9 @@ FailureOr<SmallVector<Value>> materializeGroupSlotLaneStride(
     while (currentStride > resultStride) {
       FailureOr<Value> packed = packToPreviousCarrier(
           op->getLoc(), *current, carrierBits / 2, "LOWER", rewriter);
-      if (failed(packed))
+      if (failed(packed)) {
         return fail("failed to pack group-slot lane_stride carrier");
+      }
       current = *packed;
       currentStride /= 2;
       carrierBits /= 2;
@@ -3755,8 +4137,9 @@ FailureOr<SmallVector<Value>> materializeGroupSlotLaneStride(
 
     FailureOr<Value> result =
         bitcastVReg(op->getLoc(), *current, resultType, rewriter);
-    if (failed(result))
+    if (failed(result)) {
       return fail("failed to bitcast group-slot result carrier");
+    }
     results.push_back(*result);
   }
   return results;
@@ -3830,8 +4213,9 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
               typesMatch = false;
               break;
             }
-          if (typesMatch)
+          if (typesMatch) {
             return SmallVector<Value>(inputs.begin(), inputs.end());
+          }
         }
       }
     }
@@ -3884,8 +4268,9 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
         auto materialize = rewriter.create<VintlvOp>(
             op->getLoc(), lowType, highType, lhs, rhs);
         results.push_back(materialize.getLow());
-        if (results.size() < resultTypes.size())
+        if (results.size() < resultTypes.size()) {
           results.push_back(materialize.getHigh());
+        }
       }
     } else {
       if (sourceParts.empty() || resultTypes.empty() ||
@@ -3949,8 +4334,9 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
       counts.reserve(factor);
       size_t base = totalParts / static_cast<size_t>(factor);
       size_t remainder = totalParts % static_cast<size_t>(factor);
-      for (int64_t part = 0; part < factor; ++part)
+      for (int64_t part = 0; part < factor; ++part) {
         counts.push_back(base + (static_cast<size_t>(part) < remainder ? 1 : 0));
+      }
       return counts;
     };
     auto getPartOffsets = [](ArrayRef<size_t> counts) -> SmallVector<size_t> {
@@ -3982,8 +4368,9 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
       SmallVector<size_t> sourceCounts = getPartCounts(sourceParts.size(), 4);
       SmallVector<size_t> sourceOffsets = getPartOffsets(sourceCounts);
       auto getSourcePart = [&](size_t part, size_t group) -> Value {
-        if (group < sourceCounts[part])
+        if (group < sourceCounts[part]) {
           return sourceParts[sourceOffsets[part] + group];
+        }
         return sourceParts.back();
       };
 
@@ -4021,8 +4408,9 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
         Value groupResults[] = {low.getLow(), low.getHigh(), high.getLow(),
                                 high.getHigh()};
         for (Value result : groupResults) {
-          if (results.size() >= resultTypes.size())
+          if (results.size() >= resultTypes.size()) {
             break;
+          }
           results.push_back(result);
         }
       }
@@ -4081,14 +4469,18 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
             op->getLoc(), chunkType, chunkType, low.getLow(), high.getLow());
         auto odd = rewriter.create<VdintlvOp>(
             op->getLoc(), chunkType, chunkType, low.getHigh(), high.getHigh());
-        if (i < resultCounts[0])
+        if (i < resultCounts[0]) {
           part0.push_back(even.getLow());
-        if (i < resultCounts[1])
+        }
+        if (i < resultCounts[1]) {
           part1.push_back(odd.getLow());
-        if (i < resultCounts[2])
+        }
+        if (i < resultCounts[2]) {
           part2.push_back(even.getHigh());
-        if (i < resultCounts[3])
+        }
+        if (i < resultCounts[3]) {
           part3.push_back(odd.getHigh());
+        }
       }
       results.reserve(resultTypes.size());
       results.append(part0);
@@ -4122,8 +4514,9 @@ FailureOr<SmallVector<Value>> materializeDataLayoutConversion(
     FailureOr<SmallVector<Value>> dense = materializeDataLayoutConversion(
         op, sourceParts, resultTypes, sourceLayout, contiguous,
         sourceVMIElementType, rewriter);
-    if (failed(dense))
+    if (failed(dense)) {
       return failure();
+    }
     return materializeDataLayoutConversion(op, *dense, resultTypes, contiguous,
                                            resultLayout, sourceVMIElementType,
                                            rewriter);
@@ -4157,8 +4550,9 @@ FailureOr<SmallVector<Value>> materializeEnsureLayoutConversion(
   }
 
   SmallVector<Type> resultTypes;
-  if (failed(typeConverter.convertType(resultType, resultTypes)))
+  if (failed(typeConverter.convertType(resultType, resultTypes))) {
     return failure();
+  }
   return materializeDataLayoutConversion(op, sourceParts, resultTypes,
                                          sourceLayout, resultLayout,
                                          sourceType.getElementType(), rewriter);
@@ -4168,8 +4562,9 @@ FailureOr<std::pair<Value, Value>>
 createPredicateDintlv(Location loc, Type lowType, Type highType, Value lhs,
                       Value rhs, PatternRewriter &rewriter) {
   auto maskType = dyn_cast<MaskType>(lowType);
-  if (!maskType || highType != lowType)
+  if (!maskType || highType != lowType) {
     return failure();
+  }
   if (maskType.isB8()) {
     auto op = rewriter.create<PdintlvB8Op>(loc, lowType, highType, lhs, rhs);
     return std::make_pair(op.getLow(), op.getHigh());
@@ -4189,8 +4584,9 @@ FailureOr<std::pair<Value, Value>>
 createPredicateIntlv(Location loc, Type lowType, Type highType, Value lhs,
                      Value rhs, PatternRewriter &rewriter) {
   auto maskType = dyn_cast<MaskType>(lowType);
-  if (!maskType || highType != lowType)
+  if (!maskType || highType != lowType) {
     return failure();
+  }
   if (maskType.isB8()) {
     auto op = rewriter.create<PintlvB8Op>(loc, lowType, highType, lhs, rhs);
     return std::make_pair(op.getLow(), op.getHigh());
@@ -4431,8 +4827,9 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
       if (!allTrue) {
         FailureOr<Value> mask = createAllTrueMask(
             op->getLoc(), cast<MaskType>(lhs.getType()), rewriter);
-        if (failed(mask))
+        if (failed(mask)) {
           return failure();
+        }
         allTrue = *mask;
       }
       return rewriter.create<PorOp>(op->getLoc(), lhs.getType(), lhs, rhs,
@@ -4443,8 +4840,9 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
                         MaskType maskType) -> FailureOr<Value> {
       Value packed =
           rewriter.create<PpackOp>(op->getLoc(), maskType, lowSource, lower);
-      if (!highSource)
+      if (!highSource) {
         return packed;
+      }
       Value higherPacked = rewriter.create<PpackOp>(
           op->getLoc(), maskType, *highSource, higher);
       return mergeMasks(packed, higherPacked);
@@ -4456,32 +4854,38 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
         return rewriter.notifyMatchFailure(
             op, "dense mask lane_stride pack requires mask result type");
       size_t base = resultIndex * static_cast<size_t>(laneStride);
-      if (base >= sourceParts.size())
+      if (base >= sourceParts.size()) {
         break;
+      }
 
       std::optional<Value> source1;
-      if (base + 1 < sourceParts.size())
+      if (base + 1 < sourceParts.size()) {
         source1 = sourceParts[base + 1];
+      }
       FailureOr<Value> lowHalf = packPair(sourceParts[base], source1, maskType);
-      if (failed(lowHalf))
+      if (failed(lowHalf)) {
         return failure();
+      }
       Value current = *lowHalf;
       if (laneStride == 4) {
         current =
             rewriter.create<PpackOp>(op->getLoc(), maskType, current, lower);
         if (base + 2 < sourceParts.size()) {
           std::optional<Value> source3;
-          if (base + 3 < sourceParts.size())
+          if (base + 3 < sourceParts.size()) {
             source3 = sourceParts[base + 3];
+          }
           FailureOr<Value> highHalf =
               packPair(sourceParts[base + 2], source3, maskType);
-          if (failed(highHalf))
+          if (failed(highHalf)) {
             return failure();
+          }
           Value higherPacked = rewriter.create<PpackOp>(
               op->getLoc(), maskType, *highHalf, higher);
           FailureOr<Value> merged = mergeMasks(current, higherPacked);
-          if (failed(merged))
+          if (failed(merged)) {
             return failure();
+          }
           current = *merged;
         }
       }
@@ -4500,12 +4904,15 @@ FailureOr<SmallVector<Value>> materializeMaskLayoutConversion(
 }
 
 int getMaskGranularityRank(StringRef granularity) {
-  if (granularity == "b8")
+  if (granularity == "b8") {
     return 0;
-  if (granularity == "b16")
+  }
+  if (granularity == "b16") {
     return 1;
-  if (granularity == "b32")
+  }
+  if (granularity == "b32") {
     return 2;
+  }
   return -1;
 }
 
@@ -4526,15 +4933,18 @@ LogicalResult checkSupportedMaskGranularityMaterialization(
     VMIMaskType sourceType,
     VMIMaskType resultType, std::string *reason) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return fail("requires source and result mask lane counts to match");
-  if (sourceType.getLayoutAttr() != resultType.getLayoutAttr())
+  }
+  if (sourceType.getLayoutAttr() != resultType.getLayoutAttr()) {
     return fail("requires source and result mask layouts to match");
+  }
 
   if (!VMIMaskType::isConcreteGranularity(sourceType.getGranularity()) ||
       !VMIMaskType::isConcreteGranularity(resultType.getGranularity()))
@@ -4543,10 +4953,12 @@ LogicalResult checkSupportedMaskGranularityMaterialization(
 
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(sourceArity) || failed(resultArity))
+  if (failed(sourceArity) || failed(resultArity)) {
     return fail("requires computable source/result physical arity");
-  if (*sourceArity < 1 || *resultArity < 1)
+  }
+  if (*sourceArity < 1 || *resultArity < 1) {
     return fail("requires non-empty source/result physical arity");
+  }
 
   return success();
 }
@@ -4561,8 +4973,9 @@ FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
 
   int sourceRank = getMaskGranularityRank(sourceType.getGranularity());
   int resultRank = getMaskGranularityRank(resultType.getGranularity());
-  if (std::abs(sourceRank - resultRank) != 1)
+  if (std::abs(sourceRank - resultRank) != 1) {
     return fail("mask granularity conversion must be adjacent");
+  }
 
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
   FailureOr<int64_t> factor = getVMITypeLayoutFactor(sourceType);
@@ -4579,8 +4992,9 @@ FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
   for (int64_t part = 0; part < *factor; ++part) {
     FailureOr<int64_t> sourceChunks = getVMITypeChunksInPart(sourceType, part);
     FailureOr<int64_t> resultChunks = getVMITypeChunksInPart(resultType, part);
-    if (failed(sourceChunks) || failed(resultChunks))
+    if (failed(sourceChunks) || failed(resultChunks)) {
       return fail("requires computable source/result chunks per layout part");
+    }
 
     if (resultRank > sourceRank) {
       int64_t produced = 0;
@@ -4592,8 +5006,9 @@ FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
                                                  source, partAttr("LOWER"))
                               .getResult());
         ++produced;
-        if (produced >= *resultChunks)
+        if (produced >= *resultChunks) {
           break;
+        }
         results.push_back(rewriter
                               .create<PunpackOp>(op->getLoc(), resultMaskType,
                                                  source, partAttr("HIGHER"))
@@ -4624,8 +5039,9 @@ FailureOr<SmallVector<Value>> materializeAdjacentMaskGranularityConversion(
           if (!allTrue) {
             FailureOr<Value> mask =
                 createAllTrueMask(op->getLoc(), resultMaskType, rewriter);
-            if (failed(mask))
+            if (failed(mask)) {
               return fail("failed to create all-true mask for ppack merge");
+            }
             allTrue = *mask;
           }
           packed = rewriter
@@ -4681,8 +5097,9 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityConversion(
     FailureOr<SmallVector<Value>> nextParts =
         materializeAdjacentMaskGranularityConversion(op, currentType, nextType,
                                                      currentParts, rewriter);
-    if (failed(nextParts))
+    if (failed(nextParts)) {
       return failure();
+    }
     currentType = nextType;
     currentParts = std::move(*nextParts);
   }
@@ -4694,28 +5111,34 @@ FailureOr<SmallVector<Type>> getConvertedMaskPartTypes(VMIMaskType type) {
   FailureOr<int64_t> arity = getVMIPhysicalArity(type);
   FailureOr<StringRef> physicalGranularity =
       getVMIMaskPhysicalGranularity(type);
-  if (failed(arity) || failed(physicalGranularity) || *arity < 0)
+  if (failed(arity) || failed(physicalGranularity) || *arity < 0) {
     return failure();
+  }
   SmallVector<Type> types;
   types.reserve(*arity);
   Type partType = MaskType::get(type.getContext(), *physicalGranularity);
-  for (int64_t i = 0; i < *arity; ++i)
+  for (int64_t i = 0; i < *arity; ++i) {
     types.push_back(partType);
+  }
   return types;
 }
 
 static FailureOr<VMILayoutAttr>
 getVMIMaskPhysicalCarrierLayout(VMIMaskType type) {
   VMILayoutAttr layout = type.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return failure();
+  }
   MLIRContext *ctx = type.getContext();
-  if (layout.isContiguous())
+  if (layout.isContiguous()) {
     return VMILayoutAttr::getContiguous(ctx);
-  if (layout.isDeinterleaved())
+  }
+  if (layout.isDeinterleaved()) {
     return VMILayoutAttr::getDeinterleaved(ctx, layout.getFactor());
-  if (layout.isBlockDeinterleaved())
+  }
+  if (layout.isBlockDeinterleaved()) {
     return VMILayoutAttr::getBlockDeinterleaved(ctx, layout.getFactor());
+  }
   if (layout.isGroupSlots())
     return VMILayoutAttr::getGroupSlots(ctx, layout.getNumGroups(),
                                         layout.getSlots());
@@ -4728,8 +5151,9 @@ getVMIMaskPhysicalCarrierType(VMIMaskType type) {
       getVMIMaskPhysicalGranularity(type);
   FailureOr<VMILayoutAttr> physicalLayout =
       getVMIMaskPhysicalCarrierLayout(type);
-  if (failed(physicalGranularity) || failed(physicalLayout))
+  if (failed(physicalGranularity) || failed(physicalLayout)) {
     return failure();
+  }
   return VMIMaskType::get(type.getContext(), type.getElementCount(),
                           *physicalGranularity, *physicalLayout);
 }
@@ -4743,8 +5167,9 @@ static bool isElementDeinterleavedLayout(VMILayoutAttr layout,
 FailureOr<Value> createAllFalseMaskLike(Location loc, Value value,
                                         PatternRewriter &rewriter) {
   auto maskType = dyn_cast<MaskType>(value.getType());
-  if (!maskType)
+  if (!maskType) {
     return failure();
+  }
   return createPrefixMask(loc, maskType, "PAT_ALLF", rewriter);
 }
 
@@ -4773,11 +5198,13 @@ FailureOr<SmallVector<Value>> materializeStagingDeintToContiguousMaskLayout(
       FailureOr<std::pair<Value, Value>> materialized = createPredicateIntlv(
           op->getLoc(), nextType(0), nextType(1), sourceParts[i],
           sourceParts[groups + i], rewriter);
-      if (failed(materialized))
+      if (failed(materialized)) {
         return fail("unsupported predicate intlv staging mask type");
+      }
       results.push_back(materialized->first);
-      if (results.size() < resultTypes.size())
+      if (results.size() < resultTypes.size()) {
         results.push_back(materialized->second);
+      }
       continue;
     }
 
@@ -4791,26 +5218,32 @@ FailureOr<SmallVector<Value>> materializeStagingDeintToContiguousMaskLayout(
     FailureOr<std::pair<Value, Value>> odd =
         createPredicateIntlv(op->getLoc(), nextType(0), nextType(1), p1, p3,
                              rewriter);
-    if (failed(even) || failed(odd))
+    if (failed(even) || failed(odd)) {
       return fail("unsupported predicate intlv staging mask type");
+    }
     FailureOr<std::pair<Value, Value>> low = createPredicateIntlv(
         op->getLoc(), nextType(0), nextType(1), even->first, odd->first,
         rewriter);
     FailureOr<std::pair<Value, Value>> high = createPredicateIntlv(
         op->getLoc(), nextType(2), nextType(3), even->second, odd->second,
         rewriter);
-    if (failed(low) || failed(high))
+    if (failed(low) || failed(high)) {
       return fail("unsupported predicate intlv staging mask type");
+    }
     results.push_back(low->first);
-    if (results.size() < resultTypes.size())
+    if (results.size() < resultTypes.size()) {
       results.push_back(low->second);
-    if (results.size() < resultTypes.size())
+    }
+    if (results.size() < resultTypes.size()) {
       results.push_back(high->first);
-    if (results.size() < resultTypes.size())
+    }
+    if (results.size() < resultTypes.size()) {
       results.push_back(high->second);
+    }
   }
-  if (results.size() != resultTypes.size())
+  if (results.size() != resultTypes.size()) {
     return fail("staging deinterleaved mask layout result arity mismatch");
+  }
   return results;
 }
 
@@ -4826,17 +5259,20 @@ FailureOr<SmallVector<Value>> materializeStagingContiguousToDeintMaskLayout(
     return fail("staging contiguous mask layout requires grouped result parts");
 
   int64_t groups = resultTypes.size() / factor;
-  if (sourceParts.size() > static_cast<size_t>(groups * factor))
+  if (sourceParts.size() > static_cast<size_t>(groups * factor)) {
     return fail("staging contiguous mask layout has too many source parts");
+  }
 
   SmallVector<SmallVector<Value, 4>, 4> parts(factor);
-  for (int64_t part = 0; part < factor; ++part)
+  for (int64_t part = 0; part < factor; ++part) {
     parts[part].reserve(groups);
+  }
 
   for (int64_t i = 0; i < groups; ++i) {
     size_t sourceBase = static_cast<size_t>(i * factor);
-    if (sourceBase >= sourceParts.size())
+    if (sourceBase >= sourceParts.size()) {
       return fail("staging contiguous mask layout ran out of source parts");
+    }
 
     SmallVector<Value, 4> sources;
     sources.reserve(factor);
@@ -4849,8 +5285,9 @@ FailureOr<SmallVector<Value>> materializeStagingContiguousToDeintMaskLayout(
       FailureOr<Value> zero =
           createAllFalseMaskLike(op->getLoc(), sourceParts[sourceBase],
                                  rewriter);
-      if (failed(zero))
+      if (failed(zero)) {
         return fail("failed to create all-false staging mask");
+      }
       sources.push_back(*zero);
     }
 
@@ -4859,8 +5296,9 @@ FailureOr<SmallVector<Value>> materializeStagingContiguousToDeintMaskLayout(
           createPredicateDintlv(op->getLoc(), resultTypes[i],
                                 resultTypes[groups + i], sources[0],
                                 sources[1], rewriter);
-      if (failed(materialized))
+      if (failed(materialized)) {
         return fail("unsupported predicate dintlv staging mask type");
+      }
       parts[0].push_back(materialized->first);
       parts[1].push_back(materialized->second);
       continue;
@@ -4872,16 +5310,18 @@ FailureOr<SmallVector<Value>> materializeStagingContiguousToDeintMaskLayout(
     FailureOr<std::pair<Value, Value>> high = createPredicateDintlv(
         op->getLoc(), resultTypes[2 * groups + i],
         resultTypes[3 * groups + i], sources[2], sources[3], rewriter);
-    if (failed(low) || failed(high))
+    if (failed(low) || failed(high)) {
       return fail("unsupported predicate dintlv staging mask type");
+    }
     FailureOr<std::pair<Value, Value>> even = createPredicateDintlv(
         op->getLoc(), resultTypes[i], resultTypes[2 * groups + i], low->first,
         high->first, rewriter);
     FailureOr<std::pair<Value, Value>> odd = createPredicateDintlv(
         op->getLoc(), resultTypes[groups + i], resultTypes[3 * groups + i],
         low->second, high->second, rewriter);
-    if (failed(even) || failed(odd))
+    if (failed(even) || failed(odd)) {
       return fail("unsupported predicate dintlv staging mask type");
+    }
     parts[0].push_back(even->first);
     parts[1].push_back(odd->first);
     parts[2].push_back(even->second);
@@ -4891,8 +5331,9 @@ FailureOr<SmallVector<Value>> materializeStagingContiguousToDeintMaskLayout(
   SmallVector<Value> results;
   results.reserve(resultTypes.size());
   for (int64_t part = 0; part < factor; ++part) {
-    if (parts[part].size() != static_cast<size_t>(groups))
+    if (parts[part].size() != static_cast<size_t>(groups)) {
       return fail("staging contiguous mask layout result arity mismatch");
+    }
     results.append(parts[part]);
   }
   return results;
@@ -4912,14 +5353,16 @@ materializeMaskGranularityCastLayoutConversionViaContiguous(
                        sourceType.getGranularity(), contiguous);
   FailureOr<SmallVector<Type>> contiguousTypes =
       getConvertedMaskPartTypes(contiguousType);
-  if (failed(contiguousTypes))
+  if (failed(contiguousTypes)) {
     return failure();
+  }
   FailureOr<SmallVector<Value>> contiguousParts =
       materializeMaskGranularityCastLayoutConversion(
           op, sourceType, contiguousType, sourceParts, *contiguousTypes,
           rewriter);
-  if (failed(contiguousParts))
+  if (failed(contiguousParts)) {
     return failure();
+  }
   return materializeMaskGranularityCastLayoutConversion(
       op, contiguousType, resultType, *contiguousParts, resultTypes, rewriter);
 }
@@ -4934,8 +5377,9 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityCastLayoutConversion(
 
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("mask granularity cast layout conversion requires layouts");
+  }
 
   if (sourceLayout == resultLayout) {
     if (failed(verifyIdentityPartForwarding(op, sourceParts, resultTypes,
@@ -4946,8 +5390,9 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityCastLayoutConversion(
 
   FailureOr<SmallVector<Value>> layoutParts = materializeMaskLayoutConversion(
       op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
-  if (succeeded(layoutParts))
+  if (succeeded(layoutParts)) {
     return layoutParts;
+  }
 
   bool sourceC = sourceLayout.isContiguous() && sourceLayout.getLaneStride() == 1;
   bool resultC = resultLayout.isContiguous() && resultLayout.getLaneStride() == 1;
@@ -4979,15 +5424,17 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityCastConversion(
     return failure();
   };
 
-  if (sourceType.getElementCount() != resultType.getElementCount())
+  if (sourceType.getElementCount() != resultType.getElementCount()) {
     return fail("requires source and result mask lane counts to match");
+  }
 
   FailureOr<VMIMaskType> physicalSourceType =
       getVMIMaskPhysicalCarrierType(sourceType);
   FailureOr<VMIMaskType> physicalResultType =
       getVMIMaskPhysicalCarrierType(resultType);
-  if (failed(physicalSourceType) || failed(physicalResultType))
+  if (failed(physicalSourceType) || failed(physicalResultType)) {
     return fail("requires source/result mask physical carrier types");
+  }
 
   if (*physicalSourceType == *physicalResultType) {
     if (failed(verifyIdentityPartForwarding(op, sourceParts, resultTypes,
@@ -5009,8 +5456,9 @@ FailureOr<SmallVector<Value>> materializeMaskGranularityCastConversion(
       materializeMaskGranularityConversion(op, *physicalSourceType,
                                            granularityType, sourceParts,
                                            rewriter);
-  if (failed(granularityParts))
+  if (failed(granularityParts)) {
     return failure();
+  }
   return materializeMaskGranularityCastLayoutConversion(
       op, granularityType, *physicalResultType, *granularityParts, resultTypes,
       rewriter);
@@ -5028,8 +5476,9 @@ struct OneToNVMIEnsureLayoutOpPattern
     FailureOr<SmallVector<Value>> results = materializeEnsureLayoutConversion(
         op, adaptor.getSource(), sourceType, resultType,
         *this->getTypeConverter(), rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
     replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
     return success();
   }
@@ -5062,13 +5511,15 @@ struct OneToNVMIEnsureMaskLayoutOpPattern
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     FailureOr<SmallVector<Value>> results = materializeMaskLayoutConversion(
         op, sourceParts, resultTypes, sourceLayout, resultLayout, rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
     replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
     return success();
   }
@@ -5099,15 +5550,17 @@ struct OneToNVMIEnsureMaskGranularityOpPattern
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
     FailureOr<SmallVector<Value>> results =
         materializeMaskGranularityCastConversion(
             op, sourceType, resultType, sourceParts, resultTypes, rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
     if (results->size() != resultTypes.size())
       return rewriter.notifyMatchFailure(
           op, "mask granularity cast result arity mismatch");
@@ -5140,17 +5593,19 @@ struct OneToNVMIBroadcastOpPattern : OpConversionPattern<VMIBroadcastOp> {
 
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
 
       return failure();
+    }
 
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (Type resultType : resultTypes) {
       auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType)
+      if (!vregType) {
         return rewriter.notifyMatchFailure(op, "broadcast result must be vreg");
+      }
       FailureOr<Value> mask =
           createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
       if (failed(mask))
@@ -5189,22 +5644,26 @@ FailureOr<Value> createScalarOffsetConstant(Location loc, Type type,
 FailureOr<Value> createIotaChunkBase(Location loc, Value base,
                                      int64_t laneOffset, StringRef order,
                                      PatternRewriter &rewriter) {
-  if (laneOffset == 0)
+  if (laneOffset == 0) {
     return base;
+  }
 
   FailureOr<Value> offset =
       createScalarOffsetConstant(loc, base.getType(), laneOffset, rewriter);
-  if (failed(offset))
+  if (failed(offset)) {
     return failure();
+  }
 
   if (isa<IntegerType>(base.getType())) {
-    if (order == "DESC")
+    if (order == "DESC") {
       return rewriter.create<arith::SubIOp>(loc, base, *offset).getResult();
+    }
     return rewriter.create<arith::AddIOp>(loc, base, *offset).getResult();
   }
   if (isa<FloatType>(base.getType())) {
-    if (order == "DESC")
+    if (order == "DESC") {
       return rewriter.create<arith::SubFOp>(loc, base, *offset).getResult();
+    }
     return rewriter.create<arith::AddFOp>(loc, base, *offset).getResult();
   }
 
@@ -5221,8 +5680,9 @@ FailureOr<Value> createIotaContiguousChunk(Location loc, Type resultType,
   StringRef order = orderAttr ? orderAttr.getValue() : StringRef("ASC");
   FailureOr<Value> chunkBase =
       createIotaChunkBase(loc, base, laneOffset, order, rewriter);
-  if (failed(chunkBase))
+  if (failed(chunkBase)) {
     return failure();
+  }
   return rewriter.create<VciOp>(loc, resultType, *chunkBase, orderAttr)
       .getResult();
 }
@@ -5245,17 +5705,20 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
                                                StringAttr orderAttr,
                                                PatternRewriter &rewriter) {
   auto vregType = dyn_cast<VRegType>(resultType);
-  if (!vregType)
+  if (!vregType) {
     return failure();
+  }
 
   int64_t lanesPerPart = vregType.getElementCount();
-  if (groupSize <= 0 || lanesPerPart % groupSize != 0)
+  if (groupSize <= 0 || lanesPerPart % groupSize != 0) {
     return failure();
+  }
 
   FailureOr<Value> allMask =
       createAllTrueMaskForVReg(loc, vregType, rewriter);
-  if (failed(allMask))
+  if (failed(allMask)) {
     return failure();
+  }
 
   // group_size==1: dst[i] = base for every lane — broadcast, not a ramp pack.
   if (groupSize == 1) {
@@ -5279,8 +5742,9 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
         createScalarOffsetConstant(loc, base.getType(), 0, rewriter);
     FailureOr<Value> maskScalar = createScalarOffsetConstant(
         loc, base.getType(), groupSize - 1, rewriter);
-    if (failed(zeroScalar) || failed(maskScalar))
+    if (failed(zeroScalar) || failed(maskScalar)) {
       return failure();
+    }
 
     Value laneIds =
         rewriter.create<VciOp>(loc, resultType, *zeroScalar, StringAttr{})
@@ -5313,8 +5777,9 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
       getMaskTypeForVReg(vregType, rewriter.getContext());
   FailureOr<Value> zeroScalar =
       createScalarOffsetConstant(loc, base.getType(), 0, rewriter);
-  if (failed(full) || failed(maskType) || failed(zeroScalar))
+  if (failed(full) || failed(maskType) || failed(zeroScalar)) {
     return failure();
+  }
 
   Value result = rewriter
                      .create<VdupOp>(loc, resultType, *zeroScalar, *allMask,
@@ -5326,8 +5791,9 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
       int64_t delta = localGroup * groupSize;
       FailureOr<Value> offsetScalar =
           createScalarOffsetConstant(loc, base.getType(), delta, rewriter);
-      if (failed(offsetScalar))
+      if (failed(offsetScalar)) {
         return failure();
+      }
       // ASC continuous is base+i; lane (g*S+j) holds base+g*S+j, want base+j
       // → subtract g*S. DESC continuous is base-i; want base-j → add g*S.
       if (order == "DESC") {
@@ -5353,8 +5819,9 @@ FailureOr<Value> createSubVLGroupPeriodicChunk(Location loc, Type resultType,
     FailureOr<Value> laneMask =
         createLaneRangeMask(loc, *maskType, localGroup * groupSize,
                             (localGroup + 1) * groupSize, rewriter);
-    if (failed(laneMask))
+    if (failed(laneMask)) {
       return failure();
+    }
     result = rewriter
                  .create<VselOp>(loc, resultType, adjusted, result, *laneMask)
                  .getResult();
@@ -5369,16 +5836,18 @@ FailureOr<Value> createIotaDeinterleavedChunk(Location loc, Type resultType,
                                               StringAttr orderAttr,
                                               PatternRewriter &rewriter) {
   auto vregType = dyn_cast<VRegType>(resultType);
-  if (!vregType)
+  if (!vregType) {
     return failure();
+  }
 
   FailureOr<Value> mask = createAllTrueMaskForVReg(loc, vregType, rewriter);
   FailureOr<Value> zero =
       createScalarOffsetConstant(loc, base.getType(), 0, rewriter);
   FailureOr<Value> factorScalar =
       createScalarOffsetConstant(loc, base.getType(), factor, rewriter);
-  if (failed(mask) || failed(zero) || failed(factorScalar))
+  if (failed(mask) || failed(zero) || failed(factorScalar)) {
     return failure();
+  }
 
   Value local =
       rewriter.create<VciOp>(loc, resultType, *zero, StringAttr{}).getResult();
@@ -5390,8 +5859,9 @@ FailureOr<Value> createIotaDeinterleavedChunk(Location loc, Type resultType,
   int64_t partOffset = part + factor * chunk * lanesPerPart;
   FailureOr<Value> biasedBase =
       createIotaChunkBase(loc, base, partOffset, order, rewriter);
-  if (failed(biasedBase))
+  if (failed(biasedBase)) {
     return failure();
+  }
 
   if (order == "DESC") {
     Value baseVector = rewriter
@@ -5417,8 +5887,9 @@ struct OneToNVMIIotaOpPattern : OpConversionPattern<IotaOp> {
                   ConversionPatternRewriter &rewriter) const override {
     auto resultVMIType = cast<VMIVRegType>(op.getResult().getType());
     VMILayoutAttr layout = resultVMIType.getLayoutAttr();
-    if (!layout)
+    if (!layout) {
       return rewriter.notifyMatchFailure(op, "iota requires assigned layout");
+    }
 
     FailureOr<int64_t> lanesPerPart =
         getDataLanesPerPart(resultVMIType.getElementType());
@@ -5428,16 +5899,18 @@ struct OneToNVMIIotaOpPattern : OpConversionPattern<IotaOp> {
 
     FailureOr<Value> base = getSingleValue(
         op, adaptor.getBase(), "iota base must convert to one value", rewriter);
-    if (failed(base))
+    if (failed(base)) {
       return failure();
+    }
 
     FailureOr<SmallVector<Type>> maybe_resultTypes =
 
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
 
       return failure();
+    }
 
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     SmallVector<Value> results;
@@ -5487,8 +5960,9 @@ struct OneToNVMIIotaOpPattern : OpConversionPattern<IotaOp> {
       // laneOffset = (p * physVL) % S and are shared by that key.
       llvm::DenseMap<std::pair<Type, int64_t>, Value> sharedChunks;
       for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-        if (!isa<VRegType>(resultType))
+        if (!isa<VRegType>(resultType)) {
           return rewriter.notifyMatchFailure(op, "iota result must be vreg");
+        }
 
         int64_t laneOffset = 0;
         if (groupSizeMultipleOfPhys)
@@ -5522,8 +5996,9 @@ struct OneToNVMIIotaOpPattern : OpConversionPattern<IotaOp> {
 
     if (layout.isContiguous()) {
       for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-        if (!isa<VRegType>(resultType))
+        if (!isa<VRegType>(resultType)) {
           return rewriter.notifyMatchFailure(op, "iota result must be vreg");
+        }
         FailureOr<Value> result = createIotaContiguousChunk(
             op.getLoc(), resultType, *base,
             static_cast<int64_t>(index) * *lanesPerPart, op.getOrderAttr(),
@@ -5572,8 +6047,9 @@ struct OneToNVMIConstantOpPattern : OpConversionPattern<VMIConstantOp> {
       return rewriter.notifyMatchFailure(
           op, "only splat dense data constants are supported");
     auto splatAttr = dyn_cast<TypedAttr>(denseAttr.getSplatValue<Attribute>());
-    if (!splatAttr)
+    if (!splatAttr) {
       return rewriter.notifyMatchFailure(op, "splat constant must be typed");
+    }
 
     // arith.constant only accepts signless integer types, whereas VMI vregs may
     // carry signed/unsigned element types (e.g. ui16). Remap an unsigned/signed
@@ -5590,15 +6066,17 @@ struct OneToNVMIConstantOpPattern : OpConversionPattern<VMIConstantOp> {
         rewriter.create<arith::ConstantOp>(op.getLoc(), splatAttr).getResult();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
     for (Type resultType : resultTypes) {
       auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType)
+      if (!vregType) {
         return rewriter.notifyMatchFailure(op, "constant result must be vreg");
+      }
       FailureOr<Value> mask =
           createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
       if (failed(mask))
@@ -5625,14 +6103,16 @@ struct OneToNVMIConstantMaskOpPattern
                   ConversionPatternRewriter &rewriter) const override {
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     std::string reason;
     FailureOr<SmallVector<ConstantMaskChunkMaterialization>> materializations =
         computeConstantMaskMaterialization(op, &reason);
-    if (failed(materializations))
+    if (failed(materializations)) {
       return rewriter.notifyMatchFailure(op, Twine("constant_mask ") + reason);
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -5690,16 +6170,18 @@ struct OneToNVMICreateMaskOpPattern
       FailureOr<Value> active = getSingleValue(
           op, adaptor.getActiveLanes(),
           "create_mask active_lanes must convert to one value", rewriter);
-      if (failed(active))
+      if (failed(active)) {
         return failure();
+      }
 
       FailureOr<SmallVector<Type>> maybe_resultTypes =
 
           getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-      if (failed(maybe_resultTypes))
+      if (failed(maybe_resultTypes)) {
 
         return failure();
+      }
 
       SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
       int64_t factor = layout.isDenseSplit() ? layout.getFactor() : 1;
@@ -5743,18 +6225,21 @@ struct OneToNVMICreateMaskOpPattern
           op, "create_mask active_lanes must be an integer constant");
 
     int64_t activeLanes = activeAttr.getInt();
-    if (activeLanes < 0)
+    if (activeLanes < 0) {
       activeLanes = 0;
-    if (activeLanes > resultVMIType.getElementCount())
+    }
+    if (activeLanes > resultVMIType.getElementCount()) {
       activeLanes = resultVMIType.getElementCount();
+    }
 
     FailureOr<SmallVector<Type>> maybe_resultTypes =
 
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
 
       return failure();
+    }
 
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     int64_t factor = layout.isDenseSplit() ? layout.getFactor() : 1;
@@ -5771,19 +6256,22 @@ struct OneToNVMICreateMaskOpPattern
           if (failed(padding))
             return rewriter.notifyMatchFailure(
                 op, "failed to map create_mask physical padding lane");
-          if (*padding)
+          if (*padding) {
             continue;
+          }
           anyLane = true;
           FailureOr<int64_t> logicalLane =
               mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
           if (failed(logicalLane))
             return rewriter.notifyMatchFailure(
                 op, "failed to map create_mask physical lane");
-          if (*logicalLane < activeLanes)
+          if (*logicalLane < activeLanes) {
             ++activeInChunk;
+          }
         }
-        if (!anyLane)
+        if (!anyLane) {
           break;
+        }
 
         if (results.size() >= resultTypes.size())
           return rewriter.notifyMatchFailure(
@@ -5834,8 +6322,9 @@ struct OneToNVMICreateGroupMaskOpPattern
                   ConversionPatternRewriter &rewriter) const override {
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     auto resultVMIType = cast<VMIMaskType>(op.getResult().getType());
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
@@ -5882,13 +6371,15 @@ struct OneToNVMICreateGroupMaskOpPattern
             "create_group_mask active_elems_per_group must convert to one "
             "value",
             rewriter);
-        if (failed(active))
+        if (failed(active)) {
           return failure();
+        }
         FailureOr<SmallVector<Value>> dynamicParts =
             materializeDynamicGroupMaskForType(op, *active, contiguousType,
                                                resultTypes, rewriter);
-        if (failed(dynamicParts))
+        if (failed(dynamicParts)) {
           return failure();
+        }
         contiguousParts = std::move(*dynamicParts);
       }
 
@@ -5898,8 +6389,9 @@ struct OneToNVMICreateGroupMaskOpPattern
       FailureOr<SmallVector<Value>> results = materializeMaskLayoutConversion(
           op, contiguousParts, resultTypes, contiguousLayout, resultLayout,
           rewriter);
-      if (failed(results))
+      if (failed(results)) {
         return failure();
+      }
       replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
       return success();
     }
@@ -5911,8 +6403,9 @@ struct OneToNVMICreateGroupMaskOpPattern
           op, adaptor.getActiveElemsPerGroup(),
           "create_group_mask active_elems_per_group must convert to one value",
           rewriter);
-      if (failed(active))
+      if (failed(active)) {
         return failure();
+      }
 
       VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
       if (resultLayout && resultLayout.isDeinterleaved()) {
@@ -5924,13 +6417,15 @@ struct OneToNVMICreateGroupMaskOpPattern
         FailureOr<SmallVector<Value>> contiguousParts =
             materializeDynamicGroupMaskForType(op, *active, contiguousType,
                                                resultTypes, rewriter);
-        if (failed(contiguousParts))
+        if (failed(contiguousParts)) {
           return failure();
+        }
         FailureOr<SmallVector<Value>> results = materializeMaskLayoutConversion(
             op, *contiguousParts, resultTypes, contiguousLayout, resultLayout,
             rewriter);
-        if (failed(results))
+        if (failed(results)) {
           return failure();
+        }
         replaceOpWithFlatConvertedValues(rewriter, op, *results,
                                          *this->getTypeConverter());
         return success();
@@ -5939,8 +6434,9 @@ struct OneToNVMICreateGroupMaskOpPattern
       FailureOr<SmallVector<Value>> results =
           materializeDynamicGroupMaskForType(op, *active, resultVMIType,
                                              resultTypes, rewriter);
-      if (failed(results))
+      if (failed(results)) {
         return failure();
+      }
       replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
       return success();
     }
@@ -5992,12 +6488,14 @@ struct OneToNVMILoadOpPattern : OpConversionPattern<VMILoadOp> {
     FailureOr<Value> offset =
         getSingleValue(op, adaptor.getOffset(),
                        "load offset must convert to one value", rewriter);
-    if (failed(source) || failed(offset))
+    if (failed(source) || failed(offset)) {
       return failure();
+    }
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
     if (std::optional<std::string> dist =
@@ -6006,8 +6504,9 @@ struct OneToNVMILoadOpPattern : OpConversionPattern<VMILoadOp> {
       results.reserve(resultTypes.size());
       int64_t semanticOffset = 0;
       for (auto [index, resultType] : llvm::enumerate(resultTypes)) {
-        if (!isa<VRegType>(resultType))
+        if (!isa<VRegType>(resultType)) {
           return rewriter.notifyMatchFailure(op, "load result must be vreg");
+        }
         Value chunkOffset =
             createChunkOffset(op.getLoc(), *offset, semanticOffset, rewriter);
         results.push_back(rewriter
@@ -6029,8 +6528,9 @@ struct OneToNVMILoadOpPattern : OpConversionPattern<VMILoadOp> {
 
     FailureOr<int64_t> lanesPerPart = verifyFullOrSafeReadVRegChunks(
         op, resultVMIType, op.getSource().getType(), *offset, rewriter);
-    if (failed(lanesPerPart))
+    if (failed(lanesPerPart)) {
       return failure();
+    }
 
     VMILayoutAttr contiguousLayout =
         VMILayoutAttr::getContiguous(rewriter.getContext());
@@ -6147,8 +6647,9 @@ struct OneToNVMILoadOpPattern : OpConversionPattern<VMILoadOp> {
     contiguousParts.reserve(contiguousTypes.size());
     for (auto [index, resultType] : llvm::enumerate(contiguousTypes)) {
       auto vregType = dyn_cast<VRegType>(resultType);
-      if (!vregType)
+      if (!vregType) {
         return rewriter.notifyMatchFailure(op, "load result must be vreg");
+      }
       Value chunkOffset = createChunkOffset(op.getLoc(), *offset,
                                             index * *lanesPerPart, rewriter);
       contiguousParts.push_back(rewriter
@@ -6163,8 +6664,9 @@ struct OneToNVMILoadOpPattern : OpConversionPattern<VMILoadOp> {
         op, contiguousParts, resultTypes, contiguousLayout,
         resultVMIType.getLayoutAttr(), resultVMIType.getElementType(),
         rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
 
     replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
     return success();
@@ -6186,8 +6688,9 @@ struct OneToNVMIDeinterleaveLoadOpPattern
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(),
         "deinterleave_load offset must convert to one value", rewriter);
-    if (failed(source) || failed(offset))
+    if (failed(source) || failed(offset)) {
       return failure();
+    }
 
     FailureOr<int64_t> lanesPerPart =
         getDataLanesPerPart(lowVMIType.getElementType());
@@ -6205,15 +6708,17 @@ struct OneToNVMIDeinterleaveLoadOpPattern
 
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-    if (failed(maybe_lowTypes))
+    if (failed(maybe_lowTypes)) {
 
       return failure();
+    }
 
     SmallVector<Type> lowTypes = std::move(*maybe_lowTypes);
     FailureOr<SmallVector<Type>> maybe_highTypes =
         getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    if (failed(maybe_highTypes))
+    if (failed(maybe_highTypes)) {
       return failure();
+    }
     SmallVector<Type> highTypes = std::move(*maybe_highTypes);
     if (lowTypes.size() != highTypes.size())
       return rewriter.notifyMatchFailure(
@@ -6265,8 +6770,9 @@ struct OneToNVMIGroupLoadOpPattern : OpConversionPattern<VMIGroupLoadOp> {
     FailureOr<Value> rowStride = getSingleValue(
         op, adaptor.getRowStride(),
         "group_load row_stride must convert to one value", rewriter);
-    if (failed(source) || failed(offset) || failed(rowStride))
+    if (failed(source) || failed(offset) || failed(rowStride)) {
       return failure();
+    }
 
     VMILayoutAttr resultLayout = resultVMIType.getLayoutAttr();
     if (resultLayout && resultLayout.isBlockDeinterleaved() &&
@@ -6301,9 +6807,10 @@ struct OneToNVMIGroupLoadOpPattern : OpConversionPattern<VMIGroupLoadOp> {
 
           getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-      if (failed(maybe_resultTypes))
+      if (failed(maybe_resultTypes)) {
 
         return failure();
+      }
 
       SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
       int64_t factor = resultLayout.getFactor();
@@ -6389,8 +6896,9 @@ struct OneToNVMIGroupLoadOpPattern : OpConversionPattern<VMIGroupLoadOp> {
 
         FailureOr<SmallVector<Type>> maybe_resultTypes =
             getConvertedResultTypes(op, 0, *this->getTypeConverter());
-        if (failed(maybe_resultTypes))
+        if (failed(maybe_resultTypes)) {
           return failure();
+        }
         SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
         SmallVector<Value> results;
         results.reserve(resultTypes.size());
@@ -6432,13 +6940,15 @@ struct OneToNVMIGroupLoadOpPattern : OpConversionPattern<VMIGroupLoadOp> {
 
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
 
       return failure();
+    }
 
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (static_cast<int64_t>(resultTypes.size()) != groupCount * chunksPerGroup)
+    if (static_cast<int64_t>(resultTypes.size()) != groupCount * chunksPerGroup) {
       return rewriter.notifyMatchFailure(op, "group_load arity mismatch");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -6479,8 +6989,9 @@ static LogicalResult lowerGroupSlotLoadParts(
 
   int64_t slots = layout.getSlots();
   int64_t expectedArity = ceilDivNonNegative(numGroups, slots);
-  if (static_cast<int64_t>(resultTypes.size()) != expectedArity)
+  if (static_cast<int64_t>(resultTypes.size()) != expectedArity) {
     return rewriter.notifyMatchFailure(op, "group_slot_load arity mismatch");
+  }
 
   auto makeI16 = [&](int64_t value) -> Value {
     return rewriter.create<arith::ConstantIntOp>(op->getLoc(), value, 16);
@@ -6621,8 +7132,9 @@ static LogicalResult lowerGroupBroadcastParts(
     Operation *op, ValueRange sourceParts, VMIVRegType sourceVMIType,
     VMIVRegType resultVMIType, TypeRange resultTypes, int64_t numGroups,
     ConversionPatternRewriter &rewriter, SmallVectorImpl<Value> &results) {
-  if (sourceParts.empty() || resultTypes.empty())
+  if (sourceParts.empty() || resultTypes.empty()) {
     return rewriter.notifyMatchFailure(op, "group_broadcast arity mismatch");
+  }
 
   std::string layoutReason;
   VMILayoutSupport supports;
@@ -6710,14 +7222,16 @@ static LogicalResult lowerGroupBroadcastParts(
   auto getSelector = [&](int64_t baseSlot) -> FailureOr<Value> {
     int64_t baseIndex = baseSlot * sourceLaneStride;
     auto cached = selectorByBaseIndex.find(baseIndex);
-    if (cached != selectorByBaseIndex.end())
+    if (cached != selectorByBaseIndex.end()) {
       return cached->second;
+    }
 
     if (selectorKind == SelectorKind::Constant) {
       FailureOr<Value> baseScalar = createScalarOffsetConstant(
           op->getLoc(), indexScalarType, baseIndex, rewriter);
-      if (failed(baseScalar))
+      if (failed(baseScalar)) {
         return failure();
+      }
       Value selector =
           rewriter
               .create<VdupOp>(op->getLoc(), indexType, *baseScalar, *allMask,
@@ -6730,8 +7244,9 @@ static LogicalResult lowerGroupBroadcastParts(
     if (!sharedRamp) {
       FailureOr<Value> zero = createScalarOffsetConstant(
           op->getLoc(), indexScalarType, 0, rewriter);
-      if (failed(zero))
+      if (failed(zero)) {
         return failure();
+      }
       sharedRamp =
           rewriter.create<VciOp>(op->getLoc(), indexType, *zero, StringAttr{})
               .getResult();
@@ -6756,8 +7271,9 @@ static LogicalResult lowerGroupBroadcastParts(
     if (baseIndex != 0) {
       FailureOr<Value> baseScalar = createScalarOffsetConstant(
           op->getLoc(), indexScalarType, baseIndex, rewriter);
-      if (failed(baseScalar))
+      if (failed(baseScalar)) {
         return failure();
+      }
       selector = rewriter
                      .create<VaddsOp>(op->getLoc(), indexType, selector,
                                       *baseScalar, *allMask)
@@ -6826,8 +7342,9 @@ static LogicalResult lowerGroupBroadcastParts(
           if (failed(padding))
             return rewriter.notifyMatchFailure(
                 op, "group_broadcast failed to map result padding lanes");
-          if (*padding)
+          if (*padding) {
             continue;
+          }
           FailureOr<int64_t> logical =
               mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
           if (failed(logical))
@@ -6864,8 +7381,9 @@ static LogicalResult lowerGroupBroadcastParts(
         for (int64_t chunkIndex : llvm::drop_begin(activeSourceChunks)) {
           SmallVector<int8_t> laneMaskBits(fact->lanesPerPart, 0);
           for (auto [lane, laneSourceChunk] : llvm::enumerate(laneSourceChunks))
-            if (laneSourceChunk == chunkIndex)
+            if (laneSourceChunk == chunkIndex) {
               laneMaskBits[lane] = 1;
+            }
           FailureOr<Value> laneMask = materializeConstantMaskChunk(
               op->getLoc(), *resultMaskType, laneMaskBits, rewriter);
           if (failed(laneMask))
@@ -6891,8 +7409,9 @@ static LogicalResult lowerGroupBroadcastParts(
         if (failed(padding))
           return rewriter.notifyMatchFailure(
               op, "group_broadcast failed to map result padding lanes");
-        if (*padding)
+        if (*padding) {
           continue;
+        }
         FailureOr<int64_t> logical =
             mapPhysicalLaneToLogical(resultVMIType, part, chunk, lane);
         if (failed(logical))
@@ -6900,8 +7419,9 @@ static LogicalResult lowerGroupBroadcastParts(
               op, "group_broadcast failed to map a result lane");
         int64_t actualGroup = *logical / fact->groupSize;
         int64_t expectedGroup = firstGroup;
-        if (selectorKind != SelectorKind::Constant)
+        if (selectorKind != SelectorKind::Constant) {
           expectedGroup += lane / selectorPeriod;
+        }
         if (actualGroup != expectedGroup ||
             actualGroup / sourceSlots != sourceChunk)
           return rewriter.notifyMatchFailure(
@@ -6960,16 +7480,18 @@ struct OneToNVMIGroupSlotLoadOpPattern
         op, adaptor.getSourceGroupStride(),
         "group_slot_load source_group_stride must convert to one value",
         rewriter);
-    if (failed(source) || failed(offset) || failed(sourceGroupStride))
+    if (failed(source) || failed(offset) || failed(sourceGroupStride)) {
       return failure();
+    }
 
     FailureOr<SmallVector<Type>> maybe_resultTypes =
 
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
 
       return failure();
+    }
 
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     int64_t numGroups = op.getNumGroupsAttr().getInt();
@@ -6998,20 +7520,23 @@ struct OneToNVMIMaskedLoadOpPattern
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(), "masked_load offset must convert to one value",
         rewriter);
-    if (failed(source) || failed(offset))
+    if (failed(source) || failed(offset)) {
       return failure();
+    }
 
     FailureOr<int64_t> lanesPerPart = verifyFullOrSafeReadVRegChunks(
         op, resultVMIType, (*source).getType(), *offset, rewriter);
-    if (failed(lanesPerPart))
+    if (failed(lanesPerPart)) {
       return failure();
+    }
 
     ValueRange maskParts = adaptor.getMask();
     ValueRange passthruParts = adaptor.getPassthru();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (maskParts.size() != passthruParts.size() ||
         passthruParts.size() != resultTypes.size())
@@ -7056,16 +7581,18 @@ struct OneToNVMIGatherOpPattern : OpConversionPattern<VMIGatherOp> {
     FailureOr<Value> source =
         getSingleValue(op, adaptor.getSource(),
                        "gather source must convert to one value", rewriter);
-    if (failed(source))
+    if (failed(source)) {
       return failure();
+    }
 
     ValueRange indicesParts = adaptor.getIndices();
     ValueRange maskParts = adaptor.getMask();
     ValueRange passthruParts = adaptor.getPassthru();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (indicesParts.size() != maskParts.size() ||
         indicesParts.size() != passthruParts.size() ||
@@ -7117,23 +7644,26 @@ struct OneToNVMIExpandLoadOpPattern
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(), "expand_load offset must convert to one value",
         rewriter);
-    if (failed(source) || failed(offset))
+    if (failed(source) || failed(offset)) {
       return failure();
+    }
 
     FailureOr<SmallVector<Type>> maybe_resultTypes =
 
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
 
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
 
       return failure();
+    }
 
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (isStaticAllActiveMask(op.getMask(), resultVMIType.getElementCount())) {
       FailureOr<int64_t> lanesPerPart = verifyFullOrSafeReadVRegChunks(
           op, resultVMIType, (*source).getType(), *offset, rewriter);
-      if (failed(lanesPerPart))
+      if (failed(lanesPerPart)) {
         return failure();
+      }
 
       SmallVector<Value> results;
       results.reserve(resultTypes.size());
@@ -7230,8 +7760,9 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
     FailureOr<Value> offset =
         getSingleValue(op, adaptor.getOffset(),
                        "store offset must convert to one value", rewriter);
-    if (failed(destination) || failed(offset))
+    if (failed(destination) || failed(offset)) {
       return failure();
+    }
 
     ValueRange valueParts = adaptor.getValue();
     if (std::optional<std::string> dist =
@@ -7244,15 +7775,17 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
       int64_t semanticOffset = 0;
       for (auto [index, value] : llvm::enumerate(valueParts)) {
         auto vregType = dyn_cast<VRegType>(value.getType());
-        if (!vregType)
+        if (!vregType) {
           return rewriter.notifyMatchFailure(op, "store value must be vreg");
+        }
         FailureOr<int64_t> activeLanes =
             getActiveDataLanesInPhysicalChunk(valueVMIType, index);
         if (failed(activeLanes))
           return rewriter.notifyMatchFailure(
               op, "failed to compute lane_stride store active lanes");
-        if (*activeLanes == 0)
+        if (*activeLanes == 0) {
           continue;
+        }
         auto maskType = MaskType::get(rewriter.getContext(), *maskGranularity);
         FailureOr<Value> mask = createPrefixMaskForActiveLanes(
             op.getLoc(), maskType, *activeLanes, rewriter);
@@ -7282,8 +7815,9 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
     SmallVector<Type> contiguousTypes = std::move(*maybeContiguousTypes);
     SmallVector<Type> valuePartTypes;
     valuePartTypes.reserve(valueParts.size());
-    for (Value value : valueParts)
+    for (Value value : valueParts) {
       valuePartTypes.push_back(value.getType());
+    }
     FailureOr<bool> noWiderThanContiguous =
         hasNoWiderFootprintThanContiguous(valuePartTypes, contiguousTypes);
     if (failed(noWiderThanContiguous))
@@ -7307,8 +7841,9 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
             return rewriter.notifyMatchFailure(
                 op, "vstsx2 requires matching low/high value types");
           auto vregType = dyn_cast<VRegType>(low.getType());
-          if (!vregType)
+          if (!vregType) {
             return rewriter.notifyMatchFailure(op, "store value must be vreg");
+          }
           FailureOr<Value> mask =
               createAllTrueMaskForVReg(op.getLoc(), vregType, rewriter);
           if (failed(mask))
@@ -7328,21 +7863,24 @@ struct OneToNVMIStoreOpPattern : OpConversionPattern<VMIStoreOp> {
     FailureOr<SmallVector<Value>> storeParts = materializeDataLayoutConversion(
         op, valueParts, contiguousTypes, valueVMIType.getLayoutAttr(),
         contiguousLayout, valueVMIType.getElementType(), rewriter);
-    if (failed(storeParts))
+    if (failed(storeParts)) {
       return failure();
+    }
 
     for (auto [index, value] : llvm::enumerate(*storeParts)) {
       auto vregType = dyn_cast<VRegType>(value.getType());
-      if (!vregType)
+      if (!vregType) {
         return rewriter.notifyMatchFailure(op, "store value must be vreg");
+      }
       if (!fullPhysicalChunks) {
         FailureOr<int64_t> activeLanes =
             getContiguousActiveDataLanes(valueVMIType, index);
         if (failed(activeLanes))
           return rewriter.notifyMatchFailure(
               op, "failed to compute store active lanes");
-        if (*activeLanes == 0)
+        if (*activeLanes == 0) {
           continue;
+        }
       }
       FailureOr<Value> mask =
           fullPhysicalChunks
@@ -7391,8 +7929,9 @@ struct OneToNVMIInterleaveStoreOpPattern
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(),
         "interleave_store offset must convert to one value", rewriter);
-    if (failed(destination) || failed(offset))
+    if (failed(destination) || failed(offset)) {
       return failure();
+    }
 
     ValueRange lowParts = adaptor.getLow();
     ValueRange highParts = adaptor.getHigh();
@@ -7447,8 +7986,9 @@ struct OneToNVMIGroupStoreOpPattern
     FailureOr<Value> rowStride = getSingleValue(
         op, adaptor.getRowStride(),
         "group_store row_stride must convert to one value", rewriter);
-    if (failed(destination) || failed(offset) || failed(rowStride))
+    if (failed(destination) || failed(offset) || failed(rowStride)) {
       return failure();
+    }
 
     unsigned elementBits =
         pto::getPTOStorageElemBitWidth(valueVMIType.getElementType());
@@ -7583,9 +8123,9 @@ struct OneToNVMIGroupStoreOpPattern
       if (static_cast<int64_t>(valueParts.size()) != layout.getNumGroups())
         return rewriter.notifyMatchFailure(
             op, "slots=1 group_store arity mismatch");
-      unsigned elementBits =
+      unsigned slots1ElementBits =
           pto::getPTOStorageElemBitWidth(valueVMIType.getElementType());
-      if (elementBits == 0 || 256 % elementBits != 0)
+      if (slots1ElementBits == 0 || 256 % slots1ElementBits != 0)
         return rewriter.notifyMatchFailure(
             op, "slots=1 group_store requires supported element width");
       std::optional<int64_t> constantRowStride =
@@ -7783,12 +8323,14 @@ struct OneToNVMIGroupStoreOpPattern
             Value merged = *zero;
             for (int64_t localPart = 0; localPart < 4; ++localPart) {
               int64_t partIndex = blockStart / 8 + localPart;
-              if (partIndex >= static_cast<int64_t>(valueParts.size()))
+              if (partIndex >= static_cast<int64_t>(valueParts.size())) {
                 break;
+              }
               int64_t remainingGroups = numGroups - partIndex * 8;
               int64_t activeGroups = std::min<int64_t>(8, remainingGroups);
-              if (activeGroups <= 0)
+              if (activeGroups <= 0) {
                 break;
+              }
               Value selected =
                   rewriter
                       .create<VselrOp>(op.getLoc(), firstVRegType,
@@ -8000,8 +8542,9 @@ struct OneToNVMIGroupStoreOpPattern
       return failure();
 
     ValueRange valueParts = adaptor.getValue();
-    if (static_cast<int64_t>(valueParts.size()) != groupCount * chunksPerGroup)
+    if (static_cast<int64_t>(valueParts.size()) != groupCount * chunksPerGroup) {
       return rewriter.notifyMatchFailure(op, "group_store arity mismatch");
+    }
 
     for (auto [index, value] : llvm::enumerate(valueParts)) {
       auto vregType = dyn_cast<VRegType>(value.getType());
@@ -8048,8 +8591,9 @@ struct OneToNVMIMaskedStoreOpPattern
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(),
         "masked_store offset must convert to one value", rewriter);
-    if (failed(destination) || failed(offset))
+    if (failed(destination) || failed(offset)) {
       return failure();
+    }
 
     ValueRange valueParts = adaptor.getValue();
     ValueRange maskParts = adaptor.getMask();
@@ -8079,8 +8623,9 @@ struct OneToNVMIMaskedStoreOpPattern
           if (failed(activeLanes))
             return rewriter.notifyMatchFailure(
                 op, "failed to compute lane_stride masked_store active lanes");
-          if (*activeLanes == 0)
+          if (*activeLanes == 0) {
             continue;
+          }
           FailureOr<Value> storeMask = createDenseLaneStrideStorePredicate(
               op.getLoc(), valueVMIType, index, mask, *maskGranularity,
               rewriter);
@@ -8103,24 +8648,28 @@ struct OneToNVMIMaskedStoreOpPattern
 
     SmallVector<Type> contiguousValueTypes;
     contiguousValueTypes.reserve(valueParts.size());
-    for (Value value : valueParts)
+    for (Value value : valueParts) {
       contiguousValueTypes.push_back(value.getType());
+    }
     FailureOr<SmallVector<Value>> storeParts = materializeDataLayoutConversion(
         op, valueParts, contiguousValueTypes, valueVMIType.getLayoutAttr(),
         VMILayoutAttr::getContiguous(rewriter.getContext()),
         valueVMIType.getElementType(), rewriter);
-    if (failed(storeParts))
+    if (failed(storeParts)) {
       return failure();
+    }
 
     SmallVector<Type> contiguousMaskTypes;
     contiguousMaskTypes.reserve(maskParts.size());
-    for (Value mask : maskParts)
+    for (Value mask : maskParts) {
       contiguousMaskTypes.push_back(mask.getType());
+    }
     FailureOr<SmallVector<Value>> storeMasks = materializeMaskLayoutConversion(
         op, maskParts, contiguousMaskTypes, maskVMIType.getLayoutAttr(),
         VMILayoutAttr::getContiguous(rewriter.getContext()), rewriter);
-    if (failed(storeMasks))
+    if (failed(storeMasks)) {
       return failure();
+    }
 
     if (storeParts->size() != storeMasks->size())
       return rewriter.notifyMatchFailure(
@@ -8138,8 +8687,9 @@ struct OneToNVMIMaskedStoreOpPattern
       if (failed(activeLanes))
         return rewriter.notifyMatchFailure(
             op, "failed to compute masked_store active lanes");
-      if (*activeLanes == 0)
+      if (*activeLanes == 0) {
         continue;
+      }
       FailureOr<Value> storeMask = createMaskedStorePredicate(
           op.getLoc(), valueVMIType, index, mask, vregType, rewriter);
       if (failed(storeMask))
@@ -8176,8 +8726,9 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
         op, adaptor.getSourceGroupStride(),
         "group_broadcast_load source_group_stride must convert to one value",
         rewriter);
-    if (failed(source) || failed(offset) || failed(sourceGroupStride))
+    if (failed(source) || failed(offset) || failed(sourceGroupStride)) {
       return failure();
+    }
 
     VMILayoutSupport supports;
     std::string supportReason;
@@ -8190,8 +8741,9 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
 
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
 
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     FailureOr<VMIGroupBroadcastLoadDirectFact> directFact =
@@ -8199,12 +8751,15 @@ struct OneToNVMIGroupBroadcastLoadOpPattern
     auto getBRCDist = [&]() -> std::optional<StringRef> {
       unsigned elementBits =
           pto::getPTOStorageElemBitWidth(resultVMIType.getElementType());
-      if (elementBits == 8)
+      if (elementBits == 8) {
         return StringRef("BRC_B8");
-      if (elementBits == 16)
+      }
+      if (elementBits == 16) {
         return StringRef("BRC_B16");
-      if (elementBits == 32)
+      }
+      if (elementBits == 32) {
         return StringRef("BRC_B32");
+      }
       return std::nullopt;
     };
 
@@ -8411,8 +8966,9 @@ struct OneToNVMIStrideLoadOpPattern
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (resultTypes.size() != 1 || maskParts.size() != 1)
       return rewriter.notifyMatchFailure(
@@ -8492,8 +9048,9 @@ struct OneToNVMIScatterOpPattern : OpConversionPattern<VMIScatterOp> {
     FailureOr<Value> destination = getSingleValue(
         op, adaptor.getDestination(),
         "scatter destination must convert to one value", rewriter);
-    if (failed(destination))
+    if (failed(destination)) {
       return failure();
+    }
 
     ValueRange valueParts = adaptor.getValue();
     ValueRange indicesParts = adaptor.getIndices();
@@ -8529,8 +9086,9 @@ struct OneToNVMIBinaryOpPattern : OpConversionPattern<SourceOp> {
     ValueRange rhsParts = adaptor.getRhs();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (lhsParts.size() != rhsParts.size() ||
         lhsParts.size() != resultTypes.size())
@@ -8580,8 +9138,9 @@ struct OneToNVMIVecScalarOpPattern : OpConversionPattern<SourceOp> {
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(scalar) || failed(maybeResultTypes))
+    if (failed(scalar) || failed(maybeResultTypes)) {
       return failure();
+    }
     Value scalarValue = *scalar;
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
@@ -8740,8 +9299,9 @@ struct OneToNVMIVmullOpPattern : OpConversionPattern<VMIVmullOp> {
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     FailureOr<SmallVector<Type>> maybeHighTypes =
         getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    if (failed(maybeLowTypes) || failed(maybeHighTypes))
+    if (failed(maybeLowTypes) || failed(maybeHighTypes)) {
       return failure();
+    }
     SmallVector<Type> lowTypes = std::move(*maybeLowTypes);
     SmallVector<Type> highTypes = std::move(*maybeHighTypes);
 
@@ -8806,8 +9366,9 @@ struct OneToNVMIInterleaveOpPattern : OpConversionPattern<SourceOp> {
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
     FailureOr<SmallVector<Type>> maybeHighTypes =
         getConvertedResultTypes(op, 1, *this->getTypeConverter());
-    if (failed(maybeLowTypes) || failed(maybeHighTypes))
+    if (failed(maybeLowTypes) || failed(maybeHighTypes)) {
       return failure();
+    }
     SmallVector<Type> lowTypes = std::move(*maybeLowTypes);
     SmallVector<Type> highTypes = std::move(*maybeHighTypes);
     if (lhsParts.size() != rhsParts.size() ||
@@ -8841,10 +9402,12 @@ struct OneToNVMIInterleaveOpPattern : OpConversionPattern<SourceOp> {
       return layout && layout.isContiguous() && layout.getLaneStride() == 1;
     };
     auto getElementDeintFactor = [](VMILayoutAttr layout) -> int64_t {
-      if (layout && layout.isContiguous() && layout.getLaneStride() == 1)
+      if (layout && layout.isContiguous() && layout.getLaneStride() == 1) {
         return 1;
-      if (layout && layout.isDeinterleaved() && layout.getLaneStride() == 1)
+      }
+      if (layout && layout.isDeinterleaved() && layout.getLaneStride() == 1) {
         return layout.getFactor();
+      }
       return 0;
     };
 
@@ -9020,8 +9583,9 @@ struct OneToNVMIFmaOpPattern : OpConversionPattern<VMIFmaOp> {
     ValueRange accParts = adaptor.getAcc();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (lhsParts.size() != rhsParts.size() ||
         lhsParts.size() != accParts.size() ||
@@ -9068,8 +9632,9 @@ struct OneToNVMIVexpdifOpPattern : OpConversionPattern<VMIVexpdifOp> {
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybeResultTypes))
+    if (failed(maybeResultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
     if (xParts.size() != maxParts.size() ||
         xParts.size() != maskParts.size() ||
@@ -9111,11 +9676,13 @@ struct OneToNVMIUnaryOpPattern : OpConversionPattern<SourceOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.size() != resultTypes.size())
+    if (sourceParts.size() != resultTypes.size()) {
       return rewriter.notifyMatchFailure(op, "physical unary arity mismatch");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -9152,8 +9719,9 @@ struct OneToNVMIMaskBinaryOpPattern : OpConversionPattern<SourceOp> {
     ValueRange rhsParts = adaptor.getRhs();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (lhsParts.size() != rhsParts.size() ||
         lhsParts.size() != resultTypes.size())
@@ -9196,8 +9764,9 @@ struct OneToNVMIMaskUnaryOpPattern : OpConversionPattern<SourceOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.size() != resultTypes.size())
       return rewriter.notifyMatchFailure(op,
@@ -9247,8 +9816,9 @@ struct OneToNVMICmpOpPattern : OpConversionPattern<SourceOp> {
     ValueRange rhsParts = adaptor.getRhs();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (lhsParts.size() != rhsParts.size() ||
         lhsParts.size() != resultTypes.size())
@@ -9307,8 +9877,9 @@ struct OneToNVMISelectOpPattern : OpConversionPattern<VMISelectOp> {
     ValueRange falseParts = adaptor.getFalseValue();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (maskParts.size() != trueParts.size() ||
         trueParts.size() != falseParts.size() ||
@@ -9344,8 +9915,9 @@ struct OneToNVMIVselrOpPattern : OpConversionPattern<VMIVselrOp> {
     ValueRange indexParts = adaptor.getIndex();
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybeResultTypes))
+    if (failed(maybeResultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
 
     if (sourceParts.size() != 1 || indexParts.size() != 1 ||
@@ -9386,8 +9958,9 @@ struct OneToNVMIActivePrefixIndexOpPattern
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (maskParts.size() != 1 || resultTypes.size() != 1)
       return rewriter.notifyMatchFailure(
@@ -9437,8 +10010,9 @@ struct OneToNVMICompressOpPattern : OpConversionPattern<VMICompressOp> {
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.size() != 1 || maskParts.size() != 1 ||
         resultTypes.size() != 1)
@@ -9475,8 +10049,9 @@ struct OneToNVMICompressStoreOpPattern
     FailureOr<Value> offset = getSingleValue(
         op, adaptor.getOffset(),
         "compress_store offset must convert to one value", rewriter);
-    if (failed(destination) || failed(offset))
+    if (failed(destination) || failed(offset)) {
       return failure();
+    }
 
     ValueRange valueParts = adaptor.getValue();
     ValueRange maskParts = adaptor.getMask();
@@ -9522,8 +10097,9 @@ struct OneToNVMIReduceAddIOpPattern
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
         resultTypes.size() != 1)
@@ -9609,8 +10185,9 @@ struct OneToNVMIReduceAddFOpPattern
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
         resultTypes.size() != 1)
@@ -9701,8 +10278,9 @@ classifyGroupReduceLoweringPlan(VMIVRegType sourceType, VMIMaskType maskType,
   FailureOr<VMIGroupReduceLayoutFact> fact =
       supports.getGroupReduceLayoutFactForLayouts(
           sourceType, maskType, resultType, numGroups, reason);
-  if (failed(fact))
+  if (failed(fact)) {
     return failure();
+  }
 
   switch (fact->blockClass) {
   case VMIGroupBlockClass::QuarterBlock:
@@ -9737,8 +10315,9 @@ struct OneToNVMIGroupReduceOpPattern : OpConversionPattern<OpTy> {
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
     VMILayoutSupport supports;
@@ -10204,8 +10783,9 @@ struct OneToNVMIGroupReduceOpPattern : OpConversionPattern<OpTy> {
       if (rowLocalSlots1Result) {
         results[destChunk] = *finalResult;
       } else {
-        for (int64_t chunk = 0; chunk < chunksPerGroup; ++chunk)
+        for (int64_t chunk = 0; chunk < chunksPerGroup; ++chunk) {
           results[destChunk + chunk] = *finalResult;
+        }
       }
     }
 
@@ -10216,8 +10796,9 @@ struct OneToNVMIGroupReduceOpPattern : OpConversionPattern<OpTy> {
 private:
   FailureOr<VRegType> getRowResultType(VRegType sourceType,
                                        VRegType resultType) const {
-    if constexpr (std::is_same_v<OpTy, VMIGroupReduceAddIOp>)
+    if constexpr (std::is_same_v<OpTy, VMIGroupReduceAddIOp>) {
       return getVcaddResultType(sourceType);
+    }
     return resultType;
   }
 
@@ -10266,8 +10847,9 @@ struct OneToNVMIGroupBroadcastOpPattern
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     SmallVector<Value> results;
     if (failed(lowerGroupBroadcastParts(
@@ -10306,8 +10888,9 @@ lowerVMIHistogramToVPTO(VMIOp op,
         op, "expected matching source/mask chunks");
 
   auto partType = dyn_cast<VRegType>(accParts[0].getType());
-  if (!partType)
+  if (!partType) {
     return rewriter.notifyMatchFailure(op, "expected ui16 acc parts");
+  }
   if (halfCount == 2 && accParts[1].getType() != partType)
     return rewriter.notifyMatchFailure(op,
                                        "expected matching ui16 acc parts");
@@ -10315,14 +10898,16 @@ lowerVMIHistogramToVPTO(VMIOp op,
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(sourceType.getElementType());
-  if (failed(lanesPerPart))
+  if (failed(lanesPerPart)) {
     return rewriter.notifyMatchFailure(op, "failed to compute source lanes");
+  }
 
   Location loc = op.getLoc();
   SmallVector<Value, 2> binConsts;
   binConsts.push_back(createI32Constant(loc, 0, rewriter));
-  if (halfCount == 2)
+  if (halfCount == 2) {
     binConsts.push_back(createI32Constant(loc, 1, rewriter));
+  }
 
   SmallVector<Value, 2> halves(accParts.begin(), accParts.end());
 
@@ -10330,8 +10915,9 @@ lowerVMIHistogramToVPTO(VMIOp op,
     Value source   = sourceParts[index];
     Value userMask = maskParts[index];
     auto maskType  = dyn_cast<MaskType>(userMask.getType());
-    if (!maskType || !maskType.isB8())
+    if (!maskType || !maskType.isB8()) {
       return rewriter.notifyMatchFailure(op, "expected b8 source mask");
+    }
 
     Value chunkMask = userMask;
     int64_t firstLane   = int64_t(index) * *lanesPerPart;
@@ -10397,8 +10983,9 @@ struct OneToNVMIReduceMinMaxOpPattern : OpConversionPattern<SourceOp> {
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
         resultTypes.size() != 1)
@@ -10482,16 +11069,18 @@ struct OneToNVMIExtFOpPattern : OpConversionPattern<VMIExtFOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty())
       return rewriter.notifyMatchFailure(
           op, "extf requires at least one physical source chunk");
 
     auto sourceType = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType)
+    if (!sourceType) {
       return rewriter.notifyMatchFailure(op, "expected physical extf source");
+    }
     for (Value sourcePart : sourceParts) {
       auto currentSourceType = dyn_cast<VRegType>(sourcePart.getType());
       if (!currentSourceType || currentSourceType != sourceType)
@@ -10560,8 +11149,9 @@ struct OneToNVMIExtFOpPattern : OpConversionPattern<VMIExtFOp> {
 
     FailureOr<Value> mask =
         createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-    if (failed(mask))
+    if (failed(mask)) {
       return rewriter.notifyMatchFailure(op, "failed to build extf seed mask");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -10594,8 +11184,9 @@ struct OneToNVMITruncFOpPattern : OpConversionPattern<VMITruncFOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
@@ -10655,12 +11246,14 @@ struct OneToNVMITruncFOpPattern : OpConversionPattern<VMITruncFOp> {
       return success();
     }
 
-    if (resultTypes.empty())
+    if (resultTypes.empty()) {
       return rewriter.notifyMatchFailure(op, "truncf requires result chunks");
+    }
 
     auto sourceType0 = dyn_cast<VRegType>(sourceParts.front().getType());
-    if (!sourceType0 || !isa<FloatType>(sourceType0.getElementType()))
+    if (!sourceType0 || !isa<FloatType>(sourceType0.getElementType())) {
       return rewriter.notifyMatchFailure(op, "unsupported physical truncf source type");
+    }
     unsigned sourceBits = pto::getPTOStorageElemBitWidth(sourceType0.getElementType());
     if (sourceBits != 32 && sourceBits != 16)
       return rewriter.notifyMatchFailure(
@@ -10698,8 +11291,9 @@ struct OneToNVMITruncFOpPattern : OpConversionPattern<VMITruncFOp> {
         sourceParts.size() == resultTypes.size()) {
       FailureOr<Value> sourceMask =
           createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
-      if (failed(sourceMask))
+      if (failed(sourceMask)) {
         return rewriter.notifyMatchFailure(op, "failed to build truncf masks");
+      }
       StringAttr rnd = rewriter.getStringAttr(
           getTruncFRoundMode(op, resultVRegTypes.front().getElementType()));
       StringAttr sat = op->getAttrOfType<StringAttr>("saturate");
@@ -10723,8 +11317,9 @@ struct OneToNVMITruncFOpPattern : OpConversionPattern<VMITruncFOp> {
         resultLayout.getLaneStride() != 1 &&
         sourceParts.size() == resultTypes.size()) {
       StringRef part;
-      if (resultBits == 16 && resultLayout.getLaneStride() == 2)
+      if (resultBits == 16 && resultLayout.getLaneStride() == 2) {
         part = "EVEN";                                          // 32→16
+      }
       else if (resultBits == 8 && resultLayout.getLaneStride() == 4)
         part = "P0";                                            // 32→8 (f8/hif8)
       else if (resultBits == 8 && resultLayout.getLaneStride() == 2)
@@ -10735,8 +11330,9 @@ struct OneToNVMITruncFOpPattern : OpConversionPattern<VMITruncFOp> {
 
       FailureOr<Value> sourceMask =
           createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
-      if (failed(sourceMask))
+      if (failed(sourceMask)) {
         return rewriter.notifyMatchFailure(op, "failed to build truncf masks");
+      }
 
       StringAttr rnd = rewriter.getStringAttr(
           getTruncFRoundMode(op, resultVRegTypes.front().getElementType()));
@@ -10786,8 +11382,9 @@ struct OneToNVMITruncFOpPattern : OpConversionPattern<VMITruncFOp> {
 
     FailureOr<Value> sourceMask =
         createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
-    if (failed(sourceMask))
+    if (failed(sourceMask)) {
       return rewriter.notifyMatchFailure(op, "failed to build truncf masks");
+    }
 
     StringAttr rnd = rewriter.getStringAttr(
         getTruncFRoundMode(op, resultVRegTypes.front().getElementType()));
@@ -10842,8 +11439,9 @@ struct OneToNVMIExtIOpPattern : OpConversionPattern<OpT> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty())
       return rewriter.notifyMatchFailure(
@@ -11059,8 +11657,9 @@ struct OneToNVMITruncIOpPattern : OpConversionPattern<VMITruncIOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
     VMILayoutAttr sourceLayout = sourceVMIType.getLayoutAttr();
@@ -11292,8 +11891,9 @@ struct OneToNVMITruncIOpPattern : OpConversionPattern<VMITruncIOp> {
       StringAttr part = rewriter.getStringAttr(factor == 2 ? "EVEN" : "P0");
       FailureOr<Value> sourceMask =
           createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
-      if (failed(sourceMask))
+      if (failed(sourceMask)) {
         return rewriter.notifyMatchFailure(op, "failed to build trunci masks");
+      }
 
       SmallVector<Value> results;
       results.reserve(resultTypes.size());
@@ -11330,8 +11930,9 @@ struct OneToNVMITruncIOpPattern : OpConversionPattern<VMITruncIOp> {
         createAllTrueMaskForVReg(op.getLoc(), sourceType0, rewriter);
     FailureOr<Value> resultMask =
         createAllTrueMaskForVReg(op.getLoc(), resultType0, rewriter);
-    if (failed(sourceMask) || failed(resultMask))
+    if (failed(sourceMask) || failed(resultMask)) {
       return rewriter.notifyMatchFailure(op, "failed to build trunci masks");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -11375,8 +11976,9 @@ struct OneToNVMIFPToSIOpPattern : OpConversionPattern<VMIFPToSIOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
     Type srcElem = sourceVMIType.getElementType();
@@ -11587,8 +12189,9 @@ struct OneToNVMIFPToUIOpPattern : OpConversionPattern<VMIFPToUIOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
 
     Type srcElem = sourceVMIType.getElementType();
@@ -11770,8 +12373,9 @@ struct OneToNVMISIToFPOpPattern : OpConversionPattern<VMISIToFPOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.size() != resultTypes.size())
       return rewriter.notifyMatchFailure(
@@ -11793,8 +12397,9 @@ struct OneToNVMISIToFPOpPattern : OpConversionPattern<VMISIToFPOp> {
 
       FailureOr<Value> mask =
           createAllTrueMaskForVReg(op.getLoc(), sourceType, rewriter);
-      if (failed(mask))
+      if (failed(mask)) {
         return rewriter.notifyMatchFailure(op, "failed to build sitofp mask");
+      }
       results.push_back(rewriter
                             .create<VcvtOp>(op.getLoc(), resultVRegType,
                                             sourcePart, *mask, rnd,
@@ -11816,11 +12421,13 @@ struct OneToNVMIBitcastOpPattern : OpConversionPattern<VMIBitcastOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
-    if (sourceParts.size() != resultTypes.size())
+    if (sourceParts.size() != resultTypes.size()) {
       return rewriter.notifyMatchFailure(op, "physical bitcast arity mismatch");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -11871,15 +12478,17 @@ struct OneToNVMIChannelSplitOpPattern
 
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     FailureOr<SmallVector<Value>> results =
         materializeDataLayoutConversion(op, adaptor.getSource(), resultTypes,
                                         sourceLayout, channelLayout,
                                         sourceType.getElementType(), rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
 
     replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
     return success();
@@ -11918,15 +12527,17 @@ struct OneToNVMIChannelMergeOpPattern
 
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybeResultTypes))
+    if (failed(maybeResultTypes)) {
       return failure();
+    }
     FailureOr<SmallVector<Value>> results =
         materializeDataLayoutConversion(
             op, flattenOneToNOperands(adaptor.getOperands()),
             *maybeResultTypes, channelLayout, resultLayout,
             resultType.getElementType(), rewriter);
-    if (failed(results))
+    if (failed(results)) {
       return failure();
+    }
 
     replaceOpWithFlatConvertedValues(rewriter, op, *results, *this->getTypeConverter());
     return success();
@@ -11942,8 +12553,9 @@ struct OneToNVMIShuffleOpPattern : OpConversionPattern<VMIShuffleOp> {
     ValueRange sourceParts = adaptor.getSource();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
-    if (failed(maybe_resultTypes))
+    if (failed(maybe_resultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     std::string reason;
     FailureOr<SmallVector<int64_t>> sourceFlatIndices =
@@ -12007,8 +12619,9 @@ struct OneToNVMIShuffleOpPattern : OpConversionPattern<VMIShuffleOp> {
       return rewriter.notifyMatchFailure(op,
                                          Twine("shuffle vselr ") + vselrReason);
 
-    if (vselrPlans->size() != resultTypes.size())
+    if (vselrPlans->size() != resultTypes.size()) {
       return rewriter.notifyMatchFailure(op, "shuffle vselr arity mismatch");
+    }
 
     SmallVector<Value> results;
     results.reserve(resultTypes.size());
@@ -12064,8 +12677,9 @@ Block *convertBranchDestBlock(Block *block, ConversionPatternRewriter &rewriter,
                               const TypeConverter &typeConverter,
                               llvm::DenseMap<Block *, Block *> &converted) {
   auto [it, inserted] = converted.try_emplace(block, nullptr);
-  if (!inserted)
+  if (!inserted) {
     return it->second;
+  }
 
   TypeConverter::SignatureConversion argMapping(block->getNumArguments());
   if (failed(typeConverter.convertSignatureArgs(block->getArgumentTypes(),
@@ -12170,8 +12784,9 @@ struct OneToNCFSwitchOpPattern : OpConversionPattern<cf::SwitchOp> {
          llvm::zip(op.getCaseOperands(), adaptor.getCaseOperands()))
       changed |=
           !isIdentityOneToNValueMapping(originalOperands, convertedOperands);
-    if (!changed)
+    if (!changed) {
       return failure();
+    }
 
     ValueRange flag = adaptor.getFlag();
     if (flag.size() != 1)
@@ -12185,10 +12800,12 @@ struct OneToNCFSwitchOpPattern : OpConversionPattern<cf::SwitchOp> {
 
     caseOperandStorage.reserve(op.getCaseOperandSegments().size());
     caseOperands.reserve(op.getCaseOperandSegments().size());
-    for (ArrayRef<ValueRange> convertedOperands : adaptor.getCaseOperands())
+    for (ArrayRef<ValueRange> convertedOperands : adaptor.getCaseOperands()) {
       caseOperandStorage.push_back(flattenOneToNOperands(convertedOperands));
-    for (SmallVector<Value> &operands : caseOperandStorage)
+    }
+    for (SmallVector<Value> &operands : caseOperandStorage) {
       caseOperands.push_back(operands);
+    }
 
     rewriter.replaceOpWithNewOp<cf::SwitchOp>(
         op, flag.front(), defaultDest, defaultOperands, op.getCaseValuesAttr(),
@@ -12207,11 +12824,13 @@ struct OneToNSCFExecuteRegionOpPattern
                   ConversionPatternRewriter &rewriter) const override {
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, *this->getTypeConverter());
-    if (failed(maybeResultTypes))
+    if (failed(maybeResultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
-    if (resultTypes == op->getResultTypes())
+    if (resultTypes == op->getResultTypes()) {
       return failure();
+    }
 
     auto newOp =
         rewriter.create<scf::ExecuteRegionOp>(op.getLoc(), resultTypes);
@@ -12239,11 +12858,13 @@ struct OneToNSCFIndexSwitchOpPattern
 
     FailureOr<SmallVector<Type>> maybeResultTypes =
         getConvertedResultTypes(op, *this->getTypeConverter());
-    if (failed(maybeResultTypes))
+    if (failed(maybeResultTypes)) {
       return failure();
+    }
     SmallVector<Type> resultTypes = std::move(*maybeResultTypes);
-    if (resultTypes == op->getResultTypes())
+    if (resultTypes == op->getResultTypes()) {
       return failure();
+    }
 
     auto newOp = rewriter.create<scf::IndexSwitchOp>(
         op.getLoc(), resultTypes, arg.front(), op.getCases(), op.getNumCases());
@@ -12394,48 +13015,54 @@ LogicalResult verifyNoResidualVMIIR(ModuleOp module) {
 LogicalResult checkSupportedExtFShape(VMIExtFOp op,
                                       std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (failed(supports.getExtFSupport(op, reason)))
+  if (failed(supports.getExtFSupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult checkSupportedTruncFShape(VMITruncFOp op,
                                         std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (failed(supports.getTruncFSupport(op, reason)))
+  if (failed(supports.getTruncFSupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult checkSupportedExtSIShape(VMIExtSIOp op,
                                        std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (failed(supports.getExtSISupport(op, reason)))
+  if (failed(supports.getExtSISupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult checkSupportedExtUIShape(VMIExtUIOp op,
                                        std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (failed(supports.getExtUISupport(op, reason)))
+  if (failed(supports.getExtUISupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult checkSupportedTruncIShape(VMITruncIOp op,
                                         std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (failed(supports.getTruncISupport(op, reason)))
+  if (failed(supports.getTruncISupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
 LogicalResult checkSupportedFPToSIShape(VMIFPToSIOp op,
                                         std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12443,22 +13070,25 @@ LogicalResult checkSupportedFPToSIShape(VMIFPToSIOp op,
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
+  }
 
   Type srcElem = sourceType.getElementType();
   Type dstElem = resultType.getElementType();
   auto contract = lookupVMIFpToSiContract(srcElem, dstElem);
-  if (!contract)
+  if (!contract) {
     return fail("unsupported fp-to-si conversion element type pair");
+  }
 
   unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
   unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
 
   if (srcBits == dstBits) {
     // Same-width (f32→s32, f16→s16): layout equality + arity equality.
-    if (sourceLayout != resultLayout)
+    if (sourceLayout != resultLayout) {
       return fail("same-width fp-to-si requires matching layouts");
+    }
     FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
     FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
     if (failed(sourceArity) || failed(resultArity) ||
@@ -12470,8 +13100,9 @@ LogicalResult checkSupportedFPToSIShape(VMIFPToSIOp op,
     FailureOr<VMICastLayoutFact> fact =
         layoutSupport.getCastLayoutFactForLayouts(
             sourceType, resultType, sourceLayout, resultLayout, reason);
-    if (failed(fact))
+    if (failed(fact)) {
       return failure();
+    }
   }
 
   return success();
@@ -12480,8 +13111,9 @@ LogicalResult checkSupportedFPToSIShape(VMIFPToSIOp op,
 LogicalResult checkSupportedFPToUIShape(VMIFPToUIOp op,
                                         std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12489,22 +13121,25 @@ LogicalResult checkSupportedFPToUIShape(VMIFPToUIOp op,
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
+  }
 
   Type srcElem = sourceType.getElementType();
   Type dstElem = resultType.getElementType();
   auto contract = lookupVMIFpToUIContract(srcElem, dstElem);
-  if (!contract)
+  if (!contract) {
     return fail("unsupported fp-to-ui conversion element type pair");
+  }
 
   unsigned srcBits = pto::getPTOStorageElemBitWidth(srcElem);
   unsigned dstBits = pto::getPTOStorageElemBitWidth(dstElem);
 
   if (srcBits == dstBits) {
     // Same-width: layout equality + arity equality.
-    if (sourceLayout != resultLayout)
+    if (sourceLayout != resultLayout) {
       return fail("same-width fp-to-ui requires matching layouts");
+    }
     FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
     FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
     if (failed(sourceArity) || failed(resultArity) ||
@@ -12516,8 +13151,9 @@ LogicalResult checkSupportedFPToUIShape(VMIFPToUIOp op,
     FailureOr<VMICastLayoutFact> fact =
         layoutSupport.getCastLayoutFactForLayouts(
             sourceType, resultType, sourceLayout, resultLayout, reason);
-    if (failed(fact))
+    if (failed(fact)) {
       return failure();
+    }
   }
 
   return success();
@@ -12526,8 +13162,9 @@ LogicalResult checkSupportedFPToUIShape(VMIFPToUIOp op,
 LogicalResult checkSupportedSIToFPShape(VMISIToFPOp op,
                                         std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12535,15 +13172,18 @@ LogicalResult checkSupportedSIToFPShape(VMISIToFPOp op,
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
-  if (sourceLayout != resultLayout)
+  }
+  if (sourceLayout != resultLayout) {
     return fail("requires source/result layouts to match");
+  }
   if (!isa<IntegerType>(sourceType.getElementType()) ||
       pto::getPTOStorageElemBitWidth(sourceType.getElementType()) != 32)
     return fail("requires 32-bit integer source element type");
-  if (!resultType.getElementType().isF32())
+  if (!resultType.getElementType().isF32()) {
     return fail("requires f32 result element type");
+  }
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
   if (failed(sourceArity) || failed(resultArity) ||
@@ -12554,8 +13194,9 @@ LogicalResult checkSupportedSIToFPShape(VMISIToFPOp op,
 
 LogicalResult checkSupportedBitcastShape(VMIBitcastOp op, std::string *reason) {
   VMILayoutSupport supports;
-  if (failed(supports.getBitcastSupport(op, reason)))
+  if (failed(supports.getBitcastSupport(op, reason))) {
     return failure();
+  }
   return success();
 }
 
@@ -12563,19 +13204,22 @@ LogicalResult
 checkSupportedChannelSplitShape(VMIChannelSplitOp op,
                                 std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   int64_t channels = op.getNumResults();
-  if (channels != 2 && channels != 4)
+  if (channels != 2 && channels != 4) {
     return fail("pto.vmi.channel_split supports only 2 or 4 channels");
+  }
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-  if (!sourceLayout)
+  if (!sourceLayout) {
     return fail("requires assigned source layout");
+  }
   auto expectedLayout =
       VMILayoutAttr::getDeinterleaved(op.getContext(), channels);
   if (!sourceLayout.isContiguous() && sourceLayout != expectedLayout)
@@ -12585,8 +13229,9 @@ checkSupportedChannelSplitShape(VMIChannelSplitOp op,
   for (Value result : op.getResults()) {
     VMILayoutAttr resultLayout =
         cast<VMIVRegType>(result.getType()).getLayoutAttr();
-    if (!resultLayout || !resultLayout.isContiguous())
+    if (!resultLayout || !resultLayout.isContiguous()) {
       return fail("requires every result layout to be contiguous");
+    }
   }
 
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
@@ -12594,14 +13239,17 @@ checkSupportedChannelSplitShape(VMIChannelSplitOp op,
   for (Value result : op.getResults()) {
     FailureOr<int64_t> arity =
         getVMIPhysicalArity(cast<VMIVRegType>(result.getType()));
-    if (failed(arity))
+    if (failed(arity)) {
       return fail("requires computable result physical arity");
+    }
     resultArity += *arity;
   }
-  if (failed(sourceArity))
+  if (failed(sourceArity)) {
     return fail("requires computable source physical arity");
-  if (*sourceArity != resultArity)
+  }
+  if (*sourceArity != resultArity) {
     return fail("requires source and result to have the same physical arity");
+  }
 
   return success();
 }
@@ -12610,31 +13258,36 @@ LogicalResult
 checkSupportedChannelMergeShape(VMIChannelMergeOp op,
                                 std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   int64_t channels = op.getInputs().size();
-  if (channels != 2 && channels != 4)
+  if (channels != 2 && channels != 4) {
     return fail("pto.vmi.channel_merge supports only 2 or 4 channels");
+  }
 
   int64_t inputArity = 0;
   for (Value input : op.getInputs()) {
     auto inputType = cast<VMIVRegType>(input.getType());
     VMILayoutAttr inputLayout = inputType.getLayoutAttr();
-    if (!inputLayout || !inputLayout.isContiguous())
+    if (!inputLayout || !inputLayout.isContiguous()) {
       return fail("requires every input layout to be contiguous");
+    }
     FailureOr<int64_t> arity = getVMIPhysicalArity(inputType);
-    if (failed(arity))
+    if (failed(arity)) {
       return fail("requires computable input physical arity");
+    }
     inputArity += *arity;
   }
 
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!resultLayout)
+  if (!resultLayout) {
     return fail("requires assigned result layout");
+  }
   auto expectedLayout =
       VMILayoutAttr::getDeinterleaved(op.getContext(), channels);
   if (!resultLayout.isContiguous() && resultLayout != expectedLayout)
@@ -12642,10 +13295,12 @@ checkSupportedChannelMergeShape(VMIChannelMergeOp op,
                 "deinterleaved channel layout");
 
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(resultArity))
+  if (failed(resultArity)) {
     return fail("requires computable result physical arity");
-  if (*resultArity != inputArity)
+  }
+  if (*resultArity != inputArity) {
     return fail("requires source and result to have the same physical arity");
+  }
 
   return success();
 }
@@ -12654,8 +13309,9 @@ LogicalResult
 checkSupportedActivePrefixIndexShape(VMIActivePrefixIndexOp op,
                                      std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12663,10 +13319,12 @@ checkSupportedActivePrefixIndexShape(VMIActivePrefixIndexOp op,
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!maskLayout || !resultLayout)
+  if (!maskLayout || !resultLayout) {
     return fail("requires assigned mask and result layouts");
-  if (!maskLayout.isContiguous() || !resultLayout.isContiguous())
+  }
+  if (!maskLayout.isContiguous() || !resultLayout.isContiguous()) {
     return fail("requires contiguous mask and result layouts");
+  }
 
   std::string resultFullReason;
   if (failed(checkFullDataPhysicalChunks(resultType, &resultFullReason)))
@@ -12682,8 +13340,9 @@ checkSupportedActivePrefixIndexShape(VMIActivePrefixIndexOp op,
 
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(maskArity) || failed(resultArity))
+  if (failed(maskArity) || failed(resultArity)) {
     return fail("requires computable mask and result physical arity");
+  }
   if (*maskArity != 1 || *resultArity != 1)
     return fail("requires a single physical chunk; multi-chunk prefix needs "
                 "cross-chunk carry");
@@ -12694,8 +13353,9 @@ checkSupportedActivePrefixIndexShape(VMIActivePrefixIndexOp op,
 LogicalResult checkSupportedCompressShape(VMICompressOp op,
                                           std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12705,8 +13365,9 @@ LogicalResult checkSupportedCompressShape(VMICompressOp op,
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !maskLayout || !resultLayout)
+  if (!sourceLayout || !maskLayout || !resultLayout) {
     return fail("requires assigned source, mask, and result layouts");
+  }
   if (!sourceLayout.isContiguous() || !maskLayout.isContiguous() ||
       !resultLayout.isContiguous())
     return fail("requires contiguous source, mask, and result layouts");
@@ -12720,8 +13381,9 @@ LogicalResult checkSupportedCompressShape(VMICompressOp op,
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(sourceArity) || failed(maskArity) || failed(resultArity))
+  if (failed(sourceArity) || failed(maskArity) || failed(resultArity)) {
     return fail("requires computable source, mask, and result physical arity");
+  }
   if (*sourceArity != 1 || *maskArity != 1 || *resultArity != 1)
     return fail("requires a single physical chunk; multi-chunk compress needs "
                 "cross-chunk compaction");
@@ -12733,8 +13395,9 @@ LogicalResult checkSupportedCompressStoreShape(
     VMICompressStoreOp op,
     std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12742,10 +13405,12 @@ LogicalResult checkSupportedCompressStoreShape(
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   VMILayoutAttr valueLayout = valueType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
-  if (!valueLayout || !maskLayout)
+  if (!valueLayout || !maskLayout) {
     return fail("requires assigned value and mask layouts");
-  if (!valueLayout.isContiguous() || !maskLayout.isContiguous())
+  }
+  if (!valueLayout.isContiguous() || !maskLayout.isContiguous()) {
     return fail("requires contiguous value and mask layouts");
+  }
 
   if (!isa<PtrType>(op.getDestination().getType()))
     return fail("requires !pto.ptr destination because pto.vstur is "
@@ -12759,8 +13424,9 @@ LogicalResult checkSupportedCompressStoreShape(
 
   FailureOr<int64_t> valueArity = getVMIPhysicalArity(valueType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
-  if (failed(valueArity) || failed(maskArity))
+  if (failed(valueArity) || failed(maskArity)) {
     return fail("requires computable value and mask physical arity");
+  }
   if (*valueArity != 1 || *maskArity != 1)
     return fail("requires a single physical chunk; multi-chunk "
                 "compress_store needs cross-chunk compaction and SQZN "
@@ -12774,13 +13440,15 @@ LogicalResult
 checkSupportedReduceShape(OpTy op, bool requiresReassoc,
                           std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
-  if (requiresReassoc && !op->hasAttr("reassoc"))
+  if (requiresReassoc && !op->hasAttr("reassoc")) {
     return fail("requires reassoc attr for pair-wise floating-point vcadd");
+  }
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
@@ -12788,11 +13456,13 @@ checkSupportedReduceShape(OpTy op, bool requiresReassoc,
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !maskLayout || !resultLayout)
+  if (!sourceLayout || !maskLayout || !resultLayout) {
     return fail("requires assigned source, mask, and result layouts");
+  }
   if (!sourceLayout.isContiguous() || !maskLayout.isContiguous() ||
-      !resultLayout.isContiguous())
+      !resultLayout.isContiguous()) {
     return fail("requires contiguous source, mask, and result layouts");
+  }
 
   std::string fullChunkReason;
   if (failed(checkFullDataPhysicalChunks(sourceType, &fullChunkReason)))
@@ -12808,8 +13478,9 @@ checkSupportedReduceShape(OpTy op, bool requiresReassoc,
   if (*sourceArity < 1 || *maskArity != *sourceArity)
     return fail("requires source and mask physical arity to match and be "
                 "non-empty");
-  if (*resultArity != 1)
+  if (*resultArity != 1) {
     return fail("requires one result physical chunk");
+  }
 
   return success();
 }
@@ -12819,23 +13490,29 @@ LogicalResult
 checkSupportedGroupReduceShape(OpTy op, std::string *reason = nullptr) {
   VMILayoutSupport supports;
   if constexpr (std::is_same_v<OpTy, VMIGroupReduceAddFOp>) {
-    if (succeeded(supports.getGroupReduceAddFSupport(op, reason)))
+    if (succeeded(supports.getGroupReduceAddFSupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMaxFOp>) {
-    if (succeeded(supports.getGroupReduceMaxFSupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMaxFSupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMaxIOp>) {
-    if (succeeded(supports.getGroupReduceMaxISupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMaxISupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMinFOp>) {
-    if (succeeded(supports.getGroupReduceMinFSupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMinFSupport(op, reason))) {
       return success();
+    }
   } else if constexpr (std::is_same_v<OpTy, VMIGroupReduceMinIOp>) {
-    if (succeeded(supports.getGroupReduceMinISupport(op, reason)))
+    if (succeeded(supports.getGroupReduceMinISupport(op, reason))) {
       return success();
+    }
   } else {
-    if (succeeded(supports.getGroupReduceAddISupport(op, reason)))
+    if (succeeded(supports.getGroupReduceAddISupport(op, reason))) {
       return success();
+    }
   }
   return failure();
 }
@@ -12846,31 +13523,39 @@ LogicalResult checkSupportedGroupBroadcastShape(
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   if (sourceType.getElementType() != resultType.getElementType()) {
-    if (reason)
+    if (reason) {
       *reason = "requires source/result element type to match";
+    }
     return failure();
   }
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !resultLayout)
+  if (!sourceLayout || !resultLayout) {
     return fail("requires assigned source/result layouts");
+  }
   int64_t numGroups = op.getNumGroupsAttr().getInt();
-  if (numGroups <= 0)
+  if (numGroups <= 0) {
     return fail("requires positive num_groups");
-  if (sourceType.getElementCount() != numGroups)
+  }
+  if (sourceType.getElementCount() != numGroups) {
     return fail("requires source lane count to match num_groups");
-  if (resultType.getElementCount() % numGroups != 0)
+  }
+  if (resultType.getElementCount() % numGroups != 0) {
     return fail("requires num_groups to evenly divide result lane count");
-  if (!sourceLayout.isGroupSlots() || sourceLayout.getNumGroups() != numGroups)
+  }
+  if (!sourceLayout.isGroupSlots() || sourceLayout.getNumGroups() != numGroups) {
     return fail("requires matching num_groups source layout");
-  if (resultLayout.isGroupSlots())
+  }
+  if (resultLayout.isGroupSlots()) {
     return fail("requires dense result layout");
+  }
 
   if (sourceLayout.getSlots() > 0 && sourceLayout.getSlots() != 8 &&
       sourceLayout.getSlots() != 1)
@@ -12878,8 +13563,9 @@ LogicalResult checkSupportedGroupBroadcastShape(
                 "layouts");
   VMILayoutSupport supports;
   std::string supportReason;
-  if (failed(supports.getGroupBroadcastSupport(op, &supportReason)))
+  if (failed(supports.getGroupBroadcastSupport(op, &supportReason))) {
     return fail(supportReason);
+  }
 
   FailureOr<int64_t> lanesPerPart =
       getDataLanesPerPart(sourceType.getElementType());
@@ -12890,15 +13576,17 @@ LogicalResult checkSupportedGroupBroadcastShape(
     return fail("requires matching physical lanes per part");
   FailureOr<int64_t> groupSize = getGroupSizeFromNumGroups(
       resultType, numGroups, reason);
-  if (failed(groupSize))
+  if (failed(groupSize)) {
     return failure();
+  }
   if (*lanesPerPart % *groupSize != 0 && *groupSize % *lanesPerPart != 0)
     return fail("requires derived group size to divide or be a multiple of "
                 "physical lanes per part");
 
   FailureOr<int64_t> resultFactor = getDataLayoutFactor(resultType);
-  if (failed(resultFactor))
+  if (failed(resultFactor)) {
     return fail("requires known result layout factor");
+  }
   bool laneStridedDense =
       resultLayout.isDense() && resultLayout.getLaneStride() > 1;
   if (!laneStridedDense) {
@@ -12907,8 +13595,9 @@ LogicalResult checkSupportedGroupBroadcastShape(
       return fail(Twine("requires full result physical chunks; ") +
                   fullChunkReason);
   }
-  if (*resultFactor == 1)
+  if (*resultFactor == 1) {
     return success();
+  }
   FailureOr<int64_t> resultBlockElems =
       getVMILayoutBlockElems(resultType);
   bool blockFragmentSmallGroup =
@@ -12919,8 +13608,9 @@ LogicalResult checkSupportedGroupBroadcastShape(
       *groupSize < *lanesPerPart && *groupSize >= *resultFactor &&
       *groupSize % *resultFactor == 0 &&
       *lanesPerPart % (*groupSize / *resultFactor) == 0;
-  if (blockFragmentSmallGroup || deinterleavedSmallGroup)
+  if (blockFragmentSmallGroup || deinterleavedSmallGroup) {
     return success();
+  }
   int64_t logicalSpanPerResultChunk = *lanesPerPart * *resultFactor;
   if (*groupSize < *lanesPerPart || *groupSize % logicalSpanPerResultChunk != 0)
     return fail("deinterleaved result requires every physical result chunk to "
@@ -12931,24 +13621,27 @@ LogicalResult checkSupportedGroupBroadcastShape(
 LogicalResult checkSupportedVdhistShape(VMIVdhistOp op,
                                        std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (succeeded(supports.getVdhistSupport(op, reason)))
+  if (succeeded(supports.getVdhistSupport(op, reason))) {
     return success();
+  }
   return failure();
 }
 
 LogicalResult checkSupportedVchistShape(VMIVchistOp op,
                                        std::string *reason = nullptr) {
   VMILayoutSupport supports;
-  if (succeeded(supports.getVchistSupport(op, reason)))
+  if (succeeded(supports.getVchistSupport(op, reason))) {
     return success();
+  }
   return failure();
 }
 
 LogicalResult checkSupportedVmullShape(VMIVmullOp op,
                                        std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
@@ -12962,16 +13655,19 @@ LogicalResult checkSupportedVmullShape(VMIVmullOp op,
   if (!elementType || elementType.getWidth() != 32 ||
       (!elementType.isSignless() && !elementType.isUnsigned()))
     return fail("requires element type to be exactly i32 or ui32");
-  if (aType != bType || aType != lowType || aType != highType)
+  if (aType != bType || aType != lowType || aType != highType) {
     return fail("requires identical a, b, low, and high VMI vreg types");
+  }
 
   int64_t lanes = aType.getElementCount();
-  if (lanes != 64 && lanes != 128 && lanes != 256)
+  if (lanes != 64 && lanes != 128 && lanes != 256) {
     return fail("requires logical lane count 64, 128, or 256");
+  }
 
   VMILayoutAttr layout = aType.getLayoutAttr();
-  if (!layout)
+  if (!layout) {
     return fail("requires an assigned data layout");
+  }
   bool supportedLayout =
       layout.getLaneStride() == 1 &&
       (layout.isContiguous() ||
@@ -12983,8 +13679,9 @@ LogicalResult checkSupportedVmullShape(VMIVmullOp op,
   if (maskType.getLayoutAttr() != layout)
     return fail("requires the mask and all four data values to share one "
                 "layout");
-  if (maskType.getGranularity() != "b32")
+  if (maskType.getGranularity() != "b32") {
     return fail("requires b32 mask granularity");
+  }
 
   FailureOr<int64_t> aArity = getVMIPhysicalArity(aType);
   FailureOr<int64_t> bArity = getVMIPhysicalArity(bType);
@@ -13081,15 +13778,17 @@ LogicalResult checkSupportedVMIAddcsShape(VMIVaddcsOp op,
 LogicalResult
 checkSupportedFmaShape(VMIFmaOp op, std::string *reason = nullptr) {
   auto fail = [&](const Twine &message) -> LogicalResult {
-    if (reason)
+    if (reason) {
       *reason = message.str();
+    }
     return failure();
   };
 
   auto lhsType = cast<VMIVRegType>(op.getLhs().getType());
   FailureOr<int64_t> arity = getVMIPhysicalArity(lhsType);
-  if (failed(arity) || *arity < 1)
+  if (failed(arity) || *arity < 1) {
     return fail("requires computable non-empty physical arity");
+  }
 
   return success();
 }
@@ -13097,8 +13796,9 @@ checkSupportedFmaShape(VMIFmaOp op, std::string *reason = nullptr) {
 LogicalResult
 checkSupportedReluShape(VMIReluOp op, std::string *reason = nullptr) {
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
-  if (failed(checkSupportedMaskableVReg(resultType, reason)))
+  if (failed(checkSupportedMaskableVReg(resultType, reason))) {
     return failure();
+  }
 
   return success();
 }
@@ -13160,8 +13860,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
   auto emitMaskableUnsupported = [&](Operation *op, StringRef opName,
                                      VMIVRegType type) -> WalkResult {
     std::string reason;
-    if (succeeded(checkSupportedMaskableVReg(type, &reason)))
+    if (succeeded(checkSupportedMaskableVReg(type, &reason))) {
       return WalkResult::advance();
+    }
 
     op->emitError()
         << kVMIDiagUnsupportedPrefix << opName
@@ -13207,8 +13908,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     }
     if (auto hist = dyn_cast<VMIVdhistOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedVdhistShape(hist, &reason)))
+      if (succeeded(checkSupportedVdhistShape(hist, &reason))) {
         return WalkResult::advance();
+      }
       hist.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.vdhist requires contiguous Nx{ui8|i8} source, contiguous b8 "
@@ -13218,8 +13920,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     }
     if (auto hist = dyn_cast<VMIVchistOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedVchistShape(hist, &reason)))
+      if (succeeded(checkSupportedVchistShape(hist, &reason))) {
         return WalkResult::advance();
+      }
       hist.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.vchist requires contiguous Nx{ui8|i8} source, contiguous b8 "
@@ -13248,8 +13951,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     }
     if (auto load = dyn_cast<VMIStrideLoadOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedStrideLoadShape(load, &reason)))
+      if (succeeded(checkSupportedStrideLoadShape(load, &reason))) {
         return WalkResult::advance();
+      }
       load.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.stride_load lowers through pto.vsldb only for one "
@@ -13259,8 +13963,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     }
     if (auto load = dyn_cast<VMIGroupLoadOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedGroupLoadShape(load, &reason)))
+      if (succeeded(checkSupportedGroupLoadShape(load, &reason))) {
         return WalkResult::advance();
+      }
       load.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.group_load requires contiguous full result chunks, a "
@@ -13306,8 +14011,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
         return WalkResult::interrupt();
       }
       std::string reason;
-      if (succeeded(checkSupportedMaskedLoadShape(load, &reason)))
+      if (succeeded(checkSupportedMaskedLoadShape(load, &reason))) {
         return WalkResult::advance();
+      }
       load.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.masked_load direct lowering requires a supported memory "
@@ -13318,8 +14024,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     }
     if (auto gather = dyn_cast<VMIGatherOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedGatherShape(gather, &reason)))
+      if (succeeded(checkSupportedGatherShape(gather, &reason))) {
         return WalkResult::advance();
+      }
       gather.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.gather lowers through pto.vgather2_bc + pto.vsel only "
@@ -13330,8 +14037,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     }
     if (auto load = dyn_cast<VMIExpandLoadOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedExpandLoadShape(load, &reason)))
+      if (succeeded(checkSupportedExpandLoadShape(load, &reason))) {
         return WalkResult::advance();
+      }
       load.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.expand_load direct lowering is currently supported for "
@@ -13411,8 +14119,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     }
     if (auto scatter = dyn_cast<VMIScatterOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedScatterShape(scatter, &reason)))
+      if (succeeded(checkSupportedScatterShape(scatter, &reason))) {
         return WalkResult::advance();
+      }
       scatter.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.scatter lowers through pto.vscatter only with a UB "
@@ -13526,22 +14235,29 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
       return emitMaskableUnsupported(
           op, opName, cast<VMIVRegType>(vecScalar.getResult().getType()));
     };
-    if (auto vecScalar = dyn_cast<VMIAddSOp>(op))
+    if (auto vecScalar = dyn_cast<VMIAddSOp>(op)) {
       return verifyVecScalar(vecScalar, "pto.vmi.vadds");
-    if (auto vecScalar = dyn_cast<VMIMulSOp>(op))
+    }
+    if (auto vecScalar = dyn_cast<VMIMulSOp>(op)) {
       return verifyVecScalar(vecScalar, "pto.vmi.vmuls");
-    if (auto vecScalar = dyn_cast<VMIMaxSOp>(op))
+    }
+    if (auto vecScalar = dyn_cast<VMIMaxSOp>(op)) {
       return verifyVecScalar(vecScalar, "pto.vmi.vmaxs");
-    if (auto vecScalar = dyn_cast<VMIMinSOp>(op))
+    }
+    if (auto vecScalar = dyn_cast<VMIMinSOp>(op)) {
       return verifyVecScalar(vecScalar, "pto.vmi.vmins");
-    if (auto vecScalar = dyn_cast<VMIShlSOp>(op))
+    }
+    if (auto vecScalar = dyn_cast<VMIShlSOp>(op)) {
       return verifyVecScalar(vecScalar, "pto.vmi.vshls");
-    if (auto vecScalar = dyn_cast<VMIShrSOp>(op))
+    }
+    if (auto vecScalar = dyn_cast<VMIShrSOp>(op)) {
       return verifyVecScalar(vecScalar, "pto.vmi.vshrs");
+    }
     if (auto vmull = dyn_cast<VMIVmullOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedVmullShape(vmull, &reason)))
+      if (succeeded(checkSupportedVmullShape(vmull, &reason))) {
         return WalkResult::advance();
+      }
       vmull.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.vmull requires equal 64/128/256-lane i32/ui32 data "
@@ -13585,8 +14301,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           op, "pto.vmi.ln", cast<VMIVRegType>(ln.getResult().getType()));
     if (auto relu = dyn_cast<VMIReluOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedReluShape(relu, &reason)))
+      if (succeeded(checkSupportedReluShape(relu, &reason))) {
         return WalkResult::advance();
+      }
       relu.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.relu direct lowering requires physical vreg parts with "
@@ -13621,8 +14338,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           cast<VMIVRegType>(select.getResult().getType()));
     if (auto vselr = dyn_cast<VMIVselrOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedVselrShape(vselr, &reason)))
+      if (succeeded(checkSupportedVselrShape(vselr, &reason))) {
         return WalkResult::advance();
+      }
       vselr.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.vselr supports only contiguous lane_stride=1 layouts "
@@ -13635,8 +14353,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     if (auto cmpf = dyn_cast<VMICmpFOp>(op)) {
       WalkResult physical = emitMaskableUnsupported(
           op, "pto.vmi.cmpf", cast<VMIVRegType>(cmpf.getLhs().getType()));
-      if (physical.wasInterrupted())
+      if (physical.wasInterrupted()) {
         return physical;
+      }
       if (succeeded(checkSupportedComparePredicate<VMICmpFOp>(
               op, cmpf.getPredicate())))
         return WalkResult::advance();
@@ -13646,8 +14365,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
     if (auto cmpi = dyn_cast<VMICmpIOp>(op)) {
       WalkResult physical = emitMaskableUnsupported(
           op, "pto.vmi.cmpi", cast<VMIVRegType>(cmpi.getLhs().getType()));
-      if (physical.wasInterrupted())
+      if (physical.wasInterrupted()) {
         return physical;
+      }
       if (succeeded(checkSupportedComparePredicate<VMICmpIOp>(
               op, cmpi.getPredicate())))
         return WalkResult::advance();
@@ -13669,8 +14389,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto compress = dyn_cast<VMICompressOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedCompressShape(compress, &reason)))
+      if (succeeded(checkSupportedCompressShape(compress, &reason))) {
         return WalkResult::advance();
+      }
       compress.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.compress lowers through pto.vsqz only for one "
@@ -13681,8 +14402,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto compressStore = dyn_cast<VMICompressStoreOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedCompressStoreShape(compressStore, &reason)))
+      if (succeeded(checkSupportedCompressStoreShape(compressStore, &reason))) {
         return WalkResult::advance();
+      }
       compressStore.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.compress_store lowers through pto.vsqz + pto.vstur "
@@ -13783,8 +14505,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto reduce = dyn_cast<VMIGroupReduceMinFOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedGroupReduceShape(reduce, &reason)))
+      if (succeeded(checkSupportedGroupReduceShape(reduce, &reason))) {
         return WalkResult::advance();
+      }
       reduce.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.group_reduce_minf lowers through pto.vcgmin/vmin for "
@@ -13796,8 +14519,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto reduce = dyn_cast<VMIGroupReduceMinIOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedGroupReduceShape(reduce, &reason)))
+      if (succeeded(checkSupportedGroupReduceShape(reduce, &reason))) {
         return WalkResult::advance();
+      }
       reduce.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.group_reduce_mini lowers through pto.vcgmin/vmin for "
@@ -13865,8 +14589,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto fma = dyn_cast<VMIFmaOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedFmaShape(fma, &reason)))
+      if (succeeded(checkSupportedFmaShape(fma, &reason))) {
         return WalkResult::advance();
+      }
       fma.emitError()
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.fma lowers through pto.vmula only for f16/bf16/f32 "
@@ -13877,8 +14602,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto extf = dyn_cast<VMIExtFOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedExtFShape(extf, &reason)))
+      if (succeeded(checkSupportedExtFShape(extf, &reason))) {
         return WalkResult::advance();
+      }
 
       extf.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13892,8 +14618,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto truncf = dyn_cast<VMITruncFOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedTruncFShape(truncf, &reason)))
+      if (succeeded(checkSupportedTruncFShape(truncf, &reason))) {
         return WalkResult::advance();
+      }
 
       truncf.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13907,8 +14634,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto fptosi = dyn_cast<VMIFPToSIOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedFPToSIShape(fptosi, &reason)))
+      if (succeeded(checkSupportedFPToSIShape(fptosi, &reason))) {
         return WalkResult::advance();
+      }
 
       fptosi.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13920,8 +14648,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto fptoui = dyn_cast<VMIFPToUIOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedFPToUIShape(fptoui, &reason)))
+      if (succeeded(checkSupportedFPToUIShape(fptoui, &reason))) {
         return WalkResult::advance();
+      }
 
       fptoui.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13934,8 +14663,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto sitofp = dyn_cast<VMISIToFPOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedSIToFPShape(sitofp, &reason)))
+      if (succeeded(checkSupportedSIToFPShape(sitofp, &reason))) {
         return WalkResult::advance();
+      }
 
       sitofp.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13947,8 +14677,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto extsi = dyn_cast<VMIExtSIOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedExtSIShape(extsi, &reason)))
+      if (succeeded(checkSupportedExtSIShape(extsi, &reason))) {
         return WalkResult::advance();
+      }
 
       extsi.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13964,8 +14695,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto extui = dyn_cast<VMIExtUIOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedExtUIShape(extui, &reason)))
+      if (succeeded(checkSupportedExtUIShape(extui, &reason))) {
         return WalkResult::advance();
+      }
 
       extui.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13981,8 +14713,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto trunci = dyn_cast<VMITruncIOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedTruncIShape(trunci, &reason)))
+      if (succeeded(checkSupportedTruncIShape(trunci, &reason))) {
         return WalkResult::advance();
+      }
 
       trunci.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -13999,8 +14732,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto bitcast = dyn_cast<VMIBitcastOp>(op)) {
       std::string reason;
-      if (succeeded(checkSupportedBitcastShape(bitcast, &reason)))
+      if (succeeded(checkSupportedBitcastShape(bitcast, &reason))) {
         return WalkResult::advance();
+      }
 
       bitcast.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -14055,14 +14789,17 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto shuffle = dyn_cast<VMIShuffleOp>(op)) {
       std::string reason;
-      if (succeeded(computeShuffleForwardingSourceParts(shuffle, &reason)))
+      if (succeeded(computeShuffleForwardingSourceParts(shuffle, &reason))) {
         return WalkResult::advance();
+      }
       std::string splatReason;
-      if (succeeded(computeShuffleLane0SplatSourcePart(shuffle, &splatReason)))
+      if (succeeded(computeShuffleLane0SplatSourcePart(shuffle, &splatReason))) {
         return WalkResult::advance();
+      }
       std::string vselrReason;
-      if (succeeded(computeShuffleVselrPlans(shuffle, &vselrReason)))
+      if (succeeded(computeShuffleVselrPlans(shuffle, &vselrReason))) {
         return WalkResult::advance();
+      }
 
       shuffle.emitError()
           << kVMIDiagUnsupportedPrefix
@@ -14075,8 +14812,9 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
 
     if (auto constantMask = dyn_cast<VMIConstantMaskOp>(op)) {
       std::string reason;
-      if (succeeded(computeConstantMaskMaterialization(constantMask, &reason)))
+      if (succeeded(computeConstantMaskMaterialization(constantMask, &reason))) {
         return WalkResult::advance();
+      }
 
       constantMask.emitError()
           << kVMIDiagUnsupportedPrefix

--- a/lib/PTO/Transforms/VPTOBufferMaterialization.cpp
+++ b/lib/PTO/Transforms/VPTOBufferMaterialization.cpp
@@ -18,11 +18,13 @@ namespace {
 
 static AddressSpaceAttr getNormalizedPtrMemorySpace(Attribute memorySpace,
                                                     MLIRContext *context) {
-  if (auto addrSpace = dyn_cast_or_null<AddressSpaceAttr>(memorySpace))
+  if (auto addrSpace = dyn_cast_or_null<AddressSpaceAttr>(memorySpace)) {
     return addrSpace;
-  if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace))
+  }
+  if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace)) {
     return AddressSpaceAttr::get(context,
                                  static_cast<AddressSpace>(intAttr.getInt()));
+  }
   return AddressSpaceAttr::get(context, AddressSpace::GM);
 }
 
@@ -31,8 +33,9 @@ static Value materializeMemRefView(Value value, ArrayRef<int64_t> shape,
                                    PatternRewriter &rewriter, Location loc) {
   auto memrefType =
       MemRefType::get(shape, elementType, AffineMap(), memorySpace);
-  if (value.getType() == memrefType)
+  if (value.getType() == memrefType) {
     return value;
+  }
   return rewriter
       .create<UnrealizedConversionCastOp>(
           loc, TypeRange(ArrayRef<Type>{memrefType}), value)
@@ -41,12 +44,14 @@ static Value materializeMemRefView(Value value, ArrayRef<int64_t> shape,
 
 static Value materializeTileBufferView(Value value, PatternRewriter &rewriter,
                                        Location loc) {
-  if (isa<BaseMemRefType>(value.getType()))
+  if (isa<BaseMemRefType>(value.getType())) {
     return value;
+  }
 
   auto tileType = dyn_cast<TileBufType>(value.getType());
-  if (!tileType)
+  if (!tileType) {
     return {};
+  }
 
   return materializeMemRefView(value, tileType.getShape(),
                                tileType.getElementType(),
@@ -58,21 +63,23 @@ static Value materializeTileBufferView(Value value, PatternRewriter &rewriter,
 Value materializeBufferPointer(Value value, Type elementType,
                                Attribute memorySpace,
                                PatternRewriter &rewriter, Location loc) {
-  if (!value)
+  if (!value) {
     return {};
+  }
 
   auto ptrMemorySpace =
       getNormalizedPtrMemorySpace(memorySpace, rewriter.getContext());
   auto ptrType = PtrType::get(rewriter.getContext(), elementType, ptrMemorySpace);
 
-  if (value.getType() == ptrType)
+  if (value.getType() == ptrType) {
     return value;
+  }
 
   Value memrefValue = materializeTileBufferView(value, rewriter, loc);
   auto memrefType = dyn_cast_or_null<MemRefType>(memrefValue.getType());
-  if (!memrefValue || !memrefType)
+  if (!memrefValue || !memrefType) {
     return {};
+  }
   return rewriter.create<CastPtrOp>(loc, ptrType, memrefValue).getResult();
 }
-
 } // namespace mlir::pto

--- a/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOCANN900LLVMEmitter.cpp
@@ -68,16 +68,21 @@ static Type getElementTypeFromVectorLike(Type type);
 static std::optional<int64_t> getElementCountFromVectorLike(Type type);
 
 static Type getLowPrecisionLLVMType(Type type, MLIRContext *context) {
-  if (pto::isPTOHiFloat8Type(type))
+  if (pto::isPTOHiFloat8Type(type)) {
     return LLVM::LLVMHiFloat8Type::get(context);
-  if (isa<pto::F4E1M2x2Type>(type))
+  }
+  if (isa<pto::F4E1M2x2Type>(type)) {
     return LLVM::LLVMFloat4E1M2x2Type::get(context);
-  if (isa<pto::F4E2M1x2Type>(type))
+  }
+  if (isa<pto::F4E2M1x2Type>(type)) {
     return LLVM::LLVMFloat4E2M1x2Type::get(context);
-  if (pto::isPTOFloat8E4M3LikeType(type))
+  }
+  if (pto::isPTOFloat8E4M3LikeType(type)) {
     return LLVM::LLVMFloat8E4M3Type::get(context);
-  if (pto::isPTOFloat8E5M2LikeType(type))
+  }
+  if (pto::isPTOFloat8E5M2LikeType(type)) {
     return LLVM::LLVMFloat8E5M2Type::get(context);
+  }
   return {};
 }
 
@@ -91,20 +96,23 @@ static Type normalizePayloadTypeForLLVMLowering(Type type, Builder &builder) {
   if (pto::isPTOHiFloat8x2Type(type))
     return getLLVMCompatibleVectorType(
         {2}, LLVM::LLVMHiFloat8Type::get(builder.getContext()));
-  if (Type lowpType = getLowPrecisionLLVMType(type, builder.getContext()))
+  if (Type lowpType = getLowPrecisionLLVMType(type, builder.getContext())) {
     return lowpType;
+  }
 
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (!intType.isSignless())
+    if (!intType.isSignless()) {
       return builder.getIntegerType(intType.getWidth());
+    }
     return type;
   }
 
   if (auto vecType = dyn_cast<VectorType>(type)) {
     Type normalizedElement =
         normalizePayloadTypeForLLVMLowering(vecType.getElementType(), builder);
-    if (normalizedElement == vecType.getElementType())
+    if (normalizedElement == vecType.getElementType()) {
       return type;
+    }
     return getLLVMCompatibleVectorType(vecType.getShape(), normalizedElement,
                                        vecType.getScalableDims());
   }
@@ -114,10 +122,12 @@ static Type normalizePayloadTypeForLLVMLowering(Type type, Builder &builder) {
 
 static Type normalizeGEPElementTypeForLLVMLowering(Type type,
                                                    Builder &builder) {
-  if (pto::isPTOHiFloat8x2Type(type))
+  if (pto::isPTOHiFloat8x2Type(type)) {
     return builder.getI16Type();
-  if (pto::isPTOLowPrecisionType(type))
+  }
+  if (pto::isPTOLowPrecisionType(type)) {
     return builder.getI8Type();
+  }
   if (isa<LLVM::LLVMHiFloat8Type, LLVM::LLVMFloat8E4M3Type,
           LLVM::LLVMFloat8E5M2Type, LLVM::LLVMFloat4E1M2x2Type,
           LLVM::LLVMFloat4E2M1x2Type>(type))
@@ -127,8 +137,9 @@ static Type normalizeGEPElementTypeForLLVMLowering(Type type,
     Type normalizedElement =
         normalizeGEPElementTypeForLLVMLowering(vecType.getElementType(),
                                                builder);
-    if (normalizedElement == vecType.getElementType())
+    if (normalizedElement == vecType.getElementType()) {
       return normalizePayloadTypeForLLVMLowering(type, builder);
+    }
     return getLLVMCompatibleVectorType(vecType.getShape(), normalizedElement,
                                        vecType.getScalableDims());
   }
@@ -143,12 +154,15 @@ static Type convertVPTOType(Type type, Builder &builder) {
     return getLLVMCompatibleVectorType({vecType.getElementCount()},
                                        elementType);
   }
-  if (isa<pto::MaskType>(type))
+  if (isa<pto::MaskType>(type)) {
     return VectorType::get({256}, builder.getI1Type());
-  if (isa<pto::AlignType>(type))
+  }
+  if (isa<pto::AlignType>(type)) {
     return VectorType::get({32}, builder.getI8Type());
-  if (isa<pto::StructType>(type))
+  }
+  if (isa<pto::StructType>(type)) {
     return LLVM::LLVMPointerType::get(builder.getContext());
+  }
   if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
     return LLVM::LLVMPointerType::get(
         builder.getContext(),
@@ -160,37 +174,47 @@ static Type convertVPTOType(Type type, Builder &builder) {
 static unsigned getNaturalByteAlignment(Type type) {
   if (auto vecType = dyn_cast<VectorType>(type)) {
     unsigned elemAlign = getNaturalByteAlignment(vecType.getElementType());
-    if (!elemAlign)
+    if (!elemAlign) {
       return 0;
+    }
     int64_t elems = 1;
-    for (int64_t dim : vecType.getShape())
+    for (int64_t dim : vecType.getShape()) {
       elems *= dim;
+    }
     return elemAlign * static_cast<unsigned>(elems);
   }
-  if (auto intType = dyn_cast<IntegerType>(type))
-    return llvm::divideCeil(unsigned(intType.getWidth()), 8u);
-  if (pto::isPTOHiFloat8x2Type(type))
+  if (auto intType = dyn_cast<IntegerType>(type)) {
+    return llvm::divideCeil(static_cast<unsigned>(intType.getWidth()), 8U);
+  }
+  if (pto::isPTOHiFloat8x2Type(type)) {
     return 2;
-  if (pto::isPTOLowPrecisionType(type))
+  }
+  if (pto::isPTOLowPrecisionType(type)) {
     return 1;
-  if (type.isF16() || type.isBF16())
+  }
+  if (type.isF16() || type.isBF16()) {
     return 2;
-  if (type.isF32())
+  }
+  if (type.isF32()) {
     return 4;
-  if (type.isF64())
+  }
+  if (type.isF64()) {
     return 8;
+  }
   return 0;
 }
 
 static bool hasVPTOConvertibleType(Type type) {
-  if (!type)
+  if (!type) {
     return false;
+  }
   if (isa<pto::VRegType, pto::MaskType, pto::AlignType, pto::PtrType,
           pto::StructType>(type) ||
       pto::isPTOLowPrecisionType(type))
     return true;
-  if (auto vecType = dyn_cast<VectorType>(type))
+  if (auto vecType = dyn_cast<VectorType>(type)) {
     return hasVPTOConvertibleType(vecType.getElementType());
+  }
   return false;
 }
 
@@ -200,8 +224,9 @@ static bool hasVPTOConvertibleType(TypeRange types) {
 
 static Value materializeVPTOCast(OpBuilder &builder, Type resultType,
                                  ValueRange inputs, Location loc) {
-  if (inputs.size() != 1)
+  if (inputs.size() != 1) {
     return {};
+  }
   return builder
       .create<UnrealizedConversionCastOp>(loc, TypeRange{resultType}, inputs)
       .getResult(0);
@@ -242,8 +267,9 @@ static LLVM::LLVMStructType getVPTOStructStorageType(pto::StructType structType,
     if (!frame.materialize) {
       worklist.push_back({frame.type, true});
       for (Type fieldType : frame.type.getFieldTypes()) {
-        if (auto nestedStruct = dyn_cast<pto::StructType>(fieldType))
+        if (auto nestedStruct = dyn_cast<pto::StructType>(fieldType)) {
           worklist.push_back({nestedStruct, false});
+        }
       }
       continue;
     }
@@ -271,18 +297,21 @@ getVPTOStructFieldAddress(ConversionPatternRewriter &rewriter, Location loc,
   Value address = root;
   pto::StructType currentType = rootType;
   for (auto [depth, index] : llvm::enumerate(path)) {
-    if (index < 0 || index >= static_cast<int64_t>(currentType.getNumFields()))
+    if (index < 0 || index >= static_cast<int64_t>(currentType.getNumFields())) {
       return failure();
+    }
     Type storageType = getVPTOStructStorageType(currentType, rewriter);
     address = rewriter.create<LLVM::GEPOp>(
         loc, pointerType, storageType, address,
         ArrayRef<LLVM::GEPArg>{0, static_cast<int32_t>(index)});
     Type fieldType = currentType.getFieldType(static_cast<unsigned>(index));
-    if (depth + 1 == path.size())
+    if (depth + 1 == path.size()) {
       continue;
+    }
     auto nestedStruct = dyn_cast<pto::StructType>(fieldType);
-    if (!nestedStruct)
+    if (!nestedStruct) {
       return failure();
+    }
     currentType = nestedStruct;
   }
   return address;
@@ -367,10 +396,12 @@ static Value getI32Constant(OpBuilder &builder, Location loc, uint64_t value) {
 }
 
 static bool isMxElementType(Type ty) {
-  if (auto floatType = dyn_cast<FloatType>(ty))
+  if (auto floatType = dyn_cast<FloatType>(ty)) {
     return floatType.getWidth() == 8;
-  if (isa<pto::F4E1M2x2Type, pto::F4E2M1x2Type>(ty))
+  }
+  if (isa<pto::F4E1M2x2Type, pto::F4E2M1x2Type>(ty)) {
     return true;
+  }
   std::string typeText;
   llvm::raw_string_ostream os(typeText);
   ty.print(os);
@@ -379,10 +410,12 @@ static bool isMxElementType(Type ty) {
 }
 
 static std::string getMadMxElementFragment(Type type) {
-  if (type.isF16())
+  if (type.isF16()) {
     return "f16";
-  if (type.isBF16())
+  }
+  if (type.isBF16()) {
     return "bf16";
+  }
 
   std::string typeText;
   llvm::raw_string_ostream os(typeText);
@@ -390,16 +423,21 @@ static std::string getMadMxElementFragment(Type type) {
   os.flush();
 
   std::string lower = StringRef(typeText).lower();
-  if (StringRef(lower).contains("e4m3"))
+  if (StringRef(lower).contains("e4m3")) {
     return "e4m3";
-  if (StringRef(lower).contains("e5m2"))
+  }
+  if (StringRef(lower).contains("e5m2")) {
     return "e5m2";
-  if (StringRef(lower).contains("hif4"))
+  }
+  if (StringRef(lower).contains("hif4")) {
     return "hif4";
-  if (StringRef(lower).contains("e2m1x2"))
+  }
+  if (StringRef(lower).contains("e2m1x2")) {
     return "e2m1x2";
-  if (StringRef(lower).contains("e1m2x2"))
+  }
+  if (StringRef(lower).contains("e1m2x2")) {
     return "e1m2x2";
+  }
   return {};
 }
 
@@ -407,8 +445,9 @@ static FailureOr<StringRef> buildMadMxCalleeName(MLIRContext *context,
                                                  Type lhsElem, Type rhsElem) {
   std::string lhs = getMadMxElementFragment(lhsElem);
   std::string rhs = getMadMxElementFragment(rhsElem);
-  if (lhs.empty() || rhs.empty())
+  if (lhs.empty() || rhs.empty()) {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.MMAD.MX." + lhs + rhs).getValue();
 }
 
@@ -418,19 +457,25 @@ static bool isSignedOrSignlessInteger(IntegerType intType, unsigned width) {
 }
 
 static std::string getMadRhsFragment(Type type) {
-  if (type.isF16())
+  if (type.isF16()) {
     return "f16";
-  if (type.isBF16())
+  }
+  if (type.isBF16()) {
     return "bf16";
-  if (type.isF32())
+  }
+  if (type.isF32()) {
     return "f32";
+  }
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (isSignedOrSignlessInteger(intType, 4))
+    if (isSignedOrSignlessInteger(intType, 4)) {
       return "s4";
-    if (isSignedOrSignlessInteger(intType, 8))
+    }
+    if (isSignedOrSignlessInteger(intType, 8)) {
       return "s8";
-    if (intType.isUnsigned() && intType.getWidth() == 2)
+    }
+    if (intType.isUnsigned() && intType.getWidth() == 2) {
       return "u2";
+    }
   }
 
   std::string typeText;
@@ -438,8 +483,9 @@ static std::string getMadRhsFragment(Type type) {
   type.print(os);
   os.flush();
   std::string lower = StringRef(typeText).lower();
-  if (StringRef(lower).contains("e8m0"))
+  if (StringRef(lower).contains("e8m0")) {
     return "e8m0";
+  }
   return {};
 }
 
@@ -452,13 +498,16 @@ static bool isMadE5M2ElementType(Type type) {
 }
 
 static std::string getMadDstFragment(Type type) {
-  if (type.isF16())
+  if (type.isF16()) {
     return "f16";
-  if (type.isF32())
+  }
+  if (type.isF32()) {
     return "f32";
+  }
   if (auto intType = dyn_cast<IntegerType>(type)) {
-    if (isSignedOrSignlessInteger(intType, 32))
+    if (isSignedOrSignlessInteger(intType, 32)) {
       return "s32";
+    }
   }
   return {};
 }
@@ -6942,7 +6991,7 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 3u : 2u)) {
+        resultTypes.size() != (usePostIntrinsic ? 3U : 2U)) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to convert vldsx2 result types");
     }
@@ -7008,7 +7057,7 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 2u : 1u))
+        resultTypes.size() != (usePostIntrinsic ? 2U : 1U))
       return rewriter.notifyMatchFailure(op, "failed to convert vsldb result type");
 
     Type callResultType = getPayloadABIType(
@@ -7121,7 +7170,7 @@ public:
     bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
     if (!sourceType ||
         failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 3u : 2u) ||
+        resultTypes.size() != (usePostIntrinsic ? 3U : 2U) ||
         adaptor.getAlign().getType() != resultTypes[1] ||
         (usePostIntrinsic && resultTypes[2] != adaptor.getSource().getType())) {
       return rewriter.notifyMatchFailure(op,
@@ -7223,7 +7272,7 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 1u : 0u))
+        resultTypes.size() != (usePostIntrinsic ? 1U : 0U))
       return rewriter.notifyMatchFailure(
           op, "failed to convert spr store result types");
 
@@ -7512,7 +7561,7 @@ public:
                                          "failed to convert vstus result types");
     bool usePostIntrinsic = static_cast<bool>(op.getBaseOut());
     auto baseType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getBase().getType());
-    if (!baseType || resultTypes.size() != (usePostIntrinsic ? 2u : 1u) ||
+    if (!baseType || resultTypes.size() != (usePostIntrinsic ? 2U : 1U) ||
         adaptor.getAlignIn().getType() != resultTypes[0] ||
         (usePostIntrinsic && resultTypes[1] != adaptor.getBase().getType())) {
       return rewriter.notifyMatchFailure(op,
@@ -7647,7 +7696,7 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 1u : 0u))
+        resultTypes.size() != (usePostIntrinsic ? 1U : 0U))
       return rewriter.notifyMatchFailure(
           op, "failed to convert vstas result types");
 
@@ -8323,7 +8372,7 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 1u : 0u))
+        resultTypes.size() != (usePostIntrinsic ? 1U : 0U))
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-store result types");
 
@@ -8373,7 +8422,7 @@ public:
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
                                                       resultTypes)) ||
-        resultTypes.size() != (usePostIntrinsic ? 2u : 1u))
+        resultTypes.size() != (usePostIntrinsic ? 2U : 1U))
       return rewriter.notifyMatchFailure(
           op, "failed to convert predicate-load result types");
     if (!llvmSourceType)
@@ -8962,20 +9011,20 @@ public:
     StringRef calleeName = buildSyncCallee<SyncOp>(op.getContext());
     Value srcValue = getI64Constant(rewriter, op.getLoc(), *src);
     Value dstValue = getI64Constant(rewriter, op.getLoc(), *dst);
-    
+
     Value eventIdValue = adaptor.getEventId();
     if (!eventIdValue)
       return rewriter.notifyMatchFailure(op, "missing event_id operand");
-    
+
     Value eventValue = eventIdValue;
-    
+
     while (eventValue.getDefiningOp()) {
       auto unrealizedCast = dyn_cast<UnrealizedConversionCastOp>(eventValue.getDefiningOp());
       if (!unrealizedCast || unrealizedCast.getInputs().size() != 1)
         break;
       eventValue = unrealizedCast.getInputs()[0];
     }
-    
+
     if (eventValue.getType().isIndex()) {
       eventValue = rewriter.create<arith::IndexCastOp>(op.getLoc(), 
                                                         rewriter.getI64Type(), 
@@ -8989,7 +9038,7 @@ public:
     } else {
       return rewriter.notifyMatchFailure(op, "unexpected event_id type");
     }
-    
+
     auto funcType = rewriter.getFunctionType(
         TypeRange{rewriter.getI64Type(), rewriter.getI64Type(),
                   rewriter.getI64Type()},

--- a/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
+++ b/lib/PTO/Transforms/VPTOExpandWrapperOps.cpp
@@ -38,18 +38,21 @@ enum class DmaArch { A2A3, A5 };
 constexpr uint64_t kMxScaleAddressShift = 4;
 
 static DmaArch getDmaArch(ModuleOp mod) {
-  if (!mod)
+  if (!mod) {
     return DmaArch::A2A3;
+  }
   auto arch = mod->getAttrOfType<StringAttr>("pto.target_arch");
-  if (arch && arch.getValue() == "a5")
+  if (arch && arch.getValue() == "a5") {
     return DmaArch::A5;
+  }
   return DmaArch::A2A3;
 }
 
 static pto::AddressSpaceAttr getPointerMemorySpace(Attribute memorySpace,
                                                    MLIRContext *ctx) {
-  if (auto addrSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(memorySpace))
+  if (auto addrSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(memorySpace)) {
     return addrSpace;
+  }
   if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace))
     return pto::AddressSpaceAttr::get(
         ctx, static_cast<pto::AddressSpace>(intAttr.getInt()));
@@ -58,48 +61,57 @@ static pto::AddressSpaceAttr getPointerMemorySpace(Attribute memorySpace,
 
 static bool hasZeroReinterpretOffset(memref::ReinterpretCastOp op) {
   for (int64_t offset : op.getStaticOffsets()) {
-    if (ShapedType::isDynamic(offset) || offset != 0)
+    if (ShapedType::isDynamic(offset) || offset != 0) {
       return false;
+    }
   }
   return true;
 }
 
 static Value materializeBufferPointer(Value value, PatternRewriter &rewriter,
                                       Location loc) {
-  if (!value)
+  if (!value) {
     return {};
+  }
 
   if (auto ptrType = dyn_cast<pto::PtrType>(value.getType())) {
     if (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>()) {
-      if (cast->getNumOperands() != 1 || cast->getNumResults() != 1)
+      if (cast->getNumOperands() != 1 || cast->getNumResults() != 1) {
         return {};
+      }
       Value basePtr =
           materializeBufferPointer(cast.getOperand(0), rewriter, loc);
-      if (!basePtr)
+      if (!basePtr) {
         return {};
-      if (basePtr.getType() == ptrType)
+      }
+      if (basePtr.getType() == ptrType) {
         return basePtr;
+      }
       return rewriter.create<pto::CastPtrOp>(loc, ptrType, basePtr).getResult();
     }
     return value;
   }
 
   if (auto cast = value.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (cast->getNumOperands() != 1 || cast->getNumResults() != 1)
+    if (cast->getNumOperands() != 1 || cast->getNumResults() != 1) {
       return {};
+    }
     return materializeBufferPointer(cast.getOperand(0), rewriter, loc);
   }
 
-  if (auto cast = value.getDefiningOp<memref::CastOp>())
+  if (auto cast = value.getDefiningOp<memref::CastOp>()) {
     return materializeBufferPointer(cast.getSource(), rewriter, loc);
+  }
 
-  if (auto cast = value.getDefiningOp<memref::MemorySpaceCastOp>())
+  if (auto cast = value.getDefiningOp<memref::MemorySpaceCastOp>()) {
     return materializeBufferPointer(cast.getSource(), rewriter, loc);
+  }
 
   if (auto cast = value.getDefiningOp<memref::ReinterpretCastOp>()) {
     auto resultType = dyn_cast<MemRefType>(value.getType());
-    if (!resultType)
+    if (!resultType) {
       return {};
+    }
 
     if (hasZeroReinterpretOffset(cast)) {
       Value basePtr = materializeBufferPointer(cast.getSource(), rewriter, loc);
@@ -108,16 +120,18 @@ static Value materializeBufferPointer(Value value, PatternRewriter &rewriter,
             rewriter.getContext(), resultType.getElementType(),
             getPointerMemorySpace(resultType.getMemorySpace(),
                                   rewriter.getContext()));
-        if (basePtr.getType() == ptrType)
+        if (basePtr.getType() == ptrType) {
           return basePtr;
+        }
         return rewriter.create<pto::CastPtrOp>(loc, ptrType, basePtr).getResult();
       }
     }
   }
 
   auto memrefType = dyn_cast<MemRefType>(value.getType());
-  if (!memrefType)
+  if (!memrefType) {
     return {};
+  }
 
   auto ptrType =
       pto::PtrType::get(rewriter.getContext(), memrefType.getElementType(),
@@ -127,18 +141,21 @@ static Value materializeBufferPointer(Value value, PatternRewriter &rewriter,
 }
 
 static Type getBufferElementType(Type type) {
-  if (auto ptrType = dyn_cast<pto::PtrType>(type))
+  if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
     return ptrType.getElementType();
-  if (auto memrefType = dyn_cast<BaseMemRefType>(type))
+  }
+  if (auto memrefType = dyn_cast<BaseMemRefType>(type)) {
     return memrefType.getElementType();
+  }
   return {};
 }
 
 static Value offsetBufferPointer(Value basePtr, Type elementType,
                                  Value elementOffset,
                                  PatternRewriter &rewriter, Location loc) {
-  if (!basePtr)
+  if (!basePtr) {
     return {};
+  }
 
   Value offsetIndex = elementOffset;
   if (!offsetIndex.getType().isIndex())
@@ -156,8 +173,9 @@ static bool isKnownOne(Value value) {
 }
 
 static bool shouldRestoreDmaLoopSize(Value loop1Count, Value loop2Count) {
-  if (!loop1Count)
+  if (!loop1Count) {
     return false;
+  }
   return !isKnownOne(loop1Count) || !isKnownOne(loop2Count);
 }
 
@@ -174,17 +192,21 @@ static SmallVector<pto::DmaLoopConfig> collectLoopConfigs(ValueRange counts,
 
 static Value offsetPointerByBytes(Value basePtr, Value byteOffset,
                                   PatternRewriter &rewriter, Location loc) {
-  if (!basePtr)
+  if (!basePtr) {
     return {};
+  }
 
   Value basePtrValue = materializeBufferPointer(basePtr, rewriter, loc);
   auto ptrType = dyn_cast_or_null<pto::PtrType>(basePtrValue.getType());
-  if (!ptrType)
+  if (!ptrType) {
     return {};
+  }
 
   APInt constOffset;
-  if (matchPattern(byteOffset, m_ConstantInt(&constOffset)) && constOffset.isZero())
+  if (matchPattern(byteOffset, m_ConstantInt(&constOffset)) &&
+      constOffset.isZero()) {
     return basePtrValue;
+  }
 
   auto bytePtrType =
       pto::PtrType::get(rewriter.getContext(), rewriter.getI8Type(),
@@ -204,35 +226,44 @@ static Value offsetPointerByBytes(Value basePtr, Value byteOffset,
 [[maybe_unused]] static Value materializeFpcValue(Value fpc,
                                                   PatternRewriter &rewriter,
                                                   Location loc) {
-  if (!fpc)
+  if (!fpc) {
     return {};
-  if (fpc.getType().isInteger(64))
+  }
+  if (fpc.getType().isInteger(64)) {
     return fpc;
-  if (isa<pto::PtrType>(fpc.getType()))
+  }
+  if (isa<pto::PtrType>(fpc.getType())) {
     return rewriter.create<pto::CastPtrOp>(loc, rewriter.getI64Type(), fpc);
+  }
   return {};
 }
 
 static Value materializeI64Value(Value value, PatternRewriter &rewriter,
                                  Location loc) {
-  if (!value)
+  if (!value) {
     return {};
-  if (value.getType().isInteger(64))
+  }
+  if (value.getType().isInteger(64)) {
     return value;
-  if (auto intType = dyn_cast<IntegerType>(value.getType()))
+  }
+  if (auto intType = dyn_cast<IntegerType>(value.getType())) {
     return rewriter.create<arith::ExtUIOp>(loc, rewriter.getI64Type(), value);
-  if (isa<pto::PtrType>(value.getType()))
+  }
+  if (isa<pto::PtrType>(value.getType())) {
     return rewriter.create<pto::CastPtrOp>(loc, rewriter.getI64Type(), value);
+  }
   return {};
 }
 
 static Value materializeAccStoreScalarPayload(Value value,
                                               PatternRewriter &rewriter,
                                               Location loc) {
-  if (!value)
+  if (!value) {
     return {};
-  if (Value raw = materializeI64Value(value, rewriter, loc))
+  }
+  if (Value raw = materializeI64Value(value, rewriter, loc)) {
     return raw;
+  }
 
   Type type = value.getType();
   Value f32Value = value;
@@ -249,8 +280,9 @@ static Value materializeAccStoreScalarPayload(Value value,
 static Value materializeAccStoreClipPayload(Value value, Type destinationElementType,
                                             PatternRewriter &rewriter,
                                             Location loc) {
-  if (!value)
+  if (!value) {
     return {};
+  }
 
   if (value.getType().isF16()) {
     Value bitsI16 =
@@ -259,8 +291,9 @@ static Value materializeAccStoreClipPayload(Value value, Type destinationElement
   }
 
   auto intType = dyn_cast<IntegerType>(value.getType());
-  if (!intType)
+  if (!intType) {
     return {};
+  }
 
   Value widened;
   if (auto dstIntType = dyn_cast<IntegerType>(destinationElementType);
@@ -283,8 +316,9 @@ static Value deriveMxScaleDestination(Value dataDestination,
                                       PatternRewriter &rewriter,
                                       Location loc) {
   auto ptrType = dyn_cast<pto::PtrType>(dataDestination.getType());
-  if (!ptrType)
+  if (!ptrType) {
     return {};
+  }
 
   Value dataAddress = rewriter.create<pto::CastPtrOp>(
       loc, rewriter.getI64Type(), dataDestination);
@@ -334,8 +368,9 @@ static Value buildAccStoreFpcValue(Location loc, Value preQuant,
     case pto::AccStoreQuantPreMode::QF322F16PreVec:
     case pto::AccStoreQuantPreMode::QF322BF16PreVec:
     case pto::AccStoreQuantPreMode::QS322BF16PreVec:
-      if (Value quantPtr = materializeI64Value(preQuant, rewriter, loc))
+      if (Value quantPtr = materializeI64Value(preQuant, rewriter, loc)) {
         quantAddr = encodeFixpipeBufferAddr(quantPtr, /*unitShift=*/7);
+      }
       break;
     default:
       break;
@@ -344,12 +379,14 @@ static Value buildAccStoreFpcValue(Location loc, Value preQuant,
 
   Value reluAddr;
   if (preReluMode && *preReluMode == pto::ReluPreMode::VectorRelu) {
-    if (Value reluPtr = materializeI64Value(preRelu, rewriter, loc))
+    if (Value reluPtr = materializeI64Value(preRelu, rewriter, loc)) {
       reluAddr = encodeFixpipeBufferAddr(reluPtr, /*unitShift=*/6);
+    }
   }
 
-  if (!quantAddr && !reluAddr)
+  if (!quantAddr && !reluAddr) {
     return {};
+  }
 
   Value mask = getI64Constant(loc, rewriter, 0xff);
   Value fpc = getI64Constant(loc, rewriter, 0);
@@ -400,12 +437,16 @@ static void configureAccStoreScalarPreOps(Location loc, Value preQuant,
   if (preQuantMode &&
       *preQuantMode != pto::AccStoreQuantPreMode::NoConvert &&
       !isVectorQuantMode(*preQuantMode)) {
-    if (Value quantValue = materializeAccStoreScalarPayload(preQuant, rewriter, loc))
+    if (Value quantValue =
+            materializeAccStoreScalarPayload(preQuant, rewriter, loc)) {
       rewriter.create<pto::SetQuantPreOp>(loc, quantValue);
+    }
   }
   if (preReluMode && *preReluMode == pto::ReluPreMode::ScalarRelu) {
-    if (Value reluAlpha = materializeAccStoreScalarPayload(preRelu, rewriter, loc))
+    if (Value reluAlpha =
+            materializeAccStoreScalarPayload(preRelu, rewriter, loc)) {
       rewriter.create<pto::SetReluAlphaOp>(loc, reluAlpha);
+    }
   }
   if (clipValue) {
     if (Value clip = materializeAccStoreClipPayload(clipValue,
@@ -420,8 +461,9 @@ static Value configureAccStoreCtrl(Location loc, bool allowAtomic,
                                    std::optional<pto::AccStoreAtomicOp> atomicOp,
                                    std::optional<pto::AccStoreSatMode> satMode,
                                    PatternRewriter &rewriter) {
-  if ((!allowAtomic || !atomicType || !atomicOp) && !satMode)
+  if ((!allowAtomic || !atomicType || !atomicOp) && !satMode) {
     return {};
+  }
 
   Value originalCtrl = rewriter.create<pto::GetCtrlOp>(loc);
   Value ctrl = originalCtrl;
@@ -480,22 +522,27 @@ static Value packLoopSize(Location loc, Value loop2, Value loop1,
 
 static Value castIntegerLikeTo(Location loc, Value value, Type targetType,
                                PatternRewriter &rewriter) {
-  if (value.getType() == targetType)
+  if (value.getType() == targetType) {
     return value;
+  }
 
   auto targetInt = dyn_cast<IntegerType>(targetType);
-  if (value.getType().isIndex() && targetInt)
+  if (value.getType().isIndex() && targetInt) {
     return rewriter.create<arith::IndexCastOp>(loc, targetType, value);
+  }
   if (auto sourceInt = dyn_cast<IntegerType>(value.getType())) {
     if (targetInt) {
-      if (sourceInt.getWidth() < targetInt.getWidth())
+      if (sourceInt.getWidth() < targetInt.getWidth()) {
         return rewriter.create<arith::ExtUIOp>(loc, targetType, value);
-      if (sourceInt.getWidth() > targetInt.getWidth())
+      }
+      if (sourceInt.getWidth() > targetInt.getWidth()) {
         return rewriter.create<arith::TruncIOp>(loc, targetType, value);
+      }
       return value;
     }
-    if (targetType.isIndex())
+    if (targetType.isIndex()) {
       return rewriter.create<arith::IndexCastOp>(loc, targetType, value);
+    }
   }
 
   return {};
@@ -510,8 +557,9 @@ static FailureOr<Value> packMadXt(Location loc, Value m, Value n, Value k,
   Value mI64 = castIntegerLikeTo(loc, m, i64Ty, rewriter);
   Value nI64 = castIntegerLikeTo(loc, n, i64Ty, rewriter);
   Value kI64 = castIntegerLikeTo(loc, k, i64Ty, rewriter);
-  if (!mI64 || !nI64 || !kI64)
+  if (!mI64 || !nI64 || !kI64) {
     return failure();
+  }
 
   auto constant = [&](uint64_t value) -> Value {
     return rewriter.create<arith::ConstantIntOp>(loc, value, 64);
@@ -531,20 +579,24 @@ static FailureOr<Value> packMadXt(Location loc, Value m, Value n, Value k,
         *unitFlagMode == pto::MadUnitFlagMode::CheckOnly ? 2 : 3;
     xt = bitOr(xt, shl(constant(unitFlagCtrl), 55));
   }
-  if (disableGemv)
+  if (disableGemv) {
     xt = bitOr(xt, shl(constant(1), 61));
-  if (cmatrixSource)
+  }
+  if (cmatrixSource) {
     xt = bitOr(xt, shl(constant(1), 62));
-  if (cmatrixInit)
+  }
+  if (cmatrixInit) {
     xt = bitOr(xt, shl(constant(1), 63));
+  }
   return xt;
 }
 
 static Value setCtrlBit(Location loc, Value ctrl, unsigned bitIndex, bool value,
                         PatternRewriter &rewriter) {
   Value bit = rewriter.create<arith::ConstantIntOp>(loc, bitIndex, 64);
-  if (value)
+  if (value) {
     return rewriter.create<pto::Sbitset1Op>(loc, ctrl, bit).getResult();
+  }
   return rewriter.create<pto::Sbitset0Op>(loc, ctrl, bit).getResult();
 }
 
@@ -563,9 +615,10 @@ static Value buildMadSemanticCtrl(Location loc, Value ctrl,
     ctrl = setCtrlBit(loc, ctrl, 46, false, rewriter);
     ctrl = setCtrlBit(loc, ctrl, 47, false, rewriter);
   }
-  if (satMode)
+  if (satMode) {
     ctrl = setCtrlBit(loc, ctrl, 48, *satMode == pto::MadSatMode::NoSat,
                       rewriter);
+  }
   ctrl = setCtrlBit(loc, ctrl, 51, hasNDir, rewriter);
   return ctrl;
 }
@@ -803,8 +856,9 @@ deriveLoadCbufToCbControl(Location loc, Value k, Value n, Type elementType,
                           Value mStart, Value kStart, bool transpose,
                           PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
+  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
     return failure();
+  }
   uint64_t elemBytes = elemBitWidth / 8;
   bool isFp4Packed = pto::isPTOFloat4PackedType(elementType);
 
@@ -856,8 +910,9 @@ deriveLoadCbufToCaControl(Location loc, Value m, Value k, Type elementType,
                           Value mStart, Value kStart, bool transpose,
                           PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
+  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
     return failure();
+  }
   uint64_t elemBytes = elemBitWidth / 8;
   bool isFp4Packed = pto::isPTOFloat4PackedType(elementType);
 
@@ -909,8 +964,9 @@ deriveLoadCbufToCaMxControl(Location loc, Value m, Value k, Type elementType,
                             Value startRow, Value startCol,
                             PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
+  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
     return failure();
+  }
   uint64_t elemBytes = elemBitWidth / 8;
 
   auto constant = [&](uint64_t value) -> Value {
@@ -938,8 +994,9 @@ deriveLoadCbufToCbMxControl(Location loc, Value k, Value n, Type elementType,
                             Value startRow, Value startCol,
                             PatternRewriter &rewriter) {
   unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(elementType);
-  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0)
+  if (elemBitWidth == 0 || (elemBitWidth % 8) != 0) {
     return failure();
+  }
   uint64_t elemBytes = elemBitWidth / 8;
 
   auto constant = [&](uint64_t value) -> Value {
@@ -1011,8 +1068,9 @@ struct ExpandUvldPattern : public OpRewritePattern<pto::UvldOp> {
   LogicalResult matchAndRewrite(pto::UvldOp op,
                                 PatternRewriter &rewriter) const override {
     auto vecType = dyn_cast<pto::VRegType>(op.getResult().getType());
-    if (!vecType)
+    if (!vecType) {
       return failure();
+    }
 
     Value basePtr = materializeBufferPointer(op.getSource(), rewriter, op.getLoc());
     if (!basePtr)
@@ -1035,8 +1093,9 @@ struct ExpandUvldPattern : public OpRewritePattern<pto::UvldOp> {
 enum class MadRawKind { Ordinary, OrdinaryBias, Mx, MxBias };
 
 static MadRawKind deriveMadRawKind(pto::MadSemanticOpInterface op) {
-  if (op.isMadMxFamily())
+  if (op.isMadMxFamily()) {
     return op.hasBiasOperand() ? MadRawKind::MxBias : MadRawKind::Mx;
+  }
   return op.hasBiasOperand() ? MadRawKind::OrdinaryBias
                              : MadRawKind::Ordinary;
 }
@@ -1087,8 +1146,9 @@ static LogicalResult lowerMadSemanticOp(pto::MadSemanticOpInterface op,
     satMode = satModeAttr.getValue();
 
   bool isHif8 = false;
-  if (auto lhsPtr = dyn_cast<pto::PtrType>(op.getLhs().getType()))
+  if (auto lhsPtr = dyn_cast<pto::PtrType>(op.getLhs().getType())) {
     isHif8 = pto::isPTOHiFloat8Type(lhsPtr.getElementType());
+  }
 
   Location loc = op->getLoc();
   Value ctrlSaved = rewriter.create<pto::GetCtrlOp>(loc).getResult();
@@ -1100,11 +1160,13 @@ static LogicalResult lowerMadSemanticOp(pto::MadSemanticOpInterface op,
       packMadXt(loc, op.getM(), op.getN(), op.getK(), unitFlagMode,
                 op.getDisableGemv(), op.initializesAccumulatorWithBias(),
                 op.initializesAccumulatorWithZero(), rewriter);
-  if (failed(xt))
+  if (failed(xt)) {
     return rewriter.notifyMatchFailure(op, "failed to pack mad xt");
+  }
 
-  if (failed(emitMadRawOp(op, deriveMadRawKind(op), *xt, rewriter)))
+  if (failed(emitMadRawOp(op, deriveMadRawKind(op), *xt, rewriter))) {
     return rewriter.notifyMatchFailure(op, "failed to emit mad raw op");
+  }
 
   rewriter.create<pto::SetCtrlOp>(loc, ctrlSaved);
   rewriter.eraseOp(op);
@@ -1120,8 +1182,9 @@ public:
   LogicalResult matchAndRewrite(SemanticOp op,
                                 PatternRewriter &rewriter) const override {
     auto semantic = dyn_cast<pto::MadSemanticOpInterface>(op.getOperation());
-    if (!semantic)
+    if (!semantic) {
       return failure();
+    }
     return lowerMadSemanticOp(semantic, rewriter);
   }
 };
@@ -1174,18 +1237,21 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
     }
 
     Value leftPadding = op.getLeftPaddingCount();
-    if (!leftPadding)
+    if (!leftPadding) {
       leftPadding = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
+    }
     Value rightPadding = op.getRightPaddingCount();
-    if (!rightPadding)
+    if (!rightPadding) {
       rightPadding = rewriter.create<arith::ConstantIntOp>(loc, 0, 64);
+    }
     Value dataSelect = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getI1Type(),
         rewriter.getBoolAttr(static_cast<bool>(op.getPadValue())));
 
     bool hasPad = static_cast<bool>(op.getPadValue());
-    if (Value padValue = op.getPadValue())
+    if (Value padValue = op.getPadValue()) {
       rewriter.create<pto::SetMovPadValOp>(loc, padValue);
+    }
 
     Value effectiveNBurst = (dmaArch == DmaArch::A5) ? op.getNBurst() : one;
 
@@ -1199,8 +1265,9 @@ struct ExpandDmaLoadPattern : public OpRewritePattern<pto::MteGmUbOp> {
               loc, source, destination, zero, effectiveNBurst, op.getLenBurst(),
               leftPadding, rightPadding, dataSelect, op.getL2CacheCtl(),
               op.getNburstSrcStride(), op.getNburstDstStride());
-          if (hasPad)
+          if (hasPad) {
             copyOp->setAttr("has_pad", UnitAttr::get(copyOp->getContext()));
+          }
         });
     if (dmaArch == DmaArch::A5 &&
         shouldRestoreDmaLoopSize(loop1Count, loop2Size))
@@ -1405,10 +1472,12 @@ struct ExpandBiasLoadPattern : public OpRewritePattern<pto::MteL1BtOp> {
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
     auto sourceType = dyn_cast_or_null<pto::PtrType>(source.getType());
-    if (!sourceType)
+    if (!sourceType) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like source");
-    if (!destination)
+    }
+    if (!destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
+    }
 
     Value convControl = rewriter.create<arith::ConstantIntOp>(
         loc, sourceType.getElementType().isF16() ? 1 : 0, 1);
@@ -1428,8 +1497,9 @@ struct ExpandFpLoadPattern : public OpRewritePattern<pto::MteL1FbOp> {
     Value source = materializeBufferPointer(op.getSource(), rewriter, loc);
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
-    if (!source || !destination)
+    if (!source || !destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like operands");
+    }
 
     rewriter.replaceOpWithNewOp<pto::CopyCbufToFbufOp>(
         op, source, destination, op.getNBurst(),
@@ -1483,11 +1553,13 @@ struct ExpandLeftLoadPattern : public OpRewritePattern<pto::MteL1L0aOp> {
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
     auto sourceType = dyn_cast_or_null<pto::PtrType>(source.getType());
-    if (!sourceType)
+    if (!sourceType) {
       return rewriter.notifyMatchFailure(op, "expected typed L1 source");
+    }
     Type elementType = sourceType.getElementType();
-    if (!destination)
+    if (!destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
+    }
     FailureOr<LoadCbufToCbControl> control = deriveLoadCbufToCaControl(
         loc, op.getM(), op.getK(), elementType,
         op.getStartRow(), op.getStartCol(), op.getTranspose(), rewriter);
@@ -1522,11 +1594,13 @@ struct ExpandRightLoadPattern : public OpRewritePattern<pto::MteL1L0bOp> {
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
     auto sourceType = dyn_cast_or_null<pto::PtrType>(source.getType());
-    if (!sourceType)
+    if (!sourceType) {
       return rewriter.notifyMatchFailure(op, "expected typed L1 source");
+    }
     Type elementType = sourceType.getElementType();
-    if (!destination)
+    if (!destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
+    }
     FailureOr<LoadCbufToCbControl> control = deriveLoadCbufToCbControl(
         loc, op.getK(), op.getN(), elementType,
         op.getStartRow(), op.getStartCol(), op.getTranspose(), rewriter);
@@ -1561,10 +1635,12 @@ struct ExpandLeftLoadMxPattern : public OpRewritePattern<pto::MteL1L0aMxOp> {
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
     auto sourceType = dyn_cast_or_null<pto::PtrType>(source.getType());
-    if (!sourceType)
+    if (!sourceType) {
       return rewriter.notifyMatchFailure(op, "expected typed L1 source");
-    if (!destination)
+    }
+    if (!destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
+    }
     destination = deriveMxScaleDestination(destination, rewriter, loc);
     if (!destination)
       return rewriter.notifyMatchFailure(
@@ -1610,10 +1686,12 @@ struct ExpandRightLoadMxPattern : public OpRewritePattern<pto::MteL1L0bMxOp> {
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
     auto sourceType = dyn_cast_or_null<pto::PtrType>(source.getType());
-    if (!sourceType)
+    if (!sourceType) {
       return rewriter.notifyMatchFailure(op, "expected typed L1 source");
-    if (!destination)
+    }
+    if (!destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like destination");
+    }
     destination = deriveMxScaleDestination(destination, rewriter, loc);
     if (!destination)
       return rewriter.notifyMatchFailure(
@@ -1658,8 +1736,9 @@ struct ExpandAccStorePattern : public OpRewritePattern<pto::MteL0cL1Op> {
     Value source = materializeBufferPointer(op.getSource(), rewriter, loc);
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
-    if (!source || !destination)
+    if (!source || !destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like operands");
+    }
     Value zero = getI64Constant(loc, rewriter, 0);
     Value one = getI64Constant(loc, rewriter, 1);
     configureAccStoreScalarPreOps(loc, op.getPreQuant(), op.getPreQuantMode(),
@@ -1739,8 +1818,9 @@ struct ExpandAccStorePattern : public OpRewritePattern<pto::MteL0cL1Op> {
         rewriter);
     rewriter.create<pto::CopyMatrixCcToCbufOp>(loc, source,
                                                destination, xm, xt);
-    if (originalCtrl)
+    if (originalCtrl) {
       rewriter.create<pto::SetCtrlOp>(loc, originalCtrl);
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -1755,8 +1835,9 @@ struct ExpandAccStoreGmPattern : public OpRewritePattern<pto::MteL0cGmOp> {
     Value source = materializeBufferPointer(op.getSource(), rewriter, loc);
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
-    if (!source || !destination)
+    if (!source || !destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like operands");
+    }
     Value zero = getI64Constant(loc, rewriter, 0);
     Value one = getI64Constant(loc, rewriter, 1);
     configureAccStoreScalarPreOps(loc, op.getPreQuant(), op.getPreQuantMode(),
@@ -1835,8 +1916,9 @@ struct ExpandAccStoreGmPattern : public OpRewritePattern<pto::MteL0cGmOp> {
         nz2dnEn, rewriter);
     rewriter.create<pto::CopyMatrixCcToGmOp>(loc, source,
                                              destination, xm, xt);
-    if (originalCtrl)
+    if (originalCtrl) {
       rewriter.create<pto::SetCtrlOp>(loc, originalCtrl);
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -1851,8 +1933,9 @@ struct ExpandAccStoreUbPattern : public OpRewritePattern<pto::MteL0cUbOp> {
     Value source = materializeBufferPointer(op.getSource(), rewriter, loc);
     Value destination =
         materializeBufferPointer(op.getDestination(), rewriter, loc);
-    if (!source || !destination)
+    if (!source || !destination) {
       return rewriter.notifyMatchFailure(op, "expected pointer-like operands");
+    }
     Value zero = getI64Constant(loc, rewriter, 0);
     Value one = getI64Constant(loc, rewriter, 1);
     configureAccStoreScalarPreOps(loc, op.getPreQuant(), op.getPreQuantMode(),
@@ -1936,8 +2019,9 @@ struct ExpandAccStoreUbPattern : public OpRewritePattern<pto::MteL0cUbOp> {
     rewriter.create<pto::CopyMatrixCcToUbOp>(loc, source,
                                              destination, config0,
                                              config1);
-    if (originalCtrl)
+    if (originalCtrl) {
       rewriter.create<pto::SetCtrlOp>(loc, originalCtrl);
+    }
     rewriter.eraseOp(op);
     return success();
   }
@@ -2020,8 +2104,9 @@ struct VPTOExpandWrapperOpsPass
 
   void runOnOperation() override {
     func::FuncOp func = getOperation();
-    if (func.isExternal())
+    if (func.isExternal()) {
       return;
+    }
 
     DmaArch dmaArch = getDmaArch(func->getParentOfType<ModuleOp>());
 
@@ -2054,8 +2139,9 @@ struct VPTOExpandWrapperOpsPass
                  ExpandMadSemanticPattern<pto::MadMxOp>,
                  ExpandMadSemanticPattern<pto::MadMxAccOp>,
                  ExpandMadSemanticPattern<pto::MadMxBiasOp>>(&getContext());
-    if (failed(applyPatternsGreedily(func, std::move(patterns))))
+    if (failed(applyPatternsGreedily(func, std::move(patterns)))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitter.cpp
@@ -71,15 +71,25 @@ static std::optional<int64_t> getElementCountFromVectorLike(Type type);
 
 static Type getLowPrecisionLLVMType(Type type, MLIRContext *context) {
   if (pto::isPTOHiFloat8Type(type))
+  {
     return LLVM::LLVMHiFloat8Type::get(context);
+  }
   if (isa<pto::F4E1M2x2Type>(type))
+  {
     return LLVM::LLVMFloat4E1M2x2Type::get(context);
+  }
   if (isa<pto::F4E2M1x2Type>(type))
+  {
     return LLVM::LLVMFloat4E2M1x2Type::get(context);
+  }
   if (pto::isPTOFloat8E4M3LikeType(type))
+  {
     return LLVM::LLVMFloat8E4M3Type::get(context);
+  }
   if (pto::isPTOFloat8E5M2LikeType(type))
+  {
     return LLVM::LLVMFloat8E5M2Type::get(context);
+  }
   return {};
 }
 
@@ -94,11 +104,15 @@ static Type normalizePayloadTypeForLLVMLowering(Type type, Builder &builder) {
     return getLLVMCompatibleVectorType(
         {2}, LLVM::LLVMHiFloat8Type::get(builder.getContext()));
   if (Type lowpType = getLowPrecisionLLVMType(type, builder.getContext()))
+  {
     return lowpType;
+  }
 
   if (auto intType = dyn_cast<IntegerType>(type)) {
     if (!intType.isSignless())
+    {
       return builder.getIntegerType(intType.getWidth());
+    }
     return type;
   }
 
@@ -106,7 +120,9 @@ static Type normalizePayloadTypeForLLVMLowering(Type type, Builder &builder) {
     Type normalizedElement =
         normalizePayloadTypeForLLVMLowering(vecType.getElementType(), builder);
     if (normalizedElement == vecType.getElementType())
+    {
       return type;
+    }
     return getLLVMCompatibleVectorType(vecType.getShape(), normalizedElement,
                                        vecType.getScalableDims());
   }
@@ -117,9 +133,13 @@ static Type normalizePayloadTypeForLLVMLowering(Type type, Builder &builder) {
 static Type normalizeGEPElementTypeForLLVMLowering(Type type,
                                                    Builder &builder) {
   if (pto::isPTOHiFloat8x2Type(type))
+  {
     return builder.getI16Type();
+  }
   if (pto::isPTOLowPrecisionType(type))
+  {
     return builder.getI8Type();
+  }
   if (isa<LLVM::LLVMHiFloat8Type, LLVM::LLVMFloat8E4M3Type,
           LLVM::LLVMFloat8E5M2Type, LLVM::LLVMFloat4E1M2x2Type,
           LLVM::LLVMFloat4E2M1x2Type>(type))
@@ -130,7 +150,9 @@ static Type normalizeGEPElementTypeForLLVMLowering(Type type,
         normalizeGEPElementTypeForLLVMLowering(vecType.getElementType(),
                                                builder);
     if (normalizedElement == vecType.getElementType())
+    {
       return normalizePayloadTypeForLLVMLowering(type, builder);
+    }
     return getLLVMCompatibleVectorType(vecType.getShape(), normalizedElement,
                                        vecType.getScalableDims());
   }
@@ -150,7 +172,9 @@ static Type convertVPTOType(Type type, Builder &builder) {
   if (isa<pto::AlignType>(type))
     return VectorType::get({32}, builder.getI8Type());
   if (isa<pto::StructType>(type))
+  {
     return LLVM::LLVMPointerType::get(builder.getContext());
+  }
   if (auto ptrType = dyn_cast<pto::PtrType>(type)) {
     return LLVM::LLVMPointerType::get(
         builder.getContext(),
@@ -163,36 +187,56 @@ static unsigned getNaturalByteAlignment(Type type) {
   if (auto vecType = dyn_cast<VectorType>(type)) {
     unsigned elemAlign = getNaturalByteAlignment(vecType.getElementType());
     if (!elemAlign)
+    {
       return 0;
+    }
     int64_t elems = 1;
     for (int64_t dim : vecType.getShape())
+    {
       elems *= dim;
+    }
     return elemAlign * static_cast<unsigned>(elems);
   }
   if (auto intType = dyn_cast<IntegerType>(type))
+  {
     return llvm::divideCeil(unsigned(intType.getWidth()), 8u);
+  }
   if (pto::isPTOHiFloat8x2Type(type))
+  {
     return 2;
+  }
   if (pto::isPTOLowPrecisionType(type))
+  {
     return 1;
+  }
   if (type.isF16() || type.isBF16())
+  {
     return 2;
+  }
   if (type.isF32())
+  {
     return 4;
+  }
   if (type.isF64())
+  {
     return 8;
+  }
   return 0;
 }
 
 static bool hasVPTOConvertibleType(Type type) {
   if (!type)
+  {
     return false;
+  }
   if (isa<pto::VRegType, pto::MaskType, pto::AlignType, pto::PtrType,
           pto::StructType>(type) ||
       pto::isPTOLowPrecisionType(type))
     return true;
   if (auto vecType = dyn_cast<VectorType>(type))
+  {
     return hasVPTOConvertibleType(vecType.getElementType());
+  }
   return false;
 }
 
@@ -274,17 +318,23 @@ getVPTOStructFieldAddress(ConversionPatternRewriter &rewriter, Location loc,
   pto::StructType currentType = rootType;
   for (auto [depth, index] : llvm::enumerate(path)) {
     if (index < 0 || index >= static_cast<int64_t>(currentType.getNumFields()))
+    {
       return failure();
+    }
     Type storageType = getVPTOStructStorageType(currentType, rewriter);
     address = rewriter.create<LLVM::GEPOp>(
         loc, pointerType, storageType, address,
         ArrayRef<LLVM::GEPArg>{0, static_cast<int32_t>(index)});
     Type fieldType = currentType.getFieldType(static_cast<unsigned>(index));
     if (depth + 1 == path.size())
+    {
       continue;
+    }
     auto nestedStruct = dyn_cast<pto::StructType>(fieldType);
     if (!nestedStruct)
+    {
       return failure();
+    }
     currentType = nestedStruct;
   }
   return address;
@@ -370,9 +420,13 @@ static Value getI32Constant(OpBuilder &builder, Location loc, uint64_t value) {
 
 static bool isMxElementType(Type ty) {
   if (auto floatType = dyn_cast<FloatType>(ty))
+  {
     return floatType.getWidth() == 8;
+  }
   if (isa<pto::F4E1M2x2Type, pto::F4E2M1x2Type>(ty))
+  {
     return true;
+  }
   std::string typeText;
   llvm::raw_string_ostream os(typeText);
   ty.print(os);
@@ -382,9 +436,13 @@ static bool isMxElementType(Type ty) {
 
 static std::string getMadMxElementFragment(Type type) {
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isBF16())
+  {
     return "bf16";
+  }
 
   std::string typeText;
   llvm::raw_string_ostream os(typeText);
@@ -393,15 +451,25 @@ static std::string getMadMxElementFragment(Type type) {
 
   std::string lower = StringRef(typeText).lower();
   if (StringRef(lower).contains("e4m3"))
+  {
     return "e4m3";
+  }
   if (StringRef(lower).contains("e5m2"))
+  {
     return "e5m2";
+  }
   if (StringRef(lower).contains("hif4"))
+  {
     return "hif4";
+  }
   if (StringRef(lower).contains("e2m1x2"))
+  {
     return "e2m1x2";
+  }
   if (StringRef(lower).contains("e1m2x2"))
+  {
     return "e1m2x2";
+  }
   return {};
 }
 
@@ -410,7 +478,9 @@ static FailureOr<StringRef> buildMadMxCalleeName(MLIRContext *context,
   std::string lhs = getMadMxElementFragment(lhsElem);
   std::string rhs = getMadMxElementFragment(rhsElem);
   if (lhs.empty() || rhs.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.MMAD.MX." + lhs + rhs).getValue();
 }
 
@@ -421,18 +491,30 @@ static bool isSignedOrSignlessInteger(IntegerType intType, unsigned width) {
 
 static std::string getMadRhsFragment(Type type) {
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isBF16())
+  {
     return "bf16";
+  }
   if (type.isF32())
+  {
     return "f32";
+  }
   if (auto intType = dyn_cast<IntegerType>(type)) {
     if (isSignedOrSignlessInteger(intType, 4))
+    {
       return "s4";
+    }
     if (isSignedOrSignlessInteger(intType, 8))
+    {
       return "s8";
+    }
     if (intType.isUnsigned() && intType.getWidth() == 2)
+    {
       return "u2";
+    }
   }
 
   std::string typeText;
@@ -441,7 +523,9 @@ static std::string getMadRhsFragment(Type type) {
   os.flush();
   std::string lower = StringRef(typeText).lower();
   if (StringRef(lower).contains("e8m0"))
+  {
     return "e8m0";
+  }
   return {};
 }
 
@@ -455,12 +539,18 @@ static bool isMadE5M2ElementType(Type type) {
 
 static std::string getMadDstFragment(Type type) {
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isF32())
+  {
     return "f32";
+  }
   if (auto intType = dyn_cast<IntegerType>(type)) {
     if (isSignedOrSignlessInteger(intType, 32))
+    {
       return "s32";
+    }
   }
   return {};
 }
@@ -471,15 +561,25 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
   std::string rhs = getMadRhsFragment(rhsElem);
   std::string dst = getMadDstFragment(dstElem);
   if (lhsElem.isF16() && rhs == "f16" && dst == "f32")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f162f32.c310").getValue();
+  }
   if (lhsElem.isF16() && rhs == "f16" && dst == "f16")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f162f16").getValue();
+  }
   if (lhsElem.isF16() && rhs == "f16" && dst == "s32")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f162s32.1952").getValue();
+  }
   if (lhsElem.isBF16() && rhs == "bf16" && dst == "f32")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.bf162f32.c310").getValue();
+  }
   if (lhsElem.isF32() && rhs == "f32" && dst == "f32")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f322f32.c310").getValue();
+  }
   if (isSignedOrSignlessInteger(dyn_cast<IntegerType>(lhsElem), 8) &&
       rhs == "s8" && dst == "s32")
     return StringAttr::get(context, "llvm.hivm.MAD.s8.c310").getValue();
@@ -499,13 +599,21 @@ static FailureOr<StringRef> buildMadTypedCalleeName(MLIRContext *context,
       dst == "f32")
     return StringAttr::get(context, "llvm.hivm.MAD.e4m3e4m3.c310").getValue();
   if (lhsElem.isF16() && rhs == "s4")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f16s4.c310").getValue();
+  }
   if (lhsElem.isF16() && rhs == "s8")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f16s8.c310").getValue();
+  }
   if (lhsElem.isF16() && rhs == "u2")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f16u2").getValue();
+  }
   if (lhsElem.isF16() && rhs == "e8m0")
+  {
     return StringAttr::get(context, "llvm.hivm.MAD.f16e8m0.c310").getValue();
+  }
   return failure();
 }
 
@@ -517,7 +625,9 @@ static FailureOr<StringRef> buildLaneTypedCallee(MLIRContext *context,
       getElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
 
   return StringAttr::get(context, "llvm.hivm." + stem.str() + ".v" +
                                       std::to_string(*lanes) + vec +
@@ -533,7 +643,9 @@ static FailureOr<StringRef> buildLaneTypedCalleeFromInput(MLIRContext *context,
       getElementTypeFragment(getElementTypeFromVectorLike(inputType));
   auto lanes = getElementCountFromVectorLike(inputType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
 
   return StringAttr::get(context, "llvm.hivm." + stem.str() + ".v" +
                                       std::to_string(*lanes) + vec +
@@ -543,37 +655,61 @@ static FailureOr<StringRef> buildLaneTypedCalleeFromInput(MLIRContext *context,
 
 static std::string getElementTypeFragment(Type type) {
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isBF16())
+  {
     return "bf16";
+  }
   if (type.isF32())
+  {
     return "f32";
+  }
   if (auto intType = dyn_cast<IntegerType>(type))
+  {
     return (intType.isUnsigned() ? "u" : "s") + std::to_string(intType.getWidth());
+  }
   return {};
 }
 
 static std::string getLowPrecisionElementFragment(Type type) {
   if (pto::isPTOHiFloat8x2Type(type))
+  {
     return "hif8x2";
+  }
   if (pto::isPTOHiFloat8Type(type))
+  {
     return "hif8";
+  }
   if (isa<pto::F4E1M2x2Type>(type))
+  {
     return "f4e1m2x2";
+  }
   if (isa<pto::F4E2M1x2Type>(type))
+  {
     return "f4e2m1x2";
+  }
   if (pto::isPTOFloat8E4M3LikeType(type))
+  {
     return "f8e4m3";
+  }
   if (pto::isPTOFloat8E5M2LikeType(type))
+  {
     return "f8e5m2";
+  }
   return {};
 }
 
 static std::string getMemoryElementTypeFragment(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type))
+  {
     return "i" + std::to_string(intType.getWidth());
+  }
   if (std::string elem = getElementTypeFragment(type); !elem.empty())
+  {
     return elem;
+  }
   return getLowPrecisionElementFragment(type);
 }
 
@@ -590,15 +726,21 @@ struct LowpPayloadABI {
 static std::optional<LowpPayloadABI>
 getLowpPayloadABI(Type elementType, MLIRContext *context) {
   if (!isLowpPayloadElementType(elementType))
+  {
     return std::nullopt;
+  }
   return LowpPayloadABI{IntegerType::get(context, 8), "u8"};
 }
 
 static std::string getDirectLowpVLogicElementFragment(Type type) {
   if (pto::isPTOFloat8E4M3LikeType(type))
+  {
     return "fp8e4m3";
+  }
   if (pto::isPTOFloat8E5M2LikeType(type))
+  {
     return "fp8e5m2";
+  }
   return {};
 }
 
@@ -609,7 +751,9 @@ buildDirectLowpVLogicCallee(MLIRContext *context, Type vectorType,
   auto lanes = getElementCountFromVectorLike(vectorType);
   std::string elem = getDirectLowpVLogicElementFragment(elementType);
   if (elem.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm." + stem.str() + "." +
                                       mode.str() + ".v" +
                                       std::to_string(*lanes) + elem)
@@ -623,7 +767,9 @@ buildLowpPayloadVLogicCallee(MLIRContext *context, Type vectorType,
   auto lanes = getElementCountFromVectorLike(vectorType);
   std::optional<LowpPayloadABI> abi = getLowpPayloadABI(elementType, context);
   if (!abi || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm." + stem.str() + ".v" +
                                       std::to_string(*lanes) +
                                       abi->intrinsicElementFragment.str() +
@@ -647,7 +793,9 @@ static Type getLowpPayloadCarrierType(Type vectorLikeType,
 static Type getPayloadABIType(Type semanticType, Type convertedType,
                               MLIRContext *context) {
   if (Type carrierType = getLowpPayloadCarrierType(semanticType, context))
+  {
     return carrierType;
+  }
   return convertedType;
 }
 
@@ -657,7 +805,9 @@ static Value castToPayloadABI(Location loc, Value value,
   Type carrierType =
       getLowpPayloadCarrierType(semanticType, rewriter.getContext());
   if (!carrierType || carrierType == value.getType())
+  {
     return value;
+  }
   return rewriter.create<LLVM::BitcastOp>(loc, carrierType, value);
 }
 
@@ -667,7 +817,9 @@ static Value castFromPayloadABI(
   Type carrierType =
       getLowpPayloadCarrierType(semanticType, rewriter.getContext());
   if (!carrierType || carrierType == convertedType)
+  {
     return value;
+  }
   return rewriter.create<LLVM::BitcastOp>(loc, convertedType, value);
 }
 
@@ -677,17 +829,27 @@ static std::string getAtomicElementTypeFragment(Type type,
     if (vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
       return {};
     if (vecType.getElementType().isF16())
+    {
       return "f16x2";
+    }
     if (vecType.getElementType().isBF16())
+    {
       return "bf16x2";
+    }
     return {};
   }
   if (type.isF16())
+  {
     return "fp16";
+  }
   if (type.isBF16())
+  {
     return "bf16";
+  }
   if (type.isF32())
+  {
     return "fp32";
+  }
   auto intType = dyn_cast<IntegerType>(type);
   if (!intType)
     return {};
@@ -705,7 +867,9 @@ static std::string getAtomicElementTypeFragment(Type type,
 static std::string getL0LoadElementFragment(Type type) {
   std::string elem = getElementTypeFragment(type);
   if (!elem.empty())
+  {
     return elem;
+  }
 
   std::string typeText;
   llvm::raw_string_ostream os(typeText);
@@ -724,13 +888,21 @@ static std::string getL0LoadElementFragment(Type type) {
 
 static std::string getVbrScalarFragment(Type type) {
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isBF16())
+  {
     return "bf16";
+  }
   if (type.isF32())
+  {
     return "f32";
+  }
   if (auto intType = dyn_cast<IntegerType>(type))
+  {
     return (intType.isUnsigned() ? "u" : "s") + std::to_string(intType.getWidth());
+  }
   return {};
 }
 
@@ -746,9 +918,13 @@ static std::string getShuffleIntrinsicTypeFragment(Type type) {
     }
   }
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isF32())
+  {
     return "f32";
+  }
   if (auto vecType = dyn_cast<VectorType>(type)) {
     if (vecType.getRank() == 1 && vecType.getDimSize(0) == 2 &&
         vecType.getElementType().isF16())
@@ -770,26 +946,38 @@ static std::string getReduxIntrinsicTypeFragment(Type type,
     return isUnsigned ? "u32" : "s32";
   }
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isF32())
+  {
     return "f32";
+  }
   return {};
 }
 
 static Type getElementTypeFromVectorLike(Type type) {
   if (auto vecType = dyn_cast<pto::VRegType>(type))
+  {
     return vecType.getElementType();
+  }
   if (auto vecType = dyn_cast<VectorType>(type))
+  {
     return vecType.getElementType();
+  }
   return {};
 }
 
 static std::optional<int64_t> getElementCountFromVectorLike(Type type) {
   if (auto vecType = dyn_cast<pto::VRegType>(type))
+  {
     return vecType.getElementCount();
+  }
   if (auto vecType = dyn_cast<VectorType>(type)) {
     if (vecType.getRank() != 1)
+    {
       return std::nullopt;
+    }
     return vecType.getShape().front();
   }
   return std::nullopt;
@@ -800,21 +988,31 @@ static Value castIntegerLikeTo(Operation *anchor, Value value, Type targetType) 
   builder.setInsertionPoint(anchor);
 
   if (value.getType() == targetType)
+  {
     return value;
+  }
 
   auto targetInt = dyn_cast<IntegerType>(targetType);
   if (value.getType().isIndex() && targetInt)
+  {
     return builder.create<arith::IndexCastOp>(anchor->getLoc(), targetType, value);
+  }
   if (auto sourceInt = dyn_cast<IntegerType>(value.getType())) {
     if (targetInt) {
       if (sourceInt.getWidth() < targetInt.getWidth())
+      {
         return builder.create<arith::ExtUIOp>(anchor->getLoc(), targetType, value);
+      }
       if (sourceInt.getWidth() > targetInt.getWidth())
+      {
         return builder.create<arith::TruncIOp>(anchor->getLoc(), targetType, value);
+      }
       return value;
     }
     if (targetType.isIndex())
+    {
       return builder.create<arith::IndexCastOp>(anchor->getLoc(), targetType, value);
+    }
   }
 
   return {};
@@ -825,9 +1023,13 @@ static FailureOr<Value> reinterpretPointerToAddrSpace(Operation *anchor,
                                                       unsigned targetAddressSpace) {
   auto sourcePtrType = dyn_cast<LLVM::LLVMPointerType>(value.getType());
   if (!sourcePtrType)
+  {
     return failure();
+  }
   if (sourcePtrType.getAddressSpace() == targetAddressSpace)
+  {
     return value;
+  }
 
   OpBuilder builder(anchor);
   builder.setInsertionPoint(anchor);
@@ -843,15 +1045,21 @@ static FailureOr<Value> normalizeVdupScalarOperand(OpBuilder &builder, Location 
                                                    Type resultType) {
   auto intType = dyn_cast<IntegerType>(input.getType());
   if (!intType || intType.getWidth() != 8)
+  {
     return input;
+  }
 
   Type resultElemType = getElementTypeFromVectorLike(resultType);
   std::string resultElemFragment = getElementTypeFragment(resultElemType);
   if (resultElemFragment != "s8" && resultElemFragment != "u8")
+  {
     return input;
+  }
 
   if (intType.isSignless())
+  {
     return input;
+  }
 
   Type signlessType = builder.getIntegerType(intType.getWidth());
   return builder
@@ -864,29 +1072,41 @@ static Value normalizeByteScalarOperandForHivmCall(OpBuilder &builder, Location 
                                                    Type semanticElementType) {
   auto intType = dyn_cast<IntegerType>(input.getType());
   if (!intType || intType.getWidth() != 8)
+  {
     return input;
+  }
 
   Type i16Type = builder.getIntegerType(16);
   auto semanticIntType = dyn_cast<IntegerType>(semanticElementType);
   if (semanticIntType && semanticIntType.isUnsigned())
+  {
     return builder.create<arith::ExtUIOp>(loc, i16Type, input).getResult();
+  }
   return builder.create<arith::ExtSIOp>(loc, i16Type, input).getResult();
 }
 
 static bool isCompatibleScalarForSemanticType(Type semanticType,
                                               Type scalarType) {
   if (semanticType == scalarType)
+  {
     return true;
+  }
 
   auto semanticInt = dyn_cast<IntegerType>(semanticType);
   auto scalarInt = dyn_cast<IntegerType>(scalarType);
   if (!semanticInt || !scalarInt || semanticInt.getWidth() != scalarInt.getWidth())
+  {
     return false;
+  }
 
   if (semanticInt.isSigned())
+  {
     return scalarInt.isSigned() || scalarInt.isSignless();
+  }
   if (semanticInt.isUnsigned())
+  {
     return scalarInt.isUnsigned() || scalarInt.isSignless();
+  }
   return scalarInt.isSignless();
 }
 
@@ -894,11 +1114,17 @@ static std::string getCopyElementFragment(Type elementType) {
   if (!elementType)
     return {};
   if (elementType.isF16())
+  {
     return "f16";
+  }
   if (elementType.isBF16())
+  {
     return "bf16";
+  }
   if (elementType.isF32())
+  {
     return "f32";
+  }
   // Handle FP8 family (e4m3/e5m2/e8m0/hif8) used by cube-matmul/mad_mx.
   std::string typeText;
   llvm::raw_string_ostream os(typeText);
@@ -906,15 +1132,25 @@ static std::string getCopyElementFragment(Type elementType) {
   os.flush();
   std::string lower = StringRef(typeText).lower();
   if (StringRef(lower).contains("e4m3"))
+  {
     return "e4m3";
+  }
   if (StringRef(lower).contains("e5m2"))
+  {
     return "e5m2";
+  }
   if (StringRef(lower).contains("e8m0"))
+  {
     return "e8m0";
+  }
   if (StringRef(lower).contains("hif8"))
+  {
     return "hif8";
+  }
   if (StringRef(lower).contains("e1m2x2") || StringRef(lower).contains("e2m1x2"))
+  {
     return "u8";
+  }
   if (auto intType = dyn_cast<IntegerType>(elementType)) {
     switch (intType.getWidth()) {
     case 8:
@@ -942,12 +1178,18 @@ static std::string getNd2NzCopyElementFragment(Type elementType) {
       StringRef(lower).contains("e8m0") || StringRef(lower).contains("hif8"))
     return "U8";
   if (StringRef(lower).contains("e1m2x2") || StringRef(lower).contains("e2m1x2"))
+  {
     return "U8";
+  }
 
   if (elementType.isF16() || elementType.isBF16())
+  {
     return "U16";
+  }
   if (elementType.isF32())
+  {
     return "U32";
+  }
   if (auto intType = dyn_cast<IntegerType>(elementType)) {
     switch (intType.getWidth()) {
     case 8:
@@ -965,77 +1207,133 @@ static std::string getNd2NzCopyElementFragment(Type elementType) {
 
 static std::optional<uint64_t> parsePredicatePatternImmediate(StringRef pattern) {
   if (pattern == "PAT_ALL")
+  {
     return 0;
+  }
   if (pattern == "PAT_VL1")
+  {
     return 1;
+  }
   if (pattern == "PAT_VL2")
+  {
     return 2;
+  }
   if (pattern == "PAT_VL3")
+  {
     return 3;
+  }
   if (pattern == "PAT_VL4")
+  {
     return 4;
+  }
   if (pattern == "PAT_VL8")
+  {
     return 5;
+  }
   if (pattern == "PAT_VL16")
+  {
     return 6;
+  }
   if (pattern == "PAT_VL32")
+  {
     return 7;
+  }
   if (pattern == "PAT_VL64")
+  {
     return 8;
+  }
   if (pattern == "PAT_VL128")
+  {
     return 9;
+  }
   if (pattern == "PAT_M3")
+  {
     return 10;
+  }
   if (pattern == "PAT_M4")
+  {
     return 11;
+  }
   if (pattern == "PAT_H")
+  {
     return 12;
+  }
   if (pattern == "PAT_Q")
+  {
     return 13;
+  }
   if (pattern == "PAT_ALLF")
+  {
     return 15;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parseHiLoPartImmediate(StringRef part) {
   if (part == "LOWER")
+  {
     return 0;
+  }
   if (part == "HIGHER")
+  {
     return 1;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parseRoundModeImmediate(StringRef roundMode) {
   if (roundMode == "R" || roundMode == "ROUND_R")
+  {
     return 0;
+  }
   if (roundMode == "A" || roundMode == "ROUND_A")
+  {
     return 1;
+  }
   if (roundMode == "F" || roundMode == "ROUND_F")
+  {
     return 2;
+  }
   if (roundMode == "C" || roundMode == "ROUND_C")
+  {
     return 3;
+  }
   if (roundMode == "Z" || roundMode == "ROUND_Z")
+  {
     return 4;
+  }
   if (roundMode == "O" || roundMode == "ROUND_O")
+  {
     return 5;
+  }
   if (roundMode == "H" || roundMode == "ROUND_H")
+  {
     return 6;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parseSaturationImmediate(StringRef sat) {
   if (sat == "SAT")
+  {
     return 1;
+  }
   if (sat == "NOSAT")
+  {
     return 0;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parsePartImmediate(StringRef part) {
   if (part == "EVEN" || part == "PART_EVEN")
+  {
     return 0;
+  }
   if (part == "ODD" || part == "PART_ODD")
+  {
     return 1;
+  }
   return std::nullopt;
 }
 
@@ -1047,114 +1345,190 @@ static std::optional<uint64_t> parseVcvtPartImmediate(StringRef part) {
       part == "PART_P1")
     return 1;
   if (part == "P2" || part == "PART_P2")
+  {
     return 2;
+  }
   if (part == "P3" || part == "PART_P3")
+  {
     return 3;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parsePredicateStoreDistImmediate(StringRef dist) {
   if (dist == "NORM")
+  {
     return 0;
+  }
   if (dist == "PK")
+  {
     return 1;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parsePredicateLoadDistImmediate(StringRef dist) {
   if (dist.empty() || dist == "NORM")
+  {
     return 0;
+  }
   if (dist == "US")
+  {
     return 1;
+  }
   if (dist == "DS")
+  {
     return 2;
+  }
   return std::nullopt;
 }
 
 static std::optional<int32_t> parsePostModeImmediate(StringRef mode) {
   if (mode == "NO_POST_UPDATE")
+  {
     return 0;
+  }
   if (mode == "POST_UPDATE")
+  {
     return 1;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parsePipeImmediate(StringRef pipe) {
   if (pipe == "PIPE_S")
+  {
     return 0;
+  }
   if (pipe == "PIPE_V")
+  {
     return 1;
+  }
   if (pipe == "PIPE_M")
+  {
     return 2;
+  }
   if (pipe == "PIPE_MTE1")
+  {
     return 3;
+  }
   if (pipe == "PIPE_MTE2")
+  {
     return 4;
+  }
   if (pipe == "PIPE_MTE3")
+  {
     return 5;
+  }
   if (pipe == "PIPE_ALL")
+  {
     return 6;
+  }
   if (pipe == "PIPE_MTE4")
+  {
     return 7;
+  }
   if (pipe == "PIPE_MTE5")
+  {
     return 8;
+  }
   if (pipe == "PIPE_V2")
+  {
     return 9;
+  }
   if (pipe == "PIPE_FIX")
+  {
     return 10;
+  }
   if (pipe == "VIRTUAL_PIPE_MTE2_L1A")
+  {
     return 11;
+  }
   if (pipe == "VIRTUAL_PIPE_MTE2_L1B")
+  {
     return 12;
+  }
   return std::nullopt;
 }
 
 static std::optional<uint64_t> parseEventImmediate(StringRef event) {
   if (!event.consume_front("EVENT_ID"))
+  {
     return std::nullopt;
+  }
   uint64_t value = 0;
   if (event.getAsInteger(10, value))
+  {
     return std::nullopt;
+  }
   return value;
 }
 
 static std::optional<uint64_t> parseSprImmediate(StringRef spr) {
   if (spr == "AR")
+  {
     return 74;
+  }
   return std::nullopt;
 }
 
 static std::optional<unsigned> getDistElementWidth(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type))
+  {
     return intType.getWidth();
+  }
   if (isLowpPayloadElementType(type))
+  {
     return 8;
+  }
   if (type.isF16() || type.isBF16())
+  {
     return 16;
+  }
   if (type.isF32())
+  {
     return 32;
+  }
   if (type.isF64())
+  {
     return 64;
+  }
   return std::nullopt;
 }
 
 static VcvtElemKind classifyVcvtElemType(Type type) {
   if (type.isF16())
+  {
     return VcvtElemKind::F16;
+  }
   if (type.isBF16())
+  {
     return VcvtElemKind::BF16;
+  }
   if (type.isF32())
+  {
     return VcvtElemKind::F32;
+  }
   if (pto::isPTOFloat8E4M3LikeType(type))
+  {
     return VcvtElemKind::F8E4M3;
+  }
   if (pto::isPTOFloat8E5M2LikeType(type))
+  {
     return VcvtElemKind::F8E5M2;
+  }
   if (pto::isPTOHiFloat8Type(type))
+  {
     return VcvtElemKind::HiF8;
+  }
   if (isa<pto::F4E1M2x2Type>(type))
+  {
     return VcvtElemKind::F4E1M2x2;
+  }
   if (isa<pto::F4E2M1x2Type>(type))
+  {
     return VcvtElemKind::F4E2M1x2;
+  }
   if (auto intType = dyn_cast<IntegerType>(type)) {
     switch (intType.getWidth()) {
     case 8:
@@ -1366,9 +1740,13 @@ static uint64_t determineVsqzStoreHint(pto::VsqzOp vsqz) {
   for (Operation *user : result.getUsers()) {
     auto vstur = dyn_cast<pto::VsturOp>(user);
     if (!vstur)
+    {
       continue;
+    }
     if (vstur.getValue() == result)
+    {
       return 1;
+    }
   }
   return 0;
 }
@@ -1377,43 +1755,81 @@ static std::optional<uint64_t> parseLoadDistImmediate(StringRef dist,
                                                       Type elementType) {
   auto width = getDistElementWidth(elementType);
   if (dist.empty() || dist == "NORM")
+  {
     return 0;
+  }
   if (!width)
+  {
     return std::nullopt;
+  }
   if (dist == "BRC_B8")
+  {
     return std::optional<uint64_t>(1);
+  }
   if (dist == "BRC_B16")
+  {
     return std::optional<uint64_t>(2);
+  }
   if (dist == "BRC_B32")
+  {
     return std::optional<uint64_t>(3);
+  }
   if (dist == "US_B8")
+  {
     return std::optional<uint64_t>(6);
+  }
   if (dist == "US_B16")
+  {
     return std::optional<uint64_t>(7);
+  }
   if (dist == "DS_B8")
+  {
     return std::optional<uint64_t>(8);
+  }
   if (dist == "DS_B16")
+  {
     return std::optional<uint64_t>(9);
+  }
   if (dist == "UNPK_B8")
+  {
     return std::optional<uint64_t>(13);
+  }
   if (dist == "UNPK_B16")
+  {
     return std::optional<uint64_t>(14);
+  }
   if (dist == "UNPK_B32")
+  {
     return std::optional<uint64_t>(18);
+  }
   if (dist == "BRC_BLK")
+  {
     return 15;
+  }
   if (dist == "E2B_B16")
+  {
     return std::optional<uint64_t>(16);
+  }
   if (dist == "E2B_B32")
+  {
     return std::optional<uint64_t>(17);
+  }
   if (dist == "UNPK4")
+  {
     return *width == 8 ? std::optional<uint64_t>(20) : std::nullopt;
+  }
   if (dist == "SPLT4CHN")
+  {
     return *width == 8 ? std::optional<uint64_t>(21) : std::nullopt;
+  }
   if (dist == "SPLT2CHN_B8")
+  {
     return std::optional<uint64_t>(22);
+  }
   if (dist == "SPLT2CHN_B16")
+  {
     return std::optional<uint64_t>(23);
+  }
   return std::nullopt;
 }
 
@@ -1421,15 +1837,25 @@ static std::optional<uint64_t> parseLoadX2DistImmediate(StringRef dist,
                                                         Type elementType) {
   auto width = getDistElementWidth(elementType);
   if (dist == "BDINTLV")
+  {
     return 10;
+  }
   if (!width)
+  {
     return std::nullopt;
+  }
   if (dist == "DINTLV_B8")
+  {
     return std::optional<uint64_t>(11);
+  }
   if (dist == "DINTLV_B16")
+  {
     return std::optional<uint64_t>(12);
+  }
   if (dist == "DINTLV_B32")
+  {
     return std::optional<uint64_t>(19);
+  }
   return std::nullopt;
 }
 
@@ -1438,41 +1864,75 @@ static std::optional<uint64_t> parseStoreDistImmediate(StringRef dist,
   auto width = getDistElementWidth(elementType);
   if (dist.empty()) {
     if (!width)
+    {
       return std::nullopt;
+    }
     if (*width == 8)
+    {
       return 0;
+    }
     if (*width == 16)
+    {
       return 1;
+    }
     if (*width == 32)
+    {
       return 2;
+    }
     return std::nullopt;
   }
   if (dist == "NORM_B8")
+  {
     return std::optional<uint64_t>(0);
+  }
   if (dist == "NORM_B16")
+  {
     return std::optional<uint64_t>(1);
+  }
   if (dist == "NORM_B32")
+  {
     return std::optional<uint64_t>(2);
+  }
   if (dist == "1PT_B8")
+  {
     return std::optional<uint64_t>(3);
+  }
   if (dist == "1PT_B16")
+  {
     return std::optional<uint64_t>(4);
+  }
   if (dist == "1PT_B32")
+  {
     return std::optional<uint64_t>(5);
+  }
   if (dist == "PK_B16")
+  {
     return std::optional<uint64_t>(6);
+  }
   if (dist == "PK_B32")
+  {
     return std::optional<uint64_t>(7);
+  }
   if (dist == "PK_B64")
+  {
     return std::optional<uint64_t>(10);
+  }
   if (dist == "PK4_B32")
+  {
     return std::optional<uint64_t>(12);
+  }
   if (dist == "MRG4CHN_B8")
+  {
     return std::optional<uint64_t>(13);
+  }
   if (dist == "MRG2CHN_B8")
+  {
     return std::optional<uint64_t>(14);
+  }
   if (dist == "MRG2CHN_B16")
+  {
     return std::optional<uint64_t>(15);
+  }
   return std::nullopt;
 }
 
@@ -1491,13 +1951,21 @@ static std::optional<uint64_t> parseStoreX2DistImmediate(StringRef dist,
                                                          Type elementType) {
   auto width = getDistElementWidth(elementType);
   if (!width)
+  {
     return std::nullopt;
+  }
   if (dist == "INTLV_B8")
+  {
     return std::optional<uint64_t>(8);
+  }
   if (dist == "INTLV_B16")
+  {
     return std::optional<uint64_t>(9);
+  }
   if (dist == "INTLV_B32")
+  {
     return std::optional<uint64_t>(11);
+  }
   return std::nullopt;
 }
 
@@ -1522,9 +1990,13 @@ static Value packBlockRepeatStride(Operation *anchor, Value blockStride,
 
 static std::optional<uint64_t> parseOrderImmediate(StringRef order) {
   if (order.empty() || order == "ASC")
+  {
     return 0;
+  }
   if (order == "DESC")
+  {
     return 1;
+  }
   return std::nullopt;
 }
 
@@ -1535,7 +2007,9 @@ static FailureOr<Value> packLoopPair(Operation *anchor, Value low, Value high) {
   Value lowI64 = castIntegerLikeTo(anchor, low, builder.getI64Type());
   Value highI64 = castIntegerLikeTo(anchor, high, builder.getI64Type());
   if (!lowI64 || !highI64)
+  {
     return failure();
+  }
 
   Value shift = getI64Constant(builder, anchor->getLoc(), 40);
   Value highShifted =
@@ -1551,7 +2025,9 @@ static FailureOr<Value> packLoopSize(Operation *anchor, Value loop2, Value loop1
   Value loop2I64 = castIntegerLikeTo(anchor, loop2, builder.getI64Type());
   Value loop1I64 = castIntegerLikeTo(anchor, loop1, builder.getI64Type());
   if (!loop2I64 || !loop1I64)
+  {
     return failure();
+  }
 
   Value shift = getI64Constant(builder, anchor->getLoc(), 21);
   Value loop2Shifted =
@@ -1563,7 +2039,9 @@ static FailureOr<Value> packLoopSize(Operation *anchor, Value loop2, Value loop1
 static FailureOr<Value>
 packCopyGmToUbConfig0(Operation *anchor, ValueRange operands) {
   if (operands.size() != 11)
+  {
     return failure();
+  }
 
   OpBuilder builder(anchor);
   builder.setInsertionPoint(anchor);
@@ -1605,7 +2083,9 @@ packCopyGmToUbConfig0(Operation *anchor, ValueRange operands) {
 static FailureOr<Value>
 packCopyGmToUbConfig1(Operation *anchor, ValueRange operands) {
   if (operands.size() != 11)
+  {
     return failure();
+  }
   return packLoopPair(anchor, operands[9], operands[10]);
 }
 
@@ -1622,7 +2102,9 @@ packCopyGmToUbCfgV220(Operation *anchor, ValueRange operands) {
   Value sid = getI64Operand(2);
   Value lenBurst = getI64Operand(4);
   if (!sid || !lenBurst)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1666,7 +2148,9 @@ packCopyGmToUbConfig0(Operation *anchor, Value sid, Value nBurst,
 static FailureOr<Value>
 packCopyUbToGmConfig0(Operation *anchor, ValueRange operands) {
   if (operands.size() != 8)
+  {
     return failure();
+  }
 
   OpBuilder builder(anchor);
   builder.setInsertionPoint(anchor);
@@ -1681,7 +2165,9 @@ packCopyUbToGmConfig0(Operation *anchor, ValueRange operands) {
   Value lenBurst = getI64Operand(4);
   Value l2CacheCtl = getI64Operand(5);
   if (!sid || !nBurst || !lenBurst || !l2CacheCtl)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1701,14 +2187,18 @@ packCopyUbToGmConfig0(Operation *anchor, ValueRange operands) {
 static FailureOr<Value>
 packCopyUbToGmConfig1(Operation *anchor, ValueRange operands) {
   if (operands.size() != 8)
+  {
     return failure();
+  }
   return packLoopPair(anchor, operands[6], operands[7]);
 }
 
 static FailureOr<Value>
 packCopyUbToGmCfgV220(Operation *anchor, ValueRange operands) {
   if (operands.size() != 8)
+  {
     return failure();
+  }
 
   OpBuilder builder(anchor);
   builder.setInsertionPoint(anchor);
@@ -1721,7 +2211,9 @@ packCopyUbToGmCfgV220(Operation *anchor, ValueRange operands) {
   Value sid = getI64Operand(2);
   Value lenBurst = getI64Operand(4);
   if (!sid || !lenBurst)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1761,7 +2253,9 @@ packCopyUbToGmConfig0(Operation *anchor, Value sid, Value nBurst,
 static FailureOr<Value>
 packCopyUbToUbConfig(Operation *anchor, ValueRange operands) {
   if (operands.size() != 7)
+  {
     return failure();
+  }
   OpBuilder builder(anchor);
   builder.setInsertionPoint(anchor);
   Location loc = anchor->getLoc();
@@ -1775,7 +2269,9 @@ packCopyUbToUbConfig(Operation *anchor, ValueRange operands) {
   Value srcStride = getI64Operand(5);
   Value dstStride = getI64Operand(6);
   if (!nBurst || !lenBurst || !srcStride || !dstStride)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1795,7 +2291,9 @@ packCopyUbToUbConfig(Operation *anchor, ValueRange operands) {
 static FailureOr<Value>
 packCopyCbufToUbConfig(Operation *anchor, ValueRange operands) {
   if (operands.size() != 7)
+  {
     return failure();
+  }
   OpBuilder builder(anchor);
   builder.setInsertionPoint(anchor);
   Location loc = anchor->getLoc();
@@ -1810,7 +2308,9 @@ packCopyCbufToUbConfig(Operation *anchor, ValueRange operands) {
   Value srcStride = getI64Operand(5);
   Value dstStride = getI64Operand(6);
   if (!sid || !nBurst || !lenBurst || !srcStride || !dstStride)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1831,7 +2331,9 @@ packCopyCbufToUbConfig(Operation *anchor, ValueRange operands) {
 static FailureOr<Value>
 packCopyUbToCbufConfig(Operation *anchor, ValueRange operands) {
   if (operands.size() != 7)
+  {
     return failure();
+  }
   OpBuilder builder(anchor);
   builder.setInsertionPoint(anchor);
   Location loc = anchor->getLoc();
@@ -1846,7 +2348,9 @@ packCopyUbToCbufConfig(Operation *anchor, ValueRange operands) {
   Value srcStride = getI64Operand(5);
   Value dstStride = getI64Operand(6);
   if (!sid || !nBurst || !lenBurst || !srcStride || !dstStride)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1873,7 +2377,9 @@ packCopyGmToCbufConfig0(Operation *anchor, Value nBurst, Value lenBurst) {
   Value nBurstI64 = castIntegerLikeTo(anchor, nBurst, builder.getI64Type());
   Value lenBurstI64 = castIntegerLikeTo(anchor, lenBurst, builder.getI64Type());
   if (!nBurstI64 || !lenBurstI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1899,7 +2405,9 @@ packCopyGmToCbufConfig1(Operation *anchor, Value srcStride,
   Value srcStrideI64 = castIntegerLikeTo(anchor, srcStride, builder.getI64Type());
   Value dstStrideI64 = castIntegerLikeTo(anchor, dstStride, builder.getI64Type());
   if (!srcStrideI64 || !dstStrideI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1927,7 +2435,9 @@ packCopyGmToCbufMultiConfig0(Operation *anchor, Value sid,
   Value l2CacheCtlI64 = castIntegerLikeTo(anchor, l2CacheCtl, builder.getI64Type());
   Value nValueI64 = castIntegerLikeTo(anchor, nValue, builder.getI64Type());
   if (!sidI64 || !loop1SrcStrideI64 || !l2CacheCtlI64 || !nValueI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -1956,7 +2466,9 @@ packCopyGmToCbufMultiConfig1(Operation *anchor, Value dValue,
       castIntegerLikeTo(anchor, loop4SrcStride, builder.getI64Type());
   Value smallC0EnI64 = castIntegerLikeTo(anchor, smallC0En, builder.getI64Type());
   if (!dValueI64 || !loop4SrcStrideI64 || !smallC0EnI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2020,7 +2532,9 @@ static FailureOr<Value> packCopyCbufToFbufConfig(Operation *anchor, Value nBurst
   Value sourceGapI64 = castIntegerLikeTo(anchor, sourceGap, builder.getI64Type());
   Value dstGapI64 = castIntegerLikeTo(anchor, dstGap, builder.getI64Type());
   if (!nBurstI64 || !lenBurstI64 || !sourceGapI64 || !dstGapI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2049,7 +2563,9 @@ packLoadCbufToS4Config0(Operation *anchor, Value mStart, Value kStart,
   Value mStepI64 = castIntegerLikeTo(anchor, mStep, builder.getI64Type());
   Value kStepI64 = castIntegerLikeTo(anchor, kStep, builder.getI64Type());
   if (!mStartI64 || !kStartI64 || !mStepI64 || !kStepI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2075,7 +2591,9 @@ packLoadCbufToS4Config1(Operation *anchor, Value srcStride, Value dstStride) {
   Value srcStrideI64 = castIntegerLikeTo(anchor, srcStride, builder.getI64Type());
   Value dstStrideI64 = castIntegerLikeTo(anchor, dstStride, builder.getI64Type());
   if (!srcStrideI64 || !dstStrideI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2097,7 +2615,9 @@ packLoadCbufToCaConfig0(Operation *anchor, Value mStart, Value kStart,
   Value mStepI64 = castIntegerLikeTo(anchor, mStep, builder.getI64Type());
   Value kStepI64 = castIntegerLikeTo(anchor, kStep, builder.getI64Type());
   if (!mStartI64 || !kStartI64 || !mStepI64 || !kStepI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2125,7 +2645,9 @@ packLoadCbufToCaConfig1(Operation *anchor, Value srcStride, Value dstStride) {
   Value dstStrideI64 =
       castIntegerLikeTo(anchor, dstStride, builder.getI64Type());
   if (!srcStrideI64 || !dstStrideI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2147,7 +2669,9 @@ packLoadCbufToCbConfig0(Operation *anchor, Value mStart, Value kStart,
   Value mStepI64 = castIntegerLikeTo(anchor, mStep, builder.getI64Type());
   Value kStepI64 = castIntegerLikeTo(anchor, kStep, builder.getI64Type());
   if (!mStartI64 || !kStartI64 || !mStepI64 || !kStepI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2175,7 +2699,9 @@ packLoadCbufToCbConfig1(Operation *anchor, Value srcStride, Value dstStride) {
   Value dstStrideI64 =
       castIntegerLikeTo(anchor, dstStride, builder.getI64Type());
   if (!srcStrideI64 || !dstStrideI64)
+  {
     return failure();
+  }
 
   auto shl = [&](Value value, uint64_t amount) -> Value {
     return builder.create<arith::ShLIOp>(loc, value,
@@ -2208,7 +2734,9 @@ static FailureOr<Value> packVbitsortConfig(Operation *anchor, Value repeatTimes)
 
   Value repeatI64 = castIntegerLikeTo(anchor, repeatTimes, builder.getI64Type());
   if (!repeatI64)
+  {
     return failure();
+  }
   return builder
       .create<arith::ShLIOp>(loc, repeatI64, getI64Constant(builder, loc, 56))
       .getResult();
@@ -2221,17 +2749,23 @@ static FailureOr<Value> convertElementOffsetToBytes(Operation *anchor, Value off
 
   Value offsetI32 = castIntegerLikeTo(anchor, offset, builder.getI32Type());
   if (!offsetI32)
+  {
     return failure();
+  }
 
   unsigned bitWidth = 0;
   if (auto intType = dyn_cast<IntegerType>(elementType))
+  {
     bitWidth = intType.getWidth();
+  }
   else if (isLowpPayloadElementType(elementType))
     bitWidth = 8;
   else if (auto floatType = dyn_cast<FloatType>(elementType))
     bitWidth = floatType.getWidth();
   if (bitWidth == 0 || bitWidth % 8 != 0)
+  {
     return failure();
+  }
 
   Value scale = builder.create<arith::ConstantOp>(
       anchor->getLoc(), builder.getI32IntegerAttr(bitWidth / 8));
@@ -2249,7 +2783,9 @@ materializeDynamicPltMask(ConversionPatternRewriter &rewriter,
     laneCountI32 = castIntegerLikeTo(rewriter.getInsertionBlock()->getParentOp(),
                                      laneCountI32, i32Type);
     if (!laneCountI32)
+    {
       return failure();
+    }
   }
 
   StringRef calleeName;
@@ -2259,14 +2795,18 @@ materializeDynamicPltMask(ConversionPatternRewriter &rewriter,
     calleeName = StringRef("llvm.hivm.plt.b16.v300");
   } else if (auto intType = dyn_cast<IntegerType>(vectorElemType)) {
     if (intType.getWidth() == 32)
+    {
       calleeName = StringRef("llvm.hivm.plt.b32.v300");
+    }
     else if (intType.getWidth() == 16)
       calleeName = StringRef("llvm.hivm.plt.b16.v300");
     else if (intType.getWidth() == 8)
       calleeName = StringRef("llvm.hivm.plt.b8.v300");
   }
   if (calleeName.empty())
+  {
     return failure();
+  }
 
   Type maskType = VectorType::get({256}, rewriter.getI1Type());
   auto funcType =
@@ -2284,7 +2824,9 @@ static FailureOr<StringRef> buildCarryBinaryCallee(MLIRContext *context,
       getElementTypeFragment(cast<pto::VRegType>(resultType).getElementType());
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm." + stem.str() + ".v" +
                                       std::to_string(*lanes) + vec)
       .getValue();
@@ -2293,68 +2835,116 @@ static FailureOr<StringRef> buildCarryBinaryCallee(MLIRContext *context,
 template <typename UnaryOp>
 static StringRef getUnaryMaskedStem() {
   if constexpr (std::is_same_v<UnaryOp, pto::VabsOp>)
+  {
     return "vabs";
+  }
   if constexpr (std::is_same_v<UnaryOp, pto::VexpOp>)
+  {
     return "vexp";
+  }
   if constexpr (std::is_same_v<UnaryOp, pto::VlnOp>)
+  {
     return "vln";
+  }
   if constexpr (std::is_same_v<UnaryOp, pto::VnegOp>)
+  {
     return "vneg";
+  }
   if constexpr (std::is_same_v<UnaryOp, pto::VsqrtOp>)
+  {
     return "vsqrt";
+  }
   if constexpr (std::is_same_v<UnaryOp, pto::VreluOp>)
+  {
     return "vrelu";
+  }
   if constexpr (std::is_same_v<UnaryOp, pto::VnotOp>)
+  {
     return "vnot";
+  }
   return {};
 }
 
 template <typename BinaryOp>
 static StringRef getBinaryMaskedStem() {
   if constexpr (std::is_same_v<BinaryOp, pto::VaddOp>)
+  {
     return "vadd";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VsubOp>)
+  {
     return "vsub";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VmulOp>)
+  {
     return "vmul";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VdivOp>)
+  {
     return "vdiv";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VmaxOp>)
+  {
     return "vmax";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VminOp>)
+  {
     return "vmin";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VandOp>)
+  {
     return "vand";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VorOp>)
+  {
     return "vor";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VxorOp>)
+  {
     return "vxor";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VshlOp>)
+  {
     return "vshl";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VshrOp>)
+  {
     return "vshr";
+  }
   if constexpr (std::is_same_v<BinaryOp, pto::VpreluOp>)
+  {
     return "vprelu";
+  }
   return {};
 }
 
 template <typename TernaryOp>
 static StringRef getTernaryMaskedStem() {
   if constexpr (std::is_same_v<TernaryOp, pto::VmaddOp>)
+  {
     return "vmadd";
+  }
   return {};
 }
 
 template <typename CarryOp>
 static StringRef getCarryBinaryStem() {
   if constexpr (std::is_same_v<CarryOp, pto::VaddcOp>)
+  {
     return "vaddc";
+  }
   if constexpr (std::is_same_v<CarryOp, pto::VsubcOp>)
+  {
     return "vsubc";
+  }
   if constexpr (std::is_same_v<CarryOp, pto::VaddcsOp>)
+  {
     return "vaddcs";
+  }
   if constexpr (std::is_same_v<CarryOp, pto::VsubcsOp>)
+  {
     return "vsubcs";
+  }
   return {};
 }
 
@@ -2370,7 +2960,9 @@ static FailureOr<StringRef> buildVselCallee(MLIRContext *context,
       getElementTypeFragment(cast<pto::VRegType>(resultType).getElementType());
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vsel.v" + std::to_string(*lanes) +
                                       vec)
       .getValue();
@@ -2381,7 +2973,9 @@ static FailureOr<StringRef> buildVselrCallee(MLIRContext *context,
   Type elemType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
   if (!elemType || !lanes)
+  {
     return failure();
+  }
 
   std::string vec = getElementTypeFragment(elemType);
   if (auto floatType = dyn_cast<FloatType>(elemType);
@@ -2391,7 +2985,9 @@ static FailureOr<StringRef> buildVselrCallee(MLIRContext *context,
           getLowpPayloadABI(elemType, context))
     vec = abi->intrinsicElementFragment.str();
   if (vec.empty())
+  {
     return failure();
+  }
 
   return StringAttr::get(context, "llvm.hivm.vselr.v" + std::to_string(*lanes) +
                                       vec)
@@ -2404,7 +3000,9 @@ static FailureOr<StringRef> buildVdupCallee(MLIRContext *context, pto::VdupOp op
   std::string vec = getElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
 
   if (isa<VectorType, pto::VRegType>(inputType)) {
     StringRef position = op.getPosition().value_or("LOWEST");
@@ -2423,16 +3021,22 @@ static FailureOr<StringRef> buildVbrCallee(MLIRContext *context,
                                           Type semanticElementType) {
   std::string scalar = getVbrScalarFragment(semanticElementType);
   if (scalar.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vbr." + scalar + ".v300").getValue();
 }
 
 static FailureOr<StringRef> buildPstuCallee(MLIRContext *context, pto::PstuOp op) {
   if (auto maskType = dyn_cast<pto::MaskType>(op.getValue().getType())) {
     if (maskType.isB16())
+    {
       return StringAttr::get(context, "llvm.hivm.pstu.b16").getValue();
+    }
     if (maskType.isB32())
+    {
       return StringAttr::get(context, "llvm.hivm.pstu.b32").getValue();
+    }
   }
   return failure();
 }
@@ -2443,7 +3047,9 @@ static FailureOr<StringRef> buildVstusCallee(MLIRContext *context,
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(valueType));
   auto lanes = getElementCountFromVectorLike(valueType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vstus.v" +
                                       std::to_string(*lanes) + vec)
       .getValue();
@@ -2455,7 +3061,9 @@ static FailureOr<StringRef> buildVstusPostCallee(MLIRContext *context,
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(valueType));
   auto lanes = getElementCountFromVectorLike(valueType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vstus.post.v" +
                                       std::to_string(*lanes) + vec)
       .getValue();
@@ -2698,7 +3306,9 @@ FailureOr<StringRef> buildShuffleCallee<pto::ShuffleIdxOp>(MLIRContext *context,
                                                            Type valueType) {
   std::string elem = getShuffleIntrinsicTypeFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.shfl.idx." + elem).getValue();
 }
 
@@ -2707,7 +3317,9 @@ FailureOr<StringRef> buildShuffleCallee<pto::ShuffleUpOp>(MLIRContext *context,
                                                           Type valueType) {
   std::string elem = getShuffleIntrinsicTypeFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.shfl.up." + elem).getValue();
 }
 
@@ -2716,7 +3328,9 @@ FailureOr<StringRef> buildShuffleCallee<pto::ShuffleDownOp>(MLIRContext *context
                                                             Type valueType) {
   std::string elem = getShuffleIntrinsicTypeFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.shfl.down." + elem).getValue();
 }
 
@@ -2725,7 +3339,9 @@ FailureOr<StringRef> buildShuffleCallee<pto::ShuffleBflyOp>(MLIRContext *context
                                                             Type valueType) {
   std::string elem = getShuffleIntrinsicTypeFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.shfl.bfly." + elem).getValue();
 }
 
@@ -2753,7 +3369,9 @@ FailureOr<StringRef> buildReduxCallee<pto::ReduxAddOp>(MLIRContext *context,
                                                       Attribute signednessAttr) {
   std::string elem = getReduxIntrinsicTypeFragment(valueType, signednessAttr);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.redux.add." + elem).getValue();
 }
 
@@ -2763,7 +3381,9 @@ FailureOr<StringRef> buildReduxCallee<pto::ReduxMaxOp>(MLIRContext *context,
                                                       Attribute signednessAttr) {
   std::string elem = getReduxIntrinsicTypeFragment(valueType, signednessAttr);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.redux.max." + elem).getValue();
 }
 
@@ -2773,7 +3393,9 @@ FailureOr<StringRef> buildReduxCallee<pto::ReduxMinOp>(MLIRContext *context,
                                                       Attribute signednessAttr) {
   std::string elem = getReduxIntrinsicTypeFragment(valueType, signednessAttr);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.redux.min." + elem).getValue();
 }
 
@@ -2788,10 +3410,14 @@ static FailureOr<StringRef> buildAtomicCalleeName(MLIRContext *context,
                                                   StringRef opName) {
   std::string elem = getAtomicElementTypeFragment(valueType, signednessAttr);
   if (elem.empty())
+  {
     return failure();
+  }
   auto ptrTy = dyn_cast<pto::PtrType>(ptrType);
   if (!ptrTy)
+  {
     return failure();
+  }
 
   StringRef space;
   switch (ptrTy.getMemorySpace().getAddressSpace()) {
@@ -2800,7 +3426,9 @@ static FailureOr<StringRef> buildAtomicCalleeName(MLIRContext *context,
     break;
   case pto::AddressSpace::VEC:
     if (valueType.isInteger(64))
+    {
       return failure();
+    }
     space = "S";
     break;
   default:
@@ -2839,7 +3467,9 @@ static FailureOr<StringRef> buildL1CacheLoadCallee(MLIRContext *context,
   std::string elem;
   if (auto intType = dyn_cast<IntegerType>(resultType)) {
     if (intType.getWidth() == 8)
+    {
       elem = "s8";
+    }
     else if (intType.getWidth() == 16)
       elem = "s16";
     else if (intType.getWidth() == 32)
@@ -2858,14 +3488,18 @@ static FailureOr<StringRef> buildL1CacheLoadCallee(MLIRContext *context,
   } else if (pto::isPTOPackedLdgStgVectorType(resultType)) {
     unsigned totalBits = pto::getPTOPackedLdgStgTotalBits(resultType);
     if (totalBits == 16)
+    {
       elem = "s16";
+    }
     else if (totalBits == 32)
       elem = "s32";
     else if (totalBits == 64)
       elem = "s64";
   }
   if (elem.empty())
+  {
     return failure();
+  }
   StringRef l1cacheName =
       l1cache == pto::L1Cache::Cache ? "cache" : "uncache";
   return StringAttr::get(context,
@@ -2879,7 +3513,9 @@ static FailureOr<StringRef> buildL1CacheStoreCallee(MLIRContext *context,
   std::string elem;
   if (auto intType = dyn_cast<IntegerType>(valueType)) {
     if (intType.getWidth() == 8)
+    {
       elem = "b8";
+    }
     else if (intType.getWidth() == 16)
       elem = "b16";
     else if (intType.getWidth() == 32)
@@ -2898,14 +3534,18 @@ static FailureOr<StringRef> buildL1CacheStoreCallee(MLIRContext *context,
   } else if (pto::isPTOPackedLdgStgVectorType(valueType)) {
     unsigned totalBits = pto::getPTOPackedLdgStgTotalBits(valueType);
     if (totalBits == 16)
+    {
       elem = "b16";
+    }
     else if (totalBits == 32)
       elem = "b32";
     else if (totalBits == 64)
       elem = "b64";
   }
   if (elem.empty())
+  {
     return failure();
+  }
   StringRef l1cacheName =
       l1cache == pto::L1Cache::Cache ? "cache" : "uncache";
   return StringAttr::get(context,
@@ -2932,7 +3572,9 @@ buildMulhiCallee(MLIRContext *context, Type resultType,
         .getValue();
   }
   if (resultType.isInteger(64) && signedness == pto::Signedness::Unsigned)
+  {
     return StringAttr::get(context, "llvm.hivm.mul64hi.ui").getValue();
+  }
   return failure();
 }
 
@@ -2947,60 +3589,86 @@ buildMulI32ToI64Callee(MLIRContext *context, pto::Signedness signedness) {
 
 static std::string getScalarFloatBuiltinFragment(Type type) {
   if (type.isF32())
+  {
     return "f32";
+  }
   if (type.isF16())
+  {
     return "f16";
+  }
   if (type.isBF16())
+  {
     return "bf16";
+  }
   return {};
 }
 
 static std::string getLLVMFloatBuiltinFragment(Type type) {
   std::string scalar = getScalarFloatBuiltinFragment(type);
   if (!scalar.empty())
+  {
     return scalar;
+  }
 
   auto vecType = dyn_cast<VectorType>(type);
   if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
     return {};
   Type elementType = vecType.getElementType();
   if (elementType.isF16())
+  {
     return "v2f16";
+  }
   if (elementType.isBF16())
+  {
     return "v2bf16";
+  }
   return {};
 }
 
 static std::string getHIVMFloatBuiltinFragment(Type type) {
   std::string scalar = getScalarFloatBuiltinFragment(type);
   if (!scalar.empty())
+  {
     return scalar;
+  }
 
   auto vecType = dyn_cast<VectorType>(type);
   if (!vecType || vecType.getRank() != 1 || vecType.getDimSize(0) != 2)
     return {};
   Type elementType = vecType.getElementType();
   if (elementType.isF16())
+  {
     return "f16x2";
+  }
   if (elementType.isBF16())
+  {
     return "bf16x2";
+  }
   return {};
 }
 
 static FailureOr<StringRef> buildSqrtCallee(MLIRContext *context, Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
   if (elem != "f32" && elem != "f16" && elem != "v2f16")
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.sqrt." + elem).getValue();
 }
 
 static std::string getScalarHIVMFloatShortFragment(Type type) {
   if (type.isF32())
+  {
     return "f";
+  }
   if (type.isF16())
+  {
     return "h";
+  }
   if (type.isBF16())
+  {
     return "y";
+  }
   return {};
 }
 
@@ -3012,8 +3680,9 @@ template <>
 FailureOr<StringRef> buildUnaryScalarMathCallee<pto::AbsFOp>(MLIRContext *context,
                                                              Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
-  if (elem != "f16" && elem != "f32" && elem != "v2f16" && elem != "v2bf16")
+  if (elem != "f16" && elem != "f32" && elem != "v2f16" && elem != "v2bf16") {
     return failure();
+  }
   return StringAttr::get(context, "llvm.fabs." + elem).getValue();
 }
 
@@ -3022,7 +3691,9 @@ FailureOr<StringRef> buildUnaryScalarMathCallee<pto::ExpOp>(MLIRContext *context
                                                             Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
   if (elem != "f32" && elem != "f16" && elem != "v2f16")
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.exp." + elem).getValue();
 }
 
@@ -3031,7 +3702,9 @@ FailureOr<StringRef> buildUnaryScalarMathCallee<pto::LogOp>(MLIRContext *context
                                                             Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
   if (elem != "f32" && elem != "f16" && elem != "v2f16")
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.log." + elem).getValue();
 }
 
@@ -3040,7 +3713,9 @@ FailureOr<StringRef> buildUnaryScalarMathCallee<pto::CeilOp>(MLIRContext *contex
                                                              Type valueType) {
   std::string elem = getScalarHIVMFloatShortFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.ceil." + elem).getValue();
 }
 
@@ -3049,7 +3724,9 @@ FailureOr<StringRef> buildUnaryScalarMathCallee<pto::FloorOp>(MLIRContext *conte
                                                               Type valueType) {
   std::string elem = getScalarHIVMFloatShortFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.floor." + elem).getValue();
 }
 
@@ -3058,7 +3735,9 @@ FailureOr<StringRef> buildUnaryScalarMathCallee<pto::RintOp>(MLIRContext *contex
                                                              Type valueType) {
   std::string elem = getScalarHIVMFloatShortFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.rint." + elem).getValue();
 }
 
@@ -3067,7 +3746,9 @@ FailureOr<StringRef> buildUnaryScalarMathCallee<pto::RoundOp>(MLIRContext *conte
                                                               Type valueType) {
   std::string elem = getScalarHIVMFloatShortFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.round." + elem).getValue();
 }
 
@@ -3100,14 +3781,18 @@ FailureOr<StringRef> buildBinaryScalarMathCallee<pto::PowOp>(MLIRContext *contex
                                                              Type valueType) {
   std::string elem = getLLVMFloatBuiltinFragment(valueType);
   if (elem != "f32" && elem != "f16" && elem != "v2f16")
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.pow." + elem).getValue();
 }
 
 static FailureOr<StringRef> buildFmaCallee(MLIRContext *context, Type valueType) {
   std::string elem = getHIVMFloatBuiltinFragment(valueType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.ffma." + elem + ".rrr").getValue();
 }
 
@@ -3121,21 +3806,35 @@ static std::string getConvertScalarFragment(Type type,
         !elem.empty() && !pto::isPTOFloat4PackedType(elementType))
       return elem + "x2";
     if (elementType.isF32())
+    {
       return "f32x2";
+    }
     if (elementType.isF16())
+    {
       return "f16x2";
+    }
     if (elementType.isBF16())
+    {
       return "bf16x2";
+    }
     return {};
   }
   if (type.isF32())
+  {
     return "fp32";
+  }
   if (type.isF16())
+  {
     return "fp16";
+  }
   if (type.isBF16())
+  {
     return "bf16";
+  }
   if (std::string elem = getLowPrecisionElementFragment(type); !elem.empty())
+  {
     return elem;
+  }
   auto intType = dyn_cast<IntegerType>(type);
   if (!intType || (intType.getWidth() != 32 && intType.getWidth() != 64) ||
       !signednessAttr)
@@ -3151,7 +3850,9 @@ static FailureOr<StringRef> buildConvertCallee(MLIRContext *context,
   std::string src = getConvertScalarFragment(srcType, signednessAttr);
   std::string dst = getConvertScalarFragment(dstType, signednessAttr);
   if (src.empty() || dst.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context,
                          "llvm.hivm." + src + ".to." + dst)
       .getValue();
@@ -3163,7 +3864,9 @@ static FailureOr<StringRef> buildVldsPostCallee(MLIRContext *context,
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vldsx1.post.v" +
                                       std::to_string(*lanes) + vec)
       .getValue();
@@ -3175,7 +3878,9 @@ static FailureOr<StringRef> buildVstsPostCallee(MLIRContext *context,
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(valueType));
   auto lanes = getElementCountFromVectorLike(valueType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vstsx1.post.v" +
                                       std::to_string(*lanes) + vec)
       .getValue();
@@ -3191,7 +3896,9 @@ static FailureOr<StringRef> buildVldusCallee(MLIRContext *context,
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vldus.v" +
                                       std::to_string(*lanes) + vec)
       .getValue();
@@ -3203,7 +3910,9 @@ static FailureOr<StringRef> buildVldusPostCallee(MLIRContext *context,
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vldus.post.v" +
                                       std::to_string(*lanes) + vec)
       .getValue();
@@ -3214,7 +3923,9 @@ static FailureOr<StringRef> buildVcmpCallee(MLIRContext *context, Type inputType
                                             bool isScalarCompare) {
   std::string elem = getElementTypeFragment(getElementTypeFromVectorLike(inputType));
   if (elem.empty())
+  {
     return failure();
+  }
   StringRef stem = isScalarCompare ? "vcmps" : "vcmp";
   return StringAttr::get(context, "llvm.hivm." + stem.str() + "." +
                                       cmpMode.str() + "." + elem + ".z")
@@ -3224,56 +3935,92 @@ static FailureOr<StringRef> buildVcmpCallee(MLIRContext *context, Type inputType
 template <typename VecScalarOp>
 static StringRef getVecScalarMaskedStem() {
   if constexpr (std::is_same_v<VecScalarOp, pto::VmulsOp>)
+  {
     return "vmuls";
+  }
   if constexpr (std::is_same_v<VecScalarOp, pto::VaddsOp>)
+  {
     return "vadds";
+  }
   if constexpr (std::is_same_v<VecScalarOp, pto::VmaxsOp>)
+  {
     return "vmaxs";
+  }
   if constexpr (std::is_same_v<VecScalarOp, pto::VminsOp>)
+  {
     return "vmins";
+  }
   if constexpr (std::is_same_v<VecScalarOp, pto::VlreluOp>)
+  {
     return "vlrelu";
+  }
   if constexpr (std::is_same_v<VecScalarOp, pto::VshlsOp>)
+  {
     return "vshls";
+  }
   if constexpr (std::is_same_v<VecScalarOp, pto::VshrsOp>)
+  {
     return "vshrs";
+  }
   return {};
 }
 
 template <typename ReductionOp>
 static StringRef getReductionUnaryStem() {
   if constexpr (std::is_same_v<ReductionOp, pto::VcaddOp>)
+  {
     return "vcadd";
+  }
   if constexpr (std::is_same_v<ReductionOp, pto::VcmaxOp>)
+  {
     return "vcmax";
+  }
   if constexpr (std::is_same_v<ReductionOp, pto::VcminOp>)
+  {
     return "vcmin";
+  }
   if constexpr (std::is_same_v<ReductionOp, pto::VcgaddOp>)
+  {
     return "vcgadd";
+  }
   if constexpr (std::is_same_v<ReductionOp, pto::VcgmaxOp>)
+  {
     return "vcgmax";
+  }
   if constexpr (std::is_same_v<ReductionOp, pto::VcgminOp>)
+  {
     return "vcgmin";
+  }
   if constexpr (std::is_same_v<ReductionOp, pto::VcpaddOp>)
+  {
     return "vcpadd";
+  }
   return {};
 }
 
 template <typename HistOp>
 static StringRef getHistogramCallee(MLIRContext *context) {
   if constexpr (std::is_same_v<HistOp, pto::Chistv2Op>)
+  {
     return StringAttr::get(context, "llvm.hivm.chistv2.m").getValue();
+  }
   if constexpr (std::is_same_v<HistOp, pto::Dhistv2Op>)
+  {
     return StringAttr::get(context, "llvm.hivm.dhistv2.m").getValue();
+  }
   return {};
 }
 
 template <typename ExtremaOp>
 static StringRef getExtremaPredicateStem() {
   if constexpr (std::is_same_v<ExtremaOp, pto::VcbmaxOp>)
+  {
     return "vcbmax";
+  }
   if constexpr (std::is_same_v<ExtremaOp, pto::VcbminOp>)
+  {
     return "vcbmin";
+  }
   return {};
 }
 
@@ -3290,7 +4037,9 @@ static FailureOr<StringRef> buildCopyGmToUbCallee(MLIRContext *context,
                                                   bool hasPadding) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   Type elementType = ptrType.getElementType();
 
   auto getElementSuffix = [&]() -> std::string {
@@ -3305,7 +4054,9 @@ static FailureOr<StringRef> buildCopyGmToUbCallee(MLIRContext *context,
     if (hasPadding) {
       std::string elem = getElementSuffix();
       if (elem.empty())
+      {
         return failure();
+      }
       return StringAttr::get(context,
                              "llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2." + elem)
           .getValue();
@@ -3315,7 +4066,9 @@ static FailureOr<StringRef> buildCopyGmToUbCallee(MLIRContext *context,
 
   std::string elem = getElementSuffix();
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.MOV.OUT.TO.UB.ALIGN.V2." + elem +
                                       ".DV")
       .getValue();
@@ -3348,7 +4101,9 @@ static FailureOr<StringRef> buildOrdinaryMadCallee(MLIRContext *context,
   auto rhsType = dyn_cast<pto::PtrType>(op.getRhs().getType());
   auto dstType = dyn_cast<pto::PtrType>(op.getDst().getType());
   if (!lhsType || !rhsType || !dstType)
+  {
     return failure();
+  }
 
   return buildMadTypedCalleeName(context, lhsType.getElementType(),
                                   rhsType.getElementType(),
@@ -3360,7 +4115,9 @@ static FailureOr<StringRef> buildMxMadCallee(MLIRContext *context,
   auto lhsType = dyn_cast<pto::PtrType>(op.getLhs().getType());
   auto rhsType = dyn_cast<pto::PtrType>(op.getRhs().getType());
   if (!lhsType || !rhsType)
+  {
     return failure();
+  }
   if (isMxElementType(lhsType.getElementType()) &&
       isMxElementType(rhsType.getElementType())) {
     return buildMadMxCalleeName(context, lhsType.getElementType(),
@@ -3373,10 +4130,14 @@ static FailureOr<StringRef> buildCopyGmToCbufCallee(MLIRContext *context,
                                                     Type sourceType) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   std::string elem = getCopyElementFragment(ptrType.getElementType());
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.MOV.OUT.TO.L1.ALIGN.V2." + elem +
                                       ".DV")
       .getValue();
@@ -3386,10 +4147,14 @@ static FailureOr<StringRef>
 buildCopyGmToCbufMultiNd2NzCallee(MLIRContext *context, Type sourceType) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   std::string elem = getNd2NzCopyElementFragment(ptrType.getElementType());
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.MOV.OUT.TO.L1.MULTI.ND2NZ." +
                                       elem + ".V310")
       .getValue();
@@ -3411,9 +4176,13 @@ static std::string getDn2NzCopyElementFragment(Type type) {
     return "u8";
 
   if (elementType.isF16() || elementType.isBF16())
+  {
     return "u16";
+  }
   if (elementType.isF32())
+  {
     return "u32";
+  }
 
   if (auto intType = dyn_cast<IntegerType>(elementType)) {
     switch (intType.getWidth()) {
@@ -3434,10 +4203,14 @@ static FailureOr<StringRef>
 buildCopyGmToCbufMultiDn2NzCallee(MLIRContext *context, Type sourceType) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   std::string elem = getDn2NzCopyElementFragment(sourceType);
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context,
                          "llvm.hivm.MOV.OUT.TO.L1.MULTI.DN2NZ." + elem)
       .getValue();
@@ -3447,10 +4220,14 @@ static FailureOr<StringRef> buildLoadCbufToCaCallee(MLIRContext *context,
                                                      Type sourceType) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   std::string elem = getL0LoadElementFragment(ptrType.getElementType());
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.LOAD.L1.TO.L0A.2Dv2." + elem)
       .getValue();
 }
@@ -3459,10 +4236,14 @@ static FailureOr<StringRef> buildLoadCbufToCbCallee(MLIRContext *context,
                                                      Type sourceType) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   std::string elem = getL0LoadElementFragment(ptrType.getElementType());
   if (elem.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.LOAD.L1.TO.L0B.2Dv2." + elem)
       .getValue();
 }
@@ -3471,10 +4252,14 @@ static FailureOr<StringRef> buildLoadCbufToCaS4Callee(MLIRContext *context,
                                                        Type sourceType) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   Type elementType = ptrType.getElementType();
   if (!isa<pto::F4E1M2x2Type, pto::F4E2M1x2Type>(elementType))
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.LOAD.L1.TO.L0A.2Dv2.s4")
       .getValue();
 }
@@ -3483,10 +4268,14 @@ static FailureOr<StringRef> buildLoadCbufToCbS4Callee(MLIRContext *context,
                                                        Type sourceType) {
   auto ptrType = dyn_cast<pto::PtrType>(sourceType);
   if (!ptrType)
+  {
     return failure();
+  }
   Type elementType = ptrType.getElementType();
   if (!isa<pto::F4E1M2x2Type, pto::F4E2M1x2Type>(elementType))
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.LOAD.L1.TO.L0B.2Dv2.s4")
       .getValue();
 }
@@ -3516,7 +4305,9 @@ static FailureOr<StringRef> buildCopyMatrixCcToUbCallee(MLIRContext *context,
                                                          Type destinationType) {
   auto ptrType = dyn_cast<pto::PtrType>(destinationType);
   if (!ptrType)
+  {
     return failure();
+  }
   Type dstElem = ptrType.getElementType();
   if (dstElem.isF16())
     return StringAttr::get(context, "llvm.hivm.FIX.L0C.TO.UB.f322f16.EXT")
@@ -3530,7 +4321,9 @@ static FailureOr<StringRef> buildCopyMatrixCcToUbCallee(MLIRContext *context,
 static FailureOr<StringRef> buildCopyCbufToBtCallee(pto::CopyCbufToBtOp op) {
   auto ptrType = dyn_cast<pto::PtrType>(op.getSource().getType());
   if (!ptrType)
+  {
     return failure();
+  }
   Type srcElem = ptrType.getElementType();
   if (srcElem.isF16())
     return StringAttr::get(op.getContext(), "llvm.hivm.MOV.L1.TO.BT.f16")
@@ -3657,7 +4450,9 @@ static FailureOr<StringRef> buildUnpackCallee(MLIRContext *context,
   std::string result =
       getElementTypeFragment(getElementTypeFromVectorLike(resultType));
   if (input.empty() || result.empty())
+  {
     return failure();
+  }
   return StringAttr::get(context,
                          "llvm.hivm." + stem.str() + "." + input + "2" + result)
       .getValue();
@@ -3670,7 +4465,9 @@ static FailureOr<StringRef> buildVpackCallee(MLIRContext *context, Type inputTyp
   std::string result =
       getElementTypeFragment(getElementTypeFromVectorLike(resultType));
   if (input.empty() || result.empty())
+  {
     return failure();
+  }
 
   return StringAttr::get(context, "llvm.hivm.vpack." + input + "2" + result + ".x")
       .getValue();
@@ -3842,7 +4639,9 @@ static FailureOr<StringRef> buildVldsCallee(MLIRContext *context, Type resultTyp
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vldsx1.v" + std::to_string(*lanes) +
                                       vec)
       .getValue();
@@ -3853,10 +4652,14 @@ static FailureOr<StringRef> buildVldsx2Callee(MLIRContext *context,
   Type elementType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
   if (!elementType || !lanes)
+  {
     return failure();
+  }
   std::string element = getMemoryElementTypeFragment(elementType);
   if (element.empty())
+  {
     return failure();
+  }
   return StringAttr::get(
              context, "llvm.hivm.vldsx2" +
                           std::string(post ? ".post" : "") + ".v" +
@@ -3870,17 +4673,25 @@ buildBlockStridedMemoryCallee(MLIRContext *context, Type vectorType,
   Type elementType = getElementTypeFromVectorLike(vectorType);
   auto lanes = getElementCountFromVectorLike(vectorType);
   if (!elementType || !lanes)
+  {
     return failure();
+  }
 
   std::string element;
   if (auto intType = dyn_cast<IntegerType>(elementType))
+  {
     element = "i" + std::to_string(intType.getWidth());
+  }
   else if (isLowpPayloadElementType(elementType))
     element = "i8";
   else
+  {
     element = getMemoryElementTypeFragment(elementType);
+  }
   if (element.empty())
+  {
     return failure();
+  }
 
   return StringAttr::get(context,
                          "llvm.hivm." + stem.str() +
@@ -3900,7 +4711,9 @@ static FailureOr<StringRef> buildVstsCallee(MLIRContext *context, Type valueType
       getMemoryElementTypeFragment(getElementTypeFromVectorLike(valueType));
   auto lanes = getElementCountFromVectorLike(valueType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vstsx1.v" + std::to_string(*lanes) +
                                       vec)
       .getValue();
@@ -3910,11 +4723,15 @@ static FailureOr<StringRef> buildVstsx2Callee(MLIRContext *context, Type valueTy
   Type elementType = getElementTypeFromVectorLike(valueType);
   auto lanes = getElementCountFromVectorLike(valueType);
   if (!elementType || !lanes)
+  {
     return failure();
+  }
 
   std::string element = getMemoryElementTypeFragment(elementType);
   if (element.empty())
+  {
     return failure();
+  }
 
   return StringAttr::get(context, "llvm.hivm.vstsx2.v" +
                                       std::to_string(*lanes) + element)
@@ -3928,9 +4745,13 @@ static FailureOr<StringRef> buildVsstbCallee(MLIRContext *context,
 
 static Type getVgather2SourceElementType(Type sourceType) {
   if (auto ptrType = dyn_cast<pto::PtrType>(sourceType))
+  {
     return ptrType.getElementType();
+  }
   if (auto memrefType = dyn_cast<BaseMemRefType>(sourceType))
+  {
     return memrefType.getElementType();
+  }
   return {};
 }
 
@@ -3941,7 +4762,9 @@ static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
   Type resultElemType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
   if (!sourceElemType || !resultElemType || !lanes)
+  {
     return failure();
+  }
 
   std::string vec;
   int64_t intrinsicLanes = *lanes;
@@ -3952,7 +4775,9 @@ static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
     vec = getElementTypeFragment(resultElemType);
   }
   if (vec.empty())
+  {
     return failure();
+  }
 
   return StringAttr::get(context, "llvm.hivm.vgather2.v300.v" +
                                       std::to_string(intrinsicLanes) + vec)
@@ -3962,13 +4787,19 @@ static FailureOr<StringRef> buildVgather2Callee(MLIRContext *context,
 static std::optional<uint64_t> getFixedVectorBitWidth(Type type) {
   auto vectorType = dyn_cast<VectorType>(type);
   if (!vectorType || vectorType.getRank() != 1 || vectorType.isScalable())
+  {
     return std::nullopt;
+  }
   int64_t lanes = vectorType.getDimSize(0);
   if (lanes <= 0)
+  {
     return std::nullopt;
+  }
   auto elementType = dyn_cast<IntegerType>(vectorType.getElementType());
   if (!elementType)
+  {
     return std::nullopt;
+  }
   return static_cast<uint64_t>(lanes) * elementType.getWidth();
 }
 
@@ -3980,19 +4811,25 @@ static FailureOr<Type> getVgather2OffsetsCarrierType(PatternRewriter &rewriter,
   Type elementType = getElementTypeFromVectorLike(resultType);
   auto lanes = getElementCountFromVectorLike(resultType);
   if (!sourceElemType || !elementType || !lanes || *lanes <= 0)
+  {
     return failure();
+  }
 
   Type carrierType = offsetsType;
   if (pto::getPTOStorageElemBitWidth(elementType) == 16) {
     if (*lanes % 2 != 0)
+    {
       return failure();
+    }
     carrierType = VectorType::get({*lanes / 2}, rewriter.getI32Type());
   }
 
   std::optional<uint64_t> offsetsBits = getFixedVectorBitWidth(offsetsType);
   std::optional<uint64_t> carrierBits = getFixedVectorBitWidth(carrierType);
   if (!offsetsBits || !carrierBits || *offsetsBits != *carrierBits)
+  {
     return failure();
+  }
   return carrierType;
 }
 
@@ -4028,7 +4865,9 @@ static FailureOr<StringRef> buildVmulscvtCallee(MLIRContext *context,
   auto inputLanes = getElementCountFromVectorLike(inputType);
   auto resultLanes = getElementCountFromVectorLike(resultType);
   if (!inputElemType || !resultElemType || !inputLanes || !resultLanes)
+  {
     return failure();
+  }
   if (!inputElemType.isF32() || !resultElemType.isF16() || *inputLanes != 64 ||
       *resultLanes != 128)
     return failure();
@@ -4040,7 +4879,9 @@ static FailureOr<StringRef> buildVciCallee(MLIRContext *context, Type resultType
       getElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   if (vec == "f16" || vec == "f32")
     return StringAttr::get(context, "llvm.hivm.vci.v" + std::to_string(*lanes) +
                                         vec + "." + vec)
@@ -4055,7 +4896,9 @@ static FailureOr<StringRef> buildVtrcCallee(MLIRContext *context, Type resultTyp
       getElementTypeFragment(getElementTypeFromVectorLike(resultType));
   auto lanes = getElementCountFromVectorLike(resultType);
   if (vec.empty() || !lanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vtrc." + vec + ".x").getValue();
 }
 
@@ -4068,7 +4911,9 @@ static FailureOr<StringRef> buildVexpdifCallee(MLIRContext *context,
   std::string dstElem =
       getElementTypeFragment(getElementTypeFromVectorLike(resultType));
   if (srcVec.empty() || dstElem.empty() || !srcLanes)
+  {
     return failure();
+  }
   return StringAttr::get(context, "llvm.hivm.vexpdif.v" +
                                       std::to_string(*srcLanes) + srcVec +
                                       dstElem)
@@ -4079,9 +4924,13 @@ static FailureOr<StringRef> buildVbitsortCallee(MLIRContext *context,
                                                 pto::VbitsortOp op) {
   Type sourceElemType = cast<pto::PtrType>(op.getSource().getType()).getElementType();
   if (sourceElemType.isF16())
+  {
     return StringAttr::get(context, "llvm.hivm.VBS32.V300.f16").getValue();
+  }
   if (sourceElemType.isF32())
+  {
     return StringAttr::get(context, "llvm.hivm.VBS32.V300.f32").getValue();
+  }
   return failure();
 }
 
@@ -4090,9 +4939,13 @@ static FailureOr<StringRef> buildVmrgsort4Callee(MLIRContext *context,
   Type elemType =
       cast<pto::PtrType>(op.getDestination().getType()).getElementType();
   if (elemType.isF16())
+  {
     return StringAttr::get(context, "llvm.hivm.VMRGSORT.f16.V300").getValue();
+  }
   if (elemType.isF32())
+  {
     return StringAttr::get(context, "llvm.hivm.VMRGSORT.f32.V300").getValue();
+  }
   return failure();
 }
 
@@ -4104,16 +4957,22 @@ static FailureOr<Value> packVmrgsort4SourceAddr(Operation *anchor, Value source0
   Location loc = anchor->getLoc();
   unsigned addrShift = 0;
   if (elemType.isF16())
+  {
     addrShift = 3;
+  }
   else if (elemType.isF32())
     addrShift = 3;
   else
+  {
     return failure();
+  }
 
   auto packOne = [&](Value source, uint64_t laneShift) -> FailureOr<Value> {
     FailureOr<Value> ubPtr = reinterpretPointerToAddrSpace(anchor, source, 6);
     if (failed(ubPtr))
+    {
       return failure();
+    }
     Value asInt =
         builder.create<LLVM::PtrToIntOp>(loc, builder.getI64Type(), *ubPtr);
     Value shifted = builder.create<arith::ShRUIOp>(
@@ -4121,7 +4980,9 @@ static FailureOr<Value> packVmrgsort4SourceAddr(Operation *anchor, Value source0
     Value masked = builder.create<arith::AndIOp>(
         loc, shifted, getI64Constant(builder, loc, 0xFFFFULL));
     if (laneShift == 0)
+    {
       return masked;
+    }
     return builder
         .create<arith::ShLIOp>(loc, masked,
                                getI64Constant(builder, loc, laneShift))
@@ -4133,7 +4994,9 @@ static FailureOr<Value> packVmrgsort4SourceAddr(Operation *anchor, Value source0
   FailureOr<Value> low2 = packOne(source2, 32);
   FailureOr<Value> low3 = packOne(source3, 48);
   if (failed(low0) || failed(low1) || failed(low2) || failed(low3))
+  {
     return failure();
+  }
 
   Value packed01 = builder.create<arith::OrIOp>(loc, *low0, *low1);
   Value packed23 = builder.create<arith::OrIOp>(loc, *low2, *low3);
@@ -4146,17 +5009,23 @@ static FailureOr<VcvtContract> buildVcvtContract(pto::VcvtOp op) {
   Type inputElemType = getElementTypeFromVectorLike(op.getInput().getType());
   Type resultElemType = getElementTypeFromVectorLike(op.getResult().getType());
   if (!inputElemType || !resultElemType)
+  {
     return failure();
+  }
   auto contract = lookupVcvtContract(classifyVcvtElemType(inputElemType),
                                      classifyVcvtElemType(resultElemType));
   if (!contract)
+  {
     return failure();
+  }
   return *contract;
 }
 
 static bool needsV300CtrlModeForVPTOFunc(func::FuncOp funcOp) {
   if (!pto::isPTOEntryFunction(funcOp) || funcOp.getBlocks().empty())
+  {
     return false;
+  }
 
   bool needsCtrlSetup = false;
   funcOp.walk([&](pto::VcvtOp vcvtOp) {
@@ -4316,7 +5185,9 @@ static FailureOr<Value> encodeMovPadValue(Location loc, Value value,
   }
 
   if (bitWidth != 8 && bitWidth != 16 && bitWidth != 32)
+  {
     return failure();
+  }
 
   return rewriter.create<arith::ExtUIOp>(loc, rewriter.getI64Type(), payload)
       .getResult();
@@ -4516,7 +5387,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildLaneTypedCallee(op.getContext(), op.getResult().getType(), stem, ".x");
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported unary VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
@@ -4559,13 +5432,17 @@ public:
     FailureOr<StringRef> calleeName =
         buildVsqzCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vsqz VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
     if (!resultType || !maskType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vsqz types");
+    }
 
     Value input = adaptor.getInput();
     Value mask = adaptor.getMask();
@@ -4603,13 +5480,17 @@ public:
     FailureOr<StringRef> calleeName =
         buildVusqzCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vusqz VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
     if (!resultType || !maskType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vusqz types");
+    }
 
     Value src = adaptor.getSrc();
     Value mask = adaptor.getMask();
@@ -4643,13 +5524,17 @@ public:
     FailureOr<StringRef> calleeName =
         buildVmulaCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vmula VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
     if (!resultType || !maskType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vmula types");
+    }
 
     Value acc = adaptor.getAcc();
     Value lhs = adaptor.getLhs();
@@ -4689,7 +5574,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildVmullCallee(op.getContext(), op.getLow().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vmull VPTO signature");
+    }
 
     Type inputType = this->getTypeConverter()->convertType(op.getLhs().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
@@ -4699,7 +5586,9 @@ public:
       return rewriter.notifyMatchFailure(op, "failed to convert vmull types");
     }
     if (resultTypes.size() != 2 || resultTypes[0] != resultTypes[1])
+    {
       return rewriter.notifyMatchFailure(op, "unexpected converted vmull results");
+    }
 
     Value lhs = adaptor.getLhs();
     Value rhs = adaptor.getRhs();
@@ -4782,7 +5671,9 @@ public:
       }
     }
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported binary VPTO signature");
+    }
 
     auto call = rewriter.create<func::CallOp>(op.getLoc(), *calleeName,
                                               TypeRange{callResultType},
@@ -4865,7 +5756,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildCarryBinaryCallee(op.getContext(), op.getResult().getType(), stem);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported carry VPTO signature");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
@@ -4915,23 +5808,31 @@ public:
 
     bool hasPadding = false;
     if constexpr (isGmUb)
+    {
       hasPadding = op->hasAttr("has_pad");
+    }
 
     FailureOr<StringRef> calleeName = failure();
     if constexpr (isGmUb)
       calleeName = buildCopyGmToUbCallee(op.getContext(), op.getSource().getType(),
                                          march, hasPadding);
     else
+    {
       calleeName = buildCopyUbToGmCallee(op.getContext(), march);
+    }
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported copy VPTO signature");
+    }
 
     auto llvmSourceType =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getOperands()[0].getType());
     auto llvmDestType =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getOperands()[1].getType());
     if (!llvmSourceType || !llvmDestType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer copy operands");
+    }
 
     bool isC220 = march == "dav-c220-vec" || march == "dav-c220-cube";
     bool useA3NonPadded = isC220 && isGmUb && !hasPadding;
@@ -4941,7 +5842,9 @@ public:
     FailureOr<Value> config0 = failure();
     FailureOr<Value> config1 = failure();
     if (useA3NonPadded)
+    {
       config0 = packCopyGmToUbCfgV220(op, adaptor.getOperands());
+    }
     else if (useA3UbGm)
       config0 = packCopyUbToGmCfgV220(op, adaptor.getOperands());
     else if constexpr (isGmUb) {
@@ -4952,7 +5855,9 @@ public:
       config1 = packCopyUbToGmConfig1(op, adaptor.getOperands());
     }
     if (failed(config0) || (!useSingleConfig && failed(config1)))
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize copy config");
+    }
 
     SmallVector<Value> args{adaptor.getOperands()[1], adaptor.getOperands()[0],
                             *config0};
@@ -4996,7 +5901,9 @@ public:
 
     std::string calleeName;
     if constexpr (std::is_same_v<UBOp, pto::UBVaddOp>)
+    {
       calleeName = "llvm.hivm.VADD." + elemFrag;
+    }
     else if constexpr (std::is_same_v<UBOp, pto::UBVsubOp>)
       calleeName = "llvm.hivm.VSUB." + elemFrag;
     else if constexpr (std::is_same_v<UBOp, pto::UBVmulOp>)
@@ -5014,7 +5921,9 @@ public:
     else if constexpr (std::is_same_v<UBOp, pto::UBVaddReluOp>)
       calleeName = "llvm.hivm.VADDRELU." + elemFrag;
     else
+    {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf binary op");
+    }
 
     Value dst = adaptor.getDst();
     Value src0 = adaptor.getSrc0();
@@ -5093,17 +6002,23 @@ public:
           op, "unsupported element type for ubuf shift op");
 
     if (elemFrag == "s16")
+    {
       elemFrag = "u16";
+    }
     else if (elemFrag == "s32")
       elemFrag = "u32";
 
     std::string calleeName;
     if constexpr (std::is_same_v<ShiftOp, pto::UBVshlOp>)
+    {
       calleeName = "llvm.hivm.VSHL." + elemFrag;
+    }
     else if constexpr (std::is_same_v<ShiftOp, pto::UBVshrOp>)
       calleeName = "llvm.hivm.VSHR." + elemFrag;
     else
+    {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf shift op");
+    }
 
     Value dst = adaptor.getDst();
     Value src = adaptor.getSrc();
@@ -5196,7 +6111,9 @@ public:
     // Scalar-tile ops keep signed intrinsic names (s16/s32).
     std::string calleeName;
     if constexpr (std::is_same_v<ScalarOp, pto::UBVmulSOp>)
+    {
       calleeName = "llvm.hivm.VMULS." + elemFrag;
+    }
     else if constexpr (std::is_same_v<ScalarOp, pto::UBVaddSOp>)
       calleeName = "llvm.hivm.VADDS." + elemFrag;
     else if constexpr (std::is_same_v<ScalarOp, pto::UBVmaxSOp>)
@@ -5204,7 +6121,9 @@ public:
     else if constexpr (std::is_same_v<ScalarOp, pto::UBVminSOp>)
       calleeName = "llvm.hivm.VMINS." + elemFrag;
     else
+    {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf scalar binary op");
+    }
 
     Value dst = adaptor.getDst();
     Value src = adaptor.getSrc();
@@ -5292,15 +6211,21 @@ public:
     Type elemType = ptrType.getElementType();
     std::string suffix;
     if (elemType.isF32() || elemType.isInteger(32))
+    {
       suffix = "u32";
+    }
     else if (elemType.isF16() || elemType.isInteger(16))
       suffix = "u16";
     else
+    {
       return rewriter.notifyMatchFailure(op, "unsupported element type for ubuf vdup");
+    }
 
     Value dst = adaptor.getDst();
     if (!dst || !isa<LLVM::LLVMPointerType>(dst.getType()))
+    {
       return rewriter.notifyMatchFailure(op, "unexpected converted ubuf vdup dst type");
+    }
 
     Location loc = op.getLoc();
     auto i64Ty = rewriter.getI64Type();
@@ -5363,11 +6288,15 @@ public:
           op, "unsupported element type for ubuf unary op");
 
     if (elemFrag == "s16")
+    {
       elemFrag = "u16";
+    }
 
     std::string calleeName;
     if constexpr (std::is_same_v<UnaryOp, pto::UBVnotOp>)
+    {
       calleeName = "llvm.hivm.VNOT." + elemFrag;
+    }
     else if constexpr (std::is_same_v<UnaryOp, pto::UBVabsOp>)
       calleeName = "llvm.hivm.VABS." + elemFrag;
     else if constexpr (std::is_same_v<UnaryOp, pto::UBVreluOp>) {
@@ -5384,7 +6313,9 @@ public:
     else if constexpr (std::is_same_v<UnaryOp, pto::UBVrsqrtOp>)
       calleeName = "llvm.hivm.VRSQRT." + elemFrag;
     else
+    {
       return rewriter.notifyMatchFailure(op, "unsupported ubuf unary op");
+    }
 
     Value dst = adaptor.getDst();
     Value src = adaptor.getSrc();
@@ -5542,11 +6473,15 @@ public:
     auto llvmDestType =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getOperands()[1].getType());
     if (!llvmSourceType || !llvmDestType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer copy operands");
+    }
 
     FailureOr<Value> config = packCopyUbToUbConfig(op, adaptor.getOperands());
     if (failed(config))
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize copy config");
+    }
 
     StringRef calleeName = buildCopyUbToUbCallee(op.getContext());
     SmallVector<Value> args{adaptor.getOperands()[1], adaptor.getOperands()[0],
@@ -5582,7 +6517,9 @@ public:
     Value sourceRaw = adaptor.getSource();
     Value destinationRaw = adaptor.getDestination();
     if (!sourceRaw || !destinationRaw)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
@@ -5596,11 +6533,15 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, ubufAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/ubuf pointer spaces");
+    }
 
     FailureOr<Value> config = packCopyCbufToUbConfig(op, adaptor.getOperands());
     if (failed(config))
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize copy config");
+    }
 
     StringRef calleeName = buildCopyCbufToUbCallee(op.getContext());
     auto funcType = rewriter.getFunctionType(
@@ -5634,7 +6575,9 @@ public:
     Value sourceRaw = adaptor.getSource();
     Value destinationRaw = adaptor.getDestination();
     if (!sourceRaw || !destinationRaw)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
@@ -5648,11 +6591,15 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, cbufAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map ubuf/cbuf pointer spaces");
+    }
 
     FailureOr<Value> config = packCopyUbToCbufConfig(op, adaptor.getOperands());
     if (failed(config))
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize copy config");
+    }
 
     StringRef calleeName = buildCopyUbToCbufCallee(op.getContext());
     auto funcType = rewriter.getFunctionType(
@@ -5708,7 +6655,9 @@ static LogicalResult lowerMadRawOp(pto::MadRawOpInterface op,
       reinterpretPointerToAddrSpace(op, dstRaw, ccAddressSpace);
   FailureOr<Value> bias;
   if (biasRaw)
+  {
     bias = reinterpretPointerToAddrSpace(op, biasRaw, btAddressSpace);
+  }
   if (failed(lhs) || failed(rhs) || failed(dst) ||
       (biasRaw && failed(bias))) {
     return rewriter.notifyMatchFailure(op, "failed to map cube pointer spaces");
@@ -5723,7 +6672,9 @@ static LogicalResult lowerMadRawOp(pto::MadRawOpInterface op,
 
   Value callDst = *dst;
   if (biasRaw)
+  {
     callDst = buildMadBiasDestination(op, rewriter, *dst, *bias);
+  }
   auto funcType = rewriter.getFunctionType(
       TypeRange{dst->getType(), lhs->getType(), rhs->getType(), i64Ty},
       TypeRange{});
@@ -5747,7 +6698,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto raw = dyn_cast<pto::MadRawOpInterface>(op.getOperation());
     if (!raw)
+    {
       return failure();
+    }
     return lowerMadRawOp(raw, adaptor.getOperands(), rewriter, state);
   }
 
@@ -5798,7 +6751,9 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, cbufAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/gm pointer spaces");
+    }
 
     FailureOr<StringRef> calleeName =
         buildCopyGmToCbufCallee(op.getContext(), op.getSource().getType());
@@ -5843,7 +6798,9 @@ public:
     Value sourceRaw = adaptor.getSource();
     Value destinationRaw = adaptor.getDestination();
     if (!sourceRaw || !destinationRaw)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
@@ -5857,7 +6814,9 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, cbufAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/gm pointer spaces");
+    }
 
     FailureOr<Value> config0 = packCopyGmToCbufMultiConfig0(
         op, adaptor.getSid(), adaptor.getLoop1SrcStride(),
@@ -5867,12 +6826,16 @@ public:
                                      adaptor.getLoop4SrcStride(),
                                      adaptor.getSmallc0En());
     if (failed(config0) || failed(config1))
+    {
       return rewriter.notifyMatchFailure(op, "failed to pack multi copy config");
+    }
 
     FailureOr<StringRef> calleeName = [&] (MLIRContext *ctx, Type sourceType)
         -> FailureOr<StringRef> {
       if constexpr (std::is_same_v<CopyOp, pto::CopyGmToCbufMultiNd2NzOp>)
+      {
         return buildCopyGmToCbufMultiNd2NzCallee(ctx, op.getSource().getType());
+      }
       return buildCopyGmToCbufMultiDn2NzCallee(ctx, sourceType);
     }(op.getContext(), op.getSource().getType());
     if (failed(calleeName))
@@ -5909,7 +6872,9 @@ public:
     Value sourceRaw = adaptor.getSource();
     Value destinationRaw = adaptor.getDestination();
     if (!sourceRaw || !destinationRaw)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
@@ -5923,20 +6888,26 @@ public:
     FailureOr<Value> destinationPtr =
         reinterpretPointerToAddrSpace(op, destinationRaw, btAddressSpace);
     if (failed(source) || failed(destinationPtr))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/bt pointer spaces");
+    }
 
     FailureOr<Value> config = packCopyCbufToBtConfig(
         op, adaptor.getConvControl(), adaptor.getNBurst(), adaptor.getLenBurst(),
         adaptor.getSourceGap(), adaptor.getDstGap());
     if (failed(config))
+    {
       return rewriter.notifyMatchFailure(op, "failed to pack copy_cbuf_to_bt config");
+    }
 
     Type i64Ty = rewriter.getI64Type();
     Value destination =
         rewriter.create<LLVM::PtrToIntOp>(op.getLoc(), i64Ty, *destinationPtr);
     FailureOr<StringRef> calleeName = buildCopyCbufToBtCallee(op);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported copy_cbuf_to_bt source element type");
+    }
     auto funcType = rewriter.getFunctionType(
         TypeRange{i64Ty, source->getType(), i64Ty}, TypeRange{});
     rewriter.create<func::CallOp>(op.getLoc(), *calleeName, TypeRange{},
@@ -5965,7 +6936,9 @@ public:
     Value sourceRaw = adaptor.getSource();
     Value destinationRaw = adaptor.getDestination();
     if (!sourceRaw || !destinationRaw)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
@@ -5978,13 +6951,17 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, fbufAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/fbuf pointer spaces");
+    }
 
     FailureOr<Value> config = packCopyCbufToFbufConfig(
         op, adaptor.getNBurst(), adaptor.getLenBurst(), adaptor.getSourceGap(),
         adaptor.getDstGap());
     if (failed(config))
+    {
       return rewriter.notifyMatchFailure(op, "failed to pack copy_cbuf_to_fbuf config");
+    }
 
     Type i64Ty = rewriter.getI64Type();
     StringRef calleeName = buildCopyCbufToFbufCallee(op.getContext());
@@ -6040,14 +7017,18 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, caAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/ca pointer spaces");
+    }
 
     FailureOr<Value> config0 =
         packLoadCbufToCaConfig0(op, mStart, kStart, mStep, kStep);
     FailureOr<Value> config1 =
         packLoadCbufToCaConfig1(op, srcStride, dstStride);
     if (failed(config0) || failed(config1))
+    {
       return rewriter.notifyMatchFailure(op, "failed to pack load_cbuf_to_ca config");
+    }
     Value transpose =
         getI64Constant(rewriter, op.getLoc(), op.getTranspose() ? 1 : 0);
 
@@ -6086,7 +7067,9 @@ public:
     Value sourceRaw = adaptor.getSource();
     Value destinationRaw = adaptor.getDestination();
     if (!sourceRaw || !destinationRaw)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
@@ -6102,7 +7085,9 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, targetAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/cube pointer spaces");
+    }
 
     FailureOr<Value> config0 = packLoadCbufToS4Config0(
         op, adaptor.getMStart(), adaptor.getKStart(), adaptor.getMStep(),
@@ -6111,12 +7096,16 @@ public:
         packLoadCbufToS4Config1(op, adaptor.getSrcStride(),
                                 adaptor.getDstStride());
     if (failed(config0) || failed(config1))
+    {
       return rewriter.notifyMatchFailure(op, "failed to pack load_cbuf_to_*_s4 config");
+    }
 
     Value transpose =
         castIntegerLikeTo(op, adaptor.getTranspose(), rewriter.getI64Type());
     if (!transpose)
+    {
       return rewriter.notifyMatchFailure(op, "failed to cast transpose to i64");
+    }
 
     FailureOr<StringRef> calleeName =
         std::is_same_v<LoadOp, pto::LoadCbufToCaS4Op>
@@ -6183,7 +7172,9 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, cbAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/cb pointer spaces");
+    }
 
     bool transpose = op.getTranspose();
     FailureOr<Value> config0 =
@@ -6191,7 +7182,9 @@ public:
     FailureOr<Value> config1 =
         packLoadCbufToCbConfig1(op, srcStride, dstStride);
     if (failed(config0) || failed(config1))
+    {
       return rewriter.notifyMatchFailure(op, "failed to pack load_cbuf_to_cb config");
+    }
     Value transposeValue =
         getI64Constant(rewriter, op.getLoc(), transpose ? 1 : 0);
 
@@ -6246,7 +7239,9 @@ public:
     FailureOr<Value> src = reinterpretPointerToAddrSpace(op, srcRaw, cbufAddressSpace);
     FailureOr<Value> dst = reinterpretPointerToAddrSpace(op, dstRaw, caAddressSpace);
     if (failed(src) || failed(dst))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/ca pointer spaces");
+    }
 
     Type sourceElemType = cast<pto::PtrType>(op.getSource().getType()).getElementType();
     unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(sourceElemType);
@@ -6311,7 +7306,9 @@ public:
     FailureOr<Value> src = reinterpretPointerToAddrSpace(op, srcRaw, cbufAddressSpace);
     FailureOr<Value> dst = reinterpretPointerToAddrSpace(op, dstRaw, cbAddressSpace);
     if (failed(src) || failed(dst))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cbuf/cb pointer spaces");
+    }
 
     Type sourceElemType = cast<pto::PtrType>(op.getSource().getType()).getElementType();
     unsigned elemBitWidth = pto::getPTOStorageElemBitWidth(sourceElemType);
@@ -6363,7 +7360,9 @@ public:
     Value xm = adaptor.getXm();
     Value xt = adaptor.getXt();
     if (!sourceRaw || !destinationRaw || !xm || !xt)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
 
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType())) {
@@ -6372,7 +7371,9 @@ public:
 
     Type i64Ty = rewriter.getI64Type();
     if (xm.getType() != i64Ty || xt.getType() != i64Ty)
+    {
       return rewriter.notifyMatchFailure(op, "expected i64 xm/xt operands");
+    }
 
     constexpr unsigned gmAddressSpace =
         static_cast<unsigned>(pto::AddressSpace::GM);
@@ -6382,7 +7383,9 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, gmAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cc/gm pointer spaces");
+    }
 
     StringRef calleeName = buildCopyMatrixCcToGmCallee(op.getContext());
     auto funcType = rewriter.getFunctionType(
@@ -6414,7 +7417,9 @@ public:
     Value sourceRaw = adaptor.getSource();
     Value destinationRaw = adaptor.getDestination();
     if (!sourceRaw || !destinationRaw)
+    {
       return rewriter.notifyMatchFailure(op, "expected converted operands");
+    }
     if (!isa<LLVM::LLVMPointerType>(sourceRaw.getType()) ||
         !isa<LLVM::LLVMPointerType>(destinationRaw.getType()))
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer src/dst");
@@ -6430,13 +7435,17 @@ public:
     FailureOr<Value> destination =
         reinterpretPointerToAddrSpace(op, destinationRaw, targetAddressSpace);
     if (failed(source) || failed(destination))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map cc->buf pointer spaces");
+    }
 
     Type i64Ty = rewriter.getI64Type();
     Value config0 = castIntegerLikeTo(op, adaptor.getConfig0(), i64Ty);
     Value config1 = castIntegerLikeTo(op, adaptor.getConfig1(), i64Ty);
     if (!config0 || !config1)
+    {
       return rewriter.notifyMatchFailure(op, "failed to cast config operands to i64");
+    }
 
     FailureOr<StringRef> calleeName =
         std::is_same_v<CopyOp, pto::CopyMatrixCcToCbufOp>
@@ -6570,7 +7579,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     StringRef calleeName = getHistogramCallee<HistOp>(op.getContext());
     if (calleeName.empty())
+    {
       return rewriter.notifyMatchFailure(op, "unsupported histogram op");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
@@ -6578,7 +7589,9 @@ public:
         this->getTypeConverter()->convertType(op.getSource().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
     if (!resultType || !sourceType || !maskType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert histogram types");
+    }
 
     Value acc = adaptor.getAcc();
     Value source = adaptor.getSource();
@@ -6715,12 +7728,16 @@ public:
     FailureOr<StringRef> calleeName =
         buildVselCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vsel VPTO signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
     if (!resultType || !maskType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vsel result type");
+    }
 
     Value src0 = adaptor.getSrc0();
     Value src1 = adaptor.getSrc1();
@@ -6755,12 +7772,16 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     FailureOr<StringRef> calleeName = buildVdupCallee(op.getContext(), op);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vdup VPTO signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     Type maskType = this->getTypeConverter()->convertType(op.getMask().getType());
     if (!resultType || !maskType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vdup result type");
+    }
 
     Value mask = adaptor.getMask();
     if (!mask || mask.getType() != maskType)
@@ -6824,11 +7845,15 @@ public:
         buildVbrCallee(op.getContext(),
                        cast<pto::VRegType>(op.getResult().getType()).getElementType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vbr VPTO signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vbr result type");
+    }
 
     Value scalar = adaptor.getValue();
     Type expectedScalarType =
@@ -6867,7 +7892,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildVselrCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vselr VPTO signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
@@ -6915,7 +7942,9 @@ public:
 
     Value result = call.getResult(0);
     if (intrinsicResultType != resultType)
+    {
       result = rewriter.create<LLVM::BitcastOp>(op.getLoc(), resultType, result);
+    }
     rewriter.replaceOp(op, ValueRange{result});
     return success();
   }
@@ -7081,7 +8110,9 @@ public:
 
     Value part = castIntegerLikeTo(op, adaptor.getPart(), rewriter.getI32Type());
     if (!part)
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize unpack part");
+    }
 
     auto funcType = rewriter.getFunctionType(TypeRange{srcType, part.getType()},
                                              TypeRange{resultType});
@@ -7109,17 +8140,23 @@ public:
         buildVpackCallee(op.getContext(), op.getSrc().getType(),
                          op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vpack VPTO signature");
+    }
 
     Type srcType = this->getTypeConverter()->convertType(op.getSrc().getType());
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
     if (!srcType || !resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vpack types");
+    }
 
     auto partImm = parseHiLoPartImmediate(op.getPart());
     if (!partImm)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vpack part immediate");
+    }
 
     Value src = adaptor.getSrc();
     if (!src || src.getType() != srcType) {
@@ -7238,9 +8275,13 @@ public:
     constexpr bool isScalarCompare = std::is_same_v<CmpOp, pto::VcmpsOp>;
     Type inputType = Type();
     if constexpr (isScalarCompare)
+    {
       inputType = op.getSrc().getType();
+    }
     else
+    {
       inputType = op.getSrc0().getType();
+    }
     FailureOr<StringRef> calleeName =
         buildVcmpCallee(op.getContext(), inputType, op.getCmpMode(),
                         isScalarCompare);
@@ -7302,11 +8343,15 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Value laneCount = castIntegerLikeTo(op, adaptor.getScalar(), rewriter.getI32Type());
     if (!laneCount)
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize plt lane count");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert plt result types");
+    }
 
     StringRef calleeName = buildPltCallee<PltOp>(op.getContext());
     auto funcType = rewriter.getFunctionType(TypeRange{rewriter.getI32Type()},
@@ -7371,11 +8416,15 @@ public:
     (void)adaptor;
     auto pattern = parsePredicatePatternImmediate(op.getPattern());
     if (!pattern)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported pset pattern");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert pset result types");
+    }
 
     if (isMaskOnlyUsedByOnePointStores(op.getResult())) {
       auto undef = rewriter.create<LLVM::UndefOp>(op.getLoc(), resultTypes.front());
@@ -7412,11 +8461,15 @@ public:
     (void)adaptor;
     auto pattern = parsePredicatePatternImmediate(op.getPattern());
     if (!pattern)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported pge pattern");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert pge result types");
+    }
 
     if (isMaskOnlyUsedByOnePointStores(op.getResult())) {
       auto undef = rewriter.create<LLVM::UndefOp>(op.getLoc(), resultTypes.front());
@@ -7455,17 +8508,23 @@ public:
     Type ptoResultType = op.getResult().getType();
     Type elementType = getElementTypeFromVectorLike(ptoResultType);
     if (!elementType)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vlds element type");
+    }
     auto offsetBytes = convertElementOffsetToBytes(op, adaptor.getOffset(), elementType);
     auto basePtr = dyn_cast<LLVM::LLVMPointerType>(adaptor.getSource().getType());
     auto dist =
         parseLoadDistImmediate(op.getDist().value_or("NORM"), elementType);
     if (failed(offsetBytes) || !basePtr || !dist)
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize vlds operands");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vlds result types");
+    }
 
     bool usePostIntrinsic = static_cast<bool>(op.getUpdatedBase());
     if (usePostIntrinsic) {
@@ -7481,13 +8540,17 @@ public:
             ? buildVldsPostCallee(op.getContext(), ptoResultType)
             : buildVldsCallee(op.getContext(), ptoResultType);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vlds signature");
+    }
 
     Type callValueType = getPayloadABIType(
         ptoResultType, resultTypes[0], rewriter.getContext());
     SmallVector<Type> callResultTypes{callValueType};
     if (usePostIntrinsic)
+    {
       callResultTypes.push_back(resultTypes[1]);
+    }
 
     Value distValue = getI32Constant(rewriter, op.getLoc(), *dist);
     Value postValue = getI32Constant(rewriter, op.getLoc(), usePostIntrinsic ? 1 : 0);
@@ -7525,7 +8588,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type elementType = getElementTypeFromVectorLike(op.getLow().getType());
     if (!elementType)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vldsx2 element type");
+    }
 
     auto offsetBytes =
         convertElementOffsetToBytes(op, adaptor.getOffset(), elementType);
@@ -7549,7 +8614,9 @@ public:
         buildVldsx2Callee(op.getContext(), op.getLow().getType(),
                           usePostIntrinsic);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vldsx2 signature");
+    }
 
     Type lowCallType = getPayloadABIType(
         op.getLow().getType(), resultTypes[0], rewriter.getContext());
@@ -7557,7 +8624,9 @@ public:
         op.getHigh().getType(), resultTypes[1], rewriter.getContext());
     SmallVector<Type> callResultTypes{lowCallType, highCallType};
     if (usePostIntrinsic)
+    {
       callResultTypes.push_back(resultTypes[2]);
+    }
 
     Value distValue = getI32Constant(rewriter, op.getLoc(), *dist);
     Value postValue =
@@ -7601,7 +8670,9 @@ public:
     Value packedStride =
         packBlockRepeatStride(op, adaptor.getBlockStride(), adaptor.getRepeatStride());
     if (!basePtr || !packedStride)
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize vsldb operands");
+    }
 
     bool usePostIntrinsic = op.getUpdatedBase() != nullptr;
     SmallVector<Type> resultTypes;
@@ -7614,13 +8685,17 @@ public:
         op.getResult().getType(), resultTypes[0], rewriter.getContext());
     SmallVector<Type> callResultTypes{callResultType};
     if (usePostIntrinsic)
+    {
       callResultTypes.push_back(resultTypes[1]);
+    }
 
     FailureOr<StringRef> calleeName =
         buildVsldbCallee(op.getContext(), op.getResult().getType(),
                          usePostIntrinsic);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vsldb signature");
+    }
     Value postValue =
         getI32Constant(rewriter, op.getLoc(), usePostIntrinsic ? 1 : 0);
     SmallVector<Value> args{adaptor.getSource(), packedStride, postValue,
@@ -7660,7 +8735,9 @@ public:
     (void)adaptor;
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert init_align result type");
+    }
 
     StringRef calleeName = buildInitAlignCallee(op.getContext());
     auto funcType = rewriter.getFunctionType(TypeRange{}, TypeRange{resultType});
@@ -7732,7 +8809,9 @@ public:
             ? buildVldusPostCallee(op.getContext(), op.getResult().getType())
             : buildVldusCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vldus signature");
+    }
 
     Type callValueType = getPayloadABIType(
         op.getResult().getType(), resultTypes[0], rewriter.getContext());
@@ -7752,7 +8831,9 @@ public:
     }
     SmallVector<Type> argTypes;
     for (Value arg : args)
+    {
       argTypes.push_back(arg.getType());
+    }
     auto funcType = rewriter.getFunctionType(argTypes, intrinsicResultTypes);
     auto call = rewriter.create<func::CallOp>(
         op.getLoc(), *calleeName, intrinsicResultTypes, args);
@@ -7762,7 +8843,9 @@ public:
         resultTypes[0], rewriter);
     SmallVector<Value> replacements{loaded, call.getResult(1)};
     if (usePostIntrinsic)
+    {
       replacements.push_back(call.getResult(2));
+    }
     rewriter.replaceOp(op, replacements);
     return success();
   }
@@ -7783,7 +8866,9 @@ public:
     (void)adaptor;
     auto spr = parseSprImmediate(op.getSpr());
     if (!spr)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported sprclr target");
+    }
 
     StringRef calleeName = buildSprclrCallee(op.getContext());
     Value sprValue = rewriter.create<arith::ConstantOp>(
@@ -7811,7 +8896,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto spr = parseSprImmediate(op.getSpr());
     if (!spr)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported spr store target");
+    }
     auto destType =
         dyn_cast<LLVM::LLVMPointerType>(adaptor.getDestination().getType());
     if (!destType || !adaptor.getOffset().getType().isInteger(32))
@@ -7842,9 +8929,13 @@ public:
                                               resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     if (usePostIntrinsic)
+    {
       rewriter.replaceOp(op, call.getResults());
+    }
     else
+    {
       rewriter.eraseOp(op);
+    }
     return success();
   }
 
@@ -7863,10 +8954,14 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type elementType = getElementTypeFromVectorLike(op.getValue().getType());
     if (!elementType)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vsts element type");
+    }
     Type offsetElementType = elementType;
     if (auto ptrType = dyn_cast<pto::PtrType>(op.getDestination().getType()))
+    {
       offsetElementType = ptrType.getElementType();
+    }
     else if (auto memrefType = dyn_cast<BaseMemRefType>(op.getDestination().getType()))
       offsetElementType = memrefType.getElementType();
     auto offsetBytes =
@@ -7875,14 +8970,18 @@ public:
     auto dist =
         parseStoreDistImmediate(op.getDist().value_or(""), elementType);
     if (failed(offsetBytes) || !basePtr || !dist)
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize vsts operands");
+    }
 
     FailureOr<StringRef> calleeName =
         op.getUpdatedBase()
             ? buildVstsPostCallee(op.getContext(), op.getValue().getType())
             : buildVstsCallee(op.getContext(), op.getValue().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vsts signature");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
@@ -7911,7 +9010,9 @@ public:
     // this dead operand; an LLVM undef is sufficient at this boundary.
     StringRef distToken = op.getDist().value_or("");
     if (isOnePointStoreDist(distToken))
+    {
       mask = rewriter.create<LLVM::UndefOp>(op.getLoc(), mask.getType());
+    }
     SmallVector<Value> args{value, adaptor.getDestination(), *offsetBytes,
                             distValue, zero, mask};
     auto funcType = rewriter.getFunctionType(
@@ -7923,9 +9024,13 @@ public:
                                               resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     if (usePostIntrinsic)
+    {
       rewriter.replaceOp(op, call.getResults());
+    }
     else
+    {
       rewriter.eraseOp(op);
+    }
     return success();
   }
 
@@ -7947,7 +9052,9 @@ public:
     Value packedStride =
         packBlockRepeatStride(op, adaptor.getBlockStride(), adaptor.getRepeatStride());
     if (!basePtr || !packedStride)
+    {
       return rewriter.notifyMatchFailure(op, "failed to materialize vsstb operands");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
@@ -7967,7 +9074,9 @@ public:
     FailureOr<StringRef> calleeName = buildVsstbCallee(
         op.getContext(), op.getValue().getType(), usePostIntrinsic);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vsstb signature");
+    }
     Value zeroValue = getI32Constant(rewriter, op.getLoc(), usePostIntrinsic ? 1 : 0);
     Value value = castToPayloadABI(
         op.getLoc(), adaptor.getValue(), op.getValue().getType(), rewriter);
@@ -7982,9 +9091,13 @@ public:
                                               resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName->str(), funcType});
     if (usePostIntrinsic)
+    {
       rewriter.replaceOp(op, call.getResults());
+    }
     else
+    {
       rewriter.eraseOp(op);
+    }
     return success();
   }
 
@@ -8004,7 +9117,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type elementType = getElementTypeFromVectorLike(op.getLow().getType());
     if (!elementType)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vstsx2 element type");
+    }
 
     auto offsetBytes =
         convertElementOffsetToBytes(op, adaptor.getOffset(), elementType);
@@ -8019,7 +9134,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildVstsx2Callee(op.getContext(), op.getLow().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vstsx2 signature");
+    }
 
     Value distValue = getI32Constant(rewriter, op.getLoc(), *dist);
     Value zeroValue = getI32Constant(rewriter, op.getLoc(), 0);
@@ -8056,13 +9173,19 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     FailureOr<StringRef> calleeName = buildPstuCallee(op.getContext(), op);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported pstu signature");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(), resultTypes)))
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert pstu result types");
+    }
     if (resultTypes.size() != 2)
+    {
       return rewriter.notifyMatchFailure(op, "unexpected converted pstu result arity");
+    }
 
     auto baseType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getBase().getType());
     if (!baseType || adaptor.getAlignIn().getType() != resultTypes[0] ||
@@ -8098,11 +9221,15 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type elementType = getElementTypeFromVectorLike(op.getValue().getType());
     if (!elementType)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vstus element type");
+    }
 
     auto offsetBytes = convertElementOffsetToBytes(op, adaptor.getOffset(), elementType);
     if (failed(offsetBytes))
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vstus offset");
+    }
 
     SmallVector<Type> resultTypes;
     if (failed(this->getTypeConverter()->convertTypes(op->getResultTypes(),
@@ -8124,7 +9251,9 @@ public:
       calleeName =
           buildVstusPostCallee(op.getContext(), op.getValue().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vstus signature");
+    }
     Value value = castToPayloadABI(
         op.getLoc(), adaptor.getValue(), op.getValue().getType(), rewriter);
     SmallVector<Value> args{value, adaptor.getBase(), *offsetBytes,
@@ -8155,7 +9284,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto postMode = parsePostModeImmediate(op.getMode());
     if (!postMode)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vstur mode immediate");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getAlignOut().getType());
     auto baseType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getBase().getType());
@@ -8240,7 +9371,9 @@ public:
     auto offsetBytes =
         convertElementOffsetToBytes(op, adaptor.getOffset(), dstType.getElementType());
     if (failed(offsetBytes))
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vstas offset");
+    }
 
     bool usePostIntrinsic = op.getUpdatedBase() != nullptr;
     SmallVector<Type> resultTypes;
@@ -8264,9 +9397,13 @@ public:
                                               resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     if (usePostIntrinsic)
+    {
       rewriter.replaceOp(op, call.getResults());
+    }
     else
+    {
       rewriter.eraseOp(op);
+    }
     return success();
   }
 
@@ -8293,20 +9430,26 @@ public:
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vgather2 result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVgather2Callee(op.getContext(), op.getSource().getType(),
                             op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 signature");
+    }
 
     Value offsets = adaptor.getOffsets();
     FailureOr<Type> offsetsCarrierType = getVgather2OffsetsCarrierType(
         rewriter, op.getSource().getType(), op.getResult().getType(),
         offsets.getType());
     if (failed(offsetsCarrierType))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vgather2 offsets carrier");
+    }
     if (offsets.getType() != *offsetsCarrierType)
       offsets = rewriter.create<LLVM::BitcastOp>(op.getLoc(), *offsetsCarrierType,
                                                  offsets);
@@ -8347,7 +9490,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildVgather2BcCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vgather2_bc signature");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getSource().getType(), adaptor.getOffsets().getType(),
@@ -8385,7 +9530,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildVgatherbCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vgatherb signature");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getSource().getType(), adaptor.getOffsets().getType(),
@@ -8424,12 +9571,16 @@ public:
     FailureOr<StringRef> calleeName =
         buildVscatterCallee(op.getContext(), op.getValue().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vscatter signature");
+    }
 
     FailureOr<Type> offsetsCarrierType = getVscatterOffsetsCarrierType(
         adaptor.getOffsets().getType());
     if (failed(offsetsCarrierType))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vscatter offsets carrier");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getValue().getType(), adaptor.getDestination().getType(),
@@ -8459,16 +9610,22 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type elemType = getElementTypeFromVectorLike(op.getResult().getType());
     if (!elemType)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vaxpy signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vaxpy result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVaxpyCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vaxpy callee");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getSrc1().getType(), adaptor.getSrc0().getType(),
@@ -8500,14 +9657,18 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto roundMode = parseRoundModeImmediate(op.getRnd());
     if (!roundMode)
+    {
       return rewriter.notifyMatchFailure(op, "vmulscvt requires valid rnd attr");
+    }
     if (*roundMode != 1)
       return rewriter.notifyMatchFailure(
           op, "current vmulscvt lowering only supports rnd A");
 
     auto part = parsePartImmediate(op.getPart());
     if (!part)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vmulscvt part");
+    }
 
     Type resultType =
         this->getTypeConverter()->convertType(op.getResult().getType());
@@ -8519,7 +9680,9 @@ public:
         buildVmulscvtCallee(op.getContext(), op.getInput().getType(),
                             op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vmulscvt signature");
+    }
 
     Value partValue = getI32Constant(rewriter, op.getLoc(), *part);
     auto funcType = rewriter.getFunctionType(
@@ -8550,16 +9713,22 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto order = parseOrderImmediate(op.getOrder().value_or("ASC"));
     if (!order)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vci order");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vci result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVciCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vci callee");
+    }
 
     Value indexValue = adaptor.getIndex();
     Type resultElemType =
@@ -8607,17 +9776,23 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto part = parsePartImmediate(op.getPart());
     if (!part)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vexpdif signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vexpdif result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVexpdifCallee(op.getContext(), op.getInput().getType(),
                            op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vexpdif callee");
+    }
 
     Value partValue = getI32Constant(rewriter, op.getLoc(), *part);
     auto funcType = rewriter.getFunctionType(
@@ -8659,11 +9834,15 @@ public:
 
     FailureOr<Value> config = packVbitsortConfig(op, adaptor.getRepeatTimes());
     if (failed(config))
+    {
       return rewriter.notifyMatchFailure(op, "failed to pack vbitsort config");
+    }
 
     FailureOr<StringRef> calleeName = buildVbitsortCallee(op.getContext(), op);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vbitsort signature");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{adaptor.getDestination().getType(), adaptor.getSource().getType(),
@@ -8718,11 +9897,15 @@ public:
 
     FailureOr<Value> dst = reinterpretPointerToAddrSpace(op, adaptor.getDestination(), 6);
     if (failed(dst))
+    {
       return rewriter.notifyMatchFailure(op, "failed to normalize vmrgsort4 destination");
+    }
 
     FailureOr<StringRef> calleeName = buildVmrgsort4Callee(op.getContext(), op);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vmrgsort4 signature");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{(*dst).getType(), (*packedSrc).getType(),
@@ -8751,11 +9934,15 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     FailureOr<VcvtContract> contract = buildVcvtContract(op);
     if (failed(contract))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vcvt type pair");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vcvt result type");
+    }
 
     SmallVector<Value> callArgs;
     SmallVector<Type> argTypes;
@@ -8768,7 +9955,9 @@ public:
       auto roundMode =
           op.getRndAttr() ? parseRoundModeImmediate(*op.getRnd()) : std::nullopt;
       if (!roundMode)
+      {
         return rewriter.notifyMatchFailure(op, "vcvt requires valid rnd attr");
+      }
       Value roundValue = getI32Constant(rewriter, op.getLoc(), *roundMode);
       callArgs.push_back(roundValue);
       argTypes.push_back(roundValue.getType());
@@ -8779,7 +9968,9 @@ public:
       auto saturation =
           op.getSatAttr() ? parseSaturationImmediate(*op.getSat()) : std::nullopt;
       if (!saturation)
+      {
         return rewriter.notifyMatchFailure(op, "vcvt requires valid sat attr");
+      }
       Value satValue = getI32Constant(rewriter, op.getLoc(), *saturation);
       callArgs.push_back(satValue);
       argTypes.push_back(satValue.getType());
@@ -8788,21 +9979,31 @@ public:
 
     if ((*contract).satBeforeRnd) {
       if ((*contract).requiresSat && failed(appendSatArg()))
+      {
         return failure();
+      }
       if ((*contract).requiresRnd && failed(appendRndArg()))
+      {
         return failure();
+      }
     } else {
       if ((*contract).requiresRnd && failed(appendRndArg()))
+      {
         return failure();
+      }
       if ((*contract).requiresSat && failed(appendSatArg()))
+      {
         return failure();
+      }
     }
 
     if ((*contract).requiresPart) {
       auto part =
           op.getPartAttr() ? parseVcvtPartImmediate(*op.getPart()) : std::nullopt;
       if (!part)
+      {
         return rewriter.notifyMatchFailure(op, "vcvt requires valid part attr");
+      }
       Value partValue = getI32Constant(rewriter, op.getLoc(), *part);
       callArgs.push_back(partValue);
       argTypes.push_back(partValue.getType());
@@ -8877,16 +10078,22 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto roundMode = parseRoundModeImmediate(op.getRoundMode());
     if (!roundMode)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vtrc signature");
+    }
 
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vtrc result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildVtrcCallee(op.getContext(), op.getResult().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported vtrc callee");
+    }
 
     Value roundValue = getI32Constant(rewriter, op.getLoc(), *roundMode);
     auto funcType = rewriter.getFunctionType(
@@ -8960,9 +10167,13 @@ public:
                                               resultTypes, args);
     state.plannedDecls.push_back(PlannedDecl{calleeName.str(), funcType});
     if (usePostIntrinsic)
+    {
       rewriter.replaceOp(op, call.getResults());
+    }
     else
+    {
       rewriter.eraseOp(op);
+    }
     return success();
   }
 
@@ -9140,12 +10351,16 @@ public:
     Value dimY = adaptor.getDimY();
     Value dimX = adaptor.getDimX();
     if (!dimZ || !dimY || !dimX)
+    {
       return rewriter.notifyMatchFailure(op, "missing converted SIMT dims");
+    }
 
     auto i64Type = rewriter.getI64Type();
     auto castToI64 = [&](Value value) -> Value {
       if (value.getType().isInteger(64))
+      {
         return value;
+      }
       return rewriter.create<arith::ExtUIOp>(loc, i64Type, value).getResult();
     };
 
@@ -9236,7 +10451,9 @@ static std::string buildSimtKeepResumeConstraints(
   llvm::raw_string_ostream os(result);
   for (auto [index, physicalReg] : llvm::enumerate(physicalRegs)) {
     if (index != 0)
+    {
       os << ",";
+    }
     if (physicalReg.registerCount == 2)
       os << "={TPERL" << physicalReg.baseRegister / 2 << "}";
     else
@@ -9244,7 +10461,9 @@ static std::string buildSimtKeepResumeConstraints(
   }
   if (tieInputs) {
     for (size_t index = 0; index < physicalRegs.size(); ++index)
+    {
       os << "," << index;
+    }
   }
   return os.str();
 }
@@ -9255,7 +10474,9 @@ static SmallVector<OpT, 4> collectConsecutiveOps(OpT first) {
   for (Operation *cur = first.getOperation(); cur; cur = cur->getNextNode()) {
     auto typed = dyn_cast<OpT>(cur);
     if (!typed)
+    {
       break;
+    }
     ops.push_back(typed);
   }
   return ops;
@@ -9269,13 +10490,19 @@ static bool hasPreviousSameOp(Operation *op) {
 static std::optional<unsigned> getSimtKeepResumeBitWidth(Type type) {
   if (auto intType = dyn_cast<IntegerType>(type)) {
     if (intType.getWidth() <= 64)
+    {
       return intType.getWidth();
+    }
     return std::nullopt;
   }
   if (type.isF16() || type.isBF16())
+  {
     return 16;
+  }
   if (type.isF32())
+  {
     return 32;
+  }
   return std::nullopt;
 }
 
@@ -9289,13 +10516,19 @@ static Value packSimtKeepResumePayload(Location loc, Value value,
   Type intType = rewriter.getIntegerType(*width);
   Value bits = value;
   if (!isa<IntegerType>(type))
+  {
     bits = rewriter.create<LLVM::BitcastOp>(loc, intType, value);
+  }
   else if (bits.getType() != intType)
     bits = rewriter.create<LLVM::BitcastOp>(loc, intType, bits);
   if (*width < 32)
+  {
     return rewriter.create<LLVM::ZExtOp>(loc, rewriter.getI32Type(), bits);
+  }
   if (*width == 32 && bits.getType() != rewriter.getI32Type())
+  {
     return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI32Type(), bits);
+  }
   return bits;
 }
 
@@ -9309,13 +10542,17 @@ static Value unpackSimtKeepResumePayload(Location loc, Value value,
   Type intType = rewriter.getIntegerType(*width);
   Value bits = value;
   if (*width < 32)
+  {
     bits = rewriter.create<LLVM::TruncOp>(loc, intType, bits);
+  }
   else if (bits.getType() != intType)
     bits = rewriter.create<LLVM::BitcastOp>(loc, intType, bits);
 
   if (isa<IntegerType>(resultType)) {
     if (bits.getType() == resultType)
+    {
       return bits;
+    }
     return rewriter.create<LLVM::BitcastOp>(loc, resultType, bits);
   }
   return rewriter.create<LLVM::BitcastOp>(loc, resultType, bits);
@@ -9333,15 +10570,21 @@ computeSimtKeepResumePhysicalRegs(
   physicalRegs.reserve(logicalSlots.size());
   for (auto [slot, registerCount] : logicalSlots) {
     if (slot < 0 || slot >= 123)
+    {
       return failure();
+    }
     if (registerCount == 2 && ((slot % 2) != 0 || slot + 1 >= 123))
+    {
       return failure();
+    }
     // Slots are user-assigned storage words, not dense ordinals in the current
     // keep/resume group. This keeps a consumer that resumes only a subset of
     // slots from changing where the remaining slots are read from.
     int64_t baseRegister = 4 + slot;
     if (baseRegister + static_cast<int64_t>(registerCount) - 1 > 126)
+    {
       return failure();
+    }
     physicalRegs.push_back({baseRegister, registerCount});
   }
   return physicalRegs;
@@ -9349,9 +10592,13 @@ computeSimtKeepResumePhysicalRegs(
 
 static bool isValidSimtKeepResumeSlot(int64_t slot, unsigned registerCount) {
   if (slot < 0 || slot >= 123)
+  {
     return false;
+  }
   if (registerCount == 2 && ((slot % 2) != 0 || slot + 1 >= 123))
+  {
     return false;
+  }
   return true;
 }
 
@@ -9376,7 +10623,9 @@ public:
     for (pto::KeepOp keep : keepOps) {
       Value payload = rewriter.getRemappedValue(keep.getPayload());
       if (!payload)
+      {
         return rewriter.notifyMatchFailure(keep, "payload is not remapped");
+      }
       payload = packSimtKeepResumePayload(keep.getLoc(), payload, rewriter);
       if (!payload)
         return rewriter.notifyMatchFailure(
@@ -9410,7 +10659,9 @@ public:
         LLVM::AsmDialectAttr::get(op.getContext(), LLVM::AsmDialect::AD_ATT),
         ArrayAttr{});
     for (pto::KeepOp keep : llvm::reverse(keepOps))
+    {
       rewriter.eraseOp(keep);
+    }
     return success();
   }
 };
@@ -9471,7 +10722,9 @@ public:
       Value result = unpackSimtKeepResumePayload(op.getLoc(), asmOp.getRes(),
                                                  resultType, rewriter);
       if (!result)
+      {
         return rewriter.notifyMatchFailure(op, "failed to unpack result");
+      }
       rewriter.replaceOp(op, result);
       return success();
     }
@@ -9486,11 +10739,15 @@ public:
       Value result = unpackSimtKeepResumePayload(
           resume.getLoc(), extract.getRes(), resultType, rewriter);
       if (!result)
+      {
         return rewriter.notifyMatchFailure(resume, "failed to unpack result");
+      }
       results.push_back(result);
     }
     for (auto [resume, result] : llvm::zip(resumeOps, results))
+    {
       rewriter.replaceOp(resume, result);
+    }
     return success();
   }
 };
@@ -9536,7 +10793,9 @@ public:
     auto dst = parsePipeImmediate(stringifyPIPE(op.getDstPipe().getPipe()));
     auto event = parseEventImmediate(stringifyEVENT(op.getEventId().getEvent()));
     if (!src || !dst || !event)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported sync immediate");
+    }
 
     StringRef calleeName = buildSyncCallee<SyncOp>(op.getContext());
     Value srcValue = getI64Constant(rewriter, op.getLoc(), *src);
@@ -9571,7 +10830,9 @@ public:
     auto src = parsePipeImmediate(stringifyPIPE(op.getSrcPipe().getPipe()));
     auto dst = parsePipeImmediate(stringifyPIPE(op.getDstPipe().getPipe()));
     if (!src || !dst)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported sync pipe");
+    }
 
     StringRef calleeName = buildSyncCallee<SyncOp>(op.getContext());
     Value srcValue = getI64Constant(rewriter, op.getLoc(), *src);
@@ -9579,14 +10840,18 @@ public:
     
     Value eventIdValue = adaptor.getEventId();
     if (!eventIdValue)
+    {
       return rewriter.notifyMatchFailure(op, "missing event_id operand");
+    }
     
     Value eventValue = eventIdValue;
     
     while (eventValue.getDefiningOp()) {
       auto unrealizedCast = dyn_cast<UnrealizedConversionCastOp>(eventValue.getDefiningOp());
       if (!unrealizedCast || unrealizedCast.getInputs().size() != 1)
+      {
         break;
+      }
       eventValue = unrealizedCast.getInputs()[0];
     }
     
@@ -9632,7 +10897,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
     if (!pipe)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported inter-core sync pipe");
+    }
 
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
     Value eventValue;
@@ -9685,7 +10952,9 @@ public:
 
     auto pipe = parsePipeImmediate(stringifyPIPE(op.getPipe().getPipe()));
     if (!pipe)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported barrier pipe");
+    }
 
     StringRef calleeName = buildSyncCallee<pto::BarrierOp>(op.getContext());
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipe);
@@ -9789,7 +11058,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto ptrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
     if (!ptrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+    }
 
     bool hasDst = static_cast<bool>(op.getDstAttr());
     StringRef calleeName =
@@ -9845,7 +11116,9 @@ public:
 
     auto pipeImm = parsePipeImmediate(stringifyPIPE(pipe));
     if (!pipeImm)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
+    }
 
     StringRef calleeName = buildSyncCallee<BufSyncOp>(op.getContext());
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
@@ -9896,7 +11169,9 @@ public:
 
     auto pipeImm = parsePipeImmediate(stringifyPIPE(pipe));
     if (!pipeImm)
+    {
       return rewriter.notifyMatchFailure(op, "unsupported buffer sync pipe");
+    }
 
     Value pipeValue = getI64Constant(rewriter, op.getLoc(), *pipeImm);
     Value bufIdDyn = adaptor.getBufId();
@@ -9997,7 +11272,9 @@ public:
 
     Value result = call.getResult(0);
     if (isSimtEntry)
+    {
       result = rewriter.create<arith::ExtUIOp>(op.getLoc(), resultType, result);
+    }
     rewriter.replaceOp(op, result);
     return success();
   }
@@ -10018,11 +11295,15 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vote result type");
+    }
 
     Type predType = this->getTypeConverter()->convertType(op.getPred().getType());
     if (!predType || predType != rewriter.getI1Type())
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert vote predicate type");
+    }
 
     StringRef calleeName = buildVoteCallee<VoteOp>(op.getContext());
     auto funcType = rewriter.getFunctionType(TypeRange{predType}, TypeRange{resultType});
@@ -10050,16 +11331,22 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert shuffle result type");
+    }
 
     Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
     if (!valueType || valueType != resultType)
+    {
       return rewriter.notifyMatchFailure(op, "unexpected converted shuffle operand type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildShuffleCallee<ShuffleOp>(op.getContext(), op.getValue().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported shuffle VPTO signature");
+    }
 
     IntegerAttr widthAttr = op.getWidthAttr();
     Value controlValue;
@@ -10078,7 +11365,9 @@ public:
       controlMask = 0x1f;
     }
     if (!controlValue)
+    {
       return rewriter.notifyMatchFailure(op, "missing shuffle control operand");
+    }
 
     Value control = buildShuffleControlValue(
         rewriter, op.getLoc(), controlValue, widthAttr.getInt(), controlMask);
@@ -10110,16 +11399,22 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert redux result type");
+    }
 
     Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
     if (!valueType || valueType != resultType)
+    {
       return rewriter.notifyMatchFailure(op, "unexpected converted redux operand type");
+    }
 
     FailureOr<StringRef> calleeName = buildReduxCallee<ReduxOp>(
         op.getContext(), op.getValue().getType(), op.getSignednessAttr());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported redux VPTO signature");
+    }
 
     auto funcType = rewriter.getFunctionType(TypeRange{resultType},
                                              TypeRange{resultType});
@@ -10154,13 +11449,17 @@ public:
 
     Type ptrType = this->getTypeConverter()->convertType(op.getPtr().getType());
     if (!ptrType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert atomic pointer type");
+    }
 
     FailureOr<StringRef> calleeName = buildAtomicCallee<AtomicOp>(
         op.getContext(), op.getPtr().getType(), op.getValue().getType(),
         op.getSignednessAttr());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported atomic VPTO signature");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{ptrType, valueType, rewriter.getI32Type()},
@@ -10204,13 +11503,17 @@ public:
 
     Type ptrType = this->getTypeConverter()->convertType(op.getPtr().getType());
     if (!ptrType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert atomic pointer type");
+    }
 
     FailureOr<StringRef> calleeName = buildAtomicCallee<pto::AtomicCasOp>(
         op.getContext(), op.getPtr().getType(), op.getValue().getType(),
         op.getSignednessAttr());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported atomic CAS signature");
+    }
 
     auto funcType = rewriter.getFunctionType(
         TypeRange{ptrType, compareType, valueType, rewriter.getI32Type()},
@@ -10306,7 +11609,9 @@ public:
         buildMulhiCallee(op.getContext(), op.getResult().getType(),
                          pto::Signedness::Unsigned);
     if (failed(unsignedCalleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported mul64hi signature");
+    }
 
     auto funcType =
         rewriter.getFunctionType(TypeRange{lhsType, rhsType}, TypeRange{resultType});
@@ -10352,7 +11657,9 @@ public:
     Type lhsType = getTypeConverter()->convertType(op.getLhs().getType());
     Type rhsType = getTypeConverter()->convertType(op.getRhs().getType());
     if (!resultType || !lhsType || !rhsType)
+    {
       return rewriter.notifyMatchFailure(op, "unexpected mul_i32toi64 type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildMulI32ToI64Callee(op.getContext(),
@@ -10387,12 +11694,16 @@ public:
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
     if (!resultType || !valueType || valueType != resultType)
+    {
       return rewriter.notifyMatchFailure(op, "unexpected sqrt operand/result type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildSqrtCallee(op.getContext(), op.getValue().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported sqrt VPTO signature");
+    }
 
     auto funcType = rewriter.getFunctionType(TypeRange{valueType},
                                              TypeRange{resultType});
@@ -10422,12 +11733,16 @@ public:
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     Type valueType = this->getTypeConverter()->convertType(op.getValue().getType());
     if (!resultType || !valueType || valueType != resultType)
+    {
       return rewriter.notifyMatchFailure(op, "unexpected unary scalar math type");
+    }
 
     FailureOr<StringRef> calleeName =
         buildUnaryScalarMathCallee<UnaryOp>(op.getContext(), op.getValue().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported unary scalar math signature");
+    }
 
     auto funcType = rewriter.getFunctionType(TypeRange{valueType},
                                              TypeRange{resultType});
@@ -10464,7 +11779,9 @@ public:
     FailureOr<StringRef> calleeName =
         buildBinaryScalarMathCallee<BinaryOp>(op.getContext(), op.getLhs().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported binary scalar math signature");
+    }
 
     auto funcType = rewriter.getFunctionType(TypeRange{lhsType, rhsType},
                                              TypeRange{resultType});
@@ -10500,7 +11817,9 @@ public:
     FailureOr<StringRef> calleeName = buildFmaCallee(op.getContext(),
                                                      op.getLhs().getType());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported fma scalar signature");
+    }
 
     auto funcType = rewriter.getFunctionType(TypeRange{lhsType, rhsType, accType},
                                              TypeRange{resultType});
@@ -10535,7 +11854,9 @@ public:
         buildConvertCallee(op.getContext(), op.getSrc().getType(),
                            op.getDst().getType(), op.getSignednessAttr());
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported convert signature");
+    }
 
     Value rounding = getI32Constant(
         rewriter, op.getLoc(), static_cast<uint64_t>(op.getRounding()));
@@ -10619,7 +11940,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = this->getTypeConverter()->convertType(op.getResult().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert result type");
+    }
 
     StringRef calleeName = buildBinaryI64PureCallee<BinaryOp>(op.getContext());
     auto funcType =
@@ -10647,7 +11970,9 @@ public:
   matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+    {
       return rewriter.notifyMatchFailure(op, "expected single-operand single-result cast");
+    }
     if (!hasVPTOConvertibleType(op->getOperandTypes()) &&
         !hasVPTOConvertibleType(op->getResultTypes()))
       return rewriter.notifyMatchFailure(op, "no VPTO convertible types");
@@ -10655,11 +11980,15 @@ public:
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult(0).getType());
     if (!convertedResultType)
+    {
       return rewriter.notifyMatchFailure(op, "could not convert result type");
+    }
 
     Value input = adaptor.getOperands().front();
     if (input.getType() != convertedResultType)
+    {
       return rewriter.notifyMatchFailure(op, "input type does not match converted result type");
+    }
 
     rewriter.replaceOp(op, input);
     return success();
@@ -10678,7 +12007,9 @@ public:
         getTypeConverter()->convertType(op.getResult().getType());
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(convertedResultType);
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer result");
+    }
 
     Value input = adaptor.getSrc();
     if (isa<MemRefType>(input.getType())) {
@@ -10744,12 +12075,16 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type resultType = getTypeConverter()->convertType(op.getValue().getType());
     if (!resultType)
+    {
       return rewriter.notifyMatchFailure(op, "could not convert result type");
+    }
     FailureOr<Value> address = getVPTOStructFieldAddress(
         rewriter, op.getLoc(), adaptor.getS(),
         cast<pto::StructType>(op.getS().getType()), op.getPath());
     if (failed(address))
+    {
       return rewriter.notifyMatchFailure(op, "invalid struct field path");
+    }
     rewriter.replaceOpWithNewOp<LLVM::LoadOp>(
         op, resultType, *address, getNaturalByteAlignment(resultType));
     return success();
@@ -10768,7 +12103,9 @@ public:
         rewriter, op.getLoc(), adaptor.getS(),
         cast<pto::StructType>(op.getS().getType()), op.getPath());
     if (failed(address))
+    {
       return rewriter.notifyMatchFailure(op, "invalid struct field path");
+    }
     rewriter.replaceOpWithNewOp<LLVM::StoreOp>(
         op, adaptor.getValue(), *address,
         getNaturalByteAlignment(adaptor.getValue().getType()));
@@ -10795,7 +12132,9 @@ public:
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult().getType());
     if (!convertedResultType)
+    {
       return rewriter.notifyMatchFailure(op, "failed to convert result type");
+    }
 
     Value trueValue = adaptor.getTrueValue();
     Value falseValue = adaptor.getFalseValue();
@@ -10821,7 +12160,9 @@ public:
     Type convertedResultType = getTypeConverter()->convertType(op.getResult().getType());
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(convertedResultType);
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer result type");
+    }
 
     Value offset = adaptor.getOffset();
     if (offset.getType().isIndex())
@@ -10906,7 +12247,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+    }
 
     Type convertedValueType =
         getTypeConverter()->convertType(op.getValue().getType());
@@ -10945,7 +12288,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+    }
 
     Value offset = adaptor.getOffset();
     if (offset.getType().isIndex())
@@ -10979,12 +12324,16 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+    }
 
     Type convertedValueType =
         getTypeConverter()->convertType(op.getValue().getType());
     if (!convertedValueType)
+    {
       return rewriter.notifyMatchFailure(op, "could not convert load result type");
+    }
 
     Value offset = adaptor.getOffset();
     if (offset.getType().isIndex())
@@ -11012,23 +12361,37 @@ static Type getLdgCallResultType(Type valueType, Type convertedValueType,
   if (auto intType = dyn_cast<IntegerType>(valueType)) {
     unsigned width = intType.getWidth();
     if (width == 8 || width == 16)
+    {
       return rewriter.getI32Type();
+    }
     return convertedValueType;
   }
   if (valueType.isF16() || valueType.isBF16() || valueType.isF32())
+  {
     return rewriter.getI32Type();
+  }
   if (valueType.isF64())
+  {
     return rewriter.getI64Type();
+  }
   if (pto::isPTOFloat8Type(valueType) || pto::isPTOHiFloat8Type(valueType))
+  {
     return rewriter.getI32Type();
+  }
   if (pto::isPTOPackedLdgStgVectorType(valueType)) {
     unsigned totalBits = pto::getPTOPackedLdgStgTotalBits(valueType);
     if (totalBits == 16)
+    {
       return rewriter.getI32Type();
+    }
     if (totalBits == 32)
+    {
       return rewriter.getI32Type();
+    }
     if (totalBits == 64)
+    {
       return rewriter.getI64Type();
+    }
   }
   return convertedValueType;
 }
@@ -11082,12 +12445,16 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+    }
 
     Type convertedValueType =
         getTypeConverter()->convertType(op.getValue().getType());
     if (!convertedValueType)
+    {
       return rewriter.notifyMatchFailure(op, "could not convert ldg result type");
+    }
 
     Value offset = adaptor.getOffset();
     if (offset.getType().isIndex())
@@ -11108,7 +12475,9 @@ public:
         op, elemPtr,
         static_cast<unsigned>(ptrTy.getMemorySpace().getAddressSpace()));
     if (failed(ptr))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map ldg pointer");
+    }
 
     pto::L1Cache l1cache = op.getL1cacheAttr()
                                ? op.getL1cacheAttr().getValue()
@@ -11116,7 +12485,9 @@ public:
     FailureOr<StringRef> calleeName = buildL1CacheLoadCallee(
         op.getContext(), op.getValue().getType(), l1cache);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported ldg signature");
+    }
 
     pto::LdL2Cache mode = op.getL2cacheAttr()
                                ? op.getL2cacheAttr().getValue()
@@ -11154,7 +12525,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+    }
 
     Value offset = adaptor.getOffset();
     if (offset.getType().isIndex())
@@ -11181,9 +12554,13 @@ static Value convertStgValue(Location loc, Type valueType, Value value,
   if (auto intType = dyn_cast<IntegerType>(valueType)) {
     unsigned width = intType.getWidth();
     if (width == 8)
+    {
       return rewriter.create<arith::ExtUIOp>(loc, rewriter.getI32Type(), value);
+    }
     if (width == 16)
+    {
       return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getF16Type(), value);
+    }
     return value;
   }
 
@@ -11193,11 +12570,17 @@ static Value convertStgValue(Location loc, Type valueType, Value value,
     return rewriter.create<arith::ExtUIOp>(loc, rewriter.getI32Type(), payload);
   }
   if (valueType.isBF16())
+  {
     return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getF16Type(), value);
+  }
   if (valueType.isF32())
+  {
     return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI32Type(), value);
+  }
   if (valueType.isF64())
+  {
     return rewriter.create<LLVM::BitcastOp>(loc, rewriter.getI64Type(), value);
+  }
   if (pto::isPTOPackedLdgStgVectorType(valueType)) {
     unsigned totalBits = pto::getPTOPackedLdgStgTotalBits(valueType);
     if (totalBits == 16)
@@ -11225,7 +12608,9 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     auto llvmPtrType = dyn_cast<LLVM::LLVMPointerType>(adaptor.getPtr().getType());
     if (!llvmPtrType)
+    {
       return rewriter.notifyMatchFailure(op, "expected LLVM pointer operand");
+    }
 
     Value offset = adaptor.getOffset();
     if (offset.getType().isIndex())
@@ -11246,7 +12631,9 @@ public:
         op, elemPtr,
         static_cast<unsigned>(ptrTy.getMemorySpace().getAddressSpace()));
     if (failed(ptr))
+    {
       return rewriter.notifyMatchFailure(op, "failed to map stg pointer");
+    }
 
     pto::L1Cache l1cache = op.getL1cacheAttr()
                                ? op.getL1cacheAttr().getValue()
@@ -11254,7 +12641,9 @@ public:
     FailureOr<StringRef> calleeName = buildL1CacheStoreCallee(
         op.getContext(), op.getValue().getType(), l1cache);
     if (failed(calleeName))
+    {
       return rewriter.notifyMatchFailure(op, "unsupported stg signature");
+    }
 
     pto::StL2Cache mode = op.getL2cacheAttr()
                                ? op.getL2cacheAttr().getValue()
@@ -11288,10 +12677,14 @@ public:
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     if (isa<pto::CastPtrOp>(op))
+    {
       return failure();
+    }
     Type propertyType;
     if (auto allocaOp = dyn_cast<LLVM::AllocaOp>(op))
+    {
       propertyType = allocaOp.getElemType();
+    }
     else if (auto gepOp = dyn_cast<LLVM::GEPOp>(op))
       propertyType = gepOp.getElemType();
     if (!hasVPTOConvertibleType(op->getOperandTypes()) &&
@@ -11319,9 +12712,13 @@ public:
         return rewriter.notifyMatchFailure(
             op, "failed to convert LLVM element type");
       if (auto allocaOp = dyn_cast<LLVM::AllocaOp>(converted))
+      {
         allocaOp.setElemType(convertedPropertyType);
+      }
       else
+      {
         cast<LLVM::GEPOp>(converted).setElemType(convertedPropertyType);
+      }
     }
     rewriter.replaceOp(op, converted->getResults());
     return success();
@@ -11788,7 +13185,9 @@ static void foldVPTOTypeCasts(ModuleOp module, TypeConverter &typeConverter) {
   SmallVector<UnrealizedConversionCastOp> castsToFold;
   module.walk([&](UnrealizedConversionCastOp castOp) {
     if (castOp->getNumOperands() != 1 || castOp->getNumResults() != 1)
+    {
       return;
+    }
     if (!hasVPTOConvertibleType(castOp->getOperandTypes()) &&
         !hasVPTOConvertibleType(castOp->getResultTypes()))
       return;
@@ -11822,7 +13221,9 @@ static LogicalResult lowerVPTOOps(ModuleOp module,
     return failure();
   }
   if (failed(materializeDecls(module, state.plannedDecls, diagOS)))
+  {
     return failure();
+  }
   return success();
 }
 
@@ -11888,7 +13289,9 @@ static LogicalResult lowerVPTOTypes(ModuleOp module, llvm::raw_ostream &diagOS) 
     return failure();
   }
   if (failed(materializeDecls(module, state.plannedDecls, diagOS)))
+  {
     return failure();
+  }
   foldVPTOTypeCasts(module, typeConverter);
   return success();
 }
@@ -11919,17 +13322,23 @@ static void normalizeFuncSignaturesForOfficialLLVMLowering(ModuleOp module) {
     }
 
     if (!changed)
+    {
       continue;
+    }
 
     auto newType = builder.getFunctionType(newInputs, newResults);
     funcOp.setFunctionTypeAttr(TypeAttr::get(newType));
 
     if (funcOp.isExternal())
+    {
       continue;
+    }
     Block &entry = funcOp.getBody().front();
     for (auto [arg, newType] : llvm::zip(entry.getArguments(), newInputs))
       if (arg.getType() != newType)
+      {
         arg.setType(newType);
+      }
   }
 }
 
@@ -11938,7 +13347,9 @@ static void forceV300CtrlModeForVPTOFuncs(ModuleOp module) {
 
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
     if (!needsV300CtrlModeForVPTOFunc(funcOp))
+    {
       continue;
+    }
 
     Block &entry = funcOp.getBody().front();
     builder.setInsertionPointToStart(&entry);
@@ -11959,7 +13370,9 @@ static std::optional<FunctionKernelKind> getKernelKind(ModuleOp module) {
   auto kernelKind = module->getAttrOfType<FunctionKernelKindAttr>(
       FunctionKernelKindAttr::name);
   if (!kernelKind)
+  {
     return std::nullopt;
+  }
   return kernelKind.getKernelKind();
 }
 
@@ -11997,13 +13410,17 @@ makeDeviceEmissionOptions(const VPTOEmissionOptions &baseOptions,
     options.aicoreArch = options.march;
     options.defaultTargetCPU = options.march;
     if (options.march == "dav-c220-vec")
+    {
       options.defaultTargetFeatures = kC220VecTargetFeatures.str();
+    }
     else if (options.march == "dav-c220-cube")
       options.defaultTargetFeatures = kC220CubeTargetFeatures.str();
     else if (kind == FunctionKernelKind::Cube)
       options.defaultTargetFeatures = kCubeTargetFeatures.str();
     else
+    {
       options.defaultTargetFeatures = kVecTargetFeatures.str();
+    }
   }
   return options;
 }
@@ -12015,9 +13432,13 @@ getUniqueDeviceModuleByKernelKind(ModuleOp module, FunctionKernelKind kind,
   for (ModuleOp child : module.getOps<ModuleOp>()) {
     auto kernelKind = getKernelKind(child);
     if (!kernelKind)
+    {
       continue;
+    }
     if (*kernelKind != kind)
+    {
       continue;
+    }
     if (matched) {
       diagOS << "VPTO LLVM emission failed: duplicate device module with "
              << FunctionKernelKindAttr::name << "\n";
@@ -12036,15 +13457,21 @@ static void mergeDeviceModulesByKernelKind(ModuleOp module) {
   for (ModuleOp child : module.getOps<ModuleOp>()) {
     auto kernelKind = getKernelKind(child);
     if (!kernelKind)
+    {
       continue;
+    }
 
     ModuleOp *target = nullptr;
     if (*kernelKind == FunctionKernelKind::Vector)
+    {
       target = &vectorModule;
+    }
     else if (*kernelKind == FunctionKernelKind::Cube)
       target = &cubeModule;
     else
+    {
       continue;
+    }
 
     if (!*target) {
       *target = child;
@@ -12061,7 +13488,9 @@ static void mergeDeviceModulesByKernelKind(ModuleOp module) {
   }
 
   for (ModuleOp child : modulesToErase)
+  {
     child.erase();
+  }
 }
 
 static LogicalResult renameKernelFunctionsForKernelKind(ModuleOp module,
@@ -12075,7 +13504,9 @@ static LogicalResult renameKernelFunctionsForKernelKind(ModuleOp module,
 
   StringRef suffix;
   if (*kernelKind == FunctionKernelKind::Vector)
+  {
     suffix = kVectorSuffix;
+  }
   else if (*kernelKind == FunctionKernelKind::Cube)
     suffix = kCubeSuffix;
   else {
@@ -12086,9 +13517,13 @@ static LogicalResult renameKernelFunctionsForKernelKind(ModuleOp module,
 
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
     if (!pto::hasExplicitPTOEntryAttr(funcOp))
+    {
       continue;
+    }
     if (funcOp.getSymName().ends_with(suffix))
+    {
       continue;
+    }
     funcOp.setSymName((funcOp.getSymName() + suffix).str());
   }
   return success();
@@ -12113,13 +13548,19 @@ struct LowerVPTOOpsPass final
       SmallVector<pto::AllocTileOp> deadAllocs;
       getOperation().walk([&](pto::AllocTileOp alloc) {
         if (alloc.use_empty())
+        {
           deadAllocs.push_back(alloc);
+        }
       });
       for (pto::AllocTileOp alloc : llvm::reverse(deadAllocs))
+      {
         alloc.erase();
+      }
     }
     if (failed(lowerVPTOOps(getOperation(), march, llvm::errs())))
+    {
       signalPassFailure();
+    }
   }
 
 private:
@@ -12132,7 +13573,9 @@ struct LowerVPTOTypesPass final
 
   void runOnOperation() override {
     if (failed(lowerVPTOTypes(getOperation(), llvm::errs())))
+    {
       signalPassFailure();
+    }
   }
 };
 
@@ -12156,7 +13599,9 @@ struct PrepareVPTOLLVMLoweringPass final
     pto::annotatePTOEntryFunctions(module);
     forceV300CtrlModeForVPTOFuncs(module);
     if (failed(renameKernelFunctionsForKernelKind(module, llvm::errs())))
+    {
       signalPassFailure();
+    }
   }
 };
 
@@ -12165,7 +13610,9 @@ collectSimtEntryFunctionNames(ModuleOp module) {
   llvm::StringSet<llvm::BumpPtrAllocator> simtEntries;
   module.walk([&](func::FuncOp funcOp) {
     if (funcOp->hasAttr(pto::kPTOSimtEntryAttrName))
+    {
       simtEntries.insert(funcOp.getSymName());
+    }
   });
   return simtEntries;
 }
@@ -12175,7 +13622,9 @@ static void applyArtifactVisibilityLinkage(ModuleOp sourceModule,
   llvm::StringMap<bool> externalByName;
   sourceModule.walk([&](func::FuncOp funcOp) {
     if (funcOp.isDeclaration())
+    {
       return;
+    }
     externalByName[funcOp.getSymName()] =
         pto::hasExternalArtifactVisibility(funcOp);
   });
@@ -12183,7 +13632,9 @@ static void applyArtifactVisibilityLinkage(ModuleOp sourceModule,
   for (llvm::Function &function : llvmModule) {
     auto it = externalByName.find(function.getName());
     if (it == externalByName.end())
+    {
       continue;
+    }
     if (it->second) {
       function.setLinkage(llvm::GlobalValue::ExternalLinkage);
       continue;
@@ -12215,10 +13666,14 @@ static void applySimtEntryCallingConvention(
       for (llvm::Instruction &inst : block) {
         auto *call = llvm::dyn_cast<llvm::CallBase>(&inst);
         if (!call)
+        {
           continue;
+        }
         auto *callee = call->getCalledFunction();
         if (!callee || !simtEntryNames.contains(callee->getName()))
+        {
           continue;
+        }
         call->setCallingConv(llvm::CallingConv::SimtEntry);
       }
     }
@@ -12233,7 +13688,9 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   if (!deviceModule)
     return EmittedLLVMModule{};
   if (failed(applyQueriedTargetAttrs(deviceModule, options, diagOS)))
+  {
     return failure();
+  }
 
   auto llvmContext = std::make_unique<llvm::LLVMContext>();
   registerBuiltinDialectTranslation(*deviceModule.getContext());
@@ -12249,7 +13706,9 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   applyArtifactVisibilityLinkage(deviceModule, *llvmModule);
   for (llvm::Function &func : *llvmModule) {
     if (!func.getName().starts_with("llvm.hivm.vscatter."))
+    {
       continue;
+    }
     // Work around a bug in older Bisheng releases: vscatter was not modeled
     // as writing through its destination pointer, so EarlyCSE could eliminate
     // a load after vscatter as redundant.
@@ -12259,7 +13718,9 @@ emitDeviceLLVMModule(ModuleOp deviceModule, StringRef kernelKind,
   }
   applySimtEntryCallingConvention(*llvmModule, simtEntryNames);
   if (failed(attachAIVectorScopeMetadata(*llvmModule, diagOS)))
+  {
     return failure();
+  }
   attachHIVMKernelAnnotations(*llvmModule, deviceModule);
   llvmModule->setModuleIdentifier(("ptoas.hivm.official." + kernelKind).str());
   llvmModule->setSourceFileName(("ptoas.hivm.official." + kernelKind).str());
@@ -12327,12 +13788,16 @@ LogicalResult lowerVPTOModuleToLLVMModulesBeta1(
         getUniqueDeviceModuleByKernelKind(
             loweredModule, FunctionKernelKind::Vector, diagOS);
     if (failed(vectorDeviceModule))
+    {
       return failure();
+    }
     auto cubeDeviceModule =
         getUniqueDeviceModuleByKernelKind(
             loweredModule, FunctionKernelKind::Cube, diagOS);
     if (failed(cubeDeviceModule))
+    {
       return failure();
+    }
 
     if (*vectorDeviceModule) {
       auto vectorOptions =
@@ -12341,7 +13806,9 @@ LogicalResult lowerVPTOModuleToLLVMModulesBeta1(
           emitDeviceLLVMModule(*vectorDeviceModule, "vector", vectorOptions,
                                simtEntryNames, diagOS);
       if (failed(emitted))
+      {
         return failure();
+      }
       vectorModule.context = std::move(emitted->context);
       vectorModule.module = std::move(emitted->module);
     }
@@ -12352,7 +13819,9 @@ LogicalResult lowerVPTOModuleToLLVMModulesBeta1(
           emitDeviceLLVMModule(*cubeDeviceModule, "cube", cubeOptions,
                                simtEntryNames, diagOS);
       if (failed(emitted))
+      {
         return failure();
+      }
       cubeModule.context = std::move(emitted->context);
       cubeModule.module = std::move(emitted->module);
     }

--- a/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterDispatcher.cpp
@@ -22,8 +22,9 @@ static bool usesCANN900Lowering(const VPTOEmissionOptions &options) {
 static bool containsLdStDev(ModuleOp module) {
   bool found = false;
   module.walk([&](Operation *op) {
-    if (isa<PTOLdDevOp, PTOStDevOp>(op))
+    if (isa<PTOLdDevOp, PTOStDevOp>(op)) {
       found = true;
+    }
   });
   return found;
 }
@@ -31,17 +32,19 @@ static bool containsLdStDev(ModuleOp module) {
 static LogicalResult verifyLdStDevTarget(ModuleOp module,
                                          const VPTOEmissionOptions &options,
                                          llvm::raw_ostream &diagOS) {
-  if (!containsLdStDev(module) || usesCANN900Lowering(options))
+  if (!containsLdStDev(module) || usesCANN900Lowering(options)) {
     return success();
+  }
 
   const bool isC220 = options.march == "dav-c220-vec" ||
                       options.march == "dav-c220-cube";
-  if (isC220)
+  if (isC220) {
     diagOS << "VPTO LLVM emission failed: pto.ld_dev and pto.st_dev require "
               "--pto-arch=a5\n";
-  else
+  } else {
     diagOS << "VPTO LLVM emission failed: pto.ld_dev and pto.st_dev require "
               "CANN 9.0.0 or newer official lowering\n";
+  }
   return failure();
 }
 
@@ -49,11 +52,13 @@ LogicalResult lowerVPTOModuleToLLVMModules(
     ModuleOp module, const VPTOEmissionOptions &options,
     EmittedLLVMModule &cubeModule, EmittedLLVMModule &vectorModule,
     llvm::raw_ostream &diagOS) {
-  if (failed(verifyLdStDevTarget(module, options, diagOS)))
+  if (failed(verifyLdStDevTarget(module, options, diagOS))) {
     return failure();
-  if (usesCANN900Lowering(options))
+  }
+  if (usesCANN900Lowering(options)) {
     return lowerVPTOModuleToLLVMModulesCANN900(module, options, cubeModule,
                                                vectorModule, diagOS);
+  }
   return lowerVPTOModuleToLLVMModulesBeta1(module, options, cubeModule,
                                            vectorModule, diagOS);
 }
@@ -67,8 +72,9 @@ LogicalResult lowerVPTOModuleToLLVMIRText(
   EmittedLLVMModule vectorModule;
   if (failed(
           lowerVPTOModuleToLLVMModules(module, options, cubeModule, vectorModule,
-                                       diagOS)))
+                                       diagOS))) {
     return failure();
+  }
 
   llvm::raw_string_ostream os(output);
   bool printedAny = false;
@@ -78,8 +84,9 @@ LogicalResult lowerVPTOModuleToLLVMIRText(
     printedAny = true;
   }
   if (cubeModule.module) {
-    if (printedAny)
+    if (printedAny) {
       os << "\n";
+    }
     cubeModule.module->print(os, nullptr);
     os << "\n";
   }
@@ -95,6 +102,5 @@ LogicalResult lowerVPTOModuleToLLVMIRText(
   }
   return success();
 }
-
 
 } // namespace mlir::pto

--- a/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
+++ b/lib/PTO/Transforms/VPTOLLVMEmitterHelper.cpp
@@ -69,11 +69,13 @@ struct QueriedTargetAttrs {
 };
 
 static bool hasPtoMemRefMemorySpace(Type type) {
-  if (auto memRefType = dyn_cast<MemRefType>(type))
+  if (auto memRefType = dyn_cast<MemRefType>(type)) {
     return isa<pto::AddressSpaceAttr>(memRefType.getMemorySpace());
-  if (auto functionType = dyn_cast<FunctionType>(type))
+  }
+  if (auto functionType = dyn_cast<FunctionType>(type)) {
     return llvm::any_of(functionType.getInputs(), hasPtoMemRefMemorySpace) ||
            llvm::any_of(functionType.getResults(), hasPtoMemRefMemorySpace);
+  }
   return false;
 }
 
@@ -92,16 +94,19 @@ struct ConvertPtoMemRefSpaceCarrierOp final : ConversionPattern {
   matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                   ConversionPatternRewriter &rewriter) const override {
     if (!hasPtoMemRefMemorySpace(op->getOperandTypes()) &&
-        !hasPtoMemRefMemorySpace(op->getResultTypes()))
+        !hasPtoMemRefMemorySpace(op->getResultTypes())) {
       return failure();
-    if (op->getNumRegions() != 0)
+    }
+    if (op->getNumRegions() != 0) {
       return rewriter.notifyMatchFailure(
           op, "region ops with PTO memref spaces are handled structurally");
+    }
 
     FailureOr<Operation *> converted =
         convertOpResultTypes(op, operands, *typeConverter, rewriter);
-    if (failed(converted))
+    if (failed(converted)) {
       return failure();
+    }
     return success();
   }
 };
@@ -115,8 +120,9 @@ struct ConvertMemRefReinterpretCastSpaceOp final
                   ConversionPatternRewriter &rewriter) const override {
     Type convertedResultType = getTypeConverter()->convertType(op.getType());
     auto memRefResultType = dyn_cast_or_null<MemRefType>(convertedResultType);
-    if (!memRefResultType)
+    if (!memRefResultType) {
       return rewriter.notifyMatchFailure(op, "expected memref result type");
+    }
 
     rewriter.replaceOpWithNewOp<memref::ReinterpretCastOp>(
         op, memRefResultType, adaptor.getSource(), adaptor.getOffsets(),
@@ -135,8 +141,9 @@ struct ConvertMemRefSubViewSpaceOp final
                   ConversionPatternRewriter &rewriter) const override {
     Type convertedResultType = getTypeConverter()->convertType(op.getType());
     auto memRefResultType = dyn_cast_or_null<MemRefType>(convertedResultType);
-    if (!memRefResultType)
+    if (!memRefResultType) {
       return rewriter.notifyMatchFailure(op, "expected memref result type");
+    }
 
     rewriter.replaceOpWithNewOp<memref::SubViewOp>(
         op, memRefResultType, adaptor.getSource(), op.getMixedOffsets(),
@@ -152,16 +159,19 @@ struct ConvertMemRefSpaceUnrealizedCastOp final
   LogicalResult
   matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
       return failure();
+    }
     if (!hasPtoMemRefMemorySpace(op->getOperandTypes()) &&
-        !hasPtoMemRefMemorySpace(op->getResultTypes()))
+        !hasPtoMemRefMemorySpace(op->getResultTypes())) {
       return failure();
+    }
 
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult(0).getType());
-    if (!convertedResultType)
+    if (!convertedResultType) {
       return failure();
+    }
 
     Value input = adaptor.getOperands().front();
     if (input.getType() == convertedResultType) {
@@ -174,8 +184,9 @@ struct ConvertMemRefSpaceUnrealizedCastOp final
 
 static void ensureAIVScopeDummyDecl(ModuleOp module) {
   SymbolTable symbolTable(module);
-  if (symbolTable.lookup<func::FuncOp>(kAIVScopeDummyCallee))
+  if (symbolTable.lookup<func::FuncOp>(kAIVScopeDummyCallee)) {
     return;
+  }
 
   OpBuilder builder(module.getBodyRegion());
   builder.setInsertionPointToStart(module.getBody());
@@ -187,12 +198,14 @@ static void ensureAIVScopeDummyDecl(ModuleOp module) {
 
 static bool satisfiesAIVectorScopeLatchPostcondition(llvm::Loop *loop) {
   llvm::BasicBlock *latch = loop->getLoopLatch();
-  if (!latch)
+  if (!latch) {
     return false;
+  }
 
   llvm::SmallVector<llvm::BasicBlock *, 4> preds(llvm::predecessors(latch));
-  if (preds.size() != 1)
+  if (preds.size() != 1) {
     return false;
+  }
 
   auto *predTerm = preds.front()->getTerminator();
   return predTerm && predTerm->getNumSuccessors() == 1 &&
@@ -201,8 +214,9 @@ static bool satisfiesAIVectorScopeLatchPostcondition(llvm::Loop *loop) {
 
 static LogicalResult ensureDummyPredForAIVectorScopeLatch(
     llvm::Loop *loop, llvm::raw_ostream &diagOS) {
-  if (satisfiesAIVectorScopeLatchPostcondition(loop))
+  if (satisfiesAIVectorScopeLatchPostcondition(loop)) {
     return success();
+  }
 
   llvm::BasicBlock *latch = loop->getLoopLatch();
   if (!latch) {
@@ -239,12 +253,14 @@ static FailureOr<std::string> extractQuotedLLVMFnAttr(llvm::StringRef ir,
   pattern += key.str();
   pattern += "\"=\"";
   size_t start = ir.find(pattern);
-  if (start == llvm::StringRef::npos)
+  if (start == llvm::StringRef::npos) {
     return failure();
+  }
   start += pattern.size();
   size_t end = ir.find('"', start);
-  if (end == llvm::StringRef::npos || end <= start)
+  if (end == llvm::StringRef::npos || end <= start) {
     return failure();
+  }
   return ir.slice(start, end).str();
 }
 
@@ -261,8 +277,9 @@ queryDefaultTargetAttrs(const VPTOEmissionOptions &options,
 
   std::string cacheKey =
       options.targetTriple + "|" + options.march + "|" + options.aicoreArch;
-  if (auto it = cache.find(cacheKey); it != cache.end())
+  if (auto it = cache.find(cacheKey); it != cache.end()) {
     return it->second;
+  }
 
   auto bisheng = llvm::sys::findProgramByName("bisheng");
   if (!bisheng) {
@@ -332,8 +349,9 @@ queryDefaultTargetAttrs(const VPTOEmissionOptions &options,
   };
   llvm::SmallVector<llvm::StringRef> args;
   args.reserve(argStorage.size());
-  for (const std::string &arg : argStorage)
+  for (const std::string &arg : argStorage) {
     args.push_back(arg);
+  }
 
   std::string execErr;
   bool execFailed = false;
@@ -349,13 +367,16 @@ queryDefaultTargetAttrs(const VPTOEmissionOptions &options,
   if (execFailed || rc != 0) {
     diagOS << "VPTO LLVM emission failed: bisheng target query failed\n";
     diagOS << "Command:";
-    for (llvm::StringRef arg : args)
+    for (llvm::StringRef arg : args) {
       diagOS << " " << arg;
+    }
     diagOS << "\n";
-    if (!execErr.empty())
+    if (!execErr.empty()) {
       diagOS << execErr << "\n";
-    if (!stderrText.empty())
+    }
+    if (!stderrText.empty()) {
       diagOS << stderrText << "\n";
+    }
     return failure();
   }
 
@@ -393,8 +414,9 @@ void materializeVecScopeCarrierLoops(ModuleOp module) {
 
   IRRewriter rewriter(module.getContext());
   for (pto::VecScopeOp vecScope : llvm::reverse(scopes)) {
-    if (!vecScope || vecScope.getBody().empty())
+    if (!vecScope || vecScope.getBody().empty()) {
       continue;
+    }
 
     rewriter.setInsertionPoint(vecScope);
     auto loc = vecScope.getLoc();
@@ -421,8 +443,9 @@ void materializeVecScopeCarrierLoops(ModuleOp module) {
   });
 
   for (pto::StrictVecScopeOp strictVecScope : llvm::reverse(strictScopes)) {
-    if (!strictVecScope || strictVecScope.getBody().empty())
+    if (!strictVecScope || strictVecScope.getBody().empty()) {
       continue;
+    }
 
     rewriter.setInsertionPoint(strictVecScope);
     auto loc = strictVecScope.getLoc();
@@ -436,12 +459,14 @@ void materializeVecScopeCarrierLoops(ModuleOp module) {
 
     IRMapping mapping;
     for (auto [blockArg, capture] :
-         llvm::zip(strictBody.getArguments(), strictVecScope.getCaptures()))
+         llvm::zip(strictBody.getArguments(), strictVecScope.getCaptures())) {
       mapping.map(blockArg, capture);
+    }
 
     rewriter.setInsertionPoint(yield);
-    for (Operation &nested : strictBody.getOperations())
+    for (Operation &nested : strictBody.getOperations()) {
       rewriter.clone(nested, mapping);
+    }
     rewriter.create<func::CallOp>(loc, kAIVScopeDummyCallee, TypeRange{},
                                   ValueRange{});
 
@@ -452,12 +477,14 @@ void materializeVecScopeCarrierLoops(ModuleOp module) {
 LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
                                           llvm::raw_ostream &diagOS) {
   llvm::Function *dummyCallee = llvmModule.getFunction(kAIVScopeDummyCallee);
-  if (!dummyCallee)
+  if (!dummyCallee) {
     return success();
+  }
 
   for (llvm::Function &function : llvmModule) {
-    if (function.isDeclaration())
+    if (function.isDeclaration()) {
       continue;
+    }
     llvm::DominatorTree dt(function);
     llvm::LoopInfo loopInfo(dt);
 
@@ -465,8 +492,9 @@ LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
     for (llvm::BasicBlock &block : function) {
       for (llvm::Instruction &inst : block) {
         auto *call = dyn_cast<llvm::CallInst>(&inst);
-        if (call && call->getCalledFunction() == dummyCallee)
+        if (call && call->getCalledFunction() == dummyCallee) {
           dummyCalls.push_back(call);
+        }
       }
     }
 
@@ -495,8 +523,9 @@ LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
         }
       }
 
-      if (failed(ensureDummyPredForAIVectorScopeLatch(loop, diagOS)))
+      if (failed(ensureDummyPredForAIVectorScopeLatch(loop, diagOS))) {
         return failure();
+      }
 
       dt.recalculate(function);
       loopInfo.releaseMemory();
@@ -529,18 +558,22 @@ LogicalResult attachAIVectorScopeMetadata(llvm::Module &llvmModule,
     }
   }
 
-  if (dummyCallee->use_empty())
+  if (dummyCallee->use_empty()) {
     dummyCallee->eraseFromParent();
+  }
   return success();
 }
 
 constexpr uint32_t getSimtMaxRegistersForThreads(uint32_t maxThreads) {
-  if (maxThreads > 1024)
+  if (maxThreads > 1024) {
     return 16;
-  if (maxThreads > 512)
+  }
+  if (maxThreads > 512) {
     return 32;
-  if (maxThreads > 256)
+  }
+  if (maxThreads > 256) {
     return 64;
+  }
   return 128;
 }
 
@@ -563,13 +596,15 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
       ptoEntryFunctions.insert(symName);
     }
 
-    if (!funcOp->hasAttr(pto::kPTOSimtEntryAttrName))
+    if (!funcOp->hasAttr(pto::kPTOSimtEntryAttrName)) {
       return;
+    }
 
     uint32_t maxThreads = kDefaultSimtMaxThreads;
     if (auto attr =
-            funcOp->getAttrOfType<IntegerAttr>(pto::kPTOSimtMaxThreadsAttrName))
+            funcOp->getAttrOfType<IntegerAttr>(pto::kPTOSimtMaxThreadsAttrName)) {
       maxThreads = static_cast<uint32_t>(attr.getInt());
+    }
 
     simtMaxThreadsByName[symName] = maxThreads;
   });
@@ -578,10 +613,12 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
     for (llvm::BasicBlock &block : function) {
       for (llvm::Instruction &inst : block) {
         auto *call = llvm::dyn_cast<llvm::CallBase>(&inst);
-        if (!call)
+        if (!call) {
           continue;
-        if (call->getCallingConv() == llvm::CallingConv::SimtEntry)
+        }
+        if (call->getCallingConv() == llvm::CallingConv::SimtEntry) {
           return true;
+        }
       }
     }
     return false;
@@ -612,13 +649,15 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
   };
 
   for (llvm::Function &function : llvmModule) {
-    if (function.isDeclaration())
+    if (function.isDeclaration()) {
       continue;
+    }
     if (function.getCallingConv() == llvm::CallingConv::SimtEntry) {
       uint32_t maxThreads = kDefaultSimtMaxThreads;
       if (auto it = simtMaxThreadsByName.find(function.getName());
-          it != simtMaxThreadsByName.end())
+          it != simtMaxThreadsByName.end()) {
         maxThreads = it->second;
+      }
       uint32_t maxRegisters = getSimtMaxRegistersForThreads(maxThreads);
 
       addLLVMFunctionI32Annotation(function, "simt-max-threads", maxThreads);
@@ -628,21 +667,24 @@ void attachHIVMKernelAnnotations(llvm::Module &llvmModule,
       addHIVMModuleI32Annotation("simt-max-registers", maxRegisters);
       continue;
     }
-    if (function.getLinkage() != llvm::GlobalValue::ExternalLinkage)
+    if (function.getLinkage() != llvm::GlobalValue::ExternalLinkage) {
       continue;
+    }
 
     llvm::StringRef name = function.getName();
-    if (!ptoEntryFunctions.contains(name))
+    if (!ptoEntryFunctions.contains(name)) {
       continue;
-    if (name.contains(".extracted") || name.contains(".vector.thread"))
+    }
+    if (name.contains(".extracted") || name.contains(".vector.thread")) {
       continue;
+    }
 
     addAnnotation(function, "kernel");
     addAnnotation(function, "kernel_with_simd");
-    if (callsSimtEntry(function))
+    if (callsSimtEntry(function)) {
       addAnnotation(function, "kernel_with_simt");
+    }
   }
-
 }
 
 LogicalResult
@@ -651,8 +693,9 @@ applyQueriedTargetAttrs(ModuleOp module, const VPTOEmissionOptions &options,
   FailureOr<QueriedTargetAttrs> attrs = queryDefaultTargetAttrs(options, diagOS);
   if (failed(attrs)) {
     if (options.defaultTargetCPU.empty() ||
-        options.defaultTargetFeatures.empty())
+        options.defaultTargetFeatures.empty()) {
       return failure();
+    }
     diagOS << "VPTO LLVM emission: falling back to configured default target "
               "attributes\n";
     attrs = QueriedTargetAttrs{options.defaultTargetCPU,

--- a/lib/PTO/Transforms/VPTOMaskSimplify.cpp
+++ b/lib/PTO/Transforms/VPTOMaskSimplify.cpp
@@ -43,8 +43,9 @@ struct SimplifyAllTruePredicateReorder : public OpRewritePattern<OpTy> {
 
   LogicalResult matchAndRewrite(OpTy op,
                                 PatternRewriter &rewriter) const override {
-    if (!isAllTrueMask(op.getLhs()) || !isAllTrueMask(op.getRhs()))
+    if (!isAllTrueMask(op.getLhs()) || !isAllTrueMask(op.getRhs())) {
       return failure();
+    }
 
     rewriter.replaceOp(op, {op.getLhs(), op.getRhs()});
     return success();
@@ -62,8 +63,9 @@ struct VPTOMaskSimplifyPass
                  SimplifyAllTruePredicateReorder<PdintlvB16Op>,
                  SimplifyAllTruePredicateReorder<PdintlvB32Op>>(&getContext());
 
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VPTONormalizeContainer.cpp
+++ b/lib/PTO/Transforms/VPTONormalizeContainer.cpp
@@ -44,8 +44,9 @@ static LogicalResult verifyNormalizedVPTOContainer(ModuleOp module) {
     }
   }
 
-  if (hasChildModules)
+  if (hasChildModules) {
     return success();
+  }
 
   return module.emitError()
          << "expected VPTO input to be a kernel submodule with "
@@ -60,10 +61,12 @@ struct VPTONormalizeContainerPass
     if (isVPTOKernelSubmodule(module)) {
       MLIRContext *context = module.getContext();
       SmallVector<NamedAttribute> outerAttrs;
-      for (NamedAttribute attr : module->getAttrs())
+      for (NamedAttribute attr : module->getAttrs()) {
         if (attr.getName() != SymbolTable::getSymbolAttrName() &&
-            attr.getName() != FunctionKernelKindAttr::name)
+            attr.getName() != FunctionKernelKindAttr::name) {
           outerAttrs.push_back(attr);
+        }
+      }
 
       auto child = ModuleOp::create(module.getLoc());
       child->setAttrs(module->getAttrDictionary());
@@ -74,8 +77,9 @@ struct VPTONormalizeContainerPass
       module.getBodyRegion().front().push_back(child.getOperation());
     }
 
-    if (failed(verifyNormalizedVPTOContainer(module)))
+    if (failed(verifyNormalizedVPTOContainer(module))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VPTOOptimizeVcvt.cpp
+++ b/lib/PTO/Transforms/VPTOOptimizeVcvt.cpp
@@ -31,12 +31,15 @@ static bool isOddPart(StringRef part) {
 }
 
 static bool isAllTrueMask(Value mask) {
-  if (auto op = mask.getDefiningOp<PsetB8Op>())
+  if (auto op = mask.getDefiningOp<PsetB8Op>()) {
     return op.getPattern() == "PAT_ALL";
-  if (auto op = mask.getDefiningOp<PsetB16Op>())
+  }
+  if (auto op = mask.getDefiningOp<PsetB16Op>()) {
     return op.getPattern() == "PAT_ALL";
-  if (auto op = mask.getDefiningOp<PsetB32Op>())
+  }
+  if (auto op = mask.getDefiningOp<PsetB32Op>()) {
     return op.getPattern() == "PAT_ALL";
+  }
   return false;
 }
 
@@ -47,12 +50,14 @@ static bool isPairEquivalentLoadDist(StringRef dist) {
 }
 
 static bool hasEvenOddEquivalentLanes(Value value) {
-  if (value.getDefiningOp<VbrOp>())
+  if (value.getDefiningOp<VbrOp>()) {
     return true;
+  }
 
   auto load = value.getDefiningOp<VldsOp>();
-  if (!load || value != load.getResult())
+  if (!load || value != load.getResult()) {
     return false;
+  }
 
   std::optional<StringRef> dist = load.getDist();
   return dist && isPairEquivalentLoadDist(*dist);
@@ -61,8 +66,9 @@ static bool hasEvenOddEquivalentLanes(Value value) {
 static bool isNarrowToWideVcvt(VcvtOp op) {
   auto inputType = dyn_cast<VRegType>(op.getInput().getType());
   auto resultType = dyn_cast<VRegType>(op.getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return false;
+  }
 
   unsigned inputBits = getPTOStorageElemBitWidth(inputType.getElementType());
   unsigned resultBits = getPTOStorageElemBitWidth(resultType.getElementType());
@@ -70,8 +76,9 @@ static bool isNarrowToWideVcvt(VcvtOp op) {
 }
 
 static Value stripVbitcasts(Value value) {
-  while (auto bitcast = value.getDefiningOp<VbitcastOp>())
+  while (auto bitcast = value.getDefiningOp<VbitcastOp>()) {
     value = bitcast.getInput();
+  }
   return value;
 }
 
@@ -82,35 +89,42 @@ struct AlignedUnsignedWidening {
 
 static bool isZeroGapLoad(Value value, AlignedUnsignedWidening widening) {
   auto load = stripVbitcasts(value).getDefiningOp<VldsOp>();
-  if (!load)
+  if (!load) {
     return false;
+  }
 
   auto loadType = dyn_cast<VRegType>(load.getResult().getType());
   std::optional<StringRef> dist = load.getDist();
   if (!loadType || !dist ||
       getPTOStorageElemBitWidth(loadType.getElementType()) !=
-          widening.payloadBits)
+          widening.payloadBits) {
     return false;
+  }
 
-  if (widening.payloadBits == 8 && widening.carrierBits == 16)
+  if (widening.payloadBits == 8 && widening.carrierBits == 16) {
     return *dist == "UNPK_B8";
-  if (widening.payloadBits == 16 && widening.carrierBits == 32)
+  }
+  if (widening.payloadBits == 16 && widening.carrierBits == 32) {
     return *dist == "UNPK_B16";
-  if (widening.payloadBits == 8 && widening.carrierBits == 32)
+  }
+  if (widening.payloadBits == 8 && widening.carrierBits == 32) {
     return *dist == "UNPK4";
+  }
   return false;
 }
 
 static bool isZeroGapNarrowingVcvt(Value value,
                                    AlignedUnsignedWidening widening) {
   auto cvt = value.getDefiningOp<VcvtOp>();
-  if (!cvt || !isAllTrueMask(cvt.getMask()))
+  if (!cvt || !isAllTrueMask(cvt.getMask())) {
     return false;
+  }
 
   auto inputType = dyn_cast<VRegType>(cvt.getInput().getType());
   auto resultType = dyn_cast<VRegType>(cvt.getResult().getType());
-  if (!inputType || !resultType)
+  if (!inputType || !resultType) {
     return false;
+  }
 
   unsigned inputBits = getPTOStorageElemBitWidth(inputType.getElementType());
   unsigned resultBits = getPTOStorageElemBitWidth(resultType.getElementType());
@@ -118,12 +132,14 @@ static bool isZeroGapNarrowingVcvt(Value value,
       resultBits != widening.payloadBits ||
       inputBits <= resultBits ||
       inputType.getElementCount() * inputBits !=
-          resultType.getElementCount() * resultBits)
+          resultType.getElementCount() * resultBits) {
     return false;
+  }
 
   std::optional<StringRef> part = cvt.getPart();
-  if (!part)
+  if (!part) {
     return false;
+  }
   return (inputBits == resultBits * 2 && *part == "EVEN") ||
          (inputBits == resultBits * 4 && *part == "P0");
 }
@@ -134,29 +150,35 @@ static bool isZeroGapNarrowingVcvt(Value value,
 static bool isCanonicalZeroGapCarrier(Value value,
                                       AlignedUnsignedWidening widening) {
   value = stripVbitcasts(value);
-  if (isZeroGapLoad(value, widening))
+  if (isZeroGapLoad(value, widening)) {
     return true;
-  if (isZeroGapNarrowingVcvt(value, widening))
+  }
+  if (isZeroGapNarrowingVcvt(value, widening)) {
     return true;
+  }
 
   auto unpack = value.getDefiningOp<VzunpackOp>();
-  if (!unpack)
+  if (!unpack) {
     return false;
+  }
   auto sourceType = dyn_cast<VRegType>(unpack.getSrc().getType());
   auto resultType = dyn_cast<VRegType>(unpack.getResult().getType());
-  if (!sourceType || !resultType)
+  if (!sourceType || !resultType) {
     return false;
+  }
 
   unsigned sourceBits =
       getPTOStorageElemBitWidth(sourceType.getElementType());
   unsigned resultBits =
       getPTOStorageElemBitWidth(resultType.getElementType());
   if (sourceBits == 0 || resultBits != widening.carrierBits ||
-      resultBits != sourceBits * 2 || widening.payloadBits > sourceBits)
+      resultBits != sourceBits * 2 || widening.payloadBits > sourceBits) {
     return false;
+  }
 
-  if (widening.payloadBits == sourceBits)
+  if (widening.payloadBits == sourceBits) {
     return true;
+  }
   return isCanonicalZeroGapCarrier(
       unpack.getSrc(), {widening.payloadBits, sourceBits});
 }
@@ -166,29 +188,34 @@ matchAlignedUnsignedWidening(VcvtOp op) {
   auto inputType = dyn_cast<VRegType>(op.getInput().getType());
   auto resultType = dyn_cast<VRegType>(op.getResult().getType());
   if (!inputType || !resultType || op.getRndAttr() || op.getSatAttr() ||
-      !isAllTrueMask(op.getMask()))
+      !isAllTrueMask(op.getMask())) {
     return std::nullopt;
+  }
 
   auto inputElementType = dyn_cast<IntegerType>(inputType.getElementType());
   auto resultElementType = dyn_cast<IntegerType>(resultType.getElementType());
   if (!inputElementType || !resultElementType ||
-      !inputElementType.isUnsigned() || !resultElementType.isUnsigned())
+      !inputElementType.isUnsigned() || !resultElementType.isUnsigned()) {
     return std::nullopt;
+  }
 
   unsigned inputBits = inputElementType.getWidth();
   unsigned resultBits = resultElementType.getWidth();
   if (inputBits >= resultBits ||
       inputType.getElementCount() * inputBits !=
-          resultType.getElementCount() * resultBits)
+          resultType.getElementCount() * resultBits) {
     return std::nullopt;
+  }
 
   std::optional<StringRef> part = op.getPart();
-  if (!part)
+  if (!part) {
     return std::nullopt;
+  }
   if ((resultBits == inputBits * 2 && *part != "EVEN") ||
       (resultBits == inputBits * 4 && *part != "P0") ||
-      (resultBits != inputBits * 2 && resultBits != inputBits * 4))
+      (resultBits != inputBits * 2 && resultBits != inputBits * 4)) {
     return std::nullopt;
+  }
 
   return AlignedUnsignedWidening{inputBits, resultBits};
 }
@@ -201,8 +228,9 @@ struct CanonicalizeEquivalentPartPattern : public OpRewritePattern<VcvtOp> {
     std::optional<StringRef> part = op.getPart();
     if (!part || !isOddPart(*part) || !isNarrowToWideVcvt(op) ||
         !isAllTrueMask(op.getMask()) ||
-        !hasEvenOddEquivalentLanes(op.getInput()))
+        !hasEvenOddEquivalentLanes(op.getInput())) {
       return failure();
+    }
 
     rewriter.modifyOpInPlace(
         op, [&] { op.setPartAttr(rewriter.getStringAttr("EVEN")); });
@@ -217,8 +245,9 @@ struct FoldZeroGapExtensionPattern : public OpRewritePattern<VcvtOp> {
                                 PatternRewriter &rewriter) const override {
     std::optional<AlignedUnsignedWidening> widening =
         matchAlignedUnsignedWidening(op);
-    if (!widening || !isCanonicalZeroGapCarrier(op.getInput(), *widening))
+    if (!widening || !isCanonicalZeroGapCarrier(op.getInput(), *widening)) {
       return failure();
+    }
 
     Value carrier = stripVbitcasts(op.getInput());
     Value result = carrier.getType() == op.getResult().getType()
@@ -239,8 +268,9 @@ struct VPTOOptimizeVcvtPass
     RewritePatternSet patterns(&getContext());
     patterns.add<CanonicalizeEquivalentPartPattern,
                  FoldZeroGapExtensionPattern>(&getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VPTOPtrCastCleanup.cpp
+++ b/lib/PTO/Transforms/VPTOPtrCastCleanup.cpp
@@ -31,32 +31,39 @@ struct CollapsePtrMemRefPtrBridgePattern
 
   LogicalResult matchAndRewrite(UnrealizedConversionCastOp op,
                                 PatternRewriter &rewriter) const override {
-    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
       return failure();
+    }
 
     auto resultPtrType = dyn_cast<pto::PtrType>(op.getResult(0).getType());
-    if (!resultPtrType)
+    if (!resultPtrType) {
       return failure();
+    }
 
     auto castOp = op.getOperand(0).getDefiningOp<memref::CastOp>();
-    if (!castOp || castOp->getNumOperands() != 1)
+    if (!castOp || castOp->getNumOperands() != 1) {
       return failure();
+    }
 
     auto innerCast =
         castOp.getSource().getDefiningOp<UnrealizedConversionCastOp>();
     if (!innerCast || innerCast->getNumOperands() != 1 ||
-        innerCast->getNumResults() != 1)
+        innerCast->getNumResults() != 1) {
       return failure();
+    }
 
     Value basePtr = innerCast.getOperand(0);
-    if (basePtr.getType() != resultPtrType)
+    if (basePtr.getType() != resultPtrType) {
       return failure();
+    }
 
     rewriter.replaceOp(op, basePtr);
-    if (castOp->use_empty())
+    if (castOp->use_empty()) {
       rewriter.eraseOp(castOp);
-    if (innerCast->use_empty())
+    }
+    if (innerCast->use_empty()) {
       rewriter.eraseOp(innerCast);
+    }
     return success();
   }
 };
@@ -69,8 +76,9 @@ struct VPTOPtrCastCleanupPass
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     patterns.add<CollapsePtrMemRefPtrBridgePattern>(&getContext());
-    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VPTOPtrNormalize.cpp
+++ b/lib/PTO/Transforms/VPTOPtrNormalize.cpp
@@ -39,39 +39,45 @@ namespace {
 
 static pto::AddressSpaceAttr getPointerMemorySpace(Attribute memorySpace,
                                                    MLIRContext *ctx) {
-  if (auto addrSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(memorySpace))
+  if (auto addrSpace = dyn_cast_or_null<pto::AddressSpaceAttr>(memorySpace)) {
     return addrSpace;
-  if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace))
+  }
+  if (auto intAttr = dyn_cast_or_null<IntegerAttr>(memorySpace)) {
     return pto::AddressSpaceAttr::get(
         ctx, static_cast<pto::AddressSpace>(intAttr.getInt()));
+  }
   return {};
 }
 
 static bool needsSubviewPtrConversion(memref::SubViewOp op) {
   auto resultType = dyn_cast<MemRefType>(op.getType());
-  if (!resultType)
+  if (!resultType) {
     return false;
+  }
   return static_cast<bool>(
       getPointerMemorySpace(resultType.getMemorySpace(), op.getContext()));
 }
 
 static Type convertSubviewResultType(Type type) {
   auto memrefType = dyn_cast<MemRefType>(type);
-  if (!memrefType)
+  if (!memrefType) {
     return type;
+  }
 
   auto memorySpace =
       getPointerMemorySpace(memrefType.getMemorySpace(), type.getContext());
-  if (!memorySpace)
+  if (!memorySpace) {
     return type;
+  }
 
   return pto::PtrType::get(type.getContext(), memrefType.getElementType(),
                            memorySpace);
 }
 
 static bool hasPtrNormalizeConvertibleType(Type type) {
-  if (isa<pto::PtrType>(type))
+  if (isa<pto::PtrType>(type)) {
     return true;
+  }
   auto memrefType = dyn_cast<MemRefType>(type);
   return memrefType && static_cast<bool>(getPointerMemorySpace(
                            memrefType.getMemorySpace(), type.getContext()));
@@ -94,8 +100,9 @@ static bool hasPtrNormalizeMemRefType(TypeRange types) {
 }
 
 static bool isTransientPtrMemRefBridge(Value value) {
-  if (!isa<pto::PtrType>(value.getType()))
+  if (!isa<pto::PtrType>(value.getType())) {
     return false;
+  }
   auto cast = value.getDefiningOp<UnrealizedConversionCastOp>();
   return cast && cast->getNumOperands() == 1 && cast->getNumResults() == 1 &&
          isa<BaseMemRefType>(cast.getOperand(0).getType());
@@ -104,8 +111,9 @@ static bool isTransientPtrMemRefBridge(Value value) {
 static FailureOr<SmallVector<Type>>
 convertTypes(const TypeConverter &typeConverter, TypeRange types) {
   SmallVector<Type> convertedTypes;
-  if (failed(typeConverter.convertTypes(types, convertedTypes)))
+  if (failed(typeConverter.convertTypes(types, convertedTypes))) {
     return failure();
+  }
   return convertedTypes;
 }
 
@@ -113,8 +121,9 @@ static bool isMemRefType(Type type) { return isa<BaseMemRefType>(type); }
 
 static Value materializeUnrealizedCast(OpBuilder &builder, Type resultType,
                                        ValueRange inputs, Location loc) {
-  if (inputs.size() != 1)
+  if (inputs.size() != 1) {
     return {};
+  }
   return builder
       .create<UnrealizedConversionCastOp>(loc, TypeRange{resultType}, inputs)
       .getResult(0);
@@ -124,44 +133,52 @@ static LogicalResult computeSubviewElementOffset(memref::SubViewOp op,
                                                  PatternRewriter &rewriter,
                                                  Value &offset) {
   auto sourceType = dyn_cast<MemRefType>(op.getSource().getType());
-  if (!sourceType)
+  if (!sourceType) {
     return failure();
+  }
 
   SmallVector<int64_t> strides;
   int64_t baseOffset = 0;
   if (failed(mlir::pto::getPTOMemRefStridesAndOffset(sourceType, strides,
-                                                     baseOffset)))
+                                                     baseOffset))) {
     return failure();
+  }
   // The SSA source already names the base address after ptr-boundary
   // normalization. A dynamic memref layout offset here is metadata we can
   // ignore for ptr normalization and model as zero.
-  if (baseOffset == ShapedType::kDynamic)
+  if (baseOffset == ShapedType::kDynamic) {
     baseOffset = 0;
+  }
 
   Location loc = op.getLoc();
   Value total = rewriter.create<arith::ConstantIndexOp>(loc, baseOffset);
   ArrayRef<int64_t> staticOffsets = op.getStaticOffsets();
   ValueRange dynamicOffsets = op.getOffsets();
-  if (staticOffsets.size() != strides.size())
+  if (staticOffsets.size() != strides.size()) {
     return failure();
+  }
 
   unsigned dynamicIndex = 0;
   for (auto [staticOffset, stride] : llvm::zip(staticOffsets, strides)) {
-    if (stride == 0)
+    if (stride == 0) {
       continue;
-    if (stride == ShapedType::kDynamic)
+    }
+    if (stride == ShapedType::kDynamic) {
       return failure();
+    }
 
     Value idx;
     if (ShapedType::isDynamic(staticOffset)) {
-      if (dynamicIndex >= dynamicOffsets.size())
+      if (dynamicIndex >= dynamicOffsets.size()) {
         return failure();
+      }
       idx = dynamicOffsets[dynamicIndex++];
     } else {
       idx = rewriter.create<arith::ConstantIndexOp>(loc, staticOffset);
     }
-    if (!idx.getType().isIndex())
+    if (!idx.getType().isIndex()) {
       return failure();
+    }
 
     if (stride != 1) {
       Value strideValue =
@@ -170,8 +187,9 @@ static LogicalResult computeSubviewElementOffset(memref::SubViewOp op,
     }
     total = rewriter.create<arith::AddIOp>(loc, total, idx);
   }
-  if (dynamicIndex != dynamicOffsets.size())
+  if (dynamicIndex != dynamicOffsets.size()) {
     return failure();
+  }
 
   offset = total;
   return success();
@@ -179,19 +197,23 @@ static LogicalResult computeSubviewElementOffset(memref::SubViewOp op,
 
 static Value materializeSubviewInputPtr(Value source, PatternRewriter &rewriter,
                                         Location loc) {
-  if (!source)
+  if (!source) {
     return {};
-  if (isa<pto::PtrType>(source.getType()))
+  }
+  if (isa<pto::PtrType>(source.getType())) {
     return source;
+  }
 
   auto memrefType = dyn_cast<MemRefType>(source.getType());
-  if (!memrefType)
+  if (!memrefType) {
     return {};
+  }
 
   auto memorySpace =
       getPointerMemorySpace(memrefType.getMemorySpace(), rewriter.getContext());
-  if (!memorySpace)
+  if (!memorySpace) {
     return {};
+  }
 
   auto ptrType = pto::PtrType::get(rewriter.getContext(),
                                    memrefType.getElementType(), memorySpace);
@@ -200,78 +222,96 @@ static Value materializeSubviewInputPtr(Value source, PatternRewriter &rewriter,
 
 static Value materializeScalarAccessPtr(Value source, PatternRewriter &rewriter,
                                         Location loc) {
-  if (!source)
+  if (!source) {
     return {};
+  }
 
   if (auto cast = source.getDefiningOp<UnrealizedConversionCastOp>()) {
-    if (cast->getNumOperands() != 1 || cast->getNumResults() != 1)
+    if (cast->getNumOperands() != 1 || cast->getNumResults() != 1) {
       return {};
+    }
     Value input = cast.getOperands().front();
     Value ptr = materializeScalarAccessPtr(input, rewriter, loc);
-    if (!ptr)
+    if (!ptr) {
       return {};
+    }
     auto resultType = dyn_cast<pto::PtrType>(source.getType());
-    if (!resultType)
+    if (!resultType) {
       return ptr;
-    if (ptr.getType() == resultType)
+    }
+    if (ptr.getType() == resultType) {
       return ptr;
+    }
     return rewriter.create<pto::CastPtrOp>(loc, resultType, ptr);
   }
 
-  if (isa<pto::PtrType>(source.getType()))
+  if (isa<pto::PtrType>(source.getType())) {
     return source;
+  }
 
-  if (auto cast = source.getDefiningOp<memref::CastOp>())
+  if (auto cast = source.getDefiningOp<memref::CastOp>()) {
     return materializeScalarAccessPtr(cast.getSource(), rewriter, loc);
+  }
 
   if (auto reinterpret = source.getDefiningOp<memref::ReinterpretCastOp>()) {
     auto ptrType = dyn_cast<pto::PtrType>(convertSubviewResultType(source.getType()));
-    if (!ptrType)
+    if (!ptrType) {
       return {};
+    }
 
     Value basePtr =
         materializeScalarAccessPtr(reinterpret.getSource(), rewriter, loc);
-    if (!basePtr)
+    if (!basePtr) {
       return {};
-    if (basePtr.getType() != ptrType)
+    }
+    if (basePtr.getType() != ptrType) {
       basePtr = rewriter.create<pto::CastPtrOp>(loc, ptrType, basePtr);
+    }
 
     ArrayRef<int64_t> staticOffsets = reinterpret.getStaticOffsets();
-    if (staticOffsets.size() != 1)
+    if (staticOffsets.size() != 1) {
       return {};
+    }
     int64_t staticOffset = staticOffsets.front();
     if (!ShapedType::isDynamic(staticOffset)) {
-      if (staticOffset == 0)
+      if (staticOffset == 0) {
         return basePtr;
+      }
       Value offset = rewriter.create<arith::ConstantIndexOp>(loc, staticOffset);
       return rewriter.create<pto::AddPtrOp>(loc, ptrType, basePtr, offset);
     }
 
     ValueRange dynamicOffsets = reinterpret.getOffsets();
-    if (dynamicOffsets.size() != 1 || !dynamicOffsets.front().getType().isIndex())
+    if (dynamicOffsets.size() != 1 || !dynamicOffsets.front().getType().isIndex()) {
       return {};
+    }
     return rewriter.create<pto::AddPtrOp>(loc, ptrType, basePtr,
                                           dynamicOffsets.front());
   }
 
   if (auto subview = source.getDefiningOp<memref::SubViewOp>()) {
-    if (!needsSubviewPtrConversion(subview))
+    if (!needsSubviewPtrConversion(subview)) {
       return {};
+    }
 
     Value basePtr =
         materializeScalarAccessPtr(subview.getSource(), rewriter, loc);
-    if (!basePtr)
+    if (!basePtr) {
       return {};
+    }
 
     Value offset;
-    if (failed(computeSubviewElementOffset(subview, rewriter, offset)))
+    if (failed(computeSubviewElementOffset(subview, rewriter, offset))) {
       return {};
+    }
 
     auto ptrType = dyn_cast<pto::PtrType>(convertSubviewResultType(source.getType()));
-    if (!ptrType)
+    if (!ptrType) {
       return {};
-    if (basePtr.getType() != ptrType)
+    }
+    if (basePtr.getType() != ptrType) {
       basePtr = rewriter.create<pto::CastPtrOp>(loc, ptrType, basePtr);
+    }
     return rewriter.create<pto::AddPtrOp>(loc, ptrType, basePtr, offset);
   }
 
@@ -284,10 +324,12 @@ static Value materializeScalarAccessPtr(Value source, PatternRewriter &rewriter,
 static Value materializeBoundaryOperandPtr(Value source,
                                            PatternRewriter &rewriter,
                                            Location loc) {
-  if (!source)
+  if (!source) {
     return {};
-  if (isa<pto::PtrType>(source.getType()))
+  }
+  if (isa<pto::PtrType>(source.getType())) {
     return source;
+  }
   return materializeScalarAccessPtr(source, rewriter, loc);
 }
 
@@ -297,21 +339,25 @@ static LogicalResult rewriteBufferLikeBoundaryOp(
     StringRef sourceRole, StringRef destinationRole) {
   Value source =
       materializeBoundaryOperandPtr(adaptor.getOperands()[0], rewriter, op.getLoc());
-  if (!source)
+  if (!source) {
     return rewriter.notifyMatchFailure(
         op, (Twine("failed to materialize ") + sourceRole + " ptr").str());
-  if (!isa<pto::PtrType>(source.getType()))
+  }
+  if (!isa<pto::PtrType>(source.getType())) {
     return rewriter.notifyMatchFailure(
         op, (Twine("expected ptr-form ") + sourceRole).str());
+  }
 
   Value destination = materializeBoundaryOperandPtr(adaptor.getOperands()[1],
                                                     rewriter, op.getLoc());
-  if (!destination)
+  if (!destination) {
     return rewriter.notifyMatchFailure(
         op, (Twine("failed to materialize ") + destinationRole + " ptr").str());
-  if (!isa<pto::PtrType>(destination.getType()))
+  }
+  if (!isa<pto::PtrType>(destination.getType())) {
     return rewriter.notifyMatchFailure(
         op, (Twine("expected ptr-form ") + destinationRole).str());
+  }
 
   SmallVector<Value> operands(adaptor.getOperands().begin(),
                               adaptor.getOperands().end());
@@ -336,8 +382,9 @@ struct ConvertTileBufAddrToPtrPattern
   matchAndRewrite(pto::TileBufAddrOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type convertedType = getTypeConverter()->convertType(op.getDst().getType());
-    if (!isa<pto::PtrType>(convertedType))
+    if (!isa<pto::PtrType>(convertedType)) {
       return failure();
+    }
 
     rewriter.replaceOpWithNewOp<pto::TileBufAddrOp>(op, convertedType,
                                                     adaptor.getSrc());
@@ -354,8 +401,9 @@ struct ConvertIntToPtrToCastPtrPattern
                   ConversionPatternRewriter &rewriter) const override {
     Type convertedType =
         getTypeConverter()->convertType(op.getResult().getType());
-    if (!isa<pto::PtrType>(convertedType))
+    if (!isa<pto::PtrType>(convertedType)) {
       return rewriter.notifyMatchFailure(op, "expected pointer result type");
+    }
 
     rewriter.replaceOpWithNewOp<pto::CastPtrOp>(op, convertedType,
                                                 adaptor.getAddr());
@@ -371,10 +419,12 @@ struct ConvertPtrToIntToCastPtrPattern
   matchAndRewrite(pto::PtrToIntOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type convertedType = getTypeConverter()->convertType(op.getResult().getType());
-    if (!isa<IntegerType>(convertedType))
+    if (!isa<IntegerType>(convertedType)) {
       return rewriter.notifyMatchFailure(op, "expected integer result type");
-    if (!isa<pto::PtrType>(adaptor.getPtr().getType()))
+    }
+    if (!isa<pto::PtrType>(adaptor.getPtr().getType())) {
       return rewriter.notifyMatchFailure(op, "expected pointer input type");
+    }
 
     rewriter.replaceOpWithNewOp<pto::CastPtrOp>(op, convertedType,
                                                 adaptor.getPtr());
@@ -390,19 +440,22 @@ struct ConvertCastPtrPattern : public OpConversionPattern<pto::CastPtrOp> {
                   ConversionPatternRewriter &rewriter) const override {
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult().getType());
-    if (!convertedResultType)
+    if (!convertedResultType) {
       return failure();
+    }
 
     Value input = adaptor.getInput();
     Type inputType = input.getType();
-    if (isMemRefType(inputType) || isMemRefType(convertedResultType))
+    if (isMemRefType(inputType) || isMemRefType(convertedResultType)) {
       return rewriter.notifyMatchFailure(op,
                                          "memref castptr must be eliminated");
+    }
 
     if (!isa<pto::PtrType, IntegerType>(inputType) ||
-        !isa<pto::PtrType, IntegerType>(convertedResultType))
+        !isa<pto::PtrType, IntegerType>(convertedResultType)) {
       return rewriter.notifyMatchFailure(op,
                                          "expected ptr/int castptr operands");
+    }
 
     if (inputType == convertedResultType) {
       rewriter.replaceOp(op, input);
@@ -421,24 +474,28 @@ struct ConvertSubviewToAddPtrPattern
   LogicalResult
   matchAndRewrite(memref::SubViewOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!needsSubviewPtrConversion(op))
+    if (!needsSubviewPtrConversion(op)) {
       return failure();
+    }
 
     auto ptrType =
         dyn_cast<pto::PtrType>(getTypeConverter()->convertType(op.getType()));
-    if (!ptrType)
+    if (!ptrType) {
       return rewriter.notifyMatchFailure(op, "expected ptr result type");
+    }
 
     Value basePtr =
         materializeSubviewInputPtr(adaptor.getSource(), rewriter, op.getLoc());
-    if (!basePtr)
+    if (!basePtr) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to materialize subview input ptr");
+    }
 
     Value offset;
-    if (failed(computeSubviewElementOffset(op, rewriter, offset)))
+    if (failed(computeSubviewElementOffset(op, rewriter, offset))) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to compute subview element offset");
+    }
 
     rewriter.replaceOpWithNewOp<pto::AddPtrOp>(op, ptrType, basePtr, offset);
     return success();
@@ -451,15 +508,17 @@ struct ConvertVldsSubviewOperandPattern : public OpConversionPattern<pto::VldsOp
   LogicalResult
   matchAndRewrite(pto::VldsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!isa<pto::PtrType>(adaptor.getSource().getType()))
+    if (!isa<pto::PtrType>(adaptor.getSource().getType())) {
       return failure();
+    }
 
     OperationState state(op.getLoc(), op->getName().getStringRef());
     state.addOperands({adaptor.getSource(), adaptor.getOffset()});
     FailureOr<SmallVector<Type>> resultTypes =
         convertTypes(*getTypeConverter(), op->getResultTypes());
-    if (failed(resultTypes))
+    if (failed(resultTypes)) {
       return failure();
+    }
     state.addTypes(*resultTypes);
     state.addAttributes(op->getAttrs());
     Operation *newOp = rewriter.create(state);
@@ -474,8 +533,9 @@ struct ConvertVstsSubviewOperandPattern : public OpConversionPattern<pto::VstsOp
   LogicalResult
   matchAndRewrite(pto::VstsOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!isa<pto::PtrType>(adaptor.getDestination().getType()))
+    if (!isa<pto::PtrType>(adaptor.getDestination().getType())) {
       return failure();
+    }
 
     OperationState state(op.getLoc(), op->getName().getStringRef());
     state.addOperands(
@@ -483,8 +543,9 @@ struct ConvertVstsSubviewOperandPattern : public OpConversionPattern<pto::VstsOp
          adaptor.getMask()});
     FailureOr<SmallVector<Type>> resultTypes =
         convertTypes(*getTypeConverter(), op->getResultTypes());
-    if (failed(resultTypes))
+    if (failed(resultTypes)) {
       return failure();
+    }
     state.addTypes(*resultTypes);
     state.addAttributes(op->getAttrs());
     Operation *newOp = rewriter.create(state);
@@ -500,8 +561,9 @@ struct ConvertVsstbSubviewOperandPattern
   LogicalResult
   matchAndRewrite(pto::VsstbOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (!isa<pto::PtrType>(adaptor.getDestination().getType()))
+    if (!isa<pto::PtrType>(adaptor.getDestination().getType())) {
       return failure();
+    }
 
     OperationState state(op.getLoc(), op->getName().getStringRef());
     state.addOperands({adaptor.getValue(), adaptor.getDestination(),
@@ -509,8 +571,9 @@ struct ConvertVsstbSubviewOperandPattern
                        adaptor.getMask()});
     FailureOr<SmallVector<Type>> resultTypes =
         convertTypes(*getTypeConverter(), op->getResultTypes());
-    if (failed(resultTypes))
+    if (failed(resultTypes)) {
       return failure();
+    }
     state.addTypes(*resultTypes);
     state.addAttributes(op->getAttrs());
     Operation *newOp = rewriter.create(state);
@@ -527,11 +590,13 @@ struct ConvertLoadScalarOperandToPtrPattern
   matchAndRewrite(pto::LoadScalarOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value ptr = materializeScalarAccessPtr(adaptor.getPtr(), rewriter, op.getLoc());
-    if (!ptr)
+    if (!ptr) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to materialize load_scalar ptr");
-    if (!isa<pto::PtrType>(ptr.getType()))
+    }
+    if (!isa<pto::PtrType>(ptr.getType())) {
       return rewriter.notifyMatchFailure(op, "expected ptr-form load_scalar input");
+    }
 
     rewriter.replaceOpWithNewOp<pto::LoadScalarOp>(op, op.getValue().getType(),
                                                    ptr, adaptor.getOffset());
@@ -547,11 +612,13 @@ struct ConvertStoreScalarOperandToPtrPattern
   matchAndRewrite(pto::StoreScalarOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value ptr = materializeScalarAccessPtr(adaptor.getPtr(), rewriter, op.getLoc());
-    if (!ptr)
+    if (!ptr) {
       return rewriter.notifyMatchFailure(op,
                                          "failed to materialize store_scalar ptr");
-    if (!isa<pto::PtrType>(ptr.getType()))
+    }
+    if (!isa<pto::PtrType>(ptr.getType())) {
       return rewriter.notifyMatchFailure(op, "expected ptr-form store_scalar input");
+    }
 
     rewriter.replaceOpWithNewOp<pto::StoreScalarOp>(op, ptr,
                                                     adaptor.getOffset(),
@@ -741,10 +808,12 @@ struct ConvertLoadOperandToPtrPattern : public OpConversionPattern<pto::PTOLoadO
   matchAndRewrite(pto::PTOLoadOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value ptr = materializeScalarAccessPtr(adaptor.getPtr(), rewriter, op.getLoc());
-    if (!ptr)
+    if (!ptr) {
       return rewriter.notifyMatchFailure(op, "failed to materialize load ptr");
-    if (!isa<pto::PtrType>(ptr.getType()))
+    }
+    if (!isa<pto::PtrType>(ptr.getType())) {
       return rewriter.notifyMatchFailure(op, "expected ptr-form load input");
+    }
 
     rewriter.replaceOpWithNewOp<pto::PTOLoadOp>(
         op, op.getValue().getType(), ptr, adaptor.getOffset());
@@ -760,10 +829,12 @@ struct ConvertStoreOperandToPtrPattern
   matchAndRewrite(pto::PTOStoreOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value ptr = materializeScalarAccessPtr(adaptor.getPtr(), rewriter, op.getLoc());
-    if (!ptr)
+    if (!ptr) {
       return rewriter.notifyMatchFailure(op, "failed to materialize store ptr");
-    if (!isa<pto::PtrType>(ptr.getType()))
+    }
+    if (!isa<pto::PtrType>(ptr.getType())) {
       return rewriter.notifyMatchFailure(op, "expected ptr-form store input");
+    }
 
     rewriter.replaceOpWithNewOp<pto::PTOStoreOp>(
         op, ptr, adaptor.getOffset(), adaptor.getValue());
@@ -789,9 +860,10 @@ struct ConvertSimtLaunchOp final : public OpConversionPattern<pto::SimtLaunchOp>
         // emission validation.
         if (Value normalized =
                 materializeScalarAccessPtr(originalArg, rewriter, op.getLoc())) {
-          if (normalized.getType() != ptrType)
+          if (normalized.getType() != ptrType) {
             normalized =
                 rewriter.create<pto::CastPtrOp>(op.getLoc(), ptrType, normalized);
+          }
           arg = normalized;
         }
       }
@@ -816,27 +888,33 @@ struct ConvertPtrNormalizeUnrealizedCastOp final
   LogicalResult
   matchAndRewrite(UnrealizedConversionCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (op->getNumOperands() != 1 || op->getNumResults() != 1)
+    if (op->getNumOperands() != 1 || op->getNumResults() != 1) {
       return failure();
+    }
     if (!hasPtrNormalizeConvertibleType(op->getOperandTypes()) &&
-        !hasPtrNormalizeConvertibleType(op->getResultTypes()))
+        !hasPtrNormalizeConvertibleType(op->getResultTypes())) {
       return failure();
+    }
 
     Type convertedResultType =
         getTypeConverter()->convertType(op.getResult(0).getType());
-    if (!convertedResultType)
+    if (!convertedResultType) {
       return failure();
+    }
 
     Value input = adaptor.getOperands().front();
     if (input.getType() != convertedResultType) {
       auto ptrType = dyn_cast<pto::PtrType>(convertedResultType);
-      if (!ptrType)
+      if (!ptrType) {
         return failure();
+      }
       input = materializeScalarAccessPtr(input, rewriter, op.getLoc());
-      if (!input)
+      if (!input) {
         return failure();
-      if (input.getType() != ptrType)
+      }
+      if (input.getType() != ptrType) {
         input = rewriter.create<pto::CastPtrOp>(op.getLoc(), ptrType, input);
+      }
     }
 
     rewriter.replaceOp(op, input);
@@ -852,12 +930,14 @@ struct ConvertPtrNormalizeMemRefCastOp final
   matchAndRewrite(memref::CastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!hasPtrNormalizeConvertibleType(op.getSource().getType()) &&
-        !hasPtrNormalizeConvertibleType(op.getType()))
+        !hasPtrNormalizeConvertibleType(op.getType())) {
       return failure();
+    }
 
     Type convertedResultType = getTypeConverter()->convertType(op.getType());
-    if (!convertedResultType)
+    if (!convertedResultType) {
       return failure();
+    }
 
     Value source = adaptor.getSource();
     if (source.getType() == convertedResultType) {
@@ -866,9 +946,10 @@ struct ConvertPtrNormalizeMemRefCastOp final
     }
 
     if (!isa<pto::PtrType, IntegerType>(source.getType()) ||
-        !isa<pto::PtrType, IntegerType>(convertedResultType))
+        !isa<pto::PtrType, IntegerType>(convertedResultType)) {
       return rewriter.notifyMatchFailure(
           op, "expected ptr/int memref.cast after ptr normalization");
+    }
 
     rewriter.replaceOpWithNewOp<pto::CastPtrOp>(op, convertedResultType,
                                                 source);
@@ -1049,8 +1130,9 @@ struct VPTOPtrNormalizePass
                  ConvertPtrNormalizeMemRefCastOp>(
         typeConverter, context);
 
-    if (failed(applyPartialConversion(module, target, std::move(patterns))))
+    if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
       signalPassFailure();
+    }
   }
 };
 

--- a/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
+++ b/lib/PTO/Transforms/VPTOSoftPostUpdate.cpp
@@ -36,7 +36,6 @@ namespace pto {
 using namespace mlir;
 
 namespace {
-
 // A hardware block is 32 bytes; block-strided ops count in these units.
 static constexpr int64_t kBlockSizeBytes = 32;
 
@@ -116,18 +115,23 @@ static const PostUpdateTable &getPostUpdateTable() {
 // plain byte-sized int/float rather than guess.
 static std::optional<int64_t> addPtrUnitBytes(Value base) {
   Type elemTy;
-  if (auto ptrTy = dyn_cast<pto::PtrType>(base.getType()))
+  if (auto ptrTy = dyn_cast<pto::PtrType>(base.getType())) {
     elemTy = ptrTy.getElementType();
-  else if (auto memrefTy = dyn_cast<MemRefType>(base.getType()))
+  }
+  else if (auto memrefTy = dyn_cast<MemRefType>(base.getType())) {
     elemTy = memrefTy.getElementType();
-  else
+  }
+  else {
     return std::nullopt;
+  }
 
-  if (!elemTy || !elemTy.isIntOrFloat())
+  if (!elemTy || !elemTy.isIntOrFloat()) {
     return std::nullopt;
+  }
   unsigned bits = elemTy.getIntOrFloatBitWidth();
-  if (bits == 0 || bits % 8 != 0)
+  if (bits == 0 || bits % 8 != 0) {
     return std::nullopt;
+  }
   return static_cast<int64_t>(bits / 8);
 }
 
@@ -150,8 +154,9 @@ static std::optional<int64_t> strideUnitBytes(Operation *op, StrideUnit unit,
 
 static const PostUpdateOpInfo *getPostUpdateInfo(Operation *op) {
   auto it = getPostUpdateTable().find(op->getName().getStringRef());
-  if (it == getPostUpdateTable().end())
+  if (it == getPostUpdateTable().end()) {
     return nullptr;
+  }
   return &it->second;
 }
 
@@ -215,8 +220,9 @@ static StrideExprRef makeLeaf(Value v) {
 
 // Compile-time value of `e`, if it has one.
 static std::optional<int64_t> foldConst(const StrideExprRef &e) {
-  if (!e)
+  if (!e) {
     return std::nullopt;
+  }
   switch (e->kind) {
   case StrideExpr::Kind::Const:
     return e->constant;
@@ -231,12 +237,15 @@ static std::optional<int64_t> foldConst(const StrideExprRef &e) {
   case StrideExpr::Kind::Mul: {
     auto a = foldConst(e->lhs);
     auto b = foldConst(e->rhs);
-    if (!a || !b)
+    if (!a || !b) {
       return std::nullopt;
-    if (e->kind == StrideExpr::Kind::Add)
+    }
+    if (e->kind == StrideExpr::Kind::Add) {
       return *a + *b;
-    if (e->kind == StrideExpr::Kind::Sub)
+    }
+    if (e->kind == StrideExpr::Kind::Sub) {
       return *a - *b;
+    }
     return *a * *b;
   }
   }
@@ -254,40 +263,50 @@ static StrideExprRef makeBinary(StrideExpr::Kind kind, StrideExprRef a,
 
 static StrideExprRef makeAdd(StrideExprRef a, StrideExprRef b) {
   auto ca = foldConst(a), cb = foldConst(b);
-  if (ca && cb)
+  if (ca && cb) {
     return makeConst(*ca + *cb);
-  if (ca && *ca == 0)
+  }
+  if (ca && *ca == 0) {
     return b;
-  if (cb && *cb == 0)
+  }
+  if (cb && *cb == 0) {
     return a;
+  }
   return makeBinary(StrideExpr::Kind::Add, a, b);
 }
 
 static StrideExprRef makeSub(StrideExprRef a, StrideExprRef b) {
   auto ca = foldConst(a), cb = foldConst(b);
-  if (ca && cb)
+  if (ca && cb) {
     return makeConst(*ca - *cb);
-  if (cb && *cb == 0)
+  }
+  if (cb && *cb == 0) {
     return a;
+  }
   return makeBinary(StrideExpr::Kind::Sub, a, b);
 }
 
 static StrideExprRef makeMul(StrideExprRef a, StrideExprRef b) {
   auto ca = foldConst(a), cb = foldConst(b);
-  if (ca && cb)
+  if (ca && cb) {
     return makeConst(*ca * *cb);
-  if ((ca && *ca == 0) || (cb && *cb == 0))
+  }
+  if ((ca && *ca == 0) || (cb && *cb == 0)) {
     return makeConst(0);
-  if (ca && *ca == 1)
+  }
+  if (ca && *ca == 1) {
     return b;
-  if (cb && *cb == 1)
+  }
+  if (cb && *cb == 1) {
     return a;
+  }
   return makeBinary(StrideExpr::Kind::Mul, a, b);
 }
 
 static StrideExprRef makeCast(Operation *castOp, StrideExprRef a) {
-  if (auto c = foldConst(a))
+  if (auto c = foldConst(a)) {
     return makeConst(*c);
+  }
   auto e = std::make_shared<StrideExpr>();
   e->kind = StrideExpr::Kind::Cast;
   e->castOp = castOp;
@@ -309,12 +328,15 @@ struct AffineForm {
 };
 
 static bool sameAffineAtom(const StrideExprRef &a, const StrideExprRef &b) {
-  if (!a || !b || a->kind != b->kind)
+  if (!a || !b || a->kind != b->kind) {
     return false;
-  if (a->kind == StrideExpr::Kind::Leaf)
+  }
+  if (a->kind == StrideExpr::Kind::Leaf) {
     return a->leaf == b->leaf;
-  if (a->kind != StrideExpr::Kind::Cast)
+  }
+  if (a->kind != StrideExpr::Kind::Cast) {
     return false;
+  }
   return a->castOp->getName() == b->castOp->getName() &&
          a->castOp->getOperand(0).getType() ==
              b->castOp->getOperand(0).getType() &&
@@ -325,25 +347,31 @@ static bool sameAffineAtom(const StrideExprRef &a, const StrideExprRef &b) {
 
 static bool addAffineConstant(AffineForm &form, int64_t value) {
   int64_t result;
-  if (llvm::AddOverflow(form.constant, value, result))
+  if (llvm::AddOverflow(form.constant, value, result)) {
     return false;
+  }
   form.constant = result;
   return true;
 }
 
 static bool addAffineTerm(AffineForm &form, StrideExprRef atom, int64_t coeff) {
-  if (coeff == 0)
+  if (coeff == 0) {
     return true;
+  }
   for (unsigned i = 0; i < form.terms.size(); ++i) {
-    if (!sameAffineAtom(form.terms[i].atom, atom))
+    if (!sameAffineAtom(form.terms[i].atom, atom)) {
       continue;
+    }
     int64_t result;
-    if (llvm::AddOverflow(form.terms[i].coeff, coeff, result))
+    if (llvm::AddOverflow(form.terms[i].coeff, coeff, result)) {
       return false;
-    if (result == 0)
+    }
+    if (result == 0) {
       form.terms.erase(form.terms.begin() + i);
-    else
+    }
+    else {
       form.terms[i].coeff = result;
+    }
     return true;
   }
   form.terms.push_back({std::move(atom), coeff});
@@ -352,8 +380,9 @@ static bool addAffineTerm(AffineForm &form, StrideExprRef atom, int64_t coeff) {
 
 static bool accumulateAffine(const StrideExprRef &e, int64_t scale,
                              AffineForm &form) {
-  if (!e)
+  if (!e) {
     return false;
+  }
   switch (e->kind) {
   case StrideExpr::Kind::Const: {
     int64_t scaled;
@@ -403,21 +432,24 @@ static bool accumulateAffine(const StrideExprRef &e, int64_t scale,
 
 static std::optional<AffineForm> normalizeAffine(const StrideExprRef &e) {
   AffineForm form;
-  if (!accumulateAffine(e, 1, form))
+  if (!accumulateAffine(e, 1, form)) {
     return std::nullopt;
+  }
   return form;
 }
 
 static bool equalAffineForms(const AffineForm &a, const AffineForm &b) {
-  if (a.constant != b.constant || a.terms.size() != b.terms.size())
+  if (a.constant != b.constant || a.terms.size() != b.terms.size()) {
     return false;
+  }
   for (const AffineTerm &termA : a.terms) {
-    bool found = llvm::any_of(b.terms, [&](const AffineTerm &termB) {
+    bool found = llvm::any_of(b.terms, [&termA](const AffineTerm &termB) {
       return termA.coeff == termB.coeff &&
              sameAffineAtom(termA.atom, termB.atom);
     });
-    if (!found)
+    if (!found) {
       return false;
+    }
   }
   return true;
 }
@@ -427,33 +459,39 @@ static bool isZeroAffineForm(const AffineForm &form) {
 }
 
 static bool divideAffineForm(AffineForm &form, int64_t divisor) {
-  if (divisor <= 0 || form.constant % divisor != 0)
+  if (divisor <= 0 || form.constant % divisor != 0) {
     return false;
+  }
   for (const AffineTerm &term : form.terms)
-    if (term.coeff % divisor != 0)
+    if (term.coeff % divisor != 0) {
       return false;
+    }
   form.constant /= divisor;
-  for (AffineTerm &term : form.terms)
+  for (AffineTerm &term : form.terms) {
     term.coeff /= divisor;
+  }
   return true;
 }
 
 static StrideExprRef affineFormToExpr(const AffineForm &form) {
   StrideExprRef result;
-  if (form.constant != 0)
+  if (form.constant != 0) {
     result = makeConst(form.constant);
+  }
   for (const AffineTerm &term : form.terms) {
     StrideExprRef value = term.atom;
-    if (term.coeff != 1)
+    if (term.coeff != 1) {
       value = makeMul(value, makeConst(term.coeff));
+    }
     result = result ? makeAdd(result, value) : value;
   }
   return result ? result : makeConst(0);
 }
 
 static void collectLeaves(const StrideExprRef &e, SmallVectorImpl<Value> &out) {
-  if (!e)
+  if (!e) {
     return;
+  }
   if (e->kind == StrideExpr::Kind::Leaf) {
     out.push_back(e->leaf);
     return;
@@ -479,10 +517,12 @@ static bool exprType(const StrideExprRef &e, Type &out) {
   case StrideExpr::Kind::Sub:
   case StrideExpr::Kind::Mul: {
     Type ta, tb;
-    if (!exprType(e->lhs, ta) || !exprType(e->rhs, tb))
+    if (!exprType(e->lhs, ta) || !exprType(e->rhs, tb)) {
       return false;
-    if (ta && tb && ta != tb)
+    }
+    if (ta && tb && ta != tb) {
       return false;
+    }
     out = ta ? ta : tb;
     return true;
   }
@@ -508,21 +548,24 @@ static std::optional<LinearDecomp> decomposeLinear(Value v,
                                                    scf::ForOp forOp,
                                                    DecompCache &cache) {
   // v == blockArg → {1, 0}
-  if (v == blockArg)
+  if (v == blockArg) {
     return LinearDecomp{1, makeConst(0)};
+  }
 
   auto it = cache.find(v);
-  if (it != cache.end())
+  if (it != cache.end()) {
     return it->second;
-  auto record = [&](std::optional<LinearDecomp> r) {
+  }
+  auto record = [&cache, &v](std::optional<LinearDecomp> r) {
     cache[v] = r;
     return r;
   };
 
   // v is other block arg (IV, different iter_arg, func arg) → {0, v}
   Operation *defOp = v.getDefiningOp();
-  if (!defOp)
+  if (!defOp) {
     return record(LinearDecomp{0, makeLeaf(v)});
+  }
 
   // v is loop-invariant or constant → {0, v}
   if (forOp.isDefinedOutsideOfLoop(v) ||
@@ -534,10 +577,12 @@ static std::optional<LinearDecomp> decomposeLinear(Value v,
   if (isa<arith::AddIOp, arith::SubIOp>(defOp)) {
     auto da = decomposeLinear(defOp->getOperand(0), blockArg, forOp, cache);
     auto db = decomposeLinear(defOp->getOperand(1), blockArg, forOp, cache);
-    if (!da || !db)
+    if (!da || !db) {
       return record(std::nullopt);
-    if (da->coeff == 0 && db->coeff == 0)
+    }
+    if (da->coeff == 0 && db->coeff == 0) {
       return record(LinearDecomp{0, makeLeaf(v)});
+    }
     bool isSub = isa<arith::SubIOp>(defOp);
     return record(
         LinearDecomp{isSub ? da->coeff - db->coeff : da->coeff + db->coeff,
@@ -549,17 +594,21 @@ static std::optional<LinearDecomp> decomposeLinear(Value v,
   if (auto mulOp = dyn_cast<arith::MulIOp>(defOp)) {
     auto da = decomposeLinear(mulOp.getLhs(), blockArg, forOp, cache);
     auto db = decomposeLinear(mulOp.getRhs(), blockArg, forOp, cache);
-    if (!da || !db)
+    if (!da || !db) {
       return record(std::nullopt);
-    if (da->coeff == 0 && db->coeff == 0)
+    }
+    if (da->coeff == 0 && db->coeff == 0) {
       return record(LinearDecomp{0, makeLeaf(v)});
-    if (da->coeff != 0 && db->coeff != 0)
+    }
+    if (da->coeff != 0 && db->coeff != 0) {
       return record(std::nullopt);
+    }
     const LinearDecomp &withBA = (da->coeff != 0) ? *da : *db;
     Value multiplier = (da->coeff != 0) ? mulOp.getRhs() : mulOp.getLhs();
     auto constMul = getConstantIntValue(multiplier);
-    if (!constMul)
+    if (!constMul) {
       return record(std::nullopt);
+    }
     return record(
         LinearDecomp{withBA.coeff * *constMul,
                      makeMul(withBA.increment, makeConst(*constMul))});
@@ -568,22 +617,27 @@ static std::optional<LinearDecomp> decomposeLinear(Value v,
   // v = index_cast(a) → {ca, cast(ia)} when the cast preserves loop delta
   if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
     auto d = decomposeLinear(defOp->getOperand(0), blockArg, forOp, cache);
-    if (!d)
+    if (!d) {
       return record(std::nullopt);
-    if (d->coeff == 0)
+    }
+    if (d->coeff == 0) {
       return record(LinearDecomp{0, makeLeaf(v)});
-    if (!castPreservesLoopDelta(defOp, forOp))
+    }
+    if (!castPreservesLoopDelta(defOp, forOp)) {
       return record(std::nullopt);
+    }
     return record(LinearDecomp{d->coeff, makeCast(defOp, d->increment)});
   }
 
   // v = addptr(ptr, offset) → {c_ptr, i_ptr + offset}
   if (auto addPtrOp = dyn_cast<pto::AddPtrOp>(defOp)) {
     auto dp = decomposeLinear(addPtrOp.getPtr(), blockArg, forOp, cache);
-    if (!dp)
+    if (!dp) {
       return record(std::nullopt);
-    if (dp->coeff == 0)
+    }
+    if (dp->coeff == 0) {
       return record(LinearDecomp{0, makeLeaf(v)});
+    }
     return record(LinearDecomp{
         dp->coeff, makeAdd(dp->increment, makeLeaf(addPtrOp.getOffset()))});
   }
@@ -624,12 +678,14 @@ static StrideResult getIterArgIncrement(Value v, scf::ForOp forOp) {
       DecompCache cache;
       auto decomp =
           decomposeLinear(yieldOp.getOperand(idx), blockArg, forOp, cache);
-      if (!decomp || decomp->coeff != 1)
+      if (!decomp || decomp->coeff != 1) {
         return {StrideStatus::Failed, nullptr};
+      }
 
       StrideExprRef inc = decomp->increment;
-      for (Operation *op : llvm::reverse(casts))
+      for (Operation *op : llvm::reverse(casts)) {
         inc = makeCast(op, inc);
+      }
       return {StrideStatus::Ok, inc};
     }
 
@@ -639,8 +695,9 @@ static StrideResult getIterArgIncrement(Value v, scf::ForOp forOp) {
       return {StrideStatus::NotIterArg, nullptr};
 
     if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
-      if (!castPreservesLoopDelta(defOp, forOp))
+      if (!castPreservesLoopDelta(defOp, forOp)) {
         return {StrideStatus::Failed, nullptr};
+      }
       casts.push_back(defOp);
       current = defOp->getOperand(0);
       continue;
@@ -684,8 +741,9 @@ static StrideResult getIterArgIncrement(Value v, scf::ForOp forOp) {
 using DeltaCache = DenseMap<Value, StrideExprRef>;
 
 static unsigned integerLikeBitWidth(Type type) {
-  if (type.isIndex())
+  if (type.isIndex()) {
     return 64;
+  }
   return cast<IntegerType>(type).getWidth();
 }
 
@@ -693,22 +751,26 @@ static std::optional<uint64_t> getConstantTripCount(scf::ForOp forOp) {
   auto lower = getConstantIntValue(forOp.getLowerBound());
   auto upper = getConstantIntValue(forOp.getUpperBound());
   auto step = getConstantIntValue(forOp.getStep());
-  if (!lower || !upper || !step || *step <= 0)
+  if (!lower || !upper || !step || *step <= 0) {
     return std::nullopt;
-  if (*lower >= *upper)
+  }
+  if (*lower >= *upper) {
     return 0;
+  }
 
   __int128 distance = static_cast<__int128>(*upper) - *lower;
   __int128 count = (distance + static_cast<__int128>(*step) - 1) / *step;
-  if (count > std::numeric_limits<uint64_t>::max())
+  if (count > std::numeric_limits<uint64_t>::max()) {
     return std::nullopt;
+  }
   return static_cast<uint64_t>(count);
 }
 
 static std::optional<APInt> getConstantAPInt(Value value) {
   APInt constant;
-  if (!matchPattern(value, m_ConstantInt(&constant)))
+  if (!matchPattern(value, m_ConstantInt(&constant))) {
     return std::nullopt;
+  }
   return constant;
 }
 
@@ -724,15 +786,18 @@ getConstantIterArgIncrement(BlockArgument iterArg, scf::ForOp forOp,
   unsigned idx = iterArg.getArgNumber() - 1;
   auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
   Value yielded = yieldOp.getOperand(idx);
-  if (yielded == iterArg)
+  if (yielded == iterArg) {
     return 0;
+  }
 
   if (auto addOp = yielded.getDefiningOp<arith::AddIOp>()) {
     Value increment;
-    if (addOp.getLhs() == iterArg)
+    if (addOp.getLhs() == iterArg) {
       increment = addOp.getRhs();
-    else if (addOp.getRhs() == iterArg)
+    }
+    else if (addOp.getRhs() == iterArg) {
       increment = addOp.getLhs();
+    }
     auto constant = increment ? getConstantAPInt(increment) : std::nullopt;
     if (constant)
       return isUnsigned ? static_cast<__int128>(constant->getZExtValue())
@@ -740,8 +805,9 @@ getConstantIterArgIncrement(BlockArgument iterArg, scf::ForOp forOp,
   }
 
   if (auto subOp = yielded.getDefiningOp<arith::SubIOp>()) {
-    if (isUnsigned || subOp.getLhs() != iterArg)
+    if (isUnsigned || subOp.getLhs() != iterArg) {
       return std::nullopt;
+    }
     auto constant = getConstantAPInt(subOp.getRhs());
     if (constant) {
       int64_t signedConstant = constant->getSExtValue();
@@ -763,14 +829,17 @@ static bool canonicalAddressRecurrenceDoesNotWrap(Value input,
                                                   Operation *castOp,
                                                   scf::ForOp forOp) {
   auto inputType = dyn_cast<IntegerType>(input.getType());
-  if (!inputType || inputType.getWidth() != kCanonicalAddressWidth)
+  if (!inputType || inputType.getWidth() != kCanonicalAddressWidth) {
     return false;
+  }
 
   auto tripCount = getConstantTripCount(forOp);
-  if (!tripCount)
+  if (!tripCount) {
     return false;
-  if (*tripCount == 0)
+  }
+  if (*tripCount == 0) {
     return true;
+  }
 
   bool isUnsigned = isa<arith::IndexCastUIOp>(castOp);
   APInt initialBits;
@@ -778,8 +847,9 @@ static bool canonicalAddressRecurrenceDoesNotWrap(Value input,
   if (input == forOp.getInductionVar()) {
     auto lower = getConstantAPInt(forOp.getLowerBound());
     auto step = getConstantAPInt(forOp.getStep());
-    if (!lower || !step)
+    if (!lower || !step) {
       return false;
+    }
     initialBits = *lower;
     increment = static_cast<__int128>(step->getSExtValue());
   } else {
@@ -790,8 +860,9 @@ static bool canonicalAddressRecurrenceDoesNotWrap(Value input,
     unsigned idx = iterArg.getArgNumber() - 1;
     auto initial = getConstantAPInt(forOp.getInitArgs()[idx]);
     auto step = getConstantIterArgIncrement(iterArg, forOp, isUnsigned);
-    if (!initial || !step)
+    if (!initial || !step) {
       return false;
+    }
     initialBits = *initial;
     increment = *step;
   }
@@ -828,17 +899,20 @@ static bool castPreservesLoopDelta(Operation *castOp, scf::ForOp forOp) {
 
   unsigned inputWidth = integerLikeBitWidth(input.getType());
   unsigned resultWidth = integerLikeBitWidth(castOp->getResult(0).getType());
-  if (resultWidth >= inputWidth)
+  if (resultWidth >= inputWidth) {
     return true;
+  }
 
-  if (input != forOp.getInductionVar())
+  if (input != forOp.getInductionVar()) {
     return false;
+  }
 
   auto lower = getConstantIntValue(forOp.getLowerBound());
   auto upper = getConstantIntValue(forOp.getUpperBound());
   auto step = getConstantIntValue(forOp.getStep());
-  if (!lower || !upper || !step || *step <= 0)
+  if (!lower || !upper || !step || *step <= 0) {
     return false;
+  }
   if (*lower >= *upper)
     return true; // Empty loop.
 
@@ -855,17 +929,20 @@ static bool castPreservesLoopDelta(Operation *castOp, scf::ForOp forOp) {
 static StrideExprRef computeDelta(Value v, scf::ForOp forOp,
                                   DeltaCache &cache) {
   // IV: delta = step
-  if (v == forOp.getInductionVar())
+  if (v == forOp.getInductionVar()) {
     return makeLeaf(forOp.getStep());
+  }
 
   // Constant or loop-invariant: delta = 0
-  if (forOp.isDefinedOutsideOfLoop(v))
+  if (forOp.isDefinedOutsideOfLoop(v)) {
     return makeConst(0);
+  }
 
   auto it = cache.find(v);
-  if (it != cache.end())
+  if (it != cache.end()) {
     return it->second;
-  auto record = [&](StrideExprRef r) {
+  }
+  auto record = [&cache, &v](StrideExprRef r) {
     cache[v] = r;
     return r;
   };
@@ -878,27 +955,32 @@ static StrideExprRef computeDelta(Value v, scf::ForOp forOp,
       Value yieldVal = yieldOp.getOperand(idx);
       if (auto addOp = yieldVal.getDefiningOp<arith::AddIOp>()) {
         Value other;
-        if (addOp.getLhs() == blockArg)
+        if (addOp.getLhs() == blockArg) {
           other = addOp.getRhs();
-        else if (addOp.getRhs() == blockArg)
+        }
+        else if (addOp.getRhs() == blockArg) {
           other = addOp.getLhs();
-        if (other && forOp.isDefinedOutsideOfLoop(other))
+        }
+        if (other && forOp.isDefinedOutsideOfLoop(other)) {
           return record(makeLeaf(other));
+        }
       }
       return record(nullptr);
     }
   }
 
   Operation *defOp = v.getDefiningOp();
-  if (!defOp)
+  if (!defOp) {
     return record(nullptr);
+  }
 
   // arith.addi(a, b): delta = delta(a) + delta(b)
   if (auto addOp = dyn_cast<arith::AddIOp>(defOp)) {
     auto da = computeDelta(addOp.getLhs(), forOp, cache);
     auto db = computeDelta(addOp.getRhs(), forOp, cache);
-    if (!da || !db)
+    if (!da || !db) {
       return record(nullptr);
+    }
     return record(makeAdd(da, db));
   }
 
@@ -906,8 +988,9 @@ static StrideExprRef computeDelta(Value v, scf::ForOp forOp,
   if (auto subOp = dyn_cast<arith::SubIOp>(defOp)) {
     auto da = computeDelta(subOp.getLhs(), forOp, cache);
     auto db = computeDelta(subOp.getRhs(), forOp, cache);
-    if (!da || !db)
+    if (!da || !db) {
       return record(nullptr);
+    }
     return record(makeSub(da, db));
   }
 
@@ -919,8 +1002,9 @@ static StrideExprRef computeDelta(Value v, scf::ForOp forOp,
          {std::pair{rhs, lhs}, std::pair{lhs, rhs}}) {
       if (forOp.isDefinedOutsideOfLoop(invariant)) {
         auto dv = computeDelta(variant, forOp, cache);
-        if (!dv)
+        if (!dv) {
           continue;
+        }
         return record(makeMul(makeLeaf(invariant), dv));
       }
     }
@@ -930,8 +1014,9 @@ static StrideExprRef computeDelta(Value v, scf::ForOp forOp,
   // Preserve value-preserving casts in the symbolic delta. Narrowing casts are
   // accepted only when castPreservesLoopDelta proves they cannot truncate.
   if (isa<arith::IndexCastUIOp, arith::IndexCastOp>(defOp)) {
-    if (!castPreservesLoopDelta(defOp, forOp))
+    if (!castPreservesLoopDelta(defOp, forOp)) {
       return record(nullptr);
+    }
     StrideExprRef inputDelta = computeDelta(defOp->getOperand(0), forOp, cache);
     return record(inputDelta ? makeCast(defOp, inputDelta) : nullptr);
   }
@@ -945,10 +1030,12 @@ static StrideExprRef computeDelta(Value v, scf::ForOp forOp,
 // Returns null if the stride cannot be determined.
 static StrideExprRef getStride(Value v, scf::ForOp forOp, DeltaCache &cache) {
   StrideResult r = getIterArgIncrement(v, forOp);
-  if (r.status == StrideStatus::Ok)
+  if (r.status == StrideStatus::Ok) {
     return r.expr;
-  if (r.status == StrideStatus::Failed)
+  }
+  if (r.status == StrideStatus::Failed) {
     return nullptr;
+  }
   return computeDelta(v, forOp, cache);
 }
 
@@ -962,12 +1049,14 @@ static StrideExprRef getStride(Value v, scf::ForOp forOp, DeltaCache &cache) {
 static Value materializeAtLoopEntry(Value v, scf::ForOp forOp,
                                     OpBuilder &builder) {
   // IV → lower bound
-  if (v == forOp.getInductionVar())
+  if (v == forOp.getInductionVar()) {
     return forOp.getLowerBound();
+  }
 
   // Already defined outside the loop — use directly.
-  if (forOp.isDefinedOutsideOfLoop(v))
+  if (forOp.isDefinedOutsideOfLoop(v)) {
     return v;
+  }
 
   // iter_arg → its init value
   if (auto blockArg = dyn_cast<BlockArgument>(v)) {
@@ -978,26 +1067,30 @@ static Value materializeAtLoopEntry(Value v, scf::ForOp forOp,
   }
 
   Operation *defOp = v.getDefiningOp();
-  if (!defOp || !forOp->isAncestor(defOp))
+  if (!defOp || !forOp->isAncestor(defOp)) {
     return nullptr;
+  }
 
   // Cloning duplicates the op, so it must be safe to execute an extra time and
   // its result must not depend on anything but its operands.
-  if (!isPure(defOp))
+  if (!isPure(defOp)) {
     return nullptr;
+  }
 
   // Clone the defining op with operands materialized at loop entry.
   SmallVector<Value> newOperands;
   for (Value operand : defOp->getOperands()) {
     Value materialized = materializeAtLoopEntry(operand, forOp, builder);
-    if (!materialized)
+    if (!materialized) {
       return nullptr;
+    }
     newOperands.push_back(materialized);
   }
   builder.setInsertionPoint(forOp);
   Operation *cloned = builder.clone(*defOp);
-  for (auto [i, operand] : llvm::enumerate(newOperands))
+  for (auto [i, operand] : llvm::enumerate(newOperands)) {
     cloned->setOperand(i, operand);
+  }
   // Preserve which result was asked for; `v` need not be result 0.
   return cloned->getResult(cast<OpResult>(v).getResultNumber());
 }
@@ -1007,10 +1100,12 @@ static Value materializeAtLoopEntry(Value v, scf::ForOp forOp,
 // types; finer byte units require a suitably aligned compile-time constant.
 static bool canScaleInitialOffset(Value strideOperand, int64_t elemBytes,
                                   int64_t unitBytes) {
-  if (!strideOperand || unitBytes == elemBytes || unitBytes % elemBytes == 0)
+  if (!strideOperand || unitBytes == elemBytes || unitBytes % elemBytes == 0) {
     return true;
-  if (elemBytes % unitBytes != 0)
+  }
+  if (elemBytes % unitBytes != 0) {
     return false;
+  }
   auto constant = getConstantIntValue(strideOperand);
   return constant && *constant % (elemBytes / unitBytes) == 0;
 }
@@ -1022,8 +1117,9 @@ static bool canScaleInitialOffset(Value strideOperand, int64_t elemBytes,
 // offsets in the same way as the existing lowering.
 static Value truncateElementOffsetToI32(Value offset, Location loc,
                                         OpBuilder &builder) {
-  if (!offset.getType().isIndex())
+  if (!offset.getType().isIndex()) {
     return offset;
+  }
   Value offsetI64 =
       builder.create<arith::IndexCastOp>(loc, builder.getI64Type(), offset);
   Value offsetI32 =
@@ -1037,8 +1133,9 @@ static Value truncateElementOffsetToI32(Value offset, Location loc,
 // signed, including sprsti's signed 8-bit word offset.
 static Value normalizeAddPtrOffsetToIndex(Value offset, StrideUnit strideUnit,
                                           Location loc, OpBuilder &builder) {
-  if (offset.getType().isIndex())
+  if (offset.getType().isIndex()) {
     return offset;
+  }
   if (strideUnit == StrideUnit::Block)
     return builder.create<arith::IndexCastUIOp>(loc, builder.getIndexType(),
                                                 offset);
@@ -1052,13 +1149,16 @@ static Value createInitialPtr(Value base, Value strideOperand,
                               StrideUnit strideUnit, int64_t elemBytes,
                               int64_t unitBytes, Location loc,
                               OpBuilder &builder) {
-  if (!strideOperand)
+  if (!strideOperand) {
     return base;
+  }
   auto constSo = getConstantIntValue(strideOperand);
-  if (constSo && *constSo == 0)
+  if (constSo && *constSo == 0) {
     return base;
-  if (!canScaleInitialOffset(strideOperand, elemBytes, unitBytes))
+  }
+  if (!canScaleInitialOffset(strideOperand, elemBytes, unitBytes)) {
     return nullptr;
+  }
 
   Value scaledOffset =
       strideUnit == StrideUnit::Element
@@ -1092,15 +1192,18 @@ static Value computeInitialPtr(Value base, Value strideOperand,
                                int64_t unitBytes, scf::ForOp forOp,
                                OpBuilder &builder) {
   Value baseAtEntry = materializeAtLoopEntry(base, forOp, builder);
-  if (!baseAtEntry)
+  if (!baseAtEntry) {
     return nullptr;
+  }
 
-  if (!strideOperand)
+  if (!strideOperand) {
     return baseAtEntry;
+  }
 
   Value soAtEntry = materializeAtLoopEntry(strideOperand, forOp, builder);
-  if (!soAtEntry)
+  if (!soAtEntry) {
     return nullptr;
+  }
 
   builder.setInsertionPoint(forOp);
   return createInitialPtr(baseAtEntry, soAtEntry, strideUnit, elemBytes,
@@ -1109,7 +1212,6 @@ static Value computeInitialPtr(Value base, Value strideOperand,
 
 // Rescale a per-iteration base delta from `pto.addptr` units (elements) into
 // the op's strideOperand units.  Returns null when the conversion is not exact.
-//
 // Expanding the byte-denominated form
 //     stride_new = (E*delta(base) + W*delta(strideOperand)) / W
 //                = (E/W)*delta(base) + delta(strideOperand)
@@ -1120,21 +1222,24 @@ static Value computeInitialPtr(Value base, Value strideOperand,
 // behave exactly as before this scaling existed.
 static StrideExprRef scaleBaseDelta(StrideExprRef deltaBase, int64_t elemBytes,
                                     int64_t unitBytes) {
-  if (unitBytes == elemBytes)
+  if (unitBytes == elemBytes) {
     return deltaBase;
+  }
 
   if (unitBytes % elemBytes == 0) {
     // Coarser stride unit (e.g. 32-byte blocks over 4-byte elements): the base
     // delta's affine coefficients must all land on a whole unit.
     int64_t divisor = unitBytes / elemBytes;
     auto form = normalizeAffine(deltaBase);
-    if (!form || !divideAffineForm(*form, divisor))
+    if (!form || !divideAffineForm(*form, divisor)) {
       return nullptr;
+    }
     return affineFormToExpr(*form);
   }
 
-  if (elemBytes % unitBytes == 0)
+  if (elemBytes % unitBytes == 0) {
     return makeMul(deltaBase, makeConst(elemBytes / unitBytes));
+  }
 
   return nullptr;
 }
@@ -1149,17 +1254,20 @@ static StrideExprRef combineStride(StrideExprRef deltaBase,
                                    StrideExprRef deltaOffset, int64_t elemBytes,
                                    int64_t unitBytes) {
   StrideExprRef scaledBase = scaleBaseDelta(deltaBase, elemBytes, unitBytes);
-  if (!scaledBase)
+  if (!scaledBase) {
     return nullptr;
+  }
 
   StrideExprRef total = makeAdd(scaledBase, deltaOffset);
   if (auto form = normalizeAffine(total)) {
-    if (isZeroAffineForm(*form))
+    if (isZeroAffineForm(*form)) {
       return nullptr;
+    }
     return affineFormToExpr(*form);
   }
-  if (auto constTotal = foldConst(total); constTotal && *constTotal == 0)
+  if (auto constTotal = foldConst(total); constTotal && *constTotal == 0) {
     return nullptr;
+  }
   return total;
 }
 
@@ -1171,27 +1279,34 @@ static StrideExprRef combineStride(StrideExprRef deltaBase,
 // def-chain if needed?  Pure: inspects only, never mutates the IR.
 static bool canHoistBefore(Value v, Operation *insertPt, scf::ForOp forOp,
                            DenseMap<Value, bool> &memo) {
-  if (forOp.isDefinedOutsideOfLoop(v) || isa<BlockArgument>(v))
+  if (forOp.isDefinedOutsideOfLoop(v) || isa<BlockArgument>(v)) {
     return true;
+  }
   Operation *defOp = v.getDefiningOp();
-  if (!defOp)
+  if (!defOp) {
     return true;
-  if (defOp->getBlock() != insertPt->getBlock())
+  }
+  if (defOp->getBlock() != insertPt->getBlock()) {
     return false;
+  }
   // Already earlier in the block, so usable as-is: SSA guarantees its operands
   // are defined even earlier.  This reasoning is only sound because analysis
   // creates no IR — every value examined here predates the transform.
-  if (defOp->isBeforeInBlock(insertPt))
+  if (defOp->isBeforeInBlock(insertPt)) {
     return true;
+  }
   auto it = memo.find(v);
-  if (it != memo.end())
+  if (it != memo.end()) {
     return it->second;
+  }
   memo[v] = false;
-  if (!isPure(defOp))
+  if (!isPure(defOp)) {
     return false;
+  }
   for (Value operand : defOp->getOperands())
-    if (!canHoistBefore(operand, insertPt, forOp, memo))
+    if (!canHoistBefore(operand, insertPt, forOp, memo)) {
       return false;
+    }
   memo[v] = true;
   return true;
 }
@@ -1200,24 +1315,28 @@ static bool canHoistBefore(Value v, Operation *insertPt, scf::ForOp forOp,
 // canHoistBefore has approved `v`.
 static Value hoistBefore(Value v, Operation *insertPt, scf::ForOp forOp,
                          OpBuilder &builder, DenseMap<Value, Value> &memo) {
-  if (forOp.isDefinedOutsideOfLoop(v) || isa<BlockArgument>(v))
+  if (forOp.isDefinedOutsideOfLoop(v) || isa<BlockArgument>(v)) {
     return v;
+  }
   Operation *defOp = v.getDefiningOp();
   if (!defOp || defOp->getBlock() != insertPt->getBlock() ||
       defOp->isBeforeInBlock(insertPt))
     return v;
   auto it = memo.find(v);
-  if (it != memo.end())
+  if (it != memo.end()) {
     return it->second;
+  }
 
   SmallVector<Value> newOperands;
-  for (Value operand : defOp->getOperands())
+  for (Value operand : defOp->getOperands()) {
     newOperands.push_back(hoistBefore(operand, insertPt, forOp, builder, memo));
+  }
 
   builder.setInsertionPoint(insertPt);
   Operation *cloned = builder.clone(*defOp);
-  for (auto [i, operand] : llvm::enumerate(newOperands))
+  for (auto [i, operand] : llvm::enumerate(newOperands)) {
     cloned->setOperand(i, operand);
+  }
   // Preserve which result was asked for; `v` need not be result 0.
   Value res = cloned->getResult(cast<OpResult>(v).getResultNumber());
   memo[v] = res;
@@ -1262,17 +1381,20 @@ using ConstCache = DenseMap<std::pair<int64_t, Type>, Value>;
 static Value materializeConst(int64_t c, Type ty, Location loc,
                               scf::ForOp forOp, ConstCache &cache,
                               OpBuilder &builder) {
-  if (!ty)
+  if (!ty) {
     ty = builder.getIndexType();
+  }
   auto key = std::make_pair(c, ty);
-  if (auto it = cache.find(key); it != cache.end())
+  if (auto it = cache.find(key); it != cache.end()) {
     return it->second;
+  }
 
   OpBuilder::InsertionGuard guard(builder);
   builder.setInsertionPoint(forOp);
   Value v;
-  if (ty.isIndex())
+  if (ty.isIndex()) {
     v = builder.create<arith::ConstantIndexOp>(loc, c);
+  }
   else
     v = builder.create<arith::ConstantIntOp>(loc, c,
                                              ty.getIntOrFloatBitWidth());
@@ -1308,11 +1430,13 @@ static bool constantsFitType(const StrideExprRef &e, Type wantType) {
 
 static bool satisfiesStrideConstraint(const StrideExprRef &stride,
                                       StrideConstraint constraint) {
-  if (constraint == StrideConstraint::Dynamic)
+  if (constraint == StrideConstraint::Dynamic) {
     return true;
+  }
   std::optional<int64_t> constant = foldConst(stride);
-  if (!constant)
+  if (!constant) {
     return false;
+  }
   return constraint == StrideConstraint::Constant ||
          (*constant >= -128 && *constant <= 127);
 }
@@ -1340,10 +1464,12 @@ static Value materialize(const StrideExprRef &e, Type wantType, Location loc,
   case StrideExpr::Kind::Mul: {
     Value a = materialize(e->lhs, wantType, loc, forOp, cache, builder);
     Value b = materialize(e->rhs, a.getType(), loc, forOp, cache, builder);
-    if (e->kind == StrideExpr::Kind::Add)
+    if (e->kind == StrideExpr::Kind::Add) {
       return builder.create<arith::AddIOp>(loc, a, b);
-    if (e->kind == StrideExpr::Kind::Sub)
+    }
+    if (e->kind == StrideExpr::Kind::Sub) {
       return builder.create<arith::SubIOp>(loc, a, b);
+    }
     return builder.create<arith::MulIOp>(loc, a, b);
   }
   }
@@ -1382,29 +1508,35 @@ static bool canMaterializeAs(const StrideExprRef &e, Type wantType) {
 static bool canHoistBefore(Value v, Operation *insertPt,
                            DominanceInfo &dominance,
                            DenseMap<Value, bool> &memo) {
-  if (dominance.dominates(v, insertPt))
+  if (dominance.dominates(v, insertPt)) {
     return true;
+  }
   auto it = memo.find(v);
-  if (it != memo.end())
+  if (it != memo.end()) {
     return it->second;
+  }
   memo[v] = false;
 
   Operation *defOp = v.getDefiningOp();
-  if (!defOp || defOp->getBlock() != insertPt->getBlock() || !isPure(defOp))
+  if (!defOp || defOp->getBlock() != insertPt->getBlock() || !isPure(defOp)) {
     return false;
+  }
   for (Value operand : defOp->getOperands())
-    if (!canHoistBefore(operand, insertPt, dominance, memo))
+    if (!canHoistBefore(operand, insertPt, dominance, memo)) {
       return false;
+    }
   memo[v] = true;
   return true;
 }
 
 static Value hoistBefore(Value v, Operation *insertPt, DominanceInfo &dominance,
                          OpBuilder &builder, DenseMap<Value, Value> &memo) {
-  if (dominance.dominates(v, insertPt))
+  if (dominance.dominates(v, insertPt)) {
     return v;
-  if (auto it = memo.find(v); it != memo.end())
+  }
+  if (auto it = memo.find(v); it != memo.end()) {
     return it->second;
+  }
 
   Operation *defOp = v.getDefiningOp();
   SmallVector<Value> newOperands;
@@ -1414,8 +1546,9 @@ static Value hoistBefore(Value v, Operation *insertPt, DominanceInfo &dominance,
 
   builder.setInsertionPoint(insertPt);
   Operation *cloned = builder.clone(*defOp);
-  for (auto [i, operand] : llvm::enumerate(newOperands))
+  for (auto [i, operand] : llvm::enumerate(newOperands)) {
     cloned->setOperand(i, operand);
+  }
   Value result = cloned->getResult(cast<OpResult>(v).getResultNumber());
   memo[v] = result;
   return result;
@@ -1453,8 +1586,9 @@ static Value materializeSequential(const StrideExprRef &e, Type wantType,
                                    Location loc, OpBuilder &builder) {
   switch (e->kind) {
   case StrideExpr::Kind::Const:
-    if (wantType.isIndex())
+    if (wantType.isIndex()) {
       return builder.create<arith::ConstantIndexOp>(loc, e->constant);
+    }
     return builder.create<arith::ConstantIntOp>(
         loc, e->constant, wantType.getIntOrFloatBitWidth());
   case StrideExpr::Kind::Leaf:
@@ -1471,10 +1605,12 @@ static Value materializeSequential(const StrideExprRef &e, Type wantType,
   case StrideExpr::Kind::Mul: {
     Value lhs = materializeSequential(e->lhs, wantType, loc, builder);
     Value rhs = materializeSequential(e->rhs, wantType, loc, builder);
-    if (e->kind == StrideExpr::Kind::Add)
+    if (e->kind == StrideExpr::Kind::Add) {
       return builder.create<arith::AddIOp>(loc, lhs, rhs);
-    if (e->kind == StrideExpr::Kind::Sub)
+    }
+    if (e->kind == StrideExpr::Kind::Sub) {
       return builder.create<arith::SubIOp>(loc, lhs, rhs);
+    }
     return builder.create<arith::MulIOp>(loc, lhs, rhs);
   }
   }
@@ -1520,15 +1656,19 @@ static Operation *createPostUpdateOp(Operation *op,
                                      Value stride, OpBuilder &builder) {
   OperationState state(op->getLoc(), op->getName());
   for (auto [i, operand] : llvm::enumerate(op->getOperands())) {
-    if (static_cast<int>(i) == info.baseOperandIdx)
+    if (static_cast<int>(i) == info.baseOperandIdx) {
       state.addOperands(base);
-    else if (info.strideOperandIdx && i == *info.strideOperandIdx)
+    }
+    else if (info.strideOperandIdx && i == *info.strideOperandIdx) {
       state.addOperands(stride);
-    else
+    }
+    else {
       state.addOperands(operand);
+    }
   }
-  if (!info.strideOperandIdx)
+  if (!info.strideOperandIdx) {
     state.addOperands(stride);
+  }
   state.addTypes(op->getResultTypes());
   state.addTypes(base.getType());
   state.addAttributes(op->getAttrs());
@@ -1542,12 +1682,15 @@ static Operation *createNormalOp(Operation *op, const PostUpdateOpInfo &info,
                                  OpBuilder &builder) {
   OperationState state(op->getLoc(), op->getName());
   for (auto [i, operand] : llvm::enumerate(op->getOperands())) {
-    if (static_cast<int>(i) == info.baseOperandIdx)
+    if (static_cast<int>(i) == info.baseOperandIdx) {
       state.addOperands(base);
-    else if (info.strideOperandIdx && i == *info.strideOperandIdx)
+    }
+    else if (info.strideOperandIdx && i == *info.strideOperandIdx) {
       state.addOperands(zeroStride);
-    else
+    }
+    else {
       state.addOperands(operand);
+    }
   }
   state.addTypes(op->getResultTypes());
   state.addAttributes(op->getAttrs());
@@ -1555,12 +1698,9 @@ static Operation *createNormalOp(Operation *op, const PostUpdateOpInfo &info,
 }
 
 // Remove loop-carried recurrences that became dead after post-update rewrites.
-//
 // Ordinary DCE cannot break a recurrence such as
-//
 //   %next = arith.addi %iter_arg, %step
 //   scf.yield %next
-//
 // even when neither the iter_arg nor the loop result has a real user: the
 // block argument, update, and yield form a use cycle. Compute liveness from
 // side-effecting operations and externally used loop results, close it across
@@ -1569,23 +1709,26 @@ static Operation *createNormalOp(Operation *op, const PostUpdateOpInfo &info,
 static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
                                              OpBuilder &builder) {
   unsigned numIterArgs = forOp.getInitArgs().size();
-  if (numIterArgs == 0)
+  if (numIterArgs == 0) {
     return forOp;
+  }
 
   auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
   DenseSet<Value> liveValues;
   SmallVector<Value> worklist;
   SmallVector<bool> keepIterArg(numIterArgs, false);
 
-  auto markLive = [&](Value value) {
-    if (value && liveValues.insert(value).second)
+  auto markLive = [&liveValues, &worklist](Value value) {
+    if (value && liveValues.insert(value).second) {
       worklist.push_back(value);
+    }
   };
 
   // A loop result used outside the loop keeps its corresponding backedge live.
   for (auto [idx, result] : llvm::enumerate(forOp.getResults())) {
-    if (result.use_empty())
+    if (result.use_empty()) {
       continue;
+    }
     keepIterArg[idx] = true;
     markLive(yieldOp.getOperand(idx));
   }
@@ -1597,12 +1740,14 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
   // here.
   for (Operation &op : forOp.getBody()->without_terminator()) {
     if (!isPure(&op))
-      for (Value operand : op.getOperands())
+      for (Value operand : op.getOperands()) {
         markLive(operand);
+      }
     if (op.getNumRegions() != 0) {
-      op.walk([&](Operation *nested) {
-        for (Value operand : nested->getOperands())
+      op.walk([&markLive](Operation *nested) {
+        for (Value operand : nested->getOperands()) {
           markLive(operand);
+        }
       });
     }
   }
@@ -1623,20 +1768,24 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
     }
 
     Operation *defOp = value.getDefiningOp();
-    if (!defOp || !forOp->isAncestor(defOp))
+    if (!defOp || !forOp->isAncestor(defOp)) {
       continue;
-    for (Value operand : defOp->getOperands())
+    }
+    for (Value operand : defOp->getOperands()) {
       markLive(operand);
+    }
   }
 
-  if (llvm::all_of(keepIterArg, [](bool keep) { return keep; }))
+  if (llvm::all_of(keepIterArg, [](bool keep) { return keep; })) {
     return forOp;
+  }
 
   SmallVector<Value> newInitArgs;
   newInitArgs.reserve(numIterArgs);
   for (auto [idx, init] : llvm::enumerate(forOp.getInitArgs()))
-    if (keepIterArg[idx])
+    if (keepIterArg[idx]) {
       newInitArgs.push_back(init);
+    }
 
   builder.setInsertionPoint(forOp);
   auto newForOp = builder.create<scf::ForOp>(
@@ -1648,23 +1797,26 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
   mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
   unsigned newArgIdx = 0;
   for (auto [idx, oldArg] : llvm::enumerate(forOp.getRegionIterArgs()))
-    if (keepIterArg[idx])
+    if (keepIterArg[idx]) {
       mapping.map(oldArg, newForOp.getRegionIterArgs()[newArgIdx++]);
+    }
 
   builder.setInsertionPointToStart(newForOp.getBody());
   for (Operation &op : forOp.getBody()->without_terminator()) {
-    bool hasLiveResult = llvm::any_of(op.getResults(), [&](Value result) {
+    bool hasLiveResult = llvm::any_of(op.getResults(), [&liveValues](Value result) {
       return liveValues.contains(result);
     });
-    if (!isPure(&op) || op.getNumRegions() != 0 || hasLiveResult)
+    if (!isPure(&op) || op.getNumRegions() != 0 || hasLiveResult) {
       builder.clone(op, mapping);
+    }
   }
 
   SmallVector<Value> newYields;
   newYields.reserve(newInitArgs.size());
   for (auto [idx, yielded] : llvm::enumerate(yieldOp.getOperands()))
-    if (keepIterArg[idx])
+    if (keepIterArg[idx]) {
       newYields.push_back(mapping.lookupOrDefault(yielded));
+    }
   builder.setInsertionPointToEnd(newForOp.getBody());
   builder.create<scf::YieldOp>(yieldOp.getLoc(), newYields);
 
@@ -1686,8 +1838,9 @@ static scf::ForOp pruneDeadLoopCarriedValues(scf::ForOp forOp,
 static scf::ForOp applyPostUpdateRewrites(scf::ForOp forOp,
                                           ArrayRef<PostUpdateRewrite> rewrites,
                                           OpBuilder &builder) {
-  if (rewrites.empty())
+  if (rewrites.empty()) {
     return nullptr;
+  }
 
   // Group rewrites by start-address operands, stride, and effective byte unit.
   // Ops in the same group share one iter_arg and all use the pre-update
@@ -1702,8 +1855,9 @@ static scf::ForOp applyPostUpdateRewrites(scf::ForOp forOp,
   for (auto [i, rw] : llvm::enumerate(rewrites)) {
     auto key = getGroupKey(rw);
     auto [it, inserted] = groupToIdx.try_emplace(key, groupInitPtrs.size());
-    if (inserted)
+    if (inserted) {
       groupInitPtrs.push_back(rw.initPtr);
+    }
     rwGroupIdx[i] = it->second;
   }
 
@@ -1712,8 +1866,9 @@ static scf::ForOp applyPostUpdateRewrites(scf::ForOp forOp,
   // Build new init args: original + one new pointer per group.
   SmallVector<Value> newInitArgs(forOp.getInitArgs().begin(),
                                  forOp.getInitArgs().end());
-  for (Value ptr : groupInitPtrs)
+  for (Value ptr : groupInitPtrs) {
     newInitArgs.push_back(ptr);
+  }
 
   unsigned origIterArgCount = forOp.getInitArgs().size();
 
@@ -1729,8 +1884,9 @@ static scf::ForOp applyPostUpdateRewrites(scf::ForOp forOp,
   Block *oldBody = forOp.getBody();
   Block *newBody = newForOp.getBody();
   mapping.map(forOp.getInductionVar(), newForOp.getInductionVar());
-  for (unsigned i = 0; i < origIterArgCount; ++i)
+  for (unsigned i = 0; i < origIterArgCount; ++i) {
     mapping.map(oldBody->getArgument(i + 1), newBody->getArgument(i + 1));
+  }
 
   // Clone the body, tracking old->new op correspondence.
   DenseMap<Operation *, Operation *> opMapping;
@@ -1743,13 +1899,15 @@ static scf::ForOp applyPostUpdateRewrites(scf::ForOp forOp,
   // Apply rewrites. All ops in a group use the same pre-update pointer (block
   // arg). Track the last updated_base per group for yielding.
   SmallVector<Value> groupYieldPtrs(numGroups);
-  for (unsigned g = 0; g < numGroups; ++g)
+  for (unsigned g = 0; g < numGroups; ++g) {
     groupYieldPtrs[g] = newBody->getArgument(origIterArgCount + 1 + g);
+  }
 
   for (auto [rwIdx, rw] : llvm::enumerate(rewrites)) {
     auto it = opMapping.find(rw.op);
-    if (it == opMapping.end())
+    if (it == opMapping.end()) {
       continue;
+    }
     Operation *clonedOp = it->second;
     unsigned gIdx = rwGroupIdx[rwIdx];
     Value ptr = newBody->getArgument(origIterArgCount + 1 + gIdx);
@@ -1758,8 +1916,9 @@ static scf::ForOp applyPostUpdateRewrites(scf::ForOp forOp,
     builder.setInsertionPoint(clonedOp);
 
     const PostUpdateOpInfo *info = getPostUpdateInfo(clonedOp);
-    if (!info)
+    if (!info) {
       continue;
+    }
 
     Operation *newOp =
         createPostUpdateOp(clonedOp, *info, ptr, strideNew, builder);
@@ -1780,17 +1939,20 @@ static scf::ForOp applyPostUpdateRewrites(scf::ForOp forOp,
   // Build yield: original yields + one pointer per group.
   auto oldYield = cast<scf::YieldOp>(oldBody->getTerminator());
   SmallVector<Value> newYields;
-  for (Value v : oldYield.getOperands())
+  for (Value v : oldYield.getOperands()) {
     newYields.push_back(mapping.lookupOrDefault(v));
-  for (Value ptr : groupYieldPtrs)
+  }
+  for (Value ptr : groupYieldPtrs) {
     newYields.push_back(ptr);
+  }
 
   builder.setInsertionPointToEnd(newBody);
   builder.create<scf::YieldOp>(oldYield.getLoc(), newYields);
 
   // Replace original ForOp results (only the original ones).
-  for (unsigned i = 0; i < forOp.getNumResults(); ++i)
+  for (unsigned i = 0; i < forOp.getNumResults(); ++i) {
     forOp.getResult(i).replaceAllUsesWith(newForOp.getResult(i));
+  }
 
   forOp.erase();
   return pruneDeadLoopCarriedValues(newForOp, builder);
@@ -1807,12 +1969,15 @@ using SequentialExprCache = DenseMap<Value, StrideExprRef>;
 // SSA value is reused without guessing at its semantics.
 static StrideExprRef buildSequentialExpr(Value value,
                                          SequentialExprCache &cache) {
-  if (!value)
+  if (!value) {
     return makeConst(0);
-  if (auto constant = getConstantIntValue(value))
+  }
+  if (auto constant = getConstantIntValue(value)) {
     return makeConst(*constant);
-  if (auto it = cache.find(value); it != cache.end())
+  }
+  if (auto it = cache.find(value); it != cache.end()) {
     return it->second;
+  }
 
   Operation *defOp = value.getDefiningOp();
   StrideExprRef result;
@@ -1829,8 +1994,9 @@ static StrideExprRef buildSequentialExpr(Value value,
     else if (auto rhsConst = getConstantIntValue(mul.getRhs()))
       result = makeMul(buildSequentialExpr(mul.getLhs(), cache),
                        makeConst(*rhsConst));
-    else
+    else {
       result = makeLeaf(value);
+    }
   } else if (isa_and_nonnull<arith::IndexCastOp, arith::IndexCastUIOp>(defOp)) {
     result = makeCast(defOp, buildSequentialExpr(defOp->getOperand(0), cache));
   } else {
@@ -1852,8 +2018,9 @@ static NormalizedBase normalizeSequentialBase(Value base, int64_t elemBytes,
   StrideExprRef offset = makeConst(0);
   while (auto addPtr = root.getDefiningOp<pto::AddPtrOp>()) {
     auto parentElemBytes = addPtrUnitBytes(addPtr.getPtr());
-    if (!parentElemBytes || *parentElemBytes != elemBytes)
+    if (!parentElemBytes || *parentElemBytes != elemBytes) {
       break;
+    }
     offset = makeAdd(offset, buildSequentialExpr(addPtr.getOffset(), cache));
     root = addPtr.getPtr();
   }
@@ -1894,11 +2061,13 @@ analyzeSequentialStep(const SequentialCandidate &previous,
   StrideExprRef deltaStride = makeSub(current.strideExpr, previous.strideExpr);
   StrideExprRef step = combineStride(deltaBase, deltaStride, current.elemBytes,
                                      current.unitBytes);
-  if (!step)
+  if (!step) {
     return std::nullopt;
+  }
   auto form = normalizeAffine(step);
-  if (!form || isZeroAffineForm(*form))
+  if (!form || isZeroAffineForm(*form)) {
     return std::nullopt;
+  }
   return SequentialStep{affineFormToExpr(*form), std::move(*form)};
 }
 
@@ -1914,8 +2083,9 @@ struct SequentialRun {
 
 static bool validateSequentialRun(SequentialRun &run,
                                   DominanceInfo &dominance) {
-  if (run.candidates.size() < 3)
+  if (run.candidates.size() < 3) {
     return false;
+  }
 
   SequentialCandidate *first = run.candidates.front();
   run.strideType = first->strideOperand
@@ -1937,8 +2107,9 @@ static bool validateSequentialRun(SequentialRun &run,
         candidate->strideOperand
             ? candidate->strideOperand.getType()
             : IndexType::get(candidate->op->getContext());
-    if (candidateStrideType != run.strideType)
+    if (candidateStrideType != run.strideType) {
       return false;
+    }
   }
 
   SmallVector<Value> leaves;
@@ -1969,10 +2140,12 @@ static unsigned countDeadDynamicAddPtrs(const SequentialRun &run) {
     Value value = candidate->base;
     Operation *expectedUser = candidate->op;
     while (auto addPtr = value.getDefiningOp<pto::AddPtrOp>()) {
-      if (!hasOnlyExpectedUser(value, expectedUser))
+      if (!hasOnlyExpectedUser(value, expectedUser)) {
         break;
-      if (isDynamicSequentialValue(addPtr.getOffset(), cache))
+      }
+      if (isDynamicSequentialValue(addPtr.getOffset(), cache)) {
         counted.insert(addPtr);
+      }
       expectedUser = addPtr;
       value = addPtr.getPtr();
     }
@@ -1982,14 +2155,15 @@ static unsigned countDeadDynamicAddPtrs(const SequentialRun &run) {
 
 static unsigned initialPointerCost(const SequentialRun &run) {
   SequentialCandidate *first = run.candidates.front();
-  if (!first->info->strideIsInitialOffset || !first->strideOperand)
+  if (!first->info->strideIsInitialOffset || !first->strideOperand) {
     return 0;
+  }
   auto initialOffset = getConstantIntValue(first->strideOperand);
   return initialOffset && *initialOffset == 0 ? 0 : 1;
 }
 
 static bool isRunStrideUse(OpOperand &use, const SequentialRun &run) {
-  return llvm::any_of(run.candidates, [&](SequentialCandidate *candidate) {
+  return llvm::any_of(run.candidates, [&use](SequentialCandidate *candidate) {
     return candidate->info->strideOperandIdx &&
            use.getOwner() == candidate->op &&
            use.getOperandNumber() ==
@@ -2006,8 +2180,9 @@ static void collectCumulativeOffsetOps(Value value,
   if (!isa_and_nonnull<arith::AddIOp, arith::SubIOp>(defOp) ||
       !ops.insert(defOp).second)
     return;
-  for (Value operand : defOp->getOperands())
+  for (Value operand : defOp->getOperands()) {
     collectCumulativeOffsetOps(operand, ops);
+  }
 }
 
 static bool allUsesDisappearAfterRewrite(Operation *op,
@@ -2024,25 +2199,29 @@ static bool cumulativeOffsetChainDefinitelyDies(
     const SequentialRun &run, DenseSet<Operation *> &deadOps) {
   for (SequentialCandidate *candidate :
        llvm::drop_begin(run.candidates, 2)) {
-    if (candidate->strideOperand)
+    if (candidate->strideOperand) {
       collectCumulativeOffsetOps(candidate->strideOperand, deadOps);
+    }
   }
   return !deadOps.empty() &&
-         llvm::all_of(deadOps, [&](Operation *op) {
-           return allUsesDisappearAfterRewrite(op, deadOps, run);
+llvm::all_of(deadOps, [&deadOps, &run](Operation *op) {
+            return allUsesDisappearAfterRewrite(op, deadOps, run);
          });
 }
 
 static bool collectLatePureDefinitions(Value value, Operation *runHead,
                                        DominanceInfo &dominance,
                                        DenseSet<Operation *> &clonedOps) {
-  if (dominance.dominates(value, runHead))
+  if (dominance.dominates(value, runHead)) {
     return true;
+  }
   Operation *defOp = value.getDefiningOp();
-  if (!defOp || defOp->getBlock() != runHead->getBlock() || !isPure(defOp))
+  if (!defOp || defOp->getBlock() != runHead->getBlock() || !isPure(defOp)) {
     return false;
-  if (!clonedOps.insert(defOp).second)
+  }
+  if (!clonedOps.insert(defOp).second) {
     return true;
+  }
   return llvm::all_of(defOp->getOperands(), [&](Value operand) {
     return collectLatePureDefinitions(operand, runHead, dominance, clonedOps);
   });
@@ -2062,8 +2241,9 @@ static bool isStepMaterializationCostNeutral(
     SmallVector<Value> leaves;
     collectLeaves(atom, leaves);
     for (Value leaf : leaves)
-      if (!collectLatePureDefinitions(leaf, first->op, dominance, clonedOps))
+      if (!collectLatePureDefinitions(leaf, first->op, dominance, clonedOps)) {
         return false;
+      }
   } else if (atom->kind == StrideExpr::Kind::Leaf &&
              !collectLatePureDefinitions(atom->leaf, first->op, dominance,
                                          clonedOps)) {
@@ -2072,14 +2252,15 @@ static bool isStepMaterializationCostNeutral(
 
   DenseSet<Operation *> disappearing = deadOffsetOps;
   disappearing.insert(clonedOps.begin(), clonedOps.end());
-  return llvm::all_of(clonedOps, [&](Operation *op) {
+  return llvm::all_of(clonedOps, [&disappearing, &run](Operation *op) {
     return allUsesDisappearAfterRewrite(op, disappearing, run);
   });
 }
 
 static bool isProfitableDynamicBaseRun(const SequentialRun &run) {
-  if (!run.stepForm.terms.empty())
+  if (!run.stepForm.terms.empty()) {
     return false;
+  }
   unsigned pointerCost = run.candidates.size() - 1;
   return countDeadDynamicAddPtrs(run) >
          pointerCost + initialPointerCost(run);
@@ -2103,12 +2284,14 @@ static bool isProfitableDirectSymbolicLeafRun(
   auto firstOffset = firstStrideOperand
                          ? getConstantIntValue(firstStrideOperand)
                          : std::optional<int64_t>(0);
-  if (!firstOffset || *firstOffset != 0)
+  if (!firstOffset || *firstOffset != 0) {
     return false;
+  }
 
   DenseSet<Operation *> deadOffsetOps;
-  if (!cumulativeOffsetChainDefinitelyDies(run, deadOffsetOps))
+  if (!cumulativeOffsetChainDefinitelyDies(run, deadOffsetOps)) {
     return false;
+  }
   return isStepMaterializationCostNeutral(run, deadOffsetOps, dominance);
 }
 
@@ -2146,21 +2329,24 @@ static void processSequentialBlock(Block *block, DominanceInfo &dominance,
   for (Operation &op : *block) {
     originalOps.push_back(&op);
     const PostUpdateOpInfo *info = getPostUpdateInfo(&op);
-    if (!info || isAlreadyPostUpdate(&op, *info))
+    if (!info || isAlreadyPostUpdate(&op, *info)) {
       continue;
+    }
 
     Value base, strideOperand;
     extractBaseAndStrideOperand(&op, *info, base, strideOperand);
     auto elemBytes = addPtrUnitBytes(base);
-    if (!elemBytes)
+    if (!elemBytes) {
       continue;
+    }
     auto unitBytes = strideUnitBytes(&op, info->strideUnit, *elemBytes);
-    if (!unitBytes)
+    if (!unitBytes) {
       continue;
+    }
     NormalizedBase normalized =
         normalizeSequentialBase(base, *elemBytes, exprCache);
 
-    auto bucketIt = llvm::find_if(buckets, [&](const SequentialBucket &bucket) {
+    auto bucketIt = llvm::find_if(buckets, [&op, &normalized](const SequentialBucket &bucket) {
       return bucket.opName == op.getName().getStringRef() &&
              bucket.rootBase == normalized.root;
     });
@@ -2190,16 +2376,18 @@ static void processSequentialBlock(Block *block, DominanceInfo &dominance,
       while (end < candidates.size()) {
         auto nextStep =
             analyzeSequentialStep(candidates[end - 1], candidates[end]);
-        if (!nextStep || !equalAffineForms(firstStep->form, nextStep->form))
+        if (!nextStep || !equalAffineForms(firstStep->form, nextStep->form)) {
           break;
+        }
         ++end;
       }
 
       SequentialRun run;
       run.step = firstStep->expr;
       run.stepForm = firstStep->form;
-      for (size_t i = start; i < end; ++i)
+      for (size_t i = start; i < end; ++i) {
         run.candidates.push_back(&candidates[i]);
+      }
       if (validateSequentialRun(run, dominance) &&
           isProfitableSequentialRun(run, dominance)) {
         runs.push_back(std::move(run));
@@ -2214,8 +2402,9 @@ static void processSequentialBlock(Block *block, DominanceInfo &dominance,
     }
   }
 
-  if (runs.empty())
+  if (runs.empty()) {
     return;
+  }
 
   // Materialize every accepted run before erasing any candidate op.
   for (SequentialRun &run : runs) {
@@ -2239,15 +2428,17 @@ static void processSequentialBlock(Block *block, DominanceInfo &dominance,
 
   DenseMap<Operation *, unsigned> opToRun;
   for (auto [runIdx, run] : llvm::enumerate(runs))
-    for (SequentialCandidate *candidate : run.candidates)
+    for (SequentialCandidate *candidate : run.candidates) {
       opToRun[candidate->op] = runIdx;
+    }
 
   // Rewrite in original program order so interleaved buckets maintain separate
   // pointer chains without invalidating one another.
   for (Operation *op : originalOps) {
     auto it = opToRun.find(op);
-    if (it == opToRun.end())
+    if (it == opToRun.end()) {
       continue;
+    }
     SequentialRun &run = runs[it->second];
     const PostUpdateOpInfo *info = getPostUpdateInfo(op);
     builder.setInsertionPoint(op);
@@ -2256,10 +2447,12 @@ static void processSequentialBlock(Block *block, DominanceInfo &dominance,
                                                run.zeroStride, builder)
                               : createPostUpdateOp(op, *info, run.currentPtr,
                                                    run.strideValue, builder);
-    for (unsigned result = 0; result < op->getNumResults(); ++result)
+    for (unsigned result = 0; result < op->getNumResults(); ++result) {
       op->getResult(result).replaceAllUsesWith(newOp->getResult(result));
-    if (!isLast)
+    }
+    if (!isLast) {
       run.currentPtr = newOp->getResult(newOp->getNumResults() - 1);
+    }
     op->erase();
   }
 }
@@ -2278,7 +2471,7 @@ struct VPTOSoftPostUpdatePass
     OpBuilder builder(&getContext());
 
     module.walk(
-        [&](pto::VecScopeOp vecscope) { processVecScope(vecscope, builder); });
+        [this, &builder](pto::VecScopeOp vecscope) { processVecScope(vecscope, builder); });
   }
 
 private:
@@ -2287,14 +2480,15 @@ private:
     // post-order, so nested loops already come before the loops enclosing
     // them.
     SmallVector<scf::ForOp> forOps;
-    vecscope.walk([&](scf::ForOp forOp) { forOps.push_back(forOp); });
+    vecscope.walk([&forOps](scf::ForOp forOp) { forOps.push_back(forOp); });
 
     // Process inner-to-outer, i.e. in collection order.  The order is load
     // bearing: rewriting a loop erases it, which also destroys every loop
     // nested inside it.  Visiting an enclosing loop first would leave the
     // already-collected inner ForOp handles dangling.
-    for (scf::ForOp forOp : forOps)
+    for (scf::ForOp forOp : forOps) {
       processForOp(forOp, builder);
+    }
 
     // Loop rewriting rebuilds ForOps, so collect blocks only after every loop
     // handle has been consumed. This second phase includes loop bodies and
@@ -2302,8 +2496,9 @@ private:
     SmallVector<Block *> blocks;
     collectNestedBlocks(vecscope, vecscope, blocks);
     DominanceInfo dominance(vecscope->getParentOp());
-    for (Block *block : blocks)
+    for (Block *block : blocks) {
       processSequentialBlock(block, dominance, builder);
+    }
   }
 
   void processForOp(scf::ForOp forOp, OpBuilder &builder) {
@@ -2314,12 +2509,15 @@ private:
 
     for (Operation &op : *forOp.getBody()) {
       const PostUpdateOpInfo *info = getPostUpdateInfo(&op);
-      if (!info)
+      if (!info) {
         continue;
-      if (isAlreadyPostUpdate(&op, *info))
+      }
+      if (isAlreadyPostUpdate(&op, *info)) {
         continue;
-      if (!isDirectlyInForBody(&op, forOp))
+      }
+      if (!isDirectlyInForBody(&op, forOp)) {
         continue;
+      }
 
       Value base, strideOperand;
       extractBaseAndStrideOperand(&op, *info, base, strideOperand);
@@ -2330,11 +2528,13 @@ private:
       // op's lowering expects.  Bail on pointers whose addptr unit we cannot
       // pin down rather than guess at the scale.
       std::optional<int64_t> elemBytes = addPtrUnitBytes(base);
-      if (!elemBytes)
+      if (!elemBytes) {
         continue;
+      }
       auto unitBytes = strideUnitBytes(&op, info->strideUnit, *elemBytes);
-      if (!unitBytes)
+      if (!unitBytes) {
         continue;
+      }
 
       // Analyze each operand independently: accumulator (iter_arg) first,
       // delta (IV/affine) fallback. Both return a symbolic per-iteration
@@ -2345,37 +2545,43 @@ private:
           strideOperand ? getStride(strideOperand, forOp, deltaCache)
                         : makeConst(0);
 
-      if (!deltaBase || !deltaOffset)
+      if (!deltaBase || !deltaOffset) {
         continue;
+      }
 
       StrideExprRef total =
           combineStride(deltaBase, deltaOffset, *elemBytes, *unitBytes);
-      if (!total)
+      if (!total) {
         continue;
+      }
 
       // Reject expressions whose subterms demand conflicting types, or whose
       // dynamic result cannot be materialized exactly as the op's declared
       // stride operand type.
       Type exprResultType;
-      if (!exprType(total, exprResultType))
+      if (!exprType(total, exprResultType)) {
         continue;
+      }
       Type strideType =
           strideOperand ? strideOperand.getType() : builder.getIndexType();
-      if (exprResultType && exprResultType != strideType)
+      if (exprResultType && exprResultType != strideType) {
         continue;
+      }
 
       // Reject strides whose constants do not fit the target operand type.
-      if (!constantsFitType(total, strideType))
+      if (!constantsFitType(total, strideType)) {
         continue;
-      if (!satisfiesStrideConstraint(total, info->strideConstraint))
+      }
+      if (!satisfiesStrideConstraint(total, info->strideConstraint)) {
         continue;
+      }
 
       // A stride built only from loop-invariant leaves is materialized before
       // the loop; otherwise it goes immediately before the candidate op.
       SmallVector<Value> leaves;
       collectLeaves(total, leaves);
       bool allInvariant = llvm::all_of(
-          leaves, [&](Value l) { return forOp.isDefinedOutsideOfLoop(l); });
+          leaves, [&forOp](Value l) { return forOp.isDefinedOutsideOfLoop(l); });
 
       StrideExprRef finalExpr = total;
       if (!allInvariant) {
@@ -2399,15 +2605,17 @@ private:
       Value initPtr = computeInitialPtr(
           base, initialOffsetOperand, info->strideUnit, *elemBytes, *unitBytes,
           forOp, builder);
-      if (!initPtr)
+      if (!initPtr) {
         continue;
+      }
 
       rewrites.push_back(
           {&op, base, strideOperand, strideNew, initPtr, *unitBytes});
     }
 
-    if (!rewrites.empty())
+    if (!rewrites.empty()) {
       applyPostUpdateRewrites(forOp, rewrites, builder);
+    }
   }
 };
 

--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -6674,7 +6674,6 @@ def wait_flag(src: str, dst: str, *, event_id: int = 0):
 
 
 def reserve_buffer(name, *, size, location, auto=True, base=None):
-    """``pto.reserve_buffer(name, size, location, auto=True, base=None)``."""
     space = _normalize_address_space(location)
     if space not in (_pto.AddressSpace.VEC, _pto.AddressSpace.MAT):
         raise ValueError(
@@ -6691,7 +6690,6 @@ def reserve_buffer(name, *, size, location, auto=True, base=None):
 
 
 def import_reserved_buffer(name, *, peer_func):
-    """``pto.import_reserved_buffer(name, peer_func=...)``."""
     if not isinstance(peer_func, str):
         spec = getattr(peer_func, "spec", None)
         role = getattr(spec, "role", None)

--- a/tools/ptoas/NativeModule.cpp
+++ b/tools/ptoas/NativeModule.cpp
@@ -135,8 +135,9 @@ int runPTOASFromPython(const std::vector<std::string> &arguments) {
   std::vector<std::string> storage = arguments;
   std::vector<char *> argv;
   argv.reserve(storage.size());
-  for (std::string &argument : storage)
+  for (std::string &argument : storage) {
     argv.push_back(argument.data());
+  }
 
   py::object contextOwner =
       py::module_::import("ptoas.mlir.ir").attr("Context")();

--- a/tools/ptoas/ObjectEmission.cpp
+++ b/tools/ptoas/ObjectEmission.cpp
@@ -125,27 +125,32 @@ static std::string sanitizeModuleId(llvm::StringRef raw) {
   std::string out;
   out.reserve(raw.size());
   for (char c : raw) {
-    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_')
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '_') {
       out.push_back(c);
-    else
+    }
+    else {
       out.push_back('_');
+    }
   }
-  if (out.empty())
+  if (out.empty()) {
     out = "ptoas_fatobj";
+  }
   return out;
 }
 
 static std::optional<std::string> getAscendHomePath() {
   const char *env = std::getenv("ASCEND_HOME_PATH");
-  if (!env || !*env)
+  if (!env || !*env) {
     return std::nullopt;
+  }
   return std::string(env);
 }
 
 static std::optional<std::string> getEnvPath(llvm::StringRef name) {
   const char *env = std::getenv(name.str().c_str());
-  if (!env || !*env)
+  if (!env || !*env) {
     return std::nullopt;
+  }
   return std::string(env);
 }
 
@@ -157,8 +162,9 @@ static std::string joinPath(llvm::StringRef lhs, llvm::StringRef rhs) {
 
 static std::optional<std::string> parseCANNVersionInfo(llvm::StringRef path) {
   auto buffer = llvm::MemoryBuffer::getFile(path);
-  if (!buffer)
+  if (!buffer) {
     return std::nullopt;
+  }
   llvm::StringRef content = buffer.get()->getBuffer();
   llvm::SmallVector<llvm::StringRef, 16> lines;
   content.split(lines, '\n');
@@ -166,13 +172,16 @@ static std::optional<std::string> parseCANNVersionInfo(llvm::StringRef path) {
     line = line.trim();
     llvm::StringRef keys[] = {"Version=", "version="};
     for (llvm::StringRef key : keys) {
-      if (!line.starts_with(key))
+      if (!line.starts_with(key)) {
         continue;
+      }
       llvm::StringRef value = line.drop_front(key.size()).trim();
-      if (value.consume_front("\""))
+      if (value.consume_front("\"")) {
         value.consume_back("\"");
-      if (!value.empty())
+      }
+      if (!value.empty()) {
         return value.str();
+      }
     }
   }
   return std::nullopt;
@@ -188,18 +197,21 @@ discoverCANNVersion(llvm::StringRef ascendHome) {
         "aarch64-linux/ascend_all_cann_install.info",
         "ascend_toolkit_install.info", "ascend_all_cann_install.info",
         "opp/version.info"}) {
-    if (auto version = parseCANNVersionInfo(joinPath(ascendHome, relPath)))
+    if (auto version = parseCANNVersionInfo(joinPath(ascendHome, relPath))) {
       return version;
+    }
   }
   return std::nullopt;
 }
 
 static std::optional<std::string> locateProgram(llvm::StringRef envPath,
                                                 llvm::StringRef fallbackName) {
-  if (!envPath.empty() && llvm::sys::fs::exists(envPath))
+  if (!envPath.empty() && llvm::sys::fs::exists(envPath)) {
     return envPath.str();
-  if (auto found = llvm::sys::findProgramByName(fallbackName))
+  }
+  if (auto found = llvm::sys::findProgramByName(fallbackName)) {
     return *found;
+  }
   return std::nullopt;
 }
 
@@ -209,24 +221,29 @@ static bool hasPTOISAHeader(llvm::StringRef includeDir) {
 
 static void addExistingIncludeDir(llvm::SmallVectorImpl<std::string> &dirs,
                                   llvm::StringRef path) {
-  if (path.empty() || !llvm::sys::fs::is_directory(path))
+  if (path.empty() || !llvm::sys::fs::is_directory(path)) {
     return;
-  if (llvm::is_contained(dirs, path))
+  }
+  if (llvm::is_contained(dirs, path)) {
     return;
+  }
   dirs.push_back(path.str());
 }
 
 static void addPTOISAIncludeDirs(llvm::SmallVectorImpl<std::string> &dirs,
                                  llvm::StringRef ptoIsaPath) {
-  if (ptoIsaPath.empty() || !llvm::sys::fs::is_directory(ptoIsaPath))
+  if (ptoIsaPath.empty() || !llvm::sys::fs::is_directory(ptoIsaPath)) {
     return;
+  }
   std::string includeDir = joinPath(ptoIsaPath, "include");
-  if (hasPTOISAHeader(includeDir))
+  if (hasPTOISAHeader(includeDir)) {
     addExistingIncludeDir(dirs, includeDir);
+  }
   std::string commonDir = joinPath(ptoIsaPath, "tests/common");
   addExistingIncludeDir(dirs, commonDir);
-  if (hasPTOISAHeader(ptoIsaPath))
+  if (hasPTOISAHeader(ptoIsaPath)) {
     addExistingIncludeDir(dirs, ptoIsaPath);
+  }
 }
 
 static llvm::SmallVector<std::string, 8>
@@ -234,8 +251,9 @@ discoverCppIncludeDirs(llvm::StringRef ascendHome,
                        llvm::raw_ostream &diagOS,
                        std::string &ptoIsaPath) {
   llvm::SmallVector<std::string, 8> includeDirs;
-  if (auto env = getEnvPath("PTO_ISA_PATH"))
+  if (auto env = getEnvPath("PTO_ISA_PATH")) {
     ptoIsaPath = *env;
+  }
   else if (auto env = getEnvPath("PTO_ISA_ROOT"))
     ptoIsaPath = *env;
 
@@ -292,8 +310,9 @@ static std::string resolveTargetCPU(llvm::Module &module,
   for (llvm::Function &f : module) {
     if (f.hasFnAttribute("target-cpu")) {
       std::string cpu = f.getFnAttribute("target-cpu").getValueAsString().str();
-      if (!cpu.empty())
+      if (!cpu.empty()) {
         return cpu;
+      }
     }
   }
   return getTargetCPU(fallback).str();
@@ -305,28 +324,34 @@ public:
       : tempFiles(tempFiles) {}
 
   bool emitStubSource(StringRef stubSource, llvm::raw_ostream &diagOS) {
-    if (failed(tempFiles.create("ptoas-host-stub", ".cpp", stubPath, diagOS)))
+    if (failed(tempFiles.create("ptoas-host-stub", ".cpp", stubPath, diagOS))) {
       return false;
-    if (!writeTextFile(stubPath, stubSource, diagOS))
+    }
+    if (!writeTextFile(stubPath, stubSource, diagOS)) {
       return false;
+    }
     return true;
   }
 
   bool initCommandLogs(llvm::raw_ostream &diagOS) {
-    if (failed(tempFiles.create("ptoas-stderr", ".log", stderrPath, diagOS)))
+    if (failed(tempFiles.create("ptoas-stderr", ".log", stderrPath, diagOS))) {
       return false;
+    }
     return true;
   }
 
   bool emitCubeObject(llvm::Module *module,
                       const mlir::pto::CANNToolchain &toolchain,
                       llvm::raw_ostream &diagOS) {
-    if (!module)
+    if (!module) {
       return true;
-    if (failed(tempFiles.create("ptoas-device", ".ll", cubeLLPath, diagOS)))
+    }
+    if (failed(tempFiles.create("ptoas-device", ".ll", cubeLLPath, diagOS))) {
       return false;
-    if (failed(tempFiles.create("ptoas-device", ".o", cubeObjPath, diagOS)))
+    }
+    if (failed(tempFiles.create("ptoas-device", ".o", cubeObjPath, diagOS))) {
       return false;
+    }
     return succeeded(mlir::pto::emitVPTOCubeDeviceObject(
         *module, cubeLLPath, cubeObjPath, toolchain, stderrPath, diagOS));
   }
@@ -335,10 +360,12 @@ public:
                         const mlir::pto::CANNToolchain &toolchain,
                         mlir::pto::VFSIMTSizeFixMode vfsimtSizeFixMode,
                         llvm::raw_ostream &diagOS) {
-    if (!module)
+    if (!module) {
       return true;
-    if (failed(tempFiles.create("ptoas-device", ".ll", vectorLLPath, diagOS)))
+    }
+    if (failed(tempFiles.create("ptoas-device", ".ll", vectorLLPath, diagOS))) {
       return false;
+    }
     std::string rawVectorObjPath;
     if (failed(tempFiles.create("ptoas-device-vector-raw", ".o",
                                 rawVectorObjPath, diagOS)))
@@ -360,8 +387,9 @@ public:
         mlir::pto::verifyAndPatchVFSIMTSize(
             *module, rawVectorObjPath, patchedVectorObjPath,
             vfsimtSizeFixMode, diagOS);
-    if (failed(result))
+    if (failed(result)) {
       return false;
+    }
     vectorObjPath = std::move(result->objectPath);
     return true;
   }
@@ -369,10 +397,12 @@ public:
   bool mergeDeviceObjects(const mlir::pto::CANNToolchain &toolchain,
                           llvm::raw_ostream &diagOS) {
     llvm::SmallVector<std::string, 2> deviceObjPaths;
-    if (!cubeObjPath.empty())
+    if (!cubeObjPath.empty()) {
       deviceObjPaths.push_back(cubeObjPath);
-    if (!vectorObjPath.empty())
+    }
+    if (!vectorObjPath.empty()) {
       deviceObjPaths.push_back(vectorObjPath);
+    }
     if (deviceObjPaths.empty()) {
       diagOS << "Error: VPTO fatobj emission requires at least one device module.\n";
       return false;
@@ -454,8 +484,9 @@ static bool runCommandWithStderr(llvm::StringRef program,
                                  std::optional<llvm::StringRef> stdinPath) {
   llvm::SmallVector<llvm::StringRef, 16> args;
   args.reserve(ownedArgs.size());
-  for (const std::string &arg : ownedArgs)
+  for (const std::string &arg : ownedArgs) {
     args.push_back(arg);
+  }
   llvm::SmallVector<std::optional<llvm::StringRef>, 3> redirects = {
       stdinPath, stderrPath, stderrPath};
 
@@ -463,18 +494,22 @@ static bool runCommandWithStderr(llvm::StringRef program,
   bool execFailed = false;
   int rc = llvm::sys::ExecuteAndWait(program, args, std::nullopt, redirects, 0,
                                      0, &execErr, &execFailed);
-  if (!execFailed && rc == 0)
+  if (!execFailed && rc == 0) {
     return true;
+  }
 
   diagOS << "Error: " << what << " failed\n";
   diagOS << "Command:";
-  for (llvm::StringRef arg : args)
+  for (llvm::StringRef arg : args) {
     diagOS << " " << arg;
+  }
   diagOS << "\n";
-  if (!execErr.empty())
+  if (!execErr.empty()) {
     diagOS << execErr << "\n";
-  if (auto buffer = llvm::MemoryBuffer::getFile(stderrPath))
+  }
+  if (auto buffer = llvm::MemoryBuffer::getFile(stderrPath)) {
     diagOS << buffer.get()->getBuffer() << "\n";
+  }
   return false;
 }
 
@@ -558,8 +593,9 @@ static bool compileCppDeviceSourceToObject(
       "-std=c++17",
       "-dc",
   };
-  for (const std::string &includeDir : toolchain.cppIncludeDirs)
+  for (const std::string &includeDir : toolchain.cppIncludeDirs) {
     args.push_back("-I" + includeDir);
+  }
   args.push_back("-c");
   args.push_back(cppPath.str());
   args.push_back("-o");
@@ -598,8 +634,9 @@ static bool compileCppDeviceSourceToFatobj(
       "-dc",
       "-c",
   };
-  for (const std::string &includeDir : toolchain.cppIncludeDirs)
+  for (const std::string &includeDir : toolchain.cppIncludeDirs) {
     args.push_back("-I" + includeDir);
+  }
   args.push_back(cppPath.str());
   args.push_back("-o");
   args.push_back(outObjPath.str());
@@ -610,14 +647,17 @@ static bool compileCppDeviceSourceToFatobj(
 
 static std::string resolveHostTargetCPU() {
   if (const char *envCPU = std::getenv("PTOAS_HOST_TARGET_CPU")) {
-    if (envCPU[0] != '\0')
+    if (envCPU[0] != '\0') {
       return std::string(envCPU);
+    }
   }
   std::string hostCPU = llvm::sys::getHostCPUName().str();
-  if (hostCPU == "cortex-x925")
+  if (hostCPU == "cortex-x925") {
     return "tsv200m";
-  if (hostCPU == "znver4" || hostCPU == "znver5")
+  }
+  if (hostCPU == "znver4" || hostCPU == "znver5") {
     return "znver3";
+  }
   return hostCPU;
 }
 
@@ -730,8 +770,9 @@ static bool mergeDeviceObjects(llvm::ArrayRef<std::string> deviceObjPaths,
                                llvm::StringRef ldLldPath,
                                llvm::StringRef stderrPath,
                                llvm::raw_ostream &diagOS) {
-  if (deviceObjPaths.empty())
+  if (deviceObjPaths.empty()) {
     return false;
+  }
 
   llvm::SmallVector<std::string, 16> args = {
       ldLldPath.str(),
@@ -740,8 +781,9 @@ static bool mergeDeviceObjects(llvm::ArrayRef<std::string> deviceObjPaths,
       "-Ttext",
       "0",
   };
-  for (const std::string &path : deviceObjPaths)
+  for (const std::string &path : deviceObjPaths) {
     args.push_back(path);
+  }
   args.push_back("-o");
   args.push_back(outObjPath.str());
   args.push_back("-r");
@@ -755,8 +797,9 @@ static bool linkFatobjFiles(llvm::ArrayRef<std::string> fatobjPaths,
                             const mlir::pto::CANNToolchain &toolchain,
                             llvm::StringRef stderrPath,
                             llvm::raw_ostream &diagOS) {
-  if (fatobjPaths.empty())
+  if (fatobjPaths.empty()) {
     return false;
+  }
 
   llvm::SmallVector<std::string, 32> args = {
       toolchain.bishengPath,
@@ -766,8 +809,9 @@ static bool linkFatobjFiles(llvm::ArrayRef<std::string> fatobjPaths,
       "-o",
       outObjPath.str(),
   };
-  for (const std::string &path : fatobjPaths)
+  for (const std::string &path : fatobjPaths) {
     args.push_back(path);
+  }
 
   return runCommandWithStderr(toolchain.bishengPath, args, stderrPath, diagOS,
                               "fatobj link");
@@ -778,8 +822,9 @@ static bool linkFatobjFiles(llvm::ArrayRef<std::string> fatobjPaths,
 mlir::pto::TempFileRegistry::~TempFileRegistry() { cleanup(); }
 
 void mlir::pto::TempFileRegistry::cleanup() {
-  for (const std::string &path : paths)
+  for (const std::string &path : paths) {
     llvm::sys::fs::remove(path);
+  }
   paths.clear();
 }
 
@@ -833,8 +878,9 @@ mlir::pto::CANNToolchain::create(llvm::raw_ostream &diagOS) {
       toolchain.ascendHomePath, diagOS, toolchain.ptoIsaPath);
   toolchain.cppIncludeDirs.assign(cppIncludeDirs.begin(),
                                   cppIncludeDirs.end());
-  if (failed(toolchain.validate(diagOS)))
+  if (failed(toolchain.validate(diagOS))) {
     return std::nullopt;
+  }
   return toolchain;
 }
 
@@ -915,8 +961,9 @@ mlir::LogicalResult mlir::pto::emitCppVectorDeviceObject(
     llvm::StringRef cppSource, llvm::StringRef cppPath,
     llvm::StringRef outObjPath, const CANNToolchain &toolchain,
     llvm::StringRef stderrPath, llvm::raw_ostream &diagOS) {
-  if (failed(writeCppSource(cppSource, cppPath, diagOS)))
+  if (failed(writeCppSource(cppSource, cppPath, diagOS))) {
     return failure();
+  }
   return compileCppToDeviceObject(cppPath, outObjPath,
                                   ObjectEmissionDeviceTarget::Vector,
                                   toolchain, stderrPath, diagOS);
@@ -926,8 +973,9 @@ mlir::LogicalResult mlir::pto::emitCppCubeDeviceObject(
     llvm::StringRef cppSource, llvm::StringRef cppPath,
     llvm::StringRef outObjPath, const CANNToolchain &toolchain,
     llvm::StringRef stderrPath, llvm::raw_ostream &diagOS) {
-  if (failed(writeCppSource(cppSource, cppPath, diagOS)))
+  if (failed(writeCppSource(cppSource, cppPath, diagOS))) {
     return failure();
+  }
   return compileCppToDeviceObject(cppPath, outObjPath,
                                   ObjectEmissionDeviceTarget::Cube,
                                   toolchain, stderrPath, diagOS);
@@ -937,8 +985,9 @@ mlir::LogicalResult mlir::pto::emitCppFatobj(
     llvm::StringRef cppSource, llvm::StringRef cppPath,
     llvm::StringRef outObjPath, const CANNToolchain &toolchain,
     llvm::StringRef stderrPath, llvm::raw_ostream &diagOS) {
-  if (failed(writeCppSource(cppSource, cppPath, diagOS)))
+  if (failed(writeCppSource(cppSource, cppPath, diagOS))) {
     return failure();
+  }
   return compileCppDeviceSourceToFatobj(cppPath, outObjPath, toolchain,
                                         stderrPath, diagOS)
              ? success()
@@ -971,11 +1020,13 @@ static mlir::LogicalResult renameLLVMFunction(llvm::Module &module,
                                               llvm::StringRef sourceName,
                                               llvm::StringRef abiName,
                                               llvm::raw_ostream &diagOS) {
-  if (sourceName == abiName)
+  if (sourceName == abiName) {
     return mlir::success();
+  }
   llvm::Function *function = module.getFunction(sourceName);
-  if (!function)
+  if (!function) {
     return mlir::success();
+  }
   if (llvm::Function *existing = module.getFunction(abiName);
       existing && existing != function) {
     diagOS << "Error: cannot rename LLVM symbol '" << sourceName << "' to '"
@@ -990,14 +1041,16 @@ static mlir::LogicalResult applyVPTOLLVMABINames(llvm::Module &module,
                                                  llvm::StringRef suffix,
                                                  llvm::raw_ostream &diagOS) {
   for (llvm::Function &function : module) {
-    if (function.isDeclaration() || !function.hasExternalLinkage())
+    if (function.isDeclaration() || !function.hasExternalLinkage()) {
       continue;
+    }
     llvm::StringRef name = function.getName();
     if (name.empty() || isVPTOKernelABISymbol(name) ||
         isLegacyVPTOPublicABISymbol(name))
       continue;
-    if (failed(renameLLVMFunction(module, name, (name + suffix).str(), diagOS)))
+    if (failed(renameLLVMFunction(module, name, (name + suffix).str(), diagOS))) {
       return mlir::failure();
+    }
   }
   return mlir::success();
 }
@@ -1011,8 +1064,9 @@ mlir::LogicalResult mlir::pto::emitVPTOVectorDeviceObject(
           toolchain.vptoPublicABISuffix(ObjectEmissionDeviceTarget::Vector),
           diagOS)))
     return failure();
-  if (failed(writeLLVMModule(module, llPath, diagOS)))
+  if (failed(writeLLVMModule(module, llPath, diagOS))) {
     return failure();
+  }
   return compileDeviceLLVMToObject(llPath, outObjPath,
                                    resolveTargetCPU(module,
                                                     ObjectEmissionDeviceTarget::Vector),
@@ -1030,8 +1084,9 @@ mlir::LogicalResult mlir::pto::emitVPTOCubeDeviceObject(
           toolchain.vptoPublicABISuffix(ObjectEmissionDeviceTarget::Cube),
           diagOS)))
     return failure();
-  if (failed(writeLLVMModule(module, llPath, diagOS)))
+  if (failed(writeLLVMModule(module, llPath, diagOS))) {
     return failure();
+  }
   return compileDeviceLLVMToObject(llPath, outObjPath,
                                    resolveTargetCPU(module,
                                                     ObjectEmissionDeviceTarget::Cube),
@@ -1052,17 +1107,21 @@ mlir::LogicalResult mlir::pto::emitFatobjLLVM(
   }
 
   VPTOFatobjArtifacts artifacts(tempFiles);
-  if (!artifacts.emitStubSource(stubSource, diagOS))
+  if (!artifacts.emitStubSource(stubSource, diagOS)) {
     return failure();
-  if (!artifacts.initCommandLogs(diagOS))
+  }
+  if (!artifacts.initCommandLogs(diagOS)) {
     return failure();
-  if (!artifacts.emitCubeObject(cubeModule, toolchain, diagOS))
+  }
+  if (!artifacts.emitCubeObject(cubeModule, toolchain, diagOS)) {
     return failure();
+  }
   if (!artifacts.emitVectorObject(vectorModule, toolchain,
                                   vfsimtSizeFixMode, diagOS))
     return failure();
-  if (!artifacts.mergeDeviceObjects(toolchain, diagOS))
+  if (!artifacts.mergeDeviceObjects(toolchain, diagOS)) {
     return failure();
+  }
 
   constexpr llvm::StringLiteral targetCPU = "dav-c310";
   if (!artifacts.compileHostStubToFatobj(toolchain, moduleId, targetCPU,
@@ -1114,29 +1173,35 @@ mlir::LogicalResult mlir::pto::emitFatobjLLVMWithRuntime(
   }
 
   std::optional<CANNToolchain> toolchain = CANNToolchain::create(diagOS);
-  if (!toolchain)
+  if (!toolchain) {
     return failure();
+  }
 
   TempFileRegistry tempFiles;
   VPTOFatobjArtifacts artifacts(tempFiles);
-  if (!artifacts.emitStubSource(stubSource, diagOS))
+  if (!artifacts.emitStubSource(stubSource, diagOS)) {
     return failure();
-  if (!artifacts.initCommandLogs(diagOS))
+  }
+  if (!artifacts.initCommandLogs(diagOS)) {
     return failure();
+  }
 
-  if (!artifacts.emitCubeObject(cubeModule, *toolchain, diagOS))
+  if (!artifacts.emitCubeObject(cubeModule, *toolchain, diagOS)) {
     return failure();
+  }
   if (!artifacts.emitVectorObject(vectorModule, *toolchain,
                                   vfsimtSizeFixMode, diagOS))
     return failure();
 
-  if (!artifacts.mergeDeviceObjects(*toolchain, diagOS))
+  if (!artifacts.mergeDeviceObjects(*toolchain, diagOS)) {
     return failure();
+  }
 
   std::string moduleId = sanitizeModuleId(outputFile.getFilename());
   constexpr llvm::StringLiteral hostTargetCPU = "dav-c310";
-  if (!artifacts.compileHostStub(*toolchain, moduleId, hostTargetCPU, diagOS))
+  if (!artifacts.compileHostStub(*toolchain, moduleId, hostTargetCPU, diagOS)) {
     return failure();
+  }
 
   if (!artifacts.repackFatObj(*toolchain, moduleId, hostTargetCPU,
                               outputFile.getFilename(), diagOS))

--- a/tools/ptoas/VFSIMTSizePatcher.cpp
+++ b/tools/ptoas/VFSIMTSizePatcher.cpp
@@ -112,8 +112,9 @@ template <typename T>
 static std::optional<T> takeExpected(llvm::Expected<T> value,
                                      llvm::raw_ostream &diagOS,
                                      const llvm::Twine &context) {
-  if (value)
+  if (value) {
     return std::move(*value);
+  }
   diagOS << "Error: VF_SIMT size patch: " << context << ": "
          << llvm::toString(value.takeError()) << "\n";
   return std::nullopt;
@@ -123,8 +124,9 @@ static bool functionContainsInlineAsm(const llvm::Function &function) {
   for (const llvm::BasicBlock &block : function) {
     for (const llvm::Instruction &instruction : block) {
       const auto *call = llvm::dyn_cast<llvm::CallBase>(&instruction);
-      if (call && call->isInlineAsm())
+      if (call && call->isInlineAsm()) {
         return true;
+      }
     }
   }
   return false;
@@ -147,8 +149,9 @@ collectManifest(llvm::Module &module, llvm::raw_ostream &diagOS) {
     for (llvm::BasicBlock &block : caller) {
       for (llvm::Instruction &instruction : block) {
         auto *call = llvm::dyn_cast<llvm::CallBase>(&instruction);
-        if (!call || call->getCallingConv() != llvm::CallingConv::SimtEntry)
+        if (!call || call->getCallingConv() != llvm::CallingConv::SimtEntry) {
           continue;
+        }
         llvm::Function *callee = call->getCalledFunction();
         if (!callee || callee->isDeclaration()) {
           emitError(diagOS,
@@ -188,10 +191,12 @@ readFunctions(const llvm::object::ELFObjectFileBase &object,
   unsigned symbolTables = 0;
   for (const llvm::object::SectionRef &section : object.sections()) {
     llvm::object::ELFSectionRef elfSection(section);
-    if (elfSection.getType() == llvm::ELF::SHT_SYMTAB)
+    if (elfSection.getType() == llvm::ELF::SHT_SYMTAB) {
       ++symbolTables;
-    if ((elfSection.getFlags() & llvm::ELF::SHF_EXECINSTR) == 0)
+    }
+    if ((elfSection.getFlags() & llvm::ELF::SHF_EXECINSTR) == 0) {
       continue;
+    }
     ++executableSections;
   }
   if (symbolTables != 1) {
@@ -207,22 +212,26 @@ readFunctions(const llvm::object::ELFObjectFileBase &object,
   }
 
   for (const llvm::object::ELFSymbolRef symbol : object.symbols()) {
-    if (symbol.getELFType() != llvm::ELF::STT_FUNC)
+    if (symbol.getELFType() != llvm::ELF::STT_FUNC) {
       continue;
+    }
     auto name =
         takeExpected(symbol.getName(), diagOS, "failed to read symbol name");
-    if (!name)
+    if (!name) {
       return failure();
-    if (!requiredFunctions.contains(*name))
+    }
+    if (!requiredFunctions.contains(*name)) {
       continue;
+    }
     auto address =
         takeExpected(symbol.getAddress(), diagOS,
                      llvm::Twine("failed to read address for '") + *name + "'");
     auto sectionIt =
         takeExpected(symbol.getSection(), diagOS,
                      llvm::Twine("failed to read section for '") + *name + "'");
-    if (!address || !sectionIt)
+    if (!address || !sectionIt) {
       return failure();
+    }
     if (*sectionIt == object.section_end()) {
       emitError(diagOS, llvm::Twine("function '") + *name + "' is undefined");
       return failure();
@@ -263,8 +272,9 @@ static bool isVFSIMT(uint64_t instruction) {
 static std::optional<uint16_t>
 decodeMOVKChunk(uint32_t instruction, unsigned chunk, unsigned targetRegister) {
   constexpr uint32_t kNop = 0x41400000;
-  if (instruction == kNop)
+  if (instruction == kNop) {
     return 0;
+  }
 
   constexpr uint32_t kMOVKFixedMask = 0xffc10000;
   const uint32_t expected = chunk == 1 ? 0x07410000 : 0x07810000;
@@ -292,8 +302,9 @@ static std::optional<uint64_t> decodeTargetAddress(StringRef bytes,
   // targetRegister comes from the VF_SIMT encoding. The sequence computes:
   //   target PC = address of MOV PC + sign_extend(relativeWords) * 4.
   // Reject any other sequence instead of guessing its target.
-  if (instructionOffset < 24)
+  if (instructionOffset < 24) {
     return std::nullopt;
+  }
   // Follow the register named by VF_SIMT back through MOVI/MOVK/SHLI/ADD.
   const unsigned targetRegister =
       (instruction >> kVFSIMTRegisterShift) & kScalarRegisterMask;
@@ -327,13 +338,15 @@ static std::optional<uint64_t> decodeTargetAddress(StringRef bytes,
   const unsigned pcRegister =
       (movPc >> kScalarDestinationShift) & kScalarRegisterMask;
   const unsigned addSourceRegister = (add >> 7) & kScalarRegisterMask;
-  if (pcRegister != addSourceRegister)
+  if (pcRegister != addSourceRegister) {
     return std::nullopt;
+  }
 
   std::optional<uint16_t> upper1 = decodeMOVKChunk(movk1, 1, targetRegister);
   std::optional<uint16_t> upper2 = decodeMOVKChunk(movk2, 2, targetRegister);
-  if (!upper1 || !upper2)
+  if (!upper1 || !upper2) {
     return std::nullopt;
+  }
 
   // MOVI and the optional MOVK instructions form a signed 48-bit word offset.
   const uint64_t encodedRelativeWords = (movi & 0xffff) |
@@ -346,8 +359,9 @@ static std::optional<uint64_t> decodeTargetAddress(StringRef bytes,
   const int64_t byteOffset = relativeWords * kInstructionBytes;
   if (byteOffset < 0) {
     const uint64_t magnitude = static_cast<uint64_t>(-byteOffset);
-    if (magnitude > pcAddress)
+    if (magnitude > pcAddress) {
       return std::nullopt;
+    }
     return pcAddress - magnitude;
   }
   if (static_cast<uint64_t>(byteOffset) >
@@ -375,8 +389,9 @@ decodeCallSites(const ELFFunction &caller, StringRef objectBytes,
        offset += kInstructionBytes) {
     uint64_t instruction = llvm::support::endian::read64le(
         reinterpret_cast<const uint8_t *>(bytes.data() + offset));
-    if (!isVFSIMT(instruction))
+    if (!isVFSIMT(instruction)) {
       continue;
+    }
     std::optional<uint64_t> target =
         decodeTargetAddress(bytes, caller.address, offset, instruction);
     if (!target) {
@@ -423,8 +438,9 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
   // address. Call order alone is not sufficient proof that a patch is safe.
   llvm::DenseMap<StringRef, llvm::SmallVector<const SimtCallSite *, 4>>
       callsByCaller;
-  for (const SimtCallSite &call : manifest)
+  for (const SimtCallSite &call : manifest) {
     callsByCaller[call.callerName].push_back(&call);
+  }
 
   llvm::SmallVector<PatchRecord, 4> plan;
   for (auto &entry : callsByCaller) {
@@ -435,8 +451,9 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
       return failure();
     }
     auto decoded = decodeCallSites(callerIt->second, objectBytes, diagOS);
-    if (failed(decoded))
+    if (failed(decoded)) {
       return failure();
+    }
     auto &calls = entry.second;
     struct ResolvedCall {
       const SimtCallSite *manifest = nullptr;
@@ -478,8 +495,9 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
     for (const DecodedCallSite &decodedCall : *decoded) {
       ResolvedCall *matched = nullptr;
       for (ResolvedCall &candidate : resolvedCalls) {
-        if (candidate.callee->address != decodedCall.targetAddress)
+        if (candidate.callee->address != decodedCall.targetAddress) {
           continue;
+        }
         if (matched && matched->callee->name != candidate.callee->name) {
           emitError(diagOS,
                     llvm::Twine("caller '") + entry.first +
@@ -487,8 +505,9 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
                         llvm::Twine::utohexstr(decodedCall.targetAddress));
           return failure();
         }
-        if (!matched)
+        if (!matched) {
           matched = &candidate;
+        }
       }
       if (!matched) {
         emitError(diagOS,
@@ -504,8 +523,9 @@ buildPatchPlan(llvm::ArrayRef<SimtCallSite> manifest,
            static_cast<uint16_t>(matched->callee->size / kInstructionBytes)});
     }
     for (const ResolvedCall &call : resolvedCalls) {
-      if (call.observed)
+      if (call.observed) {
         continue;
+      }
       emitError(diagOS, llvm::Twine("caller '") + entry.first +
                             "' has no decoded VF_SIMT callsite for callee '" +
                             call.callee->name + "'");
@@ -532,13 +552,15 @@ validateNoRelocationOverlap(const llvm::object::ELFObjectFileBase &object,
   // Reject a VF_SIMT covered by a relocation: the linker could overwrite the
   // patched instruction and invalidate the checks performed on the raw object.
   for (const llvm::object::SectionRef &section : object.sections()) {
-    if (section.relocation_begin() == section.relocation_end())
+    if (section.relocation_begin() == section.relocation_end()) {
       continue;
+    }
     auto relocatedSection =
         takeExpected(section.getRelocatedSection(), diagOS,
                      "failed to identify the section targeted by relocations");
-    if (!relocatedSection)
+    if (!relocatedSection) {
       return failure();
+    }
     if (*relocatedSection == object.section_end()) {
       emitError(diagOS, "relocation section has no target section");
       return failure();
@@ -592,11 +614,13 @@ analyzeObject(llvm::ArrayRef<SimtCallSite> manifest, StringRef objectPath,
     emitError(diagOS, "input is not an ELF object");
     return failure();
   }
-  if (failed(validateObjectHeader(*object, diagOS)))
+  if (failed(validateObjectHeader(*object, diagOS))) {
     return failure();
+  }
   auto functions = readFunctions(*object, manifest, diagOS);
-  if (failed(functions))
+  if (failed(functions)) {
     return failure();
+  }
   auto plan = buildPatchPlan(manifest, *functions, buffer->getBuffer(), diagOS);
   if (failed(plan) ||
       failed(validateNoRelocationOverlap(*object, *plan, diagOS)))
@@ -627,8 +651,9 @@ static LogicalResult validatePatchedBytes(StringRef rawBytes,
     }
   }
   for (size_t offset = 0; offset < rawBytes.size(); ++offset) {
-    if (rawBytes[offset] == patchedBytes[offset])
+    if (rawBytes[offset] == patchedBytes[offset]) {
       continue;
+    }
     if (!llvm::any_of(plan, [offset](const PatchRecord &record) {
           return offset >= record.decoded.fileOffset &&
                  offset < record.decoded.fileOffset + sizeof(uint64_t);
@@ -674,20 +699,23 @@ FailureOr<VFSIMTSizePatchResult> mlir::pto::verifyAndPatchVFSIMTSize(
   // output when any callsite is unsafe or inconsistent.
   VFSIMTSizePatchResult result;
   result.objectPath = rawObjectPath.str();
-  if (mode == VFSIMTSizeFixMode::Off)
+  if (mode == VFSIMTSizeFixMode::Off) {
     return result;
+  }
 
   auto manifest = collectManifest(module, diagOS);
-  if (failed(manifest))
+  if (failed(manifest)) {
     return failure();
+  }
   if (manifest->empty()) {
     diagOS << "PTOAS: VF_SIMT size verification passed; no patch required\n";
     return result;
   }
 
   auto analysis = analyzeObject(*manifest, rawObjectPath, diagOS);
-  if (failed(analysis))
+  if (failed(analysis)) {
     return failure();
+  }
 
   std::string patchedBytes = analysis->buffer->getBuffer().str();
   for (const PatchRecord &record : analysis->plan) {
@@ -749,8 +777,9 @@ FailureOr<VFSIMTSizePatchResult> mlir::pto::verifyAndPatchVFSIMTSize(
   if (failed(validatePatchedBytes(analysis->buffer->getBuffer(), patchedBytes,
                                   analysis->plan, diagOS)))
     return failure();
-  if (failed(writePatchedObject(patchedObjectPath, patchedBytes, diagOS)))
+  if (failed(writePatchedObject(patchedObjectPath, patchedBytes, diagOS))) {
     return failure();
+  }
 
   auto writtenBuffer = llvm::MemoryBuffer::getFile(patchedObjectPath);
   if (!writtenBuffer || writtenBuffer.get()->getBuffer() != patchedBytes) {
@@ -787,8 +816,9 @@ FailureOr<VFSIMTSizePatchResult> mlir::pto::verifyAndPatchVFSIMTSize(
   }
 
   for (const PatchRecord &record : analysis->plan) {
-    if (record.decoded.codeSize != kInvalidVFSIMTSize)
+    if (record.decoded.codeSize != kInvalidVFSIMTSize) {
       continue;
+    }
     diagOS << "PTOAS: patched VF_SIMT size\n"
            << "  caller: " << record.manifest->callerName << "\n"
            << "  callee: " << record.manifest->calleeName << "\n"

--- a/tools/ptoas/VPTOHostStubEmission.cpp
+++ b/tools/ptoas/VPTOHostStubEmission.cpp
@@ -26,16 +26,19 @@ struct VPTOKernelStubDecl {
 };
 
 static std::string getLogicalKernelName(llvm::StringRef symbol) {
-  if (symbol.ends_with("_mix_aiv"))
+  if (symbol.ends_with("_mix_aiv")) {
     return symbol.drop_back(strlen("_mix_aiv")).str();
-  if (symbol.ends_with("_mix_aic"))
+  }
+  if (symbol.ends_with("_mix_aic")) {
     return symbol.drop_back(strlen("_mix_aic")).str();
+  }
   return symbol.str();
 }
 
 static std::string getStubScalarCType(Type type) {
-  if (isa<IndexType>(type))
+  if (isa<IndexType>(type)) {
     return "long long";
+  }
   if (auto intType = dyn_cast<IntegerType>(type)) {
     switch (intType.getWidth()) {
     case 1:
@@ -52,18 +55,21 @@ static std::string getStubScalarCType(Type type) {
     }
   }
   if (auto floatType = dyn_cast<FloatType>(type)) {
-    if (floatType.isF32())
+    if (floatType.isF32()) {
       return "float";
-    if (floatType.isF64())
+    }
+    if (floatType.isF64()) {
       return "double";
+    }
     return "short";
   }
   return "long long";
 }
 
 static std::string getStubCType(Type type) {
-  if (isa<pto::PtrType, MemRefType>(type))
+  if (isa<pto::PtrType, MemRefType>(type)) {
     return "__gm__ void *";
+  }
   return getStubScalarCType(type);
 }
 
@@ -77,14 +83,16 @@ static LogicalResult collectVPTOKernelStubDecls(
 
   for (ModuleOp module : modules) {
     module.walk([&](func::FuncOp func) {
-      if (!pto::isPTOEntryFunction(func))
+      if (!pto::isPTOEntryFunction(func)) {
         return;
+      }
 
       std::string logicalName = getLogicalKernelName(func.getSymName());
       SmallVector<std::string> argTypes;
       argTypes.reserve(func.getNumArguments());
-      for (Type type : func.getArgumentTypes())
+      for (Type type : func.getArgumentTypes()) {
         argTypes.push_back(getStubCType(type));
+      }
 
       auto [it, inserted] =
           logicalNameToIndex.try_emplace(logicalName, decls.size());
@@ -115,8 +123,9 @@ LogicalResult mlir::pto::emitVPTOHostStubSource(ArrayRef<ModuleOp> modules,
                                                 std::string &stubSource,
                                                 llvm::raw_ostream &diagOS) {
   SmallVector<VPTOKernelStubDecl> stubDecls;
-  if (failed(collectVPTOKernelStubDecls(modules, stubDecls, diagOS)))
+  if (failed(collectVPTOKernelStubDecls(modules, stubDecls, diagOS))) {
     return failure();
+  }
 
   if (stubDecls.empty()) {
     diagOS << "Error: no PTO entry functions found for host stub emission.\n";
@@ -129,8 +138,9 @@ LogicalResult mlir::pto::emitVPTOHostStubSource(ArrayRef<ModuleOp> modules,
   for (const VPTOKernelStubDecl &decl : stubDecls) {
     os << "extern \"C\" __global__ AICORE void " << decl.logicalName << "(";
     for (size_t i = 0; i < decl.argTypes.size(); ++i) {
-      if (i)
+      if (i) {
         os << ", ";
+      }
       os << decl.argTypes[i] << " arg" << i;
     }
     os << ") {}\n";

--- a/tools/ptoas/driver.cpp
+++ b/tools/ptoas/driver.cpp
@@ -68,8 +68,9 @@ static bool parseRequestedOutputCANNVersion(
     llvm::StringRef versionText, std::optional<mlir::pto::CANNVersion> &version,
     llvm::raw_ostream &diagOS) {
   version.reset();
-  if (versionText.empty())
+  if (versionText.empty()) {
     return true;
+  }
   std::optional<mlir::pto::CANNVersion> parsed =
       mlir::pto::parseCANNVersion(versionText);
   if (!parsed) {
@@ -91,16 +92,18 @@ static bool hasCLIOption(int argc, char **argv, llvm::StringRef option) {
   const std::string optionWithValue = (option + "=").str();
   for (int i = 1; i < argc; ++i) {
     llvm::StringRef arg(argv[i]);
-    if (arg == option || arg.starts_with(optionWithValue))
+    if (arg == option || arg.starts_with(optionWithValue)) {
       return true;
+    }
   }
   return false;
 }
 
 static std::string normalizePTOASArch(llvm::StringRef archValue) {
   std::string normalized = archValue.str();
-  for (char &c : normalized)
+  for (char &c : normalized) {
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
   return normalized;
 }
 
@@ -113,8 +116,9 @@ detectPTOASTextualModuleArch(llvm::StringRef text) {
   llvm::SmallVector<llvm::StringRef, 4> matches;
   llvm::Regex archRegex(
       R"ptoarch("?(pto\.target_arch)"?[[:space:]]*=[[:space:]]*"([[:alpha:][:digit:]_]+)")ptoarch");
-  if (!archRegex.match(text, &matches) || matches.size() < 3)
+  if (!archRegex.match(text, &matches) || matches.size() < 3) {
     return std::nullopt;
+  }
   return normalizePTOASArch(matches[2]);
 }
 
@@ -144,10 +148,12 @@ static bool resolveTextInputArch(llvm::StringRef buffer, bool cliArchSpecified,
     return true;
   }
 
-  if (auto detectedArch = detectPTOASTextualModuleArch(buffer))
+  if (auto detectedArch = detectPTOASTextualModuleArch(buffer)) {
     arch = *detectedArch;
-  if (!isSupportedPTOASArch(arch))
+  }
+  if (!isSupportedPTOASArch(arch)) {
     arch = "a3";
+  }
   return true;
 }
 
@@ -164,8 +170,9 @@ static OwningOpRef<ModuleOp> decodePTOBCModule(llvm::StringRef buffer,
   }
 #else
   OwningOpRef<ModuleOp> module = ptobc::decodePTOBCToModule(bytes, context);
-  if (!module)
+  if (!module) {
     llvm::errs() << "Error: Failed to decode PTOBC.\n";
+  }
   return module;
 #endif
 }
@@ -238,14 +245,16 @@ loadInputModule(std::unique_ptr<llvm::MemoryBuffer> inputBuffer,
     if (isSupportedPTOASArch(moduleArch)) {
       arch = std::move(moduleArch);
     } else {
-      if (!isSupportedPTOASArch(arch))
+      if (!isSupportedPTOASArch(arch)) {
         arch = "a3";
+      }
       moduleOp->setAttr("pto.target_arch",
                         mlir::StringAttr::get(moduleOp->getContext(), arch));
     }
   } else {
-    if (!isSupportedPTOASArch(arch))
+    if (!isSupportedPTOASArch(arch)) {
       arch = "a3";
+    }
     moduleOp->setAttr("pto.target_arch",
                       mlir::StringAttr::get(moduleOp->getContext(), arch));
   }
@@ -260,8 +269,9 @@ loadInputModule(std::unique_ptr<llvm::MemoryBuffer> inputBuffer,
 static bool parseDriverBackend(llvm::StringRef backendStr,
                                mlir::pto::PTOBackend &out) {
   std::string s = backendStr.str();
-  for (char &c : s)
+  for (char &c : s) {
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
   if (s == "emitc") {
     out = mlir::pto::PTOBackend::EmitC;
     return true;
@@ -278,8 +288,9 @@ parseDriverBackendAttr(Operation *op,
                        std::optional<mlir::pto::PTOBackend> &backend) {
   backend = std::nullopt;
   Attribute rawBackendAttr = op->getAttr("pto.backend");
-  if (!rawBackendAttr)
+  if (!rawBackendAttr) {
     return success();
+  }
 
   auto backendAttr = dyn_cast<StringAttr>(rawBackendAttr);
   if (!backendAttr) {
@@ -299,8 +310,9 @@ parseDriverBackendAttr(Operation *op,
 
 static bool isBackendPartitionedContainer(ModuleOp module) {
   Block *body = module.getBody();
-  if (!body)
+  if (!body) {
     return false;
+  }
   return llvm::all_of(body->getOperations(),
                       [](Operation &op) { return isa<ModuleOp>(op); });
 }
@@ -333,11 +345,13 @@ static SmallVector<StringRef> collectDirectCalleeNames(ModuleOp module) {
 
 static SmallVector<StringRef> collectDirectCalleeNames(func::FuncOp funcOp) {
   SmallVector<StringRef> names;
-  if (!funcOp || funcOp.isDeclaration())
+  if (!funcOp || funcOp.isDeclaration()) {
     return names;
+  }
   funcOp.walk([&](func::CallOp callOp) {
-    if (callOp->getParentOfType<func::FuncOp>() != funcOp)
+    if (callOp->getParentOfType<func::FuncOp>() != funcOp) {
       return;
+    }
     names.push_back(callOp.getCalleeAttr().getLeafReference());
   });
   llvm::sort(names);
@@ -358,8 +372,9 @@ static void copyModuleAttrsToJobModule(ModuleOp source, ModuleOp jobModule) {
 static func::FuncOp findFunctionByLogicalName(ModuleOp module,
                                               StringRef logicalName) {
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
-    if (funcOp.getSymName() == logicalName)
+    if (funcOp.getSymName() == logicalName) {
       return funcOp;
+    }
   }
   return {};
 }
@@ -372,19 +387,23 @@ static func::FuncOp findFunctionBySymbolName(ModuleOp module,
 
 static func::FuncOp findFunctionForPeerReference(ModuleOp module,
                                                  StringRef peerRef) {
-  if (func::FuncOp exact = findFunctionBySymbolName(module, peerRef))
+  if (func::FuncOp exact = findFunctionBySymbolName(module, peerRef)) {
     return exact;
+  }
 
   func::FuncOp privateMatch;
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
-    if (mlir::pto::getPTODSLLogicalNameOrSymbolName(funcOp) != peerRef)
+    if (mlir::pto::getPTODSLLogicalNameOrSymbolName(funcOp) != peerRef) {
       continue;
+    }
 
     auto visibility = funcOp->getAttrOfType<StringAttr>("sym_visibility");
-    if (!visibility || visibility.getValue() != "private")
+    if (!visibility || visibility.getValue() != "private") {
       return funcOp;
-    if (!privateMatch)
+    }
+    if (!privateMatch) {
       privateMatch = funcOp;
+    }
   }
   return privateMatch;
 }
@@ -396,12 +415,14 @@ findSiblingSourceFunction(ModuleOp outer, ModuleOp targetChild,
   SmallVector<func::FuncOp> exactMatches;
   SmallVector<func::FuncOp> logicalMatches;
   for (ModuleOp child : outer.getOps<ModuleOp>()) {
-    if (child == targetChild)
+    if (child == targetChild) {
       continue;
+    }
     for (func::FuncOp funcOp : child.getOps<func::FuncOp>()) {
       auto visibility = funcOp->getAttrOfType<StringAttr>("sym_visibility");
-      if (visibility && visibility.getValue() == "private")
+      if (visibility && visibility.getValue() == "private") {
         continue;
+      }
       if (funcOp.getSymName() == symbolName) {
         exactMatches.push_back(funcOp);
         continue;
@@ -418,8 +439,9 @@ findSiblingSourceFunction(ModuleOp outer, ModuleOp targetChild,
         << "'; found multiple sibling public func.func definitions";
     return failure();
   }
-  if (!exactMatches.empty())
+  if (!exactMatches.empty()) {
     return exactMatches.front();
+  }
 
   if (logicalMatches.size() > 1) {
     targetChild.emitError("mixed-backend child assembly does not yet support ambiguous cross-child logical ")
@@ -427,16 +449,18 @@ findSiblingSourceFunction(ModuleOp outer, ModuleOp targetChild,
         << "'; found multiple sibling public func.func definitions";
     return failure();
   }
-  if (!logicalMatches.empty())
+  if (!logicalMatches.empty()) {
     return logicalMatches.front();
+  }
   return func::FuncOp();
 }
 
 static LogicalResult verifyImportedPeerCloneContract(func::FuncOp peerSource,
                                                      StringRef logicalName) {
   SmallVector<StringRef> directCalleeNames = collectDirectCalleeNames(peerSource);
-  if (directCalleeNames.empty())
+  if (directCalleeNames.empty()) {
     return success();
+  }
 
   peerSource.emitError(
       "mixed-backend child assembly does not yet support transitive cross-child function closure for imported peer '")
@@ -468,18 +492,21 @@ static func::FuncOp cloneFunctionDeclarationIntoModule(ModuleOp jobModule,
                                                        StringRef visibility) {
   func::FuncOp cloned =
       cloneFunctionIntoModule(jobModule, sourceFunc, newName, visibility);
-  while (!cloned.getBody().empty())
+  while (!cloned.getBody().empty()) {
     cloned.getBody().front().erase();
+  }
   return cloned;
 }
 
 static void rewriteExportedFunctionToLogicalWrapper(func::FuncOp exportedFunc,
                                                     StringRef logicalName) {
-  if (logicalName == exportedFunc.getSymName())
+  if (logicalName == exportedFunc.getSymName()) {
     return;
+  }
 
-  while (!exportedFunc.getBody().empty())
+  while (!exportedFunc.getBody().empty()) {
     exportedFunc.getBody().front().erase();
+  }
   Block *entry = exportedFunc.addEntryBlock();
   OpBuilder builder(entry, entry->begin());
 
@@ -497,16 +524,18 @@ verifyInChildLogicalWrapperAmbiguity(ModuleOp targetChild,
     auto kernelKindAttr =
         exportedFunc->getAttrOfType<mlir::pto::FunctionKernelKindAttr>(
             mlir::pto::FunctionKernelKindAttr::name);
-    if (kernelKindAttr)
+    if (kernelKindAttr) {
       continue;
+    }
     StringRef logicalName =
         mlir::pto::getPTODSLLogicalNameOrSymbolName(exportedFunc);
     grouped[logicalName].push_back(exportedFunc);
   }
 
   for (const auto &entry : grouped) {
-    if (entry.second.size() <= 1)
+    if (entry.second.size() <= 1) {
       continue;
+    }
     targetChild.emitError(
         "mixed-backend child assembly does not yet support ambiguous in-child logical reference '@")
         << entry.first
@@ -528,14 +557,16 @@ buildBackendChildCompileUnit(ModuleOp outer, ModuleOp targetChild) {
 
   SmallVector<StringRef> directCalleeNames = collectDirectCalleeNames(targetChild);
   for (StringRef calleeName : directCalleeNames) {
-    if (findFunctionByLogicalName(jobModule, calleeName))
+    if (findFunctionByLogicalName(jobModule, calleeName)) {
       continue;
+    }
     FailureOr<func::FuncOp> siblingSourceOr =
         findSiblingSourceFunction(outer, targetChild, calleeName,
                                   /*allowLogicalNameMatch=*/false,
                                   /*referenceKind=*/"function reference");
-    if (failed(siblingSourceOr))
+    if (failed(siblingSourceOr)) {
       return failure();
+    }
     func::FuncOp siblingSource = *siblingSourceOr;
     if (!siblingSource) {
       targetChild.emitError(
@@ -552,22 +583,26 @@ buildBackendChildCompileUnit(ModuleOp outer, ModuleOp targetChild) {
   SmallVector<func::FuncOp> exportedFuncs;
   for (func::FuncOp funcOp : jobModule.getOps<func::FuncOp>()) {
     auto visibility = funcOp->getAttrOfType<StringAttr>("sym_visibility");
-    if (visibility && visibility.getValue() == "private")
+    if (visibility && visibility.getValue() == "private") {
       continue;
-    if (funcOp.isExternal())
+    }
+    if (funcOp.isExternal()) {
       continue;
+    }
     exportedFuncs.push_back(funcOp);
   }
-  if (failed(verifyInChildLogicalWrapperAmbiguity(targetChild, exportedFuncs)))
+  if (failed(verifyInChildLogicalWrapperAmbiguity(targetChild, exportedFuncs))) {
     return failure();
+  }
   for (func::FuncOp exportedFunc : exportedFuncs) {
     StringRef logicalName =
         mlir::pto::getPTODSLLogicalNameOrSymbolName(exportedFunc);
     auto kernelKindAttr =
         exportedFunc->getAttrOfType<mlir::pto::FunctionKernelKindAttr>(
             mlir::pto::FunctionKernelKindAttr::name);
-    if (kernelKindAttr)
+    if (kernelKindAttr) {
       continue;
+    }
     if (!findFunctionByLogicalName(jobModule, logicalName)) {
       cloneFunctionIntoModule(jobModule, exportedFunc, logicalName, "private");
     }
@@ -579,8 +614,9 @@ buildBackendChildCompileUnit(ModuleOp outer, ModuleOp targetChild) {
         findSiblingSourceFunction(outer, targetChild, logicalName,
                                   /*allowLogicalNameMatch=*/true,
                                   /*referenceKind=*/"peer_func reference");
-    if (failed(peerSourceOr))
+    if (failed(peerSourceOr)) {
       return failure();
+    }
     func::FuncOp peerSource = *peerSourceOr;
     if (!peerSource) {
       targetChild.emitError(
@@ -589,16 +625,19 @@ buildBackendChildCompileUnit(ModuleOp outer, ModuleOp targetChild) {
           << "'; each import_reserved_buffer peer_func must resolve to one sibling public func.func";
       return failure();
     }
-    if (failed(verifyImportedPeerCloneContract(peerSource, logicalName)))
+    if (failed(verifyImportedPeerCloneContract(peerSource, logicalName))) {
       return failure();
+    }
 
     StringRef peerSymbolName = peerSource.getSymName();
-    if (!findFunctionBySymbolName(jobModule, peerSymbolName))
+    if (!findFunctionBySymbolName(jobModule, peerSymbolName)) {
       cloneFunctionIntoModule(jobModule, peerSource, peerSymbolName, "private");
+    }
 
     jobModule.walk([&](pto::ImportReservedBufferOp importOp) {
-      if (importOp.getPeerFuncAttr().getValue() != logicalName)
+      if (importOp.getPeerFuncAttr().getValue() != logicalName) {
         return;
+      }
       importOp.setPeerFuncAttr(
           FlatSymbolRefAttr::get(jobModule.getContext(), peerSymbolName));
     });
@@ -607,10 +646,12 @@ buildBackendChildCompileUnit(ModuleOp outer, ModuleOp targetChild) {
   jobModule.walk([&](pto::ImportReservedBufferOp importOp) {
     StringRef peerRef = importOp.getPeerFuncAttr().getValue();
     func::FuncOp localPeer = findFunctionForPeerReference(jobModule, peerRef);
-    if (!localPeer)
+    if (!localPeer) {
       return;
-    if (localPeer.getSymName() == peerRef)
+    }
+    if (localPeer.getSymName() == peerRef) {
       return;
+    }
     importOp.setPeerFuncAttr(
         FlatSymbolRefAttr::get(jobModule.getContext(), localPeer.getSymName()));
   });
@@ -626,26 +667,31 @@ static std::string summarizeMixedChildModule(ModuleOp module) {
   std::string summary;
   llvm::raw_string_ostream os(summary);
 
-  if (auto backendAttr = module->getAttrOfType<StringAttr>("pto.backend"))
+  if (auto backendAttr = module->getAttrOfType<StringAttr>("pto.backend")) {
     os << "backend=" << backendAttr.getValue() << " ";
-  if (auto kindAttr = module->getAttrOfType<StringAttr>("pto.kernel_kind"))
+  }
+  if (auto kindAttr = module->getAttrOfType<StringAttr>("pto.kernel_kind")) {
     os << "kernel_kind=" << kindAttr.getValue() << " ";
+  }
 
   SmallVector<std::string, 4> exportedNames;
   for (func::FuncOp funcOp : module.getOps<func::FuncOp>()) {
     auto visibility = funcOp->getAttrOfType<StringAttr>("sym_visibility");
-    if (visibility && visibility.getValue() == "private")
+    if (visibility && visibility.getValue() == "private") {
       continue;
-    if (funcOp.isExternal())
+    }
+    if (funcOp.isExternal()) {
       continue;
+    }
     exportedNames.push_back(funcOp.getSymName().str());
   }
 
   if (!exportedNames.empty()) {
     os << "exports=[";
     for (size_t i = 0; i < exportedNames.size(); ++i) {
-      if (i)
+      if (i) {
         os << ", ";
+      }
       os << exportedNames[i];
     }
     os << "]";
@@ -693,8 +739,9 @@ mlir::pto::PTOASContext::~PTOASContext() = default;
 LogicalResult
 mlir::pto::PTOASContext::initializeEnvironment(bool requiresToolchain,
                                                llvm::raw_ostream &diagOS) {
-  if (requiresToolchain)
+  if (requiresToolchain) {
     return initializeToolchain(diagOS);
+  }
   return success();
 }
 
@@ -750,12 +797,14 @@ std::string mlir::pto::PTOASContext::allocModuleId() {
 
 LogicalResult
 mlir::pto::PTOASContext::initializeToolchain(llvm::raw_ostream &diagOS) {
-  if (toolchain)
+  if (toolchain) {
     return success();
+  }
   std::optional<mlir::pto::CANNToolchain> discovered =
       mlir::pto::CANNToolchain::create(diagOS);
-  if (!discovered)
+  if (!discovered) {
     return failure();
+  }
   std::optional<CANNVersion> parsedVersion =
       parseCANNVersion(discovered->cannVersionString);
   if (!parsedVersion) {
@@ -870,12 +919,14 @@ public:
     }
 
     std::string fatobjPath;
-    if (failed(context.createTempPath("ptoas-emitc-fatobj", ".o", fatobjPath)))
+    if (failed(context.createTempPath("ptoas-emitc-fatobj", ".o", fatobjPath))) {
       return failure();
+    }
     const mlir::pto::CANNToolchain *toolchain =
         context.getToolchain(llvm::errs());
-    if (!toolchain)
+    if (!toolchain) {
       return failure();
+    }
     if (failed(mlir::pto::emitFatobjCCE(
             jobResult.textOutput, fatobjPath, *toolchain,
             context.getTempFiles(), llvm::errs()))) {
@@ -922,8 +973,9 @@ public:
     }
 
     std::string fatobjPath;
-    if (failed(context.createTempPath("ptoas-vpto-fatobj", ".o", fatobjPath)))
+    if (failed(context.createTempPath("ptoas-vpto-fatobj", ".o", fatobjPath))) {
       return failure();
+    }
 
     if (failed(emitVPTOLLVMFatobj(jobResult, context, moduleId, fatobjPath))) {
       dumpFailedMixedChildCompileUnit("vpto", summary, op);
@@ -954,12 +1006,14 @@ public:
     }
 
     std::string stderrPath;
-    if (failed(context.createTempPath("ptoas-fatobj", ".log", stderrPath)))
+    if (failed(context.createTempPath("ptoas-fatobj", ".log", stderrPath))) {
       return failure();
+    }
     const mlir::pto::CANNToolchain *toolchain =
         context.getToolchain(llvm::errs());
-    if (!toolchain)
+    if (!toolchain) {
       return failure();
+    }
     return mlir::pto::linkFatobjs(fatobjPaths, context.getOutputPath(),
                                   *toolchain, stderrPath, llvm::errs());
   }
@@ -979,8 +1033,9 @@ LogicalResult EmitCBackendJob::run(PTOASContext &context) {
       isBackendPartitionedContainer(op)) {
     FailureOr<OwningOpRef<ModuleOp>> jobModuleOr =
         buildBackendChildCompileUnit(op, children.front());
-    if (failed(jobModuleOr))
+    if (failed(jobModuleOr)) {
       return failure();
+    }
     singleChildJobModule = std::move(*jobModuleOr);
     singleChildJobModule.get()->setAttr(
         "pto.backend",
@@ -1015,8 +1070,9 @@ LogicalResult VPTOBackendJob::run(PTOASContext &context) {
       isBackendPartitionedContainer(op)) {
     FailureOr<OwningOpRef<ModuleOp>> jobModuleOr =
         buildBackendChildCompileUnit(op, children.front());
-    if (failed(jobModuleOr))
+    if (failed(jobModuleOr)) {
       return failure();
+    }
     singleChildJobModule = std::move(*jobModuleOr);
     singleChildJobModule.get()->setAttr(
         "pto.backend",
@@ -1030,8 +1086,9 @@ LogicalResult VPTOBackendJob::run(PTOASContext &context) {
           *compileUnit, context, mlir::pto::PTOBackend::VPTO, result,
           emitHostStub) != 0)
     return failure();
-  if (result.kind == mlir::pto::PTOASCompileResultKind::Text)
+  if (result.kind == mlir::pto::PTOASCompileResultKind::Text) {
     return success();
+  }
   if (result.kind != mlir::pto::PTOASCompileResultKind::VPTOObject) {
     llvm::errs() << "Error: VPTO backend job produced non-VPTO output.\n";
     return failure();
@@ -1057,13 +1114,15 @@ static LogicalResult emitVPTOLLVMFatobj(
     const mlir::pto::PTOASCompileResult &jobResult, PTOASContext &context,
     llvm::StringRef moduleId, llvm::StringRef outputPath) {
   llvm::StringRef stubSource = kEmptyHostStubSource;
-  if (!jobResult.vptoStubSource.empty())
+  if (!jobResult.vptoStubSource.empty()) {
     stubSource = jobResult.vptoStubSource;
+  }
 
   const mlir::pto::CANNToolchain *toolchain =
       context.getToolchain(llvm::errs());
-  if (!toolchain)
+  if (!toolchain) {
     return failure();
+  }
   if (failed(mlir::pto::emitFatobjLLVM(
           jobResult.vptoCubeModule.module.get(),
           jobResult.vptoVectorModule.module.get(), stubSource,
@@ -1081,13 +1140,15 @@ static LogicalResult collectChildJobs(
   SmallVector<ModuleOp, 4> children(module.getOps<ModuleOp>());
   for (ModuleOp child : children) {
     std::optional<mlir::pto::PTOBackend> childBackend;
-    if (failed(parseDriverBackendAttr(child.getOperation(), childBackend)))
+    if (failed(parseDriverBackendAttr(child.getOperation(), childBackend))) {
       return failure();
+    }
 
     FailureOr<OwningOpRef<ModuleOp>> jobModuleOr =
         buildBackendChildCompileUnit(module, child);
-    if (failed(jobModuleOr))
+    if (failed(jobModuleOr)) {
       return failure();
+    }
     OwningOpRef<ModuleOp> jobModule = std::move(*jobModuleOr);
     if (llvm::sys::Process::GetEnv("PTOAS_DEBUG_CHILD_UNIT")) {
       llvm::errs() << "// ----- child compile unit ----- //\n";
@@ -1143,8 +1204,9 @@ static LogicalResult resolveSingleBackend(
   std::optional<mlir::pto::PTOBackend> firstChildBackend;
   for (ModuleOp child : children) {
     std::optional<mlir::pto::PTOBackend> childBackend;
-    if (failed(parseDriverBackendAttr(child.getOperation(), childBackend)))
+    if (failed(parseDriverBackendAttr(child.getOperation(), childBackend))) {
       return failure();
+    }
 
     mlir::pto::PTOBackend effectiveChildBackend =
         childBackend.value_or(defaultBackend);
@@ -1152,14 +1214,17 @@ static LogicalResult resolveSingleBackend(
       firstChildBackend = effectiveChildBackend;
       continue;
     }
-    if (*firstChildBackend != effectiveChildBackend)
+    if (*firstChildBackend != effectiveChildBackend) {
       return success();
+    }
   }
 
-  if (firstChildBackend)
+  if (firstChildBackend) {
     singleBackend = *firstChildBackend;
-  else
+  }
+  else {
     singleBackend = defaultBackend;
+  }
   return success();
 }
 
@@ -1176,8 +1241,9 @@ static LogicalResult buildBackendInfo(ModuleOp module, bool cliBackendSpecified,
 
   std::optional<mlir::pto::PTOBackend> moduleBackend;
   if (!cliBackendSpecified) {
-    if (failed(parseDriverBackendAttr(module.getOperation(), moduleBackend)))
+    if (failed(parseDriverBackendAttr(module.getOperation(), moduleBackend))) {
       return failure();
+    }
   }
 
   if (failed(resolveSingleBackend(cliBackendSpecified, moduleBackend,
@@ -1234,13 +1300,15 @@ static LogicalResult runPTOASJobs(OwningOpRef<ModuleOp> &module,
   result.kind = mlir::pto::PTOASCompileResultKind::MixedObject;
 
   for (size_t i = 0, e = backendJobs.size(); i < e; ++i) {
-    if (failed(backendJobs[i]->run(context)))
+    if (failed(backendJobs[i]->run(context))) {
       return failure();
+    }
   }
 
   FatobjLinkJob linkJob(fatobjPaths);
-  if (failed(linkJob.run(context)))
+  if (failed(linkJob.run(context))) {
     return failure();
+  }
 
   return success();
 }
@@ -1277,8 +1345,9 @@ static int runPTOASDriver(int argc, char **argv,
                           MLIRContext *borrowedContext = nullptr) {
   DialectRegistry registry;
   mlir::pto::registerPTOASDialects(registry);
-  if (borrowedContext)
+  if (borrowedContext) {
     borrowedContext->appendDialectRegistry(registry);
+  }
   mlir::pto::registerPTOASPassesAndCLOptions();
   llvm::cl::SetVersionPrinter(printPTOASVersion);
 
@@ -1311,31 +1380,37 @@ static int runPTOASDriver(int argc, char **argv,
   context->initializeMLIRContext();
 
   std::unique_ptr<llvm::MemoryBuffer> inputBuffer = readInputBuffer();
-  if (!inputBuffer)
+  if (!inputBuffer) {
     return 1;
+  }
 
   std::string arch;
   OwningOpRef<ModuleOp> module = loadInputModule(
       std::move(inputBuffer), context->getMLIRContext(), cliArchSpecified, arch);
-  if (!module)
+  if (!module) {
     return 1;
+  }
   context->setArch(std::move(arch));
 
   mlir::pto::BackendInfo backendInfo;
-  if (failed(buildBackendInfo(module.get(), cliBackendSpecified, backendInfo)))
+  if (failed(buildBackendInfo(module.get(), cliBackendSpecified, backendInfo))) {
     return 1;
+  }
   context->setBackendInfo(std::move(backendInfo));
   (void)context->initializeEnvironment(
       context->getBackendInfo().requiresToolchain, llvm::errs());
 
   mlir::pto::PTOASCompileResult result;
-  if (failed(runPTOASJobs(module, *context, result)))
+  if (failed(runPTOASJobs(module, *context, result))) {
     return 1;
+  }
 
-  if (result.kind == mlir::pto::PTOASCompileResultKind::Text)
+  if (result.kind == mlir::pto::PTOASCompileResultKind::Text) {
     return failed(writeTextOutput(result.textOutput, context->getOutputPath()));
-  if (result.kind == mlir::pto::PTOASCompileResultKind::MixedObject)
+  }
+  if (result.kind == mlir::pto::PTOASCompileResultKind::MixedObject) {
     return 0;
+  }
 
   llvm::errs() << "Error: unsupported ptoas compile result.\n";
   return 1;

--- a/tools/ptoas/ptoas.cpp
+++ b/tools/ptoas/ptoas.cpp
@@ -77,7 +77,7 @@
 #include <thread>
 #include <chrono>
 #include <unistd.h>
-#include <signal.h>
+#include <csignal>
 #include <sys/types.h>
 
 extern "C" {
@@ -116,15 +116,17 @@ struct ApplySIMTEntryNoInlinePass final
 
   void runOnOperation() final {
     for (func::FuncOp func : getOperation().getOps<func::FuncOp>())
-      if (func->hasAttr(pto::kPTOSimtEntryAttrName))
+      if (func->hasAttr(pto::kPTOSimtEntryAttrName)) {
         func.setNoInline(true);
+      }
   }
 };
 
 static std::string normalizeArch(llvm::StringRef arch) {
   std::string normalized = arch.str();
-  for (char &c : normalized)
+  for (char &c : normalized) {
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
   return normalized;
 }
 
@@ -140,37 +142,44 @@ static bool isSupportedPTOASTargetArch(llvm::StringRef arch) {
 
 static std::optional<std::string> getModuleTargetArchAttr(ModuleOp module) {
   auto attr = module->getAttrOfType<mlir::StringAttr>("pto.target_arch");
-  if (!attr)
+  if (!attr) {
     return std::nullopt;
+  }
   std::string arch = normalizeArch(attr.getValue());
-  if (!isSupportedPTOASTargetArch(arch))
+  if (!isSupportedPTOASTargetArch(arch)) {
     return std::nullopt;
+  }
   return arch;
 }
 
 static std::string resolveEffectiveTargetArch(ModuleOp module,
                                               llvm::StringRef fallbackArch) {
-  if (std::optional<std::string> arch = getModuleTargetArchAttr(module))
+  if (std::optional<std::string> arch = getModuleTargetArchAttr(module)) {
     return *arch;
+  }
 
   std::optional<std::string> childArch;
   for (ModuleOp child : module.getOps<ModuleOp>()) {
     std::optional<std::string> arch = getModuleTargetArchAttr(child);
-    if (!arch)
+    if (!arch) {
       continue;
+    }
     if (!childArch) {
       childArch = std::move(arch);
       continue;
     }
-    if (*childArch != *arch)
+    if (*childArch != *arch) {
       return normalizeArch(fallbackArch);
+    }
   }
-  if (childArch)
+  if (childArch) {
     return *childArch;
+  }
 
   std::string fallback = normalizeArch(fallbackArch);
-  if (!isSupportedPTOASTargetArch(fallback))
+  if (!isSupportedPTOASTargetArch(fallback)) {
     return "a3";
+  }
   return fallback;
 }
 
@@ -231,8 +240,9 @@ void mlir::pto::loadPTOASDialects(MLIRContext &context) {
 static LogicalResult applyConfiguredPassManagerCLOptions(
     PassManager &pm, llvm::StringRef pipelineName,
     llvm::raw_ostream &diagOS = llvm::errs()) {
-  if (succeeded(mlir::applyPassManagerCLOptions(pm)))
+  if (succeeded(mlir::applyPassManagerCLOptions(pm))) {
     return success();
+  }
   diagOS << "Error: failed to apply MLIR pass manager command-line options for "
          << pipelineName << ".\n";
   return failure();
@@ -254,8 +264,9 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
 
   llvm::DenseMap<Operation *, unsigned> indegree;
   llvm::DenseMap<Operation *, SmallVector<Operation *>> outgoing;
-  for (auto func : definitions)
+  for (auto func : definitions) {
     indegree[func.getOperation()] = 0;
+  }
 
   for (auto caller : definitions) {
     Operation *callerOp = caller.getOperation();
@@ -263,18 +274,21 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
     bool hasCycle = false;
     caller.walk([&](emitc::CallOp call) {
       auto calleeAttr = call.getCalleeAttr();
-      if (!calleeAttr)
+      if (!calleeAttr) {
         return;
+      }
       auto it = definitionsByName.find(calleeAttr.getLeafReference());
-      if (it == definitionsByName.end())
+      if (it == definitionsByName.end()) {
         return;
+      }
       Operation *calleeOp = it->second.getOperation();
       if (calleeOp == callerOp) {
         hasCycle = true;
         return;
       }
-      if (!seenCallees.insert(calleeOp).second)
+      if (!seenCallees.insert(calleeOp).second) {
         return;
+      }
       outgoing[calleeOp].push_back(callerOp);
       ++indegree[callerOp];
     });
@@ -287,8 +301,9 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
 
   SmallVector<Operation *> ready;
   for (auto func : definitions) {
-    if (indegree[func.getOperation()] == 0)
+    if (indegree[func.getOperation()] == 0) {
       ready.push_back(func.getOperation());
+    }
   }
 
   SmallVector<emitc::FuncOp> sortedDefinitions;
@@ -300,8 +315,9 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
 
     for (Operation *user : outgoing[next]) {
       unsigned &userIndegree = indegree[user];
-      if (--userIndegree == 0)
+      if (--userIndegree == 0) {
         ready.push_back(user);
+      }
     }
   }
 
@@ -310,8 +326,9 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
            << "cyclic function call graph is not supported for EmitC C++ emission";
   }
 
-  if (declarations.empty() && definitions.size() <= 1)
+  if (declarations.empty() && definitions.size() <= 1) {
     return success();
+  }
 
   SmallVector<emitc::FuncOp> desiredOrder;
   desiredOrder.append(declarations.begin(), declarations.end());
@@ -325,14 +342,16 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
       break;
     }
   }
-  if (!anchor)
+  if (!anchor) {
     return success();
+  }
 
   auto advanceAnchor = [&]() {
     while (anchor) {
       anchor = anchor->getNextNode();
-      if (!anchor || isa<emitc::FuncOp>(anchor))
+      if (!anchor || isa<emitc::FuncOp>(anchor)) {
         return;
+      }
     }
   };
 
@@ -341,10 +360,12 @@ static LogicalResult reorderEmitCFunctions(ModuleOp module) {
       advanceAnchor();
       continue;
     }
-    if (anchor)
+    if (anchor) {
       func->moveBefore(anchor);
-    else
+    }
+    else {
       func->moveBefore(&body, body.end());
+    }
   }
 
   return success();
@@ -552,8 +573,9 @@ static PTOBuildLevel defaultBuildLevel() {
 
 static bool parseBuildLevel(llvm::StringRef levelStr, PTOBuildLevel &out) {
   std::string s = levelStr.str();
-  for (char &c : s)
+  for (char &c : s) {
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
   if (s == "level1") {
     out = PTOBuildLevel::Level1;
     return true;
@@ -578,9 +600,9 @@ static ReserveBufferMemSpec getReserveBufferMemSpec(PTOArch arch,
                                                     AddressSpace space) {
   switch (space) {
   case AddressSpace::VEC:
-    return {arch == PTOArch::A5 ? 253952ull : 196608ull, 256};
+    return {arch == PTOArch::A5 ? 253952uLL : 196608uLL, 256};
   case AddressSpace::MAT:
-    return {524288ull, 256};
+    return {524288uLL, 256};
   case AddressSpace::LEFT:
   case AddressSpace::RIGHT:
   case AddressSpace::ACC:
@@ -596,12 +618,14 @@ static ReserveBufferMemSpec getReserveBufferMemSpec(PTOArch arch,
 static LogicalResult validateReserveBufferBase(pto::ReserveBufferOp op,
                                                PTOArch arch) {
   auto baseAttr = op.getBaseAttr();
-  if (!baseAttr)
+  if (!baseAttr) {
     return op.emitError("expects explicit 'base'");
+  }
 
   int64_t signedBase = baseAttr.getInt();
-  if (signedBase < 0)
+  if (signedBase < 0) {
     return op.emitError("expects 'base' to be non-negative when present");
+  }
 
   ReserveBufferMemSpec spec =
       getReserveBufferMemSpec(arch, op.getLocation().getAddressSpace());
@@ -638,8 +662,9 @@ static bool validateReserveBufferLevelRules(ModuleOp module,
         return;
       }
 
-      if (op.getBaseAttr())
+      if (op.getBaseAttr()) {
         (void)validateReserveBufferBase(op, arch);
+      }
       op.emitError("pto.reserve_buffer with explicit 'base' (auto = false) is "
                    "not supported when --pto-level=level1 or level2; use "
                    "--pto-level=level3 or set auto = true");
@@ -654,8 +679,9 @@ static bool validateReserveBufferLevelRules(ModuleOp module,
       return;
     }
 
-    if (mlir::failed(validateReserveBufferBase(op, arch)))
+    if (mlir::failed(validateReserveBufferBase(op, arch))) {
       failed = true;
+    }
   });
   return !failed;
 }
@@ -667,8 +693,9 @@ static constexpr llvm::StringLiteral kAutoSyncTailPolicyMte3ToSEvent0 =
 
 static bool parseAutoSyncTailHint(llvm::StringRef hintStr, std::string &normalized) {
   std::string s = hintStr.str();
-  for (char &c : s)
+  for (char &c : s) {
     c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
   if (s == "barrier-all" || s == "barrier_all" || s == "default") {
     normalized = kAutoSyncTailPolicyBarrierAll.str();
     return true;
@@ -684,8 +711,9 @@ static bool parseAutoSyncTailHint(llvm::StringRef hintStr, std::string &normaliz
 
 static LogicalResult emitSharedPreBackendSeamIR(ModuleOp module,
                                                 llvm::StringRef outputPath) {
-  if (outputPath.empty())
+  if (outputPath.empty()) {
     return success();
+  }
 
   if (outputPath == "-") {
     module->print(llvm::outs());
@@ -716,8 +744,9 @@ static void printSharedPreBackendSeamIR(ModuleOp module) {
 static bool hasUnexpandedTileOps(ModuleOp module) {
   bool found = false;
   module.walk([&](Operation *op) {
-    if (found)
+    if (found) {
       return;
+    }
     if (isa<pto::OpPipeInterface>(op)) {
       found = true;
       return;
@@ -749,18 +778,22 @@ static bool isCppIdentifierChar(char c) {
 }
 
 static std::optional<std::string> getTextualNameFromSMRange(llvm::SMRange range) {
-  if (!range.Start.isValid() || !range.End.isValid())
+  if (!range.Start.isValid() || !range.End.isValid()) {
     return std::nullopt;
+  }
   const char *begin = range.Start.getPointer();
   const char *end = range.End.getPointer();
-  if (!begin || !end || end < begin)
+  if (!begin || !end || end < begin) {
     return std::nullopt;
+  }
   llvm::StringRef name(begin, static_cast<size_t>(end - begin));
-  if (name.empty())
+  if (name.empty()) {
     return std::nullopt;
+  }
   name = name.trim();
-  if (name.consume_front("%") && name.empty())
+  if (name.consume_front("%") && name.empty()) {
     return std::nullopt;
+  }
   return name.str();
 }
 
@@ -768,26 +801,30 @@ static SmallVector<std::string, 4>
 expandTextualResultGroupHints(const AsmParserState::OperationDefinition &opDef,
                               unsigned groupIndex) {
   SmallVector<std::string, 4> hints;
-  if (groupIndex >= opDef.resultGroups.size())
+  if (groupIndex >= opDef.resultGroups.size()) {
     return hints;
+  }
   const auto &group = opDef.resultGroups[groupIndex];
   std::optional<std::string> baseName =
       getTextualNameFromSMRange(group.definition.loc);
-  if (!baseName)
+  if (!baseName) {
     return hints;
+  }
 
   unsigned resultStart = group.startIndex;
   unsigned resultEnd = groupIndex + 1 == opDef.resultGroups.size()
                            ? opDef.op->getNumResults()
                            : opDef.resultGroups[groupIndex + 1].startIndex;
-  if (resultStart >= resultEnd)
+  if (resultStart >= resultEnd) {
     return hints;
+  }
   if (resultEnd - resultStart == 1) {
     hints.push_back(*baseName);
     return hints;
   }
-  for (unsigned idx = resultStart; idx < resultEnd; ++idx)
+  for (unsigned idx = resultStart; idx < resultEnd; ++idx) {
     hints.push_back(*baseName + "#" + std::to_string(idx - resultStart));
+  }
   return hints;
 }
 
@@ -796,24 +833,29 @@ static std::string sanitizeCppIdentifier(llvm::StringRef name) {
   sanitized.reserve(name.size() + 4);
 
   auto appendUnderscore = [&]() {
-    if (sanitized.empty() || sanitized.back() != '_')
+    if (sanitized.empty() || sanitized.back() != '_') {
       sanitized.push_back('_');
+    }
   };
 
   for (char c : name) {
-    if (isCppIdentifierChar(c))
+    if (isCppIdentifierChar(c)) {
       sanitized.push_back(c);
-    else
+    }
+    else {
       appendUnderscore();
+    }
   }
 
-  while (!sanitized.empty() && sanitized.back() == '_')
+  while (!sanitized.empty() && sanitized.back() == '_') {
     sanitized.pop_back();
+  }
 
   if (sanitized.empty())
     return {};
-  if (!isCppIdentifierStart(sanitized.front()))
+  if (!isCppIdentifierStart(sanitized.front())) {
     sanitized.insert(sanitized.begin(), '_');
+  }
   return sanitized;
 }
 
@@ -821,8 +863,9 @@ static void appendLocationNameHints(Location loc,
                                     SmallVectorImpl<std::string> &hints) {
   if (auto nameLoc = dyn_cast<NameLoc>(loc)) {
     std::string sanitized = sanitizeCppIdentifier(nameLoc.getName().getValue());
-    if (!sanitized.empty())
+    if (!sanitized.empty()) {
       hints.push_back(std::move(sanitized));
+    }
     return;
   }
 
@@ -830,21 +873,25 @@ static void appendLocationNameHints(Location loc,
     if (Attribute metadata = fusedLoc.getMetadata()) {
       if (auto strAttr = dyn_cast<StringAttr>(metadata)) {
         std::string sanitized = sanitizeCppIdentifier(strAttr.getValue());
-        if (!sanitized.empty())
+        if (!sanitized.empty()) {
           hints.push_back(std::move(sanitized));
+        }
         return;
       }
       if (auto arrayAttr = dyn_cast<ArrayAttr>(metadata)) {
         for (Attribute attr : arrayAttr) {
           auto strAttr = dyn_cast<StringAttr>(attr);
-          if (!strAttr)
+          if (!strAttr) {
             continue;
+          }
           std::string sanitized = sanitizeCppIdentifier(strAttr.getValue());
-          if (!sanitized.empty())
+          if (!sanitized.empty()) {
             hints.push_back(std::move(sanitized));
+          }
         }
-        if (!hints.empty())
+        if (!hints.empty()) {
           return;
+        }
       }
     }
 
@@ -856,8 +903,9 @@ static void appendLocationNameHints(Location loc,
 
   if (auto callSiteLoc = dyn_cast<CallSiteLoc>(loc)) {
     appendLocationNameHints(callSiteLoc.getCallee(), hints);
-    if (hints.empty())
+    if (hints.empty()) {
       appendLocationNameHints(callSiteLoc.getCaller(), hints);
+    }
   }
 }
 
@@ -876,8 +924,9 @@ static void appendRawLocationProvenance(Location loc,
                                         SmallVectorImpl<std::string> &hints) {
   if (auto nameLoc = dyn_cast<NameLoc>(loc)) {
     std::string raw = nameLoc.getName().getValue().str();
-    if (!raw.empty())
+    if (!raw.empty()) {
       hints.push_back(std::move(raw));
+    }
     return;
   }
 
@@ -885,21 +934,25 @@ static void appendRawLocationProvenance(Location loc,
     if (Attribute metadata = fusedLoc.getMetadata()) {
       if (auto strAttr = dyn_cast<StringAttr>(metadata)) {
         std::string raw = strAttr.getValue().str();
-        if (!raw.empty())
+        if (!raw.empty()) {
           hints.push_back(std::move(raw));
+        }
         return;
       }
       if (auto arrayAttr = dyn_cast<ArrayAttr>(metadata)) {
         for (Attribute attr : arrayAttr) {
           auto strAttr = dyn_cast<StringAttr>(attr);
-          if (!strAttr)
+          if (!strAttr) {
             continue;
+          }
           std::string raw = strAttr.getValue().str();
-          if (!raw.empty())
+          if (!raw.empty()) {
             hints.push_back(std::move(raw));
+          }
         }
-        if (!hints.empty())
+        if (!hints.empty()) {
           return;
+        }
       }
     }
 
@@ -911,8 +964,9 @@ static void appendRawLocationProvenance(Location loc,
 
   if (auto callSiteLoc = dyn_cast<CallSiteLoc>(loc)) {
     appendRawLocationProvenance(callSiteLoc.getCallee(), hints);
-    if (hints.empty())
+    if (hints.empty()) {
       appendRawLocationProvenance(callSiteLoc.getCaller(), hints);
+    }
   }
 }
 
@@ -921,25 +975,30 @@ static void appendRawLocationProvenance(Location loc,
 // but without sanitization.
 static SmallVector<std::string, 4> getRawResultProvenance(Operation *op) {
   SmallVector<std::string, 4> hints;
-  if (!op || op->getNumResults() == 0)
+  if (!op || op->getNumResults() == 0) {
     return hints;
+  }
   appendRawLocationProvenance(op->getLoc(), hints);
-  if (hints.empty())
+  if (hints.empty()) {
     return hints;
+  }
   hints.erase(std::remove_if(hints.begin(), hints.end(),
                               [](const std::string &name) {
                                 return name.empty();
                               }),
               hints.end());
-  if (hints.empty())
-    return hints;
-  if (op->getNumResults() == 1) {
-    if (hints.size() > 1)
-      hints.resize(1);
+  if (hints.empty()) {
     return hints;
   }
-  if (hints.size() > op->getNumResults())
+  if (op->getNumResults() == 1) {
+    if (hints.size() > 1) {
+      hints.resize(1);
+    }
+    return hints;
+  }
+  if (hints.size() > op->getNumResults()) {
     hints.resize(op->getNumResults());
+  }
   return hints;
 }
 
@@ -956,8 +1015,9 @@ static SmallVector<std::string, 4> getRawLocationProvenance(Location loc) {
 
 static Location getIndexedRawProvenanceLoc(Location fallbackLoc, unsigned index) {
   SmallVector<std::string, 4> hints = getRawLocationProvenance(fallbackLoc);
-  if (index >= hints.size())
+  if (index >= hints.size()) {
     return fallbackLoc;
+  }
   return NameLoc::get(StringAttr::get(fallbackLoc.getContext(), hints[index]),
                       fallbackLoc);
 }
@@ -968,20 +1028,24 @@ static Location attachLocationNameHints(Location baseLoc,
   SmallVector<Attribute, 4> attrs;
   attrs.reserve(hints.size());
   for (llvm::StringRef hint : hints) {
-    if (!hint.empty())
+    if (!hint.empty()) {
       attrs.push_back(StringAttr::get(context, hint));
+    }
   }
-  if (attrs.empty())
+  if (attrs.empty()) {
     return baseLoc;
-  if (attrs.size() == 1)
+  }
+  if (attrs.size() == 1) {
     return NameLoc::get(cast<StringAttr>(attrs.front()), baseLoc);
+  }
   return FusedLoc::get(ArrayRef<Location>{baseLoc}, ArrayAttr::get(context, attrs),
                        context);
 }
 
 static void applyValueNameHints(Value value, llvm::ArrayRef<std::string> hints) {
-  if (!value || hints.empty() || hasLocationNameHints(value.getLoc()))
+  if (!value || hints.empty() || hasLocationNameHints(value.getLoc())) {
     return;
+  }
   value.setLoc(attachLocationNameHints(value.getLoc(), hints, value.getContext()));
 }
 
@@ -996,8 +1060,9 @@ static void applyOperationResultNameHints(Operation *op,
   for (size_t i = 0, e = std::min<size_t>(op->getNumResults(), hints.size());
        i < e; ++i)
     limitedHints.push_back(hints[i]);
-  if (limitedHints.empty())
+  if (limitedHints.empty()) {
     return;
+  }
 
   op->setLoc(attachLocationNameHints(op->getLoc(), limitedHints, op->getContext()));
 }
@@ -1007,8 +1072,9 @@ static void splitDerivedSingleResultProvenanceLocsInRegion(Region &region);
 static void splitDerivedSingleResultProvenanceLocsInBlock(Block &block) {
   SmallVector<Operation *, 16> ops;
   ops.reserve(block.getOperations().size());
-  for (Operation &op : block)
+  for (Operation &op : block) {
     ops.push_back(&op);
+  }
 
   for (size_t i = 0; i < ops.size();) {
     Operation *op = ops[i];
@@ -1032,52 +1098,62 @@ static void splitDerivedSingleResultProvenanceLocsInBlock(Block &block) {
     size_t runSize = runEnd - i;
     if (runSize == hints.size()) {
       Location sharedLoc = op->getLoc();
-      for (size_t j = 0; j < runSize; ++j)
+      for (size_t j = 0; j < runSize; ++j) {
         ops[i + j]->setLoc(getIndexedRawProvenanceLoc(sharedLoc, j));
+      }
     }
 
     i = runEnd;
   }
 
   for (Operation &op : block) {
-    for (Region &region : op.getRegions())
+    for (Region &region : op.getRegions()) {
       splitDerivedSingleResultProvenanceLocsInRegion(region);
+    }
   }
 }
 
 static void splitDerivedSingleResultProvenanceLocsInRegion(Region &region) {
-  for (Block &block : region)
+  for (Block &block : region) {
     splitDerivedSingleResultProvenanceLocsInBlock(block);
+  }
 }
 
 static void splitDerivedSingleResultProvenanceLocs(Operation *root) {
-  if (!root)
+  if (!root) {
     return;
-  for (Region &region : root->getRegions())
+  }
+  for (Region &region : root->getRegions()) {
     splitDerivedSingleResultProvenanceLocsInRegion(region);
+  }
 }
 
 static void narrowUnusedMultiResultProvenanceLocs(Operation *root) {
-  if (!root)
+  if (!root) {
     return;
+  }
 
   root->walk([&](Operation *op) {
-    if (op->getNumResults() <= 1)
+    if (op->getNumResults() <= 1) {
       return;
+    }
 
     SmallVector<std::string, 4> hints = getRawLocationProvenance(op->getLoc());
-    if (hints.size() != op->getNumResults())
+    if (hints.size() != op->getNumResults()) {
       return;
+    }
 
     SmallVector<std::string, 4> liveHints;
     liveHints.reserve(hints.size());
     for (auto [index, result] : llvm::enumerate(op->getResults())) {
-      if (!result.use_empty())
+      if (!result.use_empty()) {
         liveHints.push_back(hints[index]);
+      }
     }
 
-    if (liveHints.empty() || liveHints.size() == hints.size())
+    if (liveHints.empty() || liveHints.size() == hints.size()) {
       return;
+    }
 
     op->setLoc(attachLocationNameHints(op->getLoc(), liveHints,
                                        op->getContext()));
@@ -1206,37 +1282,44 @@ static void collectNonEntryBlocksInSourceOrder(
   for (Region &region : op->getRegions()) {
     bool isEntryBlock = true;
     for (Block &block : region) {
-      if (!isEntryBlock && block.getNumArguments() != 0)
+      if (!isEntryBlock && block.getNumArguments() != 0) {
         blocks.push_back(&block);
+      }
       isEntryBlock = false;
-      for (Operation &nestedOp : block)
+      for (Operation &nestedOp : block) {
         collectNonEntryBlocksInSourceOrder(&nestedOp, blocks);
+      }
     }
   }
 }
 
 void mlir::pto::applyTextualNameHintsToModule(ModuleOp module,
                                               const AsmParserState &parserState) {
-  if (!module)
+  if (!module) {
     return;
+  }
 
   for (const AsmParserState::BlockDefinition &blockDef : parserState.getBlockDefs()) {
-    if (!blockDef.block)
+    if (!blockDef.block) {
       continue;
+    }
     for (auto [argIndex, argDef] : llvm::enumerate(blockDef.arguments)) {
-      if (argIndex >= blockDef.block->getNumArguments())
+      if (argIndex >= blockDef.block->getNumArguments()) {
         break;
+      }
       std::optional<std::string> hint = getTextualNameFromSMRange(argDef.loc);
-      if (!hint)
+      if (!hint) {
         continue;
+      }
       applyValueNameHints(blockDef.block->getArgument(argIndex),
                           llvm::ArrayRef<std::string>{*hint});
     }
   }
 
   for (const AsmParserState::OperationDefinition &opDef : parserState.getOpDefs()) {
-    if (!opDef.op || opDef.op->getNumResults() == 0)
+    if (!opDef.op || opDef.op->getNumResults() == 0) {
       continue;
+    }
 
     SmallVector<std::string, 4> hints;
     hints.reserve(opDef.op->getNumResults());
@@ -1246,8 +1329,9 @@ void mlir::pto::applyTextualNameHintsToModule(ModuleOp module,
           expandTextualResultGroupHints(opDef, groupIndex);
       hints.append(groupHints.begin(), groupHints.end());
     }
-    if (hints.empty())
+    if (hints.empty()) {
       continue;
+    }
     applyOperationResultNameHints(opDef.op, hints);
   }
 }
@@ -1257,8 +1341,9 @@ static FunctionBlockArgHintMap collectFunctionBlockArgNameHints(ModuleOp module)
   for (func::FuncOp func : module.getOps<func::FuncOp>()) {
     SmallVector<Block *, 8> nonEntryBlocks;
     collectNonEntryBlocksInSourceOrder(func.getOperation(), nonEntryBlocks);
-    if (nonEntryBlocks.empty())
+    if (nonEntryBlocks.empty()) {
       continue;
+    }
 
     SmallVector<SmallVector<std::string, 4>, 4> blockHints;
     blockHints.reserve(nonEntryBlocks.size());
@@ -1273,12 +1358,14 @@ static FunctionBlockArgHintMap collectFunctionBlockArgNameHints(ModuleOp module)
         }
         argHints.push_back(std::move(hints.front()));
       }
-      if (hasAllHints)
+      if (hasAllHints) {
         blockHints.push_back(std::move(argHints));
+      }
     }
 
-    if (!blockHints.empty())
+    if (!blockHints.empty()) {
       hintsByFunction[func.getSymNameAttr()] = std::move(blockHints);
+    }
   }
   return hintsByFunction;
 }
@@ -1287,13 +1374,15 @@ static void applyFunctionBlockArgNameHintsToEmitC(
     ModuleOp module, const FunctionBlockArgHintMap &blockArgHints) {
   for (emitc::FuncOp func : module.getOps<emitc::FuncOp>()) {
     auto it = blockArgHints.find(func.getSymNameAttr());
-    if (it == blockArgHints.end() || it->second.empty())
+    if (it == blockArgHints.end() || it->second.empty()) {
       continue;
+    }
 
     SmallVector<Block *, 8> nonEntryBlocks;
     collectNonEntryBlocksInSourceOrder(func.getOperation(), nonEntryBlocks);
-    if (nonEntryBlocks.size() != it->second.size())
+    if (nonEntryBlocks.size() != it->second.size()) {
       continue;
+    }
 
     bool shapeMatches = true;
     for (auto [blockIndex, block] : llvm::enumerate(nonEntryBlocks)) {
@@ -1302,8 +1391,9 @@ static void applyFunctionBlockArgNameHintsToEmitC(
         break;
       }
     }
-    if (!shapeMatches)
+    if (!shapeMatches) {
       continue;
+    }
 
     for (auto [blockIndex, block] : llvm::enumerate(nonEntryBlocks)) {
       const auto &argHints = it->second[blockIndex];
@@ -1315,11 +1405,13 @@ static void applyFunctionBlockArgNameHintsToEmitC(
 
 static SmallVector<std::string, 4> getValueNameHints(Value value) {
   SmallVector<std::string, 4> hints;
-  if (!value)
+  if (!value) {
     return hints;
+  }
   appendLocationNameHints(value.getLoc(), hints);
-  if (hints.size() > 1)
+  if (hints.size() > 1) {
     hints.resize(1);
+  }
   return hints;
 }
 
@@ -1365,8 +1457,9 @@ collectExpressionProvenance(emitc::ExpressionOp expr) {
   SmallVector<std::string, 8> provenance;
   auto appendUnique = [&](llvm::ArrayRef<std::string> names) {
     for (const std::string &name : names) {
-      if (name.empty())
+      if (name.empty()) {
         continue;
+      }
       if (std::find(provenance.begin(), provenance.end(), name) !=
           provenance.end())
         continue;
@@ -1375,10 +1468,12 @@ collectExpressionProvenance(emitc::ExpressionOp expr) {
   };
 
   expr.walk<WalkOrder::PreOrder>([&](Operation *nested) {
-    if (nested == expr.getOperation())
+    if (nested == expr.getOperation()) {
       return WalkResult::advance();
-    if (nested->getNumResults() == 0 || isa<emitc::VerbatimOp>(nested))
+    }
+    if (nested->getNumResults() == 0 || isa<emitc::VerbatimOp>(nested)) {
       return WalkResult::advance();
+    }
     appendUnique(getRawResultProvenance(nested));
     return WalkResult::advance();
   });
@@ -1394,26 +1489,30 @@ static void annotateEmitCProvenanceHints(ModuleOp module) {
 
   llvm::SmallVector<ProvenanceMarker, 32> opsToAnnotate;
   module.walk<WalkOrder::PreOrder>([&](Operation *op) {
-    if (op->getNumResults() == 0 || isa<emitc::VerbatimOp>(op))
+    if (op->getNumResults() == 0 || isa<emitc::VerbatimOp>(op)) {
       return WalkResult::advance();
+    }
 
     if (auto expr = dyn_cast<emitc::ExpressionOp>(op)) {
       SmallVector<std::string, 8> provenance = collectExpressionProvenance(expr);
-      if (provenance.empty())
+      if (provenance.empty()) {
         return WalkResult::skip();
+      }
       opsToAnnotate.push_back(
           ProvenanceMarker{op, SmallVector<std::string, 8>(provenance)});
       return WalkResult::skip();
     }
 
-    if (op->getParentOfType<emitc::ExpressionOp>())
+    if (op->getParentOfType<emitc::ExpressionOp>()) {
       return WalkResult::advance();
+    }
     // Only carry raw provenance into the C++ post-pass. Semantic renaming is
     // intentionally deferred until naming can happen inside the emitter's own
     // symbol table instead of via post-hoc C++ text rewriting.
     SmallVector<std::string, 4> provenance = getRawResultProvenance(op);
-    if (provenance.empty())
+    if (provenance.empty()) {
       return WalkResult::advance();
+    }
     opsToAnnotate.push_back(ProvenanceMarker{
         op, SmallVector<std::string, 8>(provenance.begin(), provenance.end())});
     return WalkResult::advance();
@@ -1479,8 +1578,9 @@ static bool parseMarkerArgs(llvm::StringRef argsRef,
       continue;
     }
     if (c == ')') {
-      if (parenDepth > 0)
+      if (parenDepth > 0) {
         --parenDepth;
+      }
       continue;
     }
     if (c == ',' && parenDepth == 0) {
@@ -1488,8 +1588,9 @@ static bool parseMarkerArgs(llvm::StringRef argsRef,
       partBegin = i + 1;
     }
   }
-  if (partBegin > argsRef.size())
+  if (partBegin > argsRef.size()) {
     return false;
+  }
   args.push_back(argsRef.drop_front(partBegin).trim());
   return true;
 }
@@ -1499,8 +1600,9 @@ findNextMarkerCall(const std::string &cpp, llvm::StringRef marker,
                    size_t searchPos) {
   ParsedMarkerCall call;
   call.markerPos = cpp.find(marker.str(), searchPos);
-  if (call.markerPos == std::string::npos)
+  if (call.markerPos == std::string::npos) {
     return std::nullopt;
+  }
 
   size_t lparenPos = call.markerPos + marker.size();
   if (lparenPos >= cpp.size() || cpp[lparenPos] != '(')
@@ -1514,20 +1616,23 @@ findNextMarkerCall(const std::string &cpp, llvm::StringRef marker,
       ++parenDepth;
       continue;
     }
-    if (c != ')')
+    if (c != ')') {
       continue;
+    }
     if (parenDepth == 0) {
       call.rparenPos = i;
       break;
     }
     --parenDepth;
   }
-  if (call.rparenPos == std::string::npos)
+  if (call.rparenPos == std::string::npos) {
     return call;
+  }
 
   llvm::StringRef argsRef(cpp.data() + argsBegin, call.rparenPos - argsBegin);
-  if (!parseMarkerArgs(argsRef, call.args))
+  if (!parseMarkerArgs(argsRef, call.args)) {
     call.args.clear();
+  }
   return call;
 }
 
@@ -1562,8 +1667,9 @@ static bool rewriteMarkerCallToMember(std::string &cpp, llvm::StringRef marker,
                                       unsigned expectedNumArgs) {
   return rewriteMarkerCalls(
       cpp, marker, [&](const ParsedMarkerCall &call) -> std::optional<std::string> {
-        if (call.args.size() != expectedNumArgs)
+        if (call.args.size() != expectedNumArgs) {
           return std::nullopt;
+        }
 
         std::string replacement;
         replacement.reserve(marker.size() + kMarkerCallReserveExtra);
@@ -1571,8 +1677,9 @@ static bool rewriteMarkerCallToMember(std::string &cpp, llvm::StringRef marker,
         replacement.push_back('.');
         replacement.append(memberName.str());
         replacement.push_back('(');
-        if (expectedNumArgs >= kMarkerRewriteMinArgCount)
+        if (expectedNumArgs >= kMarkerRewriteMinArgCount) {
           replacement.append(call.args[1].str());
+        }
         if (expectedNumArgs == kMarkerRewriteTernaryArgCount) {
           replacement.append(", ");
           replacement.append(call.args[2].str());
@@ -1600,10 +1707,12 @@ static bool rewriteMarkerCallToField(std::string &cpp, llvm::StringRef marker,
                                      size_t expectedNumArgs) {
   return rewriteMarkerCalls(
       cpp, marker, [&](const ParsedMarkerCall &call) -> std::optional<std::string> {
-        if (call.args.size() != expectedNumArgs)
+        if (call.args.size() != expectedNumArgs) {
           return std::nullopt;
-        if (call.args.empty())
+        }
+        if (call.args.empty()) {
           return std::nullopt;
+        }
         std::string replacement;
         replacement.reserve(call.args.front().size() + fieldName.size() + 1);
         replacement.append(call.args.front().str());
@@ -1650,21 +1759,25 @@ static void dropEmptyEmitCExpressions(Operation *rootOp) {
       toErase;
   rootOp->walk([&](emitc::ExpressionOp expr) {
     Block *body = expr.getBody();
-    if (!body)
+    if (!body) {
       return;
+    }
     auto yield = dyn_cast<emitc::YieldOp>(body->getTerminator());
-    if (!yield || yield.getNumOperands() != 1)
+    if (!yield || yield.getNumOperands() != 1) {
       return;
+    }
     Value yielded = yield.getOperand(0);
     Operation *defOp = yielded.getDefiningOp();
     bool yieldedFromOutside = !defOp || defOp->getBlock() != body;
-    if (!yieldedFromOutside && expr.getRootOp())
+    if (!yieldedFromOutside && expr.getRootOp()) {
       return;
+    }
     expr.getResult().replaceAllUsesWith(yielded);
     toErase.push_back(expr);
   });
-  for (emitc::ExpressionOp expr : llvm::reverse(toErase))
+  for (emitc::ExpressionOp expr : llvm::reverse(toErase)) {
     expr.erase();
+  }
 }
 
 static void appendEmitCIntegerAttrLiteral(std::string &storage,
@@ -1698,8 +1811,9 @@ static std::string getEmitCIntegerAttrLiteral(IntegerAttr attr) {
 static std::optional<std::string>
 getEmitCDenseIntElementsAttrLiteral(DenseIntElementsAttr attr) {
   auto tensorTy = dyn_cast<TensorType>(attr.getType());
-  if (!tensorTy)
+  if (!tensorTy) {
     return std::nullopt;
+  }
 
   Type elementType = tensorTy.getElementType();
   bool isUnsigned = false;
@@ -1713,8 +1827,9 @@ getEmitCDenseIntElementsAttrLiteral(DenseIntElementsAttr attr) {
   literal.push_back('{');
   bool first = true;
   for (const APInt &value : attr) {
-    if (!first)
+    if (!first) {
       literal.append(", ");
+    }
     first = false;
     appendEmitCIntegerAttrLiteral(literal, value, isUnsigned);
   }
@@ -1724,8 +1839,9 @@ getEmitCDenseIntElementsAttrLiteral(DenseIntElementsAttr attr) {
 
 static Attribute normalizeEmitCPrintedAttrForCppEmission(MLIRContext *ctx,
                                                          Attribute attr) {
-  if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+  if (auto intAttr = dyn_cast<IntegerAttr>(attr)) {
     return emitc::OpaqueAttr::get(ctx, getEmitCIntegerAttrLiteral(intAttr));
+  }
 
   if (auto denseAttr = dyn_cast<DenseIntElementsAttr>(attr)) {
     if (std::optional<std::string> literal =
@@ -1743,8 +1859,9 @@ static Attribute normalizeEmitCPrintedAttrForCppEmission(MLIRContext *ctx,
       changed |= normalizedElement != element;
       normalized.push_back(normalizedElement);
     }
-    if (changed)
+    if (changed) {
       return ArrayAttr::get(ctx, normalized);
+    }
   }
 
   return attr;
@@ -1812,8 +1929,9 @@ static void normalizeEmitCIntegerAttrsForCppEmission(Operation *rootOp) {
       Attribute value = constant.getValue();
       Attribute normalized =
           normalizeEmitCPrintedAttrForCppEmission(ctx, value);
-      if (normalized != value)
+      if (normalized != value) {
         constant.getProperties().setValue(normalized);
+      }
       return;
     }
 
@@ -1821,33 +1939,38 @@ static void normalizeEmitCIntegerAttrsForCppEmission(Operation *rootOp) {
       Attribute value = variable.getValue();
       Attribute normalized =
           normalizeEmitCPrintedAttrForCppEmission(ctx, value);
-      if (normalized != value)
+      if (normalized != value) {
         variable.getProperties().setValue(normalized);
+      }
       return;
     }
 
     if (auto global = dyn_cast<emitc::GlobalOp>(op)) {
       std::optional<Attribute> initialValue = global.getInitialValue();
-      if (!initialValue)
+      if (!initialValue) {
         return;
+      }
       Attribute normalized =
           normalizeEmitCPrintedAttrForCppEmission(ctx, *initialValue);
-      if (normalized != *initialValue)
+      if (normalized != *initialValue) {
         global.getProperties().setInitialValue(normalized);
+      }
       return;
     }
 
     if (auto call = dyn_cast<emitc::CallOpaqueOp>(op)) {
       if (std::optional<ArrayAttr> args = call.getArgs()) {
         ArrayAttr normalized = normalizeEmitCCallArgsForCppEmission(ctx, *args);
-        if (normalized != *args)
+        if (normalized != *args) {
           call.getProperties().setArgs(normalized);
+        }
       }
       if (std::optional<ArrayAttr> templateArgs = call.getTemplateArgs()) {
         ArrayAttr normalized =
             normalizeEmitCTemplateArgsForCppEmission(ctx, *templateArgs);
-        if (normalized != *templateArgs)
+        if (normalized != *templateArgs) {
           call.getProperties().setTemplateArgs(normalized);
+        }
       }
       return;
     }
@@ -1856,22 +1979,27 @@ static void normalizeEmitCIntegerAttrsForCppEmission(Operation *rootOp) {
 
 static Attribute getDefaultEmitCVariableInitAttr(OpBuilder &builder, Type type) {
   if (auto intTy = dyn_cast<IntegerType>(type)) {
-    if (intTy.getWidth() == 0)
+    if (intTy.getWidth() == 0) {
       return emitc::OpaqueAttr::get(builder.getContext(), "0");
+    }
     return builder.getIntegerAttr(intTy, 0);
   }
-  if (isa<IndexType>(type))
+  if (isa<IndexType>(type)) {
     return builder.getIndexAttr(0);
-  if (auto floatTy = dyn_cast<FloatType>(type))
+  }
+  if (auto floatTy = dyn_cast<FloatType>(type)) {
     return builder.getFloatAttr(floatTy, 0.0);
-  if (isa<emitc::OpaqueType, emitc::PointerType>(type))
+  }
+  if (isa<emitc::OpaqueType, emitc::PointerType>(type)) {
     return emitc::OpaqueAttr::get(builder.getContext(), "");
+  }
   return Attribute{};
 }
 
 static Type getEmitCVariableStorageType(Type valueType) {
-  if (isa<emitc::ArrayType, emitc::LValueType>(valueType))
+  if (isa<emitc::ArrayType, emitc::LValueType>(valueType)) {
     return valueType;
+  }
   return emitc::LValueType::get(valueType);
 }
 
@@ -1882,8 +2010,9 @@ static Type getEmitCVariableStorageType(Type valueType) {
 static void materializeControlFlowOperands(Operation *rootOp) {
   llvm::SmallVector<Operation *, kBranchInlineCapacity> branches;
   rootOp->walk([&](Operation *op) {
-    if (isa<cf::BranchOp, cf::CondBranchOp>(op))
+    if (isa<cf::BranchOp, cf::CondBranchOp>(op)) {
       branches.push_back(op);
+    }
   });
 
   OpBuilder builder(rootOp->getContext());
@@ -1892,13 +2021,15 @@ static void materializeControlFlowOperands(Operation *rootOp) {
     for (OpOperand &operand : op->getOpOperands()) {
       Value value = operand.get();
       auto expr = dyn_cast_or_null<emitc::ExpressionOp>(value.getDefiningOp());
-      if (!expr)
+      if (!expr) {
         continue;
+      }
 
       Attribute initAttr =
           getDefaultEmitCVariableInitAttr(builder, value.getType());
-      if (!initAttr)
+      if (!initAttr) {
         continue;
+      }
 
       Value tmp = builder
                       .create<emitc::VariableOp>(
@@ -1924,8 +2055,9 @@ static bool rewriteMarkerCallToSubscript(std::string &cpp, llvm::StringRef marke
                                          bool isStore) {
   return rewriteMarkerCalls(
       cpp, marker, [&](const ParsedMarkerCall &call) -> std::optional<std::string> {
-        if (call.args.size() != expectedNumArgs)
+        if (call.args.size() != expectedNumArgs) {
           return std::nullopt;
+        }
         std::string replacement;
         replacement.reserve(call.args[0].size() + call.args[1].size() + 8 +
                             (isStore ? call.args[2].size() : 0));
@@ -1966,16 +2098,18 @@ static void rewritePtrScalarMarkers(std::string &cpp) {
 
 static std::string getLineIndent(llvm::StringRef line) {
   size_t firstNonSpace = line.find_first_not_of(" \t");
-  if (firstNonSpace == llvm::StringRef::npos)
+  if (firstNonSpace == llvm::StringRef::npos) {
     return line.str();
+  }
   return line.take_front(firstNonSpace).str();
 }
 
 static bool isAICOREFunctionStart(llvm::StringRef trimmed) {
   if (trimmed.empty() || trimmed.starts_with("#") || trimmed.starts_with("//"))
     return false;
-  if (!trimmed.contains("AICORE"))
+  if (!trimmed.contains("AICORE")) {
     return false;
+  }
   return trimmed.contains("(");
 }
 
@@ -2007,8 +2141,9 @@ static bool stripScalarGMFlushMarkersFromLine(std::string &line) {
   size_t searchPos = 0;
   while (true) {
     auto call = findNextMarkerCall(line, kMarker, searchPos);
-    if (!call)
+    if (!call) {
       break;
+    }
     if (call->rparenPos == std::string::npos) {
       searchPos = call->markerPos + kMarker.size();
       continue;
@@ -2023,8 +2158,9 @@ static bool stripScalarGMFlushMarkersFromLine(std::string &line) {
     while (eraseEnd < line.size() &&
            (line[eraseEnd] == ' ' || line[eraseEnd] == '\t'))
       ++eraseEnd;
-    if (eraseEnd < line.size() && line[eraseEnd] == ';')
+    if (eraseEnd < line.size() && line[eraseEnd] == ';') {
       ++eraseEnd;
+    }
     while (eraseEnd < line.size() &&
            (line[eraseEnd] == ' ' || line[eraseEnd] == '\t'))
       ++eraseEnd;
@@ -2040,8 +2176,9 @@ static bool previousSignificantLineIsTailFlushPoint(
     llvm::ArrayRef<std::string> lines, size_t index) {
   for (size_t i = index; i > 0; --i) {
     llvm::StringRef prev = llvm::StringRef(lines[i - 1]).trim();
-    if (prev.empty())
+    if (prev.empty()) {
       continue;
+    }
     return prev.starts_with("#endif // __DAV_") ||
            prev.starts_with("ptoas_auto_sync_tail(");
   }
@@ -2052,8 +2189,9 @@ static bool previousSignificantLineIsExitOrTailFlushPoint(
     llvm::ArrayRef<std::string> lines, size_t index) {
   for (size_t i = index; i > 0; --i) {
     llvm::StringRef prev = llvm::StringRef(lines[i - 1]).trim();
-    if (prev.empty())
+    if (prev.empty()) {
       continue;
+    }
     return prev.starts_with("return") ||
            prev.starts_with("#endif // __DAV_") ||
            prev.starts_with("ptoas_auto_sync_tail(");
@@ -2082,8 +2220,9 @@ static std::string rewriteScalarGMStoreFlushMarkersInFunction(
     unchanged.reserve(kRewriteOutputReserveExtra);
     for (size_t i = 0; i < lines.size(); ++i) {
       unchanged.append(lines[i]);
-      if (i + 1 < lines.size() || hasTrailingNewline)
+      if (i + 1 < lines.size() || hasTrailingNewline) {
         unchanged.push_back('\n');
+      }
     }
     return unchanged;
   }
@@ -2094,8 +2233,9 @@ static std::string rewriteScalarGMStoreFlushMarkersInFunction(
   size_t fallbackIndex = lines.size();
   for (size_t i = lines.size(); i > 0; --i) {
     llvm::StringRef trimmed = llvm::StringRef(lines[i - 1]).trim();
-    if (trimmed.empty())
+    if (trimmed.empty()) {
       continue;
+    }
     if (trimmed.starts_with("}"))
       fallbackIndex = i - 1;
     break;
@@ -2119,12 +2259,14 @@ static std::string rewriteScalarGMStoreFlushMarkersInFunction(
       inserted = true;
     }
     out.append(lines[i]);
-    if (i + 1 < lines.size() || hasTrailingNewline)
+    if (i + 1 < lines.size() || hasTrailingNewline) {
       out.push_back('\n');
+    }
   }
 
-  if (!inserted)
+  if (!inserted) {
     appendScalarGMFlush(out, "  ");
+  }
   return out;
 }
 
@@ -2154,27 +2296,32 @@ static void rewriteScalarGMStoreFlushMarkers(std::string &cpp) {
     ref = split.second;
 
     llvm::StringRef trimmed = llvm::StringRef(line).trim();
-    if (!inFunction && isAICOREFunctionStart(trimmed))
+    if (!inFunction && isAICOREFunctionStart(trimmed)) {
       inFunction = true;
+    }
 
     if (!inFunction) {
       out.append(line);
-      if (hadNewline)
+      if (hadNewline) {
         out.push_back('\n');
+      }
       continue;
     }
 
     functionLines.push_back(std::move(line));
     int delta = countBraceDelta(functionLines.back());
-    if (delta != 0)
+    if (delta != 0) {
       sawFunctionBrace = true;
+    }
     braceDepth += delta;
-    if (sawFunctionBrace && braceDepth == 0)
+    if (sawFunctionBrace && braceDepth == 0) {
       flushFunction(hadNewline);
+    }
   }
 
-  if (!functionLines.empty())
+  if (!functionLines.empty()) {
     flushFunction(false);
+  }
   cpp.swap(out);
 }
 
@@ -2196,8 +2343,9 @@ static bool isPreprocessorDirectiveLine(llvm::StringRef trimmedLine) {
 // Trim only those malformed suffixes here so bisheng can compile the emitted
 // source until the upstream printer behavior is fixed.
 static void rewriteMalformedVerbatimSemicolons(std::string &cpp) {
-  if (cpp.empty())
+  if (cpp.empty()) {
     return;
+  }
 
   llvm::StringRef input(cpp);
   std::string rewritten;
@@ -2220,8 +2368,9 @@ static void rewriteMalformedVerbatimSemicolons(std::string &cpp) {
     } else {
       if (isPreprocessorDirectiveLine(trimmed) && trimmed.ends_with(";")) {
         size_t semicolonPos = current.find_last_of(';');
-        if (semicolonPos != std::string::npos)
+        if (semicolonPos != std::string::npos) {
           current.erase(semicolonPos, 1);
+        }
       } else if (!trimmed.empty() && !trimmed.starts_with("//") &&
                  !trimmed.starts_with("/*") && trimmed.ends_with(";;")) {
         size_t semicolonPos = current.find_last_of(';');
@@ -2273,10 +2422,12 @@ static bool rewriteAddPtrTraceMarkers(std::string &cpp, bool showTrace) {
     size_t replaceEnd = call->rparenPos;
     if (!showTrace) {
       size_t i = call->rparenPos + 1;
-      while (i < cpp.size() && std::isspace(static_cast<unsigned char>(cpp[i])))
+      while (i < cpp.size() && std::isspace(static_cast<unsigned char>(cpp[i]))) {
         ++i;
-      if (i < cpp.size() && cpp[i] == ';')
+      }
+      if (i < cpp.size() && cpp[i] == ';') {
         replaceEnd = i;
+      }
     }
 
     cpp.replace(call->markerPos, (replaceEnd - call->markerPos) + 1,
@@ -2297,11 +2448,13 @@ static bool isGeneratedGlobalTensorDecl(llvm::StringRef trimmed,
 
   decl = trimmed.drop_back().rtrim();
   size_t lastWs = decl.find_last_of(" \t");
-  if (lastWs == llvm::StringRef::npos)
+  if (lastWs == llvm::StringRef::npos) {
     return false;
+  }
   varName = decl.drop_front(lastWs + 1);
-  if (!varName.starts_with("v") || varName.size() <= 1)
+  if (!varName.starts_with("v") || varName.size() <= 1) {
     return false;
+  }
   return llvm::all_of(varName.drop_front(1),
                       [](char c) { return std::isdigit(c); });
 }
@@ -2330,8 +2483,9 @@ static void rewriteHoistedGlobalTensorDecls(std::string &cpp) {
     llvm::StringRef varName;
     if (isGeneratedGlobalTensorDecl(trimmed, decl, varName)) {
       size_t indentLen = line.find_first_not_of(" \t");
-      if (indentLen == std::string::npos)
+      if (indentLen == std::string::npos) {
         indentLen = 0;
+      }
       llvm::StringRef indent = line.take_front(indentLen);
 
       out.append(indent.str());
@@ -2340,10 +2494,12 @@ static void rewriteHoistedGlobalTensorDecls(std::string &cpp) {
       rewritten = true;
     }
 
-    if (!rewritten)
+    if (!rewritten) {
       out.append(line.str());
-    if (!rest.empty())
+    }
+    if (!rest.empty()) {
       out.push_back('\n');
+    }
     ref = rest;
   }
 
@@ -2354,12 +2510,15 @@ static std::optional<llvm::SmallVector<std::string, 4>>
 parseNameHintMarker(llvm::StringRef markerBody) {
   auto decodeHintMarkerToken = [](llvm::StringRef token) {
     auto hexValue = [](char c) -> int {
-      if (c >= '0' && c <= '9')
+      if (c >= '0' && c <= '9') {
         return c - '0';
-      if (c >= 'a' && c <= 'f')
+      }
+      if (c >= 'a' && c <= 'f') {
         return c - 'a' + 10;
-      if (c >= 'A' && c <= 'F')
+      }
+      if (c >= 'A' && c <= 'F') {
         return c - 'A' + 10;
+      }
       return -1;
     };
 
@@ -2384,8 +2543,9 @@ parseNameHintMarker(llvm::StringRef markerBody) {
 
   llvm::SmallVector<std::string, 4> hints;
   markerBody = markerBody.trim();
-  if (markerBody.empty())
+  if (markerBody.empty()) {
     return std::nullopt;
+  }
 
   size_t start = 0;
   while (start <= markerBody.size()) {
@@ -2393,15 +2553,18 @@ parseNameHintMarker(llvm::StringRef markerBody) {
     llvm::StringRef token = markerBody.slice(
         start, comma == llvm::StringRef::npos ? markerBody.size() : comma);
     token = token.trim();
-    if (!token.empty())
+    if (!token.empty()) {
       hints.push_back(decodeHintMarkerToken(token));
-    if (comma == llvm::StringRef::npos)
+    }
+    if (comma == llvm::StringRef::npos) {
       break;
+    }
     start = comma + 1;
   }
 
-  if (hints.empty())
+  if (hints.empty()) {
     return std::nullopt;
+  }
   return hints;
 }
 
@@ -2497,8 +2660,9 @@ static void emitProvenanceComments(std::string &segment) {
     if (names && !names->empty()) {
       out.append("// pto: ");
       for (size_t idx = 0; idx < names->size(); ++idx) {
-        if (idx != 0)
+        if (idx != 0) {
           out.append(", ");
+        }
         out.push_back('%');
         out.append(sanitizeCommentText((*names)[idx]));
       }
@@ -2532,15 +2696,17 @@ struct ConstantDeclCandidate {
 } // namespace
 
 static bool isGeneratedValueName(llvm::StringRef name) {
-  if (!name.consume_front("v") || name.empty())
+  if (!name.consume_front("v") || name.empty()) {
     return false;
+  }
   return llvm::all_of(name, [](char c) { return std::isdigit(c); });
 }
 
 static bool isConstFoldableScalarType(llvm::StringRef type) {
   type = type.trim();
-  if (type.starts_with("const ") || type.starts_with("constexpr "))
+  if (type.starts_with("const ") || type.starts_with("constexpr ")) {
     return false;
+  }
   return llvm::StringSwitch<bool>(type)
       .Cases("bool", "float", "double", "half", "bfloat16_t", true)
       .Cases("int8_t", "uint8_t", "int16_t", "uint16_t", true)
@@ -2550,10 +2716,12 @@ static bool isConstFoldableScalarType(llvm::StringRef type) {
 
 static bool isLiteralInitializer(llvm::StringRef rhs) {
   rhs = rhs.trim();
-  if (rhs.empty())
+  if (rhs.empty()) {
     return false;
-  if (rhs == "true" || rhs == "false" || rhs == "nullptr")
+  }
+  if (rhs == "true" || rhs == "false" || rhs == "nullptr") {
     return true;
+  }
 
   static const llvm::Regex kIntLiteral(
       R"(^[+-]?(0[xX][0-9A-Fa-f]+|[0-9]+)[uUlL]*$)");
@@ -2573,10 +2741,12 @@ static std::string normalizeConstInitializer(llvm::StringRef type,
   type = type.trim();
   rhs = rhs.trim();
   if (type == "bool") {
-    if (rhs == "0" || rhs == "false")
+    if (rhs == "0" || rhs == "false") {
       return "false";
-    if (rhs == "1" || rhs == "-1" || rhs == "true")
+    }
+    if (rhs == "1" || rhs == "-1" || rhs == "true") {
       return "true";
+    }
   }
   return rhs.str();
 }
@@ -2606,24 +2776,28 @@ static bool parseConstantDeclarationLine(llvm::StringRef line,
   }
 
   size_t lastWs = lhs.find_last_of(" \t");
-  if (lastWs == llvm::StringRef::npos)
+  if (lastWs == llvm::StringRef::npos) {
     return false;
+  }
 
   llvm::StringRef type = lhs.take_front(lastWs).rtrim();
   llvm::StringRef name = lhs.drop_front(lastWs + 1).trim();
-  if (!isGeneratedValueName(name) || !isConstFoldableScalarType(type))
+  if (!isGeneratedValueName(name) || !isConstFoldableScalarType(type)) {
     return false;
+  }
 
   size_t indentLen = line.find_first_not_of(" \t");
-  if (indentLen == llvm::StringRef::npos)
+  if (indentLen == llvm::StringRef::npos) {
     indentLen = 0;
+  }
   candidate.indent = line.take_front(indentLen).str();
   candidate.type = type.str();
   valueName = name.str();
 
   if (!rhs.empty()) {
-    if (!isLiteralInitializer(rhs))
+    if (!isLiteralInitializer(rhs)) {
       return false;
+    }
     candidate.hasInitializer = true;
     candidate.initializer = normalizeConstInitializer(type, rhs);
   }
@@ -2641,13 +2815,15 @@ static bool parseGeneratedValueAssignment(llvm::StringRef line,
 
   llvm::StringRef body = trimmed.drop_back().rtrim();
   size_t eqPos = body.find('=');
-  if (eqPos == llvm::StringRef::npos)
+  if (eqPos == llvm::StringRef::npos) {
     return false;
+  }
 
   llvm::StringRef lhs = body.take_front(eqPos).rtrim();
   rhs = body.drop_front(eqPos + 1).trim();
-  if (!isGeneratedValueName(lhs))
+  if (!isGeneratedValueName(lhs)) {
     return false;
+  }
   valueName = lhs;
   return true;
 }
@@ -2674,12 +2850,14 @@ static void rewriteScalarConstantDecls(std::string &cpp) {
 
       llvm::StringRef assignedName;
       llvm::StringRef rhs;
-      if (!parseGeneratedValueAssignment(lines[i], assignedName, rhs))
+      if (!parseGeneratedValueAssignment(lines[i], assignedName, rhs)) {
         continue;
+      }
 
       auto it = candidates.find(assignedName);
-      if (it == candidates.end())
+      if (it == candidates.end()) {
         continue;
+      }
 
       ConstantDeclCandidate &info = it->second;
       ++info.assignmentCount;
@@ -2693,14 +2871,17 @@ static void rewriteScalarConstantDecls(std::string &cpp) {
 
       std::string initializer;
       if (info.hasInitializer) {
-        if (info.assignmentCount != 0)
+        if (info.assignmentCount != 0) {
           continue;
+        }
         initializer = info.initializer;
       } else {
-        if (info.assignmentCount != 1)
+        if (info.assignmentCount != 1) {
           continue;
-        if (!isLiteralInitializer(info.assignmentRhs))
+        }
+        if (!isLiteralInitializer(info.assignmentRhs)) {
           continue;
+        }
         initializer = normalizeConstInitializer(
             info.type, llvm::StringRef(info.assignmentRhs));
         eraseLine[info.assignmentLine] = true;
@@ -2722,20 +2903,24 @@ static void rewriteScalarConstantDecls(std::string &cpp) {
         --braceDepth;
     }
 
-    if (depthBefore == 0 && braceDepth > 0)
+    if (depthBefore == 0 && braceDepth > 0) {
       segmentStart = i;
-    if (depthBefore > 0 && braceDepth == 0)
+    }
+    if (depthBefore > 0 && braceDepth == 0) {
       rewriteSegment(segmentStart, i);
+    }
   }
 
   std::string out;
   out.reserve(cpp.size());
   for (size_t i = 0; i < lines.size(); ++i) {
-    if (eraseLine[i])
+    if (eraseLine[i]) {
       continue;
+    }
     out.append(lines[i]);
-    if (i + 1 != lines.size())
+    if (i + 1 != lines.size()) {
       out.push_back('\n');
+    }
   }
   cpp.swap(out);
 }
@@ -2777,8 +2962,9 @@ static void prepareVPTOForEmission(PassManager &pm) {
       createVPTOExpandWrapperOpsPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTOInferVPTOVecScopePass());
-  if (enableSoftPostUpdate)
+  if (enableSoftPostUpdate) {
     kernelModulePM.addPass(pto::createVPTOSoftPostUpdatePass());
+  }
   kernelModulePM.addPass(createLoopInvariantCodeMotionPass());
   kernelModulePM.addNestedPass<func::FuncOp>(
       pto::createPTONarrowVPTOLoopCountersPass());
@@ -2843,8 +3029,9 @@ buildVPTOEmissionOptions(const pto::CANNVersion &cannVersion,
   options.targetTriple = "hiipu64-hisilicon-cce";
   options.cannVersion = cannVersion;
   std::string arch = normalizeArch(targetArch);
-  if (isA2A3Arch(arch))
+  if (isA2A3Arch(arch)) {
     options.march = "dav-c220-vec";
+  }
   return options;
 }
 
@@ -2904,8 +3091,9 @@ static LogicalResult runVPTOBackendPipeline(OwningOpRef<ModuleOp> &module,
   pm.enableVerifier();
   pm.addPass(pto::createVPTOSplitCVModulePass());
   pm.addPass(pto::createVPTONormalizeContainerPass());
-  if (hasTileOpsToExpand)
+  if (hasTileOpsToExpand) {
     lowerPTOToVPTOBackend(pm, module.get());
+  }
   auto &kernelModulePM = pm.nest<ModuleOp>();
   // Inline legal direct calls before VMI layout assignment so private helper
   // bodies participate in one caller-local layout decision. The Func
@@ -2970,8 +3158,9 @@ int mlir::pto::compilePTOASModule(
   // Validate stack-local struct provenance before every output path. In
   // particular, --emit-pto-ir returns before the EmitC validation pass and
   // VPTO does not use that pass.
-  if (failed(pto::validateStructProvenance(*module)))
+  if (failed(pto::validateStructProvenance(*module))) {
     return 1;
+  }
 
   std::string arch = resolveEffectiveTargetArch(*module, context.getArch());
 
@@ -3073,8 +3262,9 @@ int mlir::pto::compilePTOASModule(
   module->walk([&](mlir::func::FuncOp func) {
     auto hintAttr =
         func->getAttrOfType<mlir::StringAttr>("pto.auto_sync_tail_hint");
-    if (!hintAttr)
+    if (!hintAttr) {
       return;
+    }
 
     std::string normalizedHint;
     if (!parseAutoSyncTailHint(hintAttr.getValue(), normalizedHint)) {
@@ -3088,8 +3278,9 @@ int mlir::pto::compilePTOASModule(
     func->setAttr("pto.auto_sync_tail_hint",
                   mlir::StringAttr::get(module->getContext(), normalizedHint));
   });
-  if (invalidAutoSyncTailHint)
+  if (invalidAutoSyncTailHint) {
     return 1;
+  }
 
   bool hasTAssign = false;
   module->walk([&](pto::TAssignOp) { hasTAssign = true; });
@@ -3133,14 +3324,16 @@ int mlir::pto::compilePTOASModule(
 
   bool hasUserPlannedMultiAddrs = false;
   module->walk([&](pto::AllocMultiTileOp op) {
-    if (!op->hasAttr(pto::kPtoMultiBufferAddrsAttrName))
+    if (!op->hasAttr(pto::kPtoMultiBufferAddrsAttrName)) {
       return;
+    }
     op.emitError() << "attribute '" << pto::kPtoMultiBufferAddrsAttrName
                    << "' is reserved for pto-plan-memory";
     hasUserPlannedMultiAddrs = true;
   });
-  if (hasUserPlannedMultiAddrs)
+  if (hasUserPlannedMultiAddrs) {
     return 1;
+  }
 
   if (effectiveLevel == PTOBuildLevel::Level3) {
     // In level3 the caller owns local memory and PTOPlanMemory is skipped, so
@@ -3160,8 +3353,9 @@ int mlir::pto::compilePTOASModule(
         missing = true;
       }
     });
-    if (missing)
+    if (missing) {
       return 1;
+    }
   } else {
     bool hasAddr = false;
     module->walk([&](pto::AllocTileOp op) {
@@ -3178,12 +3372,14 @@ int mlir::pto::compilePTOASModule(
         hasAddr = true;
       }
     });
-    if (hasAddr)
+    if (hasAddr) {
       return 1;
+    }
   }
 
-  if (!validateReserveBufferLevelRules(*module, effectiveLevel))
+  if (!validateReserveBufferLevelRules(*module, effectiveLevel)) {
     return 1;
+  }
 
   {
     PassManager preBackendPM(module->getContext());
@@ -3206,8 +3402,9 @@ int mlir::pto::compilePTOASModule(
                       "skipping the shared PTO-to-VPTO lowering pipeline.\n";
       return 1;
     }
-    if (failed(runVPTOBackendPipeline(module, hasTileOpsToExpand)))
+    if (failed(runVPTOBackendPipeline(module, hasTileOpsToExpand))) {
       return 1;
+    }
     return emitVPTOBackendResult(*module, result, emitVPTOHostStub,
                                  context.getCANNVersionOrDefault());
   }
@@ -3215,8 +3412,9 @@ int mlir::pto::compilePTOASModule(
   // Main PassManager
   PassManager pm(module->getContext());
 
-  if (failed(applyPassManagerCLOptions(pm)))
+  if (failed(applyPassManagerCLOptions(pm))) {
     return 1;
+  }
 
   // Rank-2 → rank-5 view canonicalization is currently gated on the VPTO
   // backend to limit blast radius.  A3/A5 EmitC codegen already pads strides
@@ -3224,28 +3422,32 @@ int mlir::pto::compilePTOASModule(
   // does not need the canonicalization pass at the IR level.  When VPTO
   // validation is complete and the pass is proven stable, the gate can be
   // lifted to make it unconditional for all backends.
-  if (effectiveBackend == PTOBackend::VPTO)
+  if (effectiveBackend == PTOBackend::VPTO) {
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOCanonicalizeIRPass());
+  }
   pm.addPass(createSerialFrontendPipeLoweringPass());
   //pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOVerifyTFreePass());
   pm.addPass(pto::createPTOInferValidatePipeInitPass());
   pm.addNestedPass<mlir::func::FuncOp>(pto::createLoweringSyncToPipePass());
-  if (!disableInferLayout)
+  if (!disableInferLayout) {
     pm.addNestedPass<mlir::func::FuncOp>(pto::createInferPTOLayoutPass());
+  }
   // PTOViewToMemref is generic view lowering required by both backends; keep it
   // outside the local-memory planning gate so default A2/A3 EmitC still lowers
   // pto.make_tensor_view before backend legalization.
   const bool isA2A3 = isA2A3Arch(arch);
-  if (!isA2A3)
+  if (!isA2A3) {
     pm.addNestedPass<mlir::func::FuncOp>(pto::createPTOA5NormalizeTMovPass());
+  }
   pm.addNestedPass<mlir::func::FuncOp>(
       pto::createPTOValidateIntToPtrUsesPass());
 
   // PTODSL legality discovery happens on tile-native PTO IR before fusion.
   // Fusion may later filter the ordered `candidates` array; ExpandTileOp
   // consumes the first candidate that remains.
-  if (!isA2A3 && effectiveBackend == PTOBackend::VPTO && hasTileOpsToExpand)
+  if (!isA2A3 && effectiveBackend == PTOBackend::VPTO && hasTileOpsToExpand) {
     pm.addPass(pto::createInsertTemplateAttributesPass());
+  }
 
   // Keep frontend fusion on tile-native PTO IR and annotate last_use directly
   // on scheduled block-local spans before the shared mainline lowers tiles.
@@ -3347,8 +3549,9 @@ int mlir::pto::compilePTOASModule(
   // Materialize each `pto.multi_tile_get` as an addressed `pto.alloc_tile`;
   // dynamic selections use an `arith.select` chain over planned addresses.
   pm.addPass(pto::createPTOResolveBufferSelectPass());
-  if (effectiveBackend == PTOBackend::EmitC)
+  if (effectiveBackend == PTOBackend::EmitC) {
     pm.addPass(createNarrowUnusedMultiResultProvenancePass());
+  }
 
   module->getOperation()->setAttr(
       "pto.target_arch",
@@ -3369,12 +3572,14 @@ int mlir::pto::compilePTOASModule(
   pm.addPass(createCSEPass());
   // PTODSL backend helpers already use the tile-native ABI.
   pm.addPass(pto::createPTOInlineBackendHelpersPass());
-  if (effectiveBackend == PTOBackend::EmitC)
+  if (effectiveBackend == PTOBackend::EmitC) {
     pm.addPass(createNarrowUnusedMultiResultProvenancePass());
+  }
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
-  if (failed(applyConfiguredPassManagerCLOptions(pm, "main PTOAS pipeline")))
+  if (failed(applyConfiguredPassManagerCLOptions(pm, "main PTOAS pipeline"))) {
     return 1;
+  }
 
   if (effectiveBackend == PTOBackend::VPTO) {
     if (failed(pm.run(*module))) {
@@ -3382,17 +3587,20 @@ int mlir::pto::compilePTOASModule(
       return 1;
     }
 
-    if (ptoPrintSeamIR)
+    if (ptoPrintSeamIR) {
       printSharedPreBackendSeamIR(*module);
+    }
     if (ptoPrintSeamIR) {
       module->print(llvm::errs());
       llvm::errs() << "\n";
     }
-    if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile)))
+    if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile))) {
       return 1;
+    }
 
-    if (failed(runVPTOBackendPipeline(module, hasTileOpsToExpand)))
+    if (failed(runVPTOBackendPipeline(module, hasTileOpsToExpand))) {
       return 1;
+    }
     return emitVPTOBackendResult(*module, result, emitVPTOHostStub,
                                  context.getCANNVersionOrDefault());
   }
@@ -3402,10 +3610,12 @@ int mlir::pto::compilePTOASModule(
     return 1;
   }
 
-  if (ptoPrintSeamIR)
+  if (ptoPrintSeamIR) {
     printSharedPreBackendSeamIR(*module);
-  if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile)))
+  }
+  if (failed(emitSharedPreBackendSeamIR(*module, ptoSeamIRFile))) {
     return 1;
+  }
 
   narrowUnusedMultiResultProvenanceLocs(module.get());
   splitDerivedSingleResultProvenanceLocs(module.get());

--- a/tools/ptobc/src/canonical_printer.cpp
+++ b/tools/ptobc/src/canonical_printer.cpp
@@ -62,7 +62,9 @@ static std::string joinLines(const std::vector<std::string> &lines) {
   std::string out;
   for (size_t i = 0; i < lines.size(); ++i) {
     out += lines[i];
-    if (i + 1 < lines.size()) out.push_back('\n');
+    if (i + 1 < lines.size()) {
+      out.push_back('\n');
+    }
   }
   return out;
 }
@@ -93,7 +95,9 @@ static std::string hexFloatLiteral(mlir::FloatAttr a) {
 static void sortAttributesLexicographically(mlir::ModuleOp module) {
   module.walk([&](mlir::Operation *op) {
     auto attrs = op->getAttrs();
-    if (attrs.size() <= 1) return;
+    if (attrs.size() <= 1) {
+      return;
+    }
 
     NamedAttributeVector sorted(attrs.begin(), attrs.end());
     llvm::sort(sorted, [](const mlir::NamedAttribute &a, const mlir::NamedAttribute &b) {
@@ -157,15 +161,23 @@ static void collectSSADefsFromSignature(const std::string &line,
   // Collect `%name:` occurrences within (...) in `func.func` or `^bb` lines.
   // This is a lightweight heuristic but works for standard MLIR assembly.
   size_t lpar = line.find('(');
-  if (lpar == std::string::npos) return;
+  if (lpar == std::string::npos) {
+    return;
+  }
   size_t rpar = line.find(')', lpar + 1);
-  if (rpar == std::string::npos) return;
+  if (rpar == std::string::npos) {
+    return;
+  }
 
   for (size_t i = lpar + 1; i < rpar; ++i) {
-    if (line[i] != '%') continue;
+    if (line[i] != '%') {
+      continue;
+    }
     size_t j = i + 1;
     while (j < rpar && isSSAIdentChar(line[j])) ++j;
-    if (j == i + 1) continue;
+    if (j == i + 1) {
+      continue;
+    }
     // Must be followed by ':' to be an arg/blkarg.
     if (j < rpar && line[j] == ':') {
       out.push_back(line.substr(i + 1, j - (i + 1)));
@@ -204,18 +216,22 @@ static bool findConstantDefinition(const std::vector<std::string> &lines,
                                    const std::string &name, std::string &imm,
                                    std::string &ty) {
   for (const auto &line : lines) {
-    if (line.find('%' + name) == std::string::npos)
+    if (line.find('%' + name) == std::string::npos) {
       continue;
-    if (line.find("= arith.constant") == std::string::npos)
+    }
+    if (line.find("= arith.constant") == std::string::npos) {
       continue;
+    }
     size_t pos = line.find('%');
-    if (pos == std::string::npos)
+    if (pos == std::string::npos) {
       continue;
+    }
     size_t end = pos + 1;
     while (end < line.size() && isSSAIdentChar(line[end]))
       ++end;
-    if (line.substr(pos + 1, end - (pos + 1)) != name)
+    if (line.substr(pos + 1, end - (pos + 1)) != name) {
       continue;
+    }
     return parseConstantLine(line, imm, ty);
   }
   return false;

--- a/tools/ptobc/src/leb128.cpp
+++ b/tools/ptobc/src/leb128.cpp
@@ -19,9 +19,9 @@ namespace ptobc {
 
 namespace {
 constexpr unsigned kLeb128PayloadBits = 7;
-constexpr uint8_t kLeb128PayloadMask = 0x7fu;
-constexpr uint8_t kLeb128ContinuationBit = 0x80u;
-constexpr uint8_t kLeb128SignBit = 0x40u;
+constexpr uint8_t kLeb128PayloadMask = 0x7FU;
+constexpr uint8_t kLeb128ContinuationBit = 0x80U;
+constexpr uint8_t kLeb128SignBit = 0x40U;
 constexpr unsigned kInt64MaxShift = 63;
 constexpr unsigned kInt64BitWidth = 64;
 } // namespace

--- a/tools/ptobc/src/mlir_encode.cpp
+++ b/tools/ptobc/src/mlir_encode.cpp
@@ -296,7 +296,7 @@ static void appendAPIntBytesLE(Buffer &buffer, const llvm::APInt &bits) {
   for (unsigned i = 0; i < byteLen; ++i) {
     unsigned word = i / 8;
     unsigned off = (i % 8) * 8;
-    uint8_t byte = uint8_t((words[word] >> off) & 0xFFu);
+    uint8_t byte = uint8_t((words[word] >> off) & 0xFFU);
     buffer.bytes.push_back(byte);
   }
 }

--- a/tools/ptobc/src/ptobc_format.cpp
+++ b/tools/ptobc/src/ptobc_format.cpp
@@ -23,7 +23,7 @@ namespace ptobc {
 
 namespace {
 constexpr unsigned kBitsPerByte = 8;
-constexpr uint32_t kByteMask = 0xffu;
+constexpr uint32_t kByteMask = 0xffU;
 constexpr unsigned kU32SecondByteShift = kBitsPerByte;
 constexpr unsigned kU32ThirdByteShift = 2 * kBitsPerByte;
 constexpr unsigned kU32FourthByteShift = 3 * kBitsPerByte;


### PR DESCRIPTION
Summary:
- Complete the metrics-rule cleanup across PTOAS sources.
- Correct the SIMT keep/resume template linkage and add missing control-flow braces.

Validation:
- 115.175.35.144: configured and built all default targets (440/440) with LLVM 21.1.8 and CANN 9.0.0-beta.1.
- 115.175.35.144: ptoas 0.57 smoke test and PTOAS/MLIR/PTODSL Python imports passed.
- 115.175.35.144 simulator: scripts/sim_dsl.sh --soc-version Ascend950PR_9599 test/dsl-st passed all 10 discovered cases.

Not validated on A5 hardware; this PR uses the 144 simulator path.