### PR TITLE
fix(ptodsl): pass selection tmp as keyword

### DIFF
--- a/ptodsl/ptodsl/_ops.py
+++ b/ptodsl/ptodsl/_ops.py
@@ -4049,8 +4049,8 @@ def tsel(mask, src0, src1, dst, *, tmp=None):
         unwrap_surface_value(mask),
         unwrap_surface_value(src0),
         unwrap_surface_value(src1),
-        unwrap_surface_value(resolved_tmp),
         unwrap_surface_value(dst),
+        tmp=unwrap_surface_value(resolved_tmp),
     )
 
 
@@ -4060,9 +4060,9 @@ def tsels(mask, src, scalar, dst, *, tmp=None):
     _pto.tsels(
         unwrap_surface_value(mask),
         unwrap_surface_value(src),
-        unwrap_surface_value(resolved_tmp),
         _coerce_tile_scalar_operand(src, scalar, context="tsels"),
         unwrap_surface_value(dst),
+        tmp=unwrap_surface_value(resolved_tmp),
     )
 
 

--- a/ptodsl/tests/test_vector_cube_ops.py
+++ b/ptodsl/tests/test_vector_cube_ops.py
@@ -877,23 +877,23 @@ class VectorCubeSurfaceTest(unittest.TestCase):
                  patch.object(_ops._pto, "tsel") as tsel_op:
                 _ops.tsel(mask, src0, src1, dst)
             resolve_tmp.assert_called_once_with(dst, None, context="tsel")
-            self.assertEqual(tsel_op.call_args.args, (mask, src0, src1, synthesized_tmp, dst))
+            tsel_op.assert_called_once_with(mask, src0, src1, dst, tmp=synthesized_tmp)
 
             with patch.object(_ops, "_resolve_selection_tmp", side_effect=AssertionError("should not synthesize")), \
                  patch.object(_ops._pto, "tsel") as tsel_op:
                 _ops.tsel(mask, src0, src1, dst, tmp=tmp)
-            self.assertEqual(tsel_op.call_args.args, (mask, src0, src1, tmp, dst))
+            tsel_op.assert_called_once_with(mask, src0, src1, dst, tmp=tmp)
 
             with patch.object(_ops, "_resolve_selection_tmp", return_value=synthesized_tmp) as resolve_tmp, \
                  patch.object(_ops._pto, "tsels") as tsels_op:
                 _ops.tsels(mask, src, scalar, dst)
             resolve_tmp.assert_called_once_with(dst, None, context="tsels")
-            self.assertEqual(tsels_op.call_args.args, (mask, src, synthesized_tmp, coerced_scalar, dst))
+            tsels_op.assert_called_once_with(mask, src, coerced_scalar, dst, tmp=synthesized_tmp)
 
             with patch.object(_ops, "_resolve_selection_tmp", side_effect=AssertionError("should not synthesize")), \
                  patch.object(_ops._pto, "tsels") as tsels_op:
                 _ops.tsels(mask, src, scalar, dst, tmp=tmp)
-            self.assertEqual(tsels_op.call_args.args, (mask, src, tmp, coerced_scalar, dst))
+            tsels_op.assert_called_once_with(mask, src, coerced_scalar, dst, tmp=tmp)
 
     def test_tile_row_reductions_expose_optional_tmp_and_synthesize_one(self):
         src = SimpleNamespace(type="src_ty")


### PR DESCRIPTION
## Summary
- pass optional `tmp` to generated `tsel`/`tsels` bindings as a keyword argument
- update the existing wrapper expectations

## Root cause
The generated MLIR Python bindings define `tmp` as keyword-only, while the PTODSL wrappers passed it positionally. This caused `elementwise-1d-2d-equivalence.py` to fail in the `tsels` case with `TypeError: tsels() takes 4 positional arguments but 5 were given`.

## Validation
- `python -m pytest ptodsl/tests/test_vector_cube_ops.py -k "tile_selection_surface_exposes_optional_tmp or tile_selection_wrappers_use_explicit_tmp_or_synthesize_one" -q`
- simulator `scripts/sim_dsl.sh ... elementwise-1d-2d-equivalence.py -- --emit-mlir`

Closes the simulator compile failure for the elementwise 1D/2D equivalence case.