### PR TITLE
perf(vmi): elide neutral reduction combines

### DIFF
--- a/include/PTO/IR/VMIOps.td
+++ b/include/PTO/IR/VMIOps.td
@@ -417,64 +417,58 @@ def VMICompressStoreOp : VMI_Op<"compress_store", [DeclareOpInterfaceMethods<Mem
 }
 
 def VMIReduceAddIOp : VMI_Op<"reduce_addi"> {
-  let summary = "VMI masked integer add reduction with a 1-lane vector init";
+  let summary = "VMI masked integer add reduction";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                       VMI_VRegTypeConstraint:$init,
                        VMI_MaskTypeConstraint:$mask);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$source `,` $init `,` $mask attr-dict `:` type($source) `,` type($init) `,` type($mask) `->` type($result)";
+  let assemblyFormat = "$source `,` $mask attr-dict `:` type($source) `,` type($mask) `->` type($result)";
 }
 
 def VMIReduceAddFOp : VMI_Op<"reduce_addf"> {
   let summary = "VMI masked floating-point add reduction with explicit reassociation permission";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                       VMI_VRegTypeConstraint:$init,
                        VMI_MaskTypeConstraint:$mask,
                        OptionalAttr<UnitAttr>:$reassoc);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$source `,` $init `,` $mask attr-dict `:` type($source) `,` type($init) `,` type($mask) `->` type($result)";
+  let assemblyFormat = "$source `,` $mask attr-dict `:` type($source) `,` type($mask) `->` type($result)";
 }
 
 def VMIReduceMaxFOp : VMI_Op<"reduce_maxf"> {
-  let summary = "VMI masked floating-point maximum reduction with a 1-lane vector init";
+  let summary = "VMI masked floating-point maximum reduction";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                       VMI_VRegTypeConstraint:$init,
                        VMI_MaskTypeConstraint:$mask);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$source `,` $init `,` $mask attr-dict `:` type($source) `,` type($init) `,` type($mask) `->` type($result)";
+  let assemblyFormat = "$source `,` $mask attr-dict `:` type($source) `,` type($mask) `->` type($result)";
 }
 
 def VMIReduceMinFOp : VMI_Op<"reduce_minf"> {
-  let summary = "VMI masked floating-point minimum reduction with a 1-lane vector init";
+  let summary = "VMI masked floating-point minimum reduction";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                       VMI_VRegTypeConstraint:$init,
                        VMI_MaskTypeConstraint:$mask);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$source `,` $init `,` $mask attr-dict `:` type($source) `,` type($init) `,` type($mask) `->` type($result)";
+  let assemblyFormat = "$source `,` $mask attr-dict `:` type($source) `,` type($mask) `->` type($result)";
 }
 
 def VMIReduceMaxIOp : VMI_Op<"reduce_maxi"> {
-  let summary = "VMI masked integer maximum reduction with a 1-lane vector init";
+  let summary = "VMI masked integer maximum reduction";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                       VMI_VRegTypeConstraint:$init,
                        VMI_MaskTypeConstraint:$mask);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$source `,` $init `,` $mask attr-dict `:` type($source) `,` type($init) `,` type($mask) `->` type($result)";
