### PR TITLE
test(samples): run mgather/mscatter samples on A3 as well as A5

### DIFF
--- a/test/samples/Mgather/mgather.py
+++ b/test/samples/Mgather/mgather.py
@@ -6,6 +6,8 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
+import os
+
 from ptoas.mlir.ir import Attribute, Context, Location, Module, InsertionPoint, StringAttr, UnitAttr
 from ptoas.mlir.dialects import func, arith, pto
 from ptoas.mlir.ir import IndexType, IntegerType
@@ -17,7 +19,10 @@ def build():
 
         with Location.unknown(ctx):
             m = Module.create()
-            m.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
+            # partition_view -> MGATHER reproduces issue #1165 on both A3 and A5.
+            # runop.sh threads the resolved arch in via PTOAS_SAMPLE_ARCH.
+            arch = os.environ.get("PTOAS_SAMPLE_ARCH", "a5")
+            m.operation.attributes["pto.target_arch"] = StringAttr.get(arch)
 
             i32 = IntegerType.get_signless(32, ctx)
             ptr_i32 = pto.PtrType.get(i32, ctx)

--- a/test/samples/Mscatter/mscatter.py
+++ b/test/samples/Mscatter/mscatter.py
@@ -6,6 +6,8 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 
+import os
+
 from ptoas.mlir.ir import Context, Location, Module, InsertionPoint, StringAttr, UnitAttr
 from ptoas.mlir.dialects import func, arith, pto
 from ptoas.mlir.ir import IndexType, IntegerType
@@ -17,7 +19,10 @@ def build():
 
         with Location.unknown(ctx):
             m = Module.create()
-            m.operation.attributes["pto.target_arch"] = StringAttr.get("a5")
+            # MSCATTER -> partition_view reproduces issue #1165 on both A3 and A5.
+            # runop.sh threads the resolved arch in via PTOAS_SAMPLE_ARCH.
+            arch = os.environ.get("PTOAS_SAMPLE_ARCH", "a5")
+            m.operation.attributes["pto.target_arch"] = StringAttr.get(arch)
 
             i32 = IntegerType.get_signless(32, ctx)
             ptr_i32 = pto.PtrType.get(i32, ctx)

--- a/test/samples/runop.sh
+++ b/test/samples/runop.sh
@@ -340,11 +340,6 @@ process_one_dir() {
       echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a5"
       continue
     fi
-    if [[ ( "$base" == "mgather" || "$base" == "mscatter" ) && \
-          "${target_arch_lc}" != "a5" ]]; then
-      echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a5"
-      continue
-    fi
     if [[ "$base" == "test_intercore_sync_a3" && "$(printf '%s' "$target_arch" | tr '[:upper:]' '[:lower:]')" != "a3" ]]; then
       echo -e "${A}(${base}.py)\tSKIP\trequires --pto-arch=a3"
       continue
@@ -398,7 +393,7 @@ process_one_dir() {
     mlir="${out_subdir}/${base}-pto-ir.pto"
     cpp="${out_subdir}/${base}-pto.cpp"
 
-    if ! "$python" "$f" > "$mlir"; then
+    if ! PTOAS_SAMPLE_ARCH="${target_arch_lc}" "$python" "$f" > "$mlir"; then
       if [[ $expect_fail -eq 1 ]]; then
         echo -e "${A}(${base}.py)\tXFAIL\tpython failed as expected"
         continue


### PR DESCRIPTION
## Summary
- Parametrize the Mgather/Mscatter samples' target arch via `PTOAS_SAMPLE_ARCH` (default `a5`), instead of hardcoding `pto.target_arch="a5"`.
- Drop the `runop.sh` a5-only skip for `mgather`/`mscatter` and thread the resolved arch into the sample generation, so both A3 and A5 emit these kernels.

## Motivation
The module `pto.target_arch` attribute overrides the `--pto-arch` flag (`ptoas.cpp` `resolveEffectiveTargetArch`), so the a5-hardcoded samples could never generate A3 code. Combined with the runop.sh skip, the board test (default SOC `Ascend910` = A3) never exercised the `partition_view -> MGATHER/MSCATTER` path that triggered issue #1165. This adds A3 board regression coverage for that fix.

## Test plan
- [x] `PTOAS_SAMPLE_ARCH=a3 python mgather.py|mscatter.py | ptoas --pto-arch=a3`: rc=0, module attr `"a3"`, zero illegal `(GlobalTensor<` casts, emits `MGATHER<Row>(...)` / `MSCATTER<Row>(...)` (validated on remote A3).
- [x] Same at `a5`: unchanged behavior, rc=0, zero illegal casts.
- [ ] A3 board (Ascend910) sample run picks up the newly-generated a3 mgather/mscatter cases.