### PR TITLE
ci: validate VMI source patch on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,24 @@ permissions:
   pull-requests: read
 
 jobs:
+  vmi-source-patch-check:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate VMI source patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 packaging/ptoas-vmi/prepare_source.py \
+            --output-dir .work/ptoas-vmi-source-check \
+            --revision HEAD
+
   license-header-check:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-22.04

--- a/packaging/ptoas-vmi/pyproject.toml.patch
+++ b/packaging/ptoas-vmi/pyproject.toml.patch
@@ -18,16 +18,13 @@ diff --git a/pyproject.toml b/pyproject.toml
  editable.mode = "redirect"
 +sdist.inclusion-mode = "manual"
  install.components = ["PTOAS_Python"]
-@@ -49,11 +50,6 @@ install.components = ["PTOAS_Python"]
- [tool.scikit-build.wheel.packages]
- ptodsl = "ptodsl/ptodsl"
- ptoas = "ptodsl/ptoas"
--
+@@ -53,3 +54,4 @@ TileOps = "lib/TileOps"
  [tool.scikit-build.cmake.define]
  PTOAS_RELEASE_VERSION_OVERRIDE = { env = "PTOAS_RELEASE_VERSION_OVERRIDE", default = "" }
--
++PTOAS_CLI_VERSION_LABEL = "vmi"
+
+@@ -56,4 +58,0 @@ PTOAS_RELEASE_VERSION_OVERRIDE = { env = "PTOAS_RELEASE_VERSION_OVERRIDE", default = "" }
 -[tool.scikit-build.metadata.version]
 -provider = "scikit_build_core.metadata.regex"
 -input = "CMakeLists.txt"
 -regex = 'project\s*\(\s*ptoas\s+VERSION\s+(?P<value>[0-9]+\.[0-9]+)\s*\)'
-+PTOAS_CLI_VERSION_LABEL = "vmi"


### PR DESCRIPTION
## Summary
- run the VMI source staging path on every pull request
- update the VMI metadata patch context for the TileOps package mapping

## Validation
- `git diff --check`
- `git apply --check packaging/ptoas-vmi/pyproject.toml.patch`
- `python3 packaging/ptoas-vmi/prepare_source.py --output-dir .work/ptoas-vmi-source-pr-check --revision HEAD`
- parsed staged `pyproject.toml` with `tomllib`
- parsed `.github/workflows/ci.yml` with PyYAML