+  let assemblyFormat = "$source `,` $mask attr-dict `:` type($source) `,` type($mask) `->` type($result)";
 }
 
 def VMIReduceMinIOp : VMI_Op<"reduce_mini"> {
-  let summary = "VMI masked integer minimum reduction with a 1-lane vector init";
+  let summary = "VMI masked integer minimum reduction";
   let arguments = (ins VMI_VRegTypeConstraint:$source,
-                       VMI_VRegTypeConstraint:$init,
                        VMI_MaskTypeConstraint:$mask);
   let results = (outs VMI_VRegTypeConstraint:$result);
   let hasVerifier = 1;
-  let assemblyFormat = "$source `,` $init `,` $mask attr-dict `:` type($source) `,` type($init) `,` type($mask) `->` type($result)";
+  let assemblyFormat = "$source `,` $mask attr-dict `:` type($source) `,` type($mask) `->` type($result)";
 }
 
 def VMIGroupReduceAddFOp : VMI_Op<"group_reduce_addf"> {

--- a/lib/PTO/IR/VMI.cpp
+++ b/lib/PTO/IR/VMI.cpp
@@ -1499,7 +1499,6 @@ void VMICompressStoreOp::getEffects(
 
 LogicalResult VMIReduceAddIOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
-  auto initType = cast<VMIVRegType>(getInit().getType());
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (!isVMIIntegerLikeType(sourceType.getElementType()))
@@ -1507,22 +1506,15 @@ LogicalResult VMIReduceAddIOp::verify() {
   auto sourceIntegerType = dyn_cast<IntegerType>(sourceType.getElementType());
   if (!sourceIntegerType || sourceIntegerType.getWidth() != 32)
     return emitOpError("requires 32-bit integer source element type");
-  if (sourceType.getElementType() != initType.getElementType() ||
-      sourceType.getElementType() != resultType.getElementType())
-    return emitOpError(
-        "requires source, init, and result element types to match");
-  if (initType.getElementCount() != 1 || resultType.getElementCount() != 1)
-    return emitOpError("requires init and result to be 1-lane VMI vectors");
-  if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
-                                             {initType, resultType},
-                                             /*requireSameElement=*/true)))
-    return failure();
+  if (sourceType.getElementType() != resultType.getElementType())
+    return emitOpError("requires source and result element types to match");
+  if (resultType.getElementCount() != 1)
+    return emitOpError("requires result to be a 1-lane VMI vector");
   return verifyMaskMatchesData(getOperation(), maskType, sourceType);
 }
 
 LogicalResult VMIReduceAddFOp::verify() {
   auto sourceType = cast<VMIVRegType>(getSource().getType());
-  auto initType = cast<VMIVRegType>(getInit().getType());
   auto maskType = cast<VMIMaskType>(getMask().getType());
   auto resultType = cast<VMIVRegType>(getResult().getType());
   if (!getOperation()->hasAttr("reassoc"))
@@ -1533,22 +1525,15 @@ LogicalResult VMIReduceAddFOp::verify() {
     return emitOpError("requires floating-point-like VMI source element type");
   if (!isVMIF16OrF32Type(sourceType.getElementType()))
     return emitOpError("requires f16 or f32 source element type");
-  if (sourceType.getElementType() != initType.getElementType() ||
-      sourceType.getElementType() != resultType.getElementType())
-    return emitOpError(
-        "requires source, init, and result element types to match");
-  if (initType.getElementCount() != 1 || resultType.getElementCount() != 1)
-    return emitOpError("requires init and result to be 1-lane VMI vectors");
-  if (failed(verifyAllSameVRegShapeAndLayout(getOperation(),
-                                             {initType, resultType},
-                                             /*requireSameElement=*/true)))
-    return failure();
+  if (sourceType.getElementType() != resultType.getElementType())
+    return emitOpError("requires source and result element types to match");
+  if (resultType.getElementCount() != 1)
+    return emitOpError("requires result to be a 1-lane VMI vector");
   return verifyMaskMatchesData(getOperation(), maskType, sourceType);
 }
 
 template <typename OpTy> LogicalResult verifyReduceMinMaxFOp(OpTy op) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
-  auto initType = cast<VMIVRegType>(op.getInit().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   if (!isVMIFloatLikeType(sourceType.getElementType()))
@@ -1556,16 +1541,10 @@ template <typename OpTy> LogicalResult verifyReduceMinMaxFOp(OpTy op) {
         "requires floating-point-like VMI source element type");
   if (!isVMIF16OrF32Type(sourceType.getElementType()))
     return op.emitOpError("requires f16 or f32 source element type");
-  if (sourceType.getElementType() != initType.getElementType() ||
-      sourceType.getElementType() != resultType.getElementType())
-    return op.emitOpError(
-        "requires source, init, and result element types to match");
-  if (initType.getElementCount() != 1 || resultType.getElementCount() != 1)
-    return op.emitOpError("requires init and result to be 1-lane VMI vectors");
-  if (failed(verifyAllSameVRegShapeAndLayout(op.getOperation(),
-                                             {initType, resultType},
-                                             /*requireSameElement=*/true)))
-    return failure();
+  if (sourceType.getElementType() != resultType.getElementType())
+    return op.emitOpError("requires source and result element types to match");
+  if (resultType.getElementCount() != 1)
+    return op.emitOpError("requires result to be a 1-lane VMI vector");
   return verifyMaskMatchesData(op.getOperation(), maskType, sourceType);
 }
 
@@ -1575,7 +1554,6 @@ LogicalResult VMIReduceMinFOp::verify() { return verifyReduceMinMaxFOp(*this); }
 
 template <typename OpTy> LogicalResult verifyReduceMinMaxIOp(OpTy op) {
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
-  auto initType = cast<VMIVRegType>(op.getInit().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   auto sourceIntegerType = dyn_cast<IntegerType>(sourceType.getElementType());
@@ -1583,16 +1561,10 @@ template <typename OpTy> LogicalResult verifyReduceMinMaxIOp(OpTy op) {
       !isVMIAnyI8I16I32Type(sourceType.getElementType()))
     return op.emitOpError(
         "requires 8-bit, 16-bit, or 32-bit integer source element type");
-  if (sourceType.getElementType() != initType.getElementType() ||
-      sourceType.getElementType() != resultType.getElementType())
-    return op.emitOpError(
-        "requires source, init, and result element types to match");
-  if (initType.getElementCount() != 1 || resultType.getElementCount() != 1)
-    return op.emitOpError("requires init and result to be 1-lane VMI vectors");
-  if (failed(verifyAllSameVRegShapeAndLayout(op.getOperation(),
-                                             {initType, resultType},
-                                             /*requireSameElement=*/true)))
-    return failure();
+  if (sourceType.getElementType() != resultType.getElementType())
+    return op.emitOpError("requires source and result element types to match");
+  if (resultType.getElementCount() != 1)
+    return op.emitOpError("requires result to be a 1-lane VMI vector");
   return verifyMaskMatchesData(op.getOperation(), maskType, sourceType);
 }
 

--- a/lib/PTO/Transforms/VMILayoutAssignment.cpp
+++ b/lib/PTO/Transforms/VMILayoutAssignment.cpp
@@ -878,8 +878,6 @@ struct LayoutSolver {
       if (auto reduce = dyn_cast<VMIReduceAddIOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
-        requestDataUse(reduce.getInitMutable(), getContiguousLayout(),
-                       /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
                                   getContiguousLayout(), op)))
           return WalkResult::interrupt();
@@ -890,8 +888,6 @@ struct LayoutSolver {
       }
       if (auto reduce = dyn_cast<VMIReduceAddFOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
-                       /*late=*/false, DataLayoutSeedPhase::Reduce);
-        requestDataUse(reduce.getInitMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
                                   getContiguousLayout(), op)))
@@ -904,8 +900,6 @@ struct LayoutSolver {
       if (auto reduce = dyn_cast<VMIReduceMaxFOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
-        requestDataUse(reduce.getInitMutable(), getContiguousLayout(),
-                       /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
                                   getContiguousLayout(), op)))
           return WalkResult::interrupt();
@@ -916,8 +910,6 @@ struct LayoutSolver {
       }
       if (auto reduce = dyn_cast<VMIReduceMinFOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
-                       /*late=*/false, DataLayoutSeedPhase::Reduce);
-        requestDataUse(reduce.getInitMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
                                   getContiguousLayout(), op)))
@@ -930,8 +922,6 @@ struct LayoutSolver {
       if (auto reduce = dyn_cast<VMIReduceMaxIOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
-        requestDataUse(reduce.getInitMutable(), getContiguousLayout(),
-                       /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
                                   getContiguousLayout(), op)))
           return WalkResult::interrupt();
@@ -942,8 +932,6 @@ struct LayoutSolver {
       }
       if (auto reduce = dyn_cast<VMIReduceMinIOp>(op)) {
         requestDataUse(reduce.getSourceMutable(), getContiguousLayout(),
-                       /*late=*/false, DataLayoutSeedPhase::Reduce);
-        requestDataUse(reduce.getInitMutable(), getContiguousLayout(),
                        /*late=*/false, DataLayoutSeedPhase::Reduce);
         if (failed(requestMaskUse(reduce.getMaskMutable(),
                                   getContiguousLayout(), op)))

--- a/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
+++ b/lib/PTO/Transforms/VMILowerUnifiedToLegacy.cpp
@@ -144,48 +144,6 @@ static Value createZeroConstant(OpBuilder &builder, Location loc,
 }
 
 
-/// Create a 1-lane VMIConstantOp with the neutral element for reduction:
-///   add:  0    (int and float)
-///   max: -INF  (float), INT_MIN (int)
-///   min: +INF  (float), INT_MAX (int)
-static Value createReduceNeutralInit(OpBuilder &builder, Location loc,
-                                     Type elemType, bool isAdd, bool isMax,
-                                     Attribute layout = Attribute()) {
-  auto oneLaneType =
-      VMIVRegType::get(builder.getContext(), 1, elemType, layout);
-  auto shapedType = RankedTensorType::get({1}, elemType);
-  DenseElementsAttr attr;
-  if (auto floatTy = dyn_cast<FloatType>(elemType)) {
-    if (isAdd)
-      attr = DenseElementsAttr::get(
-          shapedType, APFloat::getZero(floatTy.getFloatSemantics()));
-    else if (isMax)
-      attr = DenseElementsAttr::get(
-          shapedType,
-          APFloat::getInf(floatTy.getFloatSemantics(), /*Negative=*/true));
-    else
-      attr = DenseElementsAttr::get(
-          shapedType,
-          APFloat::getInf(floatTy.getFloatSemantics(), /*Negative=*/false));
-  } else {
-    auto intTy = cast<IntegerType>(elemType);
-    if (isAdd)
-      attr = DenseElementsAttr::get(shapedType,
-                                    APInt::getZero(intTy.getWidth()));
-    else if (isMax)
-      attr = DenseElementsAttr::get(
-          shapedType, intTy.isUnsigned()
-                          ? APInt::getZero(intTy.getWidth())
-                          : APInt::getSignedMinValue(intTy.getWidth()));
-    else
-      attr = DenseElementsAttr::get(
-          shapedType, intTy.isUnsigned()
-                          ? APInt::getMaxValue(intTy.getWidth())
-                          : APInt::getSignedMaxValue(intTy.getWidth()));
-  }
-  return builder.create<VMIConstantOp>(loc, oneLaneType, attr).getResult();
-}
-
 /// Map a unified vcmp `cmp` mode to the predicate string for legacy
 /// cmpf/cmpi. Float operands use ordered predicates (olt, oeq, ...);
 /// integer operands select signedness from the element type.
@@ -826,20 +784,17 @@ static LogicalResult lowerVCadd(VMIvcaddOp op, OpBuilder &builder) {
     op.getResult().replaceAllUsesWith(result);
   } else {
     // Full reduce path
-    Value init = createReduceNeutralInit(builder, loc, elemType,
-                                         /*isAdd=*/true, /*isMax=*/false,
-                                         sourceType.getLayout());
     Value result;
     if (isFloat)
       result =
           builder
-              .create<VMIReduceAddFOp>(loc, resultType, source, init, mask,
+              .create<VMIReduceAddFOp>(loc, resultType, source, mask,
                                        op.getReassocAttr())
               .getResult();
     else
       result =
           builder
-              .create<VMIReduceAddIOp>(loc, resultType, source, init, mask)
+              .create<VMIReduceAddIOp>(loc, resultType, source, mask)
               .getResult();
     op.getResult().replaceAllUsesWith(result);
   }
@@ -880,17 +835,14 @@ static LogicalResult lowerVcmax(VMIvcmaxOp op, OpBuilder &builder) {
     return success();
   }
 
-  Value init = createReduceNeutralInit(builder, loc, elemType,
-                                       /*isAdd=*/false, /*isMax=*/true,
-                                       sourceType.getLayout());
   Value result;
   if (isFloat)
     result = builder
-                 .create<VMIReduceMaxFOp>(loc, resultType, source, init, mask)
+                 .create<VMIReduceMaxFOp>(loc, resultType, source, mask)
                  .getResult();
   else
     result = builder
-                 .create<VMIReduceMaxIOp>(loc, resultType, source, init, mask)
+                 .create<VMIReduceMaxIOp>(loc, resultType, source, mask)
                  .getResult();
   op.getResult().replaceAllUsesWith(result);
   op->erase();
@@ -929,17 +881,14 @@ static LogicalResult lowerVcmin(VMIvcminOp op, OpBuilder &builder) {
     return success();
   }
 
-  Value init = createReduceNeutralInit(builder, loc, elemType,
-                                       /*isAdd=*/false, /*isMax=*/false,
-                                       sourceType.getLayout());
   Value result;
   if (isFloat)
     result = builder
-                 .create<VMIReduceMinFOp>(loc, resultType, source, init, mask)
+                 .create<VMIReduceMinFOp>(loc, resultType, source, mask)
                  .getResult();
   else
     result = builder
-                 .create<VMIReduceMinIOp>(loc, resultType, source, init, mask)
+                 .create<VMIReduceMinIOp>(loc, resultType, source, mask)
                  .getResult();
   op.getResult().replaceAllUsesWith(result);
   op->erase();

--- a/lib/PTO/Transforms/VMIToVPTO.cpp
+++ b/lib/PTO/Transforms/VMIToVPTO.cpp
@@ -9519,7 +9519,6 @@ struct OneToNVMIReduceAddIOpPattern
   matchAndRewrite(VMIReduceAddIOp op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     ValueRange sourceParts = adaptor.getSource();
-    ValueRange initParts = adaptor.getInit();
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
@@ -9527,17 +9526,17 @@ struct OneToNVMIReduceAddIOpPattern
       return failure();
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
-        initParts.size() != 1 || resultTypes.size() != 1)
+        resultTypes.size() != 1)
       return rewriter.notifyMatchFailure(
-          op, "reduce_addi requires matching source/mask chunks and one "
-              "init/result chunk");
+          op, "reduce_addi requires matching source/mask chunks and one result "
+              "chunk");
 
     auto resultType = dyn_cast<VRegType>(resultTypes.front());
     auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    if (!resultType || !maskType || initParts.front().getType() != resultType)
+    if (!resultType || !maskType)
       return rewriter.notifyMatchFailure(
-          op, "reduce_addi requires matching physical source/init/result "
-              "vregs and one mask");
+          op, "reduce_addi requires matching physical source/result vregs and "
+              "one mask");
 
     for (Value sourcePart : sourceParts)
       if (sourcePart.getType() != resultType)
@@ -9550,12 +9549,6 @@ struct OneToNVMIReduceAddIOpPattern
             op, "reduce_addi requires every mask chunk to have the same "
                 "predicate type");
 
-    FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
-    if (failed(firstLaneMask))
-      return rewriter.notifyMatchFailure(
-          op, "failed to create reduce_addi first-lane mask");
-
     FailureOr<Value> combined = combineEquivalentMaskedParts<VaddOp>(
         op.getLoc(), sourceParts, maskParts, resultType, rewriter);
     if (succeeded(combined)) {
@@ -9564,23 +9557,33 @@ struct OneToNVMIReduceAddIOpPattern
               .create<VcaddOp>(op.getLoc(), resultType, *combined,
                                maskParts.front())
               .getResult();
-      Value result =
-          rewriter
-              .create<VaddOp>(op.getLoc(), resultType, reduced,
-                              initParts.front(), *firstLaneMask)
-              .getResult();
       replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{result},
+          rewriter, op, SmallVector<Value>{reduced},
           *this->getTypeConverter());
       return success();
     }
 
-    Value accumulator = initParts.front();
-    for (auto [sourcePart, maskPart] :
-         llvm::zip_equal(sourceParts, maskParts)) {
+    Value accumulator = rewriter
+                            .create<VcaddOp>(op.getLoc(), resultType,
+                                             sourceParts.front(),
+                                             maskParts.front())
+                            .getResult();
+    if (sourceParts.size() == 1) {
+      replaceOpWithFlatConvertedValues(
+          rewriter, op, SmallVector<Value>{accumulator},
+          *this->getTypeConverter());
+      return success();
+    }
+    FailureOr<Value> firstLaneMask =
+        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
+    if (failed(firstLaneMask))
+      return rewriter.notifyMatchFailure(
+          op, "failed to create reduce_addi first-lane mask");
+    for (size_t part = 1; part < sourceParts.size(); ++part) {
       Value reduced =
           rewriter
-              .create<VcaddOp>(op.getLoc(), resultType, sourcePart, maskPart)
+              .create<VcaddOp>(op.getLoc(), resultType, sourceParts[part],
+                               maskParts[part])
               .getResult();
       accumulator = rewriter
                         .create<VaddOp>(op.getLoc(), resultType, reduced,
@@ -9603,7 +9606,6 @@ struct OneToNVMIReduceAddFOpPattern
   matchAndRewrite(VMIReduceAddFOp op, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     ValueRange sourceParts = adaptor.getSource();
-    ValueRange initParts = adaptor.getInit();
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
@@ -9611,17 +9613,17 @@ struct OneToNVMIReduceAddFOpPattern
       return failure();
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
-        initParts.size() != 1 || resultTypes.size() != 1)
+        resultTypes.size() != 1)
       return rewriter.notifyMatchFailure(
-          op, "reduce_addf requires matching source/mask chunks and one "
-              "init/result chunk");
+          op, "reduce_addf requires matching source/mask chunks and one result "
+              "chunk");
 
     auto resultType = dyn_cast<VRegType>(resultTypes.front());
     auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    if (!resultType || !maskType || initParts.front().getType() != resultType)
+    if (!resultType || !maskType)
       return rewriter.notifyMatchFailure(
-          op, "reduce_addf requires matching physical source/init/result "
-              "vregs and one mask");
+          op, "reduce_addf requires matching physical source/result vregs and "
+              "one mask");
 
     for (Value sourcePart : sourceParts)
       if (sourcePart.getType() != resultType)
@@ -9634,12 +9636,6 @@ struct OneToNVMIReduceAddFOpPattern
             op, "reduce_addf requires every mask chunk to have the same "
                 "predicate type");
 
-    FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
-    if (failed(firstLaneMask))
-      return rewriter.notifyMatchFailure(
-          op, "failed to create reduce_addf first-lane mask");
-
     FailureOr<Value> combined = combineEquivalentMaskedParts<VaddOp>(
         op.getLoc(), sourceParts, maskParts, resultType, rewriter);
     if (succeeded(combined)) {
@@ -9648,23 +9644,33 @@ struct OneToNVMIReduceAddFOpPattern
               .create<VcaddOp>(op.getLoc(), resultType, *combined,
                                maskParts.front())
               .getResult();
-      Value result =
-          rewriter
-              .create<VaddOp>(op.getLoc(), resultType, reduced,
-                              initParts.front(), *firstLaneMask)
-              .getResult();
       replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{result},
+          rewriter, op, SmallVector<Value>{reduced},
           *this->getTypeConverter());
       return success();
     }
 
-    Value accumulator = initParts.front();
-    for (auto [sourcePart, maskPart] :
-         llvm::zip_equal(sourceParts, maskParts)) {
+    Value accumulator = rewriter
+                            .create<VcaddOp>(op.getLoc(), resultType,
+                                             sourceParts.front(),
+                                             maskParts.front())
+                            .getResult();
+    if (sourceParts.size() == 1) {
+      replaceOpWithFlatConvertedValues(
+          rewriter, op, SmallVector<Value>{accumulator},
+          *this->getTypeConverter());
+      return success();
+    }
+    FailureOr<Value> firstLaneMask =
+        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
+    if (failed(firstLaneMask))
+      return rewriter.notifyMatchFailure(
+          op, "failed to create reduce_addf first-lane mask");
+    for (size_t part = 1; part < sourceParts.size(); ++part) {
       Value reduced =
           rewriter
-              .create<VcaddOp>(op.getLoc(), resultType, sourcePart, maskPart)
+              .create<VcaddOp>(op.getLoc(), resultType, sourceParts[part],
+                               maskParts[part])
               .getResult();
       accumulator = rewriter
                         .create<VaddOp>(op.getLoc(), resultType, reduced,
@@ -10388,7 +10394,6 @@ struct OneToNVMIReduceMinMaxOpPattern : OpConversionPattern<SourceOp> {
       typename OpConversionPattern<SourceOp>::OneToNOpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     ValueRange sourceParts = adaptor.getSource();
-    ValueRange initParts = adaptor.getInit();
     ValueRange maskParts = adaptor.getMask();
     FailureOr<SmallVector<Type>> maybe_resultTypes =
         getConvertedResultTypes(op, 0, *this->getTypeConverter());
@@ -10396,17 +10401,17 @@ struct OneToNVMIReduceMinMaxOpPattern : OpConversionPattern<SourceOp> {
       return failure();
     SmallVector<Type> resultTypes = std::move(*maybe_resultTypes);
     if (sourceParts.empty() || sourceParts.size() != maskParts.size() ||
-        initParts.size() != 1 || resultTypes.size() != 1)
+        resultTypes.size() != 1)
       return rewriter.notifyMatchFailure(
           op, "min/max reduction requires matching source/mask chunks "
-              "and one init/result chunk");
+              "and one result chunk");
 
     auto resultType = dyn_cast<VRegType>(resultTypes.front());
     auto maskType = dyn_cast<MaskType>(maskParts.front().getType());
-    if (!resultType || !maskType || initParts.front().getType() != resultType)
+    if (!resultType || !maskType)
       return rewriter.notifyMatchFailure(
-          op, "min/max reduction requires matching physical source/"
-              "init/result vregs and one mask");
+          op, "min/max reduction requires matching physical source/result "
+              "vregs and one mask");
 
     for (Value sourcePart : sourceParts)
       if (sourcePart.getType() != resultType)
@@ -10419,12 +10424,6 @@ struct OneToNVMIReduceMinMaxOpPattern : OpConversionPattern<SourceOp> {
             op, "min/max reduction requires every mask chunk to have "
                 "the same predicate type");
 
-    FailureOr<Value> firstLaneMask =
-        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
-    if (failed(firstLaneMask))
-      return rewriter.notifyMatchFailure(
-          op, "failed to create min/max reduction first-lane mask");
-
     FailureOr<Value> combined = combineEquivalentMaskedParts<CombineOp>(
         op.getLoc(), sourceParts, maskParts, resultType, rewriter);
     if (succeeded(combined)) {
@@ -10433,22 +10432,31 @@ struct OneToNVMIReduceMinMaxOpPattern : OpConversionPattern<SourceOp> {
               .create<ChunkReduceOp>(op.getLoc(), resultType, *combined,
                                      maskParts.front())
               .getResult();
-      Value result =
-          rewriter
-              .create<CombineOp>(op.getLoc(), resultType, reduced,
-                                 initParts.front(), *firstLaneMask)
-              .getResult();
       replaceOpWithFlatConvertedValues(
-          rewriter, op, SmallVector<Value>{result}, *this->getTypeConverter());
+          rewriter, op, SmallVector<Value>{reduced}, *this->getTypeConverter());
       return success();
     }
 
-    Value accumulator = initParts.front();
-    for (auto [sourcePart, maskPart] :
-         llvm::zip_equal(sourceParts, maskParts)) {
+    Value accumulator = rewriter
+                            .create<ChunkReduceOp>(op.getLoc(), resultType,
+                                                   sourceParts.front(),
+                                                   maskParts.front())
+                            .getResult();
+    if (sourceParts.size() == 1) {
+      replaceOpWithFlatConvertedValues(
+          rewriter, op, SmallVector<Value>{accumulator},
+          *this->getTypeConverter());
+      return success();
+    }
+    FailureOr<Value> firstLaneMask =
+        createPrefixMask(op.getLoc(), maskType, "PAT_VL1", rewriter);
+    if (failed(firstLaneMask))
+      return rewriter.notifyMatchFailure(
+          op, "failed to create min/max reduction first-lane mask");
+    for (size_t part = 1; part < sourceParts.size(); ++part) {
       Value reduced = rewriter
                           .create<ChunkReduceOp>(op.getLoc(), resultType,
-                                                 sourcePart, maskPart)
+                                                 sourceParts[part], maskParts[part])
                           .getResult();
       accumulator = rewriter
                         .create<CombineOp>(op.getLoc(), resultType, reduced,
@@ -12775,18 +12783,16 @@ checkSupportedReduceShape(OpTy op, bool requiresReassoc,
     return fail("requires reassoc attr for pair-wise floating-point vcadd");
 
   auto sourceType = cast<VMIVRegType>(op.getSource().getType());
-  auto initType = cast<VMIVRegType>(op.getInit().getType());
   auto maskType = cast<VMIMaskType>(op.getMask().getType());
   auto resultType = cast<VMIVRegType>(op.getResult().getType());
   VMILayoutAttr sourceLayout = sourceType.getLayoutAttr();
-  VMILayoutAttr initLayout = initType.getLayoutAttr();
   VMILayoutAttr maskLayout = maskType.getLayoutAttr();
   VMILayoutAttr resultLayout = resultType.getLayoutAttr();
-  if (!sourceLayout || !initLayout || !maskLayout || !resultLayout)
-    return fail("requires assigned source, init, mask, and result layouts");
-  if (!sourceLayout.isContiguous() || !initLayout.isContiguous() ||
-      !maskLayout.isContiguous() || !resultLayout.isContiguous())
-    return fail("requires contiguous source, init, mask, and result layouts");
+  if (!sourceLayout || !maskLayout || !resultLayout)
+    return fail("requires assigned source, mask, and result layouts");
+  if (!sourceLayout.isContiguous() || !maskLayout.isContiguous() ||
+      !resultLayout.isContiguous())
+    return fail("requires contiguous source, mask, and result layouts");
 
   std::string fullChunkReason;
   if (failed(checkFullDataPhysicalChunks(sourceType, &fullChunkReason)))
@@ -12795,17 +12801,15 @@ checkSupportedReduceShape(OpTy op, bool requiresReassoc,
                 fullChunkReason);
 
   FailureOr<int64_t> sourceArity = getVMIPhysicalArity(sourceType);
-  FailureOr<int64_t> initArity = getVMIPhysicalArity(initType);
   FailureOr<int64_t> maskArity = getVMIPhysicalArity(maskType);
   FailureOr<int64_t> resultArity = getVMIPhysicalArity(resultType);
-  if (failed(sourceArity) || failed(initArity) || failed(maskArity) ||
-      failed(resultArity))
+  if (failed(sourceArity) || failed(maskArity) || failed(resultArity))
     return fail("requires computable physical arity");
   if (*sourceArity < 1 || *maskArity != *sourceArity)
     return fail("requires source and mask physical arity to match and be "
                 "non-empty");
-  if (*initArity != 1 || *resultArity != 1)
-    return fail("requires one init and result physical chunk");
+  if (*resultArity != 1)
+    return fail("requires one result physical chunk");
 
   return success();
 }
@@ -13697,7 +13701,7 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.reduce_addi lowers through pto.vcadd only for "
              "contiguous full 32-bit integer source chunks with matching "
-             "mask chunks and one init/result chunk ("
+             "mask chunks and one result chunk ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -13711,7 +13715,7 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.reduce_addf lowers through pto.vcadd only with "
              "reassoc, f32 contiguous full source chunks, matching mask "
-             "chunks, and one init/result chunk ("
+             "chunks, and one result chunk ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -13812,7 +13816,7 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.reduce_maxf lowers through pto.vcmax only for f16/f32 "
              "contiguous full source chunks with matching mask chunks and one "
-             "init/result chunk ("
+             "result chunk ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -13826,7 +13830,7 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.reduce_minf lowers through pto.vcmin only for f16/f32 "
              "contiguous full source chunks with matching mask chunks and one "
-             "init/result chunk ("
+             "result chunk ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -13840,7 +13844,7 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.reduce_maxi lowers through pto.vcmax only for "
              "contiguous full integer source chunks with matching mask "
-             "chunks and one init/result chunk ("
+             "chunks and one result chunk ("
           << reason << ")";
       return WalkResult::interrupt();
     }
@@ -13854,7 +13858,7 @@ verifySupportedVMIToVPTOOps(ModuleOp module,
           << kVMIDiagUnsupportedPrefix
           << "pto.vmi.reduce_mini lowers through pto.vcmin only for "
              "contiguous full integer source chunks with matching mask "
-             "chunks and one init/result chunk ("
+             "chunks and one result chunk ("
           << reason << ")";
       return WalkResult::interrupt();
     }

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf.pto
@@ -25,9 +25,8 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addf(
-// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %arg0, %arg1 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// CHECK: pto.vadd %[[REDUCED]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: return %[[REDUCED]] : !pto.vreg<64xf32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf_f16.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf_f16.pto
@@ -25,11 +25,8 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addf_f16(
-// CHECK: %[[LANE0:.*]] = pto.pset_b16 "PAT_VL1" : !pto.mask<b16>
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %arg0, %arg1
 // CHECK-SAME: !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
-// CHECK: pto.vadd %[[REDUCED]], {{.*}}, %[[LANE0]]
-// CHECK-SAME: !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
 // CHECK: return {{.*}} : !pto.vreg<128xf16>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addf_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addf_multichunk.pto
@@ -41,11 +41,10 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addf_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcadd %arg0, %arg2 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// CHECK: pto.vadd %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED1:.*]] = pto.vcadd %arg1, %arg3 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// CHECK: pto.vadd %[[RED1]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: pto.vadd %[[RED1]], %[[RED0]], %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -55,7 +54,7 @@ module {
 // CHECK: pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
 // CHECK: %[[MERGED:.*]] = pto.vadd %arg0, %arg1, %[[MASK0]]
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %[[MERGED]], %[[MASK0]]
-// CHECK: pto.vadd %[[REDUCED]], {{.*}}
+// CHECK-NOT: pto.vadd %[[REDUCED]],
 // CHECK-NOT: pto.vcadd
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addi.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addi.pto
@@ -25,9 +25,8 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addi(
-// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %arg0, %arg1 : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
-// CHECK: pto.vadd %[[REDUCED]], {{.*}}, %[[FIRST]] : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+// CHECK: return %[[REDUCED]] : !pto.vreg<64xi32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_addi_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_addi_multichunk.pto
@@ -41,11 +41,10 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_addi_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcadd %arg0, %arg2 : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
-// CHECK: pto.vadd %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED1:.*]] = pto.vcadd %arg1, %arg3 : !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
-// CHECK: pto.vadd %[[RED1]], {{.*}}, %[[FIRST]] : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
+// CHECK: pto.vadd %[[RED1]], %[[RED0]], %[[FIRST]] : !pto.vreg<64xi32>, !pto.vreg<64xi32>, !pto.mask<b32> -> !pto.vreg<64xi32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -55,7 +54,7 @@ module {
 // CHECK: pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
 // CHECK: %[[MERGED:.*]] = pto.vadd %arg0, %arg1, %[[MASK0]]
 // CHECK: %[[REDUCED:.*]] = pto.vcadd %[[MERGED]], %[[MASK0]]
-// CHECK: pto.vadd %[[REDUCED]], {{.*}}
+// CHECK-NOT: pto.vadd %[[REDUCED]],
 // CHECK-NOT: pto.vcadd
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_maxf_multichunk.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_maxf_multichunk.pto
@@ -55,21 +55,19 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_maxf_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcmax %arg0, %arg2 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// CHECK: pto.vmax %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED1:.*]] = pto.vcmax %arg1, %arg3 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// CHECK: pto.vmax %[[RED1]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: pto.vmax %[[RED1]], %[[RED0]], %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_minf_multichunk(
-// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED0:.*]] = pto.vcmin %arg0, %arg2 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// CHECK: pto.vmin %[[RED0]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: %[[FIRST:.*]] = pto.pset_b32 "PAT_VL1" : !pto.mask<b32>
 // CHECK: %[[RED1:.*]] = pto.vcmin %arg1, %arg3 : !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
-// CHECK: pto.vmin %[[RED1]], {{.*}}, %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
+// CHECK: pto.vmin %[[RED1]], %[[RED0]], %[[FIRST]] : !pto.vreg<64xf32>, !pto.vreg<64xf32>, !pto.mask<b32> -> !pto.vreg<64xf32>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast
@@ -79,7 +77,7 @@ module {
 // CHECK: pto.pset_b32 "PAT_ALL" : !pto.mask<b32>
 // CHECK: %[[MERGED:.*]] = pto.vmax %arg0, %arg1, %[[MASK0]]
 // CHECK: %[[REDUCED:.*]] = pto.vcmax %[[MERGED]], %[[MASK0]]
-// CHECK: pto.vmax %[[REDUCED]], {{.*}}
+// CHECK-NOT: pto.vmax %[[REDUCED]],
 // CHECK-NOT: pto.vcmax
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_minf.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_minf.pto
@@ -25,10 +25,8 @@ module {
 }
 
 // CHECK-LABEL: func.func @vmi_to_vpto_reduce_minf(
-// CHECK: %[[FIRST:.*]] = pto.pset_b16 "PAT_VL1" : !pto.mask<b16>
 // CHECK: %[[REDUCED:.*]] = pto.vcmin %arg0, %arg1 : !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
-// CHECK: %[[OUT:.*]] = pto.vmin %[[REDUCED]], {{.*}}, %[[FIRST]] : !pto.vreg<128xf16>, !pto.vreg<128xf16>, !pto.mask<b16> -> !pto.vreg<128xf16>
-// CHECK: return %[[OUT]]
+// CHECK: return %[[REDUCED]] : !pto.vreg<128xf16>
 // CHECK-NOT: pto.vmi.
 // CHECK-NOT: !pto.vmi.
 // CHECK-NOT: unrealized_conversion_cast

--- a/test/lit/vmi_new/vmi_to_vpto_reduce_shape_invalid.pto
+++ b/test/lit/vmi_new/vmi_to_vpto_reduce_shape_invalid.pto
@@ -38,7 +38,8 @@ module {
   }
 }
 
-// CHECK: error: 'pto.vmi.reduce_addf' op requires all layout-assigned VMI data values to have the same layout
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.reduce_addf lowers through pto.vcadd only
+// CHECK-SAME: requires contiguous source, mask, and result layouts
 
 // -----
 
@@ -72,4 +73,5 @@ module {
   }
 }
 
-// CHECK: error: 'pto.vmi.reduce_maxf' op requires all layout-assigned VMI data values to have the same layout
+// CHECK: VMI{{-}}UNSUPPORTED{{:}} pto.vmi.reduce_maxf lowers through pto.vcmax only
+// CHECK-SAME: requires contiguous source, mask, and result layouts


### PR DESCRIPTION
## Summary

- 移除内部 legacy bridge ops `pto.vmi.reduce_{addi,addf,maxi,maxf,mini,minf}` 的 `init` operand、解析格式和 verifier/layout 约束。
- `vcadd/vcmax/vcmin` lowering 不再构造归约幺元常量；单 chunk 直接返回 `vc*` 结果。
- 多 chunk lowering 以第一个 chunk 的 `vc*` 结果作为累加器，仅在后续 chunk 之间生成真实的 `vadd/vmax/vmin` combine；等价 mask 仍合并 source 后只做一次 `vc*`。
- 仅调整 VMI 内部 bridge IR，不改变统一 VMI 外部接口或 VPTO 硬件接口。

## Validation

已完成增量构建：

```text
ninja -C .work/build-issue586 pto-test-opt
```

并通过以下 reduce lowering lit 用例：

```text
vmi_to_vpto_reduce_addi.pto
vmi_to_vpto_reduce_addf.pto
vmi_to_vpto_reduce_addf_f16.pto
vmi_to_vpto_reduce_minf.pto
vmi_to_vpto_reduce_addi_multichunk.pto
vmi_to_vpto_reduce_addf_multichunk.pto
vmi_to_vpto_reduce_maxf_multichunk.pto
vmi_to_vpto_reduce_shape_invalid.pto
```

Closes mouliangyu/PTOAS#586